### PR TITLE
feat(ui): calmer motion + first-paint primitives across paramant frontend

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -471,7 +471,14 @@ function softRender(){
         </tr>`).join("")}</tbody>
       </table></div>`;
     } else {
-      dt.innerHTML=`<div style="padding:24px 20px;font-size:12px;color:${V.q};font-family:${V.mono}">No deliveries this session</div>`;
+      dt.innerHTML=`<div class="empty-state is-compact" style="border:none;background:transparent">
+        <div class="empty-state-glyph" aria-hidden="true">↯</div>
+        <p class="empty-state-title">No deliveries yet</p>
+        <p class="empty-state-hint">Run the E2E test above, or send a file from the SDK to see it land here in real time.</p>
+        <div class="empty-state-actions">
+          <button onclick="runE2ETest()" class="btn btn-secondary" style="font-size:11px;padding:10px 18px">Run E2E test</button>
+        </div>
+      </div>`;
     }
   }
   const pi=document.getElementById("poll-info");
@@ -522,7 +529,7 @@ function render(){
     <div id="hbar" style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:28px"></div>
 
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:1px;background:${V.b};border:1px solid ${V.b};margin-bottom:24px" id="stats-grid">
-      ${[1,2,3,4,5,6,7,8].map(()=>`<div style="background:${V.sur};padding:20px;opacity:.3"><div style="height:28px;background:${V.b}"></div></div>`).join("")}
+      ${[1,2,3,4,5,6,7,8].map(()=>`<div style="background:${V.sur};padding:20px"><div class="skeleton skeleton-line is-sm"></div><div class="skeleton skeleton-line is-lg" style="margin-top:10px"></div></div>`).join("")}
     </div>
 
     <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:16px">
@@ -565,7 +572,12 @@ function render(){
         <span style="font-size:11px;color:${V.q}">Relay: ${relay.l}</span>
       </div>
       <div id="delivery-table">
-        <div style="padding:40px;text-align:center;font-size:13px;color:${V.q}">Loading...</div>
+        <div class="progress-indeterminate" style="margin:0"></div>
+        <div style="padding:24px 20px">
+          <div class="skeleton skeleton-line is-md"></div>
+          <div class="skeleton skeleton-line is-md"></div>
+          <div class="skeleton skeleton-line is-sm"></div>
+        </div>
       </div>
     </div>
 
@@ -575,7 +587,8 @@ function render(){
         <a href="/ct-log" style="font-size:11px;color:${V.q}">CT log →</a>
       </div>
       <div id="audit-log" style="padding:16px 20px;min-height:80px">
-        <div style="font-size:12px;color:${V.q};font-family:${V.mono}">Loading...</div>
+        <div class="skeleton skeleton-line is-md"></div>
+        <div class="skeleton skeleton-line is-sm"></div>
       </div>
     </div>
   </div>`;
@@ -592,6 +605,12 @@ function render(){
         <span style="color:${V.q}">${esc(e.hash||"")}${e.device?" · "+esc(e.device):""}${e.latency_ms?" · "+e.latency_ms+"ms":""}</span>
       </div>`
     ).join("");
+  } else if (data) {
+    document.getElementById("audit-log").innerHTML=`<div class="empty-state is-compact" style="border:none;background:transparent;padding:12px 4px">
+      <div class="empty-state-glyph" aria-hidden="true">∅</div>
+      <p class="empty-state-title">No audit events yet</p>
+      <p class="empty-state-hint">Inbound, ACK and burn events will appear here as the relay processes traffic for your key.</p>
+    </div>`;
   }
 }
 

--- a/frontend/design-system.css
+++ b/frontend/design-system.css
@@ -74,7 +74,10 @@
   /* motion */
   --duration-fast: 120ms;
   --duration-base: 200ms;
+  --duration-slow: 320ms;
   --ease-sharp:    cubic-bezier(0.2, 0, 0, 1);
+  --ease-soft:     cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-out:      cubic-bezier(0.16, 1, 0.3, 1);
 
   /* ─── v3 legacy token aliases (remove after Phase D HTML migration) ─── */
   --black:       #0B3A6A;
@@ -102,7 +105,12 @@
 
 html {
   scroll-behavior: smooth;
+  /* keep anchor targets clear of the 56px sticky navbar */
+  scroll-padding-top: 72px;
   -webkit-text-size-adjust: 100%;
+}
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
 }
 
 img, video, svg {
@@ -183,6 +191,10 @@ h1 em::after {
 :focus-visible {
   outline: 2px solid var(--cobalt);
   outline-offset: 2px;
+  transition: outline-offset var(--duration-fast) var(--ease-out);
+}
+:focus-visible:not(:active) {
+  outline-offset: 3px;
 }
 .section-cobalt :focus-visible,
 .section-navy :focus-visible,
@@ -1107,10 +1119,14 @@ h1 em::after {
   border: 1.5px solid transparent;
   transition: background var(--duration-base) var(--ease-sharp),
               color var(--duration-base) var(--ease-sharp),
-              border-color var(--duration-base) var(--ease-sharp);
+              border-color var(--duration-base) var(--ease-sharp),
+              transform var(--duration-fast) var(--ease-out);
   white-space: nowrap;
   line-height: 1;
   user-select: none;
+}
+.btn:active:not(:disabled) {
+  transform: translateY(1px);
 }
 .btn:disabled {
   opacity: .35;
@@ -1228,11 +1244,16 @@ h1 em::after {
   background: var(--lime);
   border: 1px solid var(--navy);
   flex-shrink: 0;
-  animation: blink-step 2s steps(2, end) infinite;
+  animation: status-pulse 2.4s var(--ease-soft) infinite;
 }
+@keyframes status-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: .55; transform: scale(.92); }
+}
+/* legacy keyframe alias — keep for any hand-rolled usage */
 @keyframes blink-step {
   0%, 100% { opacity: 1; }
-  50%       { opacity: 0; }
+  50%      { opacity: .5; }
 }
 
 .status-row {
@@ -1363,6 +1384,38 @@ pre code { background: none; padding: 0; }
   text-overflow: clip;
   user-select: none;
 }
+
+
+/* ═══════════════════════════════════════════════════
+   MOTION UTILITIES
+   ═══════════════════════════════════════════════════ */
+@keyframes ds-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes ds-rise-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes ds-scale-in {
+  from { opacity: 0; transform: scale(.98); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+/* Page-level entrance — applied to <main> via .page-enter */
+.page-enter {
+  animation: ds-fade-in var(--duration-slow) var(--ease-out) both;
+}
+/* Block-level entrance — for cards, hero sections, lists, etc. */
+.rise-in {
+  animation: ds-rise-in var(--duration-slow) var(--ease-out) both;
+}
+/* Stagger helpers (use with .rise-in) */
+.rise-in.delay-1 { animation-delay:  60ms; }
+.rise-in.delay-2 { animation-delay: 120ms; }
+.rise-in.delay-3 { animation-delay: 180ms; }
+.rise-in.delay-4 { animation-delay: 240ms; }
+.rise-in.delay-5 { animation-delay: 300ms; }
 
 
 /* ═══════════════════════════════════════════════════
@@ -1790,11 +1843,15 @@ pre code { background: none; padding: 0; }
   text-decoration: none;
   color: var(--ink);
   transition: border-color var(--duration-base) var(--ease-sharp),
-              background var(--duration-base) var(--ease-sharp);
+              background var(--duration-base) var(--ease-sharp),
+              transform var(--duration-base) var(--ease-out),
+              box-shadow var(--duration-base) var(--ease-out);
 }
 .help-card:hover {
   border-color: var(--cobalt);
   background: var(--ink-ghost);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 0 -3px var(--ink-ghost);
 }
 .help-card .help-card-title {
   font-size: var(--text-base);
@@ -1813,6 +1870,10 @@ pre code { background: none; padding: 0; }
   font-family: var(--mono);
   font-size: var(--text-xs);
   color: var(--cobalt);
+  transition: transform var(--duration-base) var(--ease-out);
+}
+.help-card:hover .help-card-arrow {
+  transform: translateX(4px);
 }
 
 /* Contact / CTA prompt box */

--- a/frontend/design-system.css
+++ b/frontend/design-system.css
@@ -518,10 +518,31 @@ h1 em::after {
   padding: 40px var(--space-6);
   background: var(--bone);
   cursor: pointer;
-  transition: background var(--duration-base) var(--ease-sharp);
+  transition: background var(--duration-base) var(--ease-sharp),
+              border-color var(--duration-base) var(--ease-sharp),
+              box-shadow var(--duration-base) var(--ease-out);
 }
-.drop:hover, .drop.drag-over,
-.dropzone:hover, .dropzone.drag-over { background: var(--ink-ghost); }
+/* Idle "breathe" — subtle lime ring that invites interaction without
+   shouting. Pauses on hover/focus/drag so feedback states are clean. */
+.drop:not(:hover):not(:focus-within):not(.drag-over),
+.dropzone:not(:hover):not(:focus-within):not(.drag-over) {
+  animation: drop-breathe 3.6s var(--ease-soft) infinite;
+}
+@keyframes drop-breathe {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(178,255,63,0); }
+  50%      { box-shadow: 0 0 0 4px rgba(178,255,63,.18); }
+}
+.drop:hover, .drop:focus-within,
+.dropzone:hover, .dropzone:focus-within {
+  background: var(--ink-ghost);
+  box-shadow: 0 0 0 2px var(--ink-hair);
+}
+.drop.drag-over,
+.dropzone.drag-over {
+  background: var(--ink-ghost);
+  border-color: var(--cobalt);
+  box-shadow: 0 0 0 4px rgba(29,78,216,.18);
+}
 
 /* "01" bleeding label */
 .drop-label,
@@ -1419,6 +1440,132 @@ pre code { background: none; padding: 0; }
 
 
 /* ═══════════════════════════════════════════════════
+   EMPTY STATE
+   For zero-data tables, dashboards, lists. Replaces a sea of "—"
+   with a glyph + title + hint + optional CTA so first-time users
+   know what the surface is for and what to do next.
+   ═══════════════════════════════════════════════════ */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: var(--space-3);
+  padding: var(--space-8) var(--space-5);
+  border: 1px dashed var(--ink-hair);
+  background: var(--bone);
+  color: var(--ink-dim);
+}
+.empty-state-glyph {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border: 1.5px solid var(--ink-hair);
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  font-size: var(--text-lg);
+  font-weight: 700;
+  margin-bottom: var(--space-1);
+  background: var(--bone);
+}
+.empty-state-title {
+  font-family: var(--sans);
+  font-size: var(--text-md);
+  font-weight: 700;
+  color: var(--navy);
+  margin: 0;
+}
+.empty-state-hint {
+  font-family: var(--mono);
+  font-size: var(--text-xs);
+  letter-spacing: .04em;
+  color: var(--ink-dim);
+  max-width: 44ch;
+  line-height: 1.55;
+  margin: 0;
+}
+.empty-state-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+  justify-content: center;
+}
+
+/* Compact variant — for inside table rows or narrow cards */
+.empty-state.is-compact {
+  padding: var(--space-5) var(--space-4);
+  gap: var(--space-2);
+}
+.empty-state.is-compact .empty-state-glyph {
+  width: 28px;
+  height: 28px;
+  font-size: var(--text-sm);
+}
+
+
+/* ═══════════════════════════════════════════════════
+   SKELETON LOADING
+   Replaces flicker placeholder divs with a calm shimmer that
+   reads as "we're loading", not "we're broken".
+   ═══════════════════════════════════════════════════ */
+.skeleton {
+  display: block;
+  background: linear-gradient(
+    90deg,
+    var(--ink-ghost) 0%,
+    var(--ink-hair)  50%,
+    var(--ink-ghost) 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.4s var(--ease-soft) infinite;
+  color: transparent;
+  user-select: none;
+  pointer-events: none;
+  min-height: 1em;
+}
+.skeleton-line { height: 12px; margin: 6px 0; }
+.skeleton-line.is-sm { height: 8px;  width: 40%; }
+.skeleton-line.is-md { height: 12px; width: 70%; }
+.skeleton-line.is-lg { height: 18px; width: 50%; }
+.skeleton-block { height: 64px; }
+@keyframes skeleton-shimmer {
+  from { background-position: 200% 0; }
+  to   { background-position:  -200% 0; }
+}
+
+
+/* ═══════════════════════════════════════════════════
+   INDETERMINATE PROGRESS
+   For "Preparing…" / "Connecting…" — anything where ETA is
+   unknown. Reads as motion, not as a stuck bar.
+   ═══════════════════════════════════════════════════ */
+.progress-indeterminate {
+  position: relative;
+  width: 100%;
+  height: 3px;
+  background: var(--ink-ghost);
+  overflow: hidden;
+}
+.progress-indeterminate::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 38%;
+  background: var(--cobalt);
+  animation: progress-slide 1.4s var(--ease-soft) infinite;
+}
+@keyframes progress-slide {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(280%); }
+}
+
+
+/* ═══════════════════════════════════════════════════
    MOTION SAFETY
    ═══════════════════════════════════════════════════ */
 @media (prefers-reduced-motion: reduce) {
@@ -1428,6 +1575,16 @@ pre code { background: none; padding: 0; }
     transition-duration: .01ms !important;
   }
   .status-dot, .dot { animation: none; opacity: 1; }
+  /* Skeleton: stop shimmering, stay visibly grey so the placeholder
+     still reads as "loading" rather than a transparent gap. */
+  .skeleton { animation: none; background: var(--ink-ghost); }
+  /* Indeterminate progress: pin the bar centre so the track isn't blank. */
+  .progress-indeterminate::after {
+    animation: none;
+    transform: translateX(80%);
+  }
+  /* Dropzone: drop the breathing ring entirely. */
+  .drop, .dropzone { animation: none; }
 }
 
 /* ═══════════════════════════════════════════════════

--- a/frontend/drop.html
+++ b/frontend/drop.html
@@ -1027,8 +1027,22 @@ async function startCamera() {
     document.getElementById('scanner-video').srcObject = cameraStream;
     scanQR();
   } catch(e) {
-    // Camera not available — hide scanner
-    document.getElementById('scanner-wrap').style.display = 'none';
+    // Camera unavailable — replace the black box with an empty-state
+    // that explains why and points to the manual-link fallback below.
+    var reason = 'No camera available on this device.';
+    if (e && e.name === 'NotAllowedError') reason = 'Camera permission was blocked. Allow camera access in your browser to scan QR codes.';
+    else if (e && e.name === 'NotFoundError') reason = 'No camera detected on this device.';
+    else if (window.isSecureContext === false) reason = 'Camera requires a secure (HTTPS) connection.';
+    var wrap = document.getElementById('scanner-wrap');
+    if (wrap) {
+      wrap.style.background = 'transparent';
+      wrap.style.aspectRatio = 'auto';
+      wrap.innerHTML = '<div class="empty-state is-compact" style="border:none;background:transparent">'
+        + '<div class="empty-state-glyph" aria-hidden="true">📷</div>'
+        + '<p class="empty-state-title">Camera unavailable</p>'
+        + '<p class="empty-state-hint">' + reason + ' You can paste the link manually below instead.</p>'
+        + '</div>';
+    }
   }
 }
 

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -303,7 +303,8 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   <div class="card">
     <div class="card-head"><div class="dot amber"></div><div class="card-head-title" id="loading-title">Preparing...</div></div>
     <div class="card-body">
-      <div class="progress-wrap"><div class="progress-bar" id="pbar"></div></div>
+      <div class="progress-indeterminate" id="indeterminate-bar" style="margin:14px 0 0"></div>
+      <div class="progress-wrap" id="progress-wrap" hidden><div class="progress-bar" id="pbar"></div></div>
       <div class="status-line" id="status-msg">Starting...</div>
     </div>
   </div>
@@ -434,7 +435,16 @@ function showStep(id) {
 }
 
 function setStatus(msg, pct) {
-  document.getElementById('pbar').style.width = pct + '%';
+  var ind = document.getElementById('indeterminate-bar');
+  var wrap = document.getElementById('progress-wrap');
+  if (pct > 0) {
+    if (ind)  ind.hidden = true;
+    if (wrap) wrap.hidden = false;
+    document.getElementById('pbar').style.width = pct + '%';
+  } else {
+    if (ind)  ind.hidden = false;
+    if (wrap) wrap.hidden = true;
+  }
   document.getElementById('status-msg').textContent = msg;
 }
 

--- a/frontend/nav.css
+++ b/frontend/nav.css
@@ -103,10 +103,16 @@ nav.nav .nav-dropdown-menu {
   z-index: 400;
   max-height: calc(100vh - 70px);
   overflow-y: auto;
+  transform-origin: top left;
 }
 nav.nav .nav-dropdown.open .nav-dropdown-menu,
 nav.nav .nav-dropdown:hover .nav-dropdown-menu {
   display: block;
+  animation: nav-dropdown-in var(--duration-base) var(--ease-out) both;
+}
+@keyframes nav-dropdown-in {
+  from { opacity: 0; transform: translateY(-4px) scale(.98); }
+  to   { opacity: 1; transform: translateY(0)    scale(1); }
 }
 
 /* Divider inside panel */
@@ -167,17 +173,32 @@ nav.nav .nav-link {
   text-transform: uppercase;
   padding: var(--space-2) var(--space-3);
   text-decoration: none;
-  transition: color var(--duration-base) var(--ease-sharp);
+  transition: color var(--duration-base) var(--ease-sharp),
+              box-shadow var(--duration-base) var(--ease-out);
   white-space: nowrap;
   display: flex;
   align-items: center;
   height: 32px;
+  position: relative;
+}
+nav.nav .nav-link::after {
+  content: '';
+  position: absolute;
+  left: var(--space-3);
+  right: var(--space-3);
+  bottom: 4px;
+  height: 2px;
+  background: var(--cobalt);
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform var(--duration-base) var(--ease-out);
 }
 nav.nav .nav-link:hover { color: var(--cobalt); }
+nav.nav .nav-link:hover::after { transform: scaleX(.4); }
 nav.nav .nav-link.active {
   color: var(--cobalt);
-  box-shadow: inset 0 -2px 0 var(--cobalt);
 }
+nav.nav .nav-link.active::after { transform: scaleX(1); }
 
 /* ════════════════════════════════════════
    HAMBURGER
@@ -205,9 +226,21 @@ nav.nav .nav-hamburger span {
   width: 22px;
   height: 2px;
   background: var(--ink);
-  transition: transform var(--duration-base) var(--ease-sharp),
-              opacity var(--duration-fast);
+  transition: transform var(--duration-base) var(--ease-out),
+              opacity var(--duration-fast) var(--ease-out);
   pointer-events: none;
+  transform-origin: center;
+}
+/* Open state — animate to a clean cross via CSS instead of inline JS */
+nav.nav .nav-hamburger[aria-expanded="true"] span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+nav.nav .nav-hamburger[aria-expanded="true"] span:nth-child(2) {
+  opacity: 0;
+  transform: scaleX(.4);
+}
+nav.nav .nav-hamburger[aria-expanded="true"] span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
 }
 
 /* ════════════════════════════════════════
@@ -226,7 +259,14 @@ nav.nav .nav-hamburger span {
   overflow-y: auto;
   flex-direction: column;
 }
-.nav-mobile.open { display: flex; }
+.nav-mobile.open {
+  display: flex;
+  animation: nav-mobile-in var(--duration-slow) var(--ease-out) both;
+}
+@keyframes nav-mobile-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 
 /* Accordion group */
 .nav-mobile-group {
@@ -264,13 +304,23 @@ nav.nav .nav-hamburger span {
 .nav-mobile-group.open .nav-mobile-group-btn { color: #0B3A6A; }
 .nav-mobile-group.open .nav-mobile-group-btn::after { content: '\2212'; color: #B2FF3F; }
 
-/* Group items */
+/* Group items — animated reveal using max-height + opacity */
 .nav-mobile-group-items {
-  display: none;
+  display: flex;
   flex-direction: column;
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0 0 0;
+  transition: max-height var(--duration-base) var(--ease-out),
+              opacity var(--duration-fast) var(--ease-out),
+              padding var(--duration-base) var(--ease-out);
+}
+.nav-mobile-group.open .nav-mobile-group-items {
+  max-height: 720px;
+  opacity: 1;
   padding: 0 0 var(--space-3);
 }
-.nav-mobile-group.open .nav-mobile-group-items { display: flex; }
 
 .nav-mobile-group-items a {
   display: block;

--- a/frontend/nav.js
+++ b/frontend/nav.js
@@ -131,10 +131,6 @@
     hamburger.setAttribute('aria-expanded', 'true');
     hamburger.setAttribute('aria-label', 'Close menu');
     lockScroll();
-    var spans = hamburger.querySelectorAll('span');
-    if (spans[0]) spans[0].style.transform = 'translateY(7px) rotate(45deg)';
-    if (spans[1]) spans[1].style.opacity   = '0';
-    if (spans[2]) spans[2].style.transform = 'translateY(-7px) rotate(-45deg)';
     if (closeBtn) closeBtn.focus();
   }
 
@@ -143,8 +139,6 @@
     hamburger.setAttribute('aria-expanded', 'false');
     hamburger.setAttribute('aria-label', 'Open menu');
     unlockScroll();
-    var spans = hamburger.querySelectorAll('span');
-    spans.forEach(function (s) { s.removeAttribute('style'); });
     hamburger.focus();
   }
 


### PR DESCRIPTION
## Summary

Three commits that tighten the "windstil" feel of the paramant frontend without breaking its brutalist tone. The brief was: improve usability via animations, visuals, and how navigation behaves — and address pages that open "too zoomed-out" (no orientation, sparse forms, frozen 0% bars, silent failures).

### 1. Calmer motion across nav, status & cards (`f49c85d`)
- New tokens: `--duration-slow`, `--ease-soft`, `--ease-out`.
- Status dot: harsh `blink-step` swapped for an eased opacity+scale `status-pulse`.
- Buttons: subtle `translateY(1px)` press feedback.
- `:focus-visible` gets a small offset transition.
- Help-cards lift on hover with the arrow nudging right.
- Page entrance utilities: `.page-enter` + `.rise-in` (with `delay-1..5` stagger).
- `scroll-padding-top: 72px` so anchor links clear the sticky 56px navbar (auto under reduced-motion).
- Nav: dropdowns fade+rise+scale instead of `display:block` flits; mobile drawer slide-in; mobile accordion uses max-height transition; hamburger cross is now CSS-driven via `[aria-expanded="true"]` (inline JS span transforms removed); active link gets an animated underline via `::after`.

### 2. First-paint primitives in the design system (`d76f3b9`)
Opt-in components for surfaces that currently feel empty or stuck:
- **Dropzone breathe** — 3.6s lime ring on idle that pauses on hover/focus/drag, distinct cobalt 4px ring on `.drag-over`.
- **`.empty-state`** (+ `.is-compact`) — glyph + title + hint + actions slot for zero-data surfaces.
- **`.skeleton`** + `.skeleton-line` (`is-sm`/`is-md`/`is-lg`) + `.skeleton-block` — calm shimmer for loading placeholders.
- **`.progress-indeterminate`** — 3px bar with sliding cobalt segment for unknown-ETA states.
- All four respect `prefers-reduced-motion` with sensible static fallbacks.

### 3. Wired into the worst offenders (`d36e8b0`)
- **`dashboard.html`**: stat-cards use skeleton lines instead of flickering `opacity:.3` divs; delivery table shows indeterminate bar + skeleton rows on load and an `.empty-state` with a "Run E2E test" CTA when zero deliveries; audit log gets the same load + empty treatment.
- **`get.html`**: "Preparing…" no longer shows a frozen 0% bar — `setStatus()` swaps an indeterminate sliding bar in until a real percentage arrives.
- **`drop.html`**: camera failure (`NotAllowedError` / `NotFoundError` / non-secure context) replaces the silent `display:none` with an `.empty-state` explaining the cause and pointing at the manual-link fallback.

## Files touched

- `frontend/design-system.css` — tokens, motion utilities, dropzone, empty-state, skeleton, indeterminate, motion-safety updates.
- `frontend/nav.css` — animated dropdown/drawer/accordion/hamburger/active-link.
- `frontend/nav.js` — drop the inline span style writes (CSS owns hamburger state now).
- `frontend/dashboard.html` — wire skeleton + empty-state into stat-cards / delivery / audit.
- `frontend/get.html` — wire indeterminate bar into Preparing state.
- `frontend/drop.html` — wire empty-state into camera failure path.

## Not in this PR (intentional)

- Page-level rollout of `.empty-state` / `.skeleton` to `account.html`, `auth/*`, `admin.html` — those need copywriting decisions first.
- The `.page-enter` / `.rise-in` utilities are defined but not yet applied to `<main>` blocks across the 48 marketing pages.
- Dashboard-login onboarding copy expansion.

## Test plan

- [ ] Visit `/dashboard` without an API key — login form renders unchanged.
- [ ] Sign in to `/dashboard` with a valid key — stat-cards show shimmering skeletons until the first poll, then real numbers.
- [ ] On `/dashboard` with no transfers yet — delivery table shows the empty-state with the "Run E2E test" CTA; clicking it triggers the existing E2E flow.
- [ ] On `/dashboard` with no audit events — audit log section shows the empty-state hint.
- [ ] Open a `/get` link on a slow connection — confirm the indeterminate bar slides during "Preparing…" and is replaced by the determinate bar once decryption progress is reported.
- [ ] On `/drop` in receive mode, deny camera permission — confirm the black box is replaced by an explanatory empty-state.
- [ ] On `/send` — confirm dropzone shows the subtle lime breathe ring on idle, switches to a cobalt ring during a drag-over.
- [ ] Open any page with `prefers-reduced-motion: reduce` — skeletons stay grey (not transparent), indeterminate bar pins to a visible position, dropzone ring stops, dropdown/drawer/page transitions instant.
- [ ] Open the desktop nav dropdowns — they fade+rise in instead of snapping; mobile drawer slides in; mobile accordion expands smoothly; hamburger animates to a clean cross via CSS only.
- [ ] Tab through nav — focus rings show, active link has the animated underline, anchor jumps land below the sticky navbar.


---
_Generated by [Claude Code](https://claude.ai/code/session_01672jTkAmSSGDdo39XC8ejb)_