### PR TITLE
sdk: verify sender signatures + align py↔js cross-SDK (v3.1.0, non-breaking)

### DIFF
--- a/docs/wire-format-v1.md
+++ b/docs/wire-format-v1.md
@@ -82,6 +82,46 @@ AAD = MAGIC || VERSION || KEM_ID || SIG_ID || FLAGS || chunk_index_be32
 
 This means: an attacker who flips a bit in KEM_ID or SIG_ID causes GCM verification to fail. The algorithm selection is integrity-protected, not just the ciphertext body.
 
+### Signature input (sender authentication)
+
+When `SIG_ID != 0x0000`, the SENDER_PUB field carries the sender's **ML-DSA signing
+public key** (not the KEM key), and the SIGNATURE field is the ML-DSA signature over
+this exact byte message:
+
+```
+sign_input = CT_KEM || SENDER_PUB || NONCE || CIPHERTEXT || AAD
+```
+
+(concatenation, signed directly — ML-DSA hashes internally; AAD is the 14-byte value
+above). The receiver MUST recompute `sign_input` from the parsed fields and verify the
+signature against SENDER_PUB **before** decrypting, and reject the blob on failure.
+This is mandatory in both `sdk-py` (≥ 3.1.0) and `sdk-js`; the two are byte-identical.
+
+> **Identity binding.** A valid signature only proves the blob is self-consistent for
+> the carried SENDER_PUB. To authenticate *who* sent it, the receiver pins SENDER_PUB
+> against the expected sender's registered signing key (TOFU) — `receive(sender=…)` /
+> `receive(hash, { sender })`. Without pinning, a relay (or anyone who can place a blob)
+> may substitute its own signing key.
+
+> **History.** paramant-sdk 3.0.0 (py) signed `SHA-256(AAD || CT_KEM || SENDER_PUB ||
+> NONCE || CIPHERTEXT)` with a different field order, and its receiver never verified
+> the signature at all. 3.1.0 aligns py to the convention above (already used by sdk-js)
+> and enforces verification. The on-wire byte layout is unchanged, so the relay (which
+> stores blobs opaquely and does not verify signatures) and existing wire-v1 tooling are
+> unaffected — no version bump.
+
+### Device fingerprint (TOFU)
+
+The human-verifiable device fingerprint is computed identically in both SDKs as:
+
+```
+fingerprint = SHA-256(KEM_PUB_bytes || SIG_PUB_bytes)  →  first 10 bytes
+            → "XXXX-XXXX-XXXX-XXXX-XXXX"  (uppercase hex, five 4-char groups)
+```
+
+It binds both the KEM public key and the ML-DSA signing public key, so a swapped signing
+identity changes the fingerprint.
+
 ### Padding
 
 Payload is padded to one of {4 KB, 64 KB, 512 KB, 5 MB} to mask true size from a passive observer. Padding scheme identical to v0: zeros appended up to the chosen block size, smallest block that fits the payload is selected.

--- a/sdk-js/CHANGELOG.md
+++ b/sdk-js/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 3.1.0 — 2026-05-23
+
+Security release. Wire format unchanged (still v1) — relay and existing tooling unaffected.
+
+### Fixed
+- **Cross-SDK interop with sdk-py (F3).** sdk-py ≤ 3.0.0 signed a different message and
+  never verified, so py↔js signed transfers were broken. The signing convention
+  (`CT_KEM || SENDER_PUB || NONCE || CIPHERTEXT || AAD`) and fingerprint
+  (`SHA-256(kem_pub || sig_pub)`, first 10 bytes) are now byte-identical across both SDKs.
+  `registerPubkeys()` also sends `kyber_pub`/`dsa_pub` aliases.
+- **Receipts verified client-side (F2).** `verifyReceipt()` checks the relay's ML-DSA
+  signature against a pinned `relayIdentityPub` instead of trusting `/v2/verify-receipt`.
+  (Pass `{ allowRelayFallback: true }` to keep the old behaviour for debugging.)
+
+### Added
+- `receive(hash, { sender })` pins the sender's signing key (TOFU) to authenticate origin;
+  without it a warning is logged.
+- `GhostPipe({ relayIdentityPub })` for client-side receipt verification.
+- `computeFingerprint` is now exported.
+- A test suite for the security fixes; `npm test` script fixed (`node --test`) and
+  `test/` is now shipped in the package.
+
+### Note
+Signature verification on `_decrypt` (rejecting tampered signatures) was already present
+in this branch; 3.1.0 adds sender-key pinning and aligns the convention with sdk-py.
+
 ## 3.0.0 — 2026-04-24
 
 **Breaking release.** See README for full migration notes.

--- a/sdk-js/index.js
+++ b/sdk-js/index.js
@@ -149,6 +149,16 @@ async function sha256Hex(data) {
   return u8toHex(new Uint8Array(hash));
 }
 
+/** Canonical JSON: recursively sorted keys, no whitespace — matches Python
+ *  json.dumps(sort_keys=True, separators=(",",":")) for ASCII receipts (F2). */
+function canonicalJSON(value) {
+  if (Array.isArray(value)) return '[' + value.map(canonicalJSON).join(',') + ']';
+  if (value && typeof value === 'object') {
+    return '{' + Object.keys(value).sort().map(k => JSON.stringify(k) + ':' + canonicalJSON(value[k])).join(',') + '}';
+  }
+  return JSON.stringify(value);
+}
+
 async function sha256Bytes(data) {
   return new Uint8Array(await crypto.subtle.digest('SHA-256', data));
 }
@@ -277,6 +287,7 @@ const KNOWN_OPTS = new Set([
   'apiKey', 'device', 'relay', 'preSharedSecret',
   'verifyFingerprints', 'timeout',
   'kemId', 'sigId', 'checkCapabilities',
+  'relayIdentityPub',
 ]);
 
 const TYPO_HINTS = {
@@ -329,7 +340,7 @@ export class GhostPipe {
     const { apiKey, device, relay = '', preSharedSecret = '',
             verifyFingerprints = true, timeout = 30000,
             kemId = DEFAULT_KEM_ID, sigId = DEFAULT_SIG_ID,
-            checkCapabilities = true } = opts;
+            checkCapabilities = true, relayIdentityPub = '' } = opts;
     if (apiKey && !apiKey.startsWith('pgp_')) throw new AuthError('API key must start with pgp_');
     this.apiKey             = apiKey;
     this.device             = device;
@@ -340,6 +351,8 @@ export class GhostPipe {
     this.kemId              = kemId;
     this.sigId              = sigId;
     this.checkCapabilities  = checkCapabilities;
+    // Pinned relay identity (ML-DSA) for client-side receipt verification (F2).
+    this.relayIdentityPub   = relayIdentityPub;
     this._keypair           = null;
     this._capabilities      = null;
     // Validate algorithms early — fail fast on unknown IDs.
@@ -574,7 +587,7 @@ export class GhostPipe {
     return { blob, hash };
   }
 
-  async _decrypt(blob, pss = '') {
+  async _decrypt(blob, pss = '', { expectedSenderSigPub = null } = {}) {
     const kp = await this._loadKeypair();
     if (!isV1(blob)) throw new GhostPipeError('blob is not wire-format v1 (missing PQHB magic)');
 
@@ -614,6 +627,11 @@ export class GhostPipe {
       if (!valid) {
         throw new SignatureError(`${sig.name} signature did not verify against senderPub`);
       }
+      // Identity pinning (F1): only authenticates WHO sent it if the carried
+      // senderPub equals the expected sender's pinned signing key.
+      if (expectedSenderSigPub && u8toHex(parsed.senderPub) !== u8toHex(expectedSenderSigPub)) {
+        throw new SignatureError('sender signing key does not match the pinned/expected sender');
+      }
     }
 
     return new Uint8Array(await crypto.subtle.decrypt(
@@ -631,6 +649,8 @@ export class GhostPipe {
       sig_id:    kp.sigId,
       kem_pub:   kp.kem_pub,
       sig_pub:   kp.sig_pub || '',
+      kyber_pub: kp.kem_pub,          // legacy alias (cross-SDK with sdk-py)
+      dsa_pub:   kp.sig_pub || '',    // legacy alias
     });
     if (status !== 200 && status !== 409) throw new RelayError(status, new TextDecoder().decode(body));
     return JSON.parse(new TextDecoder().decode(body));
@@ -646,7 +666,7 @@ export class GhostPipe {
     const pubkeys = await this._fetchPubkeys(target);
     const recipientKemPub = pubkeys.kem_pub || pubkeys.kyber_pub || '';
     if (!recipientKemPub) throw new GhostPipeError(`No KEM pubkey for device '${target}'`);
-    await this._tofuCheck(target, recipientKemPub, pubkeys.sig_pub || '', pubkeys.registered_at || '');
+    await this._tofuCheck(target, recipientKemPub, pubkeys.sig_pub || pubkeys.dsa_pub || '', pubkeys.registered_at || '');
     const { blob, hash } = await this._encrypt(data, recipientKemPub, { padBlock, pss });
     const { status, body } = await this._post('/v2/inbound', {
       hash,
@@ -659,12 +679,24 @@ export class GhostPipe {
     return hash;
   }
 
-  async receive(hash_, { preSharedSecret } = {}) {
+  async receive(hash_, { preSharedSecret, sender = null } = {}) {
     const pss = preSharedSecret ?? this.preSharedSecret;
     const { status, body } = await this._get(`/v2/outbound/${hash_}`);
     if (status === 404) throw new BurnedError('Blob not found: expired, already retrieved, or never stored.');
     if (status !== 200) throw new RelayError(status, new TextDecoder().decode(body));
-    return this._decrypt(body, pss);
+
+    let expectedSenderSigPub = null;
+    if (sender) {
+      const pubkeys = await this._fetchPubkeys(sender);
+      await this._tofuCheck(sender, pubkeys.kem_pub || pubkeys.kyber_pub || '',
+                            pubkeys.sig_pub || pubkeys.dsa_pub || '', pubkeys.registered_at || '');
+      const sp = pubkeys.sig_pub || pubkeys.dsa_pub || '';
+      expectedSenderSigPub = sp ? hexToU8(sp) : null;
+    } else if (this.sigId !== SIG.NONE) {
+      console.warn('[paramant] receive() called without { sender } — the sender signature is ' +
+        'checked for validity but NOT pinned to a known device. Pass { sender } to authenticate origin.');
+    }
+    return this._decrypt(body, pss, { expectedSenderSigPub });
   }
 
   async status(hash_) {
@@ -860,10 +892,38 @@ export class GhostPipe {
     return this._json(await this._get(`/v2/ct/${index}`));
   }
 
-  async verifyReceipt(receipt) {
-    const body = typeof receipt === 'string' ? { receipt } : { receipt: JSON.stringify(receipt) };
-    const r = await this._post('/v2/verify-receipt', body);
-    return this._json(r);
+  /**
+   * Verify a delivery receipt CLIENT-SIDE against the pinned relay identity key (F2).
+   * 3.0.0 trusted the relay's own /v2/verify-receipt — but the relay is untrusted
+   * by design. With relayIdentityPub pinned (constructor or arg), the ML-DSA
+   * signature is checked locally. Pass { allowRelayFallback: true } only to debug.
+   */
+  async verifyReceipt(receipt, { relayIdentityPub, allowRelayFallback = false } = {}) {
+    if (typeof receipt === 'string') receipt = JSON.parse(new TextDecoder().decode(fromBase64(receipt)));
+    const pubHex = relayIdentityPub || this.relayIdentityPub;
+    if (!pubHex) {
+      if (!allowRelayFallback) {
+        throw new GhostPipeError(
+          'No pinned relay identity public key — cannot verify the receipt locally. ' +
+          'Construct GhostPipe with relayIdentityPub (obtained out-of-band, e.g. from the ' +
+          'CT log). Refusing to delegate verification to the untrusted relay; pass ' +
+          '{ allowRelayFallback: true } to override for debugging only.');
+      }
+      console.warn('[paramant] verifying receipt via the UNTRUSTED relay — proves nothing about authenticity.');
+      const r = await this._post('/v2/verify-receipt', { receipt: JSON.stringify(receipt) });
+      return this._json(r);
+    }
+    const r = { ...receipt };
+    const sigField = r.sig || r.signature;
+    if (!sigField) throw new GhostPipeError("Receipt has no 'sig'/'signature' field to verify");
+    delete r.sig; delete r.signature;
+    const payload = new TextEncoder().encode(canonicalJSON(r));
+    const signature = /^[0-9a-fA-F]+$/.test(sigField) ? hexToU8(sigField) : fromBase64(sigField);
+    const sig = sigEngine(SIG.ML_DSA_65);
+    let ok = false;
+    try { ok = sig.verify(signature, payload, hexToU8(pubHex)); } catch { ok = false; }
+    if (!ok) throw new GhostPipeError('Receipt signature is INVALID against the pinned relay identity key');
+    return { valid: true, verified_locally: true, ...r };
   }
 
   // ── DID ───────────────────────────────────────────────────────────────────
@@ -990,5 +1050,5 @@ async function _deriveDropKeys(entropy) {
 
 // ── Exports ───────────────────────────────────────────────────────────────────
 
-export { SECTOR_RELAYS, fetchCapabilities, wireEncode, wireDecode, buildAAD, isV1 };
+export { SECTOR_RELAYS, fetchCapabilities, wireEncode, wireDecode, buildAAD, isV1, computeFingerprint };
 export default GhostPipe;

--- a/sdk-js/package.json
+++ b/sdk-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paramant-sdk",
-  "version": "3.0.0",
-  "description": "JavaScript SDK for Paramant — real post-quantum (ML-KEM-768 + ML-DSA-65) zero-plaintext file transport, wire-format v1",
+  "version": "3.1.0",
+  "description": "JavaScript SDK for Paramant \u2014 post-quantum (ML-KEM-768 + ML-DSA-65) zero-plaintext file transport, wire-format v1 with verified sender signatures",
   "type": "module",
   "main": "./index.js",
   "module": "./index.js",
@@ -26,7 +26,8 @@
     "index.d.ts",
     "src/",
     "README.md",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "test/"
   ],
   "keywords": [
     "paramant",
@@ -63,6 +64,6 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "node --test test/"
+    "test": "node --test"
   }
 }

--- a/sdk-js/test/security-fixes.test.js
+++ b/sdk-js/test/security-fixes.test.js
@@ -1,0 +1,68 @@
+// Regression tests for the 3.1.0 security fixes (audit 2026-05-23).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'paramant-secfix-'));
+process.env.HOME = HOME; process.env.USERPROFILE = HOME;
+
+const { GhostPipe, GhostPipeError, SignatureError, SIG, computeFingerprint,
+        wireEncode, wireDecode, buildAAD } = await import('../index.js');
+const { ml_dsa65 } = await import('@noble/post-quantum/ml-dsa.js');
+
+const gp = (device, opts = {}) => new GhostPipe({ apiKey: 'pgp_testkey_0123456789abcdef',
+  device, relay: 'https://offline.invalid', checkCapabilities: false, ...opts });
+const TE = (s) => new TextEncoder().encode(s);
+const concat = (...a) => { const t = a.reduce((s, x) => s + x.length, 0), o = new Uint8Array(t); let k = 0; for (const x of a) { o.set(x, k); k += x.length; } return o; };
+
+test('F1: tampered signature is rejected', async () => {
+  const s = gp('s'), r = gp('r');
+  const { blob } = await s._encrypt(TE('authentic'), (await r._loadKeypair()).kem_pub, { padBlock: 64 * 1024 });
+  const p = wireDecode(blob);
+  const bad = Uint8Array.from(p.signature); bad[0] ^= 0xff;
+  const forged = wireEncode({ kemId: p.kemId, sigId: p.sigId, ctKem: p.ctKem, senderPub: p.senderPub,
+    signature: bad, nonce: p.nonce, ciphertext: p.ciphertext });
+  await assert.rejects(() => r._decrypt(forged), SignatureError);
+});
+
+test('F1: swapped sender key rejected when pinned', async () => {
+  const s = gp('s2'), r = gp('r2');
+  const { blob } = await s._encrypt(TE('authentic'), (await r._loadKeypair()).kem_pub, { padBlock: 64 * 1024 });
+  const p = wireDecode(blob);
+  const atk = ml_dsa65.keygen();
+  const aad = buildAAD({ kemId: p.kemId, sigId: p.sigId, chunkIndex: 0 });
+  const msg = concat(p.ctKem, atk.publicKey, p.nonce, p.ciphertext, aad);
+  const forged = wireEncode({ kemId: p.kemId, sigId: p.sigId, ctKem: p.ctKem, senderPub: atk.publicKey,
+    signature: ml_dsa65.sign(msg, atk.secretKey), nonce: p.nonce, ciphertext: p.ciphertext });
+  assert.equal(new TextDecoder().decode(await r._decrypt(forged)), 'authentic'); // valid for attacker key
+  const real = Uint8Array.from(Buffer.from((await s._loadKeypair()).sig_pub, 'hex'));
+  await assert.rejects(() => r._decrypt(forged, '', { expectedSenderSigPub: real }), SignatureError);
+});
+
+test('F3: fingerprint binds the signing key (5 groups, 20 hex)', async () => {
+  const kem = 'aa'.repeat(1184);
+  const fp1 = await computeFingerprint(kem, 'bb'.repeat(1952));
+  const fp2 = await computeFingerprint(kem, 'cc'.repeat(1952));
+  assert.notEqual(fp1, fp2);
+  assert.equal(fp1.replace(/-/g, '').length, 20);
+});
+
+test('F4: unimplemented algorithm id throws at construction', () => {
+  assert.throws(() => gp('x', { kemId: 0x00ff }));
+});
+
+test('F2: receipt verified locally; forgery and missing-key rejected', async () => {
+  const relayId = ml_dsa65.keygen();
+  const receipt = { hash: 'abc', burn_confirmed: true, sector: 'health' };
+  const canon = (v) => Array.isArray(v) ? '[' + v.map(canon).join(',') + ']'
+    : (v && typeof v === 'object') ? '{' + Object.keys(v).sort().map(k => JSON.stringify(k) + ':' + canon(v[k])).join(',') + '}'
+    : JSON.stringify(v);
+  const sig = Buffer.from(ml_dsa65.sign(TE(canon(receipt)), relayId.secretKey)).toString('hex');
+  const pinned = gp('r', { relayIdentityPub: Buffer.from(relayId.publicKey).toString('hex') });
+  assert.ok((await pinned.verifyReceipt({ ...receipt, sig })).verified_locally);
+  await assert.rejects(() => pinned.verifyReceipt({ ...receipt, burn_confirmed: false, sig }), GhostPipeError);
+  await assert.rejects(() => gp('r2').verifyReceipt({ ...receipt, sig }), GhostPipeError);
+});

--- a/sdk-py/CHANGELOG.md
+++ b/sdk-py/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to `paramant-sdk` (Python).
 
+## [3.1.0] — 2026-05-23
+
+Security release. Wire format unchanged (still v1, PQHB version `0x01`) — the relay
+and existing tooling are unaffected. Only client behaviour changes.
+
+### Fixed
+- **Sender signatures are now verified (F1).** `receive()`/`_decrypt()` previously never
+  called `sig_verify`, so a tampered signature or a swapped `sender_pub` was accepted
+  silently. The signature is now verified before decryption and the blob is rejected
+  (`SignatureError`) on failure.
+- **Cross-SDK signing convention aligned (F3).** The signed message is now
+  `CT_KEM || SENDER_PUB || NONCE || CIPHERTEXT || AAD` (matching sdk-js); 3.0.0 signed a
+  different SHA-256 input, so py-signed blobs did not verify in sdk-js. The device
+  fingerprint is now `SHA-256(kem_pub || sig_pub)` (binds the signing key) and is
+  byte-identical to sdk-js. `/v2/pubkey` registers canonical `kem_pub`/`sig_pub` plus
+  `kyber_pub`/`dsa_pub` aliases.
+- **Receipts are verified client-side (F2).** `verify_receipt()` checks the relay's
+  ML-DSA signature against a pinned `relay_identity_pub` instead of trusting the
+  untrusted relay's `/v2/verify-receipt`.
+- **Algorithm ids are no longer cosmetic (F4).** A `kem_id`/`sig_id` this build cannot
+  perform now raises `UnsupportedAlgorithm` at construction instead of silently using
+  ML-KEM-768/ML-DSA-65 while writing the requested id into the header.
+- **Safe key zeroization (F5).** Secret material is held in `bytearray` and wiped in
+  place; the 3.0.0 `ctypes.memset()` on immutable `bytes` (undefined behaviour) is gone.
+
+### Added
+- `receive(..., sender="device-id")` pins the sender's signing key (TOFU) to authenticate
+  the origin; without it a warning is emitted.
+- `GhostPipe(relay_identity_pub=...)` for client-side receipt verification.
+
+### Migration
+- Upgrade receivers and senders together. Existing keypairs are reused (no rotation).
+- Existing local TOFU `known_keys` entries use the old fingerprint formula and will raise
+  `FingerprintMismatchError` on next contact — re-`trust()` after out-of-band verification.
+
 ## [3.0.0] — 2026-04-24
 
 ### Breaking

--- a/sdk-py/paramant/crypto.py
+++ b/sdk-py/paramant/crypto.py
@@ -122,12 +122,12 @@ def aes_gcm_encrypt(key: bytes, plaintext: bytes, aad: bytes, nonce: bytes = Non
         nonce = os.urandom(12)
     if len(nonce) != 12:
         raise ValueError("AES-GCM nonce must be 12 bytes")
-    ct = AESGCM(key).encrypt(nonce, plaintext, aad)
+    ct = AESGCM(bytes(key)).encrypt(nonce, plaintext, aad)
     return nonce, ct
 
 
 def aes_gcm_decrypt(key: bytes, nonce: bytes, ciphertext: bytes, aad: bytes) -> bytes:
-    return AESGCM(key).decrypt(nonce, ciphertext, aad)
+    return AESGCM(bytes(key)).decrypt(nonce, ciphertext, aad)
 
 
 def sha256(b: bytes) -> bytes:

--- a/sdk-py/paramant_sdk.py
+++ b/sdk-py/paramant_sdk.py
@@ -31,9 +31,9 @@ import urllib.parse
 import urllib.request
 
 from paramant import capabilities, crypto, wire_format
-from paramant.errors import CapabilityMismatch, ParamantError
+from paramant.errors import CapabilityMismatch, ParamantError, UnsupportedAlgorithm
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 
 # ── Padding block sizes ────────────────────────────────────────────────────────
 BLOCKS = {
@@ -62,26 +62,23 @@ def get_relay_url(sector: str = "health", use_edge: bool = False) -> str:
 
 
 # ── Key zeroization ───────────────────────────────────────────────────────────
-_ZEROIZE_OK = sys.implementation.name == "cpython"
-if not _ZEROIZE_OK:
-    warnings.warn(
-        "paramant-sdk: key zeroization (ctypes) is not supported on "
-        f"{sys.implementation.name}. Secret key material may persist in RAM.",
-        RuntimeWarning, stacklevel=2,
-    )
+# 3.0.0 ran ctypes.memset() on immutable `bytes`, which is undefined behaviour
+# (it can corrupt interned objects, and the offset heuristic is build-specific).
+# Instead, hold secret material in `bytearray` via _secret() and wipe that in
+# place — a defined operation on every Python implementation (F5).
+def _secret(src) -> bytearray:
+    """Return a mutable, wipeable copy of secret key material."""
+    return bytearray(src)
 
 
-def _zero(b: Optional[bytes]) -> None:
+def _zero(b) -> None:
+    """Securely wipe a bytearray in place. No-op for None/empty or immutable
+    bytes (which cannot be wiped at all — better an honest no-op than UB)."""
     if not b:
         return
-    try:
-        offset = sys.getsizeof(b) - len(b) - 1
-        ctypes.memset(id(b) + offset, 0, len(b))
-    except Exception as exc:
-        warnings.warn(
-            f"paramant-sdk: _zero() failed — key material may persist in RAM: {exc}",
-            RuntimeWarning, stacklevel=2,
-        )
+    if isinstance(b, bytearray):
+        for i in range(len(b)):
+            b[i] = 0
 
 
 # ── BIP39 helpers (drop / pickup) ─────────────────────────────────────────────
@@ -123,6 +120,10 @@ class GhostPipeError(ParamantError):
     pass
 
 
+class SignatureError(GhostPipeError):
+    """Raised when a blob's ML-DSA sender signature fails to verify (F1)."""
+
+
 class FingerprintMismatchError(GhostPipeError):
     """Raised when a device's key fingerprint differs from the stored TOFU value."""
     def __init__(self, device_id: str, stored: str, received: str):
@@ -142,19 +143,21 @@ class FingerprintMismatchError(GhostPipeError):
 # ── Canonical message signed inside a v1 blob ─────────────────────────────────
 def _canonical_sign_input(aad: bytes, ct_kem: bytes, sender_pub: bytes,
                           nonce: bytes, ciphertext: bytes) -> bytes:
-    """SHA-256 over the unsigned portion of the blob (AAD + ct_kem + sender_pub + nonce + ct).
+    """The exact byte message fed to ML-DSA for sender authentication.
 
-    This is the message fed to ML-DSA-65 for sender authentication. A downstream
-    verifier (sdk-js, another sdk-py, or a relay that adopts signature
-    verification) reproduces the same hash from the parsed blob fields.
+    CANONICAL CONVENTION (must be byte-identical in sdk-py and sdk-js):
+
+        message = ct_kem || sender_pub || nonce || ciphertext || aad
+
+    signed directly with ML-DSA (the signature scheme hashes internally). This
+    matches sdk-js `_encrypt`/`_decrypt` (concat(ctKem, senderPub, nonce, ct,
+    aad)). paramant-sdk 3.0.0 (py) instead signed SHA-256(aad || …) with a
+    different field order, so py-signed blobs did not verify in sdk-js. Aligning
+    to the sdk-js convention fixes cross-SDK authentication without a wire-format
+    version bump (the bytes on the wire are unchanged; only what the SIGNATURE
+    field is computed over changes).
     """
-    h = hashlib.sha256()
-    h.update(aad)
-    h.update(ct_kem)
-    h.update(sender_pub)
-    h.update(nonce)
-    h.update(ciphertext)
-    return h.digest()
+    return bytes(ct_kem) + bytes(sender_pub) + bytes(nonce) + bytes(ciphertext) + bytes(aad)
 
 
 # ── Main client ───────────────────────────────────────────────────────────────
@@ -188,14 +191,24 @@ class GhostPipe:
         kem_id: int = crypto.DEFAULT_KEM_ID,
         sig_id: int = crypto.DEFAULT_SIG_ID,
         negotiate_on_init: bool = True,
+        relay_identity_pub: str = "",
     ):
         if not api_key.startswith("pgp_"):
             raise GhostPipeError("API key must start with pgp_")
+        # F4: reject algorithm ids this SDK build cannot actually perform, so the
+        # blob header never claims an algorithm we did not use. (Full ML-KEM-1024
+        # / ML-DSA-87 agility is a coordinated follow-up; this build does 768/65.)
+        if int(kem_id) != crypto.KEM_ID_ML_KEM_768:
+            raise UnsupportedAlgorithm("KEM", int(kem_id))
+        if int(sig_id) not in (crypto.SIG_ID_NONE, crypto.SIG_ID_ML_DSA_65):
+            raise UnsupportedAlgorithm("SIG", int(sig_id))
         self.api_key = api_key
         self.device = device
         self.secret = secret or api_key
         self.kem_id = int(kem_id)
         self.sig_id = int(sig_id)
+        # Pinned relay identity (ML-DSA-65) for client-side receipt verification (F2).
+        self.relay_identity_pub = relay_identity_pub
         _relay = (
             relay or relay_url
             or (get_relay_url(sector) if sector else "")
@@ -277,17 +290,26 @@ class GhostPipe:
             os.replace(tmp, self._known_keys_path())
 
     @staticmethod
-    def _compute_fingerprint(kyber_pub_hex: str, ecdh_pub_hex: str) -> str:
-        """Retained from v2.x for wire compatibility with the relay's
-        computeFingerprint(kyber_pub, ecdh_pub) helper. ecdh_pub_hex is the
-        server-stored identity anchor; in v3 it is not used for encryption."""
-        buf = bytes.fromhex(kyber_pub_hex or "") + bytes.fromhex(ecdh_pub_hex or "")
+    def _pick(d: dict, *names: str) -> str:
+        for n in names:
+            if d.get(n):
+                return d[n]
+        return ""
+
+    @staticmethod
+    def _compute_fingerprint(kem_pub_hex: str, sig_pub_hex: str) -> str:
+        """Canonical fingerprint, byte-identical to sdk-js computeFingerprint (F3):
+        SHA-256(kem_pub_bytes || sig_pub_bytes), first 10 bytes as five 4-hex
+        groups. Binds BOTH the KEM key and the ML-DSA signing key. 3.0.0 (py)
+        instead hashed (kyber_pub || ecdh_anchor), which ignored the signing key
+        and produced a different fingerprint than sdk-js for the same device."""
+        buf = bytes.fromhex(kem_pub_hex or "") + bytes.fromhex(sig_pub_hex or "")
         h = hashlib.sha256(buf).hexdigest()[:20].upper()
         return f"{h[0:4]}-{h[4:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}"
 
-    def _tofu_check(self, device_id: str, kyber_pub_hex: str, ecdh_pub_hex: str,
+    def _tofu_check(self, device_id: str, kem_pub_hex: str, sig_pub_hex: str,
                     registered_at: str = "") -> str:
-        fp = self._compute_fingerprint(kyber_pub_hex, ecdh_pub_hex)
+        fp = self._compute_fingerprint(kem_pub_hex, sig_pub_hex)
         keys = self._load_known_keys()
         if device_id in keys:
             stored = keys[device_id]["fingerprint"]
@@ -394,14 +416,19 @@ class GhostPipe:
 
     def _register_pubkeys(self):
         kp = self._load_keypair()
+        # Register canonical kem_pub/sig_pub (matches sdk-js) AND the legacy
+        # kyber_pub/dsa_pub/ecdh_pub fields, so the relay and peers on either
+        # SDK keep working during rollout (F3).
         body = json.dumps({
             "device_id": self.device,
-            "ecdh_pub":  kp["ecdh_pub"],
+            "kem_pub":   kp["ml_kem_pub"],
+            "sig_pub":   kp["ml_dsa_pub"],
             "kyber_pub": kp["ml_kem_pub"],
             "dsa_pub":   kp["ml_dsa_pub"],
+            "ecdh_pub":  kp.get("ecdh_pub", ""),
         }).encode()
         status, resp = self._post("/v2/pubkey", body)
-        if status != 200:
+        if status not in (200, 409):
             raise GhostPipeError(f"Pubkey registration failed: {resp.decode()[:120]}")
 
     def _fetch_receiver_pubkeys(self, recipient: str = None):
@@ -414,16 +441,17 @@ class GhostPipe:
         if status != 200:
             raise GhostPipeError(f"Pubkey fetch failed: HTTP {status}")
         d = json.loads(body)
-        ml_kem_pub = bytes.fromhex(d["kyber_pub"]) if d.get("kyber_pub") else None
-        if not ml_kem_pub:
+        kem_hex = self._pick(d, "kem_pub", "kyber_pub")  # canonical first, legacy fallback
+        sig_hex = self._pick(d, "sig_pub", "dsa_pub")
+        if not kem_hex:
             raise GhostPipeError(
-                f"Receiver {target} has no ML-KEM public key. Upgrade the receiver to paramant-sdk>=3."
+                f"Receiver {target} has no KEM public key. Upgrade the receiver to paramant-sdk>=3."
             )
         return {
-            "ml_kem_pub": ml_kem_pub,
-            "ml_dsa_pub": bytes.fromhex(d["dsa_pub"]) if d.get("dsa_pub") else b"",
-            "kyber_hex":  d.get("kyber_pub", ""),
-            "ecdh_hex":   d.get("ecdh_pub", ""),
+            "ml_kem_pub": bytes.fromhex(kem_hex),
+            "ml_dsa_pub": bytes.fromhex(sig_hex) if sig_hex else b"",
+            "kem_hex":    kem_hex,
+            "sig_hex":    sig_hex,
             "registered_at": d.get("registered_at", ""),
         }
 
@@ -443,7 +471,8 @@ class GhostPipe:
         sender_priv = bytes.fromhex(kp["ml_dsa_priv"]) if self.sig_id != 0x0000 else b""
 
         ct_kem, shared_secret = crypto.kem_encapsulate(recipient_ml_kem_pub)
-        aes_key, pss_bytes = self._derive_payload_key(shared_secret, ct_kem, pre_shared_secret)
+        ss = _secret(shared_secret)
+        aes_key, pss_bytes = self._derive_payload_key(ss, ct_kem, pre_shared_secret)
 
         aad = wire_format.build_aad(kem_id=self.kem_id, sig_id=self.sig_id, chunk_index=0)
         nonce, ciphertext = crypto.aes_gcm_encrypt(aes_key, data, aad)
@@ -468,24 +497,31 @@ class GhostPipe:
             padded = blob + os.urandom(target - len(blob))
             return padded, hashlib.sha256(padded).hexdigest()
         finally:
-            _zero(shared_secret); _zero(aes_key); _zero(pss_bytes)
+            _zero(ss); _zero(aes_key); _zero(pss_bytes)
 
     @staticmethod
-    def _derive_payload_key(shared_secret: bytes, ct_kem: bytes,
-                             pre_shared_secret: str = "") -> Tuple[bytes, bytes]:
-        """HKDF from KEM shared secret; optional PSS mixed via a distinct info label."""
+    def _derive_payload_key(shared_secret, ct_kem: bytes,
+                            pre_shared_secret: str = "") -> Tuple[bytearray, bytearray]:
+        """HKDF from KEM shared secret; optional PSS mixed via a distinct info
+        label. Returns wipeable bytearrays (F5).
+
+        NOTE: the non-PSS path uses info=b"paramant-v1-aes-key" identically to
+        sdk-js, so the derived AES key matches cross-SDK. PSS still uses SHA3-256
+        here vs SHA-256 in sdk-js — cross-SDK PSS interop is a known follow-up;
+        the default (no-PSS) path is fully cross-compatible."""
         if pre_shared_secret:
             pss_hash = hashlib.sha3_256(pre_shared_secret.encode("utf-8")).digest()
-            ikm = shared_secret + pss_hash
+            ikm = bytes(shared_secret) + pss_hash
             info = b"paramant-v1-aes-key-pss"
         else:
             pss_hash = b""
-            ikm = shared_secret
+            ikm = bytes(shared_secret)
             info = b"paramant-v1-aes-key"
         key = crypto.derive_key(ikm, salt=ct_kem[:32], info=info)
-        return key, pss_hash
+        return _secret(key), _secret(pss_hash)
 
-    def _decrypt(self, padded_blob: bytes, pre_shared_secret: str = "") -> bytes:
+    def _decrypt(self, padded_blob: bytes, pre_shared_secret: str = "",
+                 expected_sender_sig_pub: Optional[bytes] = None) -> bytes:
         kp = self._load_keypair()
         secret_key = bytes.fromhex(kp["ml_kem_priv"])
 
@@ -504,11 +540,37 @@ class GhostPipe:
                 f"blob SIG id 0x{parsed['sig_id']:04x} != client SIG id 0x{self.sig_id:04x}"
             )
 
-        shared = crypto.kem_decapsulate(secret_key, parsed["ct_kem"])
-        aes_key, pss_bytes = self._derive_payload_key(shared, parsed["ct_kem"], pre_shared_secret)
         aad = wire_format.build_aad(
             kem_id=parsed["kem_id"], sig_id=parsed["sig_id"], chunk_index=0
         )
+
+        # ── F1: verify the sender signature BEFORE decrypting. 3.0.0 (py) never
+        # called sig_verify, so a tampered signature or a swapped sender_pub was
+        # accepted silently. sdk-js already verifies; this aligns sdk-py.
+        if parsed["sig_id"] != crypto.SIG_ID_NONE:
+            sign_input = _canonical_sign_input(
+                aad, parsed["ct_kem"], parsed["sender_pub"],
+                parsed["nonce"], parsed["ciphertext"],
+            )
+            try:
+                ok = crypto.sig_verify(parsed["sender_pub"], sign_input, parsed["signature"])
+            except Exception:
+                ok = False
+            if not ok:
+                raise SignatureError(
+                    "sender signature is invalid — blob was tampered with or the "
+                    "carried signing key does not match the signature"
+                )
+            # Identity pinning: the check above only proves internal consistency.
+            # To authenticate WHO sent it, pin against the expected sender's key.
+            if expected_sender_sig_pub is not None and \
+                    parsed["sender_pub"] != expected_sender_sig_pub:
+                raise SignatureError(
+                    "sender signing key does not match the pinned/expected sender"
+                )
+
+        shared = _secret(crypto.kem_decapsulate(secret_key, parsed["ct_kem"]))
+        aes_key, pss_bytes = self._derive_payload_key(shared, parsed["ct_kem"], pre_shared_secret)
         try:
             return crypto.aes_gcm_decrypt(aes_key, parsed["nonce"], parsed["ciphertext"], aad)
         finally:
@@ -526,7 +588,7 @@ class GhostPipe:
         """
         rec = self._fetch_receiver_pubkeys(recipient)
         target_device = recipient or self.device
-        self._tofu_check(target_device, rec["kyber_hex"], rec["ecdh_hex"], rec["registered_at"])
+        self._tofu_check(target_device, rec["kem_hex"], rec["sig_hex"], rec["registered_at"])
         padded, h = self._encrypt(
             data, rec["ml_kem_pub"], pad_block=pad_block, pre_shared_secret=pre_shared_secret,
         )
@@ -590,8 +652,15 @@ class GhostPipe:
         finally:
             _zero(aes_key); _zero(entropy)
 
-    def receive(self, hash_: str, pre_shared_secret: str = "") -> Tuple[bytes, Optional[dict]]:
-        """Retrieve data from the relay by blob hash. Burn-on-read."""
+    def receive(self, hash_: str, pre_shared_secret: str = "",
+                sender: Optional[str] = None) -> Tuple[bytes, Optional[dict]]:
+        """Retrieve data from the relay by blob hash. Burn-on-read.
+
+        If `sender` is given, the blob's ML-DSA signing key is pinned against
+        that device's registered key (via TOFU) — this authenticates WHO sent
+        the blob. Without `sender`, the signature is still verified for
+        cryptographic validity (a tampered signature is rejected), but the
+        sender's identity is not bound; a warning is emitted (F1)."""
         status, raw, headers = self._get(f"/v2/outbound/{hash_}")
         if status == 404:
             raise GhostPipeError("Blob not found. Expired, already retrieved, or never stored.")
@@ -606,7 +675,21 @@ class GhostPipe:
                 receipt = json.loads(base64.b64decode(padded).decode("utf-8"))
             except Exception:
                 pass
-        data = self._decrypt(raw, pre_shared_secret=pre_shared_secret)
+
+        expected_sig_pub = None
+        if sender is not None:
+            rec = self._fetch_receiver_pubkeys(sender)
+            self._tofu_check(sender, rec["kem_hex"], rec["sig_hex"], rec["registered_at"])
+            expected_sig_pub = rec["ml_dsa_pub"] or None
+        elif self.sig_id != crypto.SIG_ID_NONE:
+            warnings.warn(
+                "paramant-sdk: receive() called without sender=... — the sender "
+                "signature is checked for validity but NOT pinned to a known "
+                "device. Pass sender='device-id' to authenticate the origin.",
+                RuntimeWarning, stacklevel=2,
+            )
+        data = self._decrypt(raw, pre_shared_secret=pre_shared_secret,
+                             expected_sender_sig_pub=expected_sig_pub)
         return data, receipt
 
     def status(self, hash_: str) -> dict:
@@ -621,7 +704,8 @@ class GhostPipe:
         if status != 200:
             raise GhostPipeError(f"Pubkey fetch failed: HTTP {status}")
         d = json.loads(body)
-        fp = self._compute_fingerprint(d.get("kyber_pub", ""), d.get("ecdh_pub", ""))
+        fp = self._compute_fingerprint(self._pick(d, "kem_pub", "kyber_pub"),
+                                       self._pick(d, "sig_pub", "dsa_pub"))
         print(f"Device:      {target}")
         print(f"Fingerprint: {fp}")
         if d.get("registered_at"):
@@ -698,19 +782,72 @@ class GhostPipe:
         _, body, _ = self._get("/health")
         return json.loads(body)
 
-    def verify_receipt(self, receipt) -> dict:
-        if isinstance(receipt, dict):
+    @staticmethod
+    def _canonical_receipt_payload(receipt: dict):
+        """(signed_payload_bytes, signature_bytes) from a receipt: the receipt
+        minus its signature field, as canonical JSON (sorted keys, no spaces).
+        The relay MUST sign the same canonical form with its ML-DSA identity."""
+        r = dict(receipt)
+        sig_field = r.pop("sig", None) or r.pop("signature", None)
+        if not sig_field:
+            raise GhostPipeError("Receipt has no 'sig'/'signature' field to verify")
+        try:
+            signature = bytes.fromhex(sig_field)
+        except ValueError:
+            pad = sig_field.replace("-", "+").replace("_", "/")
+            pad += "=" * ((4 - len(pad) % 4) % 4)
+            signature = base64.b64decode(pad)
+        payload = json.dumps(r, sort_keys=True, separators=(",", ":")).encode()
+        return payload, signature
+
+    def verify_receipt(self, receipt, relay_identity_pub: str = "",
+                       allow_relay_fallback: bool = False) -> dict:
+        """Verify a delivery receipt CLIENT-SIDE against the pinned relay
+        identity key (F2).
+
+        3.0.0 POSTed the receipt to /v2/verify-receipt and trusted the relay's
+        answer — but the relay is untrusted by design, so it could rubber-stamp
+        a forged receipt. Here the ML-DSA signature is checked locally against a
+        key pinned out-of-band (constructor relay_identity_pub or the argument).
+        Set allow_relay_fallback=True only for debugging."""
+        if isinstance(receipt, str):
+            pad = receipt.replace("-", "+").replace("_", "/")
+            pad += "=" * ((4 - len(pad) % 4) % 4)
+            receipt = json.loads(base64.b64decode(pad).decode("utf-8"))
+
+        pub_hex = relay_identity_pub or self.relay_identity_pub
+        if not pub_hex:
+            if not allow_relay_fallback:
+                raise GhostPipeError(
+                    "No pinned relay identity public key — cannot verify the receipt "
+                    "locally. Pass relay_identity_pub=... (obtained out-of-band, e.g. "
+                    "from the CT log) when constructing GhostPipe. Refusing to delegate "
+                    "verification to the untrusted relay; pass allow_relay_fallback=True "
+                    "to override for debugging only."
+                )
+            warnings.warn(
+                "paramant-sdk: verifying receipt via the UNTRUSTED relay "
+                "(/v2/verify-receipt). This proves nothing about authenticity.",
+                RuntimeWarning, stacklevel=2,
+            )
             receipt_b64 = base64.b64encode(json.dumps(receipt).encode()).decode()
-        else:
-            receipt_b64 = receipt
-        body = json.dumps({"receipt": receipt_b64}).encode()
-        status, resp = self._post("/v2/verify-receipt", body)
-        if status != 200:
-            raise GhostPipeError(f"Receipt verification failed: HTTP {status}: {resp.decode()[:120]}")
-        result = json.loads(resp)
-        if not result.get("valid"):
-            raise GhostPipeError(f'Receipt invalid: {result.get("reason", "unknown")}')
-        return result
+            status, resp = self._post("/v2/verify-receipt", json.dumps({"receipt": receipt_b64}).encode())
+            if status != 200:
+                raise GhostPipeError(f"Receipt verification failed: HTTP {status}: {resp.decode()[:120]}")
+            result = json.loads(resp)
+            if not result.get("valid"):
+                raise GhostPipeError(f'Receipt invalid: {result.get("reason", "unknown")}')
+            return result
+
+        payload, signature = self._canonical_receipt_payload(receipt)
+        try:
+            ok = crypto.sig_verify(bytes.fromhex(pub_hex), payload, signature)
+        except Exception:
+            ok = False
+        if not ok:
+            raise GhostPipeError("Receipt signature is INVALID against the pinned relay identity key")
+        return {"valid": True, "verified_locally": True,
+                **{k: v for k, v in receipt.items() if k not in ("sig", "signature")}}
 
     def _load_seq(self) -> int:
         try:

--- a/sdk-py/pyproject.toml
+++ b/sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "paramant-sdk"
-version = "3.0.0"
+version = "3.1.0"
 description = "Python SDK for PARAMANT — post-quantum file transport (ML-KEM-768 + ML-DSA-65, wire format v1)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/sdk-py/tests/test_sdk_integration.py
+++ b/sdk-py/tests/test_sdk_integration.py
@@ -33,8 +33,8 @@ def _make_gp(home_tmp, device: str, kem_id=0x0002, sig_id=0x0002):
     )
 
 
-def test_version_is_3_0_0():
-    assert paramant_sdk.__version__ == "3.0.0"
+def test_version_is_3_1_0():
+    assert paramant_sdk.__version__ == "3.1.0"
 
 
 def test_encrypt_decrypt_round_trip_signed(home_tmp):

--- a/sdk-py/tests/test_security_fixes.py
+++ b/sdk-py/tests/test_security_fixes.py
@@ -1,0 +1,117 @@
+"""
+Regression tests for the 3.1.0 security fixes (audit 2026-05-23).
+
+These pin behaviour that was exploitable/broken in 3.0.0:
+  F1  sdk-py never verified the sender signature on receive
+  F3  sdk-py and sdk-js used different sign-inputs + fingerprints (cross-SDK
+      signed blobs did not verify)
+  F4  kem_id/sig_id were cosmetic (header could claim an unused algorithm)
+  F5  zeroization ran ctypes.memset on immutable bytes (UB)
+  F2  receipts were verified by the untrusted relay
+"""
+import tempfile
+
+import pytest
+
+from paramant_sdk import GhostPipe, GhostPipeError, SignatureError, _zero, _secret, _canonical_sign_input
+from paramant import crypto, wire_format
+from paramant.errors import UnsupportedAlgorithm
+
+API_KEY = "pgp_testkey_0123456789abcdef"
+
+
+@pytest.fixture
+def home_tmp(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+def _gp(device, **kw):
+    return GhostPipe(API_KEY, device, relay="https://offline.invalid",
+                     negotiate_on_init=False, **kw)
+
+
+def _signed_blob(sender, receiver):
+    rec_pub = bytes.fromhex(receiver._load_keypair()["ml_kem_pub"])
+    return sender._encrypt(b"authentic payload" * 8, rec_pub, pad_block=64 * 1024)[0]
+
+
+# ── F3: canonical sign-input matches the sdk-js convention ────────────────────
+def test_f3_sign_input_is_js_compatible():
+    aad, ct, sp, nonce, pt = b"AAD!", b"CT", b"SENDER", b"N" * 12, b"CIPHER"
+    assert _canonical_sign_input(aad, ct, sp, nonce, pt) == ct + sp + nonce + pt + aad
+
+
+# ── F1: signature verification is enforced ────────────────────────────────────
+def test_f1_tampered_signature_rejected(home_tmp):
+    sender, receiver = _gp("snd"), _gp("rcv"); receiver._load_keypair()
+    p = wire_format.decode(_signed_blob(sender, receiver))
+    bad = bytearray(p["signature"]); bad[0] ^= 0xFF
+    forged = wire_format.encode(kem_id=p["kem_id"], sig_id=p["sig_id"], ct_kem=p["ct_kem"],
+        sender_pub=p["sender_pub"], signature=bytes(bad), nonce=p["nonce"], ciphertext=p["ciphertext"])
+    with pytest.raises(SignatureError):
+        receiver._decrypt(forged)
+
+
+def test_f1_swapped_sender_rejected_when_pinned(home_tmp):
+    sender, receiver = _gp("snd"), _gp("rcv"); receiver._load_keypair()
+    p = wire_format.decode(_signed_blob(sender, receiver))
+    atk = crypto.sig_keygen()
+    aad = wire_format.build_aad(kem_id=p["kem_id"], sig_id=p["sig_id"])
+    si = _canonical_sign_input(aad, p["ct_kem"], atk.public_key, p["nonce"], p["ciphertext"])
+    forged = wire_format.encode(kem_id=p["kem_id"], sig_id=p["sig_id"], ct_kem=p["ct_kem"],
+        sender_pub=atk.public_key, signature=crypto.sig_sign(atk.secret_key, si),
+        nonce=p["nonce"], ciphertext=p["ciphertext"])
+    assert receiver._decrypt(forged) == b"authentic payload" * 8           # valid for attacker key
+    real = bytes.fromhex(sender._load_keypair()["ml_dsa_pub"])
+    with pytest.raises(SignatureError):
+        receiver._decrypt(forged, expected_sender_sig_pub=real)            # rejected when pinned
+
+
+def test_f1_honest_round_trip(home_tmp):
+    sender, receiver = _gp("snd"), _gp("rcv"); receiver._load_keypair()
+    real = bytes.fromhex(sender._load_keypair()["ml_dsa_pub"])
+    assert receiver._decrypt(_signed_blob(sender, receiver),
+                             expected_sender_sig_pub=real) == b"authentic payload" * 8
+
+
+# ── F3: fingerprint binds the signing key, 5 groups / 20 hex ──────────────────
+def test_f3_fingerprint_binds_signing_key(home_tmp):
+    kp = _gp("dev")._load_keypair()
+    fp1 = GhostPipe._compute_fingerprint(kp["ml_kem_pub"], kp["ml_dsa_pub"])
+    fp2 = GhostPipe._compute_fingerprint(kp["ml_kem_pub"], crypto.sig_keygen().public_key.hex())
+    assert fp1 != fp2
+    assert len(fp1.replace("-", "")) == 20 and fp1.count("-") == 4
+
+
+# ── F4: unimplemented algorithm ids are rejected (no cosmetic header) ─────────
+def test_f4_unimplemented_kem_rejected(home_tmp):
+    with pytest.raises(UnsupportedAlgorithm):
+        _gp("dev", kem_id=0x0003)   # ML-KEM-1024 not performed by this build
+
+
+def test_f4_unimplemented_sig_rejected(home_tmp):
+    with pytest.raises(UnsupportedAlgorithm):
+        _gp("dev", sig_id=0x0003)   # ML-DSA-87 not performed by this build
+
+
+# ── F5: zeroization is defined and wipes ──────────────────────────────────────
+def test_f5_secret_wipes(home_tmp):
+    buf = _secret(b"\x01\x02\x03"); _zero(buf)
+    assert bytes(buf) == b"\x00\x00\x00"
+    _zero(b"immutable"); _zero(None)   # no UB, no raise
+
+
+# ── F2: receipts verified locally against a pinned relay key ──────────────────
+def test_f2_receipt_local_verify(home_tmp):
+    import json
+    relay_id = crypto.sig_keygen()
+    receipt = {"hash": "abc", "burn_confirmed": True, "sector": "health"}
+    payload = json.dumps(receipt, sort_keys=True, separators=(",", ":")).encode()
+    signed = {**receipt, "sig": crypto.sig_sign(relay_id.secret_key, payload).hex()}
+    gp = _gp("rcv", relay_identity_pub=relay_id.public_key.hex())
+    assert gp.verify_receipt(signed)["verified_locally"]
+    with pytest.raises(GhostPipeError):
+        gp.verify_receipt({**receipt, "burn_confirmed": False, "sig": signed["sig"]})
+    with pytest.raises(GhostPipeError):
+        _gp("rcv2").verify_receipt({"hash": "x", "sig": "00"})   # no pinned key


### PR DESCRIPTION
## Summary

Security fixes from the **2026-05-23 SDK audit**. **Non-breaking**: the wire format stays **v1** (PQHB version `0x01`), so the live relay (`2.5.0`, which rejects any non-v1 blob with HTTP 415) and existing tooling are unaffected — no coordinated deploy needed. Both SDKs → **3.1.0**.

The headline bug was live in `main`: **sdk-py never verified sender signatures and signed a different message than sdk-js**, so py→js signed transfers did not verify. This aligns both SDKs byte-for-byte and enforces verification.

## Fixes
- **F1** sdk-py now verifies the ML-DSA sender signature on receive (3.0.0 never called `sig_verify`); tampered signatures + swapped sender keys are rejected.
- **F3** signing convention `CT_KEM || SENDER_PUB || NONCE || CIPHERTEXT || AAD` and fingerprint `SHA-256(kem_pub || sig_pub)` are byte-identical across py + js; `/v2/pubkey` sends `kyber_pub`/`dsa_pub` aliases; documented in `docs/wire-format-v1.md`.
- **F1b** sender-key pinning via `receive(sender=…)` / `receive(hash,{sender})`.
- **F2** `verify_receipt`/`verifyReceipt` verify the relay's receipt locally against a pinned `relay_identity_pub` instead of trusting `/v2/verify-receipt`.
- **F4** reject `kem_id`/`sig_id` this build cannot perform (was silently mislabelled).
- **F5** zeroize via `bytearray`, not `ctypes.memset` on immutable bytes (UB).
- **F7** regression tests for both SDKs; fixed `node --test test/` → `node --test`; ship `test/`.

## Tests
Python **45 passed**, JS **49 passed**. Cross-SDK: a py-signed blob now verifies + decrypts in js; fingerprints match; wrong sender-pin rejected.

## Migration
Upgrade receivers + senders together. Keypairs reused (no rotation). Existing TOFU entries use the old fingerprint and raise `FingerprintMismatchError` until re-`trust()`ed.

## Out of scope (follow-ups)
Full algorithm agility + PSS hash alignment need a coordinated wire-format **v2** (relay + frontend + extensions + SDKs). `install.sh` hardening is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)