### PR TITLE
fix(relay): persist email in in-memory apiKeys map (fixes all logins → 401)

### DIFF
--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1428,7 +1428,7 @@ function _mutateUsersJson(fn) {
 
 function loadUsers() {
   if (process.env.USERS_JSON) {
-    try { const d = JSON.parse(process.env.USERS_JSON); (d.api_keys||[]).forEach(k => { if(k.active) apiKeys.set(k.key,{plan:k.plan,label:k.label||"",active:true}); }); log("info","users_loaded",{count:apiKeys.size,source:"env"}); return; } catch(e) { log("error","users_json_parse",{err:e.message}); }
+    try { const d = JSON.parse(process.env.USERS_JSON); (d.api_keys||[]).forEach(k => { if(k.active) apiKeys.set(k.key,{plan:k.plan,label:k.label||"",email:k.email||"",active:true}); }); log("info","users_loaded",{count:apiKeys.size,source:"env"}); return; } catch(e) { log("error","users_json_parse",{err:e.message}); }
   }
   try {
     const d = JSON.parse(fs.readFileSync(USERS_FILE, 'utf8'));
@@ -1456,7 +1456,7 @@ function loadTrialKeys() {
         // Don't overwrite a key already loaded from users.json
         if (!apiKeys.has(k.key)) {
           apiKeys.set(k.key, {
-            plan: 'community', label: k.label||'', active: true, dsa_pub: '',
+            plan: 'community', label: k.label||'', email: k.email||'', active: true, dsa_pub: '',
             daily_uploads: 0, daily_reset_ts: Date.now() + 86_400_000,
             is_trial: true, trial_created: k.created || Date.now(),
             uploads_today: 0, last_upload_day: '',
@@ -1928,7 +1928,7 @@ const server = http.createServer(async (req, res) => {
       const label = `trial:${name.replace(/\s+/g, '_').toLowerCase().slice(0, 40)}`;
       const trialCreated = now;
       apiKeys.set(newKey, {
-        plan: 'community', label, active: true, dsa_pub: '',
+        plan: 'community', label, email: rawEmail, active: true, dsa_pub: '',
         daily_uploads: 0, daily_reset_ts: now + DAY_MS,
         is_trial: true, trial_created: trialCreated,
         uploads_today: 0, last_upload_day: '',
@@ -3315,7 +3315,7 @@ session = client.create_session('recipient@example.com')</pre>
         return res.end(J({ error: 'Invalid email address' }));
       }
       const email = rawEmail;
-      apiKeys.set(newKey, { plan, label, active: true });
+      apiKeys.set(newKey, { plan, label, email, active: true });
       _mutateUsersJson(d => {
         d.api_keys.push({ key: newKey, plan, label, email, active: true, created: new Date().toISOString() });
         d.updated = new Date().toISOString();


### PR DESCRIPTION
## Bug
`POST /v2/admin/keys` wrote `email` to `users.json` on disk but called `apiKeys.set(newKey, { plan, label, active: true })` **without email**. `GET /v2/admin/keys` serialises the in-memory map, so every key created since the last relay restart reported `email: null`. The admin login resolves the account via `findUserByEmail` → no match → **401 `invalid_credentials` for all such users**. Account creation + TOTP setup succeed (they use the setup-token `user_id`); only login breaks. Older keys worked because the `users.json` startup loader already included email.

## Fix
Add `email` to `apiKeys.set` on key creation, and align the trial-create, trial-JSONL-load and `USERS_JSON` env-load paths (4 sites; startup loader already correct).

## Verification
- `node --check` + repo pre-commit static sanity suite: PASS
- Live e2e on health relay: signup → verify → setup → confirm → **login = 200** (was 401)
- Pre-existing `email:null` keys healed on relay restart (reload from users.json)

Deployed live (rebuild + recreate of all 5 relays) on 2026-05-26. Applies cleanly onto `main` too if you prefer to retarget.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>