### PR TITLE
M5b: ML-KEM-768 impl via @paramant/core binding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,31 @@ jobs:
             -print0 \
           | xargs -0 -n1 bash -n
           echo "All shell scripts parse OK."
+
+  relay-crypto-tests:
+    name: relay - crypto suite (@paramant/core)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      # @paramant/core is the Rust NAPI binding in the sibling paramant-core
+      # repo. Until it is published to npm it is a dev file-link, so build it
+      # here (as paramant-core's own CI does) to gate the relay crypto suite's
+      # byte-compatibility against the binding. Interim until publish.
+      - name: Install liboqs build deps
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build clang libclang-dev
+      - name: Build @paramant/core (sibling checkout)
+        run: |
+          git clone --depth 1 https://github.com/Apolloccrypt/paramant-core.git "${GITHUB_WORKSPACE}/../paramant-core"
+          cd "${GITHUB_WORKSPACE}/../paramant-core"
+          rustup show
+          cargo build -p paramant-core-node --release
+          cp target/release/libparamant_core_node.so crates/paramant-core-node/index.node
+      - name: Install relay deps (incl. file-linked @paramant/core)
+        working-directory: relay
+        run: npm install
+      - name: Relay crypto suite
+        working-directory: relay
+        run: node --test $(find crypto -name '*.test.js')

--- a/relay/crypto/impls/mlkem768.js
+++ b/relay/crypto/impls/mlkem768.js
@@ -1,4 +1,9 @@
-const { ml_kem768 } = require("@noble/post-quantum/ml-kem.js");
+// ML-KEM-768 via @paramant/core (Rust PQ-crypto core, NAPI binding). Byte-
+// compatible with the previous @noble/post-quantum implementation: same 1184/
+// 2400/1088/32 sizes and FIPS 203 wire bytes (verified by 149 relay-anchored
+// KAT interop checks in paramant-core). Returns Uint8Array to match the prior
+// return type exactly. See paramant-core docs/deploy-bridge.md (M5b).
+const core = require("@paramant/core");
 
 module.exports = {
   name: "ML-KEM-768",
@@ -8,22 +13,24 @@ module.exports = {
   sharedSecretSize: 32,
 
   generateKeyPair() {
-    const { publicKey, secretKey } = ml_kem768.keygen();
-    return { publicKey, secretKey };
+    const { publicKey, secretKey } = core.kemKeygen();
+    return { publicKey: new Uint8Array(publicKey), secretKey: new Uint8Array(secretKey) };
   },
 
   encapsulate(publicKey) {
     if (publicKey.length !== 1184) {
       throw new Error(`ML-KEM-768 public key must be 1184 bytes, got ${publicKey.length}`);
     }
-    const { cipherText, sharedSecret } = ml_kem768.encapsulate(publicKey);
-    return { ciphertext: cipherText, sharedSecret };
+    const { ciphertext, sharedSecret } = core.kemEncaps(Buffer.from(publicKey));
+    return { ciphertext: new Uint8Array(ciphertext), sharedSecret: new Uint8Array(sharedSecret) };
   },
 
   decapsulate(ciphertext, secretKey) {
     if (ciphertext.length !== 1088) {
       throw new Error(`ML-KEM-768 ciphertext must be 1088 bytes, got ${ciphertext.length}`);
     }
-    return ml_kem768.decapsulate(ciphertext, secretKey);
+    // @paramant/core kemDecaps takes (secretKey, ciphertext) -- the reverse of
+    // this function's (ciphertext, secretKey) argument order.
+    return new Uint8Array(core.kemDecaps(Buffer.from(secretKey), Buffer.from(ciphertext)));
   }
 };

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.5.0",
       "dependencies": {
         "@noble/post-quantum": "^0.6.1",
+        "@paramant/core": "file:../../paramant-core/crates/paramant-core-node",
         "argon2": "^0.44.0",
         "bip39": "^3.1.0",
         "nats": "^2.29.3",
@@ -17,6 +18,17 @@
       },
       "bin": {
         "paramant-verify-sth": "scripts/paramant-verify-sth"
+      }
+    },
+    "../../paramant-core/crates/paramant-core-node": {
+      "name": "@paramant/core",
+      "version": "0.5.0-alpha.1",
+      "license": "BUSL-1.1",
+      "devDependencies": {
+        "@napi-rs/cli": "^2.18.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@epic-web/invariant": {
@@ -80,6 +92,10 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@paramant/core": {
+      "resolved": "../../paramant-core/crates/paramant-core-node",
+      "link": true
     },
     "node_modules/@phc/format": {
       "version": "1.0.0",

--- a/relay/package.json
+++ b/relay/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@noble/post-quantum": "^0.6.1",
+    "@paramant/core": "file:../../paramant-core/crates/paramant-core-node",
     "argon2": "^0.44.0",
     "bip39": "^3.1.0",
     "nats": "^2.29.3",


### PR DESCRIPTION
## Summary

First strangler-pattern step (M5b): `relay/crypto/impls/mlkem768.js` now runs
on **@paramant/core** -- the Rust post-quantum crypto core in the sibling
[paramant-core](https://github.com/Apolloccrypt/paramant-core) repo (NAPI
binding) -- instead of `@noble/post-quantum` directly. keygen, encapsulate and
decapsulate all route through the binding.

## Why it is safe

@paramant/core is **byte-compatible** with @noble: identical FIPS 203 ML-KEM-768
wire bytes and 1184/2400/1088/32 sizes, proven by 149 relay-anchored KAT interop
checks in paramant-core (the same `tests/kat` vectors this relay's crypto is
anchored to). The wrapper returns `Uint8Array` (matching the prior return type
exactly) and corrects the `kemDecaps(secretKey, ciphertext)` argument order.

## Test results

- Relay crypto suite (`node --test crypto`): **121 passed, 0 failed** -- identical
  to the pre-swap baseline.
- Registry end-to-end smoke (`getKEM(0x0002)` keygen/encaps/decaps): shared
  secret matches, returns `Uint8Array`.

## CI

This PR adds a **relay-crypto-tests** CI job that builds @paramant/core from the
sibling repo and runs the relay crypto suite against the binding, gating this and
future crypto-touching changes for byte-equivalence with @noble via the binding
(121 tests, relay-anchored KAT). It builds the binding in-CI as an interim step
until @paramant/core is published to npm.

> Note: @paramant/core is wired as a dev file-link
> (`file:../../paramant-core/crates/paramant-core-node`), assuming the two repos
> are checked out as siblings. Replace with a published/tarball version before
> production. The binary `.node` is built per-platform, not committed.

## Rollback

Revert this PR and `npm uninstall @paramant/core`. No wire-format change, so
blobs produced during the swap window decode identically with the legacy code --
no data migration.

## Next

- Soak this single call site; if clean for 7+ days, expand to more.
- M5 acceptance per blueprint: one endpoint in dev for 60+ days (-> M7).

Co-Authored-By: Claude <noreply@anthropic.com>