### PR TITLE
Integrate production login-fixes into main

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -1222,10 +1222,9 @@ api.post("/user/billing/checkout/:token/confirm", authUser, async (req, res) => 
     return res.status(502).json({ error: 'plan_update_failed' });
   }
 
-  // Reload all relay sectors so in-memory maps stay consistent
-  await Promise.allSettled(Object.keys(SECTORS).map(s =>
-    relayFetch(s, "/v2/reload-users", "POST", {}, false, ADMIN_TOKEN)
-  ));
+  // (cross-sector /v2/reload-users trigger removed: update-plan already mutates
+  // the relay's in-memory apiKeys directly. The reload was the cause of the
+  // 2026-05-08 wipe race against the concurrent users.json write.)
 
   const now = new Date().toISOString();
   const nextBilling = session.period === 'yearly'

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1421,7 +1421,7 @@ function _mutateUsersJson(fn) {
 
 function loadUsers() {
   if (process.env.USERS_JSON) {
-    try { const d = JSON.parse(process.env.USERS_JSON); (d.api_keys||[]).forEach(k => { if(k.active) apiKeys.set(k.key,{plan:k.plan,label:k.label||"",active:true}); }); log("info","users_loaded",{count:apiKeys.size,source:"env"}); return; } catch(e) { log("error","users_json_parse",{err:e.message}); }
+    try { const d = JSON.parse(process.env.USERS_JSON); (d.api_keys||[]).forEach(k => { if(k.active) apiKeys.set(k.key,{plan:k.plan,label:k.label||"",email:k.email||"",active:true}); }); log("info","users_loaded",{count:apiKeys.size,source:"env"}); return; } catch(e) { log("error","users_json_parse",{err:e.message}); }
   }
   try {
     const d = JSON.parse(fs.readFileSync(USERS_FILE, 'utf8'));
@@ -1449,7 +1449,7 @@ function loadTrialKeys() {
         // Don't overwrite a key already loaded from users.json
         if (!apiKeys.has(k.key)) {
           apiKeys.set(k.key, {
-            plan: 'community', label: k.label||'', active: true, dsa_pub: '',
+            plan: 'community', label: k.label||'', email: k.email||'', active: true, dsa_pub: '',
             daily_uploads: 0, daily_reset_ts: Date.now() + 86_400_000,
             is_trial: true, trial_created: k.created || Date.now(),
             uploads_today: 0, last_upload_day: '',
@@ -1921,7 +1921,7 @@ const server = http.createServer(async (req, res) => {
       const label = `trial:${name.replace(/\s+/g, '_').toLowerCase().slice(0, 40)}`;
       const trialCreated = now;
       apiKeys.set(newKey, {
-        plan: 'community', label, active: true, dsa_pub: '',
+        plan: 'community', label, email: rawEmail, active: true, dsa_pub: '',
         daily_uploads: 0, daily_reset_ts: now + DAY_MS,
         is_trial: true, trial_created: trialCreated,
         uploads_today: 0, last_upload_day: '',
@@ -3266,7 +3266,7 @@ session = client.create_session('recipient@example.com')</pre>
         return res.end(J({ error: 'Invalid email address' }));
       }
       const email = rawEmail;
-      apiKeys.set(newKey, { plan, label, active: true });
+      apiKeys.set(newKey, { plan, label, email, active: true });
       _mutateUsersJson(d => {
         d.api_keys.push({ key: newKey, plan, label, email, active: true, created: new Date().toISOString() });
         d.updated = new Date().toISOString();

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1403,10 +1403,17 @@ setInterval(() => { const now = Date.now(); for (const [k,v] of outboundRateMap)
 // _writeUsersJson: low-level write (caller must already hold the snapshot).
 // _mutateUsersJson: safe read-modify-write inside the queue (use this at call sites).
 let _usersWriteQueue = Promise.resolve();
+// Atomic write: tmp + rename eliminates the O_TRUNC window where a concurrent
+// reader sees an empty file mid-write. Combined with the sanity check in
+// /v2/reload-users this prevents the apiKeys-wipe race on plan_change.
+async function _atomicWriteUsers(data) {
+  const tmp = `${USERS_FILE}.tmp.${process.pid}.${Date.now()}`;
+  await fs.promises.writeFile(tmp, JSON.stringify(data, null, 2));
+  await fs.promises.rename(tmp, USERS_FILE);
+}
 function _writeUsersJson(data) {
-  _usersWriteQueue = _usersWriteQueue.then(() =>
-    fs.promises.writeFile(USERS_FILE, JSON.stringify(data, null, 2))
-  ).catch(e => log('warn', 'users_write_error', { err: e.message }));
+  _usersWriteQueue = _usersWriteQueue.then(() => _atomicWriteUsers(data))
+    .catch(e => log('warn', 'users_write_error', { err: e.message }));
   return _usersWriteQueue;
 }
 function _mutateUsersJson(fn) {
@@ -1414,7 +1421,7 @@ function _mutateUsersJson(fn) {
     const raw = await fs.promises.readFile(USERS_FILE, 'utf8');
     const data = JSON.parse(raw);
     fn(data);
-    await fs.promises.writeFile(USERS_FILE, JSON.stringify(data, null, 2));
+    await _atomicWriteUsers(data);
   }).catch(e => log('warn', 'users_write_error', { err: e.message }));
   return _usersWriteQueue;
 }
@@ -2520,12 +2527,54 @@ session = client.create_session('recipient@example.com')</pre>
       res.writeHead(400); return res.end(J({ error: 'USERS_JSON env in gebruik — bestand reload niet van toepassing' }));
     }
     const prevCount = apiKeys.size;
+
+    // Read with retry — handle transient mid-write reads from concurrent _mutateUsersJson.
+    let parsed = null;
+    let parseErr = null;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        const raw = await fs.promises.readFile(USERS_FILE, 'utf8');
+        if (!raw || raw.trim().length === 0) throw new Error('empty file');
+        const d = JSON.parse(raw);
+        if (!d || !Array.isArray(d.api_keys)) throw new Error('invalid structure');
+        parsed = d; parseErr = null; break;
+      } catch (e) {
+        parseErr = e;
+        if (attempt < 3) await new Promise(r => setTimeout(r, 100));
+      }
+    }
+
+    if (parseErr) {
+      log('error', 'reload_users_parse_failed', { prev: prevCount, err: parseErr.message });
+      res.writeHead(500); return res.end(J({ ok: false, error: 'reload_failed', prev: prevCount }));
+    }
+
+    // Build candidate Map without touching the live one.
+    const candidate = new Map();
+    for (const k of parsed.api_keys) {
+      if (k.active) candidate.set(k.key, {
+        plan: k.plan, label: k.label||'', email: k.email||'', active: true, dsa_pub: k.dsa_pub||'',
+        daily_uploads: 0, daily_reset_ts: Date.now() + 86_400_000,
+        is_trial: !!(k.plan === 'community' && k.trial_metadata),
+        trial_created: k.created ? new Date(k.created).getTime() : null,
+        uploads_today: 0, last_upload_day: '',
+      });
+    }
+
+    // Refuse to wipe a populated Map with an empty load — defends against the
+    // 2026-05-08 race where a concurrent write left the file readable but empty.
+    if (candidate.size === 0 && prevCount > 0) {
+      log('warn', 'reload_users_rejected', { prev: prevCount, candidate: 0, reason: 'refusing_to_wipe_populated_map' });
+      res.writeHead(409); return res.end(J({ ok: false, error: 'sanity_check_failed', prev: prevCount, candidate: 0 }));
+    }
+
+    // Atomic swap.
     apiKeys.clear();
-    loadUsers();
+    candidate.forEach((v, k) => apiKeys.set(k, v));
 
     applyKeyLimitEnforcement();
-    log('info', 'reload_users', { prev: prevCount, now: apiKeys.size });
-    res.writeHead(200); return res.end(J({ ok: true, loaded: apiKeys.size }));
+    log('info', 'reload_users', { prev: prevCount, now: apiKeys.size, delta: apiKeys.size - prevCount });
+    res.writeHead(200); return res.end(J({ ok: true, loaded: apiKeys.size, prev: prevCount }));
   }
 
   // ── Ghost Pipe invite rendezvous — pubkey exchange without API key ───────────


### PR DESCRIPTION
## Situation

Production at `116.203.86.81` currently runs branch `fix/login-email-in-memory-keys`, which forked from main at `83e4c12` and carries two auth fixes that were never integrated back into main:

- **`bcdbe7d`** — persist `email` in the in-memory `apiKeys` map on key creation (login-401 fix, 2026-05-26)
- **`06e3819`** — atomic `users.json` write (tmp+rename) + `/v2/reload-users` sanity check that refuses to wipe a populated map from an empty/partial read (defends the 2026-05-08 apiKeys-wipe race)

Meanwhile main advanced with **PR #33 (M5b)** — multi-stage Dockerfile that builds the `@paramant/core` ML-KEM-768 napi binding for musl. A naive deploy of main to production would **regress both live auth fixes**.

## Resolution

Cherry-pick the two prod-only commits onto main so main becomes the true source of truth again (ADR-0003). After merge, production can `checkout main && pull` and get **M5b + auth fixes together**.

## Verification

- Cherry-pick clean, **no conflicts** (auth fixes touch `relay/relay.js` + `admin/server.js`; M5b touches `relay/Dockerfile` + `sdk-js/` — disjoint paths)
- Cherry-picked diff is **line-for-line identical** to the two commits already proven in production (verified `83e4c12..bcdbe7d` == cherry-picks)
- `node --check` passes on both changed files; `tests/static-sanity.sh` PASS
- No behavior change — these are the exact bytes already running live

## After merge

Production deploy resumes:
- `ssh` to `116.203.86.81`, `cd /opt/paramant-relay`
- tag `prod-pre-m5b-deploy-<ts>` as rollback point (fix branch also stays intact)
- `git fetch && git checkout main && git pull`
- `docker compose build` (multi-stage, builds `@paramant/core`)
- rolling restart per sector-relay
- health checks + `/v2/capabilities` (ML-KEM-768 loaded) + login-flow smoke

Rollback: `git checkout fix/login-email-in-memory-keys` (intact backup branch) or the pre-deploy tag.

## Process note

Hot-fixes that went straight to production without a PR-merge to main are an audit-trail gap. Recommend future critical fixes go through a fast PR (even a 5-min review) to keep main authoritative.