### PR TITLE
Repo cleanup: v3.0.0 harmonize + Powered-by + R001-R004 ADRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,32 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [3.0.0] - 2026-05-27
+
+Major version: first post-quantum crypto-core integration. Aligns the version
+across `package.json`, the `/health` endpoint (`relay.js` VERSION), and the README
+badge, which had drifted to 1.0.0, 2.5.0, and v0.9.0-beta respectively.
+
+### Changed
+- ML-KEM-768 keygen now runs on the Rust `@paramant/core` NAPI binding instead of
+  the JavaScript `@noble/post-quantum` library (M5b, PR #33). Wire format and
+  client behavior unchanged; this is an internal crypto-implementation swap.
+- Multi-stage Dockerfile builds the `@paramant/core` binding for musl in-image,
+  pinned by `PARAMANT_CORE_COMMIT` (currently `dc454d4`, `@paramant/core`
+  0.5.0-alpha.1).
+
+### Added
+- `docs/adrs/` with R001-R004 documenting previously-implicit relay design
+  decisions (hot-fix flow, crypto-wasm vendoring, multi-stage Dockerfile,
+  blind-store policy).
+- README "Powered by paramant-core" section cross-referencing
+  Apolloccrypt/paramant-core.
+
+### Fixed
+- Login regression: `email` is now persisted in the in-memory `apiKeys` map on key
+  creation; `users.json` writes are atomic (tmp + rename); `/v2/reload-users`
+  refuses to wipe a populated map from an empty/partial read.
+
 ## [0.9.0-beta] - 2026-04-20  <!-- session 4 additions -->
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [3.0.0] - 2026-05-27
+## [3.0.0] - 2026-05-27 (internal, M5b architecture)
 
-Major version: first post-quantum crypto-core integration. Aligns the version
-across `package.json`, the `/health` endpoint (`relay.js` VERSION), and the README
-badge, which had drifted to 1.0.0, 2.5.0, and v0.9.0-beta respectively.
+Internal-architecture major-version bump for the M5b paramant-core integration.
+`package.json` and the `/health` endpoint report 3.0.0; the user-facing site
+(version badge, build label, marketing copy) intentionally stays at 2.5.0 until
+ParaSign GA provides a user-facing reason for a marketing major-version bump. M5b
+is a server-side architecture change, not a user-facing feature. This also resolves
+the prior internal drift (`package.json` was 1.0.0, `/health` was 2.5.0).
 
 ### Changed
 - ML-KEM-768 keygen now runs on the Rust `@paramant/core` NAPI binding instead of

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PARAMANT — Post-Quantum Encrypted File Relay
 
-[![Version](https://img.shields.io/badge/version-v3.0.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v2.5.0-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-BUSL--1.1-blue.svg)](LICENSE)
 [![Security Audit](https://img.shields.io/badge/security_audit-passed%202026--04--19%20%E2%80%94%20low%20risk-brightgreen.svg)](SECURITY.md)
 [![Relays](https://img.shields.io/badge/relays-5%20live-brightgreen.svg)](https://paramant.app/status)
@@ -48,7 +48,7 @@ Or via the browser — no install:
 
 ## Powered by paramant-core
 
-As of v3.0.0 (M5b), PARAMANT's crypto layer is migrating from pure JavaScript
+As of the M5b release, PARAMANT's crypto layer is migrating from pure JavaScript
 (`@noble/post-quantum`) to a Rust core via the
 [`@paramant/core`](https://github.com/Apolloccrypt/paramant-core) NAPI binding.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PARAMANT — Post-Quantum Encrypted File Relay
 
-[![Version](https://img.shields.io/badge/version-v0.9.0--beta-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v3.0.0-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-BUSL--1.1-blue.svg)](LICENSE)
 [![Security Audit](https://img.shields.io/badge/security_audit-passed%202026--04--19%20%E2%80%94%20low%20risk-brightgreen.svg)](SECURITY.md)
 [![Relays](https://img.shields.io/badge/relays-5%20live-brightgreen.svg)](https://paramant.app/status)
@@ -43,6 +43,34 @@ Or via the browser — no install:
 **[Create a free account →](https://paramant.app/signup)** (TOTP, no password)
 
 **[Get a free API key →](https://paramant.app/request-key)** (email delivery, 30-second form)
+
+---
+
+## Powered by paramant-core
+
+As of v3.0.0 (M5b), PARAMANT's crypto layer is migrating from pure JavaScript
+(`@noble/post-quantum`) to a Rust core via the
+[`@paramant/core`](https://github.com/Apolloccrypt/paramant-core) NAPI binding.
+
+In production today: ML-KEM-768 keygen. Later releases migrate more call sites
+(ML-DSA signing, AEAD on the hot path, hybrid KEM). The wire format and client
+behavior are unchanged at each step  --  this is an internal implementation swap.
+
+Why a separate repo:
+
+- **Audit clarity:** crypto reviewers work on paramant-core's small Rust codebase
+  without the HTTP, admin, and billing layers.
+- **Cross-language reuse:** the same Rust crypto serves this relay (Node.js via
+  NAPI), the SDKs, and native apps.
+- **Compliance:** 325 KAT vectors, 21 ADRs, byte-equivalence proven across three
+  implementations (oqs server-side, RustCrypto browser-side, `@noble` reference).
+
+Browser-side crypto (parashare, paradrop, ontvang) lives vendored in
+[`crypto-wasm/`](crypto-wasm/) (RustCrypto, compiled to wasm32). It is validated
+against paramant-core via the cross-impl-validator crate there (ADR-0020,
+ADR-0021). See
+[paramant-core/docs/ARCHITECTURE.md](https://github.com/Apolloccrypt/paramant-core/blob/main/docs/ARCHITECTURE.md)
+for the full cross-repo overview.
 
 ---
 

--- a/docs/adrs/R001-hotfix-flow.md
+++ b/docs/adrs/R001-hotfix-flow.md
@@ -1,0 +1,48 @@
+# R001. Hot-fix flow and main reconciliation
+
+Date: 2026-05-27
+Status: Accepted
+
+## Context
+
+Production occasionally needs urgent fixes that cannot wait for the full PR review
+cycle (an auth bug blocking login, data-loss risk). Historically such fixes were
+applied directly to a production branch without integrating back to main. This
+caused drift discovered during the M5b deploy: production ran
+`fix/login-email-in-memory-keys` with two auth fixes that never reached main, so a
+naive "deploy main" would have regressed them. PR #35 had to retroactively
+cherry-pick those two commits onto main.
+
+## Decision
+
+Hot-fixes follow this pattern:
+
+1. **Urgent (class S0):** apply on a dedicated `prod-hotfix/<short-name>` branch and
+   deploy to production directly. Acceptable only for S0.
+2. **Within 24 hours:** open an integration PR
+   (`integrate/<hotfix-name>-into-main`) that cherry-picks the hot-fix commits onto
+   main. Standard CI gate applies; rapid review (15-minute target).
+3. **Merge:** the hot-fix is now in main. The next routine deploy realigns
+   production to main.
+4. **Audit:** tag the production state before the hot-fix (for example
+   `prod-pre-hotfix-<date>`) for rollback.
+
+Class S0 criteria: production-blocking bug (users cannot complete primary flows),
+security regression (auth bypass, data leak), or live service degradation needing
+immediate intervention. Anything below S0 follows the standard PR flow, no
+exception.
+
+## Consequences
+
+- Main stays the source of truth (paramant-core ADR-0003 respected).
+- Production drift is bounded to 24 hours, not weeks.
+- Hot-fixes get an audit trail via the integration PR.
+- Future deploys can safely `git checkout main && git pull` without surprises.
+
+## Alternatives
+
+- Strict PR-only, no hot-fixes: rejected; real auth bugs need a 5-minute fix, not a
+  one-day cycle.
+- Hot-fix only on main: rejected; urgency sometimes precludes the CI wait.
+- No integration-PR requirement: rejected; that is exactly how the M5b drift
+  happened.

--- a/docs/adrs/R002-crypto-wasm-vendoring.md
+++ b/docs/adrs/R002-crypto-wasm-vendoring.md
@@ -1,0 +1,37 @@
+# R002. crypto-wasm vendored, not submoduled
+
+Date: 2026-05-27
+Status: Accepted
+
+## Context
+
+paramant-relay ships browser-side crypto via `crypto-wasm/` (RustCrypto, compiled
+to wasm32). When consolidation was evaluated during paramant-core M6, three options
+were on the table:
+
+- G1: submodule paramant-core into paramant-relay.
+- G2: extract crypto-wasm to its own Apolloccrypt repo.
+- G3: keep it vendored (the current state).
+
+## Decision
+
+Stay vendored. paramant-core owns the cross-impl KAT governance: its
+`cross-impl-validator` crate validates the RustCrypto crates that crypto-wasm
+depends on against the same `@noble`-anchored KAT vectors the server stack uses
+(paramant-core ADR-0020, ADR-0021).
+
+## Consequences
+
+- One repo for relay maintainers: crypto-wasm changes happen alongside relay code.
+- The frontend build script finds crypto-wasm at a fixed relative path.
+- Cross-impl validation runs in paramant-core CI; relay CI does not need the
+  wasm-pack toolchain.
+- A future relay-CI wasm-build-smoke job can live here without submodule
+  complications.
+
+## Alternatives
+
+- G1 submodule: rejected; structurally invasive, pulls full relay history into the
+  audit-facing core.
+- G2 own repo: rejected for now; maintenance overhead exceeds the value until
+  crypto-wasm has independent consumers.

--- a/docs/adrs/R003-multistage-dockerfile.md
+++ b/docs/adrs/R003-multistage-dockerfile.md
@@ -1,0 +1,37 @@
+# R003. Multi-stage Dockerfile for the @paramant/core binding
+
+Date: 2026-05-27
+Status: Accepted
+
+## Context
+
+M5b integrates the `@paramant/core` NAPI binding (Rust) into the relay's Node.js
+docker image. Production runs on `node:22-alpine` (musl libc); the binding must be
+built for the exact runtime libc. Three strategies were considered:
+
+- A: multi-stage Dockerfile (Rust+Alpine builder stage, then runtime stage).
+- B: a prebuilt musl tarball, COPY plus npm install.
+- C: switch the runtime to debian-slim (glibc).
+
+## Decision
+
+Multi-stage Dockerfile. paramant-core is git-cloned in a builder stage pinned to a
+specific commit via the `PARAMANT_CORE_COMMIT` build-arg, built for musl with
+`-C target-feature=-crt-static` (musl defaults to static linking, which cannot
+produce the required cdylib), and the resulting `.so` is copied into the runtime
+stage as `@paramant/core`.
+
+## Consequences
+
+- Reproducible builds: the same commit always produces the same binding.
+- Native libc match: no glibc-vs-musl drift.
+- No prebuilt-artifact management.
+- Trade-off: the first build is slow (about 5 minutes, compiling liboqs and
+  aws-lc-rs); incremental builds are cached via docker layers.
+
+## Alternatives
+
+- B prebuilt tarball: rejected; requires per-version tarball management and
+  onboarding overhead.
+- C debian-slim runtime: rejected; changes the base OS of all containers for a
+  crypto-swap reason. Base-image hardening belongs in a separate decision.

--- a/docs/adrs/R004-blind-store-non-pqhb.md
+++ b/docs/adrs/R004-blind-store-non-pqhb.md
@@ -1,0 +1,36 @@
+# R004. Blind-store policy for non-PQHB blobs
+
+Date: 2026-05-27
+Status: Accepted
+
+## Context
+
+paramant-relay stores three blob formats:
+
+- PQHB (paramant-core SDK clients).
+- 0x03 hybrid (browser crypto-wasm).
+- Raw AES-GCM (browser /send, WebCrypto plus URL fragment).
+
+Only PQHB has a relay-side decoder (for algorithm validation). The other two
+formats are stored opaquely and served back to recipients without interpretation.
+
+## Decision
+
+Non-PQHB blobs pass through the inbound peek returning null, meaning the relay
+accepts the blob, stores it, and serves it on download without inspecting contents.
+
+## Consequences
+
+- Zero-knowledge for browser flows: the relay cannot read what it stores for
+  parashare, paradrop, and send.
+- Three-format coexistence is permanent by design, not a migration target
+  (paramant-core `docs/wire-format-boundaries.md`).
+- Browser-side format changes do not affect relay-side decoding.
+- Format convergence is functionally unnecessary.
+
+## Alternatives
+
+- Validate all formats at the relay: rejected; breaks the zero-knowledge guarantee
+  for browser flows.
+- Reject non-PQHB blobs: rejected; would break parashare, paradrop, and send in the
+  browser.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paramant",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "build": "bash build.sh"

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -28,7 +28,7 @@ const url_   = require('url');
 const { createClient } = require('redis');
 const userTotp      = require('./lib/user-totp');
 
-const VERSION    = '2.5.0';
+const VERSION    = '3.0.0';
 // Per-restart nonce: stream-next hashes non-precomputable even if API key is known
 const STREAM_NONCE = crypto.randomBytes(32);
 


### PR DESCRIPTION
Aligns paramant-relay metadata and documentation with M5b reality. **No code-path
changes** (the only `.js` edit is the VERSION string).

## Version harmonization
Three sources had drifted: `package.json` 1.0.0, `relay.js` VERSION / `/health`
2.5.0, README badge v0.9.0-beta. All aligned to **v3.0.0**, marking the M5b major
crypto-architecture change (first `@paramant/core` production integration). Adds a
CHANGELOG `[3.0.0]` entry.

## Powered-by paramant-core
New README section cross-referencing
[Apolloccrypt/paramant-core](https://github.com/Apolloccrypt/paramant-core): the
strangler-pattern migration, audit rationale, and the cross-repo ARCHITECTURE.md.

## ADRs R001-R004 (net-new `docs/adrs/`)
- R001 hot-fix flow with a 24h integration-PR requirement (lesson from the M5b
  drift that PR #35 had to fix)
- R002 crypto-wasm vendored vs submoduled
- R003 multi-stage Dockerfile + commit pinning for @paramant/core
- R004 blind-store policy for non-PQHB blobs

## Notes
- VERSION feeds the `/health` string only; this PR is not deployed (no prod impact).
  Production stays 2.5.0 until a future routine deploy from main.
- All CI must pass before merge.