### PR TITLE
Sessie 1: relay migratie naar @paramant/core + crypto-mode opt-in

### DIFF
--- a/relay/crypto/impls/mldsa65.js
+++ b/relay/crypto/impls/mldsa65.js
@@ -1,4 +1,10 @@
-const { ml_dsa65 } = require("@noble/post-quantum/ml-dsa.js");
+// ML-DSA-65 via @paramant/core (Rust PQ-crypto core, NAPI binding). Byte-
+// compatible with the previous @noble/post-quantum implementation: same
+// 1952/4032/3309 sizes and FIPS 204 wire bytes (cross-impl byte-equivalence
+// proven in paramant-core ADR-0021, 50/50 verify-KAT + seeded-keygen KAT
+// against the same @noble-anchored vectors). Returns Uint8Array to match the
+// prior return type exactly. Same migration pattern as mlkem768.js (M5b).
+const core = require("@paramant/core");
 
 module.exports = {
   name: "ML-DSA-65",
@@ -7,18 +13,22 @@ module.exports = {
   sigSize: 3309,
 
   generateKeyPair() {
-    const { publicKey, secretKey } = ml_dsa65.keygen();
-    return { publicKey, secretKey };
+    const { publicKey, secretKey } = core.mldsaKeygen();
+    return { publicKey: new Uint8Array(publicKey), secretKey: new Uint8Array(secretKey) };
   },
 
   sign(message, secretKey) {
-    return ml_dsa65.sign(message, secretKey);
+    // @paramant/core mldsaSign takes (secretKey, message) -- the reverse of
+    // this function's (message, secretKey) argument order.
+    return new Uint8Array(core.mldsaSign(Buffer.from(secretKey), Buffer.from(message)));
   },
 
   verify(signature, message, publicKey) {
     if (publicKey.length !== 1952) {
       throw new Error(`ML-DSA-65 public key must be 1952 bytes, got ${publicKey.length}`);
     }
-    return ml_dsa65.verify(signature, message, publicKey);
+    // @paramant/core mldsaVerify takes (publicKey, message, signature) -- a
+    // different order than this function's (signature, message, publicKey).
+    return core.mldsaVerify(Buffer.from(publicKey), Buffer.from(message), Buffer.from(signature));
   }
 };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -134,12 +134,13 @@ function mapCryptoErrorToHttp(err) {
 }
 // `mlDsa` is retained as an availability probe used by `if (!mlDsa)` guards
 // throughout this file. It holds the registry-resolved impl when present, or
-// null when ML-DSA-65 could not be loaded (e.g. @noble/post-quantum missing).
+// null when ML-DSA-65 could not be loaded (e.g. the @paramant/core binding is
+// missing or failed to build).
 let mlDsa = null;
 try {
   mlDsa = registry.getSig(0x0002);
   if (mlDsa) log('info', 'ml_dsa_loaded', { alg: mlDsa.name });
-} catch(e) { log('warn', 'ml_dsa_not_available', { hint: 'npm install @noble/post-quantum', err: e.message }); }
+} catch(e) { log('warn', 'ml_dsa_not_available', { hint: 'build/install @paramant/core', err: e.message }); }
 
 const ALLOWED = {
   ghost_pipe: ['/health','/v2/pubkey','/v2/inbound','/v2/anon-inbound','/v2/outbound','/v2/status',


### PR DESCRIPTION
## What

Migrates the relay's **ML-DSA-65** impl from `@noble/post-quantum` to the
`@paramant/core` NAPI binding, same pattern as `mlkem768.js` (M5b, PR #33).
This covers all ML-DSA-65 use in the relay (~10 STH-signing + receipt/signature
verify call-sites in `relay.js`, all routed through `registry.getSig(0x0002)`,
so no call-site changes). Also fixes the now-stale ML-DSA-65 load-failure hint
in `relay.js` (pointed at `@noble`, now `@paramant/core`).

## Scope: everything the binding already supports

The `@paramant/core` binding exposes ML-KEM-768 + ML-DSA-65 (+ AEAD + envelope
helpers). After this PR, **both raw primitives the binding exposes are migrated**:
- ML-KEM-768 -> `@paramant/core` (M5b, already shipped)
- ML-DSA-65 -> `@paramant/core` (this PR)

### AES-256-GCM: nothing to migrate
The relay is blind-store (ADR R004) -- no server-side AEAD on the zero-knowledge
payload path. The only server-side AES-GCM (`relay/lib/encryption.js`) encrypts
TOTP secrets at rest; that is a TOTP-context op (out of scope) and its on-disk
format differs from the binding's, so migrating it would break decryption of
existing stored secrets. It stays on Node `crypto` by design.

## Why

Source-of-truth consolidation. Byte-equivalence is proven in paramant-core
ADR-0021 (50/50 verify-KAT + seeded-keygen KAT vs the same @noble-anchored
vectors). API shapes differ (binding `mldsaSign(secretKey, msg)` /
`mldsaVerify(publicKey, msg, signature)`); the wrapper adapts them while keeping
the impl module's public API identical.

## Verification
- Relay crypto suite (CI) builds the sibling `@paramant/core` and gates the
  self-roundtrip + size + tamper behaviour of `mldsa65.js`.
- No SDK-visible API changes; wire format unchanged.

## Deploy note (before the eventual prod deploy)
The live relay-identity ML-DSA-65 keypair was generated under @noble. FIPS 204
key/signature formats are identical across @noble and the RustCrypto-based core
(proven by ADR-0021 seeded-keygen KAT), so the existing key keeps working. Worth
a quick confirm at deploy time that the relay-identity pubkey is unchanged.

## Remaining @noble (separate follow-up)
See the status comment below.

## Not deployed
PR open, not auto-deployed. M5b production soak continues.