### PR TITLE
Sessie 2: appliance foundation - onboarding wizard + add-on spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added (specification only, no implementation)
+- R007 Add-on architecture ADR: defines manifest format
+  (paramant-addon.json), capability-based permission model
+  (read:blob-metadata, subscribe:stream, etc), three communication
+  channels (webhook, WebSocket, NATS), docker-compose extension
+  lifecycle, and registry structure (official + community + local).
+- docs/addons/ directory with README + example manifest + example
+  compose fragment.
+- Zero-knowledge guarantee preserved: no capability grants access
+  to plaintext, keys, or signatures. Add-ons work on ciphertext +
+  metadata only.
+
 ### CLI
 - 12 new operator tools added to `scripts/` and available via `install-client.sh`:
   - **Sector tools:** `paramant-cra`, `paramant-firmware`, `paramant-legal`, `paramant-notary`, `paramant-payslip`, `paramant-referral`, `paramant-ticket`

--- a/docs/addons/README.md
+++ b/docs/addons/README.md
@@ -1,0 +1,43 @@
+# Paramant Add-ons
+
+Add-ons extend paramant-relay with integrations: storage mirrors,
+notification bridges, identity providers, IoT sensors, SIEM exporters.
+
+See [R007 Add-on architecture](../adrs/R007-add-on-architecture.md)
+for the specification.
+
+## Installing an add-on (planned)
+
+```bash
+paramant-addon-install https://github.com/Apolloccrypt/paramant-addons-official/storage-mirror
+paramant-addon-enable storage-mirror
+```
+
+## Status
+
+Add-on framework is specified but not yet implemented. This
+documentation is forward-looking. Track implementation progress
+via R007 ADR status.
+
+## Manifest schema
+
+See [example-manifest.json](./example-manifest.json) for a
+complete annotated example.
+
+## Available capabilities
+
+Add-ons declare what they need in their manifest. The admin reviews
+and grants capabilities during install:
+
+| Capability | What it allows | Notes |
+|---|---|---|
+| read:blob-metadata | Read blob hashes, sizes, timestamps | NOT plaintext |
+| read:audit-events | Subscribe or query CT-log entries | Public-ish data |
+| subscribe:stream | WebSocket /v2/stream blob-ready events | Real-time |
+| subscribe:nats | NATS JetStream subscription | Requires NATS configured |
+| webhook:receive | Receive POSTs from relay | HMAC-signed |
+| export:audit-format | Read /v2/audit/export | CSV/JSON exports |
+| manage:users | User CRUD via admin API | HIGH PRIVILEGE |
+
+Add-ons never get access to plaintext, encryption keys, or signing
+keys. The zero-knowledge guarantee is structural.

--- a/docs/addons/example-compose-fragment.yml
+++ b/docs/addons/example-compose-fragment.yml
@@ -1,0 +1,15 @@
+# docker-compose.fragment.yml
+# This is merged into the relay's docker-compose runtime by the
+# paramant-addon-enable script.
+
+services:
+  paramant-addon-storage-mirror:
+    image: ghcr.io/apolloccrypt/paramant-addon-storage-mirror:1.0.0
+    restart: unless-stopped
+    env_file:
+      - ./addons/storage-mirror/config/env
+    depends_on:
+      - relay-main
+    networks:
+      - paramant-net
+    # No exposed ports - communicates outbound only to relay and S3

--- a/docs/addons/example-manifest.json
+++ b/docs/addons/example-manifest.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://paramant.app/schemas/addon-manifest-v1.json",
+  "name": "paramant-addon-storage-mirror",
+  "version": "1.0.0",
+  "description": "Mirror blob ciphertext to S3 or MinIO for backup and compliance.",
+  "vendor": "Paramant Official",
+  "license": "BUSL-1.1",
+  "homepage": "https://github.com/Apolloccrypt/paramant-addons-official",
+  "compatibility": {
+    "paramant-relay": ">=3.0.0"
+  },
+  "image": "ghcr.io/apolloccrypt/paramant-addon-storage-mirror:1.0.0",
+  "capabilities": [
+    "read:blob-metadata",
+    "subscribe:stream"
+  ],
+  "communication": {
+    "channels": ["stream"],
+    "webhook_endpoint": null
+  },
+  "config_schema": {
+    "S3_ENDPOINT": {
+      "type": "string",
+      "required": true,
+      "description": "S3-compatible endpoint URL (e.g., https://s3.eu-central-1.amazonaws.com)"
+    },
+    "S3_BUCKET": {
+      "type": "string",
+      "required": true
+    },
+    "S3_ACCESS_KEY": {
+      "type": "string",
+      "required": true,
+      "secret": true
+    },
+    "S3_SECRET_KEY": {
+      "type": "string",
+      "required": true,
+      "secret": true
+    },
+    "S3_REGION": {
+      "type": "string",
+      "required": false,
+      "default": "eu-central-1"
+    }
+  }
+}

--- a/docs/adrs/R005-plug-and-play-onboarding.md
+++ b/docs/adrs/R005-plug-and-play-onboarding.md
@@ -1,0 +1,103 @@
+# R005. Plug-and-play onboarding approach
+
+Date: 2026-05-27
+
+Status: Draft
+
+## Context
+
+Self-hosting paramant-relay today is a developer-flow, not an
+appliance-flow. First-time setup requires:
+
+- Generating an ADMIN_TOKEN by hand (openssl rand -hex 32).
+- Editing .env: roughly 15 variables are relevant for a first run
+  (ADMIN_TOKEN, RELAY_MODE, sector selection, TOTP_SECRET, RESEND_API_KEY,
+  USERS_FILE/USERS_JSON, PLK_KEY, TTL/audit limits, port overrides, ...).
+- docker compose up.
+- Creating the first API key via a CLI helper (scripts/paramant-key-add.sh)
+  or an authenticated admin call (POST /api/request-key). There is no
+  scripts/paramant-admin.py despite older docs referring to one.
+- Enrolling admin TOTP by typing an otpauth:// URI printed by install.sh
+  into an authenticator app.
+
+The installers already do a lot: install.sh (458 lines) and
+frontend/install-pi.sh (379 lines, Raspberry Pi edition) install Docker +
+Compose, install certbot, prompt for an admin token and sectors, generate
+a TOTP secret, write a chmod-600 .env, and run certbot for TLS. What is
+missing is a single guided surface that takes an operator from "containers
+are up" to "first transfer sent" without hand-editing files.
+
+Compare appliance products (Home Assistant, Proxmox, Mailcow): they expose
+a first-run web wizard. We want the same experience.
+
+A CLI first-boot TUI already exists (scripts/paramant-setup.sh, tied to
+/etc/paramant/.setup-done). That belongs to the appliance / ParamantOS
+route, which is explicitly NOT the direction we are taking. install-pi.sh +
+install.sh + docker compose remain the install method.
+
+## Decision
+
+Add a first-version onboarding wizard as a web route `/setup`:
+
+1. Frontend: a new page frontend/setup.html with a multi-step wizard
+   (sectors, domain + TLS, admin email + TOTP, first user, compliance
+   template, review + apply) plus frontend/setup.js as its state machine.
+   This PR ships the UX shell only.
+
+2. Backend: new endpoints under /v2/setup/* on the existing relay that
+   accept first-time configuration. This PR ships two stubs:
+   - GET  /v2/setup/check  -- reports whether the relay is in first-time
+     mode (currently: apiKeys.size === 0).
+   - POST /v2/setup/apply  -- returns 501 Not Implemented for now; the real
+     apply logic is deferred (see Consequences / gap analysis).
+
+3. First-run gate: /setup endpoints are reachable only when the relay has
+   no users yet (apiKeys.size === 0), with an optional explicit override
+   SETUP_MODE=true in .env for re-runs. After a successful apply the gate
+   closes automatically, because the first key then exists and
+   apiKeys.size > 0. SETUP_MODE is intentionally NOT added to .env.example
+   in the scaffolding change; it is documented here and wired when apply
+   is implemented.
+
+4. Under the hood the wizard reuses existing flows rather than inventing
+   new crypto: it converges on the same .env format install.sh writes, and
+   it calls the admin panel's existing key-issuance endpoints (POST
+   /api/request-key, POST /api/sectors/:sector/keys) for the first user.
+   Pure UX layer; no new cryptography.
+
+Note on routing: relay/relay.js is a raw http.createServer dispatcher with
+a mode-gate (modeAllows, relay.js:1691) that blocks any path not listed in
+ALLOWED[RELAY_MODE] for ghost_pipe and iot modes. The /v2/setup prefix is
+therefore added to those ALLOWED arrays so the wizard works in every relay
+mode (full mode has no gate).
+
+No Linux distro. install-pi.sh + install.sh install Docker + paramant-relay,
+then the installer directs the operator to https://<domain>/setup to run
+the wizard.
+
+## Consequences
+
+- Self-hosters can go from bare metal to first transfer in under 10
+  minutes via the browser, instead of editing .env and running CLI helpers.
+- The existing .env route stays fully working (backwards compatible). The
+  CLI helpers (paramant-key-add.sh, paramant-setup.sh) remain for
+  power-users.
+- The admin panel keeps all its current features; /setup is strictly for
+  first-time configuration and is unreachable once a user exists.
+- install-pi.sh remains the Raspberry Pi entry point.
+- No OS to maintain -- only the container + a UI layer.
+- The heavy lifting is deferred: POST /v2/setup/apply business logic,
+  auto-TLS via certbot from the wizard, admin TOTP-in-browser, backup
+  strategy, compliance-template presets, and the "all systems go"
+  health-check are tracked in /tmp/plug-and-play-gaps.md and follow in
+  separate PRs.
+
+## Alternatives
+
+- ParamantOS Linux distro with a paramant-setup TUI wizard: rejected -- too
+  much OS maintenance for the value; the appliance audience is better
+  served by a container + web wizard.
+- CLI-only setup: stays available for power-users, but is not the default
+  route for the appliance audience.
+- Web onboarding via a separate dashboard app: rejected -- running /setup on
+  the existing relay is simpler than shipping another service.

--- a/docs/adrs/R007-add-on-architecture.md
+++ b/docs/adrs/R007-add-on-architecture.md
@@ -1,0 +1,211 @@
+# R007. Add-on architecture (manifest, lifecycle, security model)
+
+Date: 2026-05-27
+
+Status: Draft (specification only; implementation in later milestones)
+
+## Context
+
+paramant-relay does a small set of things well: post-quantum encrypted
+blob transit with burn-on-read. Useful integrations live just beyond
+the core: storage mirrors (S3/MinIO ciphertext spiegeling), notification
+bridges (Slack/Teams/webhook on delivery), sensor bridges (MQTT for
+IoT), identity providers (OIDC/SAML for enterprise SSO), compliance
+exporters (SIEM audit-trail export), STH monitors (cross-relay
+verification service).
+
+Building these into the relay core violates Apple-simple principle
+(BLUEPRINT.md design principle B). Forcing every self-hoster to vendor
+their own integrations wastes community effort. An add-on system is
+the correct seam.
+
+Reference architectures:
+
+- HomeAssistant: container-based add-ons, manifest-driven,
+  capability-permissions, official + community registries
+- Proxmox: helper-scripts and templates, less formal
+- Nextcloud: app marketplace, server-side PHP plugins (different model)
+
+paramant should adopt the HomeAssistant model: container-isolated
+add-ons with manifest-declared capabilities.
+
+## Decision
+
+### Add-on form factor
+
+A paramant add-on is a Docker container with a manifest file. The
+container runs alongside the relay (same docker-compose stack or
+separate host) and communicates via documented channels.
+
+### Manifest: paramant-addon.json
+
+Single JSON file in the add-on root directory. Schema:
+
+```json
+{
+  "name": "paramant-addon-storage-mirror",
+  "version": "1.0.0",
+  "description": "Mirror blob ciphertext to S3 or MinIO",
+  "vendor": "Paramant Official",
+  "license": "BUSL-1.1",
+  "homepage": "https://github.com/Apolloccrypt/paramant-addons-official",
+  "compatibility": {
+    "paramant-relay": ">=3.0.0"
+  },
+  "image": "ghcr.io/apolloccrypt/paramant-addon-storage-mirror:1.0.0",
+  "capabilities": [
+    "read:blob-metadata",
+    "subscribe:stream",
+    "subscribe:nats"
+  ],
+  "communication": {
+    "channels": ["webhook", "stream", "nats"],
+    "webhook_endpoint": "/api/inbound-event"
+  },
+  "config_schema": {
+    "S3_ENDPOINT": { "type": "string", "required": true },
+    "S3_BUCKET": { "type": "string", "required": true },
+    "S3_ACCESS_KEY": { "type": "string", "required": true, "secret": true },
+    "S3_SECRET_KEY": { "type": "string", "required": true, "secret": true }
+  }
+}
+```
+
+### Capabilities (permission model)
+
+Add-ons declare what they need. Admin grants explicitly via add-on
+install flow. No add-on gets blanket access.
+
+Defined capabilities:
+
+- `read:blob-metadata` - access blob hashes, sizes, timestamps from
+  /v2/audit, /v2/ct/log. NOT plaintext.
+- `read:audit-events` - subscribe to or query the full CT-log audit
+  stream
+- `subscribe:stream` - WebSocket to /v2/stream for real-time
+  blob_ready events
+- `subscribe:nats` - NATS JetStream subscription to "paramant.>"
+  (only if NATS_URL configured on relay)
+- `webhook:receive` - relay POSTs delivery events to add-on's declared
+  endpoint
+- `export:audit-format` - GET /v2/audit/export (CSV/JSON download)
+- `manage:users` - call admin API for user-CRUD (HIGH PRIVILEGE;
+  requires admin confirmation per call)
+
+Critical exclusions: NO capability gives access to plaintext,
+encryption keys, or signing keys. Add-ons work on ciphertext +
+metadata only. Zero-knowledge guarantee is structural, not
+policy-based.
+
+### Communication channels
+
+An add-on may use one or more of three channels. Each declared in
+manifest:
+
+1. **HTTP webhook**: relay POSTs to add-on's declared endpoint.
+   Add-on requires `webhook:receive` capability. Body is JSON event
+   (blob hash, ts, sector, recipient hash). Signed with HMAC-SHA256
+   using add-on's per-install secret.
+
+2. **WebSocket stream**: add-on connects to relay's /v2/stream with
+   ws-ticket auth (using add-on's API key). Requires `subscribe:stream`.
+
+3. **NATS JetStream**: add-on subscribes to "paramant.>" subjects on
+   the relay's NATS instance (if configured). Requires `subscribe:nats`.
+
+### Lifecycle: docker-compose extension model
+
+```
+paramant-relay/
+  docker-compose.yml          # core relay containers
+  addons/
+    storage-mirror/
+      paramant-addon.json
+      docker-compose.fragment.yml  # add-on container definition
+      config/                       # admin-supplied env-vars (gitignored)
+    notification-bridge/
+      paramant-addon.json
+      docker-compose.fragment.yml
+      config/
+```
+
+Admin scripts:
+
+- `paramant-addon-install <github-url-or-tarball>` - download, validate
+  manifest, capability-confirm with admin, write to addons/
+- `paramant-addon-enable <name>` - merge docker-compose.fragment.yml
+  into runtime, docker compose up -d for the new service
+- `paramant-addon-disable <name>` - docker compose stop, remove from runtime
+- `paramant-addon-update <name>` - check registry for newer version,
+  download, replace, restart
+- `paramant-addon-uninstall <name>` - disable + remove directory
+- `paramant-addon-list` - show installed + enabled state
+
+Web UI: addons-tab in admin panel mirrors these commands (CLI parity).
+
+### Registry
+
+Three registries:
+
+- **Official**: github.com/Apolloccrypt/paramant-addons-official
+  (curated by Paramant team, audited for compliance claims). Eerste
+  add-ons gemaakt door Paramant team.
+- **Community**: github topic `paramant-addon`. Discovery via GitHub
+  search. No curation. Install at own risk.
+- **Local**: any tarball or git URL. For private enterprise add-ons.
+
+Mogelijke uitbreiding M13+: paramant.app/addons marketplace met
+reviews + ratings.
+
+### Versioning
+
+Add-ons follow SemVer. Manifest declares `compatibility.paramant-relay`
+as a semver range. Relay refuses to install add-ons whose compat range
+excludes the running relay version.
+
+Major-version-bumps of add-on may require admin re-confirmation of
+capabilities if the new manifest requests different capabilities than
+the previous version.
+
+## Consequences
+
+- Integration ecosystem can grow without bloating relay core
+- Audit surface bounded: each add-on is reviewable independently
+- Zero-knowledge claim remains structural - add-ons cannot decrypt
+- Self-hosters and enterprise can vendor private add-ons without
+  contributing back
+- Official add-on registry becomes a Paramant product line
+  (potentially paid for enterprise tier)
+- Community add-ons grow ecosystem like HomeAssistant
+
+Trade-offs:
+
+- Adds complexity to self-hosting (admin must understand capabilities)
+- Container runtime overhead per add-on
+- Add-on quality varies in community registry (warned)
+- First-party add-on development becomes ongoing maintenance
+
+## Alternatives considered
+
+- **Built-in integrations**: rejected. Bloats core, conflicts with
+  Apple-simple principle.
+- **Node.js plugin system (require'd modules)**: rejected. Plugins
+  would run in relay process, breaking process isolation. Any plugin
+  bug crashes the relay.
+- **Lua/WASM sandbox**: rejected. Complex runtime, limited library
+  ecosystem, doesn't match "Docker is the unit of deployment" pattern
+  already used by paramant-relay.
+- **Webhook-only (no add-on framework)**: rejected. Each self-hoster
+  rebuilds integrations from scratch. No shared community work.
+
+## Implementation roadmap
+
+This ADR is specification only. Implementation in stages:
+
+1. **Foundation** (after M9 audit): paramant-addon CLI scripts,
+   manifest validation, capability-grant flow
+2. **First-party add-ons** (post-audit): storage-mirror,
+   notification-bridge, MQTT-bridge, SIEM-exporter
+3. **Admin panel addons-tab** (M11+ during plug-and-play fase)
+4. **Community registry guidelines** (M12+)
+5. **paramant.app/addons marketplace** (M13+ optional)

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Paramant - First-time setup</title>
+  <link rel="stylesheet" href="/design-system.css">
+  <link rel="stylesheet" href="/nav.css">
+</head>
+<body>
+  <main class="setup-wizard" style="max-width:640px;margin:48px auto;padding:0 20px">
+    <h1>Paramant first-time setup</h1>
+    <p>Take about 5 minutes to configure your relay. This wizard runs once;
+       it closes itself after your first user is created.</p>
+
+    <noscript>
+      <p><strong>JavaScript is required for this wizard.</strong> You can
+         still configure the relay by hand: edit <code>.env</code> and use
+         <code>scripts/paramant-key-add.sh</code>.</p>
+    </noscript>
+
+    <div class="step" data-step="1">
+      <h2>Step 1 of 6: Choose your sectors</h2>
+      <p>Each sector is a relay for a specific compliance domain.</p>
+      <label><input type="checkbox" name="sector-general" checked> General relay</label><br>
+      <label><input type="checkbox" name="sector-health"> Health (NEN 7510)</label><br>
+      <label><input type="checkbox" name="sector-finance"> Finance (NIS2/DORA)</label><br>
+      <label><input type="checkbox" name="sector-legal"> Legal (eIDAS)</label><br>
+      <label><input type="checkbox" name="sector-iot"> IoT (IEC 62443)</label>
+      <div class="actions"><button class="next" type="button">Next</button></div>
+    </div>
+
+    <div class="step" data-step="2" hidden>
+      <h2>Step 2 of 6: Domain and TLS</h2>
+      <p>What domain will users reach this relay on?</p>
+      <input type="text" name="domain" placeholder="relay.your-org.com" required>
+      <label><input type="checkbox" name="auto-tls" checked> Automatically obtain TLS via Let's Encrypt</label>
+      <p class="hint">Requires DNS A records for each sector subdomain.</p>
+      <div class="actions">
+        <button class="back" type="button">Back</button>
+        <button class="next" type="button">Next</button>
+      </div>
+    </div>
+
+    <div class="step" data-step="3" hidden>
+      <h2>Step 3 of 6: Admin email and security</h2>
+      <input type="email" name="admin-email" required placeholder="you@your-org.com">
+      <label><input type="checkbox" name="enable-totp" checked> Enable TOTP for admin login</label>
+      <div class="actions">
+        <button class="back" type="button">Back</button>
+        <button class="next" type="button">Next</button>
+      </div>
+    </div>
+
+    <div class="step" data-step="4" hidden>
+      <h2>Step 4 of 6: First user account</h2>
+      <p>Create your first user API key. You will receive it by email.</p>
+      <input type="email" name="first-user-email" required placeholder="user@your-org.com">
+      <input type="text" name="first-user-label" placeholder="my-laptop">
+      <select name="first-user-plan">
+        <option value="pro">Pro</option>
+        <option value="enterprise">Enterprise (requires PLK_KEY)</option>
+      </select>
+      <div class="actions">
+        <button class="back" type="button">Back</button>
+        <button class="next" type="button">Next</button>
+      </div>
+    </div>
+
+    <div class="step" data-step="5" hidden>
+      <h2>Step 5 of 6: Compliance template</h2>
+      <p>We will preset retention, audit, and TTL defaults for your use case.</p>
+      <select name="compliance-template">
+        <option value="generic">Generic (NIS2 baseline)</option>
+        <option value="nen7510">NEN 7510 (Dutch healthcare)</option>
+        <option value="iec62443">IEC 62443 (OT/SCADA)</option>
+        <option value="dora">DORA (financial entities)</option>
+        <option value="custom">Custom (configure manually later)</option>
+      </select>
+      <div class="actions">
+        <button class="back" type="button">Back</button>
+        <button class="next" type="button">Next</button>
+      </div>
+    </div>
+
+    <div class="step" data-step="6" hidden>
+      <h2>Step 6 of 6: Review and start</h2>
+      <p>Review your configuration before applying it.</p>
+      <pre id="review-summary" aria-live="polite"></pre>
+      <div class="actions">
+        <button class="back" type="button">Back</button>
+        <button id="apply" type="button">Apply configuration</button>
+      </div>
+      <p id="apply-status" class="hint"></p>
+    </div>
+
+    <div class="step" data-step="done" hidden>
+      <h2>Setup complete</h2>
+      <p>Your relay is configured. Sign in to the dashboard to send your
+         first file.</p>
+      <a href="/auth/login" class="btn">Sign in</a>
+    </div>
+  </main>
+
+  <script src="/setup.js"></script>
+</body>
+</html>

--- a/frontend/setup.js
+++ b/frontend/setup.js
@@ -1,0 +1,147 @@
+// /setup wizard state machine.
+// Skeleton: drives the multi-step UX and shapes the config payload.
+// The real apply logic lives behind POST /v2/setup/apply (currently a 501
+// stub per ADR R005); this file is wired so the frontend works on its own.
+
+'use strict';
+
+var STEP_ORDER = [1, 2, 3, 4, 5, 6, 'done'];
+
+var state = {
+  step: 1,
+  config: {
+    sectors: ['general'],
+    domain: '',
+    autoTls: true,
+    adminEmail: '',
+    enableTotp: true,
+    firstUserEmail: '',
+    firstUserLabel: '',
+    firstUserPlan: 'pro',
+    complianceTemplate: 'generic'
+  }
+};
+
+function $(sel, root) { return (root || document).querySelector(sel); }
+function $all(sel, root) { return Array.prototype.slice.call((root || document).querySelectorAll(sel)); }
+function stepEl(n) { return $('.step[data-step="' + n + '"]'); }
+
+// Show one step, hide the others.
+function goToStep(n) {
+  if (STEP_ORDER.indexOf(n) === -1) { return; }
+  state.step = n;
+  $all('.step').forEach(function (el) {
+    el.hidden = (el.getAttribute('data-step') !== String(n));
+  });
+  if (n === 6) { renderReview(); }
+}
+
+// Gather the inputs on a given step into state.config.
+function collectStep(n) {
+  var el = stepEl(n);
+  if (!el) { return; }
+  var c = state.config;
+  if (n === 1) {
+    c.sectors = [];
+    if ($('[name="sector-general"]', el).checked) { c.sectors.push('general'); }
+    if ($('[name="sector-health"]', el).checked) { c.sectors.push('health'); }
+    if ($('[name="sector-finance"]', el).checked) { c.sectors.push('finance'); }
+    if ($('[name="sector-legal"]', el).checked) { c.sectors.push('legal'); }
+    if ($('[name="sector-iot"]', el).checked) { c.sectors.push('iot'); }
+  } else if (n === 2) {
+    c.domain = $('[name="domain"]', el).value.trim();
+    c.autoTls = $('[name="auto-tls"]', el).checked;
+  } else if (n === 3) {
+    c.adminEmail = $('[name="admin-email"]', el).value.trim();
+    c.enableTotp = $('[name="enable-totp"]', el).checked;
+  } else if (n === 4) {
+    c.firstUserEmail = $('[name="first-user-email"]', el).value.trim();
+    c.firstUserLabel = $('[name="first-user-label"]', el).value.trim();
+    c.firstUserPlan = $('[name="first-user-plan"]', el).value;
+  } else if (n === 5) {
+    c.complianceTemplate = $('[name="compliance-template"]', el).value;
+  }
+}
+
+function renderReview() {
+  var out = $('#review-summary');
+  if (out) { out.textContent = JSON.stringify(state.config, null, 2); }
+}
+
+// Confirm we are still in first-time mode before showing the wizard.
+function checkSetupMode() {
+  return fetch('/v2/setup/check', { method: 'GET' })
+    .then(function (r) { return r.ok ? r.json() : { setupMode: true }; })
+    .then(function (data) {
+      if (data && data.setupMode === false) {
+        var main = $('.setup-wizard');
+        if (main) {
+          main.innerHTML =
+            '<h1>Setup already complete</h1>' +
+            '<p>This relay already has at least one user, so first-time ' +
+            'setup is closed. <a href="/auth/login">Sign in</a> instead.</p>';
+        }
+      }
+    })
+    .catch(function () { /* offline / no backend yet: keep the wizard usable */ });
+}
+
+// Apply config: POST to /v2/setup/apply.
+function applyConfig() {
+  collectStep(state.step);
+  renderReview();
+  var status = $('#apply-status');
+  if (status) { status.textContent = 'Applying...'; }
+  return fetch('/v2/setup/apply', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(state.config)
+  })
+    .then(function (r) {
+      return r.json().then(function (body) { return { ok: r.ok, status: r.status, body: body }; });
+    })
+    .then(function (res) {
+      if (res.ok) {
+        goToStep('done');
+      } else if (status) {
+        // Backend is a stub for now (501). Surface the message; the review
+        // payload above is still the source of truth for manual setup.
+        status.textContent = (res.body && res.body.error)
+          ? res.body.error
+          : ('Setup failed (HTTP ' + res.status + ').');
+      }
+    })
+    .catch(function () {
+      if (status) {
+        status.textContent =
+          'Could not reach the relay. Your configuration is shown above; ' +
+          'you can apply it manually for now.';
+      }
+    });
+}
+
+function wire() {
+  $all('.next').forEach(function (b) {
+    b.addEventListener('click', function () {
+      collectStep(state.step);
+      var i = STEP_ORDER.indexOf(state.step);
+      if (i !== -1 && i < STEP_ORDER.length - 1) { goToStep(STEP_ORDER[i + 1]); }
+    });
+  });
+  $all('.back').forEach(function (b) {
+    b.addEventListener('click', function () {
+      var i = STEP_ORDER.indexOf(state.step);
+      if (i > 0) { goToStep(STEP_ORDER[i - 1]); }
+    });
+  });
+  var applyBtn = $('#apply');
+  if (applyBtn) { applyBtn.addEventListener('click', applyConfig); }
+  goToStep(1);
+  checkSetupMode();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', wire);
+} else {
+  wire();
+}

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -148,14 +148,14 @@ const ALLOWED = {
                '/v2/did','/v2/ct','/v2/attest','/v2/admin','/metrics','/v2/dl',
                '/v2/key-sector','/v2/team','/v2/reload-users','/v2/drop','/v2/session',
                '/v2/ws-ticket','/v2/fingerprint','/v2/relays','/v2/request-trial','/v2/sign-dpa',
-               '/v2/sth','/v2/verify-receipt','/v2/capabilities','/ct','/ct/feed','/v2/auth','/v2/user'],
+               '/v2/sth','/v2/verify-receipt','/v2/capabilities','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup'],
   iot:        ['/health','/v2/pubkey','/v2/inbound','/v2/anon-inbound','/v2/outbound','/v2/status',
                '/v2/webhook','/v2/audit','/v2/check-key','/v2/stream','/v2/stream-next',
                '/v2/sender-pubkey','/v2/ack','/v2/delivery','/v2/monitor',
                '/v2/did','/v2/ct','/v2/attest','/v2/admin','/metrics','/v2/dl',
                '/v2/key-sector','/v2/team','/v2/reload-users','/v2/drop','/v2/session',
                '/v2/relays','/v2/request-trial','/v2/sign-dpa','/v2/sth','/v2/verify-receipt',
-               '/v2/capabilities','/ct','/ct/feed','/v2/auth','/v2/user'],
+               '/v2/capabilities','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup'],
   full:       null,
 };
 
@@ -1734,6 +1734,32 @@ const server = http.createServer(async (req, res) => {
         : 'rolling_out_q2_2026',
       capabilities_version: 1,
     }));
+  }
+
+  // -- First-time onboarding wizard (ADR R005) ----------------------------
+  // Public, no auth. Gated on first-time mode: the relay is considered fresh
+  // while it has no API keys loaded (apiKeys.size === 0), or when SETUP_MODE
+  // is explicitly set. These are scaffolding stubs: /v2/setup/check reports
+  // the gate; /v2/setup/apply is not yet implemented (returns 501).
+  function _setupModeOn() {
+    return apiKeys.size === 0 || process.env.SETUP_MODE === 'true';
+  }
+
+  // GET /v2/setup/check -- is the relay in first-time setup mode?
+  if (req.method === 'GET' && path === '/v2/setup/check') {
+    const setupMode = _setupModeOn();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    return res.end(J({ setupMode, ready: !setupMode }));
+  }
+
+  // POST /v2/setup/apply -- apply first-time configuration. Stub for now.
+  if (req.method === 'POST' && path === '/v2/setup/apply') {
+    if (!_setupModeOn()) {
+      res.writeHead(409, { 'Content-Type': 'application/json' });
+      return res.end(J({ error: 'Setup is already complete on this relay.' }));
+    }
+    res.writeHead(501, { 'Content-Type': 'application/json' });
+    return res.end(J({ error: 'Setup endpoint not yet implemented. Use the admin scripts (scripts/paramant-key-add.sh) or edit .env for now.' }));
   }
 
   // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Scaffolds the plug-and-play onboarding wizard per R005.

## Wat
- New /setup web route met 6-step wizard (frontend skeleton: setup.html + setup.js)
- Backend stubs voor GET /v2/setup/check en POST /v2/setup/apply (501)
- /v2/setup toegevoegd aan de relay mode-gate ALLOWED-lijsten
- ADR R005 documenteert de aanpak

## Niet
- Geen echte business-logica in /v2/setup/apply (501 voor nu)
- Geen breaking changes - bestaande .env + admin/CLI-route blijft werken
- Geen Linux-distro toegevoegd (install-pi.sh + install.sh blijven entry)
- .env.example onaangeroerd; SETUP_MODE alleen gedocumenteerd in R005

## Audit-correcties (t.o.v. oorspronkelijke aannames)
- Geen root install-pi.sh: zit in frontend/install-pi.sh
- Geen scripts/paramant-admin.py: user-add via paramant-key-add.sh / admin /request-key / /user/signup
- relay.js is raw http-server (geen express); mode-gate op relay.js:1691

## Volgende stappen (apart, zie /tmp/plug-and-play-gaps.md)
- Implementatie /v2/setup/apply logica (sector toggle, domein, TLS, eerste user, TOTP, compliance preset)
- Auto-TLS via certbot integration
- Backup-strategie wizard
- Health-check 'all systems go' moment