### PR TITLE
docs: rechttrek site documentation voor M5b realiteit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - **Maintenance:** `paramant-migrate`, `paramant-roadmap` (PQC migration planner), `paramant-supply-chain`
 - Total operator tools: 38 → 44
 
+### Documentation
+- Site docs rechtgetrokken voor de M5b-realiteit: crypto-stack op `/docs`
+  benoemt nu de split (client-side ML-KEM-768 via WASM, server-side
+  ML-DSA-65 via `@paramant/core`) met paramant-core attributie + repo-link;
+  self-hosting relay-identity sectie idem. `/send` FAQ verduidelijkt dat de
+  anonieme flow AES-256-GCM symmetric-only is en verwijst voor
+  post-quantum geverifieerde transfers naar ParaShare/ParaDrop. Stale
+  `scripts/paramant-admin.py`-pad rechtgezet naar `deploy/paramant-admin.py`.
+  R005 (web onboarding wizard) en R007 (add-on architecture) als
+  coming-soon vermeld. Versie-nummers bewust ongemoeid (intern 3.0.0 vs
+  marketing build 2.5.0).
+
 ### Repository
 - `scripts/` in `paramant-relay` is now the single source of truth for all CLI tools — previously split between this repo and `ParamantOS/nixos/scripts/`
 - Server-side tools moved from `scripts/` to `deploy/`: `fix-nginx-ports.py`, `paramant-admin.py`, `post-install.sh`, `preflight.sh`, `server-fix.sh`, `verify-license.js`

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -684,18 +684,21 @@ certbot certonly --nginx -d your-domain.com \
     <div class="cb">
       <div class="cb-header"><div class="cb-dots"><span class="cb-dot"></span><span class="cb-dot"></span><span class="cb-dot"></span></div><span class="cb-lang">bash</span></div>
       <pre><span class="cm"># Create your first API key</span>
-python3 scripts/paramant-admin.py add \
+python3 deploy/paramant-admin.py add \
   --label "alice" \
   --plan  pro \
   --email alice@example.com
 
 <span class="cm"># Push to all relay containers</span>
-python3 scripts/paramant-admin.py sync
+python3 deploy/paramant-admin.py sync
 
 <span class="cm"># Admin panel (requires ADMIN_TOKEN + TOTP if configured)</span>
 open https://your-domain.com/admin/</pre>
     </div>
     <p>Community Edition enforces a hard cap of 5 users — the 6th <code>add</code> returns HTTP 402. Add a <code>PLK_KEY</code> to <code>.env</code> to unlock unlimited users.</p>
+    <div class="callout"><span class="callout-label">Coming soon</span>
+      <p><strong style="color:#B2FF3F">Guided setup:</strong> a first-run web wizard at <code>/setup</code> is planned to replace hand-run admin scripts for first-time operators — generating the admin token, enrolling TOTP and minting the first key from the browser (design: ADR R005, draft).</p>
+    </div>
 
     <h2 id="selfhost-upgrade">Upgrade</h2>
     <div class="cb">
@@ -711,7 +714,10 @@ docker compose up -d --build
 
     <!-- ── Admin scripts ─────────────────────────────────────────── -->
     <h2 id="client-deb">Admin scripts</h2>
-    <p>Admin scripts ship with the relay repository under <code>scripts/</code>. After cloning <a href="https://github.com/Apolloccrypt/paramant-relay">paramant-relay</a>, run <code>python3 scripts/paramant-admin.py [command]</code> directly. No system-wide install package is currently provided — the SDK packages on PyPI (<code>paramant-sdk</code>) and npm (<code>paramant-sdk</code>) are the canonical client integrations.</p>
+    <p>Admin scripts ship with the relay repository. After cloning <a href="https://github.com/Apolloccrypt/paramant-relay">paramant-relay</a>, the server-side admin tool lives under <code>deploy/</code> — run <code>python3 deploy/paramant-admin.py [command]</code> directly. Operator helpers (key add/revoke, first-boot setup) live under <code>scripts/</code>. No system-wide install package is currently provided — the SDK packages on PyPI (<code>paramant-sdk</code>) and npm (<code>paramant-sdk</code>) are the canonical client integrations.</p>
+    <div class="callout"><span class="callout-label">Coming soon</span>
+      <p><strong style="color:#B2FF3F">Add-ons:</strong> an add-on architecture is specified for integrations that live just beyond the relay core — storage mirrors, notification bridges, SIEM exporters, OIDC/SAML SSO. Container-isolated, manifest-declared capabilities, HomeAssistant-style, working on ciphertext and metadata only (never plaintext or keys). Specification: ADR R007, draft.</p>
+    </div>
 
     <h2 id="client-cli">CLI reference</h2>
     <table>
@@ -790,6 +796,7 @@ paramant-stream --key pgp_xxx --sector health --forward https://pacs.hospital/ap
       <tr><td>Argon2id</td><td>Password-protected blob derive</td><td>RFC 9106</td></tr>
     </table>
     <p>Browser-side encryption runs as <strong>Rust/WASM</strong> compiled from <code>crypto-wasm/</code>. The WASM binary is SHA-256 verified at runtime before first use. The relay JS code has no access to decryption keys at any point.</p>
+    <p>The two halves of the stack run different builds of the same Rust crypto. <strong>ML-KEM-768 key encapsulation stays client-side</strong> (browser WASM / SDK) — the relay never performs a key exchange and never holds a private key. <strong>ML-DSA-65 runs server-side</strong> for the relay identity keypair, signed delivery receipts and signed tree heads (STH), and for verifying device and receipt signatures. Since the M5b migration (2026-05-27) that server-side ML-DSA-65 is provided by <a href="https://github.com/Apolloccrypt/paramant-core" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">paramant-core</a> — a standalone, audit-ready Rust crypto library (BUSL-1.1) consumed by the relay through its <code>@paramant/core</code> NAPI binding.</p>
 
     <h2 id="burn">Burn-on-read</h2>
     <p>After <code>GET /v2/outbound/:hash</code> the relay immediately overwrites the blob buffer with cryptographically random bytes and removes the entry from memory. Encrypted payload data is <strong>never written to disk</strong> at any point during the transfer.</p>

--- a/frontend/docs/self-hosting.md
+++ b/frontend/docs/self-hosting.md
@@ -462,6 +462,8 @@ The CT log viewer has two tabs: **Key Registrations** (all pubkey entries) and *
 
 On first boot each relay generates an ML-DSA-65 keypair and stores it in `/data/relay-identity.json`. After the server starts it signs a registration payload and POSTs it to `RELAY_PRIMARY_URL`. The registration is verified (ML-DSA-65 signature + timestamp freshness check) and appended to the CT log.
 
+Since the M5b migration (2026-05-27) the server-side ML-DSA-65 keygen, signing and verification are provided by [paramant-core](https://github.com/Apolloccrypt/paramant-core) — a standalone, audit-ready Rust crypto library (BUSL-1.1) consumed by the relay through its `@paramant/core` NAPI binding. If that binding is missing or fails to build, the relay logs `ml_dsa_not_available` and relay-to-relay signing is disabled; rebuild `@paramant/core` to restore it.
+
 **To enable for your relay stack**, add to each service's environment in `docker-compose.yml`:
 
 ```yaml

--- a/frontend/send.html
+++ b/frontend/send.html
@@ -499,6 +499,11 @@ select#ttl-select:focus{border-color:var(--cobalt)}
       <p class="faq-a">Not via the anonymous flow. The 5 MB limit applies to all tiers at the managed relay. Enterprise customers running a dedicated relay can configure a higher limit within their RAM budget. If you need to send larger files regularly, <a href="mailto:privacy@paramant.app" style="color:var(--cobalt)">contact us</a>.</p>
     </div>
 
+    <div class="faq-item">
+      <h4 style="font-size:var(--text-base);font-weight:700;letter-spacing:.01em;margin-bottom:var(--space-3);line-height:1.4">Is this post-quantum?</h4>
+      <p class="faq-a">The anonymous /send flow is <strong>AES-256-GCM only</strong> — a symmetric cipher with no asymmetric key exchange, so there is no quantum-vulnerable handshake to break. The key is generated in your browser and delivered out-of-band in the URL fragment. What /send deliberately does not provide is sender authentication or relay verification. For transfers that bind a registered device with post-quantum key encapsulation (ML-KEM-768) and post-quantum signatures (ML-DSA-65), use <a href="/parashare" style="color:var(--cobalt)">ParaShare</a> or <a href="/drop" style="color:var(--cobalt)">ParaDrop</a> instead.</p>
+    </div>
+
   </div>
 </section>
 


### PR DESCRIPTION
Site documentation reflected a pre-M5b state and referenced a crypto split that the code does not match. This rechttrekt het tegen de geverifieerde code op `origin/main`.

## Changes
- **`/docs` crypto stack**: documents the real M5b split -- client-side ML-KEM-768 (browser WASM/SDK), server-side ML-DSA-65 (relay identity, receipts, signed tree heads, signature verification) via the `@paramant/core` NAPI binding. Adds a paramant-core repo link (BUSL-1.1).
- **`/send` FAQ**: clarifies the anonymous flow is AES-256-GCM symmetric only (no asymmetric handshake, no sender auth/relay verification) and points to ParaShare/ParaDrop for post-quantum verified transfers.
- **self-hosting guide**: relay-identity section now attributes server-side ML-DSA-65 to `@paramant/core`, incl. the `ml_dsa_not_available` failure mode.
- **Stale path fix**: `scripts/paramant-admin.py` -> `deploy/paramant-admin.py` (the tool moved in the 3.0.0 repo reorg; verified its `add`/`sync` CLI is unchanged).
- **Coming-soon notes**: R005 web onboarding wizard (`/setup`) and R007 add-on architecture, both flagged as ADR drafts.
- **CHANGELOG**: Documentation entry under `[Unreleased]`.

## Audit corrections to the brief (no assumptions)
- The brief said "server-side ML-KEM-768 keygen via @paramant/core". The binding (`@paramant/core` v0.5.0-alpha.1) only exports `mldsa_keygen/sign/verify`; relay.js uses `registry.getSig(0x0002)` for ML-DSA-65. ML-KEM-768 is client-side. Attribution corrected to ML-DSA-65 accordingly.
- The brief referenced "R006 (post PR #40 merge)". `origin/main` is at the PR #34 merge; there is no R006 ADR and PR #40 is not in main. R006 is not mentioned; only R005 + R007 (both present, status Draft) are.

## Deliberate non-changes
- **Version numbers untouched.** Versioning is intentionally layered: internal `3.0.0` (M5b), marketing `build 2.5.0`, and a couple of stale `2.4.5` example outputs in api.md/self-hosting. Bumping uniformly would make the `/health` example inconsistent with the real runtime (3.0.0) or contradict marketing (2.5.0) -- out of scope and risky.
- `parashare.html` / `drop.html` already state ML-KEM-768 correctly -> no churn.

## Safety boundaries respected
No compliance/*.html, no NEN7510/IEC62443/NIS2 claims, no licence text, no SECURITY.md, no pricing numbers.

Co-Authored-By: Claude