### PR TITLE
fix(security): vervang PGP placeholder + remove /careers 404

### DIFF
--- a/docs/audit-reports/follow-up-pgp-key.md
+++ b/docs/audit-reports/follow-up-pgp-key.md
@@ -1,0 +1,40 @@
+# Follow-up: PGP key for privacy@paramant.app
+
+Date: 2026-05-27
+Status: Placeholder removed; honest notice now served at the key URL.
+Source findings: docs/audit-reports/production-site-2026-05-27.md (M-03 + /careers LOW)
+
+## What is live now
+
+`/.well-known/openpgp-key.asc` no longer contains a fake PGP block with
+`[PLACEHOLDER -- GENERATE REAL KEY AND REPLACE]`. It now serves a plain-text
+notice stating that no public key is published at this URL and that researchers
+can email privacy@paramant.app to request an out-of-band key exchange. No fake
+key, no false assurance.
+
+Both copies of security.txt (frontend/security.txt and
+frontend/.well-known/security.txt) had the `Hiring: https://paramant.app/careers`
+line removed because /careers returns 404. The `Encryption:` line is kept: the
+URL it points at now returns 200 with useful instructions instead of a
+placeholder.
+
+## What still needs to happen (Mick action)
+
+When Mick (or a designated security contact) wants a real PGP key published:
+
+1. Generate a key pair locally (do not let tooling do this -- see below):
+   `gpg --full-generate-key`  (ed25519 + cv25519, or rsa4096)
+2. Export the public block:
+   `gpg --armor --export privacy@paramant.app > openpgp-key.asc`
+3. Replace frontend/.well-known/openpgp-key.asc with the real block.
+4. Optionally add fingerprint pinning context near the `Encryption:` line in
+   both security.txt copies.
+5. Optionally publish to keys.openpgp.org (and keyserver.ubuntu.com).
+6. Update or delete this follow-up doc once the real key is live.
+
+## Why the CLI did not do this itself
+
+A PGP key asserts the cryptographic identity of the security contact. An
+autonomous CLI does not hold and must not claim that identity. Generating a key
+under privacy@paramant.app without the owner holding the private key would be a
+false claim of identity -- the opposite of what this fix is meant to remove.

--- a/frontend/.well-known/openpgp-key.asc
+++ b/frontend/.well-known/openpgp-key.asc
@@ -1,9 +1,15 @@
------BEGIN PGP PUBLIC KEY BLOCK-----
-Comment: Paramant Security Team
-Comment: This is a placeholder — real key will be published before 2026-06-01
-Comment: Until then, contact privacy@paramant.app for key exchange
-Comment: See https://paramant.app/security
+PGP public key for privacy@paramant.app
 
-[PLACEHOLDER — GENERATE REAL KEY AND REPLACE]
+A PGP public key for encrypted security disclosures is not currently
+published at this URL. To send an encrypted report:
 
------END PGP PUBLIC KEY BLOCK-----
+  1. Email privacy@paramant.app to request our current PGP key
+     fingerprint and public key block out-of-band.
+  2. Verify the fingerprint via the response and any pre-existing
+     contact channel before encrypting sensitive content.
+
+For non-encrypted disclosures, privacy@paramant.app is monitored
+during EU business hours. See https://paramant.app/security for the
+full disclosure policy.
+
+-- Paramant Security Team

--- a/frontend/.well-known/security.txt
+++ b/frontend/.well-known/security.txt
@@ -21,6 +21,3 @@ Policy: https://paramant.app/security#responsible-disclosure
 
 # Acknowledgements page (hall of fame)
 Acknowledgments: https://paramant.app/security/acknowledgements
-
-# Hiring notice
-Hiring: https://paramant.app/careers

--- a/frontend/security.txt
+++ b/frontend/security.txt
@@ -21,6 +21,3 @@ Policy: https://paramant.app/security#responsible-disclosure
 
 # Acknowledgements page (hall of fame)
 Acknowledgments: https://paramant.app/security/acknowledgements
-
-# Hiring notice
-Hiring: https://paramant.app/careers


### PR DESCRIPTION
Fixt twee findings uit de site-audit van 2026-05-27 (docs/audit-reports/production-site-2026-05-27.md).

## M-03: placeholder PGP-key
`/.well-known/openpgp-key.asc` bevatte een nep PGP-block met `[PLACEHOLDER -- GENERATE REAL KEY AND REPLACE]` en de comment "real key will be published before 2026-06-01". Onderzoekers die de `Encryption:`-link in security.txt volgen kregen die placeholder als response -- pijnlijk voor een crypto-product.

Fix: vervangen door een eerlijke plain-text melding dat er geen publieke key op die URL staat en dat onderzoekers via privacy@paramant.app om out-of-band uitwisseling kunnen vragen. **Geen nep-key**: een autonomous CLI heeft niet de cryptografische identiteit van het security-team en mag die niet claimen.

Follow-up: `docs/audit-reports/follow-up-pgp-key.md` beschrijft wat Mick moet doen voor een echte PGP-key.

## LOW: /careers 404
security.txt adverteerde `Hiring: https://paramant.app/careers` -- die pagina bestaat niet (404).

Fix: `Hiring:`-regel verwijderd uit **beide** security.txt-kopieen (`frontend/security.txt` en `frontend/.well-known/security.txt`, die identiek zijn). Bij een feitelijke hire-fase: nieuwe PR met echte content.

## Niet aangeraakt
- SECURITY.md / disclosure-policy: intact.
- `Encryption:`-regel: blijft staan want de placeholder-URL geeft nu 200 met nuttige instructies (out-of-band exchange), geen 404 of placeholder.
- Audit-rapport-doc: ongewijzigd (historisch record; de enige resterende PLACEHOLDER-strings zitten daar, beschrijvend).
- Contact-adres is `privacy@paramant.app` (niet security@) conform de bestaande security.txt.

Pure content-fix, geen code. ASCII-only. **Niet mergen** -- Mick beslist.