### PR TITLE
feat(admin): visual config panel - no more .env editing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,13 @@ STRIPE_DEVICE_PRICE_ID=
 # with non-default algorithm IDs. The official SDKs (sdk-js, sdk-py) and the
 # browser crypto always use ML-KEM-768 + ML-DSA-65, so 'core' suffices for them.
 # CRYPTO_MODE=core
+
+# -- Admin visual config editor (optional) --------------------------------------
+# Set this on the ADMIN service to enable the /admin/settings page, which lets
+# operators edit whitelisted config keys from the UI instead of hand-editing
+# this file over SSH. Point it at the env file the relays load -- normally a
+# file on a volume mounted into both the admin and relay containers.
+# Whitelist-driven (admin/lib/config-schema.js); secrets are masked + replace-
+# only. If unset, the editor stays disabled. Changes apply on the next relay
+# restart (the panel does not restart relays automatically).
+# ADMIN_CONFIG_ENV_PATH=/data/relay.env

--- a/admin/ADMIN.md
+++ b/admin/ADMIN.md
@@ -88,6 +88,40 @@ All endpoints are mounted at `/admin/api/`. Authentication: `X-Session: <session
 | `POST` | `/admin/delete-account` | `{ key, confirm: "DELETE", notify }` | Delete account |
 | `POST` | `/admin/preview-email` | `{ type, key }` | Preview email HTML + text before sending. Types: `welcome`, `setup`, `reset-confirm` |
 
+### Visual config editor
+
+| Method | Path | Body | Description |
+|--------|------|------|-------------|
+| `GET` | `/admin/config` | -- | Whitelisted config keys + current values. Secrets masked, never returned in plaintext. 503 if disabled. |
+| `PUT` | `/admin/config` | `{ changes: [{ key, value }] }` | Validate (all-or-nothing) + atomic write + backup. Audit-logged per change. |
+| `POST` | `/admin/config/restart` | -- | Returns 501 + manual restart instructions. Does NOT restart relays automatically (see below). |
+| `GET` | `/admin/config/audit` | -- | Config-scoped audit feed (`admin_config_changed`, `*_backup_created`, `*_restart_requested`). |
+
+UI: `/admin/settings.html` (linked from the dashboard header). Sidebar groups,
+type-specific controls (toggle / slider / select / input), dirty-state
+highlight, secret replace-modal, save-then-restart banner.
+
+**Enabling it.** The editor is OFF until `ADMIN_CONFIG_ENV_PATH` points at the
+env file the relays load. The admin runs as a separate process from the relays,
+so that path is normally a file on a shared volume mounted into both the admin
+and relay containers. If unset, `GET /admin/config` returns 503 and the page
+shows an "not enabled" notice -- we never guess a path and edit the wrong file.
+
+**Whitelist only.** Only keys defined in `admin/lib/config-schema.js` are
+readable or writable; any other key in the env file is invisible and untouched.
+Writes preserve comments, blank lines, and out-of-whitelist keys.
+
+**Secrets.** Secret keys are masked on read and replace-only on write.
+`ADMIN_TOKEN` and `TOTP_SECRET` (the credentials that protect this panel) are
+read-only here on purpose -- rotate them on the host so a typo + restart cannot
+lock you out of the panel.
+
+**Restart is manual by design.** Saving writes the env file; relays read env at
+startup, so changes apply on the next relay restart. The admin does NOT exec
+`docker compose restart` / `systemctl` on the relays: that would be a shell exec
+from the admin container and an automatic production action. The panel shows the
+command to run instead.
+
 ---
 
 ## Redis key layout (admin-relevant)

--- a/admin/lib/config-schema.js
+++ b/admin/lib/config-schema.js
@@ -1,0 +1,171 @@
+'use strict';
+
+// Whitelist of configuration keys that the admin panel may read and write.
+//
+// ONLY keys listed here are exposed by /api/admin/config. Anything else in the
+// env file is invisible and untouchable through the panel -- no arbitrary
+// key/value writes.
+//
+// Every key documented here is actually read by the relay (relay/relay.js,
+// relay/crypto/bootstrap.js) or by the admin service itself. We do not invent
+// config that has no effect.
+//
+// Fields:
+//   type        'number' | 'string' | 'boolean' | 'enum'
+//   ui          'input' | 'select' | 'slider' | 'toggle'  (frontend hint)
+//   group       sidebar grouping
+//   default     documented default when the key is unset
+//   options     allowed values (enum only)
+//   min/max     numeric bounds (number/slider)
+//   description short operator-facing explanation
+//   class       'relay-restart' (relay reads it at startup) or
+//               'admin-restart' (admin service reads it at startup)
+//   secret      true  -> value is masked on read; replace-only on write
+//   readonly    true  -> shown (masked) but NOT editable via the panel
+//               (used for the credentials that protect the panel itself, to
+//                avoid an operator locking themselves out)
+//
+// NOTE on effect: the admin service is a separate process from the relays, so
+// any change here takes effect on the next RELAY restart, not immediately. The
+// panel surfaces this rather than pretending to hot-reload.
+
+module.exports = {
+  // ---- Network / mode -------------------------------------------------------
+  RELAY_MODE: {
+    type: 'enum', ui: 'select', group: 'Relay', default: 'ghost_pipe',
+    options: ['ghost_pipe', 'iot', 'full'], class: 'relay-restart',
+    description: 'Which endpoint set the relay exposes.',
+  },
+  SETUP_MODE: {
+    type: 'boolean', ui: 'toggle', group: 'Relay', default: false,
+    class: 'relay-restart',
+    description: 'Open setup mode (allows first-key bootstrap even with keys present). Turn OFF in production.',
+  },
+  RELAY_SELF_URL: {
+    type: 'string', ui: 'input', group: 'Relay', default: '',
+    class: 'relay-restart',
+    description: 'Public URL of this relay, e.g. https://relay.paramant.app.',
+  },
+  RELAY_PRIMARY_URL: {
+    type: 'string', ui: 'input', group: 'Relay', default: '',
+    class: 'relay-restart',
+    description: 'URL of the primary relay this one registers with.',
+  },
+
+  // ---- Crypto ---------------------------------------------------------------
+  CRYPTO_MODE: {
+    type: 'enum', ui: 'select', group: 'Crypto', default: 'core',
+    options: ['core', 'extended'], class: 'relay-restart',
+    description: 'Algorithms loaded at startup. core = ML-KEM-768 + ML-DSA-65 only; extended = all 18 (ADR R006).',
+  },
+  PARAMANT_WIRE_VERSION: {
+    type: 'enum', ui: 'select', group: 'Crypto', default: '0',
+    options: ['0', '1'], class: 'relay-restart',
+    description: 'Set 1 to emit the self-describing v1 wire header. Leave 0 unless you know you need it.',
+  },
+
+  // ---- Limits ---------------------------------------------------------------
+  MAX_BLOB: {
+    type: 'number', ui: 'slider', group: 'Limits', default: 5242880,
+    min: 65536, max: 1073741824, class: 'relay-restart',
+    description: 'Maximum blob size in BYTES (default 5 MiB = 5242880).',
+  },
+  TTL_MS: {
+    type: 'number', ui: 'input', group: 'Limits', default: 300000,
+    min: 1000, max: 86400000, class: 'relay-restart',
+    description: 'Blob time-to-live in milliseconds (default 300000 = 5 min).',
+  },
+  ANON_RATE_PER_HOUR: {
+    type: 'number', ui: 'input', group: 'Limits', default: 10,
+    min: 0, max: 100000, class: 'relay-restart',
+    description: 'Anonymous inbound requests allowed per hour per IP.',
+  },
+  MAX_AUDIT: {
+    type: 'number', ui: 'input', group: 'Limits', default: 1000,
+    min: 100, max: 100000, class: 'relay-restart',
+    description: 'Maximum audit entries retained in the relay CT log.',
+  },
+  MAX_RELAY_REGISTRY: {
+    type: 'number', ui: 'input', group: 'Limits', default: 10000,
+    min: 100, max: 1000000, class: 'relay-restart',
+    description: 'Maximum peer relays held in the registry.',
+  },
+  RAM_LIMIT_MB: {
+    type: 'number', ui: 'slider', group: 'Limits', default: 512,
+    min: 128, max: 16384, class: 'relay-restart',
+    description: 'Soft RAM limit per relay process (MB); drives the 503 capacity guard.',
+  },
+  RAM_RESERVE_MB: {
+    type: 'number', ui: 'slider', group: 'Limits', default: 256,
+    min: 64, max: 8192, class: 'relay-restart',
+    description: 'RAM headroom reserved before the capacity guard trips (MB).',
+  },
+
+  // ---- Compliance -----------------------------------------------------------
+  ENABLE_USER_TOTP: {
+    type: 'boolean', ui: 'toggle', group: 'Compliance', default: false,
+    class: 'relay-restart',
+    description: 'Require TOTP MFA for end-user logins.',
+  },
+
+  // ---- NATS -----------------------------------------------------------------
+  NATS_URL: {
+    type: 'string', ui: 'input', group: 'NATS', default: '',
+    class: 'relay-restart',
+    description: 'NATS server URL. Empty = NATS disabled (opt-in only).',
+  },
+  NATS_USER: {
+    type: 'string', ui: 'input', group: 'NATS', default: '',
+    class: 'relay-restart',
+    description: 'NATS username (non-secret).',
+  },
+  NATS_PASS: {
+    type: 'string', ui: 'input', group: 'NATS', default: '',
+    class: 'relay-restart', secret: true,
+    description: 'NATS password. Masked; replace-only.',
+  },
+  NATS_TOKEN: {
+    type: 'string', ui: 'input', group: 'NATS', default: '',
+    class: 'relay-restart', secret: true,
+    description: 'NATS auth token. Masked; replace-only.',
+  },
+
+  // ---- Secrets (masked, replace-only) --------------------------------------
+  PLK_KEY: {
+    type: 'string', ui: 'input', group: 'Secrets', default: '',
+    class: 'relay-restart', secret: true,
+    description: 'Paramant license key (plk_...). Masked; replace-only.',
+  },
+  RESEND_API_KEY: {
+    type: 'string', ui: 'input', group: 'Secrets', default: '',
+    class: 'relay-restart', secret: true,
+    description: 'Resend API key for outbound mail. Masked; replace-only.',
+  },
+  INTERNAL_AUTH_TOKEN: {
+    type: 'string', ui: 'input', group: 'Secrets', default: '',
+    class: 'relay-restart', secret: true,
+    description: 'Shared token for internal relay<->admin calls. Masked; replace-only.',
+  },
+  STRIPE_SECRET_KEY: {
+    type: 'string', ui: 'input', group: 'Secrets', default: '',
+    class: 'relay-restart', secret: true,
+    description: 'Stripe secret key (SaaS billing only). Masked; replace-only.',
+  },
+  STRIPE_WEBHOOK_SECRET: {
+    type: 'string', ui: 'input', group: 'Secrets', default: '',
+    class: 'relay-restart', secret: true,
+    description: 'Stripe webhook signing secret. Masked; replace-only.',
+  },
+
+  // ---- Panel credentials (masked + READ-ONLY to prevent self-lockout) ------
+  ADMIN_TOKEN: {
+    type: 'string', ui: 'input', group: 'Secrets', default: '',
+    class: 'admin-restart', secret: true, readonly: true,
+    description: 'Admin panel token. Read-only here on purpose: rotate it on the host to avoid locking yourself out of this panel.',
+  },
+  TOTP_SECRET: {
+    type: 'string', ui: 'input', group: 'Secrets', default: '',
+    class: 'admin-restart', secret: true, readonly: true,
+    description: 'Admin TOTP secret. Read-only here on purpose: rotate it on the host and re-enrol your authenticator.',
+  },
+};

--- a/admin/lib/config-store.js
+++ b/admin/lib/config-store.js
@@ -1,0 +1,190 @@
+'use strict';
+
+// Reads and writes a dotenv-style config file under the control of the admin
+// panel. Whitelist-driven (admin/lib/config-schema.js): only known keys are
+// ever read out or written.
+//
+// The file path is NOT hardcoded. Set ADMIN_CONFIG_ENV_PATH to the env file the
+// relays load (typically a file on a shared volume mounted into both the admin
+// and relay containers). If it is unset, the feature reports as unavailable
+// rather than guessing a path -- we never silently edit the wrong file.
+
+const fs   = require('fs');
+const path = require('path');
+
+const schema = require('./config-schema');
+
+function envPath() {
+  return process.env.ADMIN_CONFIG_ENV_PATH || '';
+}
+
+function isEnabled() {
+  return Boolean(envPath());
+}
+
+// ---- dotenv parse/serialise (comment- and order-preserving) ----------------
+
+// Parse into { lines: [...], map: { KEY: {value, lineIndex} } }. We keep the
+// original lines so writing back preserves comments, blank lines, and any keys
+// outside our whitelist untouched.
+function parse(raw) {
+  const lines = raw.split('\n');
+  const map = {};
+  lines.forEach((line, i) => {
+    const m = /^([A-Z][A-Z0-9_]*)=(.*)$/.exec(line);
+    if (m) map[m[1]] = { value: m[2], lineIndex: i };
+  });
+  return { lines, map };
+}
+
+function readRaw() {
+  const p = envPath();
+  if (!p) throw new Error('config_unavailable');
+  if (!fs.existsSync(p)) return ''; // treat missing file as empty; we can create it
+  return fs.readFileSync(p, 'utf8');
+}
+
+// ---- masking ---------------------------------------------------------------
+
+function maskSecret(value) {
+  if (!value) return { set: false, masked: '', length: 0 };
+  return { set: true, masked: '********', length: value.length };
+}
+
+// ---- public read ------------------------------------------------------------
+
+// Returns the whitelisted keys with current values. Secrets are masked and
+// never returned in plaintext.
+function readConfig() {
+  const { map } = parse(readRaw());
+  const keys = Object.entries(schema).map(([name, spec]) => {
+    const present = Object.prototype.hasOwnProperty.call(map, name);
+    const rawVal  = present ? map[name].value : '';
+    const base = {
+      name,
+      type: spec.type,
+      ui: spec.ui,
+      group: spec.group,
+      default: spec.default,
+      options: spec.options || null,
+      min: spec.min ?? null,
+      max: spec.max ?? null,
+      description: spec.description || '',
+      class: spec.class,
+      secret: Boolean(spec.secret),
+      readonly: Boolean(spec.readonly),
+      set: present,
+    };
+    if (spec.secret) {
+      base.value = null;            // never leak the value
+      base.secret_state = maskSecret(rawVal);
+    } else {
+      base.value = present ? rawVal : '';
+    }
+    return base;
+  });
+  return { keys };
+}
+
+// ---- validation -------------------------------------------------------------
+
+// Coerce + validate a single change against the schema. Returns
+// { ok, value, error }. The returned value is the STRING to write to the file.
+function validateChange(key, value) {
+  const spec = schema[key];
+  if (!spec) return { ok: false, error: `key_not_whitelisted: ${key}` };
+  if (spec.readonly) return { ok: false, error: `key_readonly: ${key}` };
+
+  switch (spec.type) {
+    case 'boolean': {
+      const v = (value === true || value === 'true') ? 'true'
+              : (value === false || value === 'false') ? 'false'
+              : null;
+      if (v === null) return { ok: false, error: `${key}: expected boolean` };
+      return { ok: true, value: v };
+    }
+    case 'number': {
+      const n = Number(value);
+      if (!Number.isFinite(n)) return { ok: false, error: `${key}: expected number` };
+      if (spec.min != null && n < spec.min) return { ok: false, error: `${key}: below min ${spec.min}` };
+      if (spec.max != null && n > spec.max) return { ok: false, error: `${key}: above max ${spec.max}` };
+      return { ok: true, value: String(n) };
+    }
+    case 'enum': {
+      const v = String(value);
+      if (!spec.options.includes(v)) return { ok: false, error: `${key}: not in [${spec.options.join(', ')}]` };
+      return { ok: true, value: v };
+    }
+    case 'string':
+    default: {
+      const v = String(value);
+      if (/[\n\r]/.test(v)) return { ok: false, error: `${key}: newlines not allowed` };
+      return { ok: true, value: v };
+    }
+  }
+}
+
+// ---- atomic write with backup ----------------------------------------------
+
+// changes: [{ key, value }]. Validates ALL before writing ANY (all-or-nothing).
+// Returns { ok, applied: [{key, requires_restart}], backup, error }.
+function writeConfig(changes) {
+  const p = envPath();
+  if (!p) return { ok: false, error: 'config_unavailable' };
+  if (!Array.isArray(changes) || changes.length === 0) {
+    return { ok: false, error: 'no_changes' };
+  }
+
+  // Validate everything first.
+  const resolved = [];
+  for (const ch of changes) {
+    const r = validateChange(ch.key, ch.value);
+    if (!r.ok) return { ok: false, error: r.error };
+    resolved.push({ key: ch.key, value: r.value });
+  }
+
+  const raw = readRaw();
+  const { lines, map } = parse(raw);
+
+  // Apply: replace in place, or append if absent.
+  for (const { key, value } of resolved) {
+    if (Object.prototype.hasOwnProperty.call(map, key)) {
+      lines[map[key].lineIndex] = `${key}=${value}`;
+    } else {
+      // append before trailing empty lines
+      lines.push(`${key}=${value}`);
+    }
+  }
+  const out = lines.join('\n');
+
+  // Backup the current file (if it exists) before writing.
+  let backup = null;
+  if (fs.existsSync(p)) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    backup = `${p}.pre-change-${stamp}`;
+    fs.copyFileSync(p, backup);
+  }
+
+  // Atomic write: write temp in the same dir, then rename.
+  const tmp = path.join(path.dirname(p), `.${path.basename(p)}.tmp-${process.pid}`);
+  fs.writeFileSync(tmp, out, { mode: 0o600 });
+  fs.renameSync(tmp, p);
+
+  const applied = resolved.map(({ key }) => ({
+    key,
+    requires_restart: schema[key].class, // 'relay-restart' | 'admin-restart'
+  }));
+  return { ok: true, applied, backup };
+}
+
+// Mask a value for audit logging (secret -> length only; non-secret -> value).
+function auditValue(key, value) {
+  const spec = schema[key];
+  if (!spec) return '?';
+  if (spec.secret) return value ? `set(${String(value).length})` : 'unset';
+  return String(value);
+}
+
+module.exports = {
+  isEnabled, envPath, readConfig, writeConfig, validateChange, auditValue, maskSecret,
+};

--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -199,6 +199,7 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
     </nav>
     <div class="hdr-meta">
       <span class="lic">v2.4.5 · Licensed</span>
+      <a class="lo-btn" href="/admin/settings.html" style="text-decoration:none">Settings</a>
       <button class="lo-btn" onclick="doLogout()">Sign out</button>
     </div>
   </header>

--- a/admin/public/settings.html
+++ b/admin/public/settings.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Paramant Admin - Settings</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background:#F8FAFC; color:#0B3A6A; font-family:'Inter',system-ui,sans-serif; font-size:14px; -webkit-font-smoothing:antialiased; min-height:100vh; }
+  button,input,select { font-family:inherit; font-size:inherit; }
+  .mono { font-family:'IBM Plex Mono',monospace; }
+  a { color:#0B3A6A; }
+
+  /* header */
+  header { display:flex; align-items:center; justify-content:space-between; padding:14px 24px; border-bottom:1.5px solid rgba(11,58,106,.1); background:#fff; position:sticky; top:0; z-index:10; }
+  .hdr-brand { font-family:'IBM Plex Mono',monospace; font-size:11px; letter-spacing:.14em; font-weight:700; text-transform:uppercase; }
+  .hdr-back { padding:6px 12px; background:transparent; border:1.5px solid rgba(11,58,106,.2); color:#0B3A6A; cursor:pointer; font-family:'IBM Plex Mono',monospace; font-size:11px; letter-spacing:.08em; text-transform:uppercase; text-decoration:none; }
+
+  /* layout */
+  .wrap { display:flex; max-width:1100px; margin:0 auto; padding:24px; gap:24px; align-items:flex-start; }
+  .side { width:180px; flex:0 0 180px; position:sticky; top:80px; }
+  .side button { display:block; width:100%; text-align:left; background:transparent; border:none; border-left:2px solid transparent; padding:9px 12px; font-family:'IBM Plex Mono',monospace; font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:#475569; cursor:pointer; }
+  .side button.active { border-left-color:#0B3A6A; color:#0B3A6A; background:rgba(11,58,106,.04); }
+  .main { flex:1; min-width:0; }
+
+  .field { padding:16px 0; border-bottom:1px solid rgba(11,58,106,.08); }
+  .field.dirty { background:rgba(178,255,63,.12); margin:0 -12px; padding:16px 12px; }
+  .f-top { display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:6px; }
+  .f-name { font-family:'IBM Plex Mono',monospace; font-size:12px; font-weight:500; }
+  .f-desc { font-size:12px; color:#475569; margin-bottom:10px; line-height:1.4; }
+  .f-default { font-family:'IBM Plex Mono',monospace; font-size:10px; color:#94a3b8; }
+
+  .badge { display:inline-block; padding:2px 7px; font-size:10px; font-family:'IBM Plex Mono',monospace; text-transform:uppercase; letter-spacing:.06em; }
+  .badge-restart { background:rgba(234,179,8,.18); color:#854d0e; }
+  .badge-admin { background:rgba(11,58,106,.1); color:#0B3A6A; }
+  .badge-ro { background:rgba(148,163,184,.2); color:#475569; }
+
+  input[type=text], input[type=number], select { width:100%; max-width:420px; background:#fff; border:1.5px solid rgba(11,58,106,.15); padding:9px 11px; color:#0B3A6A; font-size:13px; outline:none; font-family:'IBM Plex Mono',monospace; }
+  input:focus, select:focus { border-color:#0B3A6A; }
+  input[disabled] { background:#f1f5f9; color:#94a3b8; cursor:not-allowed; }
+  .slider-row { display:flex; align-items:center; gap:12px; max-width:420px; }
+  .slider-row input[type=range] { flex:1; }
+  .slider-row input[type=number] { width:140px; }
+
+  /* toggle */
+  .toggle { position:relative; width:42px; height:24px; flex:0 0 42px; }
+  .toggle input { opacity:0; width:0; height:0; }
+  .toggle .track { position:absolute; inset:0; background:#cbd5e1; border-radius:24px; transition:background .15s; cursor:pointer; }
+  .toggle .track:before { content:""; position:absolute; height:18px; width:18px; left:3px; top:3px; background:#fff; border-radius:50%; transition:transform .15s; }
+  .toggle input:checked + .track { background:#059669; }
+  .toggle input:checked + .track:before { transform:translateX(18px); }
+
+  .secret-row { display:flex; align-items:center; gap:10px; }
+  .secret-state { font-family:'IBM Plex Mono',monospace; font-size:12px; color:#475569; }
+  .replace-btn { padding:6px 12px; background:transparent; border:1.5px solid rgba(11,58,106,.2); color:#0B3A6A; cursor:pointer; font-family:'IBM Plex Mono',monospace; font-size:11px; text-transform:uppercase; letter-spacing:.06em; }
+
+  /* footer bar */
+  .footbar { position:sticky; bottom:0; background:#fff; border-top:1.5px solid rgba(11,58,106,.12); padding:14px 24px; display:flex; align-items:center; justify-content:space-between; gap:12px; }
+  .foot-info { font-family:'IBM Plex Mono',monospace; font-size:12px; color:#475569; }
+  .btn { padding:9px 16px; background:#0B3A6A; color:#F8FAFC; border:none; font-size:11px; font-family:'IBM Plex Mono',monospace; letter-spacing:.08em; text-transform:uppercase; cursor:pointer; }
+  .btn[disabled] { opacity:.4; cursor:not-allowed; }
+  .btn-ghost { background:transparent; border:1.5px solid rgba(11,58,106,.2); color:#0B3A6A; }
+
+  .banner { display:none; background:rgba(234,179,8,.15); border-left:3px solid #ca8a04; padding:12px 16px; margin-bottom:18px; font-size:13px; color:#854d0e; }
+  .banner.show { display:block; }
+  .banner code { font-family:'IBM Plex Mono',monospace; }
+
+  /* audit */
+  .audit-row { padding:9px 0; border-bottom:1px solid rgba(11,58,106,.06); font-family:'IBM Plex Mono',monospace; font-size:12px; display:flex; gap:14px; }
+  .audit-ts { color:#94a3b8; flex:0 0 130px; }
+
+  .empty { padding:40px; text-align:center; color:#94a3b8; font-family:'IBM Plex Mono',monospace; font-size:12px; }
+
+  /* toast */
+  .toast { position:fixed; bottom:80px; left:50%; transform:translateX(-50%) translateY(20px); background:#0B3A6A; color:#fff; padding:11px 18px; font-size:13px; opacity:0; transition:opacity .2s, transform .2s; z-index:50; }
+  .toast.show { opacity:1; transform:translateX(-50%) translateY(0); }
+  .toast.err { background:#dc2626; }
+  .toast.ok { background:#059669; }
+
+  /* modal */
+  .modal-bg { display:none; position:fixed; inset:0; background:rgba(11,58,106,.4); z-index:60; align-items:center; justify-content:center; }
+  .modal-bg.show { display:flex; }
+  .modal { background:#fff; padding:24px; width:min(440px,92vw); }
+  .modal h3 { font-family:'IBM Plex Mono',monospace; font-size:13px; text-transform:uppercase; letter-spacing:.08em; margin-bottom:12px; }
+  .modal p { font-size:12px; color:#475569; margin-bottom:14px; line-height:1.5; }
+  .modal-actions { display:flex; gap:10px; justify-content:flex-end; margin-top:18px; }
+</style>
+</head>
+<body>
+<header>
+  <span class="hdr-brand">Paramant Admin / Settings</span>
+  <a class="hdr-back" href="/admin/">&larr; Dashboard</a>
+</header>
+
+<div id="banner" class="banner">
+  Restart required to apply changes. Run <code>docker compose restart</code> on the relay host.
+  <button id="restart-btn" class="replace-btn" style="margin-left:12px">Show restart command</button>
+</div>
+
+<div class="wrap">
+  <nav class="side" id="side" aria-label="Settings groups"></nav>
+  <div class="main">
+    <div id="unavailable" class="empty" style="display:none"></div>
+    <div id="fields"></div>
+  </div>
+</div>
+
+<div class="footbar">
+  <span class="foot-info" id="foot-info">No unsaved changes</span>
+  <div style="display:flex;gap:10px">
+    <button id="discard" class="btn btn-ghost" disabled>Discard</button>
+    <button id="save" class="btn" disabled>Save changes</button>
+  </div>
+</div>
+
+<!-- Secret replace modal -->
+<div class="modal-bg" id="modal-bg">
+  <div class="modal">
+    <h3 id="modal-title">Replace secret</h3>
+    <p id="modal-desc"></p>
+    <input type="text" id="modal-input" autocomplete="off" spellcheck="false" placeholder="New value">
+    <div class="modal-actions">
+      <button class="btn btn-ghost" id="modal-cancel">Cancel</button>
+      <button class="btn" id="modal-ok">Set value</button>
+    </div>
+  </div>
+</div>
+
+<script src="/admin/settings.js"></script>
+</body>
+</html>

--- a/admin/public/settings.js
+++ b/admin/public/settings.js
@@ -1,0 +1,235 @@
+'use strict';
+
+// Visual config editor. Reuses the admin session from the SPA (sessionStorage
+// 'adm_session'); redirects to the login at /admin/ if absent or rejected.
+
+var SESSION = sessionStorage.getItem('adm_session') || '';
+if (!SESSION) location.href = '/admin/';
+
+var state = {
+  keys: [],          // schema + current values from the server
+  dirty: {},         // key -> new value (string) pending save
+  group: null,       // active group
+  modalKey: null,    // secret key being replaced
+};
+
+function esc(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function toast(msg, type) {
+  var el = document.createElement('div');
+  el.className = 'toast' + (type ? ' ' + type : '');
+  el.textContent = msg;
+  el.setAttribute('role', 'status');
+  document.body.appendChild(el);
+  requestAnimationFrame(function () { requestAnimationFrame(function () { el.classList.add('show'); }); });
+  setTimeout(function () { el.classList.remove('show'); setTimeout(function () { el.remove(); }, 250); }, 3200);
+}
+
+function api(path, opts) {
+  opts = opts || {};
+  var headers = { 'X-Session': SESSION, 'Content-Type': 'application/json' };
+  if (opts.headers) for (var k in opts.headers) headers[k] = opts.headers[k];
+  return fetch('/admin/api' + path, { method: opts.method || 'GET', headers: headers, body: opts.body })
+    .then(function (r) {
+      if (r.status === 401) { sessionStorage.removeItem('adm_session'); location.href = '/admin/'; throw new Error('unauthorized'); }
+      var ct = r.headers.get('content-type') || '';
+      return (ct.indexOf('json') >= 0 ? r.json().catch(function () { return null; }) : Promise.resolve(null))
+        .then(function (data) { return { ok: r.ok, status: r.status, data: data }; });
+    });
+}
+
+function groups() {
+  var seen = [];
+  state.keys.forEach(function (k) { if (seen.indexOf(k.group) < 0) seen.push(k.group); });
+  return seen;
+}
+
+function renderSidebar() {
+  var side = document.getElementById('side');
+  side.innerHTML = '';
+  groups().forEach(function (g) {
+    var b = document.createElement('button');
+    b.textContent = g;
+    if (g === state.group) b.className = 'active';
+    b.onclick = function () { state.group = g; render(); };
+    side.appendChild(b);
+  });
+}
+
+function fieldValue(k) {
+  // Returns the value to display: dirty override, else current.
+  if (Object.prototype.hasOwnProperty.call(state.dirty, k.name)) return state.dirty[k.name];
+  return k.secret ? null : (k.value || '');
+}
+
+function setDirty(name, value) {
+  state.dirty[name] = value;
+  refreshFooter();
+  render();
+}
+
+function badge(k) {
+  if (k.readonly) return '<span class="badge badge-ro">read-only</span>';
+  if (k.class === 'admin-restart') return '<span class="badge badge-admin">admin restart</span>';
+  return '<span class="badge badge-restart">relay restart</span>';
+}
+
+function controlHtml(k) {
+  var dirty = Object.prototype.hasOwnProperty.call(state.dirty, k.name);
+  if (k.secret) {
+    var ss = k.secret_state || { set: false };
+    var stateTxt = dirty ? 'pending new value' : (ss.set ? 'set (' + ss.length + ' chars)' : 'not set');
+    var btn = k.readonly ? '' : '<button class="replace-btn" data-replace="' + esc(k.name) + '">Replace</button>';
+    return '<div class="secret-row"><span class="secret-state">' + esc(stateTxt) + '</span>' + btn + '</div>';
+  }
+  if (k.readonly) {
+    return '<input type="text" value="' + esc(fieldValue(k)) + '" disabled>';
+  }
+  if (k.type === 'boolean') {
+    var on = String(fieldValue(k)) === 'true';
+    return '<label class="toggle"><input type="checkbox" data-key="' + esc(k.name) + '"' + (on ? ' checked' : '') + '><span class="track"></span></label>';
+  }
+  if (k.type === 'enum') {
+    var opts = (k.options || []).map(function (o) {
+      return '<option value="' + esc(o) + '"' + (String(fieldValue(k)) === String(o) ? ' selected' : '') + '>' + esc(o) + '</option>';
+    }).join('');
+    return '<select data-key="' + esc(k.name) + '">' + opts + '</select>';
+  }
+  if (k.ui === 'slider' && k.type === 'number') {
+    var v = fieldValue(k) === '' ? k.default : fieldValue(k);
+    return '<div class="slider-row">' +
+      '<input type="range" data-key="' + esc(k.name) + '" min="' + k.min + '" max="' + k.max + '" value="' + esc(v) + '">' +
+      '<input type="number" data-key="' + esc(k.name) + '" data-mirror="1" min="' + k.min + '" max="' + k.max + '" value="' + esc(v) + '"></div>';
+  }
+  if (k.type === 'number') {
+    return '<input type="number" data-key="' + esc(k.name) + '"' +
+      (k.min != null ? ' min="' + k.min + '"' : '') + (k.max != null ? ' max="' + k.max + '"' : '') +
+      ' value="' + esc(fieldValue(k)) + '">';
+  }
+  return '<input type="text" data-key="' + esc(k.name) + '" value="' + esc(fieldValue(k)) + '">';
+}
+
+function render() {
+  renderSidebar();
+  var host = document.getElementById('fields');
+  host.innerHTML = '';
+  var list = state.keys.filter(function (k) { return k.group === state.group; });
+  list.forEach(function (k) {
+    var dirty = Object.prototype.hasOwnProperty.call(state.dirty, k.name);
+    var div = document.createElement('div');
+    div.className = 'field' + (dirty ? ' dirty' : '');
+    div.innerHTML =
+      '<div class="f-top"><span class="f-name">' + esc(k.name) + '</span>' + badge(k) + '</div>' +
+      '<div class="f-desc">' + esc(k.description) + '</div>' +
+      controlHtml(k) +
+      '<div class="f-default" style="margin-top:8px">default: ' + esc(String(k.default)) + '</div>';
+    host.appendChild(div);
+  });
+  wireControls();
+}
+
+function wireControls() {
+  document.querySelectorAll('[data-key]').forEach(function (el) {
+    var key = el.getAttribute('data-key');
+    if (el.type === 'checkbox') {
+      el.onchange = function () { setDirty(key, el.checked ? 'true' : 'false'); };
+    } else if (el.type === 'range') {
+      el.oninput = function () {
+        var mirror = document.querySelector('input[type=number][data-key="' + key + '"]');
+        if (mirror) mirror.value = el.value;
+        setDirtyNoRender(key, el.value);
+      };
+      el.onchange = function () { setDirty(key, el.value); };
+    } else {
+      el.onchange = function () { setDirty(key, el.value); };
+    }
+  });
+  document.querySelectorAll('[data-replace]').forEach(function (btn) {
+    btn.onclick = function () { openModal(btn.getAttribute('data-replace')); };
+  });
+}
+
+// Update dirty without a full re-render (keeps slider focus while dragging).
+function setDirtyNoRender(name, value) {
+  state.dirty[name] = value;
+  refreshFooter();
+}
+
+function refreshFooter() {
+  var n = Object.keys(state.dirty).length;
+  document.getElementById('foot-info').textContent = n ? (n + ' unsaved change' + (n > 1 ? 's' : '')) : 'No unsaved changes';
+  document.getElementById('save').disabled = n === 0;
+  document.getElementById('discard').disabled = n === 0;
+}
+
+// ---- secret replace modal ---------------------------------------------------
+function openModal(key) {
+  state.modalKey = key;
+  var spec = state.keys.find(function (k) { return k.name === key; });
+  document.getElementById('modal-title').textContent = 'Replace ' + key;
+  document.getElementById('modal-desc').textContent = (spec && spec.description) || 'Enter a new value. It is sent over your authenticated session and stored in the env file.';
+  document.getElementById('modal-input').value = '';
+  document.getElementById('modal-bg').classList.add('show');
+  document.getElementById('modal-input').focus();
+}
+function closeModal() { state.modalKey = null; document.getElementById('modal-bg').classList.remove('show'); }
+
+// ---- load + save ------------------------------------------------------------
+function load() {
+  api('/admin/config').then(function (r) {
+    if (r.status === 503) {
+      document.getElementById('unavailable').style.display = 'block';
+      document.getElementById('unavailable').textContent =
+        (r.data && r.data.message) || 'Visual config editor is not enabled (ADMIN_CONFIG_ENV_PATH unset).';
+      document.getElementById('side').innerHTML = '';
+      return;
+    }
+    if (!r.ok || !r.data) { toast('Failed to load config', 'err'); return; }
+    state.keys = r.data.keys || [];
+    if (!state.group && state.keys.length) state.group = state.keys[0].group;
+    render();
+    refreshFooter();
+  });
+}
+
+function save() {
+  var changes = Object.keys(state.dirty).map(function (k) { return { key: k, value: state.dirty[k] }; });
+  if (!changes.length) return;
+  document.getElementById('save').disabled = true;
+  api('/admin/config', { method: 'PUT', body: JSON.stringify({ changes: changes }) }).then(function (r) {
+    if (!r.ok) {
+      toast((r.data && r.data.message) || 'Save failed', 'err');
+      document.getElementById('save').disabled = false;
+      return;
+    }
+    var n = (r.data.applied || []).length;
+    toast(n + ' change' + (n > 1 ? 's' : '') + ' saved', 'ok');
+    state.dirty = {};
+    if (r.data.requires_restart) document.getElementById('banner').classList.add('show');
+    load();
+  });
+}
+
+function init() {
+  document.getElementById('save').onclick = save;
+  document.getElementById('discard').onclick = function () { state.dirty = {}; refreshFooter(); render(); };
+  document.getElementById('modal-cancel').onclick = closeModal;
+  document.getElementById('modal-bg').onclick = function (e) { if (e.target.id === 'modal-bg') closeModal(); };
+  document.getElementById('modal-ok').onclick = function () {
+    var v = document.getElementById('modal-input').value;
+    if (state.modalKey) setDirty(state.modalKey, v);
+    closeModal();
+  };
+  document.getElementById('restart-btn').onclick = function () {
+    api('/admin/config/restart', { method: 'POST' }).then(function (r) {
+      toast((r.data && r.data.message) || 'Restart the relays manually to apply.', '');
+    });
+  };
+  load();
+}
+
+if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+else init();

--- a/admin/server.js
+++ b/admin/server.js
@@ -7,6 +7,7 @@ const crypto  = require('crypto');
 const path    = require('path');
 const { initRedis, redis } = require('./lib/redis');
 const { logAuditEvent, getAuditEvents } = require('./lib/audit');
+const configStore = require('./lib/config-store');
 
 const PORT        = parseInt(process.env.PORT || '4200', 10);
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN || '';
@@ -358,6 +359,88 @@ api.post('/reload-all', authMiddleware, async (req, res) => {
   });
   try { await logAuditEvent('admin', 'admin_relay_reload_all', { admin_ip: req.headers['x-real-ip'] || 'unknown' }); } catch {}
   res.json({ ok: Object.values(results).every(r => r.ok), results });
+});
+
+// -- Visual config (env-file editor) -----------------------------------------
+// Whitelist-driven read/write of the relay env file so operators do not have to
+// SSH in and hand-edit .env. Disabled unless ADMIN_CONFIG_ENV_PATH points at a
+// file the admin can reach (typically a shared volume). See admin/lib/
+// config-schema.js + config-store.js and ADMIN.md.
+
+api.get('/admin/config', authMiddleware, (req, res) => {
+  if (!configStore.isEnabled()) {
+    return res.status(503).json({
+      error: 'config_unavailable',
+      message: 'Set ADMIN_CONFIG_ENV_PATH to the relay env file to enable the visual config editor.',
+    });
+  }
+  try {
+    res.json({ ok: true, enabled: true, ...configStore.readConfig() });
+  } catch (err) {
+    res.status(500).json({ error: 'config_read_failed', message: err.message });
+  }
+});
+
+api.put('/admin/config', authMiddleware, async (req, res) => {
+  if (!configStore.isEnabled()) {
+    return res.status(503).json({ error: 'config_unavailable' });
+  }
+  const changes = Array.isArray(req.body && req.body.changes) ? req.body.changes : null;
+  if (!changes) return res.status(400).json({ error: 'bad_request', message: 'Body must be { changes: [{ key, value }] }' });
+
+  const result = configStore.writeConfig(changes);
+  if (!result.ok) return res.status(400).json({ error: 'config_write_failed', message: result.error });
+
+  const admin_ip = req.headers['x-real-ip'] || 'unknown';
+  // Audit each change with masked values; never log secrets in plaintext.
+  for (const ch of changes) {
+    try {
+      await logAuditEvent('admin', 'admin_config_changed', {
+        key: ch.key,
+        new_value: configStore.auditValue(ch.key, ch.value),
+        admin_ip,
+      });
+    } catch {}
+  }
+  if (result.backup) {
+    try { await logAuditEvent('admin', 'admin_config_backup_created', { backup_file: result.backup, admin_ip }); } catch {}
+  }
+
+  const requiresRestart = result.applied.some(a => a.requires_restart);
+  res.json({
+    ok: true,
+    applied: result.applied,
+    requires_restart: requiresRestart,
+    restart_targets: [...new Set(result.applied.map(a => a.requires_restart))],
+    rolled_back: false,
+  });
+});
+
+// Restart is a deliberate manual operator step. The admin service does NOT
+// execute docker/systemctl on the relays: that would be a shell exec from the
+// admin container and an automatic production action. We return instructions
+// and let the operator run it.
+api.post('/admin/config/restart', authMiddleware, async (req, res) => {
+  const admin_ip = req.headers['x-real-ip'] || 'unknown';
+  try { await logAuditEvent('admin', 'admin_config_restart_requested', { admin_ip }); } catch {}
+  res.status(501).json({
+    ok: false,
+    manual_restart_required: true,
+    message: 'Config saved. Restart the relays to apply: `docker compose restart` on the relay host (or your orchestrator equivalent). The admin panel does not restart production services automatically.',
+  });
+});
+
+// Config-scoped audit feed for the panel's Configuration tab.
+api.get('/admin/config/audit', authMiddleware, async (req, res) => {
+  try {
+    const events = await getAuditEvents('admin', {
+      limit: 100,
+      event_types: ['admin_config_changed', 'admin_config_backup_created', 'admin_config_restart_requested'],
+    });
+    res.json({ ok: true, events });
+  } catch (err) {
+    res.status(500).json({ error: 'audit_read_failed', message: err.message });
+  }
 });
 
 // ── Self-service trial key request — DEPRECATED 2026-04-21 ──────────────────


### PR DESCRIPTION
Operators kunnen whitelisted config-variabelen nu via `/admin/settings` beheren in plaats van SSH + hand-edit van `.env`.

## Wat erin zit
- **admin/lib/config-schema.js** -- whitelist van config-keys. Alleen keys die relay.js / bootstrap.js of de admin-service echt lezen; geen verzonnen config. Per key: type, UI-hint, groep, default, validatiebounds, restart-class, secret/readonly-flags.
- **admin/lib/config-store.js** -- dotenv read/write op een pad uit `ADMIN_CONFIG_ENV_PATH`. Behoudt comments + niet-whitelisted keys, all-or-nothing validatie, atomic rename, timestamped backup, secret-masking.
- **Endpoints** (achter bestaande `authMiddleware`): `GET /api/admin/config`, `PUT /api/admin/config`, `POST /api/admin/config/restart`, `GET /api/admin/config/audit`.
- **admin/public/settings.html + settings.js** -- standalone pagina in de dashboard-design (Inter + IBM Plex Mono, petrol/lime), hergebruikt de SPA-sessie. Sidebar-groepen, type-specifieke controls (toggle/slider/select/input), dirty-state, secret replace-modal, save-then-restart banner. Link vanuit dashboard-header.
- Docs in ADMIN.md + .env.example.

## Veiligheidsbeslissingen (afwijkend van het ruwe script, bewust)
- **Whitelist-only**: geen arbitraire .env-keys; rest van het bestand blijft onaangeroerd.
- **Secrets masked + replace-only**; waarden lekken nooit via GET.
- **ADMIN_TOKEN + TOTP_SECRET zijn read-only** in het panel -- het zou een footgun zijn als het panel z'n eigen toegangscredential kan wijzigen + restarten en je jezelf buitensluit. Rotatie doe je op de host.
- **Restart is handmatig by design**: `POST /config/restart` geeft 501 + instructie i.p.v. `docker compose restart` / `systemctl` uit te voeren. Shell-exec vanuit de admin-container + automatische prod-actie valt buiten de veiligheidsgrenzen. De relays lezen env bij startup, dus wijzigingen gelden na de volgende relay-restart -- het panel toont het commando.
- **Disabled tenzij opt-in**: zonder `ADMIN_CONFIG_ENV_PATH` geeft GET 503 en toont de pagina een 'not enabled'-melding. We raden nooit een pad en bewerken nooit het verkeerde bestand. (De admin draait als apart proces van de relays; het pad is normaliter een gedeeld volume.)
- **Auth-laag ongewijzigd** (authMiddleware/login niet aangeraakt).
- Wijzigingen worden **niet automatisch gedeployed naar productie** -- alleen het lokale env-bestand op het opgegeven pad.

## Audit-log
Elke wijziging logt `admin_config_changed` (key + masked value + admin_ip), plus `admin_config_backup_created` en `admin_config_restart_requested`, via de bestaande Redis audit-store. Zichtbaar via `GET /admin/config/audit`.

## Tests
- `node -c` op alle nieuwe JS + server.js: OK.
- Functionele round-trip van config-store: masking, whitelist-block, readonly-block, enum/min-validatie, atomic write met comment/onbekende-key-behoud, backup, all-or-nothing rollback, audit-masking -- alle groen.

ASCII-only. Backwards-compatible: directe .env-editing blijft werken; het panel is een tweede pad. **Niet mergen** -- Mick beslist.