### PR TITLE
feat(m11): /setup wizard from scaffold to working flow

### DIFF
--- a/frontend/all-systems-go.html
+++ b/frontend/all-systems-go.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Paramant - All systems</title>
+  <link rel="stylesheet" href="/design-system.css">
+  <link rel="stylesheet" href="/nav.css">
+  <style>
+    .asg { max-width: 560px; margin: 64px auto; padding: 0 24px; }
+    .asg-hero { text-align: center; margin-bottom: 40px; }
+    .asg-dot-lg { width: 56px; height: 56px; border-radius: 50%; margin: 0 auto 20px;
+      display: flex; align-items: center; justify-content: center; font-size: 28px; color: #fff; }
+    .asg-overall-green  { background: #1a8f4c; }
+    .asg-overall-yellow { background: #c08a00; }
+    .asg-overall-red    { background: #b00020; }
+    .asg-overall-loading{ background: #cfd6df; }
+    .asg-title { font-size: 22px; font-weight: 700; margin: 0 0 6px; letter-spacing: -0.01em; }
+    .asg-sub { color: #667; margin: 0; font-size: 14px; }
+    .asg-list { border: 1px solid #e6e9ee; border-radius: 12px; overflow: hidden; }
+    .asg-row { display: flex; align-items: center; gap: 14px; padding: 16px 18px;
+      border-bottom: 1px solid #eef1f5; cursor: default; }
+    .asg-row:last-child { border-bottom: none; }
+    .asg-dot { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; }
+    .asg-green  { background: #1a8f4c; }
+    .asg-yellow { background: #c08a00; }
+    .asg-red    { background: #b00020; }
+    .asg-loading{ background: #cfd6df; }
+    .asg-name { font-weight: 600; text-transform: capitalize; flex: 1; }
+    .asg-detail { color: #889; font-size: 13px; text-align: right; }
+    .asg-actions { margin-top: 28px; text-align: center; }
+    .asg-meta { margin-top: 18px; text-align: center; color: #99a; font-size: 12px; }
+  </style>
+</head>
+<body>
+  <main class="asg">
+    <div class="asg-hero">
+      <div id="overall-dot" class="asg-dot-lg asg-overall-loading">&middot;</div>
+      <h1 id="overall-title" class="asg-title">Checking systems...</h1>
+      <p id="overall-sub" class="asg-sub">Running a deep health check on your relay.</p>
+    </div>
+
+    <div id="checks" class="asg-list">
+      <div class="asg-row"><span class="asg-dot asg-loading"></span><span class="asg-name">loading</span></div>
+    </div>
+
+    <div class="asg-actions">
+      <a class="btn" href="/dashboard">Go to dashboard</a>
+    </div>
+    <p id="asg-meta" class="asg-meta"></p>
+  </main>
+
+  <script>
+  'use strict';
+  function esc(s){ return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;'); }
+  function cap(s){ return s ? s.charAt(0).toUpperCase()+s.slice(1) : s; }
+
+  function render(data){
+    var overall = (data && data.overall) || 'red';
+    var dot = document.getElementById('overall-dot');
+    var title = document.getElementById('overall-title');
+    var sub = document.getElementById('overall-sub');
+    dot.className = 'asg-dot-lg asg-overall-' + overall;
+    if (overall === 'green') {
+      dot.innerHTML = '&#10003;'; title.textContent = 'All systems go';
+      sub.textContent = 'Your relay ' + esc(data.version||'') + ' is healthy and ready.';
+    } else if (overall === 'yellow') {
+      dot.innerHTML = '!'; title.textContent = 'Up, with warnings';
+      sub.textContent = 'The relay is running; some checks need attention below.';
+    } else {
+      dot.innerHTML = '&times;'; title.textContent = 'Attention needed';
+      sub.textContent = 'One or more checks failed. See details below.';
+    }
+    var box = document.getElementById('checks');
+    var checks = (data && data.checks) || [];
+    box.innerHTML = checks.map(function(c){
+      return '<div class="asg-row">' +
+        '<span class="asg-dot asg-' + esc(c.status) + '"></span>' +
+        '<span class="asg-name">' + esc(cap(c.name)) + '</span>' +
+        '<span class="asg-detail">' + esc(c.detail) + '</span>' +
+        '</div>';
+    }).join('');
+    document.getElementById('asg-meta').textContent =
+      'Relay ' + esc(data.version||'?') + ' / sector ' + esc(data.sector||'?') + ' - updated ' + new Date().toLocaleTimeString();
+  }
+
+  function poll(){
+    fetch('/v2/health/deep', { cache: 'no-store' })
+      .then(function(r){ return r.json(); })
+      .then(render)
+      .catch(function(){
+        document.getElementById('overall-title').textContent = 'Cannot reach the relay';
+        document.getElementById('overall-sub').textContent = 'The /v2/health/deep endpoint did not respond.';
+        document.getElementById('overall-dot').className = 'asg-dot-lg asg-overall-red';
+        document.getElementById('overall-dot').innerHTML = '&times;';
+      });
+  }
+  poll();
+  setInterval(poll, 5000);
+  </script>
+</body>
+</html>

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -33,9 +33,11 @@
     <div class="step" data-step="2" hidden>
       <h2>Step 2 of 6: Domain and TLS</h2>
       <p>What domain will users reach this relay on?</p>
-      <input type="text" name="domain" placeholder="relay.your-org.com" required>
+      <input type="text" name="domain" placeholder="relay.your-org.com">
+      <p class="hint">Leave blank to run in localhost mode (no public domain, no TLS).</p>
       <label><input type="checkbox" name="auto-tls" checked> Automatically obtain TLS via Let's Encrypt</label>
       <p class="hint">Requires DNS A records for each sector subdomain.</p>
+      <p id="dns-status" class="hint" aria-live="polite"></p>
       <div class="actions">
         <button class="back" type="button">Back</button>
         <button class="next" type="button">Next</button>
@@ -86,19 +88,20 @@
     <div class="step" data-step="6" hidden>
       <h2>Step 6 of 6: Review and start</h2>
       <p>Review your configuration before applying it.</p>
-      <pre id="review-summary" aria-live="polite"></pre>
+      <div id="review-summary" aria-live="polite"></div>
       <div class="actions">
         <button class="back" type="button">Back</button>
         <button id="apply" type="button">Apply configuration</button>
       </div>
-      <p id="apply-status" class="hint"></p>
+      <p id="apply-status" class="hint" aria-live="polite"></p>
     </div>
 
     <div class="step" data-step="done" hidden>
-      <h2>Setup complete</h2>
-      <p>Your relay is configured. Sign in to the dashboard to send your
-         first file.</p>
-      <a href="/auth/login" class="btn">Sign in</a>
+      <h2>Your relay is live</h2>
+      <div id="done-body">
+        <p>Setup complete. Sign in to the dashboard to send your first file.</p>
+        <a href="/auth/login" class="btn">Sign in</a>
+      </div>
     </div>
   </main>
 

--- a/frontend/setup.js
+++ b/frontend/setup.js
@@ -1,7 +1,7 @@
 // /setup wizard state machine.
-// Skeleton: drives the multi-step UX and shapes the config payload.
-// The real apply logic lives behind POST /v2/setup/apply (currently a 501
-// stub per ADR R005); this file is wired so the frontend works on its own.
+// Drives the multi-step UX, validates each step, previews the config with
+// per-section edit links, and applies it via POST /v2/setup/apply.
+// Vanilla ES5, single file, no external dependencies (matches setup.html).
 
 'use strict';
 
@@ -22,11 +22,13 @@ var state = {
   }
 };
 
+var EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+var DOMAIN_RE = /^(?=.{1,253}$)([a-z0-9](-?[a-z0-9])*\.)+[a-z]{2,}$/;
+
 function $(sel, root) { return (root || document).querySelector(sel); }
 function $all(sel, root) { return Array.prototype.slice.call((root || document).querySelectorAll(sel)); }
 function stepEl(n) { return $('.step[data-step="' + n + '"]'); }
 
-// Show one step, hide the others.
 function goToStep(n) {
   if (STEP_ORDER.indexOf(n) === -1) { return; }
   state.step = n;
@@ -34,9 +36,9 @@ function goToStep(n) {
     el.hidden = (el.getAttribute('data-step') !== String(n));
   });
   if (n === 6) { renderReview(); }
+  if (window.scrollTo) { window.scrollTo(0, 0); }
 }
 
-// Gather the inputs on a given step into state.config.
 function collectStep(n) {
   var el = stepEl(n);
   if (!el) { return; }
@@ -63,12 +65,96 @@ function collectStep(n) {
   }
 }
 
-function renderReview() {
-  var out = $('#review-summary');
-  if (out) { out.textContent = JSON.stringify(state.config, null, 2); }
+// Validate a step. Returns null when OK, or an error string to show inline.
+function validateStep(n) {
+  var c = state.config;
+  if (n === 1) {
+    return c.sectors.length ? null : 'Select at least one sector.';
+  }
+  if (n === 2) {
+    if (c.domain && !DOMAIN_RE.test(c.domain.toLowerCase())) {
+      return 'That domain looks invalid. Use e.g. relay.your-org.com, or leave it blank for localhost mode.';
+    }
+    return null; // empty domain = localhost mode, allowed
+  }
+  if (n === 3) {
+    return EMAIL_RE.test(c.adminEmail) ? null : 'A valid admin email is required.';
+  }
+  if (n === 4) {
+    if (c.firstUserEmail && !EMAIL_RE.test(c.firstUserEmail)) {
+      return 'First-user email is invalid. Leave it blank to skip creating a user now.';
+    }
+    return null; // first user is optional
+  }
+  return null;
 }
 
-// Confirm we are still in first-time mode before showing the wizard.
+function showStepError(n, msg) {
+  var el = stepEl(n);
+  if (!el) { return; }
+  var box = $('.step-error', el);
+  if (!box) {
+    box = document.createElement('p');
+    box.className = 'step-error hint';
+    box.setAttribute('role', 'alert');
+    box.style.color = '#b00020';
+    var actions = $('.actions', el);
+    el.insertBefore(box, actions);
+  }
+  box.textContent = msg || '';
+  box.style.display = msg ? '' : 'none';
+}
+
+// Client-side DNS preflight (informational) when a domain is entered.
+function dnsPreflight() {
+  var out = $('#dns-status');
+  if (!out) { return; }
+  var domain = $('[name="domain"]', stepEl(2)).value.trim().toLowerCase();
+  if (!domain) { out.textContent = ''; return; }
+  if (!DOMAIN_RE.test(domain)) { out.textContent = ''; return; }
+  out.textContent = 'Checking DNS for ' + domain + '...';
+  fetch('/v2/setup/dns-check?domain=' + encodeURIComponent(domain))
+    .then(function (r) { return r.json(); })
+    .then(function (d) {
+      if (d && d.resolves) {
+        out.textContent = 'DNS OK: ' + domain + ' -> ' + (d.addresses || []).join(', ');
+        out.style.color = '#0a7';
+      } else {
+        out.textContent = 'DNS not resolving yet for ' + domain + '. You can still continue and configure DNS later.';
+        out.style.color = '#a60';
+      }
+    })
+    .catch(function () { out.textContent = ''; });
+}
+
+function esc(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;'); }
+
+function renderReview() {
+  var c = state.config;
+  var out = $('#review-summary');
+  if (!out) { return; }
+  var rows = [
+    { step: 1, label: 'Sectors', value: c.sectors.join(', ') },
+    { step: 2, label: 'Domain', value: c.domain ? (c.domain + (c.autoTls ? ' (auto-TLS)' : ' (no TLS)')) : 'localhost mode' },
+    { step: 3, label: 'Admin', value: c.adminEmail + (c.enableTotp ? ' (TOTP on)' : '') },
+    { step: 4, label: 'First user', value: c.firstUserEmail ? (c.firstUserEmail + ' / ' + (c.firstUserLabel || 'first-user') + ' / ' + c.firstUserPlan) : 'skip for now' },
+    { step: 5, label: 'Compliance', value: c.complianceTemplate }
+  ];
+  var html = '<dl class="review-list">';
+  rows.forEach(function (r) {
+    html += '<div class="review-row" style="display:flex;justify-content:space-between;gap:12px;padding:6px 0;border-bottom:1px solid #eee">' +
+      '<dt style="color:#666">' + esc(r.label) + '</dt>' +
+      '<dd style="margin:0;text-align:right"><span>' + esc(r.value) + '</span> ' +
+      '<button type="button" class="edit-link" data-edit="' + r.step + '" style="background:none;border:none;color:#1d4ed8;cursor:pointer;font-size:12px">Edit</button></dd>' +
+      '</div>';
+  });
+  html += '</dl>';
+  out.innerHTML = html;
+  $all('.edit-link', out).forEach(function (b) {
+    b.addEventListener('click', function () { goToStep(parseInt(b.getAttribute('data-edit'), 10)); });
+  });
+}
+
 function checkSetupMode() {
   return fetch('/v2/setup/check', { method: 'GET' })
     .then(function (r) { return r.ok ? r.json() : { setupMode: true }; })
@@ -86,36 +172,79 @@ function checkSetupMode() {
     .catch(function () { /* offline / no backend yet: keep the wizard usable */ });
 }
 
-// Apply config: POST to /v2/setup/apply.
+function renderDone(res) {
+  var body = $('#done-body');
+  if (!body) { return; }
+  var b = (res && res.body) || {};
+  var html = '<p>Your relay is configured and your admin key is ready. ' +
+    '<strong>Copy it now</strong> -- it is shown only once.</p>';
+  if (b.admin_api_key) {
+    html += '<p style="font-family:monospace;background:#f5f7fa;border:1px solid #e0e0e0;padding:10px;word-break:break-all">' +
+      esc(b.admin_api_key) + '</p>' +
+      '<button type="button" id="copy-key" class="btn">Copy admin key</button>';
+  }
+  if (b.first_user_api_key) {
+    html += '<p class="hint">First-user key: <code>' + esc(b.first_user_api_key_masked || '') + '</code> (delivered separately).</p>';
+  }
+  if (b.next_step === 'restart_relay') {
+    html += '<p class="hint">A new <code>.env</code> was written' +
+      (b.env_backed_up ? ' (previous one backed up to <code>.env.pre-setup</code>)' : '') +
+      '. Restart the relay (<code>docker compose up -d</code>) to apply compliance and TLS settings.</p>';
+  }
+  html += '<div class="actions" style="margin-top:16px">' +
+    '<a class="btn" href="' + esc(b.health_url || '/all-systems-go') + '">Check all systems</a> ' +
+    '<a class="btn" href="' + esc((b.dashboard_url || '/dashboard')) + '?welcome=1">Go to dashboard</a>' +
+    '</div>';
+  body.innerHTML = html;
+  var copyBtn = $('#copy-key');
+  if (copyBtn && b.admin_api_key) {
+    copyBtn.addEventListener('click', function () {
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(b.admin_api_key).then(function () { copyBtn.textContent = 'Copied'; });
+      }
+    });
+  }
+}
+
 function applyConfig() {
   collectStep(state.step);
-  renderReview();
   var status = $('#apply-status');
-  if (status) { status.textContent = 'Applying...'; }
+  var applyBtn = $('#apply');
+  if (status) { status.style.color = ''; status.textContent = 'Configuring...'; }
+  if (applyBtn) { applyBtn.disabled = true; }
   return fetch('/v2/setup/apply', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(state.config)
   })
     .then(function (r) {
-      return r.json().then(function (body) { return { ok: r.ok, status: r.status, body: body }; });
+      return r.json().then(function (body) { return { ok: r.ok, status: r.status, body: body }; })
+        .catch(function () { return { ok: r.ok, status: r.status, body: {} }; });
     })
     .then(function (res) {
       if (res.ok) {
         goToStep('done');
-      } else if (status) {
-        // Backend is a stub for now (501). Surface the message; the review
-        // payload above is still the source of truth for manual setup.
+        renderDone(res);
+        return;
+      }
+      if (applyBtn) { applyBtn.disabled = false; }
+      if (!status) { return; }
+      status.style.color = '#b00020';
+      if (res.status >= 500) {
+        status.textContent = 'Setup failed (HTTP ' + res.status + '). ' +
+          ((res.body && res.body.error) ? res.body.error : 'Check the relay logs: docker compose logs relay');
+      } else {
+        // 4xx: validation -- show message and let the user correct an earlier step.
         status.textContent = (res.body && res.body.error)
           ? res.body.error
-          : ('Setup failed (HTTP ' + res.status + ').');
+          : ('Please review your input (HTTP ' + res.status + ').');
       }
     })
     .catch(function () {
+      if (applyBtn) { applyBtn.disabled = false; }
       if (status) {
-        status.textContent =
-          'Could not reach the relay. Your configuration is shown above; ' +
-          'you can apply it manually for now.';
+        status.style.color = '#b00020';
+        status.textContent = 'Could not reach the relay. Your configuration is shown above; you can apply it manually for now.';
       }
     });
 }
@@ -124,6 +253,9 @@ function wire() {
   $all('.next').forEach(function (b) {
     b.addEventListener('click', function () {
       collectStep(state.step);
+      var err = validateStep(state.step);
+      if (err) { showStepError(state.step, err); return; }
+      showStepError(state.step, '');
       var i = STEP_ORDER.indexOf(state.step);
       if (i !== -1 && i < STEP_ORDER.length - 1) { goToStep(STEP_ORDER[i + 1]); }
     });
@@ -134,6 +266,8 @@ function wire() {
       if (i > 0) { goToStep(STEP_ORDER[i - 1]); }
     });
   });
+  var domainInput = $('[name="domain"]', stepEl(2));
+  if (domainInput) { domainInput.addEventListener('blur', dnsPreflight); }
   var applyBtn = $('#apply');
   if (applyBtn) { applyBtn.addEventListener('click', applyConfig); }
   goToStep(1);

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,19 @@ REPO="https://github.com/Apolloccrypt/paramant-relay"
 VERSION="v2.4.5"
 MIN_RAM_MB=512
 MIN_DISK_GB=4
+INSTALL_T0=$(date +%s)   # for the "download to dashboard" timer
+
+# Open a URL in the operator's browser when on a desktop; otherwise print it.
+open_browser() {
+  local url="$1"
+  if [[ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ]] && command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url" >/dev/null 2>&1 &
+  elif command -v open >/dev/null 2>&1; then
+    open "$url" >/dev/null 2>&1 &
+  else
+    info "Open this in your browser to finish setup: ${url}"
+  fi
+}
 
 # ── Banner ───────────────────────────────────────────────────────────────────
 echo -e "
@@ -165,20 +178,30 @@ fi
 step "Step 4/8 — Configuration"
 echo ""
 
-# Domain
-while true; do
-  read -rp "  $(echo -e "${W}Domain name${E}") (e.g. relay.example.com): " DOMAIN
+# Domain (optional). Source order: PARAMANT_DOMAIN env > first CLI arg > prompt.
+# An empty domain means localhost mode (no public domain, no Let's Encrypt).
+DOMAIN="${PARAMANT_DOMAIN:-${1:-}}"
+DOMAIN="${DOMAIN// /}"
+if [[ -z "$DOMAIN" ]]; then
+  read -rp "  $(echo -e "${W}Domain name${E}") (blank = localhost mode): " DOMAIN
   DOMAIN="${DOMAIN// /}"
-  [[ -n "$DOMAIN" ]] && break
-  warn "Domain cannot be empty"
-done
+fi
+if [[ -n "$DOMAIN" ]]; then
+  RELAY_MODE="domain"
+else
+  RELAY_MODE="localhost"
+  info "No domain set - installing in localhost mode (self-signed TLS, no Let's Encrypt)."
+fi
 
-# Email for Let's Encrypt
-while true; do
-  read -rp "  $(echo -e "${W}Email address${E}") (for SSL certificate): " LE_EMAIL
-  [[ "$LE_EMAIL" =~ ^[^@]+@[^@]+\.[^@]+$ ]] && break
-  warn "Enter a valid email address"
-done
+# Email for Let's Encrypt (only needed in domain mode)
+LE_EMAIL=""
+if [[ "$RELAY_MODE" == "domain" ]]; then
+  while true; do
+    read -rp "  $(echo -e "${W}Email address${E}") (for SSL certificate): " LE_EMAIL
+    [[ "$LE_EMAIL" =~ ^[^@]+@[^@]+\.[^@]+$ ]] && break
+    warn "Enter a valid email address"
+  done
+fi
 
 # Admin token
 echo ""
@@ -203,8 +226,9 @@ read -rp "  $(echo -e "${W}License key${E}") ${D}(plk_... for Pro, Enter to skip
 
 echo ""
 ok "Configuration complete"
-dim "  Domain:  ${DOMAIN}"
-dim "  Email:   ${LE_EMAIL}"
+dim "  Mode:    ${RELAY_MODE}"
+dim "  Domain:  ${DOMAIN:-localhost}"
+dim "  Email:   ${LE_EMAIL:-(n/a in localhost mode)}"
 dim "  Sectors: ${SECTORS}"
 dim "  Token:   ${ADMIN_TOKEN:0:8}...${ADMIN_TOKEN: -4}"
 
@@ -253,10 +277,19 @@ ENV
 chmod 600 "${INSTALL_DIR}/.env"
 ok ".env written (chmod 600)"
 
-# ── TLS certificates via Let's Encrypt ───────────────────────────────────────
-step "Step 7/8 — Obtaining TLS certificate"
+# -- TLS certificates ----------------------------------------------------------
+step "Step 7/8 - TLS certificate"
 
 mkdir -p "${INSTALL_DIR}/deploy/certs"
+
+if [[ "$RELAY_MODE" == "localhost" ]]; then
+  info "localhost mode: generating a self-signed certificate (no Let's Encrypt)."
+  openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+    -keyout "${INSTALL_DIR}/deploy/certs/key.pem" \
+    -out "${INSTALL_DIR}/deploy/certs/cert.pem" \
+    -subj "/CN=localhost" 2>/dev/null
+  ok "Self-signed certificate installed for localhost"
+else
 
 # Stop anything on port 80 temporarily for standalone challenge
 info "Obtaining certificate for ${DOMAIN}..."
@@ -297,6 +330,7 @@ else
     -subj "/CN=${DOMAIN}" 2>/dev/null
   warn "Self-signed cert installed — replace with Let's Encrypt when DNS is ready"
 fi
+fi   # end RELAY_MODE TLS branch
 
 # ── Launch stack ──────────────────────────────────────────────────────────────
 step "Step 8/8 — Launching relay stack"
@@ -335,7 +369,11 @@ fi
 
 # Final healthcheck
 echo ""
-HEALTH_RESP=$(curl -sk "https://${DOMAIN}/health" 2>/dev/null || curl -sk "http://127.0.0.1/health" 2>/dev/null || echo '{}')
+if [[ "$RELAY_MODE" == "domain" ]]; then
+  HEALTH_RESP=$(curl -sk "https://${DOMAIN}/health" 2>/dev/null || curl -sk "http://127.0.0.1:3000/health" 2>/dev/null || echo '{}')
+else
+  HEALTH_RESP=$(curl -sk "http://127.0.0.1:3000/health" 2>/dev/null || echo '{}')
+fi
 HEALTH_OK=$(echo "$HEALTH_RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('ok','false'))" 2>/dev/null || echo "false")
 HEALTH_VER=$(echo "$HEALTH_RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('version','?'))" 2>/dev/null || echo "?")
 HEALTH_EDI=$(echo "$HEALTH_RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('edition','?'))" 2>/dev/null || echo "?")
@@ -426,6 +464,23 @@ CLISCRIPT
 chmod +x /usr/local/bin/paramant
 ok "paramant CLI installed → /usr/local/bin/paramant"
 
+# -- Open the first-time setup wizard ------------------------------------------
+if [[ "$RELAY_MODE" == "domain" ]]; then
+  SETUP_URL="https://${DOMAIN}/setup"
+else
+  SETUP_URL="http://localhost:3000/setup"
+fi
+ELAPSED=$(( $(date +%s) - INSTALL_T0 ))
+echo ""
+step "Finish in your browser"
+info "Opening the setup wizard: ${SETUP_URL}"
+open_browser "$SETUP_URL"
+if (( ELAPSED <= 90 )); then
+  ok "From download to dashboard in ${ELAPSED}s (target: 90s)."
+else
+  info "Install took ${ELAPSED}s (first Docker build dominates; later runs are faster)."
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo -e "${C}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${E}"
@@ -433,7 +488,13 @@ echo -e "${G}${BOLD}  PARAMANT installed successfully!${E}"
 echo -e "${C}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${E}"
 echo ""
 TOTP_URI="otpauth://totp/PARAMANT%20Admin?secret=${TOTP_SECRET}&issuer=PARAMANT&algorithm=SHA1&digits=6&period=30"
-echo -e "  ${W}Relay URL:${E}    https://${DOMAIN}/health"
+if [[ "$RELAY_MODE" == "domain" ]]; then
+  echo -e "  ${W}Relay URL:${E}    https://${DOMAIN}/health"
+  echo -e "  ${W}Setup:${E}        https://${DOMAIN}/setup"
+else
+  echo -e "  ${W}Relay URL:${E}    http://localhost:3000/health"
+  echo -e "  ${W}Setup:${E}        http://localhost:3000/setup"
+fi
 echo -e "  ${W}Admin token:${E}  ${ADMIN_TOKEN:0:8}...${ADMIN_TOKEN: -4}  (stored in ${INSTALL_DIR}/.env)"
 echo -e "  ${W}Install dir:${E}  ${INSTALL_DIR}"
 echo -e "  ${W}Edition:${E}      Community (up to 5 API keys)"

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1756,14 +1756,210 @@ const server = http.createServer(async (req, res) => {
     return res.end(J({ setupMode, ready: !setupMode }));
   }
 
-  // POST /v2/setup/apply -- apply first-time configuration. Stub for now.
+  // GET /v2/setup/dns-check?domain=... -- informational DNS preflight.
+  // Gated on setup mode so it cannot be used as a general resolver.
+  if (req.method === 'GET' && path === '/v2/setup/dns-check') {
+    if (!_setupModeOn()) {
+      res.writeHead(409, { 'Content-Type': 'application/json' });
+      return res.end(J({ error: 'Setup is already complete on this relay.' }));
+    }
+    const domain = (query.domain || '').toString().trim().toLowerCase();
+    if (!domain || !/^(?=.{1,253}$)([a-z0-9](-?[a-z0-9])*\.)+[a-z]{2,}$/.test(domain)) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      return res.end(J({ error: 'A valid fully-qualified domain is required.' }));
+    }
+    try {
+      const addrs = await require('dns').promises.lookup(domain, { all: true });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(J({ ok: true, domain, resolves: addrs.length > 0, addresses: addrs.map(a => a.address) }));
+    } catch (e) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(J({ ok: true, domain, resolves: false, error: e.code || e.message }));
+    }
+  }
+
+  // POST /v2/setup/apply -- apply first-time configuration.
+  // Writes .env (atomic, backing up any existing one), mints the admin and
+  // optional first-user API keys via the canonical apiKeys + users.json path,
+  // applies a compliance preset, and records a setup_completed audit event.
+  // TLS issuance is intentionally NOT run here -- it requires root + certbot
+  // and is handled by install.sh / scripts/paramant-tls-bootstrap.sh.
   if (req.method === 'POST' && path === '/v2/setup/apply') {
     if (!_setupModeOn()) {
       res.writeHead(409, { 'Content-Type': 'application/json' });
       return res.end(J({ error: 'Setup is already complete on this relay.' }));
     }
-    res.writeHead(501, { 'Content-Type': 'application/json' });
-    return res.end(J({ error: 'Setup endpoint not yet implemented. Use the admin scripts (scripts/paramant-key-add.sh) or edit .env for now.' }));
+    try {
+      const body = JSON.parse((await readBody(req, 16384)).toString());
+      const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      const domainRe = /^(?=.{1,253}$)([a-z0-9](-?[a-z0-9])*\.)+[a-z]{2,}$/;
+
+      // -- validate sectors --
+      const VALID_SECTORS = new Set(['general', 'health', 'finance', 'legal', 'iot']);
+      const sectors = Array.isArray(body.sectors) ? body.sectors.filter(s => VALID_SECTORS.has(s)) : [];
+      if (sectors.length === 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        return res.end(J({ error: 'Select at least one valid sector.' }));
+      }
+      // -- validate domain (null = localhost mode) --
+      let domain = null;
+      if (typeof body.domain === 'string' && body.domain.trim()) {
+        domain = body.domain.trim().toLowerCase();
+        if (!domainRe.test(domain)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          return res.end(J({ error: 'Invalid domain. Leave blank for localhost mode.' }));
+        }
+      }
+      // -- validate admin email --
+      const adminEmail = (body.adminEmail || (body.admin && body.admin.email) || '').toString().trim();
+      if (!adminEmail || adminEmail.length > 254 || !emailRe.test(adminEmail)) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        return res.end(J({ error: 'A valid admin email is required.' }));
+      }
+      const enableTotp = body.enableTotp !== false;
+      const autoTls = !!body.autoTls && !!domain;
+      // -- compliance preset --
+      const VALID_PLANS = new Set(['community', 'dev', 'pro', 'licensed', 'enterprise']);
+      const PRESETS = {
+        generic:  { BLOB_TTL_MS: 3600000, AUDIT_RETENTION_DAYS: 90,   ML_DSA_REQUIRED: 'false', CRYPTO_MODE: 'core' },
+        nen7510:  { BLOB_TTL_MS: 1800000, AUDIT_RETENTION_DAYS: 2555, ML_DSA_REQUIRED: 'true',  CRYPTO_MODE: 'core' },
+        iec62443: { BLOB_TTL_MS: 900000,  AUDIT_RETENTION_DAYS: 365,  ML_DSA_REQUIRED: 'true',  CRYPTO_MODE: 'core' },
+        dora:     { BLOB_TTL_MS: 3600000, AUDIT_RETENTION_DAYS: 1825, ML_DSA_REQUIRED: 'true',  CRYPTO_MODE: 'core' },
+        custom:   {},
+        none:     {},
+      };
+      const tpl = Object.prototype.hasOwnProperty.call(PRESETS, body.complianceTemplate) ? body.complianceTemplate : 'generic';
+      const preset = PRESETS[tpl];
+      // -- optional first user --
+      let firstUser = null;
+      const fuEmail = (body.firstUserEmail || (body.first_user && body.first_user.email) || '').toString().trim();
+      if (fuEmail) {
+        if (fuEmail.length > 254 || !emailRe.test(fuEmail)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          return res.end(J({ error: 'First-user email is invalid. Leave it blank to skip.' }));
+        }
+        firstUser = {
+          email: fuEmail,
+          label: (body.firstUserLabel || '').toString().slice(0, 128) || 'first-user',
+          plan: VALID_PLANS.has(body.firstUserPlan) ? body.firstUserPlan : 'pro',
+        };
+      }
+
+      // -- mint keys (canonical apiKeys + users.json pattern) --
+      const mint = (plan, label, email) => {
+        const k = 'pgp_' + crypto.randomBytes(32).toString('hex');
+        apiKeys.set(k, { plan, label, email, active: true });
+        return k;
+      };
+      const adminKey = mint('enterprise', 'setup-admin', adminEmail);
+      const firstUserKey = firstUser ? mint(firstUser.plan, firstUser.label, firstUser.email) : null;
+      await _mutateUsersJson(d => {
+        d.api_keys = d.api_keys || [];
+        const now = new Date().toISOString();
+        d.api_keys.push({ key: adminKey, plan: 'enterprise', label: 'setup-admin', email: adminEmail, active: true, created: now, is_admin: true });
+        if (firstUserKey) d.api_keys.push({ key: firstUserKey, plan: firstUser.plan, label: firstUser.label, email: firstUser.email, active: true, created: now });
+        d.updated = now;
+      }).catch(we => log('warn', 'setup_persist_failed', { err: we.message }));
+
+      // -- write .env (atomic temp+rename, back up existing) --
+      const envPath = process.env.SETUP_ENV_FILE || path.join(process.cwd(), '.env');
+      const envLines = [
+        '# Generated by Paramant /setup on ' + new Date().toISOString(),
+        'SECTORS=' + sectors.join(','),
+        domain ? ('DOMAIN=' + domain) : '# DOMAIN= (localhost mode)',
+        'RELAY_MODE=' + (domain ? 'domain' : 'localhost'),
+        'AUTO_TLS=' + (autoTls ? 'true' : 'false'),
+        'ADMIN_EMAIL=' + adminEmail,
+        'ADMIN_TOTP_ENABLED=' + (enableTotp ? 'true' : 'false'),
+        'COMPLIANCE_TEMPLATE=' + tpl,
+      ].concat(Object.keys(preset).map(k => k + '=' + preset[k]))
+       .concat(['SETUP_MODE=false']);
+      let envWritten = false, envBackedUp = false;
+      try {
+        if (fs.existsSync(envPath)) { fs.copyFileSync(envPath, envPath + '.pre-setup'); envBackedUp = true; }
+        const tmp = envPath + '.tmp.' + process.pid + '.' + Date.now();
+        fs.writeFileSync(tmp, envLines.join('\n') + '\n', { mode: 0o600 });
+        fs.renameSync(tmp, envPath);
+        envWritten = true;
+      } catch (we) { log('warn', 'setup_env_write_failed', { err: we.message, path: envPath }); }
+
+      // -- audit --
+      try { auditAppend(adminKey, 'setup_completed', { sectors: sectors.join(','), domain: domain || 'localhost', template: tpl, tls: autoTls, first_user: !!firstUserKey }); } catch (ae) { log('warn', 'setup_audit_failed', { err: ae.message }); }
+      log('info', 'setup_completed', { sectors: sectors.join(','), domain: domain || 'localhost', template: tpl, env_written: envWritten });
+
+      const proto = domain ? 'https' : 'http';
+      const host = domain || (req.headers.host || 'localhost');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(J({
+        ok: true,
+        admin_api_key: adminKey,
+        admin_api_key_masked: adminKey.slice(0, 12) + '...',
+        first_user_api_key: firstUserKey,
+        first_user_api_key_masked: firstUserKey ? firstUserKey.slice(0, 12) + '...' : null,
+        sectors,
+        compliance_template: tpl,
+        env_written: envWritten,
+        env_backed_up: envBackedUp,
+        tls: autoTls ? 'pending' : 'n/a',
+        next_step: envWritten ? 'restart_relay' : 'all_systems_go',
+        dashboard_url: proto + '://' + host + '/dashboard',
+        health_url: proto + '://' + host + '/all-systems-go',
+      }));
+    } catch (e) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      return res.end(J({ error: e.message }));
+    }
+  }
+
+  // GET /v2/health/deep -- aggregated readiness check for the post-setup page.
+  // Public read (no auth) so the setup wizard and /all-systems-go can show it.
+  if (req.method === 'GET' && path === '/v2/health/deep') {
+    const checks = [];
+    const add = (name, status, detail) => checks.push({ name, status, detail });
+
+    add('relay', 'green', 'relay ' + VERSION + ' (' + SECTOR + ') up');
+
+    const cmode = process.env.CRYPTO_MODE || 'core';
+    add('crypto', mlDsa ? 'green' : 'yellow',
+      mlDsa ? ('ML-DSA-65 loaded, mode=' + cmode) : ('ML-DSA-65 unavailable (build @paramant/core), mode=' + cmode));
+
+    try {
+      const dir = process.env.SETUP_ENV_FILE ? path.dirname(process.env.SETUP_ENV_FILE) : process.cwd();
+      const probe = path.join(dir, '.health-write-' + process.pid);
+      fs.writeFileSync(probe, 'ok'); fs.unlinkSync(probe);
+      add('storage', 'green', 'data dir writable');
+    } catch (e) { add('storage', 'red', 'not writable: ' + (e.code || e.message)); }
+
+    const rs = ramStatus();
+    add('memory', rs.ram_ok ? 'green' : 'yellow', rs.rss_mb + 'MB rss / ' + rs.ram_limit_mb + 'MB limit');
+
+    try {
+      if (typeof fs.statfsSync === 'function') {
+        const st = fs.statfsSync(process.cwd());
+        const freeGb = (st.bsize * st.bavail) / 1e9;
+        add('disk', freeGb > 1 ? 'green' : 'yellow', freeGb.toFixed(1) + 'GB free');
+      } else { add('disk', 'yellow', 'statfs unavailable on this Node'); }
+    } catch (e) { add('disk', 'yellow', e.code || 'unknown'); }
+
+    let tlsStatus = 'yellow', tlsDetail = 'TLS terminated at the edge (not on this relay)';
+    try {
+      const certFile = process.env.TLS_CERT_FILE || path.join(process.cwd(), 'deploy/certs/cert.pem');
+      if (fs.existsSync(certFile) && typeof crypto.X509Certificate === 'function') {
+        const cert = new crypto.X509Certificate(fs.readFileSync(certFile));
+        const days = Math.floor((new Date(cert.validTo).getTime() - Date.now()) / 86400000);
+        tlsStatus = days > 14 ? 'green' : (days > 0 ? 'yellow' : 'red');
+        tlsDetail = days + ' days until expiry';
+      }
+    } catch (e) { tlsDetail = 'cert unreadable: ' + (e.code || e.message); }
+    add('tls', tlsStatus, tlsDetail);
+
+    add('users', apiKeys.size > 0 ? 'green' : 'yellow', apiKeys.size + ' API key(s) loaded');
+    add('audit', 'green', 'Merkle hash chain active');
+
+    const rank = { green: 0, yellow: 1, red: 2 };
+    const overall = checks.reduce((m, c) => (rank[c.status] > rank[m] ? c.status : m), 'green');
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    return res.end(J({ overall, version: VERSION, sector: SECTOR, checks }));
   }
 
   // ═══════════════════════════════════════════════════════════════════════

--- a/scripts/paramant-tls-bootstrap.sh
+++ b/scripts/paramant-tls-bootstrap.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# paramant-tls-bootstrap -- obtain a Let's Encrypt certificate for a relay domain.
+#
+# Called by install.sh (as root) after /setup has been applied with a domain.
+# NOT called by the relay process itself: TLS issuance needs root + certbot,
+# which the containerised relay must not have.
+#
+# Usage: paramant-tls-bootstrap.sh DOMAIN ADMIN_EMAIL [EXTRA_DOMAIN ...]
+# Exit codes: 0 ok | 2 DNS mismatch | 3 certbot missing | 4 certbot failed
+set -euo pipefail
+
+DOMAIN="${1:?usage: $0 DOMAIN ADMIN_EMAIL [EXTRA_DOMAIN ...]}"
+ADMIN_EMAIL="${2:?need admin email}"
+shift 2 || true
+EXTRA_DOMAINS=("$@")
+
+log() { echo "[tls-bootstrap] $*"; }
+
+# -- DNS preflight: does DOMAIN resolve to this host's public IP? --
+EXPECTED_IP="$(curl -fsS --max-time 8 https://api.ipify.org 2>/dev/null || curl -fsS --max-time 8 ifconfig.me 2>/dev/null || echo '')"
+ACTUAL_IP="$(dig +short "$DOMAIN" A | grep -E '^[0-9.]+$' | head -1 || true)"
+
+if [[ -z "$EXPECTED_IP" ]]; then
+  log "WARN: could not determine public IP; skipping DNS preflight."
+elif [[ -z "$ACTUAL_IP" ]]; then
+  log "DNS_MISMATCH: $DOMAIN does not resolve to an A record yet."
+  exit 2
+elif [[ "$EXPECTED_IP" != "$ACTUAL_IP" ]]; then
+  log "DNS_MISMATCH: $DOMAIN -> $ACTUAL_IP, this host is $EXPECTED_IP."
+  log "Point an A record at $EXPECTED_IP and re-run."
+  exit 2
+else
+  log "DNS OK: $DOMAIN -> $ACTUAL_IP"
+fi
+
+# -- certbot availability --
+if ! command -v certbot >/dev/null 2>&1; then
+  log "CERTBOT_MISSING: install certbot (e.g. apt install certbot python3-certbot-nginx)."
+  exit 3
+fi
+
+# -- build -d args (primary + any sector subdomains) --
+DOMAIN_ARGS=(-d "$DOMAIN")
+for d in "${EXTRA_DOMAINS[@]:-}"; do
+  [[ -n "$d" ]] && DOMAIN_ARGS+=(-d "$d")
+done
+
+log "Requesting certificate for: $DOMAIN ${EXTRA_DOMAINS[*]:-}"
+if certbot certonly --nginx --non-interactive --agree-tos \
+     --email "$ADMIN_EMAIL" "${DOMAIN_ARGS[@]}"; then
+  log "TLS_OK: $DOMAIN"
+  exit 0
+else
+  log "CERTBOT_FAILED: see /var/log/letsencrypt/letsencrypt.log"
+  exit 4
+fi


### PR DESCRIPTION
M11 first cut: takes the PR #38 /setup scaffold to a working plug-and-play install flow.

## What works now
- **POST /v2/setup/apply** (was a 501 stub): validates input, mints the admin + optional first-user API keys via the canonical `apiKeys` + `users.json` path, writes `.env` atomically (backs up any existing to `.env.pre-setup`), applies a per-template compliance preset (TTL / retention / ML-DSA-required / CRYPTO_MODE), records a `setup_completed` audit event. Returns the admin key once + `dashboard_url` / `health_url` / `next_step`.
- **GET /v2/setup/dns-check?domain=** : setup-gated informational DNS preflight.
- **GET /v2/health/deep** : aggregated readiness (relay, crypto mode, storage write, memory, disk, TLS expiry, users, audit) with green/yellow/red per check + overall.
- **/setup wizard** (`setup.js`/`setup.html`): per-step validation, review step with per-section Edit links, apply flow with loading + inline 4xx/5xx errors, one-time admin-key display with copy, links to `/all-systems-go` and `/dashboard?welcome=1`, client-side DNS preflight.
- **/all-systems-go.html** : Apple-style page polling `/v2/health/deep`.
- **scripts/paramant-tls-bootstrap.sh** : root-run certbot helper with DNS preflight + clear exit codes.
- **install.sh** : domain optional (localhost mode = self-signed, no Lets Encrypt), auto-opens the browser at `/setup`, reports download-to-dashboard elapsed vs 90s. Backwards compatible.

## Safety
- `/v2/setup/apply` and `/v2/setup/dns-check` are gated on `apiKeys.size === 0 || SETUP_MODE=true`, so a configured production relay returns 409 and is never overwritten.
- No existing relay.js routes modified; only the two `/v2/setup/*` endpoints extended and two new read-only routes added.
- TLS issuance stays out of the relay process (root+certbot in install.sh / bootstrap script).
- No production deploy. No force-push.

## Decisions made autonomously
- Brief said apply should "write .env + call admin request-key": implemented via the canonical in-memory `apiKeys.set` + `_mutateUsersJson` persistence (the real key path) rather than an internal HTTP call, and `.env` is written to `SETUP_ENV_FILE || cwd/.env` with backup. This makes the relay usable immediately (setup mode closes once a key exists).
- Compliance presets are concrete env sets per template (generic/nen7510/iec62443/dora; custom/none = no preset).

## KNOWN LIMITATION (honest, needs a follow-up)
The self-host topology does not yet serve the static frontend: the relay image (Dockerfile) copies only `relay.js`/`lib`/`crypto` (not `frontend/`), and `deploy/nginx-selfhost.conf` proxies `location /` straight to the relay with no static `root`. install.sh also does not install that nginx config or a webroot. So in a fresh self-host install the wizard HTML at `/setup` is not actually served yet -- the backend endpoints work, but a webroot/static-serving step (mirroring how prod serves `frontend/` from `/home/paramant/app`) is still required for the browser flow end-to-end. I deliberately did NOT add a static handler to `relay.js` (out of the stated boundary) or rewire docker-compose/nginx untested in this autonomous cut. This is the #1 follow-up to make the install genuinely one-shot.

## Tests
Syntax-checked: `node --check` on relay.js + setup.js, `bash -n` on install.sh + tls-bootstrap. ASCII-only in all additions. Full relay/SDK suites run in CI.

Co-Authored-By: Claude