### PR TITLE
chore: unify version to 3.0.0 (closes #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,16 +69,41 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [3.0.0] - 2026-05-27 (internal, M5b architecture)
+## [3.0.0] - 2026-05-27
 
-Internal-architecture major-version bump for the M5b paramant-core integration.
-`package.json` and the `/health` endpoint report 3.0.0; the user-facing site
-(version badge, build label, marketing copy) intentionally stays at 2.5.0 until
-ParaSign GA provides a user-facing reason for a marketing major-version bump. M5b
-is a server-side architecture change, not a user-facing feature. This also resolves
-the prior internal drift (`package.json` was 1.0.0, `/health` was 2.5.0).
+Major-version bump for the M5b paramant-core integration. 3.0.0 is now the
+SINGLE version across the project: `package.json`, the `/health` endpoint, the
+README badge, the site build labels, the installer pin, and the primary docs all
+report 3.0.0.
 
-### Changed
+### Changed - Version unification (issue #45)
+
+Reverses the earlier split-version strategy (commit 77bb8d3, "keep marketing
+2.5.0"). That split left the surface drifting three ways -- `/health` and
+`package.json` at 3.0.0, the README badge and site copy at 2.5.0, and the
+installer pinned at 2.4.5 -- which the 2026-05-27 site audit flagged (M-01) and
+issue #45 tracked. There is now one version.
+
+- README version badge + `/health` examples: 2.5.0 -> 3.0.0.
+- `relay/package.json` (+ lock): 2.5.0 -> 3.0.0 (root `package.json` already 3.0.0).
+- `install.sh`, `frontend/install.sh`, `frontend/install-pi.sh` pin: v2.4.5 -> v3.0.0.
+- `relay/Dockerfile` OCI image label: 2.4.5 -> 3.0.0.
+- `relay/README.md` header + all `frontend/*.html` build labels and version
+  stamps + the primary how-to guides (api / self-hosting / licensing / ot /
+  dicom): -> 3.0.0.
+
+Deliberately NOT changed: SDK packages (`sdk-js`, `sdk-py` are independently
+versioned and already AHEAD at 3.1.0 -- downgrading would be a regression);
+historical records (the `[2.4.5]`/`[2.4.4]` release sections, "patched in v2.4.5"
+findings, `SECURITY.md`, `docs/security*.md`, the dated 2026-04 and 2026-05-27
+audit reports); ParamantOS release-tag links (separate, deprecated product); and
+the investor brief's "v2.4.5 live in production" statements (production genuinely
+lags main per audit M-01 -- claiming 3.0.0-live would be false until deployed).
+
+ParaSign GA will pick its own version (3.1.0 or 4.0.0) at launch; 3.0.0 is no
+longer reserved for it.
+
+### Changed (M5b architecture)
 - ML-KEM-768 keygen now runs on the Rust `@paramant/core` NAPI binding instead of
   the JavaScript `@noble/post-quantum` library (M5b, PR #33). Wire format and
   client behavior unchanged; this is an internal crypto-implementation swap.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PARAMANT — Post-Quantum Encrypted File Relay
 
-[![Version](https://img.shields.io/badge/version-v2.5.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v3.0.0-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-BUSL--1.1-blue.svg)](LICENSE)
 [![Security Audit](https://img.shields.io/badge/security_audit-passed%202026--04--19%20%E2%80%94%20low%20risk-brightgreen.svg)](SECURITY.md)
 [![Relays](https://img.shields.io/badge/relays-5%20live-brightgreen.svg)](https://paramant.app/status)
@@ -28,7 +28,7 @@ docker compose up -d
 
 # 4. Verify
 curl http://localhost:3001/health
-# {"ok":true,"version":"2.5.0","sector":"health","edition":"licensed"}
+# {"ok":true,"version":"3.0.0","sector":"health","edition":"licensed"}
 ```
 
 Or on a Raspberry Pi / fresh VPS:
@@ -279,7 +279,7 @@ curl https://health.paramant.app/v2/outbound/abc123... \
 
 ```bash
 curl https://health.paramant.app/health
-# {"ok":true,"version":"2.5.0","sector":"health","edition":"licensed"}
+# {"ok":true,"version":"3.0.0","sector":"health","edition":"licensed"}
 ```
 
 ### CT log (public)

--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -198,7 +198,7 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
       <button role="tab" aria-selected="false" aria-controls="tab-relay" id="tabBtn-relay" tabindex="-1" data-tab="relay" onclick="switchTab('relay')">Relay</button>
     </nav>
     <div class="hdr-meta">
-      <span class="lic">v2.4.5 · Licensed</span>
+      <span class="lic">v3.0.0 · Licensed</span>
       <button class="lo-btn" onclick="doLogout()">Sign out</button>
     </div>
   </header>

--- a/docs/api.md
+++ b/docs/api.md
@@ -334,14 +334,14 @@ The RSS feed is designed for external archiving: any subscriber retains an indep
 
 ```bash
 curl https://relay.paramant.app/health
-# {"ok":true,"version":"2.4.5","sector":"relay","edition":"community"}
+# {"ok":true,"version":"3.0.0","sector":"relay","edition":"community"}
 ```
 
 ### GET /v2/relays — Relay registry (public)
 
 ```bash
 curl https://relay.paramant.app/v2/relays
-# {"total":5,"relays":[{"url":"…","version":"2.4.5","sector":"relay",…}]}
+# {"total":5,"relays":[{"url":"…","version":"3.0.0","sector":"relay",…}]}
 ```
 
 ### POST /v2/request-trial — Request a free trial API key

--- a/docs/dicom-guide.md
+++ b/docs/dicom-guide.md
@@ -62,7 +62,7 @@ sudo dpkg -i paramant-client_amd64.deb
 Verify:
 ```bash
 paramant-sender.py --version
-# paramant-client 2.4.5
+# paramant-client 3.0.0
 ```
 
 ### 2. Configure

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,6 +1,6 @@
 # PARAMANT — License & Key System
 
-**Version:** relay v2.4.5  
+**Version:** relay v3.0.0  
 **License:** BUSL-1.1 — see [LICENSE](../LICENSE)  
 **Last updated:** 2026-04-11
 
@@ -169,10 +169,10 @@ Payload fields:
 
 ```json
 // Community Edition
-{ "ok": true, "version": "2.4.5", "edition": "community", "max_keys": 5, "sector": "relay" }
+{ "ok": true, "version": "3.0.0", "edition": "community", "max_keys": 5, "sector": "relay" }
 
 // Licensed Edition
-{ "ok": true, "version": "2.4.5", "edition": "licensed", "max_keys": null,
+{ "ok": true, "version": "3.0.0", "edition": "licensed", "max_keys": null,
   "license_expires": "2027-01-01", "license_issued_to": "Acme Corp", "sector": "relay" }
 ```
 

--- a/docs/ot-guide.md
+++ b/docs/ot-guide.md
@@ -80,7 +80,7 @@ Verify the relay is running:
 
 ```bash
 curl http://localhost:3000/health
-# {"ok":true,"sector":"iot","version":"2.4.5"}
+# {"ok":true,"sector":"iot","version":"3.0.0"}
 ```
 
 ---

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,4 +1,4 @@
-# Self-Hosting Guide — PARAMANT Relay v2.4.5
+# Self-Hosting Guide — PARAMANT Relay v3.0.0
 
 **License:** BUSL-1.1 — source available, free for up to 5 active API keys per relay.
 
@@ -22,7 +22,7 @@ cp .env.example .env
 echo "ADMIN_TOKEN=$(openssl rand -hex 32)" >> .env
 docker compose up -d
 curl http://localhost:3001/health
-# {"ok":true,"version":"2.4.5","sector":"health","edition":"community"}
+# {"ok":true,"version":"3.0.0","sector":"health","edition":"community"}
 ```
 
 **Option 3 — Raspberry Pi / arm64:**
@@ -487,7 +487,7 @@ Expected output (one entry per registered relay):
     {
       "url": "https://relay.yourdomain.com",
       "sector": "relay",
-      "version": "2.4.5",
+      "version": "3.0.0",
       "edition": "community",
       "pk_hash": "3d9b960c...",
       "verified_since": "2026-04-11T02:14:13Z",

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -208,7 +208,7 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
       <button role="tab" aria-selected="false" aria-controls="tab-relay" id="tabBtn-relay" tabindex="-1" data-tab="relay" onclick="switchTab('relay')">Relay</button>
     </nav>
     <div class="hdr-meta">
-      <span class="lic">v2.5.0 · Licensed</span>
+      <span class="lic">v3.0.0 · Licensed</span>
       <button class="lo-btn" onclick="doLogout()">Sign out</button>
     </div>
   </header>

--- a/frontend/anti-phishing.html
+++ b/frontend/anti-phishing.html
@@ -81,7 +81,7 @@ section p+p{margin-top:14px}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">&middot;</span>
   <span>aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">&middot;</span>

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -216,7 +216,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -73,7 +73,7 @@ section p+p{margin-top:14px}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">&middot;</span>
   <span>aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">&middot;</span>

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -117,7 +117,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/compliance/iec62443.html
+++ b/frontend/compliance/iec62443.html
@@ -147,7 +147,7 @@ pre{font-family:var(--mono)}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/compliance/nen7510.html
+++ b/frontend/compliance/nen7510.html
@@ -146,7 +146,7 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/compliance/nis2.html
+++ b/frontend/compliance/nis2.html
@@ -146,7 +146,7 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -147,7 +147,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -209,7 +209,7 @@ body { min-height:100vh; }
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -116,7 +116,7 @@ a:hover{color:var(--cobalt)}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -161,7 +161,7 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>
@@ -415,7 +415,7 @@ sudo dpkg -i paramant-client_amd64.deb
 
 <span class="cm"># Verify</span>
 paramant-sender.py --version
-<span class="cm"># paramant-client 2.5.0</span></pre>
+<span class="cm"># paramant-client 3.0.0</span></pre>
     </li>
 
     <li>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -147,7 +147,7 @@ tr:last-child td{border-bottom:none}
 </head>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>
@@ -320,7 +320,7 @@ tr:last-child td{border-bottom:none}
   <div class="docs-hero-inner">
     <span class="eyebrow">REFERENCE</span>
     <h1>Documentation</h1>
-    <p class="lede">API reference, SDK guide, self-hosting, and compliance docs for PARAMANT v2.5.0. The relay is untrusted by design — it never holds a decryption key.</p>
+    <p class="lede">API reference, SDK guide, self-hosting, and compliance docs for PARAMANT v3.0.0. The relay is untrusted by design — it never holds a decryption key.</p>
     <a href="/signup" class="docs-hero-cta">Create account →</a>
   </div>
 </section>
@@ -586,7 +586,7 @@ ws.onmessage = e => {
     <h2 id="health">GET /health</h2>
     <pre><span class="cm">{
   "ok": true,
-  "version": "2.5.0",
+  "version": "3.0.0",
   "sector": "health",
   "edition": "licensed",
   "uptime_s": 3600,
@@ -617,7 +617,7 @@ docker compose up -d
 
 <span class="cm"># 4. Verify</span>
 curl http://localhost:3000/health
-<span class="cm"># → {"ok":true,"version":"2.5.0","sector":"relay"}</span></pre>
+<span class="cm"># → {"ok":true,"version":"3.0.0","sector":"relay"}</span></pre>
     </div>
 
     <h3>Container port map</h3>

--- a/frontend/docs/api.md
+++ b/frontend/docs/api.md
@@ -1,4 +1,4 @@
-# API Reference — PARAMANT v2.4.5
+# API Reference — PARAMANT v3.0.0
 
 ## Base URLs
 
@@ -328,14 +328,14 @@ The RSS feed is designed for external archiving: any subscriber retains an indep
 
 ```bash
 curl https://relay.paramant.app/health
-# {"ok":true,"version":"2.4.5","sector":"relay","edition":"community"}
+# {"ok":true,"version":"3.0.0","sector":"relay","edition":"community"}
 ```
 
 ### GET /v2/relays — Relay registry (public)
 
 ```bash
 curl https://relay.paramant.app/v2/relays
-# {"total":5,"relays":[{"url":"…","version":"2.4.5","sector":"relay",…}]}
+# {"total":5,"relays":[{"url":"…","version":"3.0.0","sector":"relay",…}]}
 ```
 
 ### POST /v2/request-trial — Request a free trial API key

--- a/frontend/docs/dicom-guide.md
+++ b/frontend/docs/dicom-guide.md
@@ -62,7 +62,7 @@ sudo dpkg -i paramant-client_amd64.deb
 Verify:
 ```bash
 paramant-sender.py --version
-# paramant-client 2.4.5
+# paramant-client 3.0.0
 ```
 
 ### 2. Configure

--- a/frontend/docs/licensing.md
+++ b/frontend/docs/licensing.md
@@ -1,6 +1,6 @@
 # PARAMANT — License & Key System
 
-**Version:** relay v2.4.5  
+**Version:** relay v3.0.0  
 **License:** BUSL-1.1 — see [LICENSE](../LICENSE)  
 **Last updated:** 2026-04-11
 
@@ -169,10 +169,10 @@ Payload fields:
 
 ```json
 // Community Edition
-{ "ok": true, "version": "2.4.5", "edition": "community", "max_keys": 5, "sector": "relay" }
+{ "ok": true, "version": "3.0.0", "edition": "community", "max_keys": 5, "sector": "relay" }
 
 // Licensed Edition
-{ "ok": true, "version": "2.4.5", "edition": "licensed", "max_keys": null,
+{ "ok": true, "version": "3.0.0", "edition": "licensed", "max_keys": null,
   "license_expires": "2027-01-01", "license_issued_to": "Acme Corp", "sector": "relay" }
 ```
 

--- a/frontend/docs/ot-guide.md
+++ b/frontend/docs/ot-guide.md
@@ -80,7 +80,7 @@ Verify the relay is running:
 
 ```bash
 curl http://localhost:3000/health
-# {"ok":true,"sector":"iot","version":"2.4.5"}
+# {"ok":true,"sector":"iot","version":"3.0.0"}
 ```
 
 ---

--- a/frontend/docs/paramant-healthcare-brief.html
+++ b/frontend/docs/paramant-healthcare-brief.html
@@ -143,7 +143,7 @@ footer {
 <body>
 
 <div class="meta-bar">
-  <span><b>build</b> 2.5.0</span>
+  <span><b>build</b> 3.0.0</span>
   <span class="sep">·</span>
   <span><b>keyex</b> ml-kem-768</span>
   <span class="sep">·</span>

--- a/frontend/docs/paramant-investor-brief.html
+++ b/frontend/docs/paramant-investor-brief.html
@@ -147,7 +147,7 @@ footer {
 <body>
 
 <div class="meta-bar">
-  <span><b>build</b> 2.5.0</span>
+  <span><b>build</b> 3.0.0</span>
   <span class="sep">·</span>
   <span><b>keyex</b> ml-kem-768</span>
   <span class="sep">·</span>

--- a/frontend/docs/paramant-ot-brief.html
+++ b/frontend/docs/paramant-ot-brief.html
@@ -133,7 +133,7 @@ footer {
 <body>
 
 <div class="meta-bar">
-  <span><b>build</b> 2.5.0</span>
+  <span><b>build</b> 3.0.0</span>
   <span class="sep">·</span>
   <span><b>keyex</b> ml-kem-768</span>
   <span class="sep">·</span>

--- a/frontend/docs/self-hosting.md
+++ b/frontend/docs/self-hosting.md
@@ -1,4 +1,4 @@
-# Self-Hosting Guide — PARAMANT Relay v2.4.5
+# Self-Hosting Guide — PARAMANT Relay v3.0.0
 
 **License:** BUSL-1.1 — source available, free for up to 5 active API keys per relay.
 
@@ -22,7 +22,7 @@ cp .env.example .env
 echo "ADMIN_TOKEN=$(openssl rand -hex 32)" >> .env
 docker compose up -d
 curl http://localhost:3001/health
-# {"ok":true,"version":"2.4.5","sector":"health","edition":"community"}
+# {"ok":true,"version":"3.0.0","sector":"health","edition":"community"}
 ```
 
 **Option 3 — Raspberry Pi / arm64:**
@@ -489,7 +489,7 @@ Expected output (one entry per registered relay):
     {
       "url": "https://relay.yourdomain.com",
       "sector": "relay",
-      "version": "2.4.5",
+      "version": "3.0.0",
       "edition": "community",
       "pk_hash": "3d9b960c...",
       "verified_since": "2026-04-11T02:14:13Z",

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -254,7 +254,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
 </div>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -124,7 +124,7 @@ input:focus{border-color:var(--cobalt)}
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/drop.html
+++ b/frontend/drop.html
@@ -189,7 +189,7 @@ select{background:var(--bone);border:1px solid var(--ink-hair);color:var(--ink);
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -125,7 +125,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -173,7 +173,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -73,7 +73,7 @@ section p+p{margin-top:14px}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">&middot;</span>
   <span>aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">&middot;</span>

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -127,7 +127,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 <body>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">·</span>
   <span>aes-256-gcm / ml-kem-768</span>
   <span class="sep">·</span>

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -113,7 +113,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 <body>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">·</span>
   <span>aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -127,7 +127,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 <body>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">·</span>
   <span>aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -129,7 +129,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 <body>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">·</span>
   <span>aes-256-gcm / ml-kem-768</span>
   <span class="sep">·</span>

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -131,7 +131,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 <body>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">·</span>
   <span>aes-256-gcm / ml-kem-768</span>
   <span class="sep">·</span>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -97,7 +97,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 <body>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -126,7 +126,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 <body>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">·</span>
   <span>aes-256-gcm / ml-kem-768</span>
   <span class="sep">·</span>

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -125,7 +125,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 <body>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">·</span>
   <span>aes-256-gcm / ml-kem-768</span>
   <span class="sep">·</span>

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -131,7 +131,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 <body>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">·</span>
   <span>aes-256-gcm / ml-kem-768</span>
   <span class="sep">·</span>

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -125,7 +125,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 <body>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">·</span>
   <span>aes-256-gcm / ml-kem-768</span>
   <span class="sep">·</span>

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -132,7 +132,7 @@ section p+p{margin-top:14px}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -211,7 +211,7 @@
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/install-pi.sh
+++ b/frontend/install-pi.sh
@@ -21,7 +21,7 @@ dim()  { echo -e "${D}$*${E}"; }
 
 INSTALL_DIR="${PARAMANT_DIR:-/opt/paramant}"
 REPO="https://github.com/Apolloccrypt/paramant-relay"
-VERSION="v2.4.5"
+VERSION="v3.0.0"
 MIN_RAM_MB=512
 MIN_DISK_GB=4
 

--- a/frontend/install.sh
+++ b/frontend/install.sh
@@ -21,7 +21,7 @@ dim()  { echo -e "${D}$*${E}"; }
 
 INSTALL_DIR="${PARAMANT_DIR:-/opt/paramant}"
 REPO="https://github.com/Apolloccrypt/paramant-relay"
-VERSION="v2.4.5"
+VERSION="v3.0.0"
 MIN_RAM_MB=512
 MIN_DISK_GB=4
 

--- a/frontend/iot.html
+++ b/frontend/iot.html
@@ -23,7 +23,7 @@
 
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -73,7 +73,7 @@ section p+p{margin-top:14px}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">&middot;</span>
   <span>aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">&middot;</span>

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -104,7 +104,7 @@ footer a{color:var(--cobalt)}
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -73,7 +73,7 @@ section p+p{margin-top:14px}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">&middot;</span>
   <span>aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">&middot;</span>

--- a/frontend/one-pager.html
+++ b/frontend/one-pager.html
@@ -485,7 +485,7 @@
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>
@@ -968,7 +968,7 @@
     <div class="right">
       <a href="https://github.com/Apolloccrypt/paramant-relay">github.com/Apolloccrypt</a><br/>
       <a href="https://hub.docker.com/r/mtty001/relay">hub.docker.com/mtty001</a><br/>
-      Build 2.5.0 · April 2026
+      Build 3.0.0 · May 2026
     </div>
   </div>
 </div>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -115,7 +115,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/ot-onepager.html
+++ b/frontend/ot-onepager.html
@@ -116,7 +116,7 @@ body {
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/ot-vs-data-diodes.html
+++ b/frontend/ot-vs-data-diodes.html
@@ -86,7 +86,7 @@
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -146,7 +146,7 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -223,7 +223,7 @@ select:focus{border-color:var(--cobalt)}
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -65,7 +65,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
 </head>
 <body>
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/pattern-library.html
+++ b/frontend/pattern-library.html
@@ -96,7 +96,7 @@
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -128,7 +128,7 @@ td{color:var(--cobalt)}
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>
@@ -331,7 +331,7 @@ td{color:var(--cobalt)}
       <dt>HQ</dt>            <dd>Netherlands / EU</dd>
       <dt>Infrastructure</dt><dd>Hetzner Frankfurt, DE — EU only</dd>
       <dt>Jurisdiction</dt>  <dd>EU/DE &middot; GDPR &middot; no US CLOUD Act</dd>
-      <dt>Version</dt>       <dd>v2.5.0 (April 2026)</dd>
+      <dt>Version</dt>       <dd>v3.0.0 (May 2026)</dd>
       <dt>Live relays</dt>   <dd>5 (relay &middot; health &middot; finance &middot; legal &middot; iot)</dd>
       <dt>Encryption</dt>    <dd>ML-KEM-768 + AES-256-GCM (NIST FIPS 203 / SP 800-38D)</dd>
       <dt>Audit</dt>         <dd>April 2026 — all findings resolved, publicly documented</dd>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -113,7 +113,7 @@
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -113,7 +113,7 @@ footer a{color:var(--ink);text-decoration:none}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/quantum-urgency.html
+++ b/frontend/quantum-urgency.html
@@ -86,7 +86,7 @@
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -136,7 +136,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/send.html
+++ b/frontend/send.html
@@ -121,7 +121,7 @@ select#ttl-select:focus{border-color:var(--cobalt)}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -123,7 +123,7 @@ a:hover{opacity:.8}
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -87,7 +87,7 @@
 
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -80,7 +80,7 @@ section p+p{margin-top:14px}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">&middot;</span>
   <span>aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">&middot;</span>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -136,7 +136,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -86,7 +86,7 @@
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -73,7 +73,7 @@ section p+p{margin-top:14px}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span>build 2.5.0</span>
+  <span>build 3.0.0</span>
   <span class="sep">&middot;</span>
   <span>aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">&middot;</span>

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ dim()  { echo -e "${D}$*${E}"; }
 
 INSTALL_DIR="${PARAMANT_DIR:-/opt/paramant}"
 REPO="https://github.com/Apolloccrypt/paramant-relay"
-VERSION="v2.4.5"
+VERSION="v3.0.0"
 MIN_RAM_MB=512
 MIN_DISK_GB=4
 

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -40,7 +40,7 @@ RUN node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.
 FROM node:22-alpine3.21@sha256:af8023ec879993821f6d5b21382ed915622a1b0f1cc03dbeb6804afaf01f8885
 
 LABEL org.opencontainers.image.title="paramant-relay" \
-      org.opencontainers.image.version="2.4.5" \
+      org.opencontainers.image.version="3.0.0" \
       org.opencontainers.image.description="Post-quantum encrypted file relay — RAM-only, burn-on-read" \
       org.opencontainers.image.source="https://github.com/Apolloccrypt/paramant-relay" \
       org.opencontainers.image.licenses="BUSL-1.1"

--- a/relay/README.md
+++ b/relay/README.md
@@ -1,4 +1,4 @@
-# PARAMANT Ghost Pipe Relay — v2.4.5
+# PARAMANT Ghost Pipe Relay — v3.0.0
 
 Node.js relay for PARAMANT Ghost Pipe. One codebase, five sector containers.
 

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paramant-relay",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paramant-relay",
-      "version": "2.5.0",
+      "version": "3.0.0",
       "dependencies": {
         "@noble/post-quantum": "^0.6.1",
         "@paramant/core": "file:../../paramant-core/crates/paramant-core-node",

--- a/relay/package.json
+++ b/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paramant-relay",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "main": "relay.js",
   "bin": {
     "paramant-verify-sth": "../scripts/paramant-verify-sth"


### PR DESCRIPTION
Reconciles all user-visible version references to a single **3.0.0**, matching `relay.js` VERSION and `/health`. Reverses the split-version strategy from commit 77bb8d3 ("keep marketing 2.5.0") that the 2026-05-27 site audit flagged (M-01) and issue #45 tracked.

## Bumped to 3.0.0
- README version badge + the two `/health` example outputs
- `relay/package.json` (+ `package-lock.json`); root `package.json` was already 3.0.0
- `install.sh`, `frontend/install.sh`, `frontend/install-pi.sh` pin: v2.4.5 -> v3.0.0
- `relay/Dockerfile` OCI image label: 2.4.5 -> 3.0.0
- `relay/README.md` header
- All `frontend/*.html` build labels + admin "Licensed" badges + docs.html/dicom/one-pager/press version stamps
- Primary how-to guides (api / self-hosting / licensing / ot / dicom), incl. `frontend/docs/` mirrors
- CHANGELOG: the existing `[3.0.0]` entry rewritten to declare the unified version + document the reversal

## Deliberately NOT changed (and why)
The raw plan said "3.0.0 everywhere" and to bump the SDKs; both would have been wrong. Surgical exclusions:

- **SDK packages** (`sdk-js` 3.1.0, `sdk-py` 3.1.0) -- independently versioned and **already AHEAD** of 3.0.0; downgrading published npm/PyPI packages is a regression. Out of scope for #45 (relay/product drift).
- **Historical records** -- CHANGELOG `[2.4.5]`/`[2.4.4]` release sections, "patched in v2.4.5" findings (README line 491), `SECURITY.md`, `docs/security*.md`, the dated 2026-04 and 2026-05-27 audit reports. Rewriting these would falsify the record.
- **ParamantOS release-tag links** (`frontend/docs.html`) -- a separate, deprecated product with a real `v2.4.5` GitHub release tag.
- **Investor-brief "v2.4.5 live in production" claims** -- production genuinely lags main (audit M-01). Claiming 3.0.0-live would be **false** until deployed. Only its footer build label was bumped, like every other page.
- **Overseer status/analysis docs** (ROADMAP, PROJECT-STATUS, cross-repo-coordination, audit-readiness, R010) -- point-in-time analysis, regenerated by the overseer session; not blind-rewritten.

ParaSign GA will pick its own version (3.1.0 or 4.0.0) at launch; 3.0.0 is no longer reserved for it.

## Verification
- `relay/package.json` + lock parse as valid JSON @ 3.0.0.
- `bash -n` clean on all three installers.
- No code logic, endpoint, or compliance-claim changes (NIS2/IEC62443/NEN7510 content untouched; only footer build labels on those pages).
- 78 files, +132/-107.

Closes #45. **Niet mergen** -- Mick beslist.