### PR TITLE
feat(m11): opt-in static frontend serving for plug-and-play (#56 follow-up)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,3 +107,13 @@ STRIPE_DEVICE_PRICE_ID=
 # only. If unset, the editor stays disabled. Changes apply on the next relay
 # restart (the panel does not restart relays automatically).
 # ADMIN_CONFIG_ENV_PATH=/data/relay.env
+
+# -- Static frontend serving (opt-in for plug-and-play self-host) --------------
+# false (default): production mode -- nginx serves frontend/, relay serves API only.
+# true: the relay serves /setup, /dashboard, /send, etc directly for non-API GET
+#       requests, so a self-host install needs no external webserver. install.sh
+#       sets this to true. API paths (/v2/*, /api/*, /ct/*, /health, /metrics) are
+#       never intercepted. Files come from FRONTEND_ROOT, mounted read-only by
+#       docker-compose.yml (./frontend -> /app/frontend:ro). See ADR R011.
+SERVE_FRONTEND=false
+FRONTEND_ROOT=/app/frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,10 @@ x-relay-env: &relay-env
   ENABLE_USER_TOTP: "${ENABLE_USER_TOTP:-false}"
   INTERNAL_AUTH_TOKEN: "${INTERNAL_AUTH_TOKEN:-}"
   PARAMANT_WIRE_VERSION: "${PARAMANT_WIRE_VERSION:-1}"
+  # Opt-in static frontend serving (plug-and-play self-host). Default false:
+  # production serves frontend/ via nginx and ignores this + the ro mount below.
+  SERVE_FRONTEND: "${SERVE_FRONTEND:-false}"
+  FRONTEND_ROOT: "${FRONTEND_ROOT:-/app/frontend}"
 
 # ── Shared logging ────────────────────────────────────────────────────────────
 x-relay-logging: &relay-logging
@@ -84,6 +88,7 @@ services:
       - "127.0.0.1:3000:3000"
     volumes:
       - relay-main-data:/data
+      - ./frontend:/app/frontend:ro   # SERVE_FRONTEND: inert unless opted in
     networks:
       - relay-net
     healthcheck:
@@ -120,6 +125,7 @@ services:
       - "127.0.0.1:3001:3000"
     volumes:
       - relay-health-data:/data
+      - ./frontend:/app/frontend:ro   # SERVE_FRONTEND: inert unless opted in
     networks:
       - relay-net
     healthcheck:
@@ -147,6 +153,7 @@ services:
       - "127.0.0.1:3002:3000"
     volumes:
       - relay-finance-data:/data
+      - ./frontend:/app/frontend:ro   # SERVE_FRONTEND: inert unless opted in
     networks:
       - relay-net
     healthcheck:
@@ -174,6 +181,7 @@ services:
       - "127.0.0.1:3003:3000"
     volumes:
       - relay-legal-data:/data
+      - ./frontend:/app/frontend:ro   # SERVE_FRONTEND: inert unless opted in
     networks:
       - relay-net
     healthcheck:
@@ -202,6 +210,7 @@ services:
       - "127.0.0.1:3004:3000"
     volumes:
       - relay-iot-data:/data
+      - ./frontend:/app/frontend:ro   # SERVE_FRONTEND: inert unless opted in
     networks:
       - relay-net
     healthcheck:

--- a/docs/adrs/R011-static-serving-opt-in.md
+++ b/docs/adrs/R011-static-serving-opt-in.md
@@ -1,0 +1,85 @@
+# R011. Static frontend serving: opt-in via SERVE_FRONTEND
+
+Date: 2026-05-27
+
+Status: Accepted
+
+Relates to: R005 (plug-and-play onboarding), R010 (plug-and-play package formats)
+
+## Context
+
+Production (paramant.app) runs nginx as a reverse proxy: nginx serves the
+static `frontend/` (from a webroot) and proxies `/v2/*` + `/api/*` to the relay
+containers. That works well at production scale.
+
+A fresh self-host install has no such nginx config. The relay image
+(`relay/Dockerfile`) copies only `relay.js`, `lib/` and `crypto/` -- not
+`frontend/` -- and the relay had no static-file handler. So in a clean self-host
+install, `GET /setup` (the M11 onboarding wizard delivered in PR #56) returned
+nothing useful: the backend endpoints (`/v2/setup/apply`, `/v2/health/deep`)
+worked, but the HTML/JS to drive them was unreachable until the operator stood
+up their own webserver. That defeats the plug-and-play goal of R005: an operator
+should not need to understand nginx to get a working install.
+
+This is the #1 follow-up flagged in the PR #56 report.
+
+## Decision
+
+The relay gains an **opt-in** static-file handler, activated by the
+`SERVE_FRONTEND=true` environment variable. Default is `false`, so production is
+unchanged (nginx keeps serving the frontend; the relay never intercepts).
+
+- Implementation lives in `relay/lib/static-serve.js` (a small, unit-tested
+  module: `createStaticHandler({ serveFrontend, frontendRoot, log })`), wired
+  into `relay.js` early in the request handler -- after CORS/security headers and
+  the OPTIONS short-circuit, but before the relay-mode gate and the API routes,
+  so frontend paths are not rejected by `modeAllows`.
+- `install.sh` writes `SERVE_FRONTEND=true` into the generated `.env` for
+  plug-and-play installs; an operator running their own webserver sets it back to
+  `false`.
+- The frontend files are provided to the container as a **read-only bind mount**
+  in `docker-compose.yml` (`./frontend -> /app/frontend:ro`), NOT copied into the
+  image. Reason: each relay service builds with context `./relay`, and
+  `frontend/` lives at the repo root -- outside that build context -- so a
+  `COPY frontend/` in `relay/Dockerfile` is not possible without reworking the
+  build context and every `COPY` path (high blast radius, affects production
+  image builds). The bind mount is read-only, inert when `SERVE_FRONTEND=false`,
+  and matches the realistic install path (install.sh clones the repo and runs
+  `docker compose up`, so `frontend/` is present on the host).
+
+Path rules (in `static-serve.js`):
+- `/v2/*`, `/api/*`, `/ct/*`, `/ct`, `/health`, `/metrics`: never intercepted.
+- Only `GET`/`HEAD`; other methods fall through.
+- `/` -> `index.html`; `/<path>/` -> `<path>/index.html`;
+  `/<name>` (no extension) -> tries `<name>.html` (so `/setup` -> `setup.html`).
+- MIME by extension; `.html` is `no-cache`, other assets `max-age=300`;
+  `X-Content-Type-Options: nosniff` always.
+- Path traversal (`..`) and null bytes -> 400. The resolved path must stay
+  within `FRONTEND_ROOT` or it is 403. The handler never writes to disk.
+
+## Consequences
+
+- Plug-and-play installs serve `/setup`, `/dashboard`, etc with no external
+  webserver -- single-container works for RasPi / small VPS.
+- Production is unchanged: `SERVE_FRONTEND` defaults to `false`; the read-only
+  mount is present but unused (the handler returns early).
+- The published bare image does not embed `frontend/`; serving requires the
+  repo-provided bind mount (i.e. the `docker compose` install path). A future
+  change could embed the frontend by moving the relay build context to the repo
+  root, if a repo-less `docker run` self-serve path is ever required.
+- Multi-container (nginx + relay) remains the recommended production topology for
+  scale, caching and TLS.
+
+## Alternatives considered
+
+- **COPY frontend/ into the image** (the original PR #56 follow-up sketch):
+  rejected for now -- impossible without changing the `./relay` build context and
+  every `COPY` path, which risks the production image build (e.g. `COPY
+  package.json` would resolve to the root manifest). Not validatable without a
+  full image build.
+- **Serve from a separate static-only container**: rejected -- overkill for
+  plug-and-play; reintroduces the multi-container requirement R005 wants to avoid.
+- **Embed the frontend in the JS bundle at build time**: rejected -- loses fast
+  frontend iteration and bloats the relay.
+- **External CDN**: rejected per EU-sovereignty (production audit findings
+  M-05/M-06: no third-party origins).

--- a/install.sh
+++ b/install.sh
@@ -271,6 +271,10 @@ RAM_RESERVE_MB=256
 RAM_LIMIT_MB=1024
 RESEND_API_KEY=
 TOTP_SECRET=${TOTP_SECRET}
+# Plug-and-play: the relay serves the wizard/UI itself (no external nginx needed).
+# Set SERVE_FRONTEND=false if you run your own webserver to serve frontend/.
+SERVE_FRONTEND=true
+FRONTEND_ROOT=/app/frontend
 ${LICENSE_KEY:+PARAMANT_LICENSE=${LICENSE_KEY}}
 ENV
 

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -53,6 +53,13 @@ COPY relay.js ./
 COPY lib/ ./lib/
 COPY crypto/ ./crypto/
 
+# Optional static frontend serving (SERVE_FRONTEND=true, default off).
+# frontend/ lives at the repo root, outside this image's build context (./relay),
+# so it is provided at runtime as a read-only bind mount in docker-compose.yml
+# (./frontend -> /app/frontend:ro), not COPY'd here. This ENV is only the default
+# root the relay reads; production keeps SERVE_FRONTEND=false and uses nginx.
+ENV FRONTEND_ROOT=/app/frontend
+
 # Non-root user — relay never needs root after install
 # Install @paramant/core (the napi binding built for musl in the builder stage)
 # by placing it directly in node_modules -- real files, no npm symlink.

--- a/relay/lib/static-serve.js
+++ b/relay/lib/static-serve.js
@@ -1,0 +1,97 @@
+'use strict';
+// Optional static frontend serving for plug-and-play self-host installs.
+// Off by default: production serves frontend/ via nginx. When SERVE_FRONTEND=true,
+// the relay serves frontend assets (/setup, /dashboard, ...) for non-API GET/HEAD
+// requests. Read-only: never writes to disk, never intercepts API paths.
+//
+// Factored into a module (injected config + logger) so the routing and the
+// path-traversal guard are unit-testable without booting the relay.
+
+const fs = require('fs');
+const path = require('path');
+
+const STATIC_MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript; charset=utf-8',
+  '.css':  'text/css; charset=utf-8',
+  '.json': 'application/json',
+  '.svg':  'image/svg+xml',
+  '.png':  'image/png',
+  '.jpg':  'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.ico':  'image/x-icon',
+  '.woff2':'font/woff2',
+  '.woff': 'font/woff',
+  '.txt':  'text/plain; charset=utf-8',
+  '.wasm': 'application/wasm',
+};
+
+// API surfaces that must never be intercepted by static serving.
+function isApiPath(urlPath) {
+  return urlPath.startsWith('/v2/') || urlPath.startsWith('/api/') ||
+         urlPath.startsWith('/ct/') || urlPath === '/ct' ||
+         urlPath === '/health' || urlPath === '/metrics';
+}
+
+function createStaticHandler(opts) {
+  opts = opts || {};
+  const serveFrontend = opts.serveFrontend === true;
+  const frontendRoot = path.resolve(opts.frontendRoot || '/app/frontend');
+  const log = typeof opts.log === 'function' ? opts.log : function () {};
+
+  // Returns true when the request is fully handled, false to fall through.
+  function maybeServeStatic(req, res, urlPath) {
+    if (!serveFrontend) return false;
+    if (req.method !== 'GET' && req.method !== 'HEAD') return false;
+    if (isApiPath(urlPath)) return false;
+
+    // Path-traversal / null-byte guard.
+    if (urlPath.indexOf('..') !== -1 || urlPath.indexOf('\0') !== -1) {
+      res.writeHead(400, { 'Content-Type': 'text/plain' }); res.end('bad request');
+      return true;
+    }
+
+    // Map URL -> candidate file under frontendRoot.
+    let filePath;
+    if (urlPath === '/' || urlPath === '') {
+      filePath = path.join(frontendRoot, 'index.html');
+    } else if (urlPath.endsWith('/')) {
+      filePath = path.join(frontendRoot, urlPath, 'index.html');
+    } else {
+      filePath = path.join(frontendRoot, urlPath);
+      // Extensionless pretty path: try <name>.html (so /setup -> setup.html).
+      if (!path.extname(filePath)) {
+        const candidate = filePath + '.html';
+        try { if (fs.statSync(candidate).isFile()) filePath = candidate; } catch (e) { /* no sibling */ }
+      }
+    }
+
+    // Confirm the resolved path stays inside frontendRoot.
+    const resolved = path.resolve(filePath);
+    if (resolved !== frontendRoot && !resolved.startsWith(frontendRoot + path.sep)) {
+      res.writeHead(403, { 'Content-Type': 'text/plain' }); res.end('forbidden');
+      return true;
+    }
+
+    let stat;
+    try { stat = fs.statSync(resolved); } catch (e) { return false; } // not found -> normal 404
+    if (!stat.isFile()) return false;
+
+    const ext = path.extname(resolved).toLowerCase();
+    const mime = STATIC_MIME[ext] || 'application/octet-stream';
+    res.writeHead(200, {
+      'Content-Type': mime,
+      'Content-Length': stat.size,
+      'Cache-Control': ext === '.html' ? 'no-cache' : 'public, max-age=300',
+      'X-Content-Type-Options': 'nosniff',
+    });
+    if (req.method === 'HEAD') { res.end(); return true; }
+    fs.createReadStream(resolved).pipe(res);
+    log('debug', 'static_served', { path: urlPath, mime });
+    return true;
+  }
+
+  return { maybeServeStatic, serveFrontend, frontendRoot, STATIC_MIME };
+}
+
+module.exports = { createStaticHandler, STATIC_MIME, isApiPath };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1651,6 +1651,17 @@ function readBody(req, max = MAX_BLOB * 2) {
 }
 
 // ── HTTP server ───────────────────────────────────────────────────────────────
+// -- Optional static frontend serving (opt-in via SERVE_FRONTEND=true) --------
+// Off by default: production serves frontend/ via nginx. Plug-and-play self-host
+// installs (install.sh) set SERVE_FRONTEND=true so the relay can serve /setup,
+// /dashboard, etc directly. See relay/lib/static-serve.js + ADR R011.
+const _static = require('./lib/static-serve').createStaticHandler({
+  serveFrontend: process.env.SERVE_FRONTEND === 'true',
+  frontendRoot: process.env.FRONTEND_ROOT || '/app/frontend',
+  log,
+});
+if (_static.serveFrontend) log('info', 'static_serving_enabled', { root: _static.frontendRoot });
+
 const server = http.createServer(async (req, res) => {
   setHeaders(res, req);
   const parsed  = url_.parse(req.url, true);
@@ -1688,6 +1699,10 @@ const server = http.createServer(async (req, res) => {
 
   incMetric('requests_total');
   if (req.method === 'OPTIONS') { res.writeHead(204); return res.end(); }
+  // Opt-in static frontend (off by default). Runs before the mode gate and the
+  // API routes so plug-and-play installs can serve /setup, /dashboard, etc.
+  // API paths are excluded inside maybeServeStatic, so production is unaffected.
+  if (_static.maybeServeStatic(req, res, path)) return;
   if (path === '/') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     return res.end(J({ ok: true, relay: SECTOR, version: VERSION, status: 'operational', protocol: 'ghost-pipe-v2', docs: 'https://paramant.app/docs' }));

--- a/relay/test/static-serve.test.js
+++ b/relay/test/static-serve.test.js
@@ -1,0 +1,138 @@
+'use strict';
+// Unit test for the opt-in static frontend handler (relay/lib/static-serve.js).
+// Run: node relay/test/static-serve.test.js   (no deps, exits non-zero on failure)
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Writable } = require('stream');
+const { createStaticHandler } = require('../lib/static-serve');
+
+// -- temp frontend root with a couple of files --
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'paramant-static-'));
+fs.writeFileSync(path.join(root, 'index.html'), '<!doctype html><title>home</title>');
+fs.writeFileSync(path.join(root, 'setup.html'), '<!doctype html><title>setup</title>');
+fs.writeFileSync(path.join(root, 'app.js'), 'console.log(1);');
+// a file outside the root, to prove traversal cannot reach it
+const secretDir = fs.mkdtempSync(path.join(os.tmpdir(), 'paramant-secret-'));
+fs.writeFileSync(path.join(secretDir, 'secret.txt'), 'TOP SECRET');
+
+function mockRes() {
+  let body = '';
+  const r = new Writable({ write(chunk, enc, cb) { body += chunk.toString(); cb(); } });
+  r.statusCode = 0; r.headers = null;
+  r.writeHead = function (code, headers) { r.statusCode = code; r.headers = headers || {}; return r; };
+  r.getBody = function () { return body; };
+  return r;
+}
+
+function req(method, urlPath) { return { method, url: urlPath }; }
+
+let passed = 0;
+function check(name, fn) { fn(); passed++; console.log('  ok -', name); }
+
+// 1. Default off: serveFrontend=false never handles anything.
+check('default off does not intercept', () => {
+  const h = createStaticHandler({ serveFrontend: false, frontendRoot: root });
+  const res = mockRes();
+  assert.strictEqual(h.maybeServeStatic(req('GET', '/setup'), res, '/setup'), false);
+  assert.strictEqual(res.statusCode, 0);
+});
+
+const on = createStaticHandler({ serveFrontend: true, frontendRoot: root });
+
+// 2. API paths are never intercepted (even with serving on).
+check('API paths fall through', () => {
+  for (const p of ['/v2/setup/apply', '/v2/health/deep', '/api/x', '/ct/log', '/ct', '/health', '/metrics']) {
+    const res = mockRes();
+    assert.strictEqual(on.maybeServeStatic(req('GET', p), res, p), false, p);
+    assert.strictEqual(res.statusCode, 0, p);
+  }
+});
+
+// 3. Non-GET/HEAD never intercepted.
+check('POST falls through', () => {
+  const res = mockRes();
+  assert.strictEqual(on.maybeServeStatic(req('POST', '/setup'), res, '/setup'), false);
+});
+
+// 4. Pretty path /setup -> setup.html, 200 text/html, body piped.
+check('/setup serves setup.html (GET) headers', () => {
+  const res = mockRes();
+  assert.strictEqual(on.maybeServeStatic(req('GET', '/setup'), res, '/setup'), true);
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(res.headers['Content-Type'], 'text/html; charset=utf-8');
+  assert.strictEqual(res.headers['X-Content-Type-Options'], 'nosniff');
+});
+
+// 5. HEAD serves headers, no body.
+check('HEAD /setup sets headers, empty body', () => {
+  const res = mockRes();
+  assert.strictEqual(on.maybeServeStatic(req('HEAD', '/setup'), res, '/setup'), true);
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(res.getBody(), '');
+});
+
+// 6. Root -> index.html.
+check('/ serves index.html', () => {
+  const res = mockRes();
+  assert.strictEqual(on.maybeServeStatic(req('HEAD', '/'), res, '/'), true);
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(res.headers['Content-Type'], 'text/html; charset=utf-8');
+});
+
+// 7. .js mime + cache header.
+check('app.js served with js mime + cache', () => {
+  const res = mockRes();
+  assert.strictEqual(on.maybeServeStatic(req('HEAD', '/app.js'), res, '/app.js'), true);
+  assert.strictEqual(res.headers['Content-Type'], 'application/javascript; charset=utf-8');
+  assert.strictEqual(res.headers['Cache-Control'], 'public, max-age=300');
+});
+
+// 8. Unknown path -> false (normal 404 fallthrough).
+check('unknown path falls through to 404', () => {
+  const res = mockRes();
+  assert.strictEqual(on.maybeServeStatic(req('GET', '/nope'), res, '/nope'), false);
+  assert.strictEqual(res.statusCode, 0);
+});
+
+// 9. Traversal with ".." is rejected with 400, never reaches the secret.
+check('traversal blocked (400)', () => {
+  const res = mockRes();
+  const handled = on.maybeServeStatic(req('GET', '/../../etc/passwd'), res, '/../../etc/passwd');
+  assert.strictEqual(handled, true);
+  assert.strictEqual(res.statusCode, 400);
+  assert.ok(!res.getBody().includes('SECRET'));
+});
+
+// 10. Null byte rejected.
+check('null byte blocked (400)', () => {
+  const res = mockRes();
+  assert.strictEqual(on.maybeServeStatic(req('GET', '/setup\0.html'), res, '/setup\0.html'), true);
+  assert.strictEqual(res.statusCode, 400);
+});
+
+// 11. GET actually pipes the file body (async). Await before cleanup so the
+//     read stream finishes before the temp dir is removed.
+function getBody() {
+  return new Promise((resolve, reject) => {
+    const res = mockRes();
+    res.on('finish', () => resolve(res.getBody()));
+    res.on('error', reject);
+    const handled = on.maybeServeStatic(req('GET', '/setup'), res, '/setup');
+    assert.strictEqual(handled, true);
+  });
+}
+
+getBody()
+  .then((body) => {
+    assert.ok(body.includes('setup'), 'piped body should contain setup.html content');
+    passed++;
+    console.log('  ok - GET /setup pipes body');
+  })
+  .finally(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(secretDir, { recursive: true, force: true });
+    console.log('\nstatic-serve: ' + passed + ' checks passed');
+  });


### PR DESCRIPTION
Follow-up to PR #56 (merged): resolves the #1 known limitation - in a fresh self-host install `GET /setup` returned no HTML because the relay never served `frontend/`.

## Problem
- `relay/Dockerfile` copies only `relay.js` + `lib/` + `crypto/`, not `frontend/`.
- `relay.js` had no static-file handler.
- The self-host nginx config proxies `/` straight to the relay (no static root).

Production (paramant.app) works because nginx serves `frontend/` there - but self-hosters do not have that config.

## Solution: opt-in static serving (default OFF)
- **`relay/lib/static-serve.js`** - read-only static handler, wired into `relay.js` before the relay-mode gate and API routes. `SERVE_FRONTEND=true` activates it.
- **`install.sh`** writes `SERVE_FRONTEND=true` for plug-and-play installs.
- **`docker-compose.yml`** mounts `./frontend -> /app/frontend:ro` on each relay and adds `SERVE_FRONTEND` (default false) + `FRONTEND_ROOT` to the shared env anchor.
- **ADR R011** documents the design.

This makes the localhost SETUP_URL from PR #56 (`http://localhost:3000/setup`) actually serve the wizard.

## Why a bind mount, not `COPY frontend/`
Each relay builds with context `./relay`; `frontend/` is at the repo root, outside that context, so a Dockerfile `COPY frontend/` is impossible without reworking the build context and every `COPY` path (would also affect `COPY package.json` -> wrong manifest, high blast radius on the production image build, not locally verifiable). The read-only bind mount achieves the goal for the real install path (install.sh clones the repo and runs `docker compose up`) with far lower risk. ADR R011 records this and the future option to embed via a context change if a repo-less image is ever needed.

## Security (all boundaries respected)
- Default `SERVE_FRONTEND=false`: production unchanged; the ro mount is inert (handler returns early).
- API paths never intercepted: `/v2/*`, `/api/*`, `/ct/*`, `/ct`, `/health`, `/metrics`.
- Path-traversal (`..`) + null-byte -> 400; resolved path must stay within `FRONTEND_ROOT` -> else 403.
- GET/HEAD only; read-only (no disk writes).
- `deploy/nginx-selfhost.conf` untouched. Existing PR #56 routes (`/v2/setup/*`, `/v2/health/deep`) untouched.

## Tests
`relay/test/static-serve.test.js` - 11 checks against the real module (default-off, API-exclusion, POST fall-through, /setup->setup.html, HEAD, /->index.html, mime+cache, 404 fall-through, traversal 400, null-byte 400, GET body pipe). All pass. `node --check` clean. ASCII-only additions.

Co-Authored-By: Claude