### PR TITLE
ops: deploy runbook + smoke tests + rollback for v3.0.0

### DIFF
--- a/docs/RUNBOOK-DEPLOY-3.0.0.md
+++ b/docs/RUNBOOK-DEPLOY-3.0.0.md
@@ -1,0 +1,207 @@
+# Deploy Runbook - paramant.app v3.0.0
+
+Target server: `116.203.86.81` (Hetzner). Mick runs this manually over SSH.
+The relays are **built from source** by docker-compose (`build: ./relay`), so
+deploy = git pull + `docker compose build` + recreate. There is no registry
+image to pull. Rollback restores the previously-built local images (see below),
+not an earlier git commit.
+
+Adjust `COMPOSE_DIR` below if the checkout is not at `/home/paramant/app`.
+
+```
+COMPOSE_DIR=/home/paramant/app
+BACKUP_DIR=/home/paramant/backups
+```
+
+Service / port map (docker-compose.yml, all bound to 127.0.0.1):
+
+| service        | container               | port |
+|----------------|-------------------------|------|
+| relay-main     | paramant-relay-main     | 3000 |
+| relay-health   | paramant-relay-health   | 3001 |
+| relay-finance  | paramant-relay-finance  | 3002 |
+| relay-legal    | paramant-relay-legal    | 3003 |
+| relay-iot      | paramant-relay-iot      | 3004 |
+| admin          | paramant-relay-admin    | 4200 |
+
+nginx (paramant.app) proxies: `/health` and `/v2/` -> relay-main:3000,
+`/admin/` -> admin:4200, `/.well-known/` -> static, `/ /setup /dashboard /docs`
+-> frontend upstream.
+
+---
+
+## Pre-deploy checklist
+
+- [ ] All open 3.0.0 PRs merged to main in order (e.g. #58 admin CLI and any
+      others), CI green on each.
+- [ ] `main` HEAD updated; CI green on main.
+- [ ] Version is 3.0.0 in `package.json` and `relay/package.json` (PR #57).
+- [ ] M5b soak status acknowledged (we deploy regardless).
+- [ ] `curl` and `jq` available on the machine you run the smoke test from.
+- [ ] You can reach the server: `ssh root@116.203.86.81`.
+
+---
+
+## Deploy procedure
+
+### Step 1: Backup current state + tag rollback images
+
+This is what makes rollback possible. It tags every currently-running relay/
+admin image and writes a manifest that `scripts/rollback-3.0.0.sh` reads.
+
+```bash
+ssh root@116.203.86.81
+cd /home/paramant/app          # = $COMPOSE_DIR
+
+TS=$(date +%Y%m%d-%H%M)
+mkdir -p /home/paramant/backups
+MANIFEST=/home/paramant/backups/rollback-images-$TS.txt
+: > "$MANIFEST"
+
+for svc in relay-main relay-health relay-finance relay-legal relay-iot admin; do
+  cid=$(docker compose ps -q "$svc" 2>/dev/null)
+  [ -z "$cid" ] && { echo "skip $svc (not running)"; continue; }
+  img=$(docker inspect --format '{{.Config.Image}}' "$cid")
+  rb="paramant-rollback/$svc:$TS"
+  docker tag "$img" "$rb"
+  echo "$svc|$img|$rb" >> "$MANIFEST"
+  echo "tagged $svc -> $rb"
+done
+
+# Pointer the rollback script looks for first:
+ln -sfn "$MANIFEST" /home/paramant/backups/rollback-images-latest.txt
+
+# Snapshot compose state + env (env may hold secrets; keep backups dir private)
+docker compose ps  > /home/paramant/backups/state-pre-3.0.0-$TS.txt
+cp .env /home/paramant/backups/.env-pre-3.0.0-$TS
+
+echo "Backup tagged at $TS; manifest: $MANIFEST"
+```
+
+Verify the manifest is non-empty before continuing:
+
+```bash
+cat /home/paramant/backups/rollback-images-latest.txt
+```
+
+### Step 2: Pull new code + build images
+
+```bash
+cd /home/paramant/app
+git fetch origin
+git status            # confirm clean; stash/commit any local edits first
+git pull origin main
+
+# Build from source (relays + admin share build contexts ./relay and ./admin)
+docker compose build
+```
+
+### Step 3: Confirm .env
+
+Only `CRYPTO_MODE` is relevant for the R006 crypto change. Core mode keeps a
+single KEM (ML-KEM-768) loaded; it is the default, set it explicitly for clarity:
+
+```bash
+cd /home/paramant/app
+grep -q "^CRYPTO_MODE=" .env || echo "CRYPTO_MODE=core" >> .env
+```
+
+The frontend is static and served by nginx (frontend upstream), not by the
+relay - there is no SERVE_FRONTEND/FRONTEND_ROOT to set. `git pull` already
+updated the frontend assets.
+
+### Step 4: Recreate services + wait for health
+
+```bash
+cd /home/paramant/app
+
+# Backend first
+docker compose up -d --no-deps relay-main
+
+# Wait for health (relay-main is on 127.0.0.1:3000)
+for i in $(seq 1 30); do
+  if curl -fs --max-time 3 http://127.0.0.1:3000/health >/dev/null; then
+    echo "relay-main healthy"; break
+  fi
+  sleep 2
+done
+
+# Then the sector relays + admin
+docker compose up -d --no-deps relay-health relay-finance relay-legal relay-iot admin
+
+# If nginx config changed (it usually does not for this deploy):
+# sudo nginx -t && sudo systemctl reload nginx
+```
+
+### Step 5: Smoke test
+
+From your laptop (or on the server). On the server, pass the local relay URL as
+the 2nd arg so the deep-health check runs too:
+
+```bash
+# From laptop (public only):
+bash scripts/post-deploy-verify.sh https://paramant.app
+
+# On the server (adds /health/deep):
+bash scripts/post-deploy-verify.sh https://paramant.app http://127.0.0.1:3000
+```
+
+Exit codes:
+
+- `0` = all green
+- `1` = non-critical failures (investigate, no rollback)
+- `2` = CRITICAL failure (health/version/capabilities) -> consider rollback
+
+A markdown report is written to `/tmp/deploy-verify-<epoch>.md`.
+
+### Step 6: Monitor ~30 minutes
+
+```bash
+# Tail relay logs
+docker compose logs -f --tail=200 relay-main
+
+# Spot-check the relay audit chain (admin token from .env)
+curl -s -H "X-Admin-Token: $ADMIN_TOKEN" http://127.0.0.1:3000/v2/audit \
+  | jq '.events[0:10]' 2>/dev/null
+```
+
+Watch for: 5xx spikes (code), 4xx spikes (config), memory growth (leak), or
+user reports.
+
+---
+
+## Rollback (if needed)
+
+Triggered by a CRITICAL smoke-test failure (exit 2) or clear breakage.
+
+```bash
+ssh root@116.203.86.81
+cd /home/paramant/app
+COMPOSE_DIR=/home/paramant/app bash scripts/rollback-3.0.0.sh
+```
+
+The script confirms (yes/no), restores the images tagged in Step 1's manifest,
+recreates the containers **without rebuilding** (so the new source is ignored),
+waits for `:3000/health`, and optionally restores `.env`.
+
+Manual fallback (single service):
+
+```bash
+# Find a saved rollback tag
+docker images | grep paramant-rollback
+# Restore it to the compose image name the container expects, then recreate
+IMG=$(docker inspect --format '{{.Config.Image}}' paramant-relay-main)
+docker tag paramant-rollback/relay-main:<TS> "$IMG"
+docker compose up -d --no-deps --force-recreate relay-main
+```
+
+---
+
+## Post-deploy checklist
+
+- [ ] Smoke test exits 0 (or only known non-critical failures understood).
+- [ ] 30-minute soak monitored, no error spikes.
+- [ ] Update `CHANGELOG.md` with the 3.0.0 live date.
+- [ ] Announce in community channels.
+- [ ] Close the deploy tracking issue.
+- [ ] Tag the release: `git tag v3.0.0 && git push origin v3.0.0`.

--- a/scripts/post-deploy-verify.sh
+++ b/scripts/post-deploy-verify.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Post-deploy smoke test suite for paramant 3.0.0.
+# Run AFTER the deploy completes. Exits 0 if all critical checks pass.
+#
+# Usage:
+#   scripts/post-deploy-verify.sh [SITE_URL] [RELAY_LOCAL_URL]
+#     SITE_URL         public base, default https://paramant.app
+#     RELAY_LOCAL_URL  optional; e.g. http://127.0.0.1:3000 when run ON the
+#                      server, used only for endpoints nginx does not expose
+#                      publicly (/health/deep). Omitted -> those checks SKIP.
+#
+# Requires: curl, jq. ASCII-only output.
+#
+# Routing reality (deploy/nginx-paramant-public.conf):
+#   paramant.app/health     -> relay-main:3000   (exact match only)
+#   paramant.app/v2/...      -> relay-main:3000   (/v2/admin is 404 publicly)
+#   paramant.app/admin/...   -> admin:4200
+#   paramant.app/.well-known -> static files
+#   paramant.app/  /setup /dashboard /docs -> frontend upstream
+#   /health/deep is NOT publicly routed -> use RELAY_LOCAL_URL on the server.
+
+set -uo pipefail
+
+SITE="${1:-https://paramant.app}"
+RELAY_LOCAL="${2:-}"
+REPORT="/tmp/deploy-verify-$(date +%s).md"
+PASS=0
+FAIL=0
+SKIP=0
+CRITICAL=0
+
+CURL="curl -sS --max-time 15"
+
+note() { echo "$1" | tee -a "$REPORT"; }
+
+# check NAME EXPECTED ACTUAL [critical=yes|no]
+check() {
+  local name="$1" expected="$2" actual="$3" critical="${4:-no}"
+  if [ "$expected" = "$actual" ]; then
+    note "PASS: $name ($actual)"
+    PASS=$((PASS+1))
+  else
+    note "FAIL: $name (expected '$expected', got '$actual')"
+    FAIL=$((FAIL+1))
+    [ "$critical" = "yes" ] && CRITICAL=$((CRITICAL+1))
+  fi
+}
+
+# contains NAME HAYSTACK NEEDLE [critical=yes|no]
+contains() {
+  local name="$1" hay="$2" needle="$3" critical="${4:-no}"
+  if printf '%s' "$hay" | grep -q "$needle"; then
+    note "PASS: $name (found '$needle')"
+    PASS=$((PASS+1))
+  else
+    note "FAIL: $name (missing '$needle')"
+    FAIL=$((FAIL+1))
+    [ "$critical" = "yes" ] && CRITICAL=$((CRITICAL+1))
+  fi
+}
+
+skip() { note "SKIP: $1"; SKIP=$((SKIP+1)); }
+
+http_code() {
+  local code
+  code=$($CURL -o /dev/null -w "%{http_code}" "$1" 2>/dev/null)
+  echo "${code:-000}"
+}
+
+{
+  echo "# Post-deploy verify - $(date -Iseconds)"
+  echo "Site: $SITE"
+  echo "Relay-local: ${RELAY_LOCAL:-<not provided>}"
+  echo ""
+} > "$REPORT"
+
+note "== CRITICAL: relay /health =="
+HEALTH_JSON=$($CURL "$SITE/health" 2>/dev/null)
+HEALTH_VER=$(printf '%s' "$HEALTH_JSON" | jq -r '.version // empty' 2>/dev/null)
+check "/health HTTP" "200" "$(http_code "$SITE/health")" yes
+check "/health version" "3.0.0" "$HEALTH_VER" yes
+
+note ""
+note "== CRITICAL: /v2/capabilities (R006 core = 1 KEM) =="
+CAPS=$($CURL "$SITE/v2/capabilities" 2>/dev/null)
+KEMS=$(printf '%s' "$CAPS" | jq -r '.kem | length' 2>/dev/null)
+KEM0=$(printf '%s' "$CAPS" | jq -r '.kem[0].name // empty' 2>/dev/null)
+SIGS=$(printf '%s' "$CAPS" | jq -r '.sig | length' 2>/dev/null)
+check "/v2/capabilities KEM count" "1" "$KEMS" yes
+check "/v2/capabilities KEM[0] name" "ML-KEM-768" "$KEM0" no
+check "/v2/capabilities sig count (none + ML-DSA-65)" "2" "$SIGS" no
+
+note ""
+note "== relay deep health (server-local only) =="
+if [ -n "$RELAY_LOCAL" ]; then
+  check "/health/deep HTTP" "200" "$(http_code "$RELAY_LOCAL/health/deep")" no
+else
+  skip "/health/deep (no RELAY_LOCAL_URL given; run on server with http://127.0.0.1:3000)"
+fi
+
+note ""
+note "== frontend pages =="
+check "/setup reachable" "200" "$(http_code "$SITE/setup")" no
+check "/docs reachable"  "200" "$(http_code "$SITE/docs")" no
+DASH=$($CURL -L "$SITE/dashboard" 2>/dev/null)
+contains "/dashboard renders cards" "$DASH" "cards-grid" no
+HOME=$($CURL -L "$SITE/" 2>/dev/null)
+contains "homepage advertises PQC" "$HOME" "ML-KEM" no
+
+note ""
+note "== admin pages =="
+check "/admin/settings.html reachable" "200" "$(http_code "$SITE/admin/settings.html")" no
+check "/admin/cli.html reachable"      "200" "$(http_code "$SITE/admin/cli.html")" no
+
+note ""
+note "== well-known / hygiene =="
+PGP=$($CURL "$SITE/.well-known/openpgp-key.asc" 2>/dev/null)
+if printf '%s' "$PGP" | grep -q "PLACEHOLDER"; then
+  note "FAIL: PGP placeholder still live"
+  FAIL=$((FAIL+1))
+else
+  note "PASS: PGP no placeholder"
+  PASS=$((PASS+1))
+fi
+
+{
+  echo ""
+  echo "## Summary"
+  echo "- PASS: $PASS"
+  echo "- FAIL: $FAIL"
+  echo "- SKIP: $SKIP"
+  echo "- CRITICAL FAIL: $CRITICAL"
+} >> "$REPORT"
+
+echo ""
+echo "Report written to: $REPORT"
+echo "------------------------------------------------------------"
+echo "PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP  CRITICAL=$CRITICAL"
+
+if [ "$CRITICAL" -gt 0 ]; then
+  echo ""
+  echo "CRITICAL FAILURES DETECTED - CONSIDER ROLLBACK (scripts/rollback-3.0.0.sh)"
+  exit 2
+elif [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Non-critical failures - investigate but no rollback needed"
+  exit 1
+else
+  echo ""
+  echo "ALL CHECKS PASSED"
+  exit 0
+fi

--- a/scripts/rollback-3.0.0.sh
+++ b/scripts/rollback-3.0.0.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Emergency rollback for the paramant 3.0.0 deploy.
+# Run ONLY after a failed deploy + a CRITICAL FAIL signal from
+# scripts/post-deploy-verify.sh. Mick runs this manually (with sudo if the
+# docker socket needs it).
+#
+# MODEL: relays are built from source (docker-compose `build: ./relay`); there
+# is no registry image to re-pull. So rollback restores the PREVIOUS LOCALLY
+# BUILT images that the pre-deploy backup step tagged, then recreates the
+# containers from those images WITHOUT rebuilding. It does NOT touch git.
+#
+# It relies on a manifest written by the backup step (see RUNBOOK Step 1):
+#   /home/paramant/backups/rollback-images-latest.txt
+# with lines:  <service>|<compose-image-name>|<rollback-tag>
+#
+# Env overrides:
+#   COMPOSE_DIR   directory containing docker-compose.yml (default /home/paramant/app)
+#   MANIFEST      explicit manifest path (default: newest rollback-images-*.txt)
+#   BACKUP_DIR    where backups/manifests live (default /home/paramant/backups)
+
+set -uo pipefail
+
+COMPOSE_DIR="${COMPOSE_DIR:-/home/paramant/app}"
+BACKUP_DIR="${BACKUP_DIR:-/home/paramant/backups}"
+HEALTH_URL="${HEALTH_URL:-http://127.0.0.1:3000/health}"
+
+echo "PARAMANT 3.0.0 ROLLBACK"
+echo "======================="
+echo "Compose dir: $COMPOSE_DIR"
+echo ""
+echo "This restores the previously-built relay/admin images (last good deploy)"
+echo "and recreates the containers. It does NOT revert git or rebuild."
+echo ""
+read -r -p "Confirm rollback (yes/no): " confirm
+[ "$confirm" = "yes" ] || { echo "Aborted."; exit 1; }
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker not found."
+  exit 1
+fi
+
+cd "$COMPOSE_DIR" 2>/dev/null || { echo "ERROR: cannot cd to $COMPOSE_DIR"; exit 1; }
+if [ ! -f docker-compose.yml ] && [ ! -f compose.yml ]; then
+  echo "ERROR: no docker-compose.yml in $COMPOSE_DIR"
+  exit 1
+fi
+
+# Locate the manifest produced by the backup step.
+MANIFEST="${MANIFEST:-}"
+if [ -z "$MANIFEST" ]; then
+  if [ -f "$BACKUP_DIR/rollback-images-latest.txt" ]; then
+    MANIFEST="$BACKUP_DIR/rollback-images-latest.txt"
+  else
+    MANIFEST=$(ls -t "$BACKUP_DIR"/rollback-images-*.txt 2>/dev/null | head -1)
+  fi
+fi
+
+if [ -z "$MANIFEST" ] || [ ! -f "$MANIFEST" ]; then
+  echo "ERROR: no rollback manifest found in $BACKUP_DIR."
+  echo "The pre-deploy backup step (RUNBOOK Step 1) did not run, or backups are gone."
+  echo "Manual rollback:"
+  echo "  docker images | grep paramant-rollback     # find a saved tag"
+  echo "  docker tag paramant-rollback/relay-main:<TS> <compose-image-name>"
+  echo "  docker compose up -d --no-deps --force-recreate relay-main"
+  exit 1
+fi
+
+echo "Using manifest: $MANIFEST"
+echo ""
+
+SERVICES=""
+RESTORED=0
+MISSING=0
+while IFS='|' read -r svc image rbtag; do
+  [ -z "${svc:-}" ] && continue
+  case "$svc" in \#*) continue;; esac
+  if ! docker image inspect "$rbtag" >/dev/null 2>&1; then
+    echo "  WARN: rollback image missing for $svc ($rbtag) - skipping"
+    MISSING=$((MISSING+1))
+    continue
+  fi
+  echo "  restoring $svc: $rbtag -> $image"
+  docker tag "$rbtag" "$image"
+  SERVICES="$SERVICES $svc"
+  RESTORED=$((RESTORED+1))
+done < "$MANIFEST"
+
+if [ "$RESTORED" -eq 0 ]; then
+  echo "ERROR: no rollback images could be restored. Aborting."
+  exit 1
+fi
+
+echo ""
+echo "Recreating services (no rebuild):$SERVICES"
+# --force-recreate picks up the retagged image; NO --build so source is ignored.
+# shellcheck disable=SC2086
+docker compose up -d --no-deps --force-recreate $SERVICES
+
+echo ""
+echo "Waiting for relay health at $HEALTH_URL ..."
+HEALTHY=no
+for _ in $(seq 1 30); do
+  if curl -fs --max-time 3 "$HEALTH_URL" >/dev/null 2>&1; then
+    echo "  relay healthy after rollback"
+    HEALTHY=yes
+    break
+  fi
+  sleep 2
+done
+[ "$HEALTHY" = "yes" ] || echo "  WARN: relay not healthy after 60s - check 'docker compose logs relay-main'"
+
+# Optional .env restore.
+LATEST_ENV=$(ls -t "$BACKUP_DIR"/.env-pre-* 2>/dev/null | head -1)
+if [ -n "${LATEST_ENV:-}" ]; then
+  echo ""
+  read -r -p "Restore .env from $LATEST_ENV ? (yes/no): " restore_env
+  if [ "$restore_env" = "yes" ]; then
+    cp "$LATEST_ENV" "$COMPOSE_DIR/.env"
+    echo "  .env restored; recreating relay-main to apply"
+    docker compose up -d --no-deps --force-recreate relay-main
+  fi
+fi
+
+echo ""
+echo "Rollback complete: restored=$RESTORED missing=$MISSING"
+echo "Re-run: scripts/post-deploy-verify.sh https://paramant.app"
+[ "$MISSING" -eq 0 ] && [ "$HEALTHY" = "yes" ] && exit 0 || exit 1


### PR DESCRIPTION
Tooling for the v3.0.0 deploy to 116.203.86.81. No code changes -- only
scripts and a runbook. All three are run manually by Mick (with sudo where the
docker socket needs it); nothing touches production automatically.

## Files
- **scripts/post-deploy-verify.sh** -- post-deploy smoke suite.
  - CRITICAL (exit 2 -> consider rollback): `/health` 200 + `version==3.0.0`,
    `/v2/capabilities` R006 core = 1 KEM.
  - Non-critical (exit 1): `/setup`, `/dashboard` (cards-grid), `/docs`,
    `/admin/settings.html`, `/admin/cli.html`, PGP placeholder, homepage PQC
    claim, capabilities KEM/sig names.
  - Optional server-local `/health/deep` via 2nd arg (not publicly routed).
  - Writes a markdown report to `/tmp/deploy-verify-<epoch>.md`.
- **docs/RUNBOOK-DEPLOY-3.0.0.md** -- step-by-step SSH procedure.
- **scripts/rollback-3.0.0.sh** -- confirm-gated emergency rollback.

## Accuracy notes (verified against the repo, not assumed)
- Relays are **built from source** (`build: ./relay`) -- there is **no**
  `mtty001/relay` registry image. So the runbook deploys with
  `git pull` + `docker compose build`, and **rollback restores the previously
  *built* local images** (tagged in the backup step), recreating containers
  without rebuild -- i.e. previous docker tag, NOT an earlier git commit, per
  the safety boundary.
- Real ports/services used: relay-main `:3000`, sectors `:3001-3004`,
  admin `:4200`. nginx routes `/health` + `/v2/` -> relay-main, `/admin/` ->
  admin, frontend pages -> frontend upstream.
- Corrected from the original sketch: health port is 3000 (not 1691); the deep
  endpoint is `/health/deep` (not `/v2/health/deep`); dropped the fictional
  `SERVE_FRONTEND`/`FRONTEND_ROOT` env (frontend is nginx-static);
  `/v2/capabilities` shape is `{wire_version, kem[], sig[]}` and core mode = 1
  KEM (ML-KEM-768) + 2 sig, which the suite asserts.
- The backup step writes a manifest (`rollback-images-latest.txt`) that the
  rollback script consumes.

## Verification done here
- `bash -n` on both scripts; ASCII-only confirmed.
- Smoke suite run against an unreachable target: correct PASS/FAIL/SKIP
  accounting and exit-code logic (critical fail -> exit 2).
- Rollback manifest-parsing loop tested with a synthetic manifest.
- Not run against live paramant.app or the server (that is Mick's to run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)