### PR TITLE
ops: webroot sync 3.0.0 (2026-05-27)

### DIFF
--- a/docs/audit-reports/webroot-sync-20260527-2320.md
+++ b/docs/audit-reports/webroot-sync-20260527-2320.md
@@ -1,0 +1,79 @@
+# Webroot sync — paramant.app → main (3.0.0)
+
+- **Datum:** 2026-05-27T23:23:00+02:00
+- **Host:** 116.203.86.81 (paramant-relay)
+- **Webroot:** `/home/paramant/app` (nginx `server_name paramant.app`, `root /home/paramant/app`)
+- **Bron:** `origin/main` @ `ffb04a8` (PR #63, deploy v3.0.0)
+- **Backup:** `/home/paramant/backups/webroot-pre-3.0.0-20260527-2320.tar.gz` (2.7 MB) — volledige rollback
+
+## Aanleiding
+
+Backend-deploy v3.0.0 was geslaagd; de nginx-served static frontend liep nog
+achter. Doel: webroot bijwerken naar `main`, nginx reloaden, smoke-test.
+
+## Afwijking van het oorspronkelijke plan (belangrijk)
+
+Het plan ging uit van een git-getrackte webroot (`git pull`) of een
+`rsync -av --delete frontend/ → webroot/`. Recon toonde dat beide aannames
+**productie zouden breken**:
+
+1. **`/home/paramant/app` is geen git-repo** → de `git pull`-tak triggert niet.
+2. **`frontend/dist/` is gitignored** (`.gitignore` r.12–13) en wordt door
+   `build.sh` gegenereerd. Een verse `git clone` bevat **geen `dist/`**. Een
+   `rsync --delete` zou de live `dist/` (10 assets: `sw.js` service-worker,
+   `noble-mlkem*` PQ-crypto-bundles, `nav.js`, `globe.gl`, `relay-status.js`,
+   `ct-stats.js`) volledig wissen → frontend kapot.
+3. **`terms.html`** bestaat live maar in géén enkele branch → zou permanent
+   verloren gaan.
+
+**Gekozen veilige variant:**
+`rsync -rlptDv --exclude='dist/' --chown=paramant:paramant frontend/ → webroot/`
+(zónder `--delete`). Dit overlayt alle main-updates, voegt ontbrekende
+bestanden toe, en behoudt `dist/`, `terms.html` en de bestaande backups.
+Bron = verse `git clone --branch main` (niet de gedeelde lokale checkout).
+
+Vooraf geverifieerd dat de overlay geen live-only hotfix terugdraait:
+`signup.html` gebruikt zowel live als in main `dpa_accepted`, en main is hier
+juist *vóór* (volledige DPA-accept-checkbox + `/dpa`-links + validatie).
+
+## Resultaat sync
+
+- 92 bestanden gewijzigd/toegevoegd; 3 nieuw: `setup.html`, `setup.js`,
+  `all-systems-go.html` (M11 setup-wizard).
+- Nieuwe submappen mee uit main: `pkg/` (WASM-crypto), `js/`, `images/`,
+  `vendor/`, `security/`, `signup/`.
+- `dist/` (10 files) en `terms.html` behouden.
+- `nginx -t` ok → `systemctl reload nginx` ok.
+
+## Smoke-test
+
+Endpoint-codes:
+
+```
+/                              200
+/setup                         200   (<title>Paramant - First-time setup</title>)
+/setup.js                      200
+/all-systems-go                200
+/docs                          200   (versie: 3.0.0)
+/dpa                           200
+/signup                        200
+/dist/sw.js                    200   (behouden)
+/pkg/paramant_crypto_bg.wasm   200
+/terms                         200   (behouden)
+```
+
+`scripts/post-deploy-verify.sh https://paramant.app` → **PASS=11 FAIL=1 SKIP=1 CRITICAL=0**
+
+- Alle kritieke checks PASS: `/health` 3.0.0, `/v2/capabilities` R006-core
+  (1× ML-KEM-768, 2 sigs), PGP geen placeholder, admin-pagina's bereikbaar.
+- Enige FAIL: `/dashboard missing 'cards-grid'` — **niet-kritiek en geen
+  regressie**: de cards-feature zit op `feat/dashboard-cards` (PR #39, nog
+  niet in main). Matcht de bestaande "LIVE_WITH_NON_CRITICAL_ISSUES"-status
+  van main (PR #63).
+
+## Rollback
+
+```
+ssh root@116.203.86.81 \
+  'cd /home/paramant && tar -xzf backups/webroot-pre-3.0.0-20260527-2320.tar.gz'
+```


### PR DESCRIPTION
Sync van `/home/paramant/app` (nginx root voor paramant.app) uit `main` na de v3.0.0 backend-deploy.

## Afwijking van het plan
De geplande `rsync --delete` zou productie hebben gebroken:
- `/home/paramant/app` is **geen git-repo** (git-pull-tak triggert niet)
- `frontend/dist/` is **gitignored** (build-output van `build.sh`) → een verse clone heeft geen `dist/`; `--delete` zou de live `sw.js` + `noble-mlkem*` PQ-crypto-bundles wissen
- `terms.html` bestaat live maar in **geen branch** → zou verdwijnen

**Gekozen:** non-destructieve overlay (`rsync` zonder `--delete`, `dist/` excluded), bron = verse `git clone --branch main`. `dist/` + `terms.html` behouden.

## Resultaat
- Backup: `/home/paramant/backups/webroot-pre-3.0.0-20260527-2320.tar.gz`
- 92 files gewijzigd/toegevoegd; 3 nieuw (setup-wizard: `setup.html`, `setup.js`, `all-systems-go.html`)
- `nginx -t` ok → reload ok
- Smoke: **PASS=11 FAIL=1 SKIP=1 CRITICAL=0** — enige FAIL (`/dashboard` cards-grid) is niet-kritiek en geen regressie (cards zitten in onmerged PR #39)
- `/docs` toont nu 3.0.0

Rapport: `docs/audit-reports/webroot-sync-20260527-2320.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)