### PR TITLE
feat(site): /trust customer-transparency page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   R005 (web onboarding wizard) en R007 (add-on architecture) als
   coming-soon vermeld. Versie-nummers bewust ongemoeid (intern 3.0.0 vs
   marketing build 2.5.0).
+- New customer-facing `/trust` page (`frontend/trust.html`): plain-language
+  transparency on how license-check works, what Paramant can and cannot see
+  of a relay, how to verify a deployment (source / image / planned signed
+  releases / CT log), and which remote actions are possible versus
+  structurally impossible. Every claim tagged Live or Planned; planned items
+  link to the public protocol ADRs (R013 licensing, R014 management plane,
+  R015 releases, R016 open-core). Linked from the About nav and footer on all
+  pages, plus cross-refs from `/docs` and `/security`.
 
 ### Repository
 - `scripts/` in `paramant-relay` is now the single source of truth for all CLI tools — previously split between this repo and `ParamantOS/nixos/scripts/`

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -99,6 +99,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -180,6 +181,7 @@
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -217,6 +219,7 @@
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -157,6 +157,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -238,6 +239,7 @@
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/anti-phishing.html
+++ b/frontend/anti-phishing.html
@@ -158,6 +158,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -239,6 +240,7 @@ section p+p{margin-top:14px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -386,6 +388,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -293,6 +293,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -374,6 +375,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -834,6 +836,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -150,6 +150,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -231,6 +232,7 @@ section p+p{margin-top:14px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -317,6 +319,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -194,6 +194,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -275,6 +276,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -390,6 +392,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -125,6 +125,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -206,6 +207,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -356,6 +358,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -224,6 +224,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -305,6 +306,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -642,6 +644,7 @@ FLAGS    1 byte    reserved for future features</pre>
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -286,6 +286,7 @@ body { min-height:100vh; }
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -367,6 +368,7 @@ body { min-height:100vh; }
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -745,6 +747,7 @@ setInterval(load, 30000);
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -193,6 +193,7 @@ a:hover{color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
         <li role="none"><a href="/press" role="menuitem">Press kit</a></li>
@@ -274,6 +275,7 @@ a:hover{color:var(--cobalt)}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -238,6 +238,7 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -319,6 +320,7 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -595,6 +597,7 @@ paramant-receiver.py \
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -224,6 +224,7 @@ tr:last-child td{border-bottom:none}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -305,6 +306,7 @@ tr:last-child td{border-bottom:none}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -362,6 +364,7 @@ tr:last-child td{border-bottom:none}
     <h3>Security</h3>
     <a href="#threat-model">Threat model</a>
     <a href="#audits">Security audits</a>
+    <a href="/trust">Trust &amp; transparency</a>
     <h3>Compliance</h3>
     <a href="#compliance-nis2">NIS2 / DORA</a>
     <a href="#compliance-nen7510">NEN 7510</a>
@@ -1000,6 +1003,7 @@ window.addEventListener('scroll', () => {
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -161,6 +161,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -242,6 +243,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -201,6 +201,7 @@ input:focus{border-color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -282,6 +283,7 @@ input:focus{border-color:var(--cobalt)}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -443,6 +445,7 @@ input:focus{border-color:var(--cobalt)}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/drop.html
+++ b/frontend/drop.html
@@ -267,6 +267,7 @@ select{background:var(--bone);border:1px solid var(--ink-hair);color:var(--ink);
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -348,6 +349,7 @@ select{background:var(--bone);border:1px solid var(--ink-hair);color:var(--ink);
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -639,6 +641,7 @@ select{background:var(--bone);border:1px solid var(--ink-hair);color:var(--ink);
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -202,6 +202,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -283,6 +284,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -367,6 +369,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -250,6 +250,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -331,6 +332,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -605,6 +607,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -150,6 +150,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -231,6 +232,7 @@ section p+p{margin-top:14px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -320,6 +322,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -209,6 +209,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -290,6 +291,7 @@ section p+p{margin-top:14px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -506,6 +508,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -289,6 +289,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -370,6 +371,7 @@
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -744,6 +746,7 @@
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -150,6 +150,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -231,6 +232,7 @@ section p+p{margin-top:14px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -307,6 +309,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/legal.html
+++ b/frontend/legal.html
@@ -226,6 +226,7 @@ body {
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -307,6 +308,7 @@ body {
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -181,6 +181,7 @@ footer a{color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -262,6 +263,7 @@ footer a{color:var(--cobalt)}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -354,6 +356,7 @@ Website: https://paramant.app</div>
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -150,6 +150,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -231,6 +232,7 @@ section p+p{margin-top:14px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -308,6 +310,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/one-pager.html
+++ b/frontend/one-pager.html
@@ -562,6 +562,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -643,6 +644,7 @@
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -991,6 +993,7 @@
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -192,6 +192,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -273,6 +274,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -378,6 +380,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/ot-vs-data-diodes.html
+++ b/frontend/ot-vs-data-diodes.html
@@ -163,6 +163,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -244,6 +245,7 @@
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -596,6 +598,7 @@
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -223,6 +223,7 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -304,6 +305,7 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -513,6 +515,7 @@ Level 1  Field devices  ──────────────────�
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -300,6 +300,7 @@ select:focus{border-color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -381,6 +382,7 @@ select:focus{border-color:var(--cobalt)}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -143,6 +143,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -224,6 +225,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -289,6 +291,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -205,6 +205,7 @@ td{color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -286,6 +287,7 @@ td{color:var(--cobalt)}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -409,6 +411,7 @@ td{color:var(--cobalt)}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -190,6 +190,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -271,6 +272,7 @@
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -466,6 +468,7 @@
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -190,6 +190,7 @@ footer a{color:var(--ink);text-decoration:none}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -271,6 +272,7 @@ footer a{color:var(--ink);text-decoration:none}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -366,6 +368,7 @@ footer a{color:var(--ink);text-decoration:none}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/quantum-urgency.html
+++ b/frontend/quantum-urgency.html
@@ -163,6 +163,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -244,6 +245,7 @@
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -467,6 +469,7 @@
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -149,6 +149,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -230,6 +231,7 @@
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -284,6 +286,7 @@
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -213,6 +213,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -294,6 +295,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -521,6 +523,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </table>
   <p style="margin-top:12px"><a href="https://github.com/Apolloccrypt/ParamantOS" target="_blank">ParamantOS on GitHub &rarr;</a></p>
 
+  <h2 id="customer-transparency">Customer transparency</h2>
+  <p>Security is also about knowing what the vendor can and cannot do. The <a href="/trust">Trust &amp; Transparency page</a> documents, in plain terms, how license-check works, what Paramant can see of your relay (and what it never can), how to verify your deployment, and which remote actions are possible versus structurally impossible. Each claim there is tagged as live today or planned, with links to the public protocol specifications.</p>
+
 </main>
 
 <footer>
@@ -536,6 +541,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/send.html
+++ b/frontend/send.html
@@ -199,6 +199,7 @@ select#ttl-select:focus{border-color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -280,6 +281,7 @@ select#ttl-select:focus{border-color:var(--cobalt)}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -534,6 +536,7 @@ select#ttl-select:focus{border-color:var(--cobalt)}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -174,6 +174,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -255,6 +256,7 @@
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -200,6 +200,7 @@ a:hover{opacity:.8}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -281,6 +282,7 @@ a:hover{opacity:.8}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -437,6 +439,7 @@ a:hover{opacity:.8}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -164,6 +164,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -245,6 +246,7 @@
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -571,6 +573,7 @@
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -157,6 +157,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -238,6 +239,7 @@ section p+p{margin-top:14px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -421,6 +423,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -213,6 +213,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -294,6 +295,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -337,6 +339,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -1,0 +1,541 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Trust &amp; Transparency — PARAMANT</title>
+<meta name="description" content="How Paramant works with your relay: how license-check is specified, what we can see, how to verify your deployment, and what we can and cannot do remotely. Open-core, customer-verifiable.">
+<meta property="og:title" content="Trust &amp; Transparency — PARAMANT">
+<meta property="og:description" content="How Paramant works with your relay: how license-check is specified, what we can see, how to verify your deployment, and what we can and cannot do remotely. Open-core, customer-verifiable.">
+<meta property="og:url" content="https://paramant.app/trust">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Trust &amp; Transparency — PARAMANT">
+<meta name="twitter:description" content="How Paramant works with your relay: how license-check is specified, what we can see, how to verify your deployment, and what we can and cannot do remotely. Open-core, customer-verifiable.">
+<link rel="canonical" href="https://paramant.app/trust">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="manifest" href="/manifest.json">
+<meta name="theme-color" content="#0B3A6A">
+
+<link rel="stylesheet" href="/design-system.css?v=19">
+<link rel="stylesheet" href="/nav.css?v=13">
+  <style>
+*{box-sizing:border-box;margin:0;padding:0}
+html{scroll-behavior:smooth}
+.page-hero--navy{background:var(--navy);border-color:transparent}
+.page-hero--navy .eyebrow{background:var(--lime);color:var(--navy)}
+.page-hero--navy h1{color:var(--bone)}
+.page-hero--navy .lede{color:rgba(248,250,252,.8)}
+main{max-width:780px;margin:0 auto;padding:48px 48px 120px}
+h1{font-size:36px;font-weight:600;letter-spacing:-.03em;margin-bottom:12px}
+.lead{font-size:var(--text-base);color:var(--ink-dim);line-height:1.7;margin-bottom:48px;max-width:580px}
+h2{font-size:18px;font-weight:600;letter-spacing:-.01em;margin-bottom:12px;margin-top:56px}
+h3{font-size:var(--text-xs);font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:16px;margin-top:40px}
+p{color:var(--ink-dim);line-height:1.8;margin-bottom:16px;font-size:var(--text-base)}
+p strong{color:var(--cobalt)}
+a{color:var(--ink);text-decoration:none}
+a:hover{opacity:.7}
+em{color:var(--cobalt)}
+.card{border:1px solid var(--ink-hair);padding:24px 28px;margin-bottom:16px}
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.stat-n{font-size:32px;font-weight:600;color:var(--ink);margin-bottom:4px}
+.stat-l{font-size:var(--text-xs);color:var(--ink-dim);letter-spacing:.04em}
+.check{color:var(--ink);margin-right:8px}
+.table{width:100%;border-collapse:collapse}
+.table th{text-align:left;padding:10px 14px;color:var(--ink-dim);font-weight:500;font-size:var(--text-xs);text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--ink-hair)}
+.table td{padding:10px 14px;color:var(--ink-dim);border-bottom:1px solid var(--ink-ghost);vertical-align:top;font-size:var(--text-sm)}
+.table td:first-child{color:var(--ink);white-space:nowrap}
+.table tr:last-child td{border-bottom:none}
+.divider{border:none;border-top:1px solid var(--ink-hair);margin:56px 0}
+.timeline-item{display:flex;gap:20px;margin-bottom:24px}
+.timeline-dot{width:8px;height:8px;background:var(--lime);margin-top:7px;flex-shrink:0}
+.timeline-date{font-size:var(--text-xs);color:var(--ink-dim);min-width:90px;padding-top:2px}
+.timeline-content{flex:1}
+.timeline-title{font-size:var(--text-base);color:var(--ink);margin-bottom:2px}
+.timeline-desc{font-size:var(--text-sm);color:var(--ink-dim)}
+footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:16px}
+.footer-links{display:flex;gap:20px;flex-wrap:wrap}
+.footer-links a{font-size:var(--text-xs);color:var(--cobalt)}
+.footer-meta{font-size:var(--text-xs);color:var(--ink-dim)}
+.see-also{font-size:var(--text-sm);color:var(--ink-dim);margin-top:8px}
+.see-also a{text-decoration:underline;text-decoration-color:var(--ink-hair)}
+ul{margin:0 0 16px 0;padding-left:20px}
+li{color:var(--ink-dim);line-height:1.8;font-size:var(--text-base);margin-bottom:4px}
+dl{margin:0 0 16px 0}
+dt{color:var(--ink);font-weight:600;font-size:var(--text-sm);margin-top:16px}
+dd{color:var(--ink-dim);line-height:1.75;font-size:var(--text-sm);margin:4px 0 0 0;padding-left:0}
+pre{background:var(--ink-ghost);border:1px solid var(--ink-hair);padding:16px 18px;overflow-x:auto;font-size:var(--text-sm);line-height:1.6;margin-bottom:16px}
+pre code{font-family:var(--mono);color:var(--ink)}
+code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
+.badge{display:inline-block;font-size:11px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;padding:2px 8px;border:1px solid var(--ink-hair);vertical-align:middle;margin-left:8px}
+.badge-live{color:var(--cobalt);border-color:var(--cobalt)}
+.badge-planned{color:var(--ink-dim);border-color:var(--ink-hair)}
+.note{border-left:3px solid var(--ink-hair);padding:4px 0 4px 16px;margin:0 0 16px;font-size:var(--text-sm);color:var(--ink-dim);line-height:1.75}
+.note--planned{border-left-color:var(--ink-dim)}
+@media(max-width:640px){
+  main{padding:48px 20px 80px}
+  h1{font-size:26px}
+  .grid2{grid-template-columns:1fr}
+  footer{padding:32px 20px;flex-direction:column}
+}
+</style>
+<style>
+.nav-help {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  font-family: IBM Plex Mono, monospace;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: #475569;
+  text-decoration: none;
+  border: 1px solid #E2E8F0;
+  transition: all 140ms ease;
+  margin-right: 12px;
+}
+.nav-help::before {
+  content: "?";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: 1.5px solid #64748b;
+  border-radius: 50%;
+  font-size: 11px;
+  font-weight: 700;
+  color: #64748b;
+  font-family: Inter, sans-serif;
+  line-height: 1;
+}
+.nav-help:hover {
+  color: #0B3A6A;
+  border-color: #B2FF3F;
+  background: rgba(178, 255, 63, 0.08);
+}
+.nav-help:hover::before {
+  border-color: #0B3A6A;
+  color: #0B3A6A;
+  background: #B2FF3F;
+}
+.nav-help:focus-visible {
+  outline: 2px solid #B2FF3F;
+  outline-offset: 2px;
+}
+.nav-help-mobile {
+  display: block;
+  padding: 12px 20px;
+  font-family: IBM Plex Mono, monospace;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  color: #475569;
+  text-decoration: none;
+  border-bottom: 1px solid #e2e8f0;
+}
+.nav-help-mobile:hover {
+  color: #0B3A6A;
+  background: rgba(178, 255, 63, 0.08);
+}
+@media (max-width: 900px) {
+  .nav-help { display: none; }
+}
+</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+
+<div class="meta-bar">
+  <span class="">build 2.5.0</span>
+  <span class="sep">·</span>
+  <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
+  <span class="sep">·</span>
+  <span class="">eu/de · ram only</span>
+</div>
+<nav class="nav">
+  <a href="/" class="nav-logo"><span class="logo-para">Para</span><span class="logo-mant">MANT</span></a>
+
+  <ul class="nav-links">
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
+        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
+        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
+      </ul>
+    </li>
+
+    <li><a href="/pricing" class="nav-link">Pricing</a></li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Developers</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/docs" role="menuitem">Docs</a></li>
+        <li role="none"><a href="/docs#api" role="menuitem">API reference</a></li>
+        <li role="none"><a href="/ct-log" role="menuitem">CT Log</a></li>
+        <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay" role="menuitem">GitHub</a></li>
+        <li role="none"><a href="https://hub.docker.com/r/mtty001/relay" role="menuitem">Docker Hub</a></li>
+        <li role="none"><a href="/changelog" role="menuitem">Changelog</a></li>
+      </ul>
+    </li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
+        <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
+        <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
+        <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
+        <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
+        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
+        <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
+      </ul>
+    </li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Compliance</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li class="nav-subheader" role="presentation">Standards</li>
+        <li role="none"><a href="/compliance/nis2" role="menuitem">NIS2 (EU 2022/2555)</a></li>
+        <li role="none"><a href="/compliance/iec62443" role="menuitem">IEC 62443 (Industrial IoT)</a></li>
+        <li role="none"><a href="/compliance/nen7510" role="menuitem">NEN 7510 (Dutch Healthcare)</a></li>
+        <li class="nav-subheader" role="presentation">Sovereignty</li>
+        <li role="none"><a href="/sovereignty" role="menuitem">Jurisdiction</a></li>
+        <li role="none"><a href="/government" role="menuitem">Government &amp; public sector</a></li>
+        <li class="nav-subheader" role="presentation">OT</li>
+        <li role="none"><a href="/ot" role="menuitem">OT guide</a></li>
+        <li role="none"><a href="/ot-vs-data-diodes" role="menuitem">OT vs data diodes</a></li>
+        <li class="nav-subheader" role="presentation">Post-quantum</li>
+        <li role="none"><a href="/hndl" role="menuitem">HNDL threat</a></li>
+        <li role="none"><a href="/quantum-urgency" role="menuitem">Quantum urgency</a></li>
+        <li role="none"><a href="/crypto-agility" role="menuitem">Crypto agility</a></li>
+        <li class="nav-subheader" role="presentation">Legal</li>
+        <li role="none"><a href="/dpa" role="menuitem">Data Processing Agreement</a></li>
+      </ul>
+    </li>
+
+    <li><a href="/vs" class="nav-link">Compare</a></li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">About</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/status" role="menuitem">Status</a></li>
+        <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
+        <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
+        <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
+        <li role="none"><a href="/license" role="menuitem">License</a></li>
+        <li role="none"><a href="/press" role="menuitem">Press kit</a></li>
+        <li role="none"><a href="mailto:privacy@paramant.app" role="menuitem">Contact</a></li>
+      </ul>
+    </li>
+
+  </ul>
+
+  <div class="nav-auth" id="nav-auth">
+    <a href="/auth/login" class="nav-signin">Sign in</a>
+    <a href="/signup" class="nav-cta">Create account</a>
+  </div>
+
+  <button class="nav-hamburger" id="nav-hamburger" aria-label="Open menu" aria-expanded="false">
+    <span></span><span></span><span></span>
+  </button>
+</nav>
+<div class="nav-mobile" id="nav-mobile">
+  <div class="nav-mobile-group">
+    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
+    <div class="nav-mobile-group-items">
+      <a href="/send">Send a file</a>
+      <a href="/parashare">ParaShare</a>
+      <a href="/drop">ParaDrop</a>
+      <a href="/dashboard">Dashboard</a>
+    </div>
+  </div>
+
+  <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
+
+  <div class="nav-mobile-group">
+    <button class="nav-mobile-group-btn" aria-expanded="false">Developers</button>
+    <div class="nav-mobile-group-items">
+      <a href="/docs">Docs</a>
+      <a href="/docs#api">API reference</a>
+      <a href="/ct-log">CT Log</a>
+      <a href="https://github.com/Apolloccrypt/paramant-relay">GitHub</a>
+      <a href="https://hub.docker.com/r/mtty001/relay">Docker Hub</a>
+      <a href="/changelog">Changelog</a>
+    </div>
+  </div>
+
+  <div class="nav-mobile-group">
+    <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
+    <div class="nav-mobile-group-items">
+      <a href="/docs#self-hosting">Deploy guide</a>
+      <a href="/install.sh">install.sh</a>
+      <a href="/install-pi.sh">install-pi.sh</a>
+      <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
+      <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
+      <a href="/download">ParamantOS</a>
+      <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
+    </div>
+  </div>
+
+  <div class="nav-mobile-group">
+    <button class="nav-mobile-group-btn" aria-expanded="false">Compliance</button>
+    <div class="nav-mobile-group-items">
+      <a href="/compliance/nis2">NIS2 (EU 2022/2555)</a>
+      <a href="/compliance/iec62443">IEC 62443 (Industrial IoT)</a>
+      <a href="/compliance/nen7510">NEN 7510 (Dutch Healthcare)</a>
+      <a href="/sovereignty">Jurisdiction</a>
+      <a href="/government">Government &amp; public sector</a>
+      <a href="/ot">OT guide</a>
+      <a href="/ot-vs-data-diodes">OT vs data diodes</a>
+      <a href="/hndl">HNDL threat</a>
+      <a href="/quantum-urgency">Quantum urgency</a>
+      <a href="/crypto-agility">Crypto agility</a>
+      <a href="/dpa">Data Processing Agreement</a>
+    </div>
+  </div>
+
+  <a href="/vs" class="nav-mobile-standalone">Compare</a>
+
+  <div class="nav-mobile-group">
+    <button class="nav-mobile-group-btn" aria-expanded="false">About</button>
+    <div class="nav-mobile-group-items">
+      <a href="/status">Status</a>
+      <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
+      <a href="/sla">SLA</a>
+      <a href="/partners">Partners</a>
+      <a href="/license">License</a>
+      <a href="/press">Press kit</a>
+      <a href="mailto:privacy@paramant.app">Contact</a>
+    </div>
+  </div>
+
+  <a href="/help" class="nav-mobile-standalone">Help</a>
+</div>
+<section class="page-hero page-hero--navy">
+<div class="page-hero-inner">
+  <span class="eyebrow">TRANSPARENCY</span>
+  <h1>Trust &amp; Verification</h1>
+  <p class="lede">How Paramant works with your relay. What we can see, what we can do, and how you verify both — without taking our word for it.</p>
+</div>
+</section>
+
+<main id="main-content">
+
+  <h3>How to read this page</h3>
+  <div class="card">
+    <p style="margin:0 0 12px;line-height:1.8">Paramant is moving from a single self-hosted binary to an open-core product: the relay stays open and runs entirely on your server, while Paramant operates a central licensing and management plane. That transition is partly live and partly still on paper.</p>
+    <p style="margin:0;line-height:1.8">So every claim below is tagged. <span class="badge badge-live">Live</span> means it works today on the public relay. <span class="badge badge-planned">Planned</span> means it is specified in a public design document (an ADR) but not yet implemented — we mark it so you are never told a capability exists before it does.</p>
+  </div>
+
+  <!-- ───────────────────── License-check ───────────────────── -->
+  <h2 id="license-check">How license-check works</h2>
+
+  <p><strong>Today <span class="badge badge-live">Live</span></strong> the relay's entitlement is an <em>offline</em> license. Your <code>PLK_KEY</code> is a license token signed by Paramant (Ed25519) that the relay verifies locally against an embedded public key. It carries a user cap, an expiry and who it was issued to. The relay does <strong>not</strong> phone home to validate it: with no key, or an expired one, the relay simply runs as Community Edition (5 users). Nothing leaves your server to check a license.</p>
+
+  <p><strong>Planned <span class="badge badge-planned">Planned</span></strong> to sell tiers with capabilities beyond a user-count, the design adds an <em>online</em> license-check. Under that model your relay calls a Paramant licensing endpoint at startup and every 6 hours. The request carries your license-key, a relay-identity (the fingerprint of the ML-DSA-65 public key your relay generates on first boot), the relay version, and a telemetry block that is off by default.</p>
+
+  <p>The response is a <strong>signed capability-set</strong> — which features your tier unlocks — valid for a few hours. Your relay verifies the ML-DSA-65 signature against an embedded Paramant licensing key; an unsigned or invalid response is rejected. If the licensing endpoint is unreachable, the relay keeps using its last cached capability-set for up to 7 days, then degrades to Community mode. There are no surprise lockouts: an outage on our side cannot instantly disable your relay.</p>
+
+  <p class="see-also">Full wire-protocol specification: ADR R013 (Draft) in the public <a href="https://github.com/Apolloccrypt/paramant-relay/tree/main/docs/adrs">ADR directory</a>.</p>
+
+  <!-- ───────────────────── What we see ───────────────────── -->
+  <h2 id="what-we-see">What Paramant sees of your relay</h2>
+
+  <p>With today's offline license, the answer is simple: <strong>nothing at runtime</strong> — the relay makes no licensing call. The breakdown below describes the <span class="badge badge-planned">Planned</span> online model, so you can judge it before it ships.</p>
+
+  <h3>Always (each check-in)</h3>
+  <ul>
+    <li>Your license-key — how we identify your subscription</li>
+    <li>Your relay's identity fingerprint (ML-DSA-65 public-key hash)</li>
+    <li>Your relay's version number</li>
+    <li>The timestamp of the check-in</li>
+  </ul>
+
+  <h3>Only if you opt in (telemetry, off by default)</h3>
+  <ul>
+    <li>Aggregate user count — a number, never identities</li>
+    <li>Aggregate transfer count per 24h — a number, never hashes</li>
+    <li>Error rates (5xx rate, auth-failure rate)</li>
+    <li>Uptime</li>
+  </ul>
+
+  <h3>Never — even with telemetry on</h3>
+  <ul>
+    <li>File content — we do not hold your decryption keys, anywhere</li>
+    <li>Identities of your users (emails, names)</li>
+    <li>File hashes — they would link to specific transfers</li>
+    <li>Source or destination addresses of your transfers</li>
+    <li>CT-log content beyond aggregate counts</li>
+  </ul>
+
+  <p class="note note--planned"><span class="badge badge-planned">Planned</span> Before telemetry can be enabled, the admin panel will show a preview of the exact payload your relay would send, with no hidden fields, so opting in is an informed choice rather than a blind toggle.</p>
+
+  <!-- ───────────────────── Verify ───────────────────── -->
+  <h2 id="verify-deployment">How to verify your deployment</h2>
+
+  <p>You do not have to trust these statements — the public surface lets you check them.</p>
+
+  <h3>1. Source <span class="badge badge-live">Live</span></h3>
+  <p>Everything that runs on your server is in the public <a href="https://github.com/Apolloccrypt/paramant-relay">GitHub repository</a> under BUSL-1.1: the relay, the admin panel, the SDKs, and the license-<em>client</em> code that does the check-in. You can read exactly what your relay does — including every field it would send — and build it yourself:</p>
+  <pre><code>git clone https://github.com/Apolloccrypt/paramant-relay
+cd paramant-relay
+git checkout v3.0.0
+docker compose build   # build locally instead of pulling the published image</code></pre>
+
+  <h3>2. Published image <span class="badge badge-live">Live</span></h3>
+  <p>The <a href="https://hub.docker.com/r/mtty001/relay">Docker Hub image</a> is built from that repository by the project's public GitHub Actions workflow. You can compare a locally built image against the published tag, or skip the published image entirely and run your own build.</p>
+
+  <h3>3. Signed releases <span class="badge badge-planned">Planned</span></h3>
+  <p>Cryptographically signed release artifacts (so you can verify provenance without a local rebuild) are part of the supply-chain design but not yet in place. Once live, verification will look like:</p>
+  <pre><code>cosign verify mtty001/relay:3.0.0 \
+  --key https://paramant.app/.well-known/paramant-release.pub</code></pre>
+  <p class="see-also">Release-signing and supply-chain integrity are tracked in the release-process ADR (R015, in progress) in the public <a href="https://github.com/Apolloccrypt/paramant-relay/tree/main/docs/adrs">ADR directory</a>.</p>
+
+  <h3>4. Behaviour <span class="badge badge-live">Live</span></h3>
+  <p>Every transfer your relay handles is appended to its own public <a href="/ct-log">Certificate Transparency log</a>, a signed Merkle tree you can inspect and archive independently. The relay's logs record its outbound calls; once online license-check ships, each check-in is logged too, so you can watch what your relay sends.</p>
+
+  <!-- ───────────────────── Remote actions ───────────────────── -->
+  <h2 id="remote-actions">What Paramant can do remotely</h2>
+
+  <p>The remote-action model below is <span class="badge badge-planned">Planned</span> — specified, not yet implemented. The structural limits in "Not possible", however, hold <span class="badge badge-live">Live</span> today, because they follow from the architecture rather than from policy.</p>
+
+  <p>In the design, every remote action is recorded to <strong>your relay's own CT log</strong>, where you can verify it independently: you see what was done, when, and by which Paramant role (Owner or Support). Our internal audit-trail additionally records which individual acted, but that record is private to us.</p>
+
+  <h3>Possible remote actions (planned)</h3>
+  <dl>
+    <dt>Issue a short-lived support key</dt>
+    <dd>A time-boxed key for debugging an issue you reported. You can revoke it immediately from your admin panel.</dd>
+
+    <dt>Offer an update</dt>
+    <dd>Make a new release available to your relay. How it applies follows your tier: a banner you act on, an opt-in update window, or explicit approval — never a silent push you did not agree to.</dd>
+
+    <dt>Set drain mode</dt>
+    <dd>Ask the relay to refuse new uploads, finish in-flight transfers, then idle — used ahead of maintenance.</dd>
+
+    <dt>Adjust your capability-set</dt>
+    <dd>Apply a tier change (trial extension, upgrade after payment). It takes effect on the next check-in.</dd>
+  </dl>
+
+  <h3>Not possible — structurally <span class="badge badge-live">Live</span></h3>
+  <ul>
+    <li>Read your file content — we never hold decryption keys, anywhere</li>
+    <li>Rewrite your CT log after the fact — Merkle-tree integrity prevents it</li>
+    <li>Bypass your local TOTP or admin key — there is no backdoor in the source, and the source is public</li>
+    <li>Reach your users' data or another deployment — relays are isolated by design</li>
+    <li>Switch off your audit log — CT-log writes are not gated by any capability</li>
+  </ul>
+
+  <p class="see-also">Remote-action protocol: the management-plane ADR (R014, in progress) in the public <a href="https://github.com/Apolloccrypt/paramant-relay/tree/main/docs/adrs">ADR directory</a>.</p>
+
+  <!-- ───────────────────── Open-core ───────────────────── -->
+  <h2 id="open-core">Open-core: what is open, what is closed</h2>
+
+  <p>Paramant follows the open-core model used by HashiCorp, GitLab, Elastic and Sentry: the software you run is open; the service operating it is not.</p>
+
+  <h3>Open — BUSL-1.1, public on GitHub <span class="badge badge-live">Live</span></h3>
+  <ul>
+    <li>The relay — everything that runs on your server</li>
+    <li>The SDKs and CLI tools</li>
+    <li>The frontend — admin panel, setup wizard, dashboard</li>
+    <li>The license-<em>client</em> — the check-in code on your relay</li>
+    <li>All ADRs, including the licensing and management-plane protocols</li>
+    <li>The cryptographic specification and test vectors</li>
+  </ul>
+  <p><a href="https://github.com/Apolloccrypt/paramant-relay">View the public repository &rarr;</a></p>
+
+  <h3>Closed — operated privately by Paramant</h3>
+  <ul>
+    <li>The license-<em>server</em> — the service side of the check-in</li>
+    <li>The internal fleet-management dashboard</li>
+    <li>The customer and billing databases</li>
+    <li>Support tooling and email templates</li>
+  </ul>
+  <p>The <em>protocols</em> are public; only our implementation of the server side is private — the same way GitLab keeps its operations private while its core stays open. Because the protocol and the client are open, you can audit exactly what your relay says to us and what it accepts back.</p>
+
+  <p class="see-also">The open-core split is documented in the open-core ADR (R016) in the public <a href="https://github.com/Apolloccrypt/paramant-relay/tree/main/docs/adrs">ADR directory</a>.</p>
+
+  <!-- ───────────────────── Independent verification ───────────────────── -->
+  <h2 id="independent">Independent verification</h2>
+
+  <p>Three external security audits in April 2026 reviewed the relay code; the findings and patch timeline are on the <a href="/security#audits">security page</a>. A further external review of the v3.0.0 and open-core architecture is <span class="badge badge-planned">planned</span>; results will be published there when complete.</p>
+
+  <p>If you are running your own audit, the public surface — relay, SDKs, frontend and the protocol specifications — is enough to verify every claim on this page for yourself.</p>
+
+  <!-- ───────────────────── Questions ───────────────────── -->
+  <h2 id="questions">Questions</h2>
+
+  <p>Security reports and questions: <a href="mailto:privacy@paramant.app">privacy@paramant.app</a>. For sensitive material, our PGP key and full policy are in <a href="/.well-known/security.txt">security.txt</a>.</p>
+
+  <p>General questions: <a href="mailto:privacy@paramant.app">privacy@paramant.app</a>.</p>
+
+  <p>Commercial and license questions: see <a href="/pricing">pricing</a> or email <a href="mailto:hello@paramant.app">hello@paramant.app</a>.</p>
+
+</main>
+<footer>
+  <div class="container-lg">
+    <div class="footer-grid">
+      <div>
+        <div class="logo" style="margin-bottom:var(--space-3)"><span class="a">Para</span><span class="b">MANT</span></div>
+        <p style="font-size:var(--text-xs);color:var(--ink-dim);line-height:1.7;max-width:220px">Encrypted file relay. RAM-only. Burn-on-read.</p>
+        <p style="font-family:var(--mono);font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-4);line-height:1.8">FIPS 203 / 204 &middot; Hetzner DE<br>GDPR &middot; no US CLOUD Act<br>BUSL-1.1 &middot; &copy; 2026 PARAMANT</p>
+      </div>
+      <div>
+        <div class="footer-col-label">Trust</div>
+        <div class="footer-links">
+          <a href="/status">Status</a>
+          <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
+          <a href="/ct-log">CT Log</a>
+          <a href="/license">License</a>
+          <a href="/press">Press kit</a>
+        </div>
+      </div>
+      <div>
+        <div class="footer-col-label">Legal</div>
+        <div class="footer-links">
+          <a href="/dpa">Data Processing Agreement</a>
+          <a href="/sla">SLA</a>
+          <a href="/compliance/nis2">Compliance overview</a>
+        </div>
+      </div>
+      <div>
+        <div class="footer-col-label">Self-host</div>
+        <div class="footer-links">
+          <a href="/docs#self-hosting">Deploy guide</a>
+          <a href="/install.sh">install.sh</a>
+          <a href="/install-pi.sh">install-pi.sh</a>
+          <a href="/download">ParamantOS</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+        </div>
+      </div>
+      <div>
+        <div class="footer-col-label">Connect</div>
+        <div class="footer-links">
+          <a href="mailto:privacy@paramant.app">Contact</a>
+          <a href="/signup">Create account</a>
+          <a href="/auth/login">Sign in</a>
+          <a href="/help">Help</a>
+          <a href="/partners">Partners</a>
+          <a href="/changelog">Changelog</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<script src="/nav.js?v=12" defer></script>
+<script src="/js/nav-auth.js" defer></script>
+</body>
+</html>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -163,6 +163,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -244,6 +245,7 @@
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -573,6 +575,7 @@
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -150,6 +150,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -231,6 +232,7 @@ section p+p{margin-top:14px}
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -324,6 +326,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>


### PR DESCRIPTION
Customer-facing transparency page for the open-core productisation. Pure frontend; no backend changes. Built on the existing `security.html` boilerplate (design-system.css / nav.css), so nav, footer and styling match the rest of the site.

## The page (`frontend/trust.html`)
Calm, explicit, no marketing fluff. Sections: how license-check works, what Paramant sees, how to verify your deployment, what we can/cannot do remotely, the open-core split, independent verification, and contact.

**Honesty model — the important part.** The license-server, telemetry, remote-actions and signed releases are *specified but not yet built* (R013 is a Draft ADR; the relay today uses an offline Ed25519 `PLK_KEY` with no phone-home). So every claim is tagged **Live** (works today) or **Planned** (specified in a public ADR, not implemented). This keeps the page within the safety rule "no claims about features that don't exist yet without a planned tag" — and a transparency page that overclaimed would defeat its own purpose.

## Integration
- `Trust` added to the About dropdown + mobile nav across **all 45 pages**, and to the footer Trust column where that footer exists (39 pages).
- Cross-refs: `/docs` sidebar (under Security) and a new "Customer transparency" section on `/security`.

## Deliberate deviations from the brief (flagged for review)
- **ADR cross-links point to the public ADR directory on GitHub**, not `/docs#R013` anchors. Those anchors don't exist, and R014/R015/R016 are not yet in `main` (R013 is in PR #65, Draft). Linking the real directory avoids dead links and overclaiming.
- **Cosign verification is tagged Planned** — there is no image signing in CI yet and no `paramant-release.pub`. Kept the example under a Planned badge.
- **Contact uses `privacy@paramant.app`** (the real security contact per `.well-known/security.txt`) and `hello@paramant.app`; the brief's `security@paramant.app` does not exist, so it was not invented.
- **Telemetry-preview / license.log** referenced as Planned (tied to the unbuilt check-in).
- Build label kept at `2.5.0` to match the rest of `main` (marketing version is intentionally held at 2.5.0 per CHANGELOG).

No compliance-claim changes, no private `management.paramant.app` URLs, no customer or team names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)