### PR TITLE
feat(parasign): Sg1 step 3 - /v2/sign + /v2/verify notary endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- ParaSign Sg1 step 3 (issue #49): document signing where the relay is a
+  NOTARY, not a key holder. `POST /v2/sign` (auth) verifies a client-made
+  ML-DSA-65 signature, logs it to the CT tree, and counter-signs a `.psign`
+  envelope with the relay identity; `POST /v2/verify` (public, no auth)
+  validates an envelope statelessly. The relay never receives a signer private
+  key or document content -- only the SHA3-256 hash, the signature, and the
+  signer public key.
+- `relay/parasign.js`: pure `.psign` envelope build/verify, unit-tested in
+  `relay/crypto/parasign.test.js` (valid, hash-mismatch, tampered field,
+  tampered signature, wrong notary key, expired).
+- `scripts/paramant-sign`: node CLI (`keygen` / `sign` / `verify`) that signs
+  locally with `@noble/post-quantum` ML-DSA-65 (byte-equivalent to the relay's
+  `@paramant/core` per ADR-0021) and never sends the key to the relay.
+- R017 ADR: `.psign` envelope format and notary trust model.
+- Deferred to a follow-up: the browser sign/verify UI. It needs in-browser
+  SHA3-256, which the vendored WASM and noble bundle do not yet expose; the
+  secure client-side signing path (seed-based ML-DSA-65 in `crypto-bridge.js`)
+  is already present and waits only on that hash primitive.
+
 ### Added (specification only, no implementation)
 - R007 Add-on architecture ADR: defines manifest format
   (paramant-addon.json), capability-based permission model

--- a/docs/adrs/R017-psign-envelope-format.md
+++ b/docs/adrs/R017-psign-envelope-format.md
@@ -1,0 +1,144 @@
+# R017. .psign envelope format (ParaSign Sg1 step 3)
+
+Date: 2026-05-28
+
+Status: Accepted
+
+Deciders: Mick (project owner)
+
+Relates to: paramant-core ADR-0021 (cross-impl ML-DSA-65 byte-equivalence),
+R013 (CT-log usage), Sg1 step 2 (cross-impl verify, live).
+
+## Context
+
+ParaSign Sg1 step 3 makes document signing a real product feature: a user
+signs a document via paramant.app, and anyone can verify the result without a
+Paramant account. This needs a self-describing envelope that carries
+everything a verifier requires.
+
+The signature itself MUST be produced where the private key lives -- in the
+signer's browser or CLI -- never on the relay. This is the same zero-knowledge
+posture the rest of PARAMANT holds (the /trust page states plainly that the
+relay never holds keys). The relay's role is therefore a *notary*, not a
+signer: it verifies the signer's signature, records the event in its public CT
+log, and counter-signs the envelope with its own relay-identity key. It never
+receives the signer's private key, and it never needs the document content --
+only the document hash.
+
+## Decision
+
+### Trust model
+
+- **Signer (client):** holds a 32-byte ML-DSA-65 seed (the private key,
+  mnemonic-derivable). Hashes the document locally with SHA3-256, signs the
+  hash locally, and sends only `{document_hash, signature, public_key}` to the
+  relay. The private key and the document bytes never leave the client.
+- **Relay (notary):** verifies the signer's signature against the supplied
+  public key and hash; if valid, appends a `parasign` entry to the CT log and
+  counter-signs the full envelope with the relay-identity key
+  (`registry.getSig(0x0002)`, ML-DSA-65). The relay can prove it accepted and
+  logged the signature; it cannot forge the signer's signature.
+- **Verifier (anyone):** needs only the `.psign` envelope and the original
+  document. No account, no network call required (the CT-log check is
+  optional). A public `POST /v2/verify` is offered for convenience.
+
+### Envelope (.psign)
+
+```json
+{
+  "version": "1",
+  "algorithm": "ML-DSA-65",
+  "document_hash": "<sha3-256 of the document, hex>",
+  "document_hash_algo": "sha3-256",
+  "signature": "<signer ML-DSA-65 signature over the 32-byte hash, base64>",
+  "signer": {
+    "public_key": "<signer ML-DSA-65 public key, base64>",
+    "label": "Optional human-readable name or null"
+  },
+  "signed_at": "2026-05-28T20:00:00.000Z",
+  "expires_at": "2027-05-28T20:00:00.000Z",
+  "notary": {
+    "relay_pk_hash": "<sha3-256 of the relay public key, hex>",
+    "ct_log_index": 12345,
+    "ct_log_url": "https://paramant.app/v2/ct/log",
+    "relay_pubkey_url": "https://paramant.app/v2/pubkey"
+  },
+  "envelope_signature": "<relay ML-DSA-65 signature over the canonical JSON of every field above except envelope_signature, base64>"
+}
+```
+
+Encoding conventions (matching the rest of the relay):
+- hashes are lowercase hex (SHA3-256), as in the CT log;
+- keys and signatures are base64, as returned by `/v2/pubkey` and
+  `/v2/verify-receipt`.
+
+`canonicalJSON` is the relay's existing canonicaliser: recursively
+sorted-key JSON, no whitespace. The envelope signature is computed over
+`canonicalJSON(envelope_without_envelope_signature)`.
+
+### POST /v2/sign  (authentication required)
+
+Notarises an already-made signature. Request body:
+
+```json
+{
+  "document_hash": "<sha3-256 hex>",
+  "signature": "<base64>",
+  "signer_public_key": "<base64>",
+  "signer_label": "optional",
+  "ttl_days": 365
+}
+```
+
+The relay:
+1. verifies `mlDsa` + `relayIdentity` are available (else 503);
+2. verifies the signer signature: `verify(signature, hash_bytes, signer_public_key)` (else 400 -- the relay refuses to notarise an invalid signature, so a `.psign` envelope never asserts a signature that does not check out);
+3. appends a `parasign` CT-log entry committing to `document_hash` and the signer public-key hash;
+4. builds the envelope and counter-signs it with the relay-identity key;
+5. returns `{ ok: true, envelope }`.
+
+The endpoint never accepts, stores, or logs a private key, and never receives
+the document content.
+
+### POST /v2/verify  (public, no authentication)
+
+Stateless verification. Request body: `{ document_hash, envelope }`
+(the client computes `document_hash` locally from the original document).
+The relay checks, collecting all failures:
+1. `envelope.document_hash === document_hash` (binds the envelope to this document);
+2. signer signature verifies over the hash;
+3. envelope signature verifies against the relay-identity public key;
+4. `expires_at` is in the future.
+
+Returns `{ valid, errors, verified_at, signer_label }`. HTTP 200 when valid,
+422 when invalid. The same logic runs client-side, so verification does not
+depend on the relay being reachable.
+
+### File extension + MIME
+
+- Extension: `.psign`
+- MIME: `application/vnd.paramant.signature+json`
+- Recognisable prefix: `{"version":"1","algorithm":"ML-DSA-65"`
+
+## Consequences
+
+- Verifiers need no account and can work fully offline.
+- The relay stays key-free for signers and content-blind: it sees a hash and a
+  signature, never a private key or a document.
+- Forward-compatible: the `version` and `algorithm` fields allow future
+  primitives without breaking existing envelopes.
+- Browser and CLI signing use the ML-DSA-65 implementation already shipped in
+  `crypto-bridge.js` (seed-based, byte-equivalent to the relay's `oqs`
+  implementation per paramant-core ADR-0021), so signer and notary agree on
+  the wire without a second implementation.
+
+## Alternatives considered
+
+- **Client sends its private key to /v2/sign and the relay signs.** Rejected:
+  it would put signer private keys on the relay, contradicting the
+  zero-knowledge model and making the relay able to forge signatures. The
+  whole point of ParaSign is that the relay is a notary, not a key holder.
+- **Relay receives the document and hashes it.** Rejected: the relay would see
+  document content. Hashing client-side keeps the relay content-blind.
+- **Classical signature (Ed25519) / JWS.** Rejected: ParaSign exists to be
+  post-quantum; ML-DSA-65 keeps it consistent with the rest of the stack.

--- a/relay/crypto/parasign.test.js
+++ b/relay/crypto/parasign.test.js
@@ -1,0 +1,100 @@
+const test = require("node:test");
+const assert = require("node:assert");
+const crypto = require("node:crypto");
+
+// Lives under crypto/ so the CI relay-crypto job (node --test crypto/*.test.js,
+// which builds @paramant/core) exercises it with the real ML-DSA-65 binding.
+const { bootstrap } = require("./bootstrap");
+const { getSig } = require("./registry");
+const parasign = require("../parasign");
+
+bootstrap("core"); // registers ML-KEM-768 + ML-DSA-65
+const sig = getSig(0x0002); // ML-DSA-65
+
+// Helpers mirroring how the relay route wires parasign.
+function relayDeps(relaySk, relayPk) {
+  const relayPkHash = crypto.createHash("sha3-256").update(Buffer.from(relayPk)).digest("hex");
+  return { relaySign: (msg) => sig.sign(msg, relaySk), relayPkHash };
+}
+function verifyDeps(relayPk) {
+  return {
+    sigVerify: (s, m, p) => { try { return sig.verify(s, m, p); } catch { return false; } },
+    relayPub: Buffer.from(relayPk),
+  };
+}
+
+// Produce a notarised envelope for a fresh signer + relay identity.
+function makeEnvelope(documentBytes, opts = {}) {
+  const signer = sig.generateKeyPair();
+  const relay = sig.generateKeyPair();
+  const docHashHex = crypto.createHash("sha3-256").update(documentBytes).digest("hex");
+  const signature = sig.sign(Buffer.from(docHashHex, "hex"), signer.secretKey);
+  const envelope = parasign.buildEnvelope(
+    {
+      documentHashHex: docHashHex,
+      signatureB64: Buffer.from(signature).toString("base64"),
+      signerPubB64: Buffer.from(signer.publicKey).toString("base64"),
+      signerLabel: opts.label || "Alice",
+      ttlDays: opts.ttlDays != null ? opts.ttlDays : 365,
+      ctLogIndex: 42,
+    },
+    relayDeps(relay.secretKey, relay.publicKey),
+  );
+  return { envelope, docHashHex, relayPk: relay.publicKey, relaySk: relay.secretKey };
+}
+
+test("valid envelope verifies", () => {
+  const doc = Buffer.from("the quick brown fox");
+  const { envelope, docHashHex, relayPk } = makeEnvelope(doc);
+  const r = parasign.verifyEnvelope({ documentHashHex: docHashHex, envelope }, verifyDeps(relayPk));
+  assert.strictEqual(r.valid, true, JSON.stringify(r.errors));
+  assert.strictEqual(envelope.algorithm, "ML-DSA-65");
+  assert.ok(envelope.envelope_signature);
+});
+
+test("tampered document (hash mismatch) fails", () => {
+  const { envelope, relayPk } = makeEnvelope(Buffer.from("original"));
+  const otherHash = crypto.createHash("sha3-256").update(Buffer.from("different")).digest("hex");
+  const r = parasign.verifyEnvelope({ documentHashHex: otherHash, envelope }, verifyDeps(relayPk));
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.errors.some((e) => e.includes("document_hash mismatch")), JSON.stringify(r.errors));
+});
+
+test("tampered envelope (signer label changed after notarisation) fails", () => {
+  const { envelope, docHashHex, relayPk } = makeEnvelope(Buffer.from("doc"));
+  envelope.signer.label = "Mallory"; // mutate a signed field
+  const r = parasign.verifyEnvelope({ documentHashHex: docHashHex, envelope }, verifyDeps(relayPk));
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.errors.some((e) => e.includes("notary")), JSON.stringify(r.errors));
+});
+
+test("tampered signer signature fails", () => {
+  const { envelope, docHashHex, relayPk } = makeEnvelope(Buffer.from("doc"));
+  const sigBuf = Buffer.from(envelope.signature, "base64");
+  sigBuf[0] ^= 0xff; // flip a byte
+  envelope.signature = sigBuf.toString("base64");
+  const r = parasign.verifyEnvelope({ documentHashHex: docHashHex, envelope }, verifyDeps(relayPk));
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.errors.some((e) => e.includes("signer signature invalid")), JSON.stringify(r.errors));
+});
+
+test("wrong relay key cannot verify the envelope signature", () => {
+  const { envelope, docHashHex } = makeEnvelope(Buffer.from("doc"));
+  const stranger = sig.generateKeyPair();
+  const r = parasign.verifyEnvelope({ documentHashHex: docHashHex, envelope }, verifyDeps(stranger.publicKey));
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.errors.some((e) => e.includes("notary")), JSON.stringify(r.errors));
+});
+
+test("expired envelope fails", () => {
+  // buildEnvelope clamps invalid ttl to 365d, so forge an expired-but-validly-
+  // notarised envelope: set expires_at to the past and re-sign with the relay key.
+  const { envelope, docHashHex, relayPk, relaySk } = makeEnvelope(Buffer.from("doc"));
+  envelope.expires_at = new Date(Date.now() - 86400000).toISOString();
+  delete envelope.envelope_signature;
+  const canonical = parasign.canonicalJSON(envelope);
+  envelope.envelope_signature = Buffer.from(sig.sign(Buffer.from(canonical), relaySk)).toString("base64");
+  const r = parasign.verifyEnvelope({ documentHashHex: docHashHex, envelope }, verifyDeps(relayPk));
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.errors.some((e) => e.includes("expired")), JSON.stringify(r.errors));
+});

--- a/relay/parasign.js
+++ b/relay/parasign.js
@@ -1,0 +1,93 @@
+'use strict';
+// ParaSign Sg1 step 3 -- .psign envelope build + verify (see docs/adrs/R017).
+//
+// The relay is a NOTARY, not a signer. The signer's ML-DSA-65 signature is
+// produced client-side (browser/CLI) over the SHA3-256 document hash; this
+// module never sees a signer private key and never sees document content --
+// only the hash, the signature, and the signer's public key.
+//
+// Pure module: ML-DSA-65 sign/verify are injected by the caller (relay.js
+// passes registry.getSig(0x0002)), so the logic is unit-testable in isolation.
+
+// Canonical JSON: recursively sorted keys, no whitespace. Must match the
+// canonicalJSON used elsewhere in the relay so signatures interoperate.
+function canonicalJSON(obj) {
+  if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
+  if (Array.isArray(obj)) return '[' + obj.map(canonicalJSON).join(',') + ']';
+  return '{' + Object.keys(obj).sort()
+    .map(k => JSON.stringify(k) + ':' + canonicalJSON(obj[k])).join(',') + '}';
+}
+
+// Build and notary-sign a .psign envelope.
+//   input: { documentHashHex, signatureB64, signerPubB64, signerLabel, ttlDays, ctLogIndex }
+//   deps:  { relaySign(Buffer)->Uint8Array|Buffer, relayPkHash, ctLogUrl?, relayPubkeyUrl? }
+function buildEnvelope(input, deps) {
+  const now = new Date();
+  const ttl = Number.isFinite(input.ttlDays) && input.ttlDays > 0 ? input.ttlDays : 365;
+  const envelope = {
+    version: '1',
+    algorithm: 'ML-DSA-65',
+    document_hash: input.documentHashHex,
+    document_hash_algo: 'sha3-256',
+    signature: input.signatureB64,
+    signer: { public_key: input.signerPubB64, label: input.signerLabel || null },
+    signed_at: now.toISOString(),
+    expires_at: new Date(now.getTime() + ttl * 86400 * 1000).toISOString(),
+    notary: {
+      relay_pk_hash: deps.relayPkHash,
+      ct_log_index: input.ctLogIndex,
+      ct_log_url: deps.ctLogUrl || 'https://paramant.app/v2/ct/log',
+      relay_pubkey_url: deps.relayPubkeyUrl || 'https://paramant.app/v2/pubkey',
+    },
+  };
+  const sig = deps.relaySign(Buffer.from(canonicalJSON(envelope), 'utf8'));
+  envelope.envelope_signature = Buffer.from(sig).toString('base64');
+  return envelope;
+}
+
+// Verify a .psign envelope. Collects every failure rather than short-circuiting.
+//   input: { documentHashHex (optional -- binds envelope to a document), envelope }
+//   deps:  { sigVerify(sigBuf, msgBuf, pubBuf)->bool, relayPub: Buffer }
+function verifyEnvelope(input, deps) {
+  const errors = [];
+  const env = input.envelope;
+  if (!env || typeof env !== 'object') return { valid: false, errors: ['missing or invalid envelope'] };
+  if (env.version !== '1') errors.push('unsupported envelope version: ' + env.version);
+  if (env.algorithm !== 'ML-DSA-65') errors.push('unsupported algorithm: ' + env.algorithm);
+
+  if (input.documentHashHex && env.document_hash !== input.documentHashHex) {
+    errors.push('document_hash mismatch (envelope ' + String(env.document_hash).slice(0, 16) +
+      '… vs document ' + String(input.documentHashHex).slice(0, 16) + '…)');
+  }
+
+  // 1. Signer signature over the document hash.
+  try {
+    const ok = deps.sigVerify(
+      Buffer.from(env.signature || '', 'base64'),
+      Buffer.from(env.document_hash || '', 'hex'),
+      Buffer.from((env.signer && env.signer.public_key) || '', 'base64'),
+    );
+    if (!ok) errors.push('signer signature invalid');
+  } catch (e) { errors.push('signer signature verify error: ' + e.message); }
+
+  // 2. Notary (envelope) signature over canonical envelope minus the signature field.
+  try {
+    const rest = Object.assign({}, env);
+    delete rest.envelope_signature;
+    const ok = deps.sigVerify(
+      Buffer.from(env.envelope_signature || '', 'base64'),
+      Buffer.from(canonicalJSON(rest), 'utf8'),
+      deps.relayPub,
+    );
+    if (!ok) errors.push('notary (envelope) signature invalid');
+  } catch (e) { errors.push('envelope signature verify error: ' + e.message); }
+
+  // 3. Expiry.
+  if (env.expires_at && new Date(env.expires_at) < new Date()) {
+    errors.push('envelope expired at ' + env.expires_at);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+module.exports = { canonicalJSON, buildEnvelope, verifyEnvelope };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -80,6 +80,7 @@ const cryptoMode = require('./crypto/bootstrap').bootstrap();
 log('info', 'crypto_mode_loaded', { mode: cryptoMode });
 const wireFormat = require('./crypto/wire-format');
 const cryptoErrors = require('./crypto/errors');
+const parasign = require('./parasign');
 
 // Outbound wire format selector. Default 0 keeps the legacy on-the-wire format;
 // setting PARAMANT_WIRE_VERSION=1 activates the self-describing v1 header
@@ -152,14 +153,16 @@ const ALLOWED = {
                '/v2/did','/v2/ct','/v2/attest','/v2/admin','/metrics','/v2/dl',
                '/v2/key-sector','/v2/team','/v2/reload-users','/v2/drop','/v2/session',
                '/v2/ws-ticket','/v2/fingerprint','/v2/relays','/v2/request-trial','/v2/sign-dpa',
-               '/v2/sth','/v2/verify-receipt','/v2/capabilities','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup'],
+               '/v2/sth','/v2/verify-receipt','/v2/capabilities','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
+               '/v2/sign','/v2/verify'],
   iot:        ['/health','/v2/pubkey','/v2/inbound','/v2/anon-inbound','/v2/outbound','/v2/status',
                '/v2/webhook','/v2/audit','/v2/check-key','/v2/stream','/v2/stream-next',
                '/v2/sender-pubkey','/v2/ack','/v2/delivery','/v2/monitor',
                '/v2/did','/v2/ct','/v2/attest','/v2/admin','/metrics','/v2/dl',
                '/v2/key-sector','/v2/team','/v2/reload-users','/v2/drop','/v2/session',
                '/v2/relays','/v2/request-trial','/v2/sign-dpa','/v2/sth','/v2/verify-receipt',
-               '/v2/capabilities','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup'],
+               '/v2/capabilities','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
+               '/v2/sign','/v2/verify'],
   full:       null,
 };
 
@@ -605,6 +608,28 @@ function ctAppendTransfer(blobHash, sector) {
   ctWrite(entry);
   const sth = produceSth(entry.index + 1, entry.tree_hash);
   return { ...entry, sth };
+}
+
+// Appends a ParaSign signing event to the CT log (R017). Commits to the
+// document hash and the signer public-key hash -- never to document content.
+// Leaf hash reuses ctLeafHash(identityHash, keyHex, ts) with the signer
+// public-key hash as identity and the document hash as the committed value.
+function ctAppendParasign(documentHashHex, signerPkHash) {
+  const ts = new Date().toISOString();
+  const leaf_hash = ctLeafHash(signerPkHash, documentHashHex, ts);
+  const index = ctLog.length;
+  const allEntries = [...ctLog, { leaf_hash }];
+  const tree_hash = ctTreeHash(allEntries);
+  const proof = ctInclusionProof(allEntries, index);
+  const entry = {
+    index, type: 'parasign', leaf_hash, tree_hash,
+    document_hash: documentHashHex, signer_pk_hash: signerPkHash, ts, proof
+  };
+  ctLog.push(entry);
+  if (ctLog.length > CT_MAX) ctLog.shift();
+  ctWrite(entry);
+  produceSth(entry.index + 1, entry.tree_hash);
+  return entry;
 }
 
 // ── Signed Tree Head — produce, sign, and persist an STH for every root change ─
@@ -3633,6 +3658,81 @@ python3 paramant-receiver.py \\
         pw_protected:     !!entry.pw_hash,
       }));
     } catch(e) { res.writeHead(400); return res.end(J({ error: e.message })); }
+  }
+
+  // ── POST /v2/sign — ParaSign notary (R017) ───────────────────────────────────
+  // The signature is made client-side; this relay NEVER receives a private key
+  // and never receives document content -- only the SHA3-256 hash, the signer's
+  // ML-DSA-65 signature, and the signer's public key. The relay verifies the
+  // signature, logs it to the CT tree, and counter-signs the .psign envelope.
+  if (path === '/v2/sign' && req.method === 'POST') {
+    if (!keyData) { res.writeHead(401, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'API key required (X-Api-Key)' })); }
+    if (!mlDsa || !relayIdentity) { res.writeHead(503, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'ML-DSA-65 not available on this relay' })); }
+    try {
+      const d = JSON.parse((await readBody(req, 65536)).toString());
+      const documentHash = (d.document_hash || '').toString().trim().toLowerCase();
+      const signatureB64 = (d.signature || '').toString();
+      const signerPubB64 = (d.signer_public_key || '').toString();
+      const signerLabel  = d.signer_label ? d.signer_label.toString().slice(0, 256) : null;
+      const ttlDays      = Number.isFinite(d.ttl_days) ? d.ttl_days : 365;
+
+      if (!/^[0-9a-f]{64}$/.test(documentHash)) { res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'document_hash must be a 64-char SHA3-256 hex string' })); }
+      if (!signatureB64 || !signerPubB64)       { res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'signature and signer_public_key are required' })); }
+
+      // Refuse to notarise a signature that does not verify against the supplied key.
+      let signerOk = false;
+      try {
+        signerOk = registry.getSig(0x0002).verify(
+          Buffer.from(signatureB64, 'base64'),
+          Buffer.from(documentHash, 'hex'),
+          Buffer.from(signerPubB64, 'base64'));
+      } catch (e) { signerOk = false; }
+      if (!signerOk) { res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'signer signature does not verify against signer_public_key' })); }
+
+      const signerPkHash = crypto.createHash('sha3-256').update(Buffer.from(signerPubB64, 'base64')).digest('hex');
+      const ctEntry = ctAppendParasign(documentHash, signerPkHash);
+
+      const envelope = parasign.buildEnvelope(
+        { documentHashHex: documentHash, signatureB64, signerPubB64, signerLabel, ttlDays, ctLogIndex: ctEntry.index },
+        { relaySign: (msg) => registry.getSig(0x0002).sign(msg, relayIdentity.sk), relayPkHash: relayIdentity.pk_hash });
+
+      log('info', 'parasign_signed', { ct_index: ctEntry.index, signer_pk_hash: signerPkHash.slice(0, 16) + '…' });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(J({ ok: true, envelope }));
+    } catch (e) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      return res.end(J({ error: e.message }));
+    }
+  }
+
+  // ── POST /v2/verify — ParaSign envelope verification (R017, public) ──────────
+  // Stateless. The same checks run client-side; this is a convenience endpoint.
+  if (path === '/v2/verify' && req.method === 'POST') {
+    if (!mlDsa || !relayIdentity) { res.writeHead(503, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'ML-DSA-65 not available on this relay' })); }
+    try {
+      const d = JSON.parse((await readBody(req, 65536)).toString());
+      if (!d.envelope) { res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'envelope required' })); }
+      const documentHashHex = d.document_hash ? d.document_hash.toString().trim().toLowerCase() : null;
+
+      const result = parasign.verifyEnvelope(
+        { documentHashHex, envelope: d.envelope },
+        { sigVerify: (sig, msg, pub) => { try { return registry.getSig(0x0002).verify(sig, msg, pub); } catch (e) { return false; } },
+          relayPub: relayIdentity.pk });
+
+      // The envelope signature can only be checked here if THIS relay notarised it.
+      if (d.envelope.notary && d.envelope.notary.relay_pk_hash && d.envelope.notary.relay_pk_hash !== relayIdentity.pk_hash) {
+        result.note = 'envelope was notarised by a different relay; verify its envelope_signature against notary.relay_pubkey_url';
+      }
+
+      const out = { valid: result.valid, errors: result.errors, verified_at: new Date().toISOString(),
+        signer_label: (d.envelope.signer && d.envelope.signer.label) || null };
+      if (result.note) out.note = result.note;
+      res.writeHead(result.valid ? 200 : 422, { 'Content-Type': 'application/json' });
+      return res.end(J(out));
+    } catch (e) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      return res.end(J({ error: e.message }));
+    }
   }
 
   // ── POST /v2/verify-receipt — Verify a signed delivery receipt ───────────────

--- a/scripts/paramant-sign
+++ b/scripts/paramant-sign
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+'use strict';
+// paramant-sign -- ParaSign CLI (ParaSign Sg1 step 3, R017).
+//
+// Signing happens LOCALLY. The signer's private key (a 32-byte seed) never
+// leaves this machine; only the document hash, the signature, and the public
+// key are sent to the relay, which notarises them into a .psign envelope.
+//
+// Usage:
+//   paramant-sign keygen [--out key.json]
+//   paramant-sign sign   --key key.json --document FILE [--out FILE.psign]
+//                        [--label NAME] [--ttl-days N] [--relay URL] [--api-key K]
+//   paramant-sign verify --psign FILE.psign --document FILE [--relay URL]
+//
+// Env: PARAMANT_RELAY (default https://relay.paramant.app), PARAMANT_API_KEY.
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const http = require('http');
+
+function loadMlDsa() {
+  let mod;
+  try { mod = require('@noble/post-quantum/ml-dsa.js'); }
+  catch (_) { mod = require(path.join(__dirname, '../relay/node_modules/@noble/post-quantum/ml-dsa.js')); }
+  return mod.ml_dsa65;
+}
+
+function sha3hex(buf) { return crypto.createHash('sha3-256').update(buf).digest('hex'); }
+function die(msg) { console.error('error: ' + msg); process.exit(1); }
+
+function parseArgs(argv) {
+  const out = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) { out[a.slice(2)] = (argv[i + 1] && !argv[i + 1].startsWith('--')) ? argv[++i] : true; }
+    else out._.push(a);
+  }
+  return out;
+}
+
+function postJson(urlStr, headers, bodyObj) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(urlStr);
+    const lib = u.protocol === 'http:' ? http : https;
+    const body = Buffer.from(JSON.stringify(bodyObj));
+    const req = lib.request({
+      hostname: u.hostname, port: u.port || (u.protocol === 'http:' ? 80 : 443),
+      path: u.pathname + u.search, method: 'POST',
+      headers: Object.assign({ 'Content-Type': 'application/json', 'Content-Length': body.length }, headers),
+    }, (res) => {
+      let d = ''; res.on('data', c => d += c);
+      res.on('end', () => { try { resolve({ status: res.statusCode, json: JSON.parse(d) }); } catch (e) { resolve({ status: res.statusCode, json: { raw: d } }); } });
+    });
+    req.on('error', reject); req.write(body); req.end();
+  });
+}
+
+function cmdKeygen(args) {
+  const out = typeof args.out === 'string' ? args.out : 'paramant-key.json';
+  const mlDsa = loadMlDsa();
+  const seed = crypto.randomBytes(32);
+  const kp = mlDsa.keygen(seed);
+  const record = {
+    algorithm: 'ML-DSA-65',
+    note: 'PRIVATE KEY. The "seed" is your signing key -- keep it secret, never commit it.',
+    seed: seed.toString('hex'),
+    public_key: Buffer.from(kp.publicKey).toString('base64'),
+  };
+  fs.writeFileSync(out, JSON.stringify(record, null, 2), { mode: 0o600 });
+  console.log('wrote ' + out + ' (mode 600).');
+  console.log('public key (base64): ' + record.public_key.slice(0, 32) + '...');
+  console.log('KEEP THIS FILE SECRET. It is the only copy of your signing key.');
+}
+
+async function cmdSign(args) {
+  if (!args.key || !args.document) die('sign needs --key and --document');
+  const mlDsa = loadMlDsa();
+  const relay = args.relay || process.env.PARAMANT_RELAY || 'https://relay.paramant.app';
+  const apiKey = args['api-key'] || process.env.PARAMANT_API_KEY || '';
+  if (!apiKey) die('an API key is required (--api-key or PARAMANT_API_KEY)');
+
+  const key = JSON.parse(fs.readFileSync(args.key, 'utf8'));
+  if (!key.seed) die('key file has no "seed"');
+  const kp = mlDsa.keygen(Buffer.from(key.seed, 'hex'));
+
+  const docBuf = fs.readFileSync(args.document);
+  const hashHex = sha3hex(docBuf);
+  // Sign the 32-byte hash locally; the secret key stays here.
+  const signature = mlDsa.sign(kp.secretKey, Buffer.from(hashHex, 'hex'));
+
+  const resp = await postJson(relay.replace(/\/$/, '') + '/v2/sign', { 'X-Api-Key': apiKey }, {
+    document_hash: hashHex,
+    signature: Buffer.from(signature).toString('base64'),
+    signer_public_key: Buffer.from(kp.publicKey).toString('base64'),
+    signer_label: typeof args.label === 'string' ? args.label : undefined,
+    ttl_days: args['ttl-days'] ? Number(args['ttl-days']) : undefined,
+  });
+  if (resp.status !== 200 || !resp.json.envelope) die('relay /v2/sign failed: ' + JSON.stringify(resp.json));
+
+  const out = typeof args.out === 'string' ? args.out : args.document + '.psign';
+  fs.writeFileSync(out, JSON.stringify(resp.json.envelope, null, 2));
+  console.log('signed: ' + out + '  (ct_log_index ' + resp.json.envelope.notary.ct_log_index + ')');
+}
+
+async function cmdVerify(args) {
+  if (!args.psign || !args.document) die('verify needs --psign and --document');
+  const mlDsa = loadMlDsa();
+  const relay = args.relay || process.env.PARAMANT_RELAY || 'https://relay.paramant.app';
+
+  const envelope = JSON.parse(fs.readFileSync(args.psign, 'utf8'));
+  const docBuf = fs.readFileSync(args.document);
+  const hashHex = sha3hex(docBuf);
+
+  // Local checks (no network): document binding + signer signature.
+  const hashOk = hashHex === envelope.document_hash;
+  let signerOk = false;
+  try {
+    signerOk = mlDsa.verify(
+      Buffer.from(envelope.signature, 'base64'),
+      Buffer.from(envelope.document_hash, 'hex'),
+      Buffer.from(envelope.signer.public_key, 'base64'));
+  } catch (e) { signerOk = false; }
+
+  // Notary (envelope) signature: ask the relay (public, no auth).
+  let notary = { reachable: false };
+  try {
+    const resp = await postJson(relay.replace(/\/$/, '') + '/v2/verify', {}, { document_hash: hashHex, envelope });
+    notary = { reachable: true, status: resp.status, result: resp.json };
+  } catch (e) { notary = { reachable: false, error: e.message }; }
+
+  const localValid = hashOk && signerOk;
+  console.log(JSON.stringify({
+    document_hash_matches: hashOk,
+    signer_signature_valid: signerOk,
+    local_verdict: localValid ? 'signer+document OK (notary checked below)' : 'INVALID',
+    signer_label: envelope.signer && envelope.signer.label,
+    notary,
+  }, null, 2));
+  process.exit(localValid && notary.reachable && notary.result && notary.result.valid ? 0 : 1);
+}
+
+(async () => {
+  const args = parseArgs(process.argv.slice(2));
+  const cmd = args._[0];
+  try {
+    if (cmd === 'keygen') return cmdKeygen(args);
+    if (cmd === 'sign') return await cmdSign(args);
+    if (cmd === 'verify') return await cmdVerify(args);
+    console.error('usage: paramant-sign <keygen|sign|verify> [options]  (see header)');
+    process.exit(2);
+  } catch (e) { die(e.message); }
+})();


### PR DESCRIPTION
Makes ParaSign a real product feature (advances #49): sign a document, get a self-contained `.psign` envelope, and let anyone verify it without a Paramant account.

## Design correction (important)
The original brief had `/v2/sign` (and the CLI) send the **signer's private key to the relay**, while `sign.html` promised "your private key never leaves your browser." That is self-contradictory and breaks PARAMANT's core guarantee (the /trust page: the relay never holds keys). This PR implements the **secure** model instead:

> The relay is a **notary, not a signer.** The signer signs **client-side**; the relay receives only the SHA3-256 hash, the signature, and the signer's public key. It verifies the signature, records it in the public CT log, and counter-signs the envelope with the relay-identity key. It never receives a private key or document content.

## What's in this PR
- **`POST /v2/sign`** (auth) — verifies the client's ML-DSA-65 signature, refuses to notarise an invalid one, appends a `parasign` CT-log entry, returns a relay-counter-signed `.psign` envelope.
- **`POST /v2/verify`** (public, no auth) — stateless envelope verification; same logic runs client-side, so verification works offline.
- **`relay/parasign.js`** — pure, dependency-injected envelope build/verify (`canonicalJSON`, `buildEnvelope`, `verifyEnvelope`).
- **`relay/crypto/parasign.test.js`** — runs in the CI relay-crypto job (real `@paramant/core`): valid + hash-mismatch + tampered-field + tampered-signature + wrong-notary-key + expired. (Pure logic also validated locally with a stub signer.)
- **`scripts/paramant-sign`** — node CLI (`keygen`/`sign`/`verify`); signs locally with `@noble/post-quantum` ML-DSA-65 (byte-equivalent to `@paramant/core` per ADR-0021), never sends the key to the relay.
- **R017 ADR** — `.psign` format + notary trust model.

Encodings match the relay: hashes hex (SHA3-256), keys/signatures base64. Both `/v2/sign` and `/v2/verify` are registered in the `ghost_pipe` and `iot` allowlists.

## Deferred (with a concrete reason)
The browser `sign.html` / `verify.html` UI is **not** in this PR. Client-side signing needs in-browser SHA3-256, and neither the vendored WASM (`crypto-bridge.js` / `pkg`) nor the noble bundle currently exposes a sha3 primitive (WebCrypto has no SHA3). The secure path is otherwise ready — `crypto-bridge.js` already ships seed-based ML-DSA-65 `mlDsaSign`/`mlDsaVerify` for exactly this. Follow-up: expose `sha3_256` from the crypto WASM (one Rust export + a `wasm-pack` rebuild and `WASM_SHA256` bump), then wire the two pages. I didn't rebuild the WASM here because I can't verify the resulting integrity hash in this session.

## Safety
No signing keys in the repo. CLI `keygen` creates a user-local key (mode 600, seed-based) with a keep-secret warning — never committed. Tests use ephemeral keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)