### PR TITLE
ops: mega audit (no regression) + /trust version-label fix

### DIFF
--- a/docs/audit-reports/mega-audit-20260528-0017.md
+++ b/docs/audit-reports/mega-audit-20260528-0017.md
@@ -1,0 +1,121 @@
+# paramant.app mega audit + restore - 2026-05-28
+
+## Verdict
+
+Site is **operational and fully on 3.0.0**. The reported regression
+("admin/* weggehaald, dashboard rendert leeg") was **NOT reproduced**: the
+webroot is complete and current, `/admin` is reachable, and `/dashboard`
+renders with cards. **No production write actions were required or performed.**
+One repo content bug was found and fixed (`/trust` stale build label). Three
+features are not-yet-live because their PRs/deploys are pending (ParaSign,
+license-server) -- expected per the goal's own "als ... in main / als deploy
+klaar" conditions.
+
+## Phase 1 - Backend health (read-only)
+
+- PASS: /health version = 3.0.0
+- PASS: /v2/capabilities R006 core (KEM=1, SIG=2)
+- PASS: health.paramant.app = 3.0.0
+- PASS: finance.paramant.app = 3.0.0
+- PASS: legal.paramant.app = 3.0.0
+- PASS: iot.paramant.app = 3.0.0
+
+## Phase 2/3 - Webroot integrity (the alleged regression)
+
+- WEBROOT = /home/paramant/app (served by internal nginx :8080 block).
+- PASS: 0 files missing in webroot vs `origin/main:frontend/` (85 files).
+- PASS: key files byte-identical to main (sha256): index, docs, trust,
+  dashboard, pricing, security, setup.
+- NOTE: `/admin` is served by **proxy to the admin container (:4200)**, NOT the
+  webroot. The absence of a `webroot/admin/` directory is normal and correct;
+  it is not a regression. The prior sync (PR #70) used `rsync` WITHOUT
+  `--delete` and removed nothing.
+- CONCLUSION: no regression, nothing missing, no restore needed.
+
+## Phase 7 - Nav-link reachability (44 paths)
+
+PASS (200/301/302), 41 paths incl: /, /send, /parashare, /drop, /dashboard,
+/pricing, /docs, /ct-log, /changelog, /install.sh, /install-pi.sh, /signup,
+/auth/login, /setup, /all-systems-go, /compliance/{nis2,iec62443,nen7510},
+/sovereignty, /government, /ot, /ot-vs-data-diodes, /hndl, /quantum-urgency,
+/crypto-agility, /vs, /status, /security, /trust, /sla, /partners, /license,
+/press, /help, /privacy, /terms, /dpa, /admin/, /admin/settings.html,
+/admin/cli.html, /.well-known/security.txt, /.well-known/openpgp-key.asc
+
+- FAIL: /sign (404) -- ParaSign page; not in main (feature PR #73 unmerged). Expected.
+- FAIL: /verify (404) -- as above. Expected.
+- FAIL: /.well-known/paramant-licensing.pub (404) -- license-server not deployed. Expected.
+
+## Phase 8 - Content claims
+
+- PASS: version 3.0.0 on /, /docs, /pricing, /dashboard, /security.
+- FIXED (this PR): /trust showed `build 2.5.0` -- stale label in
+  `frontend/trust.html:154`, corrected to `build 3.0.0`. (Goes live on next
+  merge + webroot sync.)
+- NOTE: /docs also contains historical `v2.4.5` references -- intentional per
+  the version-unify ADR (historical/"patched in" mentions deliberately kept).
+  Not a defect.
+- PASS: PGP key has no PLACEHOLDER.
+- INFO: /security and /trust do not mention `@paramant/core` (not a
+  requirement for those pages; /docs does).
+
+## Phase 9 - Dashboard render (the user complaint)
+
+- PASS: dashboard 55,007 bytes, 37 card/cards-grid/card-header elements.
+  Renders fully; NOT empty.
+
+## Phase 10 - Admin pages
+
+- PASS: /admin/ 200 ("PARAMANT - Admin")
+- PASS: /admin/settings.html 200 ("Paramant Admin - Settings")
+- PASS: /admin/cli.html 200
+
+## Phase 11 - ParaSign + license-server
+
+- /v2/sign POST -> 405, /v2/verify POST -> 405 (AMBIGUOUS: routed to relay but
+  method/endpoint not active; the notary endpoints land in open PR #73, not yet
+  merged. Logged, not asserted working.)
+- license.paramant.app/health -> 000 (DNS/service not up; license-server not
+  deployed yet). Expected.
+
+## Phase 12 - PWA / service worker
+
+- PASS: /sw.js 200, /manifest.json 200. (SW present and serving.)
+
+## Phase 13 - Security headers (homepage)
+
+- PASS: strict-transport-security, content-security-policy,
+  x-content-type-options, x-frame-options, referrer-policy -- all present.
+
+## Phase 14 - Open PRs
+
+- #73 [MERGEABLE/CLEAN] feat(parasign): Sg1 step 3 - /v2/sign + /v2/verify.
+  NOT auto-merged: it is a `feat:` (backend crypto), outside the docs/ops/chore
+  auto-merge scope. Merging + deploying it would light up /v2/sign, /v2/verify
+  and (if it includes them) the /sign /verify pages. Left for explicit review.
+- No docs/ops/chore PRs were open, so none were auto-merged.
+
+## Write actions
+
+- Production: **NONE.** No restore/rsync/reload/container-restart was needed
+  (webroot complete + current).
+- Repo: 1 content fix -- `frontend/trust.html` build label 2.5.0 -> 3.0.0
+  (in this PR).
+
+## Skipped (with reasons)
+
+- Admin restore (rsync admin/public/ -> webroot/admin/): SKIPPED. /admin is
+  container-served; webroot admin files are never served by nginx. Would be
+  dead clutter.
+- Admin container restart: SKIPPED. Container healthy (~uptime ok); hard rule
+  "containers blijven draaien".
+- Frontend rsync + nginx reload: SKIPPED. Webroot already byte-matches main;
+  no config changed. Avoided a pointless production write.
+
+## Remaining follow-ups for Mick (not auto-actioned)
+
+1. Merge + deploy PR #73 to bring ParaSign /v2/sign + /v2/verify (and /sign,
+   /verify pages if bundled) live.
+2. Deploy license-server so license.paramant.app/health = 200 and publish
+   /.well-known/paramant-licensing.pub.
+3. Merge this PR + sync webroot to push the /trust 3.0.0 label live.

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -151,7 +151,7 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
 <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span class="">build 2.5.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
   <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>


### PR DESCRIPTION
Full Apple-level audit of paramant.app + one repo content fix. Per-check
pass/fail in `docs/audit-reports/mega-audit-20260528-0017.md`.

## Verdict: site is operational, fully on 3.0.0
The reported regression ("admin/* weggehaald, dashboard rendert leeg") was
**NOT reproduced**. Webroot is complete and byte-identical to main; `/admin`
is reachable (it's proxied to the admin container, never served from the
webroot); `/dashboard` renders (55 KB, 37 card elements). **No production write
actions were needed or performed.**

## Results (summary)
- Backend: relay + 4 sectors all 3.0.0; `/v2/capabilities` R006 core (1 KEM / 2 sig). PASS
- Nav: 41/44 paths 200. The 3 non-200 are expected/not-yet-deployed: `/sign`, `/verify` (ParaSign PR #73 unmerged), `/.well-known/paramant-licensing.pub` (license-server not deployed).
- `/admin/`, `/admin/settings.html`, `/admin/cli.html`: all 200.
- `/dashboard`: 55 KB, 37 cards (not empty).
- SW + manifest: 200. All 5 security headers present.
- ParaSign `/v2/sign|verify`: 405 (ambiguous; feature in open PR #73). license.paramant.app: 000 (not deployed).

## Fix in this PR
`frontend/trust.html` showed a stale `build 2.5.0` -> corrected to `3.0.0`.
(Goes live on next webroot sync after merge.)

## Deliberately NOT done (per safety rules / false premise)
- No `admin/public/ -> webroot/admin/` rsync (admin is container-served; would be dead files).
- No admin container restart (healthy; "containers blijven draaien").
- No frontend rsync / nginx reload (webroot already current; nothing to change).
- Did NOT auto-merge PR #73 (`feat(parasign)`) -- outside docs/ops/chore scope; backend feature needs explicit review + deploy.

## Follow-ups for Mick
1. Review + merge + deploy PR #73 (ParaSign /v2/sign + /v2/verify).
2. Deploy license-server (license.paramant.app, licensing.pub).
3. Merge this PR + sync webroot to push the /trust 3.0.0 label live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)