### PR TITLE
feat(ui): make all admin tooling discoverable (hub links + docs)

### DIFF
--- a/admin/public/cli.html
+++ b/admin/public/cli.html
@@ -51,6 +51,12 @@
     width: 26px; height: 26px; cursor: pointer; font-size: 13px;
   }
   .help-toggle:hover { color: var(--text); border-color: var(--accent); }
+  .cli-navlink {
+    font-size: 11px; color: var(--muted); text-decoration: none;
+    border: 1px solid var(--border); border-radius: 6px;
+    padding: 4px 10px; transition: color .15s, border-color .15s;
+  }
+  .cli-navlink:hover { color: var(--text); border-color: var(--accent); }
   .terminal-container {
     flex: 1; min-height: 0; padding: 8px 10px;
     background: var(--bg);
@@ -99,6 +105,8 @@
     <h1>Paramant CLI</h1>
     <span class="connection-status" id="conn">connecting</span>
     <span class="spacer"></span>
+    <a class="cli-navlink" href="/admin/">Hub</a>
+    <a class="cli-navlink" href="/admin/settings.html">Settings</a>
     <button class="help-toggle" id="help-btn" title="Show help">?</button>
   </header>
 

--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -201,6 +201,10 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
       <span class="lic">v3.0.0 · Licensed</span>
       <a class="lo-btn" href="/admin/settings.html" style="text-decoration:none">Settings</a>
       <a class="lo-btn" href="/admin/cli.html" style="text-decoration:none">CLI</a>
+      <a class="lo-btn" data-toolhub href="/dashboard" style="text-decoration:none">Dashboard</a>
+      <a class="lo-btn" data-toolhub href="/ct-log" style="text-decoration:none">CT log</a>
+      <a class="lo-btn" data-toolhub href="/status" style="text-decoration:none">Status</a>
+      <a class="lo-btn" data-toolhub href="/docs#operator-scripts" style="text-decoration:none">Scripts</a>
       <button class="lo-btn" onclick="doLogout()">Sign out</button>
     </div>
   </header>

--- a/admin/public/settings.html
+++ b/admin/public/settings.html
@@ -92,7 +92,10 @@
 <body>
 <header>
   <span class="hdr-brand">Paramant Admin / Settings</span>
-  <a class="hdr-back" href="/admin/">&larr; Dashboard</a>
+  <span style="display:flex;gap:8px">
+    <a class="hdr-back" href="/admin/cli.html">CLI</a>
+    <a class="hdr-back" href="/admin/">&larr; Hub</a>
+  </span>
 </header>
 
 <div id="banner" class="banner">

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -373,6 +373,7 @@ tr:last-child td{border-bottom:none}
     <a href="#compliance-nen7510">NEN 7510</a>
     <a href="#compliance-iec62443">IEC 62443</a>
     <h3>FAQ</h3>
+    <a href="#operator-scripts">Operator scripts</a>
     <a href="#faq">Frequently asked</a>
   </div>
 
@@ -951,6 +952,22 @@ python3 scripts/paramant-admin.py sync</pre>
     <p><a href="/compliance/iec62443" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">View full IEC 62443 compliance documentation →</a></p>
 
     <!-- ── FAQ ──────────────────────────────────────────────────── -->
+    <!-- Operator scripts -->
+    <h2 id="operator-scripts">Operator scripts</h2>
+    <p>Self-host operators get a set of command-line helpers under <code>scripts/</code> in the <a href="https://github.com/Apolloccrypt/paramant-relay" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">paramant-relay</a> repo. SSH into your relay host and run them from the repo root. For most of these there is an in-browser equivalent at <a href="/admin/cli" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">/admin/cli</a> (admin login required).</p>
+    <ul>
+      <li><strong>Keys.</strong> <code>scripts/paramant-key-add.sh</code> &mdash; provision an API key.</li>
+      <li><strong>Signing.</strong> <code>scripts/paramant-sign</code> &mdash; ParaSign CLI: sign a document (ML-DSA-65, client-side) and notarise it into a <code>.psign</code> envelope, or verify one. See ADR R017.</li>
+      <li><strong>Deploy safety.</strong> <code>scripts/post-deploy-verify.sh</code> &mdash; post-deploy smoke test (exit 2 on critical failure); <code>scripts/rollback-3.0.0.sh</code> &mdash; roll back to the previously-built relay image.</li>
+      <li><strong>Backups.</strong> <code>scripts/backup-users-json.sh</code> &mdash; age-encrypted backup of relay key metadata (already wired into cron, 03:15 daily; decrypt only in tmpfs).</li>
+    </ul>
+    <div class="cb">
+      <div class="cb-header"><div class="cb-dots"><span class="cb-dot"></span><span class="cb-dot"></span><span class="cb-dot"></span></div><span class="cb-lang">bash</span></div>
+      <pre><span class="cm"># on the relay host, from the repo root</span>
+./scripts/paramant-key-add.sh "customer-acme" pro ops@acme.example
+./scripts/post-deploy-verify.sh https://paramant.app</pre>
+    </div>
+
     <h2 id="faq">Frequently asked questions</h2>
 
     <div class="faq-item">


### PR DESCRIPTION
Makes the built admin tooling **discoverable** from the web interface, grounded
in the real design system (no guessed tokens, no hardcoded off-palette colors).

## Changes (+33/-1, additive)
- **Admin SPA header**: adds Dashboard / CT log / Status / Scripts links (reuses
  the SPA's own `.lo-btn` class; joins the existing Settings + CLI links). The
  tab panels are JS-`innerHTML`-replaced, so the hub lives in the header where it
  persists.
- **`admin/cli.html` + `settings.html`**: cross-nav (Hub / CLI / Settings) using
  each page's existing styles.
- **`/docs`**: new "Operator scripts" section + sidebar entry documenting
  `paramant-key-add`, `paramant-sign`, `post-deploy-verify`, `rollback-3.0.0`,
  `backup-users-json`, with a pointer to `/admin/cli`.

## Why this is NOT a "restyle" (deliberate scope, per the rules)
The prompt asked to restyle cli/settings via `components-parasign.css` and the
design system. Investigation found:
- `cli.html` and `settings.html` are **already on the PARAMANT palette**
  (`#0B3A6A` navy, `#F8FAFC` bone, `#B2FF3F` lime + IBM Plex Mono) and are
  **tightly JS-coupled** (`cli.js`/`settings.js`) with their **own** `.btn`,
  `.main`, `.modal`, `.field` classes.
- `components-parasign.css` **doesn't exist** (the `/sign`+`/verify` overhaul it
  came from was never built — those pages are 404).
- The prompt's CSS used tokens that **don't exist** (`--accent`, `--surface`,
  `--text-muted`) which would fall back to **hardcoded off-palette colors** —
  violating "color scheme is sacred / no hardcoded colors".
- Linking `design-system.css` into these apps would **collide** with their
  same-named classes and risk breaking them.

So I delivered discoverability + cross-nav (the actual goal) without a risky,
no-gain restyle. ParaSign `/sign`+`/verify` deferred until its backend is
deployed (per your choice). Auth flow / TOTP / SPA logic untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)