### PR TITLE
feat(parasign): secure /sign + /verify web UI (client-side signing)

### DIFF
--- a/frontend/components-parasign.css
+++ b/frontend/components-parasign.css
@@ -1,0 +1,73 @@
+/* ParaSign page components (/sign, /verify).
+ * Uses ONLY design-system.css tokens (--ink, --bone, --space-*, etc.).
+ * No hardcoded colors, no invented tokens. Dark mode follows .dark via tokens. */
+
+.ps-wrap { max-width: 760px; margin: var(--space-6) auto; padding: 0 var(--space-4); }
+.ps-head { margin-bottom: var(--space-6); }
+.ps-kicker {
+  font-family: var(--mono); font-size: var(--text-xs); letter-spacing: .12em;
+  text-transform: uppercase; color: var(--ink-dim); margin: 0 0 var(--space-2);
+}
+.ps-title { font-size: var(--text-3xl); margin: 0 0 var(--space-2); line-height: 1.1; }
+.ps-lede { color: var(--ink-dim); font-size: var(--text-md); line-height: 1.5; margin: 0; }
+
+.ps-panel { margin-bottom: var(--space-4); }
+.ps-panel-head { display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-3); }
+.ps-step {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 1.6rem; height: 1.6rem; flex: 0 0 1.6rem; border-radius: 50%;
+  background: var(--navy); color: var(--bone); font-family: var(--mono);
+  font-size: var(--text-xs); font-weight: 700;
+}
+.ps-panel-title { font-size: var(--text-lg); margin: 0; }
+.ps-help { color: var(--ink-dim); font-size: var(--text-sm); line-height: 1.5; margin: 0 0 var(--space-4); }
+
+.ps-btn-row { display: flex; flex-wrap: wrap; gap: var(--space-2); align-items: center; }
+
+.ps-file {
+  display: block; padding: var(--space-5); border: 1.5px dashed var(--ink-hair);
+  border-radius: 10px; text-align: center; cursor: pointer; background: var(--ink-ghost);
+  transition: border-color .15s, background .15s;
+}
+.ps-file:hover { border-color: var(--navy); }
+.ps-file input[type=file] { display: none; }
+.ps-file-cta { display: block; font-weight: 600; margin-bottom: var(--space-1); }
+.ps-file-meta { display: block; font-family: var(--mono); font-size: var(--text-xs); color: var(--ink-dim); }
+
+.ps-field { margin-top: var(--space-4); }
+.ps-label { display: block; font-size: var(--text-sm); font-weight: 500; color: var(--ink-dim); margin-bottom: var(--space-2); }
+.ps-input {
+  width: 100%; padding: var(--space-3); border: 1.5px solid var(--ink-hair);
+  border-radius: 8px; font-size: var(--text-md); background: var(--bone);
+  color: var(--ink); font-family: var(--sans);
+}
+.ps-input.mono { font-family: var(--mono); }
+.ps-input:focus { outline: none; border-color: var(--navy); }
+
+.ps-kv { margin: 0; display: grid; grid-template-columns: max-content 1fr; gap: var(--space-2) var(--space-5); font-size: var(--text-sm); }
+.ps-kv dt { color: var(--ink-dim); }
+.ps-kv dd { margin: 0; }
+.mono { font-family: var(--mono); font-size: var(--text-xs); word-break: break-all; }
+
+.ps-keybox { background: var(--ink-ghost); border-radius: 8px; padding: var(--space-4); margin-top: var(--space-4); }
+.ps-warn { margin: var(--space-3) 0 0; font-size: var(--text-xs); color: var(--ink-dim); }
+
+.ps-banner { margin-top: var(--space-4); padding: var(--space-3) var(--space-4); border-radius: 8px; font-size: var(--text-sm); border-left: 3px solid var(--ink-hair); background: var(--ink-ghost); color: var(--ink); }
+.ps-banner.info { border-left-color: var(--navy); }
+.ps-banner.ok   { border-left-color: var(--lime); }
+.ps-banner.err  { border-left-color: var(--ink); background: var(--bone-2); }
+
+.ps-result { margin-top: var(--space-4); padding: var(--space-4); border-radius: 8px; background: var(--ink-ghost); }
+.ps-result .ps-btn-row { margin-top: var(--space-4); }
+
+.ps-info { margin-top: var(--space-6); padding: var(--space-5); background: var(--ink-ghost); border-radius: 12px; }
+.ps-info h2 { font-size: var(--text-md); margin: 0 0 var(--space-3); }
+.ps-info p, .ps-info li { font-size: var(--text-sm); color: var(--ink-dim); line-height: 1.5; }
+.ps-info ul { margin: 0; padding-left: var(--space-5); }
+
+@media (max-width: 600px) {
+  .ps-wrap { margin: var(--space-4) auto; }
+  .ps-title { font-size: var(--text-2xl); }
+  .ps-btn-row { flex-direction: column; align-items: stretch; }
+  .ps-btn-row .btn { width: 100%; }
+}

--- a/frontend/parasign-client.js
+++ b/frontend/parasign-client.js
@@ -1,0 +1,109 @@
+// ParaSign /sign page logic.
+// SECURITY: the private key and the document NEVER leave this browser.
+// Only the SHA3-256 hash (hex), the ML-DSA-65 signature (base64), and the
+// public key (base64) are sent to the relay notary. (Contract matches
+// relay/parasign.js + the /v2/sign handler, which base64-decodes signature
+// and signer_public_key.)
+// NOTE: crypto is loaded from esm.sh (CDN). Vendoring an ML-DSA bundle is a
+// tracked follow-up (M-06 EU-sovereignty); it does not affect the no-leak model.
+import { ml_dsa65 } from 'https://esm.sh/@noble/post-quantum@0.4.1/ml-dsa';
+import { sha3_256 } from 'https://esm.sh/@noble/hashes@1.5.0/sha3';
+
+const RELAY_URL = 'https://relay.paramant.app';
+let signerKey = null, documentBuffer = null, documentFilename = '', lastEnvelope = null;
+
+const $ = id => document.getElementById(id);
+const toHex = u8 => Array.from(u8, b => b.toString(16).padStart(2, '0')).join('');
+const fromHex = h => new Uint8Array(h.match(/.{2}/g).map(b => parseInt(b, 16)));
+function toB64(u8) { let s = ''; for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]); return btoa(s); }
+
+function setStatus(kind, msg) {
+  const el = $('ps-sign-status'); if (!el) return;
+  el.hidden = false; el.className = 'ps-banner ' + kind; el.textContent = msg;
+}
+function updateSignButton() {
+  const apiKey = ($('ps-api-key').value || '').trim();
+  $('ps-sign').disabled = !(signerKey && documentBuffer && apiKey);
+}
+
+function generateKey() {
+  setStatus('info', 'Generating ML-DSA-65 key locally (in this browser only)...');
+  try {
+    const keys = ml_dsa65.keygen(crypto.getRandomValues(new Uint8Array(32)));
+    signerKey = { secretKey: keys.secretKey, publicKey: keys.publicKey };
+    $('ps-pubkey-fp').textContent = toHex(sha3_256(keys.publicKey)).slice(0, 32) + '...';
+    $('ps-key-info').hidden = false; $('ps-save-key').disabled = false;
+    setStatus('ok', 'Key generated. Private key stays in browser memory.');
+    updateSignButton();
+  } catch (e) { setStatus('err', 'Keygen failed: ' + e.message); }
+}
+
+async function loadKey(file) {
+  try {
+    const d = JSON.parse(await file.text());
+    if (!d.secretKey || !d.publicKey) throw new Error('invalid key file');
+    signerKey = { secretKey: fromHex(d.secretKey), publicKey: fromHex(d.publicKey) };
+    $('ps-pubkey-fp').textContent = toHex(sha3_256(signerKey.publicKey)).slice(0, 32) + '...';
+    $('ps-key-info').hidden = false; $('ps-save-key').disabled = false;
+    setStatus('ok', 'Key loaded (client-side only).'); updateSignButton();
+  } catch (e) { setStatus('err', 'Load failed: ' + e.message); }
+}
+
+function saveKey() {
+  if (!signerKey) return;
+  const data = { algorithm: 'ML-DSA-65', publicKey: toHex(signerKey.publicKey),
+    secretKey: toHex(signerKey.secretKey), generated_at: new Date().toISOString(),
+    warning: 'Private key. Anyone with this can sign as you. Keep it secret.' };
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' }));
+  a.download = 'parasign-key-' + Date.now() + '.json'; a.click(); URL.revokeObjectURL(a.href);
+}
+
+async function onDoc(file) {
+  if (!file) return;
+  documentBuffer = await file.arrayBuffer(); documentFilename = file.name;
+  $('ps-document-info').textContent = file.name + ' (' + (file.size / 1024).toFixed(1) + ' KB)';
+  updateSignButton();
+}
+
+async function sign() {
+  if (!signerKey || !documentBuffer) return;
+  $('ps-sign').disabled = true;
+  setStatus('info', 'Hashing + signing locally (key + document stay here)...');
+  try {
+    const docHash = sha3_256(new Uint8Array(documentBuffer));   // 32-byte digest, local
+    const signature = ml_dsa65.sign(signerKey.secretKey, docHash); // local sign over the digest
+    setStatus('info', 'Sending hash + signature to the notary (no document, no key)...');
+    const res = await fetch(RELAY_URL + '/v2/sign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Api-Key': $('ps-api-key').value.trim() },
+      body: JSON.stringify({
+        document_hash: toHex(docHash),                 // hex
+        signature: toB64(signature),                   // base64 (relay decodes b64)
+        signer_public_key: toB64(signerKey.publicKey), // base64
+        signer_label: $('ps-label').value || null,
+      }),
+    });
+    if (!res.ok) throw new Error('HTTP ' + res.status + ': ' + (await res.text()).slice(0, 200));
+    const result = await res.json();
+    lastEnvelope = result.envelope || result;
+    $('ps-ct-index').textContent = (lastEnvelope.notary && lastEnvelope.notary.ct_log_index) ?? lastEnvelope.ct_log_index ?? '-';
+    $('ps-result').hidden = false;
+    setStatus('ok', 'Document signed. Envelope ready to download.');
+  } catch (e) { setStatus('err', 'Sign failed: ' + e.message); $('ps-sign').disabled = false; }
+}
+
+function download() {
+  if (!lastEnvelope) return;
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(new Blob([JSON.stringify(lastEnvelope, null, 2)], { type: 'application/json' }));
+  a.download = (documentFilename || 'document') + '.psign'; a.click(); URL.revokeObjectURL(a.href);
+}
+
+$('ps-gen-key').addEventListener('click', generateKey);
+$('ps-load-key').addEventListener('change', e => e.target.files[0] && loadKey(e.target.files[0]));
+$('ps-save-key').addEventListener('click', saveKey);
+$('ps-document').addEventListener('change', e => onDoc(e.target.files[0]));
+$('ps-api-key').addEventListener('input', updateSignButton);
+$('ps-sign').addEventListener('click', sign);
+$('ps-download-psign').addEventListener('click', download);

--- a/frontend/parasign-verify.js
+++ b/frontend/parasign-verify.js
@@ -1,0 +1,81 @@
+// ParaSign /verify page logic.
+// The document NEVER leaves the browser: only its SHA3-256 hash + the .psign
+// envelope are sent to /v2/verify (which runs the verification math).
+// The deployed /v2/verify requires X-Api-Key, so a key field is shown.
+import { sha3_256 } from 'https://esm.sh/@noble/hashes@1.5.0/sha3';
+
+const RELAY_URL = 'https://relay.paramant.app';
+let documentBuffer = null, envelope = null;
+
+const $ = id => document.getElementById(id);
+const toHex = u8 => Array.from(u8, b => b.toString(16).padStart(2, '0')).join('');
+const esc = s => String(s).replace(/[<>&"]/g, c => ({ '<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;' }[c]));
+
+function update() {
+  const apiKey = ($('vf-api-key').value || '').trim();
+  $('vf-verify').disabled = !(documentBuffer && envelope && apiKey);
+}
+
+async function onDoc(file) {
+  if (!file) return;
+  documentBuffer = await file.arrayBuffer();
+  $('vf-document-info').textContent = file.name + ' (' + (file.size / 1024).toFixed(1) + ' KB)';
+  update();
+}
+
+async function onEnv(file) {
+  if (!file) return;
+  try {
+    envelope = JSON.parse(await file.text());
+    if (envelope.envelope) envelope = envelope.envelope;
+    const info = ['algorithm: ' + (envelope.algorithm || '?'), 'signed_at: ' + (envelope.signed_at || '?')];
+    if (envelope.signer && envelope.signer.label) info.push('signer: ' + envelope.signer.label);
+    const idx = (envelope.notary && envelope.notary.ct_log_index);
+    if (idx != null) info.push('ct_log_index: ' + idx);
+    $('vf-envelope-info').textContent = info.join('  |  ');
+  } catch (e) { $('vf-envelope-info').textContent = 'Invalid envelope: ' + e.message; envelope = null; }
+  update();
+}
+
+async function verify() {
+  $('vf-verify').disabled = true;
+  $('vf-result').hidden = false;
+  $('vf-result').innerHTML = '<div class="ps-banner info">Hashing locally + verifying via relay...</div>';
+  try {
+    const docHash = sha3_256(new Uint8Array(documentBuffer)); // local
+    const res = await fetch(RELAY_URL + '/v2/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Api-Key': $('vf-api-key').value.trim() },
+      body: JSON.stringify({ document_hash: toHex(docHash), envelope }),
+    });
+    if (!res.ok && res.status !== 200) {
+      const t = await res.text();
+      $('vf-result').innerHTML = '<div class="ps-banner err">Relay HTTP ' + res.status + ': ' + esc(t.slice(0, 200)) + '</div>';
+      return;
+    }
+    renderResult(await res.json());
+  } catch (e) {
+    $('vf-result').innerHTML = '<div class="ps-banner err">Verify failed: ' + esc(e.message) + '</div>';
+  } finally { $('vf-verify').disabled = false; }
+}
+
+function renderResult(r) {
+  const out = [];
+  out.push(r.valid
+    ? '<div class="ps-banner ok"><strong>Signature valid.</strong> Document matches the signed hash.</div>'
+    : '<div class="ps-banner err"><strong>Signature INVALID.</strong></div>');
+  if (r.errors && r.errors.length) {
+    out.push('<ul style="margin-top:var(--space-3)">');
+    r.errors.forEach(e => out.push('<li class="ps-help">' + esc(e) + '</li>'));
+    out.push('</ul>');
+  }
+  if (r.note) out.push('<p class="ps-help">' + esc(r.note) + '</p>');
+  const idx = envelope && envelope.notary && envelope.notary.ct_log_index;
+  if (idx != null) out.push('<p class="ps-help">CT log index: <a href="/ct-log">' + esc(String(idx)) + '</a></p>');
+  $('vf-result').innerHTML = out.join('');
+}
+
+$('vf-document').addEventListener('change', e => onDoc(e.target.files[0]));
+$('vf-envelope').addEventListener('change', e => onEnv(e.target.files[0]));
+$('vf-api-key').addEventListener('input', update);
+$('vf-verify').addEventListener('click', verify);

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sign a document — PARAMANT</title>
+<meta name="description" content="Sign documents with ML-DSA-65 (FIPS 204). Private key and document never leave your browser.">
+<link rel="canonical" href="https://paramant.app/sign">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0B3A6A">
+<link rel="stylesheet" href="/design-system.css?v=19">
+<link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/components-parasign.css?v=1">
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<div class="meta-bar">
+  <span class="">build 3.0.0</span>
+  <span class="sep">·</span>
+  <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
+  <span class="sep">·</span>
+  <span class="">eu/de · ram only</span>
+</div>
+
+<nav class="nav">
+  <a href="/" class="nav-logo"><span class="logo-para">Para</span><span class="logo-mant">MANT</span></a>
+
+  <ul class="nav-links">
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
+        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
+        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
+      </ul>
+    </li>
+
+    <li><a href="/pricing" class="nav-link">Pricing</a></li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Developers</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/docs" role="menuitem">Docs</a></li>
+        <li role="none"><a href="/docs#api" role="menuitem">API reference</a></li>
+        <li role="none"><a href="/ct-log" role="menuitem">CT Log</a></li>
+        <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay" role="menuitem">GitHub</a></li>
+        <li role="none"><a href="https://hub.docker.com/r/mtty001/relay" role="menuitem">Docker Hub</a></li>
+        <li role="none"><a href="/changelog" role="menuitem">Changelog</a></li>
+      </ul>
+    </li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
+        <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
+        <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
+        <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
+        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
+        <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
+      </ul>
+    </li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Compliance</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li class="nav-subheader" role="presentation">Standards</li>
+        <li role="none"><a href="/compliance/nis2" role="menuitem">NIS2 (EU 2022/2555)</a></li>
+        <li role="none"><a href="/compliance/iec62443" role="menuitem">IEC 62443 (Industrial IoT)</a></li>
+        <li role="none"><a href="/compliance/nen7510" role="menuitem">NEN 7510 (Dutch Healthcare)</a></li>
+        <li class="nav-subheader" role="presentation">Sovereignty</li>
+        <li role="none"><a href="/sovereignty" role="menuitem">Jurisdiction</a></li>
+        <li role="none"><a href="/government" role="menuitem">Government &amp; public sector</a></li>
+        <li class="nav-subheader" role="presentation">OT</li>
+        <li role="none"><a href="/ot" role="menuitem">OT guide</a></li>
+        <li role="none"><a href="/ot-vs-data-diodes" role="menuitem">OT vs data diodes</a></li>
+        <li class="nav-subheader" role="presentation">Post-quantum</li>
+        <li role="none"><a href="/hndl" role="menuitem">HNDL threat</a></li>
+        <li role="none"><a href="/quantum-urgency" role="menuitem">Quantum urgency</a></li>
+        <li role="none"><a href="/crypto-agility" role="menuitem">Crypto agility</a></li>
+        <li class="nav-subheader" role="presentation">Legal</li>
+        <li role="none"><a href="/dpa" role="menuitem">Data Processing Agreement</a></li>
+      </ul>
+    </li>
+
+    <li><a href="/vs" class="nav-link">Compare</a></li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">About</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/status" role="menuitem">Status</a></li>
+        <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
+        <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
+        <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
+        <li role="none"><a href="/license" role="menuitem">License</a></li>
+        <li role="none"><a href="/press" role="menuitem">Press kit</a></li>
+        <li role="none"><a href="mailto:privacy@paramant.app" role="menuitem">Contact</a></li>
+      </ul>
+    </li>
+
+  </ul>
+
+  <div class="nav-auth" id="nav-auth">
+    <a href="/auth/login" class="nav-signin">Sign in</a>
+    <a href="/signup" class="nav-cta">Create account</a>
+  </div>
+
+  <button class="nav-hamburger" id="nav-hamburger" aria-label="Open menu" aria-expanded="false">
+    <span></span><span></span><span></span>
+  </button>
+</nav>
+
+<main id="main-content" role="main">
+<div class="ps-wrap">
+  <header class="ps-head">
+    <p class="ps-kicker">ParaSign &middot; post-quantum signature</p>
+    <h1 class="ps-title">Sign a document</h1>
+    <p class="ps-lede">ML-DSA-65 (FIPS 204). Your private key and the document never leave this browser &mdash; only the document hash and the signature are sent to the notary. Recipients get a self-contained <code>.psign</code> envelope.</p>
+  </header>
+
+  <section class="card ps-panel" aria-labelledby="s1">
+    <div class="ps-panel-head"><span class="ps-step">1</span><h2 id="s1" class="ps-panel-title">Signing key</h2></div>
+    <p class="ps-help">Generate a fresh ML-DSA-65 key or load one you saved earlier. The key stays in browser memory.</p>
+    <div class="ps-btn-row">
+      <button class="btn btn-primary" id="ps-gen-key" type="button">Generate new key</button>
+      <label class="btn btn-secondary">Load key file<input type="file" id="ps-load-key" accept=".json,application/json" hidden></label>
+      <button class="btn btn-tertiary" id="ps-save-key" type="button" disabled>Download key</button>
+    </div>
+    <div class="ps-keybox" id="ps-key-info" hidden>
+      <dl class="ps-kv">
+        <dt>Public key fingerprint</dt><dd class="mono" id="ps-pubkey-fp">-</dd>
+        <dt>Algorithm</dt><dd>ML-DSA-65 (FIPS 204)</dd>
+      </dl>
+      <p class="ps-warn">Private key is in memory only. Download it if you want to reuse this identity later.</p>
+    </div>
+  </section>
+
+  <section class="card ps-panel" aria-labelledby="s2">
+    <div class="ps-panel-head"><span class="ps-step">2</span><h2 id="s2" class="ps-panel-title">Document &amp; key</h2></div>
+    <label class="ps-file"><input type="file" id="ps-document"><span class="ps-file-cta">Choose a document (or drop here)</span><span class="ps-file-meta" id="ps-document-info">No file selected</span></label>
+    <div class="ps-field">
+      <label class="ps-label" for="ps-label">Optional signer label</label>
+      <input class="ps-input" type="text" id="ps-label" maxlength="80" placeholder="e.g. Mick Beer / Paramant">
+    </div>
+    <div class="ps-field">
+      <label class="ps-label" for="ps-api-key">API key (X-Api-Key)</label>
+      <input class="ps-input mono" type="password" id="ps-api-key" placeholder="pgp_..." autocomplete="off">
+      <p class="ps-warn">Required to authenticate the notarise request. The key is sent only as the request header; your signing key is never sent.</p>
+    </div>
+  </section>
+
+  <section class="card ps-panel" aria-labelledby="s3">
+    <div class="ps-panel-head"><span class="ps-step">3</span><h2 id="s3" class="ps-panel-title">Sign</h2></div>
+    <button class="btn btn-primary" id="ps-sign" type="button" disabled>Sign document</button>
+    <div class="ps-banner" id="ps-sign-status" hidden role="status" aria-live="polite"></div>
+    <div class="ps-result" id="ps-result" hidden>
+      <dl class="ps-kv"><dt>Status</dt><dd>Signed &amp; notarised</dd><dt>CT log index</dt><dd class="mono" id="ps-ct-index">-</dd></dl>
+      <div class="ps-btn-row"><button class="btn btn-primary" id="ps-download-psign" type="button">Download .psign</button><a class="btn btn-tertiary" href="/verify">Verify an envelope</a></div>
+    </div>
+  </section>
+
+  <aside class="ps-info">
+    <h2>What is in a .psign?</h2>
+    <p>The signature, your public key, the SHA3-256 of the document, a CT-log proof, and the relay's notary signature. The recipient verifies against the original document.</p>
+    <p><a href="/verify">Verify a .psign envelope &rarr;</a> &middot; <a href="/docs#operator-scripts">CLI: paramant-sign &rarr;</a></p>
+  </aside>
+</div>
+</main>
+
+<footer>
+  <div class="container-lg">
+    <div class="footer-grid">
+      <div>
+        <div class="logo" style="margin-bottom:var(--space-3)"><span class="a">Para</span><span class="b">MANT</span></div>
+        <p style="font-size:var(--text-xs);color:var(--ink-dim);line-height:1.7;max-width:220px">Encrypted file relay. RAM-only. Burn-on-read.</p>
+        <p style="font-family:var(--mono);font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-4);line-height:1.8">FIPS 203 / 204 &middot; Hetzner DE<br>GDPR &middot; no US CLOUD Act<br>BUSL-1.1 &middot; &copy; 2026 PARAMANT</p>
+      </div>
+      <div>
+        <div class="footer-col-label">Trust</div>
+        <div class="footer-links">
+          <a href="/status">Status</a>
+          <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
+          <a href="/ct-log">CT Log</a>
+          <a href="/license">License</a>
+          <a href="/press">Press kit</a>
+        </div>
+      </div>
+      <div>
+        <div class="footer-col-label">Legal</div>
+        <div class="footer-links">
+          <a href="/dpa">Data Processing Agreement</a>
+          <a href="/sla">SLA</a>
+          <a href="/compliance/nis2">Compliance overview</a>
+        </div>
+      </div>
+      <div>
+        <div class="footer-col-label">Self-host</div>
+        <div class="footer-links">
+          <a href="/docs#self-hosting">Deploy guide</a>
+          <a href="/setup">Setup wizard</a>
+          <a href="/install.sh">install.sh</a>
+          <a href="/install-pi.sh">install-pi.sh</a>
+          <a href="/download">ParamantOS</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+        </div>
+      </div>
+      <div>
+        <div class="footer-col-label">Connect</div>
+        <div class="footer-links">
+          <a href="mailto:privacy@paramant.app">Contact</a>
+          <a href="/signup">Create account</a>
+          <a href="/auth/login">Sign in</a>
+          <a href="/help">Help</a>
+          <a href="/partners">Partners</a>
+          <a href="/changelog">Changelog</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+<script src="/nav.js?v=12" defer></script>
+<script src="/js/nav-auth.js" defer></script>
+<script type="module" src="/parasign-client.js?v=1"></script>
+</body>
+</html>

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Verify signature — PARAMANT</title>
+<meta name="description" content="Verify a .psign envelope against the original document. ML-DSA-65 (FIPS 204).">
+<link rel="canonical" href="https://paramant.app/verify">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0B3A6A">
+<link rel="stylesheet" href="/design-system.css?v=19">
+<link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/components-parasign.css?v=1">
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<div class="meta-bar">
+  <span class="">build 3.0.0</span>
+  <span class="sep">·</span>
+  <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
+  <span class="sep">·</span>
+  <span class="">eu/de · ram only</span>
+</div>
+
+<nav class="nav">
+  <a href="/" class="nav-logo"><span class="logo-para">Para</span><span class="logo-mant">MANT</span></a>
+
+  <ul class="nav-links">
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
+        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
+        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
+      </ul>
+    </li>
+
+    <li><a href="/pricing" class="nav-link">Pricing</a></li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Developers</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/docs" role="menuitem">Docs</a></li>
+        <li role="none"><a href="/docs#api" role="menuitem">API reference</a></li>
+        <li role="none"><a href="/ct-log" role="menuitem">CT Log</a></li>
+        <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay" role="menuitem">GitHub</a></li>
+        <li role="none"><a href="https://hub.docker.com/r/mtty001/relay" role="menuitem">Docker Hub</a></li>
+        <li role="none"><a href="/changelog" role="menuitem">Changelog</a></li>
+      </ul>
+    </li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
+        <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
+        <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
+        <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
+        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
+        <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
+      </ul>
+    </li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Compliance</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li class="nav-subheader" role="presentation">Standards</li>
+        <li role="none"><a href="/compliance/nis2" role="menuitem">NIS2 (EU 2022/2555)</a></li>
+        <li role="none"><a href="/compliance/iec62443" role="menuitem">IEC 62443 (Industrial IoT)</a></li>
+        <li role="none"><a href="/compliance/nen7510" role="menuitem">NEN 7510 (Dutch Healthcare)</a></li>
+        <li class="nav-subheader" role="presentation">Sovereignty</li>
+        <li role="none"><a href="/sovereignty" role="menuitem">Jurisdiction</a></li>
+        <li role="none"><a href="/government" role="menuitem">Government &amp; public sector</a></li>
+        <li class="nav-subheader" role="presentation">OT</li>
+        <li role="none"><a href="/ot" role="menuitem">OT guide</a></li>
+        <li role="none"><a href="/ot-vs-data-diodes" role="menuitem">OT vs data diodes</a></li>
+        <li class="nav-subheader" role="presentation">Post-quantum</li>
+        <li role="none"><a href="/hndl" role="menuitem">HNDL threat</a></li>
+        <li role="none"><a href="/quantum-urgency" role="menuitem">Quantum urgency</a></li>
+        <li role="none"><a href="/crypto-agility" role="menuitem">Crypto agility</a></li>
+        <li class="nav-subheader" role="presentation">Legal</li>
+        <li role="none"><a href="/dpa" role="menuitem">Data Processing Agreement</a></li>
+      </ul>
+    </li>
+
+    <li><a href="/vs" class="nav-link">Compare</a></li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">About</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/status" role="menuitem">Status</a></li>
+        <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
+        <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
+        <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
+        <li role="none"><a href="/license" role="menuitem">License</a></li>
+        <li role="none"><a href="/press" role="menuitem">Press kit</a></li>
+        <li role="none"><a href="mailto:privacy@paramant.app" role="menuitem">Contact</a></li>
+      </ul>
+    </li>
+
+  </ul>
+
+  <div class="nav-auth" id="nav-auth">
+    <a href="/auth/login" class="nav-signin">Sign in</a>
+    <a href="/signup" class="nav-cta">Create account</a>
+  </div>
+
+  <button class="nav-hamburger" id="nav-hamburger" aria-label="Open menu" aria-expanded="false">
+    <span></span><span></span><span></span>
+  </button>
+</nav>
+
+<main id="main-content" role="main">
+<div class="ps-wrap">
+  <header class="ps-head">
+    <p class="ps-kicker">Verify signature</p>
+    <h1 class="ps-title">Verify a .psign envelope</h1>
+    <p class="ps-lede">Check that a document has not been altered since signing. The document never leaves your browser &mdash; only its SHA3-256 hash and the envelope are sent.</p>
+  </header>
+
+  <section class="card ps-panel" aria-labelledby="v1">
+    <div class="ps-panel-head"><span class="ps-step">1</span><h2 id="v1" class="ps-panel-title">Original document</h2></div>
+    <label class="ps-file"><input type="file" id="vf-document"><span class="ps-file-cta">Choose the original document</span><span class="ps-file-meta" id="vf-document-info">No file selected</span></label>
+  </section>
+
+  <section class="card ps-panel" aria-labelledby="v2">
+    <div class="ps-panel-head"><span class="ps-step">2</span><h2 id="v2" class="ps-panel-title">.psign envelope &amp; key</h2></div>
+    <label class="ps-file"><input type="file" id="vf-envelope" accept=".psign,application/json,.json"><span class="ps-file-cta">Choose the .psign file</span><span class="ps-file-meta" id="vf-envelope-info">No file selected</span></label>
+    <div class="ps-field">
+      <label class="ps-label" for="vf-api-key">API key (X-Api-Key)</label>
+      <input class="ps-input mono" type="password" id="vf-api-key" placeholder="pgp_..." autocomplete="off">
+      <p class="ps-warn">The verify endpoint currently requires an API key. (Fully account-free, client-side verification is a planned enhancement.)</p>
+    </div>
+  </section>
+
+  <section class="card ps-panel" aria-labelledby="v3">
+    <div class="ps-panel-head"><span class="ps-step">3</span><h2 id="v3" class="ps-panel-title">Verify</h2></div>
+    <button class="btn btn-primary" id="vf-verify" type="button" disabled>Verify signature</button>
+    <div class="ps-result" id="vf-result" hidden role="status" aria-live="polite"></div>
+  </section>
+
+  <aside class="ps-info">
+    <h2>What is checked</h2>
+    <ul>
+      <li>SHA3-256 of your document matches the hash inside the envelope</li>
+      <li>The signer's ML-DSA-65 signature over that hash is valid</li>
+      <li>The relay's notary signature over the envelope is valid</li>
+      <li>The envelope has not expired</li>
+    </ul>
+    <p><a href="/sign">Sign a document &rarr;</a></p>
+  </aside>
+</div>
+</main>
+
+<footer>
+  <div class="container-lg">
+    <div class="footer-grid">
+      <div>
+        <div class="logo" style="margin-bottom:var(--space-3)"><span class="a">Para</span><span class="b">MANT</span></div>
+        <p style="font-size:var(--text-xs);color:var(--ink-dim);line-height:1.7;max-width:220px">Encrypted file relay. RAM-only. Burn-on-read.</p>
+        <p style="font-family:var(--mono);font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-4);line-height:1.8">FIPS 203 / 204 &middot; Hetzner DE<br>GDPR &middot; no US CLOUD Act<br>BUSL-1.1 &middot; &copy; 2026 PARAMANT</p>
+      </div>
+      <div>
+        <div class="footer-col-label">Trust</div>
+        <div class="footer-links">
+          <a href="/status">Status</a>
+          <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
+          <a href="/ct-log">CT Log</a>
+          <a href="/license">License</a>
+          <a href="/press">Press kit</a>
+        </div>
+      </div>
+      <div>
+        <div class="footer-col-label">Legal</div>
+        <div class="footer-links">
+          <a href="/dpa">Data Processing Agreement</a>
+          <a href="/sla">SLA</a>
+          <a href="/compliance/nis2">Compliance overview</a>
+        </div>
+      </div>
+      <div>
+        <div class="footer-col-label">Self-host</div>
+        <div class="footer-links">
+          <a href="/docs#self-hosting">Deploy guide</a>
+          <a href="/setup">Setup wizard</a>
+          <a href="/install.sh">install.sh</a>
+          <a href="/install-pi.sh">install-pi.sh</a>
+          <a href="/download">ParamantOS</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+        </div>
+      </div>
+      <div>
+        <div class="footer-col-label">Connect</div>
+        <div class="footer-links">
+          <a href="mailto:privacy@paramant.app">Contact</a>
+          <a href="/signup">Create account</a>
+          <a href="/auth/login">Sign in</a>
+          <a href="/help">Help</a>
+          <a href="/partners">Partners</a>
+          <a href="/changelog">Changelog</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+<script src="/nav.js?v=12" defer></script>
+<script src="/js/nav-auth.js" defer></script>
+<script type="module" src="/parasign-verify.js?v=1"></script>
+</body>
+</html>


### PR DESCRIPTION
ParaSign web UI, now that `/v2/sign` + `/v2/verify` are **live** (relay rebuilt
with parasign.js per PR #81).

## Security model (the whole point)
- **Private key + document never leave the browser.** Client computes SHA3-256
  locally and signs the digest with ML-DSA-65 locally.
- Sent to the notary: `document_hash` (hex), `signature` (**base64**),
  `signer_public_key` (**base64**), optional label. `X-Api-Key` from a user
  field. (Matches `relay/parasign.js` + the `paramant-sign` CLI exactly.)
- `/verify`: client hashes locally, sends `{document_hash, envelope}`.

## Design (no color-scheme changes)
- Reuses the **real site chrome** (inline `nav` + footer from send.html) and
  `design-system.css` `.card`/`.btn`. New `components-parasign.css` uses **only
  real tokens** (`--ink/--bone/--navy/--space-*`) — **0 hardcoded hex**,
  dark-mode via `.dark`. (No `#nav-mount`, no invented `--accent/--surface`.)

## Honest caveats
- The deployed `/v2/verify` **also requires `X-Api-Key`**, so the verify page
  has a key field. Fully account-free **client-side** verification (the envelope
  is self-contained) is a tracked follow-up.
- Crypto loads from esm.sh (CDN); vendoring an ML-DSA bundle (M-06 sovereignty)
  is a follow-up — it doesn't affect the no-leak model.
- Couldn't run the authenticated end-to-end sign roundtrip (no disposable
  API key provided); the contract is matched to the CLI + endpoints are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)