### PR TITLE
fix(parasign): cache-bust ParaSign assets to v2

### DIFF
--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -11,7 +11,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
-<link rel="stylesheet" href="/components-parasign.css?v=1">
+<link rel="stylesheet" href="/components-parasign.css?v=2">
 </head>
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -303,6 +303,6 @@
 </footer>
 <script src="/nav.js?v=12" defer></script>
 <script src="/js/nav-auth.js" defer></script>
-<script type="module" src="/parasign-client.js?v=1"></script>
+<script type="module" src="/parasign-client.js?v=2"></script>
 </body>
 </html>

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -11,7 +11,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
-<link rel="stylesheet" href="/components-parasign.css?v=1">
+<link rel="stylesheet" href="/components-parasign.css?v=2">
 </head>
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -288,6 +288,6 @@
 </footer>
 <script src="/nav.js?v=12" defer></script>
 <script src="/js/nav-auth.js" defer></script>
-<script type="module" src="/parasign-verify.js?v=1"></script>
+<script type="module" src="/parasign-verify.js?v=2"></script>
 </body>
 </html>


### PR DESCRIPTION
Bumps the parasign JS/CSS query versions to `?v=2` so browsers that cached the pre-fix (esm.sh) modules fetch the working vendored ones on a normal reload. Follows PR #86 (vendored crypto). No logic change.