### PR TITLE
fix(nav): ParaSign + Verify in Products (desktop + hamburger), site-wide

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -39,6 +39,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -127,6 +129,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -97,6 +97,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -185,6 +187,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/anti-phishing.html
+++ b/frontend/anti-phishing.html
@@ -98,6 +98,8 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -186,6 +188,8 @@ section p+p{margin-top:14px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -233,6 +233,8 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -321,6 +323,8 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -90,6 +90,8 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -178,6 +180,8 @@ section p+p{margin-top:14px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -134,6 +134,8 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -222,6 +224,8 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -65,6 +65,8 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -153,6 +155,8 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -164,6 +164,8 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -252,6 +254,8 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -226,6 +226,8 @@ body { min-height:100vh; }
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -314,6 +316,8 @@ body { min-height:100vh; }
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -194,6 +194,8 @@ a:hover{color:var(--cobalt)}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -281,6 +283,8 @@ a:hover{color:var(--cobalt)}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -178,6 +178,8 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -266,6 +268,8 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -164,6 +164,8 @@ tr:last-child td{border-bottom:none}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -252,6 +254,8 @@ tr:last-child td{border-bottom:none}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -101,6 +101,8 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -189,6 +191,8 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -141,6 +141,8 @@ input:focus{border-color:var(--cobalt)}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -229,6 +231,8 @@ input:focus{border-color:var(--cobalt)}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/drop.html
+++ b/frontend/drop.html
@@ -207,6 +207,8 @@ select{background:var(--bone);border:1px solid var(--ink-hair);color:var(--ink);
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -295,6 +297,8 @@ select{background:var(--bone);border:1px solid var(--ink-hair);color:var(--ink);
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -142,6 +142,8 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -230,6 +232,8 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -190,6 +190,8 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -278,6 +280,8 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -90,6 +90,8 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -178,6 +180,8 @@ section p+p{margin-top:14px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -149,6 +149,8 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -237,6 +239,8 @@ section p+p{margin-top:14px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -41,6 +41,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -129,6 +131,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -90,6 +90,8 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -178,6 +180,8 @@ section p+p{margin-top:14px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/legal.html
+++ b/frontend/legal.html
@@ -166,6 +166,8 @@ body {
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -254,6 +256,8 @@ body {
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -121,6 +121,8 @@ footer a{color:var(--cobalt)}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -209,6 +211,8 @@ footer a{color:var(--cobalt)}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -90,6 +90,8 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -178,6 +180,8 @@ section p+p{margin-top:14px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/one-pager.html
+++ b/frontend/one-pager.html
@@ -502,6 +502,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -590,6 +592,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -132,6 +132,8 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -220,6 +222,8 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/ot-vs-data-diodes.html
+++ b/frontend/ot-vs-data-diodes.html
@@ -103,6 +103,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -191,6 +193,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -163,6 +163,8 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -251,6 +253,8 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -240,6 +240,8 @@ select:focus{border-color:var(--cobalt)}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -328,6 +330,8 @@ select:focus{border-color:var(--cobalt)}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -83,6 +83,8 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -171,6 +173,8 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -145,6 +145,8 @@ td{color:var(--cobalt)}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -233,6 +235,8 @@ td{color:var(--cobalt)}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -130,6 +130,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -218,6 +220,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -130,6 +130,8 @@ footer a{color:var(--ink);text-decoration:none}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -218,6 +220,8 @@ footer a{color:var(--ink);text-decoration:none}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/quantum-urgency.html
+++ b/frontend/quantum-urgency.html
@@ -103,6 +103,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -191,6 +193,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -89,6 +89,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -177,6 +179,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -153,6 +153,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -241,6 +243,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/send.html
+++ b/frontend/send.html
@@ -139,6 +139,8 @@ select#ttl-select:focus{border-color:var(--cobalt)}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -227,6 +229,8 @@ select#ttl-select:focus{border-color:var(--cobalt)}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -34,6 +34,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -122,6 +124,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -114,6 +114,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -202,6 +204,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -140,6 +140,8 @@ a:hover{opacity:.8}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -228,6 +230,8 @@ a:hover{opacity:.8}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -104,6 +104,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -192,6 +194,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -97,6 +97,8 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -185,6 +187,8 @@ section p+p{margin-top:14px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -153,6 +153,8 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -241,6 +243,8 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -168,6 +168,8 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -256,6 +258,8 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -34,6 +34,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -122,6 +124,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -103,6 +103,8 @@
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -191,6 +193,8 @@
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -90,6 +90,8 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
+        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
+        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -178,6 +180,8 @@ section p+p{margin-top:14px}
       <a href="/send">Send a file</a>
       <a href="/parashare">ParaShare</a>
       <a href="/drop">ParaDrop</a>
+      <a href="/sign">ParaSign</a>
+      <a href="/verify">Verify signature</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>


### PR DESCRIPTION
ParaSign/Verify were live but **missing from the Products nav** everywhere (only 2/53 pages linked /sign) — including the mobile hamburger drawer (reported on /get). Adds both after ParaDrop in the Products group across **47 pages**, in the desktop dropdown and the mobile drawer. Inline nav markup only; nav.js/nav.css untouched.