### PR TITLE
feat: dashboard quick-actions hub + public Receive landing

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -353,6 +353,27 @@ a:hover{color:var(--cobalt)}
   <a href="/help" class="nav-mobile-standalone">Help</a>
 </div>
 
+<style id="ps-launch-css">
+.launch-wrap{max-width:1100px;margin:24px auto 0;padding:0 20px}
+.launch-head{font-family:var(--mono);font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:12px}
+.launch-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px}
+.launch-card{display:block;padding:16px;border:1px solid var(--ink-hair);border-radius:12px;background:transparent;text-decoration:none;color:var(--ink);transition:border-color .15s,transform .15s}
+.launch-card:hover{border-color:var(--cobalt);transform:translateY(-2px)}
+.launch-card .lt{font-weight:700;font-size:14px;margin-bottom:4px;font-family:var(--sans)}
+.launch-card .ld{font-size:12px;color:var(--ink-dim);line-height:1.4}
+@media(max-width:600px){.launch-grid{grid-template-columns:1fr 1fr}}
+</style>
+<section class="launch-wrap" aria-label="Quick actions">
+  <div class="launch-head">Quick actions</div>
+  <div class="launch-grid">
+    <a class="launch-card" href="/send"><div class="lt">Send a file</div><div class="ld">Anonymous, burn-on-read</div></a>
+    <a class="launch-card" href="/parashare"><div class="lt">ParaShare</div><div class="ld">Verified, signed receipts</div></a>
+    <a class="launch-card" href="/drop"><div class="lt">ParaDrop</div><div class="ld">Device-to-device</div></a>
+    <a class="launch-card" href="/sign"><div class="lt">ParaSign</div><div class="ld">Sign a document</div></a>
+    <a class="launch-card" href="/verify"><div class="lt">Verify signature</div><div class="ld">Check a .psign</div></a>
+    <a class="launch-card" href="/get"><div class="lt">Receive</div><div class="ld">Open a secure link</div></a>
+  </div>
+</section>
 <div id="root"></div>
 
 <div id="side-panel-backdrop" class="side-panel-backdrop" onclick="closeSidePanel()"></div>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -303,6 +303,20 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 </div>
 <main id="main-content">
 
+<!-- No token: public receive landing -->
+<div class="step" id="step-enter">
+  <h1>Receive a file</h1>
+  <p class="sub">Paste the secure link you were sent. The file decrypts in your browser &mdash; the relay never has the key. No account needed.</p>
+  <div class="card">
+    <div class="card-body">
+      <input id="enter-link" type="text" placeholder="https://paramant.app/get?t=..." autocomplete="off" spellcheck="false" style="width:100%;padding:12px;border:1px solid var(--ink-hair);border-radius:8px;font-family:var(--mono);font-size:13px;background:var(--bone);color:var(--ink)">
+      <div class="status-line err" id="enter-err" style="margin-top:8px"></div>
+      <button class="btn" onclick="goReceive()" style="margin-top:14px">Receive</button>
+    </div>
+  </div>
+  <p class="sub" style="margin-top:16px">Have a 6-digit code instead? Use <a href="/drop">ParaDrop</a>.</p>
+</div>
+
 <!-- Downloading + decrypting -->
 <div class="step active" id="step-loading">
   <h1>Secure file incoming</h1>
@@ -465,11 +479,25 @@ function formatSize(n) {
   return n + ' B';
 }
 
+function goReceive() {
+  const el = document.getElementById('enter-link');
+  const errEl = document.getElementById('enter-err');
+  if (errEl) errEl.textContent = '';
+  const v = (el && el.value || '').trim();
+  if (!v) return;
+  try { location.href = new URL(v, location.origin).href; }
+  catch { if (errEl) errEl.textContent = 'That does not look like a valid receive link.'; }
+}
+
 async function init() {
   const params = new URLSearchParams(location.search);
   const token = params.get('t');
   const fragment = location.hash.slice(1);
 
+  if (!token && !fragment) {
+    showStep('step-enter');
+    return;
+  }
   if (!token || !fragment) {
     showError('Invalid link — missing download token or encryption key.');
     return;


### PR DESCRIPTION
**Dashboard (/dashboard):** adds a static **Quick actions** launcher (Send / ParaShare / ParaDrop / ParaSign / Verify / Receive) above the `#root` SPA container — hub-of-launchers. The **PR #54 cards render() is untouched** (launcher is static HTML before `#root`, 0 JS changes). Real tokens only, dark-mode safe, no hardcoded hex.

**/get (public Receive):** opening `/get` without a token now shows a friendly **'Receive a file'** landing (paste your secure link) instead of a generic error — a no-account recipient entry. Reuses the existing burn-on-read flow; inline JS syntax-checked. Points code-based recipients to ParaDrop.

Respects escapes: no nav.js/nav.css, no design-system.css, no auth-flow, no PR #54 cards logic.