### PR TITLE
feat(home): work-model clarity + dashboard prominent

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -41,9 +41,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -131,9 +132,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -99,9 +99,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -189,9 +190,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/anti-phishing.html
+++ b/frontend/anti-phishing.html
@@ -100,9 +100,10 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -190,9 +191,10 @@ section p+p{margin-top:14px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -235,9 +235,10 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -325,9 +326,10 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -92,9 +92,10 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -182,9 +183,10 @@ section p+p{margin-top:14px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -136,9 +136,10 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -226,9 +227,10 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -67,9 +67,10 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -157,9 +158,10 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -166,9 +166,10 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -256,9 +257,10 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -228,9 +228,10 @@ body { min-height:100vh; }
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -318,9 +319,10 @@ body { min-height:100vh; }
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -97,9 +97,10 @@ main.hub { max-width: 1100px; margin: 0 auto; padding: var(--space-5) var(--spac
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -187,9 +188,10 @@ main.hub { max-width: 1100px; margin: 0 auto; padding: var(--space-5) var(--spac
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -180,9 +180,10 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -270,9 +271,10 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -166,9 +166,10 @@ tr:last-child td{border-bottom:none}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -256,9 +257,10 @@ tr:last-child td{border-bottom:none}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -103,9 +103,10 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -193,9 +194,10 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -143,9 +143,10 @@ input:focus{border-color:var(--cobalt)}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -233,9 +234,10 @@ input:focus{border-color:var(--cobalt)}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/drop.html
+++ b/frontend/drop.html
@@ -209,9 +209,10 @@ select{background:var(--bone);border:1px solid var(--ink-hair);color:var(--ink);
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -299,9 +300,10 @@ select{background:var(--bone);border:1px solid var(--ink-hair);color:var(--ink);
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -144,9 +144,10 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -234,9 +235,10 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -192,9 +192,10 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -282,9 +283,10 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -92,9 +92,10 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -182,9 +183,10 @@ section p+p{margin-top:14px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -151,9 +151,10 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -241,9 +242,10 @@ section p+p{margin-top:14px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -43,9 +43,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -133,9 +134,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 
@@ -204,12 +206,22 @@
 
 <section class="home-hero">
   <span class="eyebrow">post-quantum &middot; eu sovereign &middot; zero-knowledge</span>
-  <h1>Encrypted file transfer that leaves no trace.</h1>
-  <p class="lede">Send files anonymously, sign documents with post-quantum signatures, or deploy a self-hosted relay for healthcare, finance, legal, or industrial IoT. Burn on read. EU/DE only.</p>
+  <h1>Your encrypted workspace for files and signatures.</h1>
+  <p class="lede">Sign in to your dashboard with an API key and TOTP to send encrypted files, sign documents with post-quantum signatures, and share device-to-device. Everything client-side encrypted, burn on read, bound to your account. EU/DE only.</p>
   <div class="home-cta">
-    <a class="btn btn-primary" href="/send">Send a file now</a>
-    <a class="btn btn-secondary" href="/docs#self-hosting">Self-host guide</a>
+    <a class="btn btn-primary" href="/dashboard">Open your dashboard</a>
+    <a class="btn btn-secondary" href="/signup">Create account</a>
+    <a class="btn btn-tertiary" href="/docs#self-hosting">Self-host guide</a>
   </div>
+</section>
+
+<section class="home-section" aria-labelledby="howwork-h">
+  <header class="home-section-head"><span class="eyebrow">How Paramant works</span><h2 id="howwork-h">One dashboard. Every tool.</h2><p>Paramant is account-bound. You work from a single dashboard; the people you send to need nothing at all.</p></header>
+  <ol class="steps">
+    <li><h3>Sign in</h3><p>Your API key plus a TOTP code. No password to phish, no shared secret in your inbox.</p></li>
+    <li><h3>Work from your dashboard</h3><p>Send, share, drop, and sign &mdash; all in one place, every transfer bound to your account and your audit log.</p></li>
+    <li><h3>Recipients need no account</h3><p>They open your link or verify your .psign signature with just the valid info you sent them. Zero-knowledge for them, full audit trail for you.</p></li>
+  </ol>
 </section>
 
 <aside class="trust-bar" aria-label="Trust signals">
@@ -222,7 +234,7 @@
 <section class="home-section" aria-labelledby="prod-h">
   <header class="home-section-head"><span class="eyebrow">Products</span><h2 id="prod-h">Four ways to use Paramant.</h2><p>One relay, four endpoints. Each tuned for a different transfer pattern. All client-side encrypted, all burn-on-read.</p></header>
   <div class="pgrid">
-    <a class="pcard" href="/send"><span class="ptag">anonymous</span><h3>Send a file</h3><p>Drop a file, share the link, burns after one read. No account, no signup. AES-256-GCM in-browser.</p><span class="pcta">Send now</span></a>
+    <a class="pcard" href="/send"><span class="ptag">fast</span><h3>Send a file</h3><p>Drop a file from your dashboard, share the link, burns after one read. AES-256-GCM in-browser, bound to your account.</p><span class="pcta">Send a file</span></a>
     <a class="pcard" href="/parashare"><span class="ptag">verified</span><h3>ParaShare</h3><p>End-to-end ML-KEM-768 hybrid with ML-DSA-65 signed receipts. Cryptographic proof of who sent what to whom.</p><span class="pcta">Try ParaShare</span></a>
     <a class="pcard" href="/drop"><span class="ptag">device-to-device</span><h3>ParaDrop</h3><p>AirDrop alternative across iOS, Android, Windows, Linux. QR or 6-digit pairing. Encrypted in transit, burn on read.</p><span class="pcta">Use ParaDrop</span></a>
     <a class="pcard" href="/sign"><span class="ptag">new &middot; parasign</span><h3>Sign documents</h3><p>Post-quantum ML-DSA-65 signatures. Self-contained .psign envelope. CT-log backed.</p><span class="pcta">Sign a document</span></a>

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -92,9 +92,10 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -182,9 +183,10 @@ section p+p{margin-top:14px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/legal.html
+++ b/frontend/legal.html
@@ -168,9 +168,10 @@ body {
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -258,9 +259,10 @@ body {
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -123,9 +123,10 @@ footer a{color:var(--cobalt)}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -213,9 +214,10 @@ footer a{color:var(--cobalt)}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -92,9 +92,10 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -182,9 +183,10 @@ section p+p{margin-top:14px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/one-pager.html
+++ b/frontend/one-pager.html
@@ -504,9 +504,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -594,9 +595,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -134,9 +134,10 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -224,9 +225,10 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/ot-vs-data-diodes.html
+++ b/frontend/ot-vs-data-diodes.html
@@ -105,9 +105,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -195,9 +196,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -165,9 +165,10 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -255,9 +256,10 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -242,9 +242,10 @@ select:focus{border-color:var(--cobalt)}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -332,9 +333,10 @@ select:focus{border-color:var(--cobalt)}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 
@@ -1377,8 +1379,7 @@ function updateGlobeTransfer(userLat, userLng) {
         <a href="/send">Send a file</a>
         <a href="/parashare">ParaShare</a>
         <a href="/drop">ParaDrop</a>
-        <a href="/dashboard">Dashboard</a>
-        <a href="/ct-log">CT Log</a>
+          <a href="/ct-log">CT Log</a>
         <a href="/docs">Docs</a>
         <a href="/pricing">Pricing</a>
         <a href="/vs">vs. alternatives</a>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -85,9 +85,10 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -175,9 +176,10 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -147,9 +147,10 @@ td{color:var(--cobalt)}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -237,9 +238,10 @@ td{color:var(--cobalt)}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -132,9 +132,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -222,9 +223,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -132,9 +132,10 @@ footer a{color:var(--ink);text-decoration:none}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -222,9 +223,10 @@ footer a{color:var(--ink);text-decoration:none}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/quantum-urgency.html
+++ b/frontend/quantum-urgency.html
@@ -105,9 +105,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -195,9 +196,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -91,9 +91,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -181,9 +182,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -155,9 +155,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -245,9 +246,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/send.html
+++ b/frontend/send.html
@@ -141,9 +141,10 @@ select#ttl-select:focus{border-color:var(--cobalt)}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -231,9 +232,10 @@ select#ttl-select:focus{border-color:var(--cobalt)}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -36,9 +36,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -126,9 +127,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -116,9 +116,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -206,9 +207,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -142,9 +142,10 @@ a:hover{opacity:.8}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -232,9 +233,10 @@ a:hover{opacity:.8}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -106,9 +106,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -196,9 +197,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -99,9 +99,10 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -189,9 +190,10 @@ section p+p{margin-top:14px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -155,9 +155,10 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -245,9 +246,10 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -170,9 +170,10 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -260,9 +261,10 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -36,9 +36,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -126,9 +127,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -105,9 +105,10 @@
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -195,9 +196,10 @@
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -92,9 +92,10 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
         <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -182,9 +183,10 @@ section p+p{margin-top:14px}
       <a href="/drop">ParaDrop</a>
       <a href="/sign">ParaSign</a>
       <a href="/verify">Verify signature</a>
-      <a href="/dashboard">Dashboard</a>
     </div>
   </div>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 


### PR DESCRIPTION
Hero reframed to dashboard-workspace model, dashboard nav prominent, anonymous framing removed (Model A alignment).

## Changes
- **Hero**: H1 'Your encrypted workspace for files and signatures.' + lede explaining key+TOTP sign-in. Primary CTA = `Open your dashboard`; secondary `Create account`; tertiary `Self-host guide`.
- **New section** 'How Paramant works' — 3 steps: sign in / work from dashboard / recipients need no account. Uses existing `home-section` + `steps` classes.
- **Send product card** on homepage: removed `anonymous` tag + 'No account, no signup' line (contradicted Model A).
- **Nav (47 pages)**: Dashboard moved out of Products dropdown to top-level (`nav-link nav-link-strong`) just before Pricing. Mobile: standalone link above Pricing.

## Out of scope
Design-system + color scheme untouched. Tool pages untouched. Nav.css/nav.js untouched.