### PR TITLE
feat(copy): Model A - remove anonymous/no-account messaging

### DIFF
--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -701,20 +701,20 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
   <div class="arch-inner">
     <div class="section-num">07</div>
     <h2 class="section-title">Two modes</h2>
-    <p class="section-desc">Paramant has two transfer modes. Anonymous one-shot sending requires no account. Verified ParaShare adds identity, post-quantum key exchange, and cryptographic proof of origin.</p>
+    <p class="section-desc">Paramant has two transfer modes. Quick /send is an in-browser one-shot link with no sender-to-receiver identity binding. Verified ParaShare adds identity, post-quantum key exchange, and cryptographic proof of origin.</p>
 
     <table class="modes-table">
       <thead>
         <tr>
           <th>Feature</th>
-          <th><span class="mode-badge">Anonymous<br>Send a file</span></th>
+          <th><span class="mode-badge">Quick send<br>Send a file</span></th>
           <th><span class="mode-badge mode-badge--lime">Verified<br>ParaShare</span></th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td>Account needed</td>
-          <td>No</td>
+          <td>Yes (sign-in gate)</td>
           <td>Yes</td>
         </tr>
         <tr>
@@ -744,7 +744,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
         </tr>
         <tr>
           <td>Good for</td>
-          <td>Quick one-off shares, no signup friction</td>
+          <td>Quick one-off browser-encrypted shares</td>
           <td>Legal, healthcare, financial, compliance workflows</td>
         </tr>
       </tbody>
@@ -757,7 +757,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
   <div class="arch-inner">
     <div class="section-num">08</div>
     <h2 class="section-title">Components</h2>
-    <p class="section-desc">The relay is one piece. Around it sit official SDKs, two browser extensions, and the WebApp tools (ParaShare, ParaDrop, anonymous send). Each surface is at a different stage of the wire-format-v1 migration. Here is the honest state today.</p>
+    <p class="section-desc">The relay is one piece. Around it sit official SDKs, two browser extensions, and the WebApp tools (ParaShare, ParaDrop, /send). Each surface is at a different stage of the wire-format-v1 migration. Here is the honest state today.</p>
 
     <table class="modes-table">
       <thead>
@@ -794,9 +794,9 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
           <td>Same WASM bridge as ParaShare. Pre-v1 layout. Migration to v1 in progress.</td>
         </tr>
         <tr>
-          <td><strong>Send (anonymous)</strong></td>
-          <td>One-shot link, no account. Used by the <code>/send</code> page.</td>
-          <td>AES-256-GCM, browser-generated key delivered in the URL fragment. Anonymous flow by design — not a v1 candidate.</td>
+          <td><strong>Send (browser-encrypted)</strong></td>
+          <td>One-shot link encrypted in the browser. Used by the <code>/send</code> page (sign-in gated).</td>
+          <td>AES-256-GCM, browser-generated key delivered in the URL fragment. No identity-binding by design — not a v1 candidate.</td>
         </tr>
         <tr>
           <td><strong>Chromium extension</strong></td>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -539,11 +539,11 @@ FLAGS    1 byte    reserved for future features</pre>
           <td>migrating to v1</td>
         </tr>
         <tr>
-          <td>Send (anonymous link)</td>
+          <td>Send (browser-encrypted link)</td>
           <td>—</td>
           <td>—</td>
           <td>AES-256-GCM, key in URL fragment</td>
-          <td>anonymous flow by design</td>
+          <td>no identity-binding by design</td>
         </tr>
         <tr>
           <td>Chromium extension</td>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -285,8 +285,8 @@ main.hub { max-width: 1100px; margin: 0 auto; padding: var(--space-5) var(--spac
         <a class="action-card" href="/get" aria-label="Receive a file">
           <div class="icon" aria-hidden="true">←</div>
           <h2>Receive a file</h2>
-          <p>Open a secure link someone sent you. Decryption happens in your browser; no account needed.</p>
-          <div class="pq-line">No account · zero-knowledge</div>
+          <p>Open a secure link someone sent you. Decryption happens locally in your browser.</p>
+          <div class="pq-line">Browser-only · zero-knowledge</div>
         </a>
       </div>
     </section>
@@ -398,8 +398,8 @@ main.hub { max-width: 1100px; margin: 0 auto; padding: var(--space-5) var(--spac
 //
 // We do NOT touch the API key here. The API key is shown (masked) on the
 // account page; the dashboard's job is to confirm the user is signed in and
-// surface launchers into the tool pages. Anonymous flows (/send /get) work
-// without a session too; gated tools handle their own X-Api-Key.
+// surface launchers into the tool pages. The recipient flow (/get) is the
+// only public one; sender tools require a session.
 (function(){
   'use strict';
 

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -400,7 +400,7 @@ tr:last-child td{border-bottom:none}
 
     <!-- ── Quick start ──────────────────────────────────────────── -->
     <h2 id="quickstart">Quick start</h2>
-    <p>Send your first encrypted file in under 5 minutes. No account required — <a href="/signup" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">create a free account here</a> (TOTP protected, key visible in dashboard).</p>
+    <p>Send your first encrypted file in under 5 minutes. <a href="/signup" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">Create a free account here</a> (TOTP protected, key visible in dashboard).</p>
 
     <div class="step-row"><div class="step-num">1</div><div class="step-body"><p style="color:var(--ink-dim);font-size:13px">Install the SDK (Python 3.10+ or Node 18+; both ship the same wire-format-v1 encoder)</p></div></div>
     <div class="cb">
@@ -537,7 +537,7 @@ hash_, receipt = gp.send_with_receipt(open("pacs008.xml","rb").read())
       <tr><th>Method</th><th>Endpoint</th><th>Description</th><th>Auth</th></tr>
       <tr><td><span class="method get">GET</span></td><td>/health</td><td>Node status, version, uptime, edition</td><td>—</td></tr>
       <tr><td><span class="method post">POST</span></td><td>/v2/inbound</td><td>Upload encrypted blob from an authenticated client (RAM-only)</td><td>Key</td></tr>
-      <tr><td><span class="method post">POST</span></td><td>/v2/anon-inbound</td><td>Upload from an anonymous client — no API key, used by /send</td><td>—</td></tr>
+      <tr><td><span class="method post">POST</span></td><td>/v2/anon-inbound</td><td>Upload from a browser client — used by /send (browser AES-256-GCM, key in URL fragment)</td><td>—</td></tr>
       <tr><td><span class="method get">GET</span></td><td>/v2/outbound/:hash</td><td>Download + burn — one retrieval only</td><td>Key</td></tr>
       <tr><td><span class="method get">GET</span></td><td>/v2/status/:hash</td><td>Check blob availability without consuming</td><td>Key</td></tr>
       <tr><td><span class="method post">POST</span></td><td>/v2/ack</td><td>Confirm delivery, log latency to CT</td><td>Key</td></tr>
@@ -834,7 +834,7 @@ paramant-stream --key pgp_xxx --sector health --forward https://pacs.hospital/ap
     <p>Two-step burn: first the blob is zeroed in-place, then the Map entry is deleted. This prevents a brief window where a partial read could occur.</p>
 
     <h2 id="padding">5 MB fixed padding (ParaShare)</h2>
-    <p>ParaShare authenticated blobs are padded to exactly 5,242,880 bytes (5 MiB) with cryptographically random bytes before upload. An observer on the network cannot determine the size, type, or content of the transferred file — effective DPI masking for classified data flows. Anonymous blobs retain their actual encrypted size up to 5 MB.</p>
+    <p>ParaShare authenticated blobs are padded to exactly 5,242,880 bytes (5 MiB) with cryptographically random bytes before upload. An observer on the network cannot determine the size, type, or content of the transferred file — effective DPI masking for classified data flows. Quick /send blobs retain their actual encrypted size up to 5 MB.</p>
 
     <h2 id="ct-log">Certificate Transparency log</h2>
     <p>Every transfer hash and device registration is appended to a public Merkle tree. The root hash changes with every write and is publicly verifiable. Anyone can prove a transfer occurred without learning what was transferred.</p>
@@ -899,7 +899,7 @@ python3 scripts/paramant-admin.py sync</pre>
       <tr><th>What a compromised relay can do</th><th>What it cannot do</th></tr>
       <tr><td>Deny or delay service</td><td>Read file contents (no decryption key)</td></tr>
       <tr><td>Learn transfer timing and frequency</td><td>Substitute a registered ML-KEM public key (CT log prevents rollback)</td></tr>
-      <tr><td>Observe ParaShare blob sizes (all fixed 5 MB) or anonymous blob sizes (variable, up to 5 MB)</td><td>Forge relay signatures (ML-DSA-65 key is per-relay, signed)</td></tr>
+      <tr><td>Observe ParaShare blob sizes (all fixed 5 MB) or /send blob sizes (variable, up to 5 MB)</td><td>Forge relay signatures (ML-DSA-65 key is per-relay, signed)</td></tr>
       <tr><td>Block a specific device hash</td><td>Decrypt any stored ciphertext</td></tr>
     </table>
     <p>The threat model assumes network-level attackers, compromised relay operators, and post-quantum adversaries. Encryption uses a hybrid scheme (ML-KEM-768 + ECDH P-256) so that breaking <em>either</em> primitive is not sufficient — both must be broken simultaneously.</p>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -306,7 +306,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 <!-- No token: public receive landing -->
 <div class="step" id="step-enter">
   <h1>Receive a file</h1>
-  <p class="sub">Paste the secure link you were sent. The file decrypts in your browser &mdash; the relay never has the key. No account needed.</p>
+  <p class="sub">Paste the secure link you were sent. The file decrypts in your browser &mdash; the relay never has the key.</p>
   <div class="card">
     <div class="card-body">
       <input id="enter-link" type="text" placeholder="https://paramant.app/get?t=..." autocomplete="off" spellcheck="false" style="width:100%;padding:12px;border:1px solid var(--ink-hair);border-radius:8px;font-family:var(--mono);font-size:13px;background:var(--bone);color:var(--ink)">

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -544,7 +544,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
         <div class="step-body">
           <h4>Create account</h4>
           <p>Go to <a href="/signup">paramant.app/signup</a>.
-          No credit card. No account. You receive a <code>pgp_</code> key for end-user access
+          No credit card. You receive a <code>pgp_</code> key for end-user access
           or a <code>plk_</code> key to unlock your self-hosted relay beyond 5 users.</p>
         </div>
       </div>
@@ -582,7 +582,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
     <div>
       <h3>Paramant Community Edition is free.</h3>
       <p>
-        Self-host in under two minutes. No credit card. No account required.<br>
+        Self-host in under two minutes. No credit card. BUSL-1.1 source available.<br>
         Questions: <a href="mailto:privacy@paramant.app?subject=Government%20-%20PQC">privacy@paramant.app</a>
       </p>
       <div class="cta-actions" style="margin-top:14px">

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -492,7 +492,7 @@ section p+p{margin-top:14px}
 
   <div class="cta">
     <p>
-      ParaShare authenticated transfers use <code>ML-KEM-768 + AES-256-GCM</code>. Anonymous /send transfers use AES-256-GCM only. Files exist in RAM only,
+      ParaShare authenticated transfers use <code>ML-KEM-768 + AES-256-GCM</code>. Quick /send transfers use AES-256-GCM only. Files exist in RAM only,
       destroyed after one read. No storage, no trace, no target.
     </p>
     <a href="/signup" class="btn-primary">Create account →</a>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -205,7 +205,7 @@
 <section class="home-hero">
   <span class="eyebrow">post-quantum &middot; eu sovereign &middot; zero-knowledge</span>
   <h1>Encrypted file transfer that leaves no trace.</h1>
-  <p class="lede">Send files anonymously, sign documents with post-quantum signatures, or deploy a self-hosted relay for healthcare, finance, legal, or industrial IoT. Burn on read. EU/DE only.</p>
+  <p class="lede">Send encrypted files, sign documents with post-quantum signatures, or deploy a self-hosted relay for healthcare, finance, legal, or industrial IoT. Burn on read. EU/DE only.</p>
   <div class="home-cta">
     <a class="btn btn-primary" href="/send">Send a file now</a>
     <a class="btn btn-secondary" href="/docs#self-hosting">Self-host guide</a>
@@ -222,7 +222,7 @@
 <section class="home-section" aria-labelledby="prod-h">
   <header class="home-section-head"><span class="eyebrow">Products</span><h2 id="prod-h">Four ways to use Paramant.</h2><p>One relay, four endpoints. Each tuned for a different transfer pattern. All client-side encrypted, all burn-on-read.</p></header>
   <div class="pgrid">
-    <a class="pcard" href="/send"><span class="ptag">anonymous</span><h3>Send a file</h3><p>Drop a file, share the link, burns after one read. No account, no signup. AES-256-GCM in-browser.</p><span class="pcta">Send now</span></a>
+    <a class="pcard" href="/send"><span class="ptag">encrypted</span><h3>Send a file</h3><p>Encrypt a file in your browser, share a one-time link. Burns after one read. Sign in to send. AES-256-GCM.</p><span class="pcta">Send now</span></a>
     <a class="pcard" href="/parashare"><span class="ptag">verified</span><h3>ParaShare</h3><p>End-to-end ML-KEM-768 hybrid with ML-DSA-65 signed receipts. Cryptographic proof of who sent what to whom.</p><span class="pcta">Try ParaShare</span></a>
     <a class="pcard" href="/drop"><span class="ptag">device-to-device</span><h3>ParaDrop</h3><p>AirDrop alternative across iOS, Android, Windows, Linux. QR or 6-digit pairing. Encrypted in transit, burn on read.</p><span class="pcta">Use ParaDrop</span></a>
     <a class="pcard" href="/sign"><span class="ptag">new &middot; parasign</span><h3>Sign documents</h3><p>Post-quantum ML-DSA-65 signatures. Self-contained .psign envelope. CT-log backed.</p><span class="pcta">Sign a document</span></a>

--- a/frontend/one-pager.html
+++ b/frontend/one-pager.html
@@ -801,7 +801,7 @@
         <td>RAM only, zero disk persistence, burn on first read</td>
       </tr>
       <tr>
-        <td>File size (anonymous)</td>
+        <td>File size (/send)</td>
         <td>5 MB padded · up to 500 MB via chunking (Q2 2026)</td>
       </tr>
       <tr>
@@ -929,7 +929,7 @@
       <div class="op-tier">
         <div class="op-tier-name">Community Edition</div>
         <div class="op-tier-price">Free · ≤5 users</div>
-        <p>BUSL-1.1 source available. Self-hosted on Docker or Raspberry Pi. All cryptographic features included. No account, no telemetry.</p>
+        <p>BUSL-1.1 source available. Self-hosted on Docker or Raspberry Pi. All cryptographic features included. No telemetry.</p>
       </div>
       <div class="op-tier">
         <div class="op-tier-name">Professional</div>

--- a/frontend/pattern-library.html
+++ b/frontend/pattern-library.html
@@ -347,7 +347,7 @@
     <div class="card">
       <p style="font-size:var(--text-xs); color:var(--ink-dim); letter-spacing:.1em; text-transform:uppercase; margin-bottom:var(--space-3);">01 / send</p>
       <h4 style="margin-bottom:var(--space-3);">ParaSend</h4>
-      <p style="font-size:var(--text-base); color:var(--ink-dim);">Keyless, anonymous file transfer. No account. Burn-on-read.</p>
+      <p style="font-size:var(--text-base); color:var(--ink-dim);">Keyless browser-encrypted file transfer. Burn-on-read.</p>
     </div>
     <div class="card">
       <p style="font-size:var(--text-xs); color:var(--ink-dim); letter-spacing:.1em; text-transform:uppercase; margin-bottom:var(--space-3);">02 / share</p>
@@ -367,7 +367,7 @@
       <div class="card">
         <p style="font-size:var(--text-xs); color:var(--black-dim); letter-spacing:.1em; text-transform:uppercase; margin-bottom:var(--space-3);">01 / send</p>
         <h4 style="margin-bottom:var(--space-3);">ParaSend</h4>
-        <p style="font-size:var(--text-base); color:var(--black-dim);">Keyless, anonymous file transfer. No account. Burn-on-read.</p>
+        <p style="font-size:var(--text-base); color:var(--black-dim);">Keyless browser-encrypted file transfer. Burn-on-read.</p>
       </div>
       <div class="card">
         <p style="font-size:var(--text-xs); color:var(--black-dim); letter-spacing:.1em; text-transform:uppercase; margin-bottom:var(--space-3);">02 / share</p>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -373,7 +373,7 @@ td{color:var(--cobalt)}
   <div class="grid">
     <div class="card">
       <h3>ParaShare — file transfer UI</h3>
-      <p style="font-size:13px">Browser-based send/receive. No account. No install.</p>
+      <p style="font-size:13px">Browser-based send/receive. No install.</p>
       <a href="/parashare" class="dl-btn">Live demo &rarr;</a>
     </div>
     <div class="card">

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -5,15 +5,15 @@
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Pricing — PARAMANT</title>
-<meta name="description" content="PARAMANT pricing. Free forever: AES-256-GCM, 5 MB, RAM-only, no account. Pro coming soon. Enterprise: dedicated relay, ML-KEM-768, 7-day TTL, SLA.">
+<meta name="description" content="PARAMANT pricing. Free forever: AES-256-GCM, 5 MB, RAM-only. Pro coming soon. Enterprise: dedicated relay, ML-KEM-768, 7-day TTL, SLA.">
 <meta property="og:title" content="Pricing — PARAMANT">
-<meta property="og:description" content="PARAMANT pricing. Free forever: AES-256-GCM, 5 MB, RAM-only, no account. Pro coming soon. Enterprise: dedicated relay, ML-KEM-768, 7-day TTL, SLA.">
+<meta property="og:description" content="PARAMANT pricing. Free forever: AES-256-GCM, 5 MB, RAM-only. Pro coming soon. Enterprise: dedicated relay, ML-KEM-768, 7-day TTL, SLA.">
 <meta property="og:url" content="https://paramant.app/pricing">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Pricing — PARAMANT">
-<meta name="twitter:description" content="PARAMANT pricing. Free forever: AES-256-GCM, 5 MB, RAM-only, no account. Pro coming soon. Enterprise: dedicated relay, ML-KEM-768, 7-day TTL, SLA.">
+<meta name="twitter:description" content="PARAMANT pricing. Free forever: AES-256-GCM, 5 MB, RAM-only. Pro coming soon. Enterprise: dedicated relay, ML-KEM-768, 7-day TTL, SLA.">
 <link rel="canonical" href="https://paramant.app/pricing">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
@@ -299,9 +299,9 @@
       <span style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)">Three tiers</span>
     </div>
     <p style="font-size:var(--text-md);color:var(--ink);line-height:1.75;margin-bottom:var(--space-6)">
-      Send files for free. No account required. Scale when you need audit trails, team access, or a dedicated relay.
+      Send files for free with a Paramant account. Scale when you need audit trails, team access, or a dedicated relay.
     </p>
-    <a href="/send" class="btn btn-secondary">No account? Send a file instantly &rarr;</a>
+    <a href="/send" class="btn btn-secondary">Sign in and send a file &rarr;</a>
   </div>
 </section>
 
@@ -314,7 +314,7 @@
         <div class="tier-name">Free</div>
         <div class="tier-price">&euro;0</div>
         <div class="tier-price-note">Forever &middot; no card required</div>
-        <p style="font-size:var(--text-base);color:var(--ink);margin-bottom:var(--space-5);line-height:1.65">For one-off anonymous sends. No account, no tracking.</p>
+        <p style="font-size:var(--text-base);color:var(--ink);margin-bottom:var(--space-5);line-height:1.65">For one-off browser-encrypted sends. No tracking.</p>
         <ul class="tier-features">
           <li>AES-256-GCM, browser-generated key</li>
           <li>5 MB per file</li>
@@ -384,7 +384,7 @@
 
     <div class="prose-section">
       <h3>Encryption</h3>
-      <p>Every tier uses the same cryptography. Anonymous transfers use AES-256-GCM with a browser-generated key that lives only in the URL fragment. Verified transfers via ParaShare use ML-KEM-768 plus ECDH P-256 hybrid key exchange with ML-DSA-65 signed receipts. There is no lesser encryption at lower tiers. Cryptography is not a paywalled feature at Paramant.</p>
+      <p>Every tier uses the same cryptography. Quick /send transfers use AES-256-GCM with a browser-generated key that lives only in the URL fragment. Verified transfers via ParaShare use ML-KEM-768 plus ECDH P-256 hybrid key exchange with ML-DSA-65 signed receipts. There is no lesser encryption at lower tiers. Cryptography is not a paywalled feature at Paramant.</p>
     </div>
 
     <div class="prose-section">
@@ -429,8 +429,8 @@
     </div>
 
     <div class="faq-item">
-      <p class="faq-q">Does the anonymous /send flow use ML-KEM-768?</p>
-      <div class="faq-a">No. The anonymous send flow (/send, no account) uses AES-256-GCM with a browser-generated key delivered in the URL fragment. The key never reaches the relay. ML-KEM-768 + ECDH P-256 hybrid key exchange is used by <a href="/parashare">ParaShare</a> — the registered-device, verified-transfer flow.</div>
+      <p class="faq-q">Does the /send flow use ML-KEM-768?</p>
+      <div class="faq-a">No. The /send flow uses AES-256-GCM with a browser-generated key delivered in the URL fragment. The key never reaches the relay. ML-KEM-768 + ECDH P-256 hybrid key exchange is used by <a href="/parashare">ParaShare</a> — the registered-device, verified-transfer flow.</div>
     </div>
 
     <div class="faq-item">

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -296,8 +296,8 @@ footer a{color:var(--ink);text-decoration:none}
 <p class="updated">Last updated: April 2, 2026</p>
 
 <h2>Core principle</h2>
-<p><strong>PARAMANT collects no personal data.</strong></p>
-<p>No account required for ParaShare Free. No email. No phone number. No IP logging. No cookies. No tracking pixels. No analytics. No advertisements.</p>
+<p><strong>PARAMANT collects only what is strictly required to operate your account.</strong></p>
+<p>An email address is required to create an account and recover access. No phone number. No IP logging (beyond what Cloudflare handles in transit). Only a strictly-necessary session cookie (no tracking cookies). No tracking pixels. No analytics. No advertisements.</p>
 
 <h2>How Ghost Pipe &amp; ParaShare work</h2>
 <p>All files are encrypted <strong>client-side in your browser</strong> using post-quantum cryptography (ML-KEM-768 + ECDH P-256 + AES-256-GCM + HKDF-SHA256) before they ever reach our servers. The relay never sees plaintext at any point.</p>
@@ -321,7 +321,7 @@ footer a{color:var(--ink);text-decoration:none}
 <ul>
 <li>Store personal data of any kind</li>
 <li>Log or store IP addresses beyond what Cloudflare handles in transit</li>
-<li>Use cookies or browser fingerprinting</li>
+<li>Use tracking cookies or browser fingerprinting (only a strictly-necessary session cookie is set after login)</li>
 <li>Run advertising or tracking scripts</li>
 <li>Share any data with third parties</li>
 <li>Write file data to disk at any point</li>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -330,7 +330,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
   <div class="card" style="margin-top:14px;border-left:3px solid var(--cobalt)">
     <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px">Where the zero-knowledge guarantee holds today</div>
-    <p style="margin:0;line-height:1.75;font-size:var(--text-sm)">The guarantee above applies to transfers from the official SDKs (sdk-py 3.0.0, sdk-js 3.0.0), the WebApp tools (ParaShare, ParaDrop), and the anonymous <code>/send</code> link flow — every one of those encrypts in the client before bytes leave the device. The Chromium and Outlook extensions currently take a server-side encryption path while their client-side crypto is being finished; until that migration lands, treat extension uploads as relay-side, not zero-knowledge. Per-client status: <a href="/crypto-agility#06">crypto-agility § 06</a>.</p>
+    <p style="margin:0;line-height:1.75;font-size:var(--text-sm)">The guarantee above applies to transfers from the official SDKs (sdk-py 3.0.0, sdk-js 3.0.0), the WebApp tools (ParaShare, ParaDrop), and the <code>/send</code> link flow — every one of those encrypts in the client before bytes leave the device. The Chromium and Outlook extensions currently take a server-side encryption path while their client-side crypto is being finished; until that migration lands, treat extension uploads as relay-side, not zero-knowledge. Per-client status: <a href="/crypto-agility#06">crypto-agility § 06</a>.</p>
   </div>
 
   <p style="font-size:var(--text-sm);color:var(--ink-dim)">For the full audit history, patch timeline, and cryptographic architecture, see the <a href="/architecture">architecture page</a>.</p>
@@ -356,7 +356,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </table>
 
   <h3>Hybrid key exchange</h3>
-  <p>ParaShare authenticated transfers use ML-KEM-768 <em>and</em> ECDH P-256 simultaneously. The shared secret is the concatenation of both — breaking one provides no advantage. This protects against store-now-decrypt-later attacks while maintaining compatibility with classical infrastructure. Anonymous /send transfers use AES-256-GCM with a browser-generated key delivered in the URL fragment.</p>
+  <p>ParaShare authenticated transfers use ML-KEM-768 <em>and</em> ECDH P-256 simultaneously. The shared secret is the concatenation of both — breaking one provides no advantage. This protects against store-now-decrypt-later attacks while maintaining compatibility with classical infrastructure. Quick /send transfers use AES-256-GCM with a browser-generated key delivered in the URL fragment.</p>
 
   <p style="margin-top:10px;font-size:var(--text-sm);color:var(--ink-dim)">See also: <a href="/hndl">Harvest Now, Decrypt Later &rarr;</a> — why data collected today can be decrypted at Q-Day, and how RAM-only transfer removes the target.</p>
 
@@ -378,7 +378,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     </div>
     <div class="card">
       <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px">5 MB padding</div>
-      <p style="margin:0">ParaShare authenticated uploads are padded to a fixed 5 MB block for DPI masking. Anonymous uploads are stored at their actual encrypted size, up to a 5 MB maximum.</p>
+      <p style="margin:0">ParaShare authenticated uploads are padded to a fixed 5 MB block for DPI masking. Quick /send uploads are stored at their actual encrypted size, up to a 5 MB maximum.</p>
     </div>
     <div class="card">
       <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px">ML-DSA-65 relay identity</div>

--- a/frontend/send.html
+++ b/frontend/send.html
@@ -5,15 +5,15 @@
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Send a file — PARAMANT</title>
-<meta name="description" content="Send any file securely. No account. Your browser encrypts with AES-256-GCM. The key lives in the link. Burn on first read.">
+<meta name="description" content="Send any file securely. Sign in, your browser encrypts with AES-256-GCM, the key lives in the link. Burn on first read.">
 <meta property="og:title" content="Send a file — PARAMANT">
-<meta property="og:description" content="Send any file securely. No account. Your browser encrypts with AES-256-GCM. The key lives in the link. Burn on first read.">
+<meta property="og:description" content="Send any file securely. Sign in, your browser encrypts with AES-256-GCM, the key lives in the link. Burn on first read.">
 <meta property="og:url" content="https://paramant.app/send">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Send a file — PARAMANT">
-<meta name="twitter:description" content="Send any file securely. No account. Your browser encrypts with AES-256-GCM. The key lives in the link. Burn on first read.">
+<meta name="twitter:description" content="Send any file securely. Sign in, your browser encrypts with AES-256-GCM, the key lives in the link. Burn on first read.">
 <link rel="canonical" href="https://paramant.app/send">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -307,7 +307,7 @@ select#ttl-select:focus{border-color:var(--cobalt)}
 
       <!-- Left: copy + spec -->
       <div>
-        <p style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.16em;text-transform:uppercase;color:var(--cobalt);margin-bottom:var(--space-5)">KEYLESS &middot; ANONYMOUS &middot; 5 MB</p>
+        <p style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.16em;text-transform:uppercase;color:var(--cobalt);margin-bottom:var(--space-5)">KEYLESS &middot; BROWSER-ENCRYPTED &middot; 5 MB</p>
         <h1 style="font-size:clamp(3rem,8vw,8rem);line-height:1.0;letter-spacing:-.04em;margin-bottom:var(--space-5)">Drop a file.<br>Burn it after<br>one read.</h1>
         <p style="font-size:var(--text-md);color:var(--ink);line-height:1.7;max-width:48ch;margin-bottom:var(--space-5)">Your browser encrypts before upload. The key lives in the link, never on the relay. When the receiver opens the link, the file is gone.</p>
         <table class="spec-table">
@@ -380,7 +380,7 @@ select#ttl-select:focus{border-color:var(--cobalt)}
             <div class="status-line" id="status-msg"></div>
           </div>
 
-          <p style="font-family:var(--mono);font-size:var(--text-sm);color:var(--ink-dim);margin-top:var(--space-3);letter-spacing:.04em">5 MB limit &middot; no account needed &middot; <a href="/parashare" style="color:var(--cobalt)">need verified transfers?</a></p>
+          <p style="font-family:var(--mono);font-size:var(--text-sm);color:var(--ink-dim);margin-top:var(--space-3);letter-spacing:.04em">5 MB limit &middot; sign in to send &middot; <a href="/parashare" style="color:var(--cobalt)">need verified transfers?</a></p>
 
         </div>
 
@@ -470,7 +470,7 @@ select#ttl-select:focus{border-color:var(--cobalt)}
       <h2>When you need more than this.</h2>
       <span style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--ink-dim)">Alternatives</span>
     </div>
-    <p style="font-size:var(--text-base);color:var(--ink);line-height:1.75;margin-bottom:var(--space-7)">Anonymous links are the fastest way to send something. For transfers where you need to prove who sent the file, or where the receiver must verify the relay before trusting a key, use ParaShare. For sending between two browsers on the same network with no relay in the middle, use ParaDrop.</p>
+    <p style="font-size:var(--text-base);color:var(--ink);line-height:1.75;margin-bottom:var(--space-7)">Browser-encrypted links are the fastest way to send something. For transfers where you need to prove who sent the file, or where the receiver must verify the relay before trusting a key, use ParaShare. For sending between two browsers on the same network with no relay in the middle, use ParaDrop.</p>
     <div class="cluster" style="--cluster-gap:var(--space-4)">
       <a href="/parashare" class="btn btn-secondary">Try ParaShare &rarr;</a>
       <a href="/drop" class="btn btn-secondary">Try ParaDrop &rarr;</a>
@@ -504,12 +504,12 @@ select#ttl-select:focus{border-color:var(--cobalt)}
 
     <div class="faq-item">
       <h4 style="font-size:var(--text-base);font-weight:700;letter-spacing:.01em;margin-bottom:var(--space-3);line-height:1.4">Can I send files larger than 5 MB?</h4>
-      <p class="faq-a">Not via the anonymous flow. The 5 MB limit applies to all tiers at the managed relay. Enterprise customers running a dedicated relay can configure a higher limit within their RAM budget. If you need to send larger files regularly, <a href="mailto:privacy@paramant.app" style="color:var(--cobalt)">contact us</a>.</p>
+      <p class="faq-a">Not via the quick /send flow. The 5 MB limit applies to all tiers at the managed relay. Enterprise customers running a dedicated relay can configure a higher limit within their RAM budget. If you need to send larger files regularly, <a href="mailto:privacy@paramant.app" style="color:var(--cobalt)">contact us</a>.</p>
     </div>
 
     <div class="faq-item">
       <h4 style="font-size:var(--text-base);font-weight:700;letter-spacing:.01em;margin-bottom:var(--space-3);line-height:1.4">Is this post-quantum?</h4>
-      <p class="faq-a">The anonymous /send flow is <strong>AES-256-GCM only</strong> — a symmetric cipher with no asymmetric key exchange, so there is no quantum-vulnerable handshake to break. The key is generated in your browser and delivered out-of-band in the URL fragment. What /send deliberately does not provide is sender authentication or relay verification. For transfers that bind a registered device with post-quantum key encapsulation (ML-KEM-768) and post-quantum signatures (ML-DSA-65), use <a href="/parashare" style="color:var(--cobalt)">ParaShare</a> or <a href="/drop" style="color:var(--cobalt)">ParaDrop</a> instead.</p>
+      <p class="faq-a">The /send flow is <strong>AES-256-GCM only</strong> — a symmetric cipher with no asymmetric key exchange, so there is no quantum-vulnerable handshake to break. The key is generated in your browser and delivered out-of-band in the URL fragment. What /send deliberately does not provide is sender-to-receiver identity binding or relay verification. For transfers that bind a registered device with post-quantum key encapsulation (ML-KEM-768) and post-quantum signatures (ML-DSA-65), use <a href="/parashare" style="color:var(--cobalt)">ParaShare</a> or <a href="/drop" style="color:var(--cobalt)">ParaDrop</a> instead.</p>
     </div>
 
   </div>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -396,12 +396,12 @@
           <td class="no">Not available</td>
         </tr>
         <tr>
-          <td class="strong">Anonymous sending (no account)</td>
-          <td class="yes">ParaSend, 5 MB</td>
-          <td class="no">Account required</td>
-          <td class="no">Account required</td>
-          <td class="yes">Up to 3 GB free</td>
-          <td class="no">Authentication required</td>
+          <td class="strong">Browser-side encryption on public-link send</td>
+          <td class="yes">ParaSend, browser AES-256-GCM, 5 MB</td>
+          <td class="yes">Browser SDK</td>
+          <td class="yes">Native client</td>
+          <td class="no">Server-side encryption</td>
+          <td class="partial">Browser SDK (optional)</td>
         </tr>
         <tr>
           <td class="strong">ISO 27001 certification</td>

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -295,7 +295,7 @@ section p+p{margin-top:14px}
     <div class="workflow-block">
       <div class="step-list">
         <div class="step-row"><div class="step-num">01</div><div class="step-body"><strong>Compliance officer</strong> generates a one-time upload link via ParaShare and distributes it through the internal reporting channel</div></div>
-        <div class="step-row"><div class="step-num">02</div><div class="step-body"><strong>Reporter</strong> accesses the link and uploads their report document — no account required, no identity logged</div></div>
+        <div class="step-row"><div class="step-num">02</div><div class="step-body"><strong>Reporter</strong> follows the link and uploads their report document via the organisation-issued channel — no identity logged</div></div>
         <div class="step-row"><div class="step-num">03</div><div class="step-body"><strong>Only the compliance officer</strong> can decrypt and download the report</div></div>
         <div class="step-row"><div class="step-num">04</div><div class="step-body"><strong>After download</strong>, the relay wipes the ciphertext from RAM — no persistent copy anywhere on the infrastructure</div></div>
         <div class="step-row"><div class="step-num">05</div><div class="step-body"><strong>ML-DSA-65 receipt</strong> is generated automatically, satisfying the 7-day acknowledgment requirement (Art. 9(b))</div></div>


### PR DESCRIPTION
Phase 3 of Model A. Server-side gate (Phase 2) lands separately.

Every transfer is now bound to an authenticated user; the copy must match.
This PR rewrites the marketing claims that promoted \"anonymous\",
\"no account\", or \"no signup\" framing on 17 pages.

## Rewritten
- index hero + send-card tag/copy
- send.html: meta descriptions, \"KEYLESS ANONYMOUS\" strapline, FAQ
- pricing.html: meta, Free-tier card, FAQ row
- dashboard.html: receive-card subline + internal comment
- docs.html: quickstart, endpoint description, padding section, threat table
- security.html: zero-knowledge scope, hybrid-KEX paragraph, padding card
- architecture.html: two-modes table + components row
- crypto-agility.html: matrix row \"Send (anonymous link)\"
- vs.html: comparison row \"Anonymous sending\"
- get.html, government.html, one-pager.html, pattern-library.html, press.html,
  hndl.html, whistleblower-channel.html: localised rewrites
- privacy.html: core-principle rewritten to be honest about account email
  + strictly-necessary session cookie (\"no cookies\" was false post PR #93)

## Untouched (legitimately not marketing)
- crypto-agility.html SIG_ID 0x0000 protocol enum (wire-format internal)
- drop.html crossorigin=\"anonymous\" HTML attribute
- vs.html row describing WeTransfer's positioning (about competitor)

## Test plan
- [ ] Render each page locally and eyeball for awkward breaks
- [ ] Deploy via webroot sync (no container rebuild needed)
- [ ] Verify zero \"anonymous|no account|no signup\" hits on production HTML
- [ ] Privacy policy: legal review of revised \"Core principle\" paragraph