### PR TITLE
feat(security): Model A gate on /send /parashare /drop /sign

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -1143,6 +1143,14 @@ api.get("/user/dashboard-fragment", authUser, async (req, res) => {
   }
 });
 
+// GET /api/user/check
+// Lightweight session-validity probe for nginx auth_request on gated tool
+// routes (/send, /parashare, /drop, /sign). authUser handles the cookie check
+// and returns 401 on miss; this handler only fires on hit.
+api.get("/user/check", authUser, (req, res) => {
+  res.status(200).end();
+});
+
 // GET /api/user/account
 api.get("/user/account", authUser, async (req, res) => {
   const { user_id, email } = req.userSession;

--- a/deploy/nginx-paramant-live.conf
+++ b/deploy/nginx-paramant-live.conf
@@ -37,7 +37,16 @@ server {
         alias /home/paramant/app/outlook/manifest.xml;
         default_type application/xml;
     }
-    location = /drop { try_files /drop.html =404; }
+    # ── Gated tool routes (Model A): no tool markup served without a valid
+    # session. Subrequest hits the existing authUser middleware via
+    # /api/user/check (defined below). 401 -> redirect to /auth/login.
+    # /verify and /get stay public (recipient path).
+    location = /send       { auth_request /api/user/check; error_page 401 = @login_redirect; try_files /send.html       =404; }
+    location = /parashare  { auth_request /api/user/check; error_page 401 = @login_redirect; try_files /parashare.html  =404; }
+    location = /drop       { auth_request /api/user/check; error_page 401 = @login_redirect; try_files /drop.html       =404; }
+    location = /sign       { auth_request /api/user/check; error_page 401 = @login_redirect; try_files /sign.html       =404; }
+    location @login_redirect { return 302 /auth/login?next=$uri; }
+
     location = /signup { try_files /signup.html =404; }
     location = /signup/verified { try_files /signup/verified.html =404; }
     location = /account { try_files /account.html =404; }
@@ -57,6 +66,20 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         client_max_body_size 4k;
+    }
+
+    # Internal-only session-validity probe used by auth_request on gated
+    # tool routes above. Placed before the broader /api/user/ block so the
+    # exact-match wins. No login-rate-limit (this fires per page load, not
+    # per login attempt) and no body forwarding (GET only).
+    location = /api/user/check {
+        internal;
+        proxy_pass http://127.0.0.1:4200/admin/api/user/check;
+        proxy_set_header Host $host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
     }
 
     location /api/user/ {


### PR DESCRIPTION
The Model A gate piece that PR #94 didn't cover. Tool routes (other than
/dashboard which is already gated via fragment) now refuse to serve
markup to unauthenticated visitors.

## Approach (Optie A, server-side via nginx auth_request)

- **admin/server.js**: tiny GET /api/user/check endpoint, reuses authUser
  middleware. 200 on valid cookie, 401 otherwise. No body, no logic.
- **nginx**: exact-match locations for /send, /parashare, /drop, /sign add
  auth_request /api/user/check; on 401 -> 302 /auth/login?next=$uri via
  named @login_redirect location.
- **nginx**: internal-only /api/user/check proxy_pass placed BEFORE the
  broader /api/user/ block so the exact-match wins. No login-rate-limit on
  this path (fires per gated page load, not per login attempt).

## Recipient path stays public
/verify and /get are not in the gated set.

## Why not in relay.js (the original prompt's assumption)
- Tool pages are static HTML in /home/paramant/app served by nginx, NOT
  by relay.js (which only handles /v2/*).
- Session validation lives in admin/server.js with Redis-backed
  paramant_user_session cookie. relay.js has no Redis client.
- Reusing the existing authUser middleware via nginx auth_request keeps
  the auth path single-source-of-truth.

## Deploy ordering (critical)
1. Rebuild admin container first (so /api/user/check exists).
2. THEN copy nginx config + nginx -t verify + reload.
Reversed ordering would point auth_request at a 404 endpoint and break
the gated tool routes for several seconds.

## Test plan
- [ ] Build admin, restart, verify /api/user/check returns 401 unauth
- [ ] Copy nginx config, nginx -t, reload
- [ ] curl https://paramant.app/send -> 302 to /auth/login?next=/send
- [ ] curl https://paramant.app/parashare -> 302 to /auth/login?next=/parashare
- [ ] curl https://paramant.app/drop -> 302
- [ ] curl https://paramant.app/sign -> 302
- [ ] curl https://paramant.app/verify -> 200 (public)
- [ ] curl https://paramant.app/get -> 200 (public)
- [ ] After legit login: /send loads normally