### PR TITLE
feat(parasign): account-bound signing identity (backend)

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -474,19 +474,22 @@ function parseCookies(req) {
 }
 
 // Call relay internal endpoint (with X-Internal-Auth)
-async function callRelay(endpoint, body) {
+async function callRelay(endpoint, body, method = "POST") {
   const relayUrl = SECTORS.health;
-  const res = await fetch(`${relayUrl}${endpoint}`, {
-    method: "POST",
+  const opts = {
+    method,
     headers: {
       "Content-Type": "application/json",
       "X-Admin-Token": ADMIN_TOKEN,
       "Authorization": `Bearer ${ADMIN_TOKEN}`,
       "X-Internal-Auth": INTERNAL_TOKEN,
     },
-    body: JSON.stringify(body),
     keepalive: false,
-  });
+  };
+  if (method !== "GET" && method !== "HEAD") {
+    opts.body = JSON.stringify(body || {});
+  }
+  const res = await fetch(`${relayUrl}${endpoint}`, opts);
   return res;
 }
 
@@ -1189,6 +1192,56 @@ function maskIp(ip) {
 // GET /api/user/account/key
 api.get("/user/account/key", authUser, async (req, res) => {
   res.json({ api_key: req.userSession.user_id });
+});
+
+// ── Account-bound signing identity (proxies to relay /v2/user/signing-key) ──
+// The browser talks to admin (session-cookie); admin forwards to relay with
+// the internal-auth token. user_id is taken from the session, never from the
+// request body — so a logged-in attacker cannot enroll a pubkey for someone else.
+
+// POST /api/user/account/signing-key — enroll a new pubkey (body: { pk_b64, label, totp })
+api.post("/user/account/signing-key", authUser, async (req, res) => {
+  const { user_id } = req.userSession;
+  const { pk_b64, label, totp } = req.body || {};
+  if (!pk_b64 || typeof pk_b64 !== "string") return res.status(400).json({ error: "missing_pk_b64" });
+  if (!totp || !/^\d{6}$/.test(String(totp))) return res.status(400).json({ error: "totp_required" });
+  try {
+    const relayRes = await callRelay("/v2/user/signing-key", { user_id, pk_b64, label, totp }, "POST");
+    const body = await relayRes.json().catch(() => ({ error: "bad_relay_response" }));
+    return res.status(relayRes.status).json(body);
+  } catch (err) {
+    console.error("[user/signing-key POST]", err.message);
+    return res.status(502).json({ error: "relay_unreachable" });
+  }
+});
+
+// GET /api/user/account/signing-key — list this user's enrolled keys
+api.get("/user/account/signing-key", authUser, async (req, res) => {
+  const { user_id } = req.userSession;
+  try {
+    const relayRes = await callRelay(`/v2/user/signing-key?user_id=${encodeURIComponent(user_id)}`, null, "GET");
+    const body = await relayRes.json().catch(() => ({ error: "bad_relay_response" }));
+    return res.status(relayRes.status).json(body);
+  } catch (err) {
+    console.error("[user/signing-key GET]", err.message);
+    return res.status(502).json({ error: "relay_unreachable" });
+  }
+});
+
+// DELETE /api/user/account/signing-key — revoke a pubkey (body: { pk_hash_sha3, totp })
+api.delete("/user/account/signing-key", authUser, async (req, res) => {
+  const { user_id } = req.userSession;
+  const { pk_hash_sha3, totp } = req.body || {};
+  if (!pk_hash_sha3 || !/^[0-9a-f]{64}$/.test(pk_hash_sha3)) return res.status(400).json({ error: "invalid_pk_hash" });
+  if (!totp || !/^\d{6}$/.test(String(totp))) return res.status(400).json({ error: "totp_required" });
+  try {
+    const relayRes = await callRelay("/v2/user/signing-key", { user_id, pk_hash_sha3, totp }, "DELETE");
+    const body = await relayRes.json().catch(() => ({ error: "bad_relay_response" }));
+    return res.status(relayRes.status).json(body);
+  } catch (err) {
+    console.error("[user/signing-key DELETE]", err.message);
+    return res.status(502).json({ error: "relay_unreachable" });
+  }
 });
 
 // POST /api/user/account/backup-codes/regenerate

--- a/relay/lib/user-signing.js
+++ b/relay/lib/user-signing.js
@@ -1,0 +1,147 @@
+'use strict';
+// Account-bound signing identity store.
+//
+// Persists the *public half* of a user's ML-DSA-65 signing key alongside the
+// rest of their account state. Private keys never reach the server — only
+// the public key, its SHA3-256 fingerprint, and an optional label.
+//
+// Multiple keys per user (GitHub-SSH style). Revoke keeps history (sets
+// revoked_at) so old envelopes remain "valid at signing time" verifiable.
+//
+// Redis layout:
+//   paramant:user:signing_pk:${userId}      → JSON array of pk entries
+//   paramant:signing_pk_index:${pk_hash}    → JSON { userId }  (O(1) reverse lookup)
+//
+// Each entry shape:
+//   { alg: 'ML-DSA-65', pk_b64, pk_hash_sha3, label, enrolled_at, revoked_at|null }
+
+const crypto = require('crypto');
+
+const ALG = 'ML-DSA-65';
+const ML_DSA_65_PK_LEN = 1952; // bytes; per NIST FIPS 204
+
+function _userKey(userId) { return `paramant:user:signing_pk:${userId}`; }
+function _indexKey(pkHash) { return `paramant:signing_pk_index:${pkHash}`; }
+
+function _isHex64(s) { return typeof s === 'string' && /^[0-9a-f]{64}$/.test(s); }
+
+function _computePkHash(pkB64) {
+  const pkBuf = Buffer.from(pkB64, 'base64');
+  if (pkBuf.length !== ML_DSA_65_PK_LEN) {
+    throw new Error(`invalid ML-DSA-65 public key length: ${pkBuf.length} (expected ${ML_DSA_65_PK_LEN})`);
+  }
+  return crypto.createHash('sha3-256').update(pkBuf).digest('hex');
+}
+
+async function _readArray(redisClient, userId) {
+  const raw = await redisClient.get(_userKey(userId));
+  if (!raw) return [];
+  try { const parsed = JSON.parse(raw); return Array.isArray(parsed) ? parsed : []; }
+  catch { return []; }
+}
+
+async function _writeArray(redisClient, userId, arr) {
+  await redisClient.set(_userKey(userId), JSON.stringify(arr));
+}
+
+// Append a new enrollment. Server computes pk_hash itself — never trusts client.
+// Idempotent: re-enrolling the same pk for the same user returns the existing
+// entry (and clears revoked_at if it was revoked, treating it as re-enrollment).
+async function storeSigningPk(redisClient, userId, { pk_b64, label }) {
+  if (!userId) throw new Error('userId required');
+  if (typeof pk_b64 !== 'string' || !pk_b64) throw new Error('pk_b64 required');
+  const pk_hash_sha3 = _computePkHash(pk_b64); // also validates length
+  const cleanLabel = (label || '').toString().slice(0, 64);
+
+  // Reverse-index conflict check: same pk_hash already mapped to a *different* user?
+  const idxRaw = await redisClient.get(_indexKey(pk_hash_sha3));
+  if (idxRaw) {
+    try {
+      const idx = JSON.parse(idxRaw);
+      if (idx.userId && idx.userId !== userId) {
+        throw new Error('pubkey already enrolled to a different account');
+      }
+    } catch (e) {
+      if (e.message === 'pubkey already enrolled to a different account') throw e;
+      // malformed index entry — overwrite below
+    }
+  }
+
+  const arr = await _readArray(redisClient, userId);
+  const existing = arr.find(e => e.pk_hash_sha3 === pk_hash_sha3);
+  const now = new Date().toISOString();
+
+  if (existing) {
+    // Re-enrollment of a previously revoked key clears the revocation.
+    existing.revoked_at = null;
+    if (cleanLabel) existing.label = cleanLabel;
+    await _writeArray(redisClient, userId, arr);
+    await redisClient.set(_indexKey(pk_hash_sha3), JSON.stringify({ userId }));
+    return { entry: existing, reenrolled: true };
+  }
+
+  const entry = {
+    alg: ALG,
+    pk_b64,
+    pk_hash_sha3,
+    label: cleanLabel || null,
+    enrolled_at: now,
+    revoked_at: null,
+  };
+  arr.push(entry);
+  await _writeArray(redisClient, userId, arr);
+  await redisClient.set(_indexKey(pk_hash_sha3), JSON.stringify({ userId }));
+  return { entry, reenrolled: false };
+}
+
+async function getSigningPks(redisClient, userId) {
+  return _readArray(redisClient, userId);
+}
+
+async function getActiveSigningPks(redisClient, userId) {
+  const arr = await _readArray(redisClient, userId);
+  return arr.filter(e => !e.revoked_at);
+}
+
+// Marks the entry with matching pk_hash_sha3 as revoked. History is kept so
+// envelopes that quoted this pubkey remain verifiable against the snapshot.
+async function revokeSigningPk(redisClient, userId, pkHashSha3) {
+  if (!_isHex64(pkHashSha3)) throw new Error('pk_hash_sha3 must be 64-char hex');
+  const arr = await _readArray(redisClient, userId);
+  const idx = arr.findIndex(e => e.pk_hash_sha3 === pkHashSha3);
+  if (idx < 0) return { revoked: false, reason: 'not_found' };
+  if (arr[idx].revoked_at) return { revoked: false, reason: 'already_revoked', entry: arr[idx] };
+  arr[idx].revoked_at = new Date().toISOString();
+  await _writeArray(redisClient, userId, arr);
+  // Keep the reverse-index intact so lookups for old signatures still resolve
+  // (showing revoked_at on the result so the verifier can decide).
+  return { revoked: true, entry: arr[idx] };
+}
+
+// Public lookup. Exact-hash match only — never a prefix scan — so an attacker
+// cannot enumerate the keyspace. Rate-limiting is the caller's responsibility.
+// Returns { userId, entry } or null. Caller decides what to project (e.g., add
+// email from user-meta).
+async function lookupByPkHash(redisClient, pkHashSha3) {
+  if (!_isHex64(pkHashSha3)) return null;
+  const idxRaw = await redisClient.get(_indexKey(pkHashSha3));
+  if (!idxRaw) return null;
+  let userId;
+  try { userId = JSON.parse(idxRaw).userId; } catch { return null; }
+  if (!userId) return null;
+  const arr = await _readArray(redisClient, userId);
+  const entry = arr.find(e => e.pk_hash_sha3 === pkHashSha3);
+  if (!entry) return null;
+  return { userId, entry };
+}
+
+module.exports = {
+  ALG,
+  ML_DSA_65_PK_LEN,
+  storeSigningPk,
+  getSigningPks,
+  getActiveSigningPks,
+  revokeSigningPk,
+  lookupByPkHash,
+  _computePkHash, // exposed for relay-side hash binding (e.g., revoke validation)
+};

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -27,6 +27,7 @@ const path   = require('path');
 const url_   = require('url');
 const { createClient } = require('redis');
 const userTotp      = require('./lib/user-totp');
+const userSigning   = require('./lib/user-signing');
 
 const VERSION    = '3.0.0';
 // Per-restart nonce: stream-next hashes non-precomputable even if API key is known
@@ -154,7 +155,7 @@ const ALLOWED = {
                '/v2/key-sector','/v2/team','/v2/reload-users','/v2/drop','/v2/session',
                '/v2/ws-ticket','/v2/fingerprint','/v2/relays','/v2/request-trial','/v2/sign-dpa',
                '/v2/sth','/v2/verify-receipt','/v2/capabilities','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
-               '/v2/sign','/v2/verify'],
+               '/v2/sign','/v2/verify','/v2/lookup-signer'],
   iot:        ['/health','/v2/pubkey','/v2/inbound','/v2/anon-inbound','/v2/outbound','/v2/status',
                '/v2/webhook','/v2/audit','/v2/check-key','/v2/stream','/v2/stream-next',
                '/v2/sender-pubkey','/v2/ack','/v2/delivery','/v2/monitor',
@@ -162,7 +163,7 @@ const ALLOWED = {
                '/v2/key-sector','/v2/team','/v2/reload-users','/v2/drop','/v2/session',
                '/v2/relays','/v2/request-trial','/v2/sign-dpa','/v2/sth','/v2/verify-receipt',
                '/v2/capabilities','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
-               '/v2/sign','/v2/verify'],
+               '/v2/sign','/v2/verify','/v2/lookup-signer'],
   full:       null,
 };
 
@@ -624,6 +625,32 @@ function ctAppendParasign(documentHashHex, signerPkHash) {
   const entry = {
     index, type: 'parasign', leaf_hash, tree_hash,
     document_hash: documentHashHex, signer_pk_hash: signerPkHash, ts, proof
+  };
+  ctLog.push(entry);
+  if (ctLog.length > CT_MAX) ctLog.shift();
+  ctWrite(entry);
+  produceSth(entry.index + 1, entry.tree_hash);
+  return entry;
+}
+
+// Appends a signing-pubkey lifecycle event (enroll / revoke) to the CT log so
+// identity changes are tamper-evident. user_id is hashed (SHA3-256) before
+// emission — verifiers see a stable identity-handle without the raw API key.
+// `eventType` must be 'signing_pk_enrolled' or 'signing_pk_revoked'.
+function ctAppendSigningPkEvent(eventType, userId, signerPkHash) {
+  if (eventType !== 'signing_pk_enrolled' && eventType !== 'signing_pk_revoked') {
+    throw new Error('invalid eventType: ' + eventType);
+  }
+  const ts = new Date().toISOString();
+  const userIdHash = crypto.createHash('sha3-256').update(String(userId)).digest('hex');
+  const leaf_hash = ctLeafHash(userIdHash, signerPkHash, ts);
+  const index = ctLog.length;
+  const allEntries = [...ctLog, { leaf_hash }];
+  const tree_hash = ctTreeHash(allEntries);
+  const proof = ctInclusionProof(allEntries, index);
+  const entry = {
+    index, type: eventType, leaf_hash, tree_hash,
+    user_id_hash: userIdHash, signer_pk_hash: signerPkHash, ts, proof
   };
   ctLog.push(entry);
   if (ctLog.length > CT_MAX) ctLog.shift();
@@ -1301,6 +1328,18 @@ function checkKeyRateOk(ip) {
   b.count++; checkKeyRateLimits.set(ip, b); return true;
 }
 setInterval(() => { const now = Date.now(); for (const [k, v] of checkKeyRateLimits) if (now > v.resetAt + 60000) checkKeyRateLimits.delete(k); }, 120_000);
+
+// Per-IP rate limit for /v2/lookup-signer/:pk_hash (max 30/min) — prevents
+// enumeration of (pubkey → email) bindings even though only exact hash matches.
+const lookupSignerRateLimits = new Map();
+function lookupSignerRateOk(ip) {
+  const now = Date.now();
+  const b = lookupSignerRateLimits.get(ip) || { count: 0, resetAt: now + 60000 };
+  if (now > b.resetAt) { b.count = 0; b.resetAt = now + 60000; }
+  if (b.count >= 30) return false;
+  b.count++; lookupSignerRateLimits.set(ip, b); return true;
+}
+setInterval(() => { const now = Date.now(); for (const [k, v] of lookupSignerRateLimits) if (now > v.resetAt + 60000) lookupSignerRateLimits.delete(k); }, 120_000);
 
 // Per-IP rate limit for /v2/status/:hash (max 60/min) — prevents hash enumeration
 const statusRateLimits = new Map();
@@ -2137,12 +2176,171 @@ const server = http.createServer(async (req, res) => {
     }
   }
 
+  // ═══════════════════════════════════════════════════════════════════════
+  // Account-bound signing identity (ML-DSA-65 public-key enrollment)
+  // ═══════════════════════════════════════════════════════════════════════
+  // Stores the *public half* of a user's signing key. Private keys never
+  // reach the server. Multi-device (array per user); revoke keeps history.
+  // Internal — X-Internal-Auth only — the admin server proxies user-session
+  // requests through these.
+
+  // POST /v2/user/signing-key — enroll a new pubkey. TOTP-gated.
+  if (req.method === "POST" && path === "/v2/user/signing-key") {
+    if (!_internalOk()) return _internalReject();
+    try {
+      const { user_id, pk_b64, label, totp } = JSON.parse((await readBody(req, 16384)).toString());
+      if (!user_id) { res.writeHead(400); return res.end(J({ error: "missing_user_id" })); }
+      if (!pk_b64 || typeof pk_b64 !== "string") { res.writeHead(400); return res.end(J({ error: "missing_pk_b64" })); }
+      if (!totp || !/^\d{6}$/.test(String(totp))) { res.writeHead(400); return res.end(J({ error: "totp_required" })); }
+      // TOTP gate — sensitive op, prevents session-hijack pk-swap
+      const totpSecret = await userTotp.getUserTotpSecret(redisClient, user_id);
+      if (!totpSecret) { res.writeHead(403); return res.end(J({ error: "no_totp_setup" })); }
+      const totpResult = await verifyTotpGeneric(totp, totpSecret, {
+        algorithm: "sha256", window: 1,
+        replayKey: `paramant:user:replay:${user_id}`,
+      });
+      if (!totpResult.valid) { res.writeHead(403); return res.end(J({ error: "invalid_totp" })); }
+      // Store (server-side pk_hash computation — never trust client)
+      let result;
+      try {
+        result = await userSigning.storeSigningPk(redisClient, user_id, { pk_b64, label });
+      } catch (e) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        return res.end(J({ error: e.message }));
+      }
+      const ctEntry = ctAppendSigningPkEvent("signing_pk_enrolled", user_id, result.entry.pk_hash_sha3);
+      log("info", "signing_pk_enrolled", {
+        user_id: String(user_id).slice(0, 12) + "…",
+        pk_hash: result.entry.pk_hash_sha3.slice(0, 16) + "…",
+        reenrolled: result.reenrolled,
+        ct_index: ctEntry.index,
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(J({
+        ok: true,
+        pk_hash_sha3: result.entry.pk_hash_sha3,
+        label: result.entry.label,
+        enrolled_at: result.entry.enrolled_at,
+        reenrolled: result.reenrolled,
+        ct_index: ctEntry.index,
+      }));
+    } catch (err) {
+      console.error("[user/signing-key POST]", err.message);
+      res.writeHead(500); return res.end(J({ error: "internal" }));
+    }
+  }
+
+  // GET /v2/user/signing-key — list the user's enrolled keys (no TOTP, read-only).
+  // Returns metadata only (pk_hash, label, timestamps); pk_b64 is intentionally
+  // omitted so the index leaks no key material if the list response is logged.
+  if (req.method === "GET" && path === "/v2/user/signing-key") {
+    if (!_internalOk()) return _internalReject();
+    try {
+      const user_id = query.user_id;
+      if (!user_id) { res.writeHead(400); return res.end(J({ error: "missing_user_id" })); }
+      const arr = await userSigning.getSigningPks(redisClient, user_id);
+      const projected = arr.map(e => ({
+        alg: e.alg,
+        pk_hash_sha3: e.pk_hash_sha3,
+        label: e.label,
+        enrolled_at: e.enrolled_at,
+        revoked_at: e.revoked_at,
+      }));
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(J({ ok: true, keys: projected, total: projected.length }));
+    } catch (err) {
+      console.error("[user/signing-key GET]", err.message);
+      res.writeHead(500); return res.end(J({ error: "internal" }));
+    }
+  }
+
+  // DELETE /v2/user/signing-key — revoke a pubkey. TOTP-gated. Keeps history
+  // (sets revoked_at) so older envelopes remain verifiable as "valid at signing time".
+  if (req.method === "DELETE" && path === "/v2/user/signing-key") {
+    if (!_internalOk()) return _internalReject();
+    try {
+      const { user_id, pk_hash_sha3, totp } = JSON.parse((await readBody(req, 4096)).toString());
+      if (!user_id || !pk_hash_sha3) { res.writeHead(400); return res.end(J({ error: "missing_fields" })); }
+      if (!totp || !/^\d{6}$/.test(String(totp))) { res.writeHead(400); return res.end(J({ error: "totp_required" })); }
+      const totpSecret = await userTotp.getUserTotpSecret(redisClient, user_id);
+      if (!totpSecret) { res.writeHead(403); return res.end(J({ error: "no_totp_setup" })); }
+      const totpResult = await verifyTotpGeneric(totp, totpSecret, {
+        algorithm: "sha256", window: 1,
+        replayKey: `paramant:user:replay:${user_id}`,
+      });
+      if (!totpResult.valid) { res.writeHead(403); return res.end(J({ error: "invalid_totp" })); }
+      let result;
+      try {
+        result = await userSigning.revokeSigningPk(redisClient, user_id, pk_hash_sha3);
+      } catch (e) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        return res.end(J({ error: e.message }));
+      }
+      if (!result.revoked) {
+        const code = result.reason === "not_found" ? 404 : 409;
+        res.writeHead(code, { "Content-Type": "application/json" });
+        return res.end(J({ error: result.reason }));
+      }
+      const ctEntry = ctAppendSigningPkEvent("signing_pk_revoked", user_id, pk_hash_sha3);
+      log("info", "signing_pk_revoked", {
+        user_id: String(user_id).slice(0, 12) + "…",
+        pk_hash: pk_hash_sha3.slice(0, 16) + "…",
+        ct_index: ctEntry.index,
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(J({ ok: true, revoked_at: result.entry.revoked_at, ct_index: ctEntry.index }));
+    } catch (err) {
+      console.error("[user/signing-key DELETE]", err.message);
+      res.writeHead(500); return res.end(J({ error: "internal" }));
+    }
+  }
+
   // ── GET /v2/check-key ───────────────────────────────────────────────────────
   if (path === '/v2/check-key') {
     if (!checkKeyRateOk(clientIp)) { res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': '60' }); return res.end(J({ error: 'Too many requests. Retry after 60 seconds.' })); }
     const kd = apiKeys.get(apiKey);
     res.writeHead(200, { 'Content-Type': 'application/json' });
     return res.end(J({ valid: !!(kd?.active), plan: kd?.plan || null }));
+  }
+
+  // ── GET /v2/lookup-signer/:pk_hash — public reverse-lookup for verifiers ──
+  // Exact 64-hex-char SHA3-256 match only — no prefix scan, no enumeration.
+  // The caller must already possess the envelope (= the pk) to ask; we return
+  // label + email (if enrolled). Rate-limited 30/min/IP to blunt scraping.
+  if (req.method === 'GET' && path.startsWith('/v2/lookup-signer/')) {
+    if (!lookupSignerRateOk(clientIp)) {
+      res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': '60' });
+      return res.end(J({ error: 'Too many requests. Retry after 60 seconds.' }));
+    }
+    const pkHash = path.slice('/v2/lookup-signer/'.length);
+    if (!/^[0-9a-f]{64}$/.test(pkHash)) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      return res.end(J({ error: 'pk_hash must be 64-char SHA3-256 hex' }));
+    }
+    try {
+      const found = await userSigning.lookupByPkHash(redisClient, pkHash);
+      if (!found) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        return res.end(J({ found: false }));
+      }
+      let email = null;
+      try {
+        const metaRaw = await redisClient.get(`paramant:user:meta:${found.userId}`);
+        if (metaRaw) { const m = JSON.parse(metaRaw); email = m.email || null; }
+      } catch {}
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(J({
+        found: true,
+        alg: found.entry.alg,
+        label: found.entry.label,
+        email,
+        enrolled_at: found.entry.enrolled_at,
+        revoked_at: found.entry.revoked_at,
+      }));
+    } catch (err) {
+      console.error('[lookup-signer]', err.message);
+      res.writeHead(500); return res.end(J({ error: 'internal' }));
+    }
   }
 
   // ── POST /v2/request-trial — Self-service trial key request (public, no auth) ──


### PR DESCRIPTION
## Summary

First step of PQ-DocuSign: persistent ML-DSA-65 public-key enrollment per
account. Model 2 / Option A — private key stays client-side; only the
public half lives on the account.

**Backend only.** Frontend + `/v2/sign` account-binding follow in separate PRs.

## What's in this PR

- **`relay/lib/user-signing.js`** — store/get/revoke pubkey array per user
  (multi-device, GitHub-SSH style). Revoke sets `revoked_at` so envelopes
  signed earlier remain verifiable as "valid at signing time". Reverse-index
  `paramant:signing_pk_index:${pk_hash}` for O(1) lookup; no scan.
- **`POST /v2/user/signing-key`** — enroll. TOTP-gated. Server computes
  `pk_hash_sha3` itself (never trusts client). Validates ML-DSA-65 pk length.
- **`GET /v2/user/signing-key`** — list own keys (no TOTP; read-only).
- **`DELETE /v2/user/signing-key`** — revoke. TOTP-gated. Keeps history.
- **`GET /v2/lookup-signer/:pk_hash`** — public reverse-lookup for verifiers.
  Exact 64-hex SHA3 match only, no enumeration. Rate-limited 30/min/IP.
- **CT-log events** `signing_pk_enrolled` / `signing_pk_revoked` — tamper-
  evident identity history. `user_id` is SHA3-hashed before emission so
  raw API keys never enter the log.
- **`admin/server.js` proxy** — three browser-facing routes (`POST/GET/DELETE
  /api/user/account/signing-key`) under session-cookie auth. `user_id` is
  taken from the session, never from the request body — so a logged-in
  attacker cannot enroll a pubkey for another account. `callRelay()` is now
  method-aware (backward-compat default `POST`).

## Privacy posture

The public lookup intentionally binds `pk_hash → email`. That is by-design
for signing — the recipient MUST know who signed. Two guards keep it
non-enumerable:

1. Exact 64-char SHA3 hex match only (no prefix scan).
2. 30/min/IP rate limit.

Anyone calling lookup must already possess the envelope (= the pk hash),
so it answers a "who" the caller already half-knows.

## What is NOT in this PR

- No frontend changes (account page UI follows).
- No `/v2/sign` changes — it still accepts an arbitrary `signer_public_key`.
  Account-binding at sign time comes in a follow-up.
- No `signer.account_verified` field on `.psign` envelopes yet.

## Test plan

- [ ] CI green
- [ ] `GET /v2/lookup-signer/<unknown>` returns 404
- [ ] `POST /v2/user/signing-key` no-auth returns 401
- [ ] Rate-limit on lookup fires within 30 reqs
- [ ] Login still works (`/auth/login` returns 200)
- [ ] Manual: enroll a pk via admin proxy after merge, then lookup returns email

🤖 Generated with [Claude Code](https://claude.com/claude-code)