### PR TITLE
feat(public): info-only site, tool access via dashboard only

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -33,16 +33,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -124,16 +115,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -91,16 +91,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -182,16 +173,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/anti-phishing.html
+++ b/frontend/anti-phishing.html
@@ -92,16 +92,7 @@ section p+p{margin-top:14px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -183,16 +174,7 @@ section p+p{margin-top:14px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
@@ -379,7 +361,7 @@ section p+p{margin-top:14px}
 <div style="background:var(--cobalt);padding:52px 48px;text-align:center">
   <h2 style="font-size:24px;font-weight:600;letter-spacing:-.02em;margin-bottom:10px;color:var(--bone-on-navy)">See burn-on-read in action.</h2>
   <p style="font-size:14px;color:var(--bone-on-navy-dim);margin-bottom:28px;max-width:520px;margin-left:auto;margin-right:auto">Send a file. Get a link. Open the link. Refresh. Watch it return HTTP 410. That is the phishing mitigation, end to end.</p>
-  <a href="/parashare" class="btn-primary">Send a test file &rarr;</a>
+  <a href="/dashboard" class="btn-primary">Open your dashboard &rarr;</a>
   <a href="/architecture" class="btn-sec">How it works &rarr;</a>
 </div>
 

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -227,16 +227,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -318,16 +309,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -84,16 +84,7 @@ section p+p{margin-top:14px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -175,16 +166,7 @@ section p+p{margin-top:14px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -18,15 +18,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -104,15 +96,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/dashboard">Dashboard</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -18,15 +18,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -104,15 +96,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/dashboard">Dashboard</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -18,15 +18,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -104,15 +96,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/dashboard">Dashboard</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -29,15 +29,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -115,15 +107,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/dashboard">Dashboard</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -19,15 +19,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -105,15 +97,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/dashboard">Dashboard</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -128,16 +128,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -219,16 +210,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -59,16 +59,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -150,16 +141,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -158,16 +158,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -249,16 +240,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -220,16 +220,7 @@ body { min-height:100vh; }
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -311,16 +302,7 @@ body { min-height:100vh; }
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -40,16 +40,7 @@ main.pa-main { max-width: 1100px; margin: 0 auto; padding: var(--space-5) var(--
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -131,16 +122,7 @@ main.pa-main { max-width: 1100px; margin: 0 auto; padding: var(--space-5) var(--
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -172,16 +172,7 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -263,16 +254,7 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -158,16 +158,7 @@ tr:last-child td{border-bottom:none}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -249,16 +240,7 @@ tr:last-child td{border-bottom:none}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -95,16 +95,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -186,16 +177,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -135,16 +135,7 @@ input:focus{border-color:var(--cobalt)}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -226,16 +217,7 @@ input:focus{border-color:var(--cobalt)}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/drop.html
+++ b/frontend/drop.html
@@ -201,16 +201,7 @@ select{background:var(--bone);border:1px solid var(--ink-hair);color:var(--ink);
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -292,16 +283,7 @@ select{background:var(--bone);border:1px solid var(--ink-hair);color:var(--ink);
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -136,16 +136,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -227,16 +218,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
@@ -353,7 +335,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
     <span class="tag green">AES-256-GCM</span>
   </div>
 
-  <a href="/send" class="btn btn-outline">Send a file</a>
+  <a href="/dashboard" class="btn btn-outline">Open your dashboard</a>
 </div>
 
 <!-- Burned / already used -->
@@ -361,7 +343,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   <span class="burned-icon" style="margin-top:16px">&#x1F525;</span>
   <p class="burned-msg">This file has already been downloaded and burned.</p>
   <p class="burned-sub">Paramant links are single-use. Once downloaded, the file is permanently deleted from the relay.</p>
-  <a href="/send" class="btn btn-outline" style="max-width:280px;margin:24px auto 0">Send a file</a>
+  <a href="/dashboard" class="btn btn-outline" style="max-width:280px;margin:24px auto 0">Open your dashboard</a>
 </div>
 
 <!-- Error -->
@@ -374,7 +356,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <div class="status-line err" id="error-msg"></div>
     </div>
   </div>
-  <a href="/send" class="btn btn-outline">Send a file</a>
+  <a href="/dashboard" class="btn btn-outline">Open your dashboard</a>
 </div>
 
 </main>

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -184,16 +184,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -275,16 +266,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -84,16 +84,7 @@ section p+p{margin-top:14px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -175,16 +166,7 @@ section p+p{margin-top:14px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -143,16 +143,7 @@ section p+p{margin-top:14px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -234,16 +225,7 @@ section p+p{margin-top:14px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -35,16 +35,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -126,16 +117,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
@@ -231,13 +213,13 @@
   <span><strong>BUSL-1.1</strong> source-available</span>
 </aside>
 
-<section class="home-section" aria-labelledby="prod-h">
+<section class="home-section" id="products" aria-labelledby="prod-h">
   <header class="home-section-head"><span class="eyebrow">Products</span><h2 id="prod-h">Four ways to use Paramant.</h2><p>One relay, four endpoints. Each tuned for a different transfer pattern. All client-side encrypted, all burn-on-read.</p></header>
   <div class="pgrid">
-    <a class="pcard" href="/send"><span class="ptag">fast</span><h3>Send a file</h3><p>Drop a file from your dashboard, share the link, burns after one read. AES-256-GCM in-browser, bound to your account.</p><span class="pcta">Send a file</span></a>
-    <a class="pcard" href="/parashare"><span class="ptag">verified</span><h3>ParaShare</h3><p>End-to-end ML-KEM-768 hybrid with ML-DSA-65 signed receipts. Cryptographic proof of who sent what to whom.</p><span class="pcta">Try ParaShare</span></a>
-    <a class="pcard" href="/drop"><span class="ptag">device-to-device</span><h3>ParaDrop</h3><p>AirDrop alternative across iOS, Android, Windows, Linux. QR or 6-digit pairing. Encrypted in transit, burn on read.</p><span class="pcta">Use ParaDrop</span></a>
-    <a class="pcard" href="/sign"><span class="ptag">new &middot; parasign</span><h3>Sign documents</h3><p>Post-quantum ML-DSA-65 signatures. Self-contained .psign envelope. CT-log backed.</p><span class="pcta">Sign a document</span></a>
+    <a class="pcard" href="/dashboard"><span class="ptag">fast</span><h3>Send a file</h3><p>Drop a file from your dashboard, share the link, burns after one read. AES-256-GCM in-browser, bound to your account.</p><span class="pcta">Open your dashboard</span></a>
+    <a class="pcard" href="/dashboard"><span class="ptag">verified</span><h3>ParaShare</h3><p>End-to-end ML-KEM-768 hybrid with ML-DSA-65 signed receipts. Cryptographic proof of who sent what to whom.</p><span class="pcta">Open your dashboard</span></a>
+    <a class="pcard" href="/dashboard"><span class="ptag">device-to-device</span><h3>ParaDrop</h3><p>AirDrop alternative across iOS, Android, Windows, Linux. QR or 6-digit pairing. Encrypted in transit, burn on read.</p><span class="pcta">Open your dashboard</span></a>
+    <a class="pcard" href="/dashboard"><span class="ptag">new &middot; parasign</span><h3>Sign documents</h3><p>Post-quantum ML-DSA-65 signatures. Self-contained .psign envelope. CT-log backed.</p><span class="pcta">Open your dashboard</span></a>
   </div>
 </section>
 
@@ -246,10 +228,10 @@
   <div class="sgrid">
     <article class="scard"><span class="slabel">Healthcare</span><h3>DICOM, referrals, lab results</h3><p class="suse">Send scans and patient records between care providers, designed for NEN 7510 with per-access CT log proof.</p><div class="schips"><a class="schip" href="/compliance/nen7510">NEN 7510</a><a class="schip" href="/sovereignty">GDPR</a></div><div class="slink"><a href="https://health.paramant.app">health.paramant.app &rarr;</a></div></article>
     <article class="scard"><span class="slabel">Finance</span><h3>Settlement files, payment data</h3><p class="suse">Payment files with per-transaction Merkle proofs. EU jurisdiction, no US Cloud Act, no metadata retention.</p><div class="schips"><a class="schip" href="/compliance/nis2">NIS2</a><a class="schip" href="/banken">Banking</a></div><div class="slink"><a href="https://finance.paramant.app">finance.paramant.app &rarr;</a></div></article>
-    <article class="scard"><span class="slabel">Legal &amp; notary</span><h3>Court documents, deeds</h3><p class="suse">Signed documents cryptographically destroyed after receipt. Tamper-evident proof of delivery without storing content.</p><div class="schips"><a class="schip" href="/sovereignty">Sovereignty</a><a class="schip" href="/sign">ParaSign</a></div><div class="slink"><a href="https://legal.paramant.app">legal.paramant.app &rarr;</a></div></article>
+    <article class="scard"><span class="slabel">Legal &amp; notary</span><h3>Court documents, deeds</h3><p class="suse">Signed documents cryptographically destroyed after receipt. Tamper-evident proof of delivery without storing content.</p><div class="schips"><a class="schip" href="/sovereignty">Sovereignty</a><a class="schip" href="/dashboard">ParaSign</a></div><div class="slink"><a href="https://legal.paramant.app">legal.paramant.app &rarr;</a></div></article>
     <article class="scard"><span class="slabel">Industrial IoT</span><h3>PLC telemetry, SCADA data</h3><p class="suse">Quantum-safe data diode. PLCs push outbound only, no inbound port, no VPN. Works on a Raspberry Pi.</p><div class="schips"><a class="schip" href="/compliance/iec62443">IEC 62443</a><a class="schip" href="/ot">OT guide</a></div><div class="slink"><a href="https://iot.paramant.app">iot.paramant.app &rarr;</a></div></article>
     <article class="scard"><span class="slabel">Government &amp; public</span><h3>Sovereign data routing</h3><p class="suse">EU-only infrastructure. No US parent company, no CLOUD Act jurisdiction. For ministries and agencies.</p><div class="schips"><a class="schip" href="/government">Government brief</a><a class="schip" href="/sovereignty">Sovereignty</a></div></article>
-    <article class="scard"><span class="slabel">Supply chain</span><h3>Firmware, SBOM, code-signing</h3><p class="suse">Distribute firmware and signed artifacts with CT-log proof. Toward EU CRA readiness.</p><div class="schips"><a class="schip" href="/hndl">CRA</a><a class="schip" href="/sign">ParaSign</a></div></article>
+    <article class="scard"><span class="slabel">Supply chain</span><h3>Firmware, SBOM, code-signing</h3><p class="suse">Distribute firmware and signed artifacts with CT-log proof. Toward EU CRA readiness.</p><div class="schips"><a class="schip" href="/hndl">CRA</a><a class="schip" href="/dashboard">ParaSign</a></div></article>
   </div>
 </section>
 

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -84,16 +84,7 @@ section p+p{margin-top:14px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -175,16 +166,7 @@ section p+p{margin-top:14px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/legal.html
+++ b/frontend/legal.html
@@ -160,16 +160,7 @@ body {
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -251,16 +242,7 @@ body {
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -115,16 +115,7 @@ footer a{color:var(--cobalt)}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -206,16 +197,7 @@ footer a{color:var(--cobalt)}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -84,16 +84,7 @@ section p+p{margin-top:14px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -175,16 +166,7 @@ section p+p{margin-top:14px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/one-pager.html
+++ b/frontend/one-pager.html
@@ -496,16 +496,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -587,16 +578,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -126,16 +126,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -217,16 +208,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/ot-vs-data-diodes.html
+++ b/frontend/ot-vs-data-diodes.html
@@ -97,16 +97,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -188,16 +179,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -157,16 +157,7 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -248,16 +239,7 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -234,16 +234,7 @@ select:focus{border-color:var(--cobalt)}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -325,16 +316,7 @@ select:focus{border-color:var(--cobalt)}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
@@ -1376,9 +1358,7 @@ function updateGlobeTransfer(userLat, userLng) {
     <div>
       <div class="footer-col-label">Product</div>
       <div class="footer-links">
-        <a href="/send">Send a file</a>
-        <a href="/parashare">ParaShare</a>
-        <a href="/drop">ParaDrop</a>
+        <a href="/dashboard">Open your dashboard</a>
           <a href="/ct-log">CT Log</a>
         <a href="/docs">Docs</a>
         <a href="/pricing">Pricing</a>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -77,16 +77,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -168,16 +159,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -139,16 +139,7 @@ td{color:var(--cobalt)}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -230,16 +221,7 @@ td{color:var(--cobalt)}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
@@ -376,7 +358,7 @@ td{color:var(--cobalt)}
     <div class="card">
       <h3>ParaShare — file transfer UI</h3>
       <p style="font-size:13px">Browser-based send/receive. No install.</p>
-      <a href="/parashare" class="dl-btn">Live demo &rarr;</a>
+      <a href="/dashboard" class="dl-btn">Open your dashboard &rarr;</a>
     </div>
     <div class="card">
       <h3>CT log — public Merkle audit trail</h3>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -124,16 +124,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -215,16 +206,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
@@ -303,7 +285,7 @@
     <p style="font-size:var(--text-md);color:var(--ink);line-height:1.75;margin-bottom:var(--space-6)">
       Send files for free with a Paramant account. Scale when you need audit trails, team access, or a dedicated relay.
     </p>
-    <a href="/send" class="btn btn-secondary">Sign in and send a file &rarr;</a>
+    <a href="/dashboard" class="btn btn-secondary">Open your dashboard &rarr;</a>
   </div>
 </section>
 
@@ -325,7 +307,7 @@
           <li>10 uploads per hour per IP</li>
           <li>Up to 5 registered devices for ParaShare</li>
         </ul>
-        <a href="/send" class="btn btn-primary" style="display:block;text-align:center">Send a file free &rarr;</a>
+        <a href="/dashboard" class="btn btn-primary" style="display:block;text-align:center">Open your dashboard &rarr;</a>
       </div>
 
       <div class="tier-card featured">

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -124,16 +124,7 @@ footer a{color:var(--ink);text-decoration:none}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -215,16 +206,7 @@ footer a{color:var(--ink);text-decoration:none}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/quantum-urgency.html
+++ b/frontend/quantum-urgency.html
@@ -97,16 +97,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -188,16 +179,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
@@ -450,7 +432,7 @@
     <p style="color:var(--bone);max-width:720px;margin-top:16px">The decision of which channel to use for sensitive data is not academic. It determines what will be readable to adversaries in 2030, 2032, 2035. Most organizations will look back on 2026 and wish they had migrated six months sooner.</p>
 
     <div style="margin-top:48px;display:flex;gap:16px;flex-wrap:wrap">
-      <a href="/parashare" class="btn btn-primary">Start with ParaShare</a>
+      <a href="/dashboard" class="btn btn-primary">Open your dashboard</a>
       <a href="/hndl" class="btn btn-secondary-inverse">Full HNDL briefing</a>
       <a href="/security" class="btn btn-secondary-inverse">Technical details</a>
     </div>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -83,16 +83,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -174,16 +165,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -147,16 +147,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -238,16 +229,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/send.html
+++ b/frontend/send.html
@@ -133,16 +133,7 @@ select#ttl-select:focus{border-color:var(--cobalt)}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -224,16 +215,7 @@ select#ttl-select:focus{border-color:var(--cobalt)}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
@@ -474,8 +456,8 @@ select#ttl-select:focus{border-color:var(--cobalt)}
     </div>
     <p style="font-size:var(--text-base);color:var(--ink);line-height:1.75;margin-bottom:var(--space-7)">Browser-encrypted links are the fastest way to send something. For transfers where you need to prove who sent the file, or where the receiver must verify the relay before trusting a key, use ParaShare. For sending between two browsers on the same network with no relay in the middle, use ParaDrop.</p>
     <div class="cluster" style="--cluster-gap:var(--space-4)">
-      <a href="/parashare" class="btn btn-secondary">Try ParaShare &rarr;</a>
-      <a href="/drop" class="btn btn-secondary">Try ParaDrop &rarr;</a>
+      <a href="/dashboard" class="btn btn-secondary">Open your dashboard &rarr;</a>
+      <a href="/dashboard" class="btn btn-secondary">Open your dashboard &rarr;</a>
     </div>
   </div>
 </section>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -28,16 +28,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -119,16 +110,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -108,16 +108,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -199,16 +190,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -134,16 +134,7 @@ a:hover{opacity:.8}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -225,16 +216,7 @@ a:hover{opacity:.8}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -98,16 +98,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -189,16 +180,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
@@ -558,7 +540,7 @@
     <p style="color:var(--bone);max-width:680px;font-size:16px;line-height:1.55;margin-top:20px">Paramant is built to still make sense in five and ten years. That means post-quantum cryptography today, EU jurisdiction permanently, and architecture that makes jurisdictional questions mostly moot because there is simply no data to ask about.</p>
 
     <div style="margin-top:48px;display:flex;gap:16px;flex-wrap:wrap">
-      <a href="/send" class="btn btn-primary">Send a file</a>
+      <a href="/dashboard" class="btn btn-primary">Open your dashboard</a>
       <a href="/security" class="btn btn-secondary-inverse">Technical details</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay" class="btn btn-secondary-inverse" target="_blank" rel="noopener">Self-host on GitHub</a>
     </div>

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -91,16 +91,7 @@ section p+p{margin-top:14px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -182,16 +173,7 @@ section p+p{margin-top:14px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -147,16 +147,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -238,16 +229,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -162,16 +162,7 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -253,16 +244,7 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -28,16 +28,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -119,16 +110,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
@@ -233,7 +215,7 @@
       <li>The relay's notary signature over the envelope is valid</li>
       <li>The envelope has not expired</li>
     </ul>
-    <p><a href="/sign">Sign a document &rarr;</a></p>
+    <p><a href="/dashboard">Open your dashboard &rarr;</a></p>
   </aside>
 </div>
 </main>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -97,16 +97,7 @@
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -188,16 +179,7 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
@@ -560,7 +542,7 @@
     <p style="color:var(--bone);max-width:720px;margin-top:16px">For any other use case, one of the alternatives above is likely a better fit. That honesty is the point.</p>
 
     <div style="margin-top:48px;display:flex;gap:16px;flex-wrap:wrap">
-      <a href="/send" class="btn btn-primary">Try Paramant</a>
+      <a href="/dashboard" class="btn btn-primary">Open your dashboard</a>
       <a href="/sovereignty" class="btn btn-secondary-inverse">Why jurisdiction matters</a>
       <a href="/docs" class="btn btn-secondary-inverse">Technical docs</a>
     </div>

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -84,16 +84,7 @@ section p+p{margin-top:14px}
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/send" role="menuitem">Send a file</a></li>
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/sign" role="menuitem">ParaSign</a></li>
-        <li role="none"><a href="/verify" role="menuitem">Verify signature</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
 
     <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
@@ -175,16 +166,7 @@ section p+p{margin-top:14px}
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/send">Send a file</a>
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/sign">ParaSign</a>
-      <a href="/verify">Verify signature</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
 
   <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 


### PR DESCRIPTION
Tool links out of the nav. Explainer cards + cross-page CTAs redirect to /dashboard (gated). 52 pages touched mechanically for nav consistency, 14 CTA swaps to /dashboard across 9 pages. nav.css/.js untouched; design-system.css untouched. Inline info-text tool mentions in FAQ <p> copy kept on purpose. ASCII discipline preserved.