### PR TITLE
fix(security): gate redirect uses https://$host (not internal :8080)

### DIFF
--- a/deploy/nginx-paramant-live.conf
+++ b/deploy/nginx-paramant-live.conf
@@ -45,7 +45,10 @@ server {
     location = /parashare  { auth_request /api/user/check; error_page 401 = @login_redirect; try_files /parashare.html  =404; }
     location = /drop       { auth_request /api/user/check; error_page 401 = @login_redirect; try_files /drop.html       =404; }
     location = /sign       { auth_request /api/user/check; error_page 401 = @login_redirect; try_files /sign.html       =404; }
-    location @login_redirect { return 302 /auth/login?next=$uri; }
+    # Hardcoded https:// because nginx listens on 127.0.0.1:8080 behind
+    # Caddy; a bare /path redirect makes nginx synthesize an absolute URL
+    # with the internal :8080 port, which is unreachable from outside.
+    location @login_redirect { return 302 https://$host/auth/login?next=$uri; }
 
     location = /signup { try_files /signup.html =404; }
     location = /signup/verified { try_files /signup/verified.html =404; }


### PR DESCRIPTION
Follow-up to PR #97. Production verified the gate fires but the Location header contained the internal listener port. Same logic, fixed redirect target.