### PR TITLE
feat(parasign): IndexedDB signing-key vault (passphrase-KEK)

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -339,9 +339,40 @@
   </div>
 </section>
 
-<section class="section">
+<section class="section" id="signing-identity-section">
   <div class="marker">
     <div class="num">03</div>
+    <h2>Signing identity.</h2>
+    <div class="tag">ML-DSA-65<br>persistent</div>
+  </div>
+
+  <div class="grid2">
+    <div class="card">
+      <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px;color:var(--navy)">
+        Enrolled keys
+      </div>
+      <p style="margin:0 0 12px" id="signing-empty" class="small">Checking your account...</p>
+      <ul id="signing-list" style="margin:0;padding:0;list-style:none"></ul>
+      <p class="small mt-2">
+        Public keys are bound to your account so verifiers can attribute signatures. Private keys never leave your browser. <a href="/sign">Manage at /sign</a>.
+      </p>
+    </div>
+
+    <div class="card">
+      <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px;color:var(--navy)">
+        Browser vault
+      </div>
+      <p style="margin:0 0 12px" id="vault-status" class="small">Checking this browser...</p>
+      <p class="small mt-2">
+        <strong>Your passphrase encrypts your signing key in this browser. We never see it and we cannot reset it. If you forget it, this key is gone.</strong> Download a backup key file at <a href="/sign">/sign</a>.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="marker">
+    <div class="num">04</div>
     <h2>Active sessions.</h2>
     <div class="tag">devices<br>signed in</div>
   </div>
@@ -357,7 +388,7 @@
 
 <section class="section" id="billing-section">
   <div class="marker">
-    <div class="num">04</div>
+    <div class="num">05</div>
     <h2>Plan &amp; billing.</h2>
     <div class="tag">subscription<br>and history</div>
   </div>
@@ -397,7 +428,7 @@
 
 <section class="section">
   <div class="marker">
-    <div class="num">05</div>
+    <div class="num">06</div>
     <h2>Session.</h2>
     <div class="tag">this browser<br>right now</div>
   </div>
@@ -410,7 +441,7 @@
 
 <section class="section">
   <div class="marker">
-    <div class="num">06</div>
+    <div class="num">07</div>
     <h2>Delete account.</h2>
     <div class="tag">permanent<br>cannot undo</div>
   </div>
@@ -638,6 +669,102 @@
   loadBilling();
   loadBillingHistory();
 })();
+</script>
+
+<script type="module">
+import { vaultAvailable, vaultList } from '/vendor/vault.js';
+
+const escHtml = s => String(s == null ? '' : s)
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;').replace(/'/g, '&#x27;');
+
+function fmtTs(iso) {
+  if (!iso) return '-';
+  try { return new Date(iso).toLocaleString(); } catch { return iso; }
+}
+
+async function loadEnrolledKeys() {
+  const listEl = document.getElementById('signing-list');
+  const emptyEl = document.getElementById('signing-empty');
+  try {
+    const res = await fetch('/api/user/account/signing-key', { credentials: 'include' });
+    if (!res.ok) {
+      emptyEl.textContent = 'Could not load enrolled keys (HTTP ' + res.status + ').';
+      return;
+    }
+    const data = await res.json();
+    const keys = (data.keys || []);
+    if (!keys.length) {
+      emptyEl.textContent = 'No signing keys enrolled on your account yet. Visit /sign to generate one and enroll it.';
+      listEl.innerHTML = '';
+      return;
+    }
+    emptyEl.hidden = true;
+    listEl.innerHTML = keys.map(k => {
+      const fp = escHtml((k.pk_hash_sha3 || '').slice(0, 16));
+      const lbl = k.label ? escHtml(k.label) : '<em>no label</em>';
+      const enrolled = escHtml(fmtTs(k.enrolled_at));
+      const revoked = k.revoked_at ? ' &middot; revoked ' + escHtml(fmtTs(k.revoked_at)) : '';
+      const alg = escHtml(k.alg || '?');
+      const btn = k.revoked_at
+        ? ''
+        : '<button type="button" class="btn btn-secondary btn-small" data-revoke="' + escHtml(k.pk_hash_sha3) + '">Revoke</button>';
+      return '<li style="padding:12px 0;border-bottom:1px solid var(--border-soft, #e5e7eb)">' +
+        '<div style="font-weight:600">' + lbl + '</div>' +
+        '<div class="mono small" style="margin:4px 0">' + fp + '...</div>' +
+        '<div class="small" style="color:var(--muted, #6b7280)">' + alg + ' &middot; enrolled ' + enrolled + revoked + '</div>' +
+        (btn ? '<div style="margin-top:8px">' + btn + '</div>' : '') +
+        '</li>';
+    }).join('');
+    listEl.querySelectorAll('button[data-revoke]').forEach(b => {
+      b.addEventListener('click', () => revokeKey(b.getAttribute('data-revoke')));
+    });
+  } catch (e) {
+    emptyEl.textContent = 'Could not load enrolled keys: ' + e.message;
+  }
+}
+
+async function revokeKey(pkHash) {
+  const totp = window.prompt('Revoke this signing key?\n\nEnter your 6-digit TOTP code to confirm.');
+  if (!totp) return;
+  if (!/^\d{6}$/.test(totp)) { alert('TOTP must be 6 digits.'); return; }
+  try {
+    const res = await fetch('/api/user/account/signing-key', {
+      method: 'DELETE',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pk_hash_sha3: pkHash, totp }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) { alert('Revoke failed: ' + (body.error || ('HTTP ' + res.status))); return; }
+    await loadEnrolledKeys();
+  } catch (e) { alert('Revoke failed: ' + e.message); }
+}
+
+async function loadVaultStatus() {
+  const el = document.getElementById('vault-status');
+  if (!(await vaultAvailable())) {
+    el.textContent = 'IndexedDB or WebCrypto not available in this browser. You can still generate a key at /sign and download a backup file.';
+    return;
+  }
+  try {
+    const list = await vaultList();
+    if (!list.length) {
+      el.textContent = 'No keys saved in this browser yet. Go to /sign to generate one and save it here.';
+      return;
+    }
+    const fmt = e => (e.label ? e.label : '(no label)') + ' [' + (e.pk_hash || '').slice(0, 12) + '...]';
+    const last = list.reduce((acc, e) => (e.last_used_at && (!acc || e.last_used_at > acc) ? e.last_used_at : acc), null);
+    el.textContent = list.length + ' key' + (list.length === 1 ? '' : 's') + ' saved in this browser'
+      + (last ? '. Last used ' + fmtTs(last) : '. Never unlocked yet')
+      + '. Keys: ' + list.map(fmt).join(', ');
+  } catch (e) {
+    el.textContent = 'Could not read browser vault: ' + e.message;
+  }
+}
+
+loadEnrolledKeys();
+loadVaultStatus();
 </script>
 
 </body>

--- a/frontend/parasign-client.js
+++ b/frontend/parasign-client.js
@@ -7,6 +7,7 @@
 // Crypto is vendored same-origin (frontend/vendor/paramant-pqc.js, built from
 // @noble/post-quantum + @noble/hashes) so it loads under the site CSP (script-src 'self').
 import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
+import { vaultAvailable, vaultList, vaultStore, vaultUnlock } from '/vendor/vault.js';
 
 const RELAY_URL = 'https://relay.paramant.app';
 let signerKey = null, documentBuffer = null, documentFilename = '', lastEnvelope = null;
@@ -15,6 +16,12 @@ const $ = id => document.getElementById(id);
 const toHex = u8 => Array.from(u8, b => b.toString(16).padStart(2, '0')).join('');
 const fromHex = h => new Uint8Array(h.match(/.{2}/g).map(b => parseInt(b, 16)));
 function toB64(u8) { let s = ''; for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]); return btoa(s); }
+function fromB64(s) {
+  const bin = atob(s);
+  const u8 = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i);
+  return u8;
+}
 
 function setStatus(kind, msg) {
   const el = $('ps-sign-status'); if (!el) return;
@@ -25,14 +32,20 @@ function updateSignButton() {
   $('ps-sign').disabled = !(signerKey && documentBuffer && apiKey);
 }
 
+function showKeyInfo() {
+  $('ps-pubkey-fp').textContent = toHex(sha3_256(signerKey.publicKey)).slice(0, 32) + '...';
+  $('ps-key-info').hidden = false;
+  $('ps-save-key').disabled = false;
+  const saveVaultBtn = $('ps-save-vault'); if (saveVaultBtn) saveVaultBtn.disabled = false;
+}
+
 function generateKey() {
   setStatus('info', 'Generating ML-DSA-65 key locally (in this browser only)...');
   try {
     const keys = ml_dsa65.keygen(crypto.getRandomValues(new Uint8Array(32)));
     signerKey = { secretKey: keys.secretKey, publicKey: keys.publicKey };
-    $('ps-pubkey-fp').textContent = toHex(sha3_256(keys.publicKey)).slice(0, 32) + '...';
-    $('ps-key-info').hidden = false; $('ps-save-key').disabled = false;
-    setStatus('ok', 'Key generated. Private key stays in browser memory.');
+    showKeyInfo();
+    setStatus('ok', 'Key generated. Save to this browser, download a backup, or sign right now.');
     updateSignButton();
   } catch (e) { setStatus('err', 'Keygen failed: ' + e.message); }
 }
@@ -42,8 +55,7 @@ async function loadKey(file) {
     const d = JSON.parse(await file.text());
     if (!d.secretKey || !d.publicKey) throw new Error('invalid key file');
     signerKey = { secretKey: fromHex(d.secretKey), publicKey: fromHex(d.publicKey) };
-    $('ps-pubkey-fp').textContent = toHex(sha3_256(signerKey.publicKey)).slice(0, 32) + '...';
-    $('ps-key-info').hidden = false; $('ps-save-key').disabled = false;
+    showKeyInfo();
     setStatus('ok', 'Key loaded (client-side only).'); updateSignButton();
   } catch (e) { setStatus('err', 'Load failed: ' + e.message); }
 }
@@ -99,6 +111,110 @@ function download() {
   a.download = (documentFilename || 'document') + '.psign'; a.click(); URL.revokeObjectURL(a.href);
 }
 
+// --- Vault flows (additive; throwaway key + JSON file paths stay intact) ---
+
+let pendingVaultId = null;
+
+function showForm(id, show) {
+  const el = $(id); if (!el) return;
+  el.hidden = !show;
+  if (show) {
+    const firstInput = el.querySelector('input');
+    if (firstInput) firstInput.focus();
+  }
+}
+
+async function refreshVaultRow() {
+  if (!(await vaultAvailable())) return;
+  let list = [];
+  try { list = await vaultList(); } catch { return; }
+  const row = $('ps-vault-row');
+  const sel = $('ps-vault-select');
+  if (!row || !sel) return;
+  if (!list.length) { row.hidden = true; return; }
+  sel.innerHTML = '';
+  for (const e of list) {
+    const opt = document.createElement('option');
+    opt.value = e.id;
+    const fp = (e.pk_hash || '').slice(0, 12);
+    opt.textContent = (e.label ? e.label + ' ' : '') + '(' + fp + '...)';
+    sel.appendChild(opt);
+  }
+  row.hidden = false;
+}
+
+function onSaveVaultClick() {
+  if (!signerKey) return;
+  setStatus('info', 'Choose a passphrase to encrypt this key in your browser.');
+  showForm('ps-vault-form', true);
+}
+
+async function onVaultConfirm() {
+  if (!signerKey) return;
+  const p1 = ($('ps-vault-pass').value || '');
+  const p2 = ($('ps-vault-pass2').value || '');
+  if (p1.length < 8) { setStatus('err', 'Passphrase must be at least 8 characters.'); return; }
+  if (p1 !== p2)     { setStatus('err', 'Passphrases do not match.'); return; }
+  setStatus('info', 'Deriving KEK with PBKDF2 (this takes a moment)...');
+  try {
+    const pk_b64 = toB64(signerKey.publicKey);
+    const pk_hash = toHex(sha3_256(signerKey.publicKey));
+    const label = $('ps-label').value || null;
+    await vaultStore({
+      alg: 'ML-DSA-65',
+      label,
+      pk_b64,
+      pk_hash,
+      secretKeyBytes: signerKey.secretKey,
+      passphrase: p1,
+    });
+    $('ps-vault-pass').value = ''; $('ps-vault-pass2').value = '';
+    showForm('ps-vault-form', false);
+    await refreshVaultRow();
+    setStatus('ok', 'Key saved in this browser. You can now sign without re-generating.');
+  } catch (e) { setStatus('err', 'Save failed: ' + e.message); }
+}
+
+function onVaultCancel() {
+  $('ps-vault-pass').value = ''; $('ps-vault-pass2').value = '';
+  showForm('ps-vault-form', false);
+}
+
+function onUnlockClick() {
+  const sel = $('ps-vault-select');
+  if (!sel || !sel.value) return;
+  pendingVaultId = sel.value;
+  setStatus('info', 'Enter the passphrase for this key.');
+  showForm('ps-unlock-form', true);
+}
+
+async function onUnlockConfirm() {
+  const pass = ($('ps-unlock-pass').value || '');
+  if (!pass) return;
+  setStatus('info', 'Deriving KEK + decrypting (this takes a moment)...');
+  try {
+    const r = await vaultUnlock(pendingVaultId, pass);
+    signerKey = { secretKey: r.secretKeyBytes, publicKey: fromB64(r.pk_b64) };
+    showKeyInfo();
+    if (r.label) $('ps-label').value = r.label;
+    $('ps-unlock-pass').value = '';
+    showForm('ps-unlock-form', false);
+    setStatus('ok', 'Key unlocked. Ready to sign.');
+    updateSignButton();
+  } catch (e) {
+    $('ps-unlock-pass').value = '';
+    setStatus('err', e.message === 'wrong passphrase' ? 'Wrong passphrase. Try again.' : 'Unlock failed: ' + e.message);
+  }
+}
+
+function onUnlockCancel() {
+  $('ps-unlock-pass').value = '';
+  pendingVaultId = null;
+  showForm('ps-unlock-form', false);
+}
+
+// --- Wire up ---
+
 $('ps-gen-key').addEventListener('click', generateKey);
 $('ps-load-key').addEventListener('change', e => e.target.files[0] && loadKey(e.target.files[0]));
 $('ps-save-key').addEventListener('click', saveKey);
@@ -106,3 +222,13 @@ $('ps-document').addEventListener('change', e => onDoc(e.target.files[0]));
 $('ps-api-key').addEventListener('input', updateSignButton);
 $('ps-sign').addEventListener('click', sign);
 $('ps-download-psign').addEventListener('click', download);
+
+const saveVaultBtn = $('ps-save-vault'); if (saveVaultBtn) saveVaultBtn.addEventListener('click', onSaveVaultClick);
+const vaultConfirm = $('ps-vault-confirm'); if (vaultConfirm) vaultConfirm.addEventListener('click', onVaultConfirm);
+const vaultCancel  = $('ps-vault-cancel');  if (vaultCancel)  vaultCancel.addEventListener('click', onVaultCancel);
+const unlockBtn    = $('ps-vault-unlock');  if (unlockBtn)    unlockBtn.addEventListener('click', onUnlockClick);
+const unlockOk     = $('ps-unlock-confirm');if (unlockOk)     unlockOk.addEventListener('click', onUnlockConfirm);
+const unlockNo     = $('ps-unlock-cancel'); if (unlockNo)     unlockNo.addEventListener('click', onUnlockCancel);
+
+// On page-load: scan vault, show the picker if keys exist.
+refreshVaultRow();

--- a/frontend/parasign-verify.js
+++ b/frontend/parasign-verify.js
@@ -9,7 +9,16 @@ let documentBuffer = null, envelope = null;
 
 const $ = id => document.getElementById(id);
 const toHex = u8 => Array.from(u8, b => b.toString(16).padStart(2, '0')).join('');
-const esc = s => String(s).replace(/[<>&"]/g, c => ({ '<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;' }[c]));
+const esc = s => String(s == null ? '' : s)
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;').replace(/'/g, '&#x27;');
+
+function fromB64(s) {
+  const bin = atob(s);
+  const u8 = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i);
+  return u8;
+}
 
 function update() {
   const apiKey = ($('vf-api-key').value || '').trim();
@@ -53,13 +62,43 @@ async function verify() {
       $('vf-result').innerHTML = '<div class="ps-banner err">Relay HTTP ' + res.status + ': ' + esc(t.slice(0, 200)) + '</div>';
       return;
     }
-    renderResult(await res.json());
+    await renderResult(await res.json());
   } catch (e) {
     $('vf-result').innerHTML = '<div class="ps-banner err">Verify failed: ' + esc(e.message) + '</div>';
   } finally { $('vf-verify').disabled = false; }
 }
 
-function renderResult(r) {
+// Resolve "Signed by <label> (<email>)" via the public lookup endpoint.
+// Returns an HTML fragment (already-escaped) or '' if no attribution found.
+async function lookupSignerHtml(envelope) {
+  try {
+    const pkB64 = envelope && envelope.signer && envelope.signer.public_key;
+    if (!pkB64) return '';
+    const pkBytes = fromB64(pkB64);
+    const pkHash = toHex(sha3_256(pkBytes));
+    const res = await fetch(RELAY_URL + '/v2/lookup-signer/' + pkHash);
+    if (res.status === 404) {
+      return '<p class="ps-help">Signer not linked to a Paramant account. Identified by public-key fingerprint <code class="mono">'
+        + esc(pkHash.slice(0, 16)) + '...</code> only.</p>';
+    }
+    if (!res.ok) return '';
+    const d = await res.json();
+    if (!d.found) return '';
+    const label = d.label ? esc(d.label) : '<em>(no label)</em>';
+    const email = d.email ? esc(d.email) : '<em>(unverified)</em>';
+    const algo  = esc(d.alg || '?');
+    let html = '<p class="ps-help"><strong>Signed by ' + label + ' (' + email + ')</strong> &middot; ' + algo + '</p>';
+    if (d.revoked_at) {
+      html += '<p class="ps-help">This key was revoked on ' + esc(d.revoked_at)
+        + '. The signature is still cryptographically valid; treat as valid if signed before that date.</p>';
+    } else if (d.enrolled_at) {
+      html += '<p class="ps-help">Key enrolled on ' + esc(d.enrolled_at) + '.</p>';
+    }
+    return html;
+  } catch { return ''; }
+}
+
+async function renderResult(r) {
   const out = [];
   out.push(r.valid
     ? '<div class="ps-banner ok"><strong>Signature valid.</strong> Document matches the signed hash.</div>'
@@ -72,7 +111,13 @@ function renderResult(r) {
   if (r.note) out.push('<p class="ps-help">' + esc(r.note) + '</p>');
   const idx = envelope && envelope.notary && envelope.notary.ct_log_index;
   if (idx != null) out.push('<p class="ps-help">CT log index: <a href="/ct-log">' + esc(String(idx)) + '</a></p>');
+  // First paint without attribution so the user sees the valid/invalid badge fast.
   $('vf-result').innerHTML = out.join('');
+  // Then enrich with public-key lookup (best-effort, can be 404).
+  if (r.valid) {
+    const attr = await lookupSignerHtml(envelope);
+    if (attr) $('vf-result').innerHTML = out.join('') + attr;
+  }
 }
 
 $('vf-document').addEventListener('change', e => onDoc(e.target.files[0]));

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -188,18 +188,54 @@
 
   <section class="card ps-panel" aria-labelledby="s1">
     <div class="ps-panel-head"><span class="ps-step">1</span><h2 id="s1" class="ps-panel-title">Signing key</h2></div>
-    <p class="ps-help">Generate a fresh ML-DSA-65 key or load one you saved earlier. The key stays in browser memory.</p>
+    <p class="ps-help">Generate a fresh ML-DSA-65 key, unlock one from this browser, or load a key file. The private key never leaves the browser.</p>
+
+    <div class="ps-vault-row" id="ps-vault-row" hidden>
+      <label class="ps-label" for="ps-vault-select">Use a key from this browser</label>
+      <select class="ps-input" id="ps-vault-select"></select>
+      <button class="btn btn-primary" id="ps-vault-unlock" type="button">Unlock</button>
+    </div>
+
     <div class="ps-btn-row">
       <button class="btn btn-primary" id="ps-gen-key" type="button">Generate new key</button>
       <label class="btn btn-secondary">Load key file<input type="file" id="ps-load-key" accept=".json,application/json" hidden></label>
       <button class="btn btn-tertiary" id="ps-save-key" type="button" disabled>Download key</button>
+      <button class="btn btn-secondary" id="ps-save-vault" type="button" disabled>Save to this browser</button>
     </div>
+
+    <div class="ps-vault-form" id="ps-vault-form" hidden>
+      <p class="ps-help"><strong>Set a passphrase to encrypt this key in your browser.</strong> We never see it and we cannot reset it. If you forget it, this key is gone. Download a backup file too, to be safe.</p>
+      <div class="ps-field">
+        <label class="ps-label" for="ps-vault-pass">Passphrase (8 chars min)</label>
+        <input class="ps-input mono" type="password" id="ps-vault-pass" autocomplete="new-password" minlength="8">
+      </div>
+      <div class="ps-field">
+        <label class="ps-label" for="ps-vault-pass2">Confirm passphrase</label>
+        <input class="ps-input mono" type="password" id="ps-vault-pass2" autocomplete="new-password" minlength="8">
+      </div>
+      <div class="ps-btn-row">
+        <button class="btn btn-primary" id="ps-vault-confirm" type="button">Save in browser</button>
+        <button class="btn btn-tertiary" id="ps-vault-cancel" type="button">Cancel</button>
+      </div>
+    </div>
+
+    <div class="ps-vault-form" id="ps-unlock-form" hidden>
+      <div class="ps-field">
+        <label class="ps-label" for="ps-unlock-pass">Passphrase for the selected key</label>
+        <input class="ps-input mono" type="password" id="ps-unlock-pass" autocomplete="current-password">
+      </div>
+      <div class="ps-btn-row">
+        <button class="btn btn-primary" id="ps-unlock-confirm" type="button">Unlock</button>
+        <button class="btn btn-tertiary" id="ps-unlock-cancel" type="button">Cancel</button>
+      </div>
+    </div>
+
     <div class="ps-keybox" id="ps-key-info" hidden>
       <dl class="ps-kv">
         <dt>Public key fingerprint</dt><dd class="mono" id="ps-pubkey-fp">-</dd>
         <dt>Algorithm</dt><dd>ML-DSA-65 (FIPS 204)</dd>
       </dl>
-      <p class="ps-warn">Private key is in memory only. Download it if you want to reuse this identity later.</p>
+      <p class="ps-warn">Private key is in memory only. Save it to this browser (encrypted) or download a key file if you want to reuse this identity.</p>
     </div>
   </section>
 

--- a/frontend/vendor/vault.js
+++ b/frontend/vendor/vault.js
@@ -1,0 +1,243 @@
+// ParaSign signing-key vault.
+//
+// Persists ML-DSA-65 private keys in IndexedDB, encrypted with a passphrase-
+// derived KEK (PBKDF2-SHA256 600000 iter -> AES-256-GCM). All WebCrypto-
+// native, zero dependencies, same-origin only (loads under script-src 'self').
+//
+// Envelope layout (forward-compatible with WebAuthn-PRF in PR 2):
+//   {
+//     id:          <pk_hash_sha3, used as IDB primary key>,
+//     alg:         'ML-DSA-65',
+//     label:       <string|null>,
+//     pk_b64:      <public key, base64, plain (public)>,
+//     pk_hash:     <SHA3-256 hex of the raw public key>,
+//     enrolled_at: <ISO timestamp>,
+//     wraps: [
+//       { kekSource: 'passphrase', kdf: 'PBKDF2-SHA256', iter, salt, iv, ciphertext }
+//       // PR 2 appends   { kekSource: 'webauthn-prf', credentialId, iv, ciphertext }
+//     ]
+//   }
+//
+// The wraps array is what lets a second KEK source (Face ID / Touch ID via
+// WebAuthn-PRF) be added later without re-encrypting or migrating data.
+
+const DB_NAME    = 'paramant';
+const STORE_NAME = 'signing-keys';
+const DB_VERSION = 1;
+const PBKDF2_ITER = 600000;
+const PBKDF2_HASH = 'SHA-256';
+const KEK_NAME    = 'AES-GCM';
+const KEK_BITS    = 256;
+const SALT_BYTES  = 16;
+const IV_BYTES    = 12;
+
+// --- Base64 helpers (Uint8Array <-> base64 string). Same idiom the relay uses.
+function b64Encode(u8) {
+  let s = '';
+  for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]);
+  return btoa(s);
+}
+function b64Decode(s) {
+  const bin = atob(s);
+  const u8 = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i);
+  return u8;
+}
+
+// --- IDB open (idempotent). Creates store on first call.
+function vaultOpen() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror   = () => reject(req.error || new Error('IDB open failed'));
+    req.onblocked = () => reject(new Error('IDB blocked (another tab is upgrading)'));
+  });
+}
+
+function _tx(db, mode) {
+  return db.transaction(STORE_NAME, mode).objectStore(STORE_NAME);
+}
+function _toPromise(req) {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror   = () => reject(req.error);
+  });
+}
+
+// --- Metadata-only listing. Never returns plaintext secret material.
+//     Returns array of { id, alg, label, pk_b64, pk_hash, enrolled_at, kekSources, lastUsedAt }.
+export async function vaultList() {
+  const db = await vaultOpen();
+  const all = await _toPromise(_tx(db, 'readonly').getAll());
+  db.close();
+  return all.map(e => ({
+    id:          e.id,
+    alg:         e.alg,
+    label:       e.label || null,
+    pk_b64:      e.pk_b64,
+    pk_hash:     e.pk_hash,
+    enrolled_at: e.enrolled_at,
+    last_used_at: e.last_used_at || null,
+    kekSources:  (e.wraps || []).map(w => w.kekSource),
+  }));
+}
+
+// --- Passphrase -> KEK via PBKDF2-SHA256 (600k iter -> AES-GCM 256).
+async function _deriveKekFromPassphrase(passphrase, salt) {
+  const passBytes = new TextEncoder().encode(String(passphrase));
+  const baseKey = await crypto.subtle.importKey(
+    'raw', passBytes, { name: 'PBKDF2' }, false, ['deriveKey'],
+  );
+  const kek = await crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: PBKDF2_ITER, hash: PBKDF2_HASH },
+    baseKey,
+    { name: KEK_NAME, length: KEK_BITS },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+  // Wipe the passphrase bytes from our copy. (V8 will GC the TextEncoder
+  // result; we cannot reach into the WebCrypto-internal copy. This is a
+  // best-effort hygiene step.)
+  passBytes.fill(0);
+  return kek;
+}
+
+// --- Store an entry. If id already exists, the new passphrase-wrap REPLACES
+//     the existing passphrase-wrap on that entry (so the user can change
+//     passphrases). Other wraps (e.g. PR 2's prf wrap) are left intact.
+export async function vaultStore({ alg, label, pk_b64, pk_hash, secretKeyBytes, passphrase }) {
+  if (!alg || !pk_b64 || !pk_hash) throw new Error('vaultStore: alg, pk_b64, pk_hash required');
+  if (!(secretKeyBytes instanceof Uint8Array) || secretKeyBytes.length === 0) {
+    throw new Error('vaultStore: secretKeyBytes (Uint8Array) required');
+  }
+  if (!passphrase || String(passphrase).length < 8) {
+    throw new Error('vaultStore: passphrase of at least 8 chars required');
+  }
+
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const iv   = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const kek  = await _deriveKekFromPassphrase(passphrase, salt);
+  const ct   = new Uint8Array(
+    await crypto.subtle.encrypt({ name: KEK_NAME, iv }, kek, secretKeyBytes),
+  );
+
+  const wrap = {
+    kekSource:  'passphrase',
+    kdf:        'PBKDF2-SHA256',
+    iter:       PBKDF2_ITER,
+    salt:       b64Encode(salt),
+    iv:         b64Encode(iv),
+    ciphertext: b64Encode(ct),
+  };
+
+  const db = await vaultOpen();
+  const store = _tx(db, 'readwrite');
+  const existing = await _toPromise(store.get(pk_hash));
+
+  const entry = existing ? { ...existing } : {
+    id:          pk_hash,
+    alg,
+    label:       label || null,
+    pk_b64,
+    pk_hash,
+    enrolled_at: new Date().toISOString(),
+    wraps:       [],
+    last_used_at: null,
+  };
+  // Update label if provided (idempotent re-store)
+  if (label) entry.label = label;
+  // Replace existing passphrase wrap if there is one, else append
+  entry.wraps = (entry.wraps || []).filter(w => w.kekSource !== 'passphrase');
+  entry.wraps.push(wrap);
+
+  await _toPromise(store.put(entry));
+  db.close();
+
+  return {
+    id: entry.id,
+    alg: entry.alg,
+    label: entry.label,
+    pk_hash: entry.pk_hash,
+    enrolled_at: entry.enrolled_at,
+    kekSources: entry.wraps.map(w => w.kekSource),
+  };
+}
+
+// --- Unlock with passphrase. Returns the raw secretKeyBytes (Uint8Array) so
+//     the caller can hand it to ml_dsa65.sign(). Throws 'wrong passphrase' on
+//     auth-tag mismatch, 'no such key' if the id is unknown, 'no passphrase
+//     wrap' if the entry has no passphrase KEK source.
+export async function vaultUnlock(id, passphrase) {
+  if (!id) throw new Error('vaultUnlock: id required');
+  if (!passphrase) throw new Error('vaultUnlock: passphrase required');
+
+  const db = await vaultOpen();
+  const entry = await _toPromise(_tx(db, 'readonly').get(id));
+  if (!entry) { db.close(); throw new Error('no such key'); }
+  const wrap = (entry.wraps || []).find(w => w.kekSource === 'passphrase');
+  if (!wrap) { db.close(); throw new Error('no passphrase wrap'); }
+
+  const salt = b64Decode(wrap.salt);
+  const iv   = b64Decode(wrap.iv);
+  const ct   = b64Decode(wrap.ciphertext);
+  const kek  = await _deriveKekFromPassphrase(passphrase, salt);
+
+  let plain;
+  try {
+    plain = new Uint8Array(
+      await crypto.subtle.decrypt({ name: KEK_NAME, iv }, kek, ct),
+    );
+  } catch (e) {
+    db.close();
+    // GCM auth-tag failure = wrong passphrase (or tampered ciphertext)
+    throw new Error('wrong passphrase');
+  }
+
+  // Touch last_used_at so the account UI can show 'recently used'
+  try {
+    const rw = _tx(db, 'readwrite');
+    const fresh = await _toPromise(rw.get(id));
+    if (fresh) {
+      fresh.last_used_at = new Date().toISOString();
+      await _toPromise(rw.put(fresh));
+    }
+  } catch {}
+  db.close();
+
+  return {
+    secretKeyBytes: plain,
+    pk_b64:         entry.pk_b64,
+    pk_hash:        entry.pk_hash,
+    label:          entry.label,
+  };
+}
+
+// --- Delete an entry. Used when the user revokes locally (server-side
+//     revocation is a separate DELETE /api/user/account/signing-key call).
+export async function vaultDelete(id) {
+  if (!id) throw new Error('vaultDelete: id required');
+  const db = await vaultOpen();
+  await _toPromise(_tx(db, 'readwrite').delete(id));
+  db.close();
+}
+
+// --- Feature-probe. Pages can call this on load to decide whether to show
+//     the vault UI. (IDB + WebCrypto are both standard in modern browsers,
+//     but private-mode/Safari quirks can disable IDB.)
+export async function vaultAvailable() {
+  try {
+    if (typeof indexedDB === 'undefined') return false;
+    if (!crypto || !crypto.subtle) return false;
+    const db = await vaultOpen();
+    db.close();
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

ML-DSA-65 private keys persist encrypted in IndexedDB, surviving tab-close
and reload. Encrypted with a passphrase-derived KEK (PBKDF2-SHA256 600k
iter then AES-256-GCM). All WebCrypto-native, zero deps. Public half
enrolls on the account via the PR #98 endpoints (TOTP-gated) so verifiers
can attribute signatures.

Frontend-only PR. Backend was PR #98. /v2/sign account-binding is a
future PR.

## What's in this PR

- **`frontend/vendor/vault.js`** (new, 243 lines) - IDB store + PBKDF2 KEK
  + AES-GCM envelope. Multi-wrap entry shape so a Face ID / WebAuthn-PRF
  KEK source can be added later (PR 2) without re-encrypting.
- **`frontend/parasign-client.js`** - save-to-vault + unlock-on-load flows.
  Existing `generateKey()` / `saveKey()` / `loadKey()` paths kept intact
  (additive, no lockout during rollout).
- **`frontend/sign.html`** - vault picker + passphrase form + unlock form.
  Reuses existing design-system classes (`ps-input`, `ps-field`,
  `ps-btn-row`, `ps-keybox`).
- **`frontend/account.html`** - new 'Signing identity' section (03) with:
  enrolled keys list (from `/api/user/account/signing-key`), browser-vault
  status, prominent 'passphrase cannot be reset, download a backup'
  warning, per-key revoke (TOTP-gated). Other section numbers shifted 03-06
  to 04-07.
- **`frontend/parasign-verify.js`** - shows 'Signed by &lt;label&gt; (&lt;email&gt;)'
  via public `/v2/lookup-signer`. Escapes all user-visible fields
  (including single quotes - addresses pentest finding L5). Falls back to
  fingerprint-only on 404.

## Security posture

- **Passphrase never leaves the browser.** Pure local for KEK derivation.
- **TOTP is for account-binding only** (enroll/revoke on the relay).
- **PBKDF2 SHA-256 600000 iter** = OWASP 2023 baseline; ~1-2s unlock on
  modern laptops. Acceptable for sign-time.
- **AES-256-GCM** auth-tag failure on wrong passphrase = 'wrong passphrase'
  error (no plaintext leak).
- **Multi-wrap envelope** means PR 2 (WebAuthn-PRF) appends a new wrap
  entry without touching the passphrase wrap. Rollback-safe.
- **No npm deps.** Only WebCrypto + the existing noble-bundle.
- **CSP-safe.** No external imports. Same-origin only.
- **No design drift.** 0 hardcoded colors in vault.js. All UI elements
  reuse existing classes.
- **No ParaPear in signing-flow** (signing stays sober).
- **ASCII only.** No em-dashes.

## What this does NOT change

- `/v2/sign` still accepts any `signer_public_key`. Account-binding at
  sign time is a follow-up PR.
- No relay restart required. Webroot sync is enough.

## Test plan

- [ ] CI green (relay tests should not be affected; frontend has no test
      harness)
- [ ] `vault.js` reachable at `/vendor/vault.js` post-deploy
- [ ] PR #98 endpoints still 404/401 as before
- [ ] `/sign`, `/account`, `/auth/login` still load (no lockout)
- [ ] Manual e2e (Mick, after login):
  1. `/account` shows 'Signing identity' section (03)
  2. Generate at `/sign`, set passphrase, see warning
  3. Save to browser vault
  4. Refresh page - vault picker appears
  5. Unlock with passphrase - can sign
  6. Wrong passphrase - 'Wrong passphrase. Try again.'
  7. Enroll public key (TOTP) - appears on /account
  8. Verify a .psign - shows 'Signed by &lt;label&gt; (&lt;email&gt;)'

Backend = PR #98. Frontend = this PR. Face ID via WebAuthn-PRF = PR 2.

Generated with [Claude Code](https://claude.com/claude-code)