### PR TITLE
fix(admin): self-contain UI, drop external nav buttons

### DIFF
--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -4,98 +4,96 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT · Admin</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
 <style>
+:root{--ff-sans:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;--ff-mono:'IBM Plex Mono',ui-monospace,'SF Mono','JetBrains Mono',Menlo,Consolas,'Liberation Mono',monospace}
 *{margin:0;padding:0;box-sizing:border-box}
-body{background:#F8FAFC;color:#0B3A6A;font-family:'Inter',system-ui,sans-serif;font-size:14px;-webkit-font-smoothing:antialiased;min-height:100vh}
+body{background:#F8FAFC;color:#0B3A6A;font-family:var(--ff-sans);font-size:14px;-webkit-font-smoothing:antialiased;min-height:100vh}
 button,input,select{font-family:inherit;font-size:inherit}
 /* Login */
 .lw{display:flex;align-items:center;justify-content:center;min-height:100vh;padding:24px}
 .lb{width:100%;max-width:340px}
-.l-brand{font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.15em;text-transform:uppercase;color:#475569;margin-bottom:20px}
+.l-brand{font-family:var(--ff-mono);font-size:11px;letter-spacing:.15em;text-transform:uppercase;color:#475569;margin-bottom:20px}
 .l-title{font-size:22px;font-weight:600;color:#0B3A6A;margin-bottom:6px}
 .l-sub{font-size:13px;color:#475569;margin-bottom:26px;line-height:1.5}
-.l-lbl{display:block;font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:#475569;margin-bottom:6px}
-.l-inp{width:100%;background:#fff;border:1.5px solid rgba(11,58,106,.15);padding:10px 12px;color:#0B3A6A;font-size:13px;outline:none;margin-bottom:12px;font-family:'IBM Plex Mono',monospace;transition:border-color .15s}
+.l-lbl{display:block;font-family:var(--ff-mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:#475569;margin-bottom:6px}
+.l-inp{width:100%;background:#fff;border:1.5px solid rgba(11,58,106,.15);padding:10px 12px;color:#0B3A6A;font-size:13px;outline:none;margin-bottom:12px;font-family:var(--ff-mono);transition:border-color .15s}
 .l-inp:focus{border-color:#1D4ED8}
 .l-totp{font-size:20px;letter-spacing:.2em;margin-bottom:18px}
-.l-btn{width:100%;background:#0B3A6A;color:#F8FAFC;border:none;padding:11px;font-size:12px;font-weight:700;cursor:pointer;font-family:'IBM Plex Mono',monospace;letter-spacing:.1em;text-transform:uppercase;transition:background .15s}
+.l-btn{width:100%;background:#0B3A6A;color:#F8FAFC;border:none;padding:11px;font-size:12px;font-weight:700;cursor:pointer;font-family:var(--ff-mono);letter-spacing:.1em;text-transform:uppercase;transition:background .15s}
 .l-btn:hover{background:#1D4ED8}
 .l-btn:disabled{opacity:.5;cursor:default}
-.l-err{font-size:12px;color:#dc2626;margin-top:10px;font-family:'IBM Plex Mono',monospace;display:none}
-.l-note{font-size:11px;color:#94a3b8;margin-top:12px;text-align:center;font-family:'IBM Plex Mono',monospace}
+.l-err{font-size:12px;color:#dc2626;margin-top:10px;font-family:var(--ff-mono);display:none}
+.l-note{font-size:11px;color:#94a3b8;margin-top:12px;text-align:center;font-family:var(--ff-mono)}
 /* Shell */
 .shell{display:none;flex-direction:column;min-height:100vh}
-.hdr{display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:52px;border-bottom:1.5px solid rgba(11,58,106,.08);background:#F8FAFC;position:sticky;top:0;z-index:50}
-.hdr-brand{font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.14em;font-weight:700;color:#0B3A6A;text-transform:uppercase;white-space:nowrap}
+.hdr{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:0 24px;height:56px;border-bottom:1px solid rgba(11,58,106,.1);background:#F8FAFC;position:sticky;top:0;z-index:50;box-shadow:0 1px 0 rgba(11,58,106,.02)}
+.hdr-brand{font-family:var(--ff-mono);font-size:11px;letter-spacing:.14em;font-weight:700;color:#0B3A6A;text-transform:uppercase;white-space:nowrap}
 .tabs{display:flex;gap:0;overflow-x:auto}
-.tabs button{background:transparent;border:none;border-bottom:2px solid transparent;padding:16px 16px 14px;font-family:'Inter',sans-serif;font-size:13px;color:#475569;cursor:pointer;white-space:nowrap;transition:color .15s}
+.tabs button{background:transparent;border:none;border-bottom:2px solid transparent;padding:16px 16px 14px;font-family:var(--ff-sans);font-size:13px;color:#475569;cursor:pointer;white-space:nowrap;transition:color .15s}
 .tabs button.on{color:#0B3A6A;border-bottom-color:#1D4ED8;font-weight:600}
 .tabs button:hover:not(.on){color:#0B3A6A}
-.hdr-meta{display:flex;gap:10px;align-items:center;flex-shrink:0}
-.lic{background:rgba(178,255,63,.22);color:#0B3A6A;padding:4px 10px;font-size:11px;font-family:'IBM Plex Mono',monospace;white-space:nowrap}
-.lo-btn{padding:6px 12px;background:transparent;border:1.5px solid rgba(11,58,106,.2);color:#0B3A6A;cursor:pointer;font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.08em;text-transform:uppercase;transition:border-color .15s}
+.hdr-meta{display:flex;gap:8px;align-items:center;flex-shrink:0}
+.lic{background:rgba(178,255,63,.18);color:#0B3A6A;padding:5px 10px;font-size:10px;letter-spacing:.06em;font-family:var(--ff-mono);white-space:nowrap}
+.lo-btn{padding:6px 12px;background:transparent;border:1.5px solid rgba(11,58,106,.2);color:#0B3A6A;cursor:pointer;font-family:var(--ff-mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;transition:border-color .15s}
 .lo-btn:hover{border-color:#0B3A6A}
 .main{flex:1;padding:24px;max-width:1400px;width:100%;margin:0 auto}
 .panel{display:none}.panel.on{display:block}
 /* Stat cards */
 .sg{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:20px}
-.sc{background:#fff;border:1px solid rgba(11,58,106,.08);padding:20px}
-.sc-lbl{font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:#475569;margin-bottom:10px}
-.sc-val{font-size:30px;font-weight:500;color:#0B3A6A;font-family:'IBM Plex Mono',monospace;line-height:1}
+.sc{background:#fff;border:1px solid rgba(11,58,106,.1);padding:20px}
+.sc-lbl{font-family:var(--ff-mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:#475569;margin-bottom:10px}
+.sc-val{font-size:28px;font-weight:500;color:#0B3A6A;font-family:var(--ff-mono);line-height:1}
 /* Cards */
-.card{background:#fff;border:1px solid rgba(11,58,106,.08);padding:20px;margin-bottom:16px}
-.card-hdr{font-size:12px;font-weight:600;color:#0B3A6A;margin-bottom:14px;display:flex;align-items:center;justify-content:space-between;font-family:'IBM Plex Mono',monospace;letter-spacing:.06em;text-transform:uppercase}
-.card-hdr small{font-size:11px;font-weight:400;color:#475569;text-transform:none;letter-spacing:0;font-family:'Inter',sans-serif}
+.card{background:#fff;border:1px solid rgba(11,58,106,.1);padding:20px;margin-bottom:16px}
+.card-hdr{font-size:12px;font-weight:600;color:#0B3A6A;margin-bottom:14px;display:flex;align-items:center;justify-content:space-between;font-family:var(--ff-mono);letter-spacing:.06em;text-transform:uppercase}
+.card-hdr small{font-size:11px;font-weight:400;color:#475569;text-transform:none;letter-spacing:0;font-family:var(--ff-sans)}
 .g2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
 .g3{display:grid;grid-template-columns:2fr 1fr 1fr;gap:16px}
 /* Table */
 .tbl{width:100%;border-collapse:collapse;font-size:13px}
-.tbl th{text-align:left;padding:9px 12px;font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:#475569;border-bottom:1.5px solid rgba(11,58,106,.08)}
+.tbl th{text-align:left;padding:9px 12px;font-family:var(--ff-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:#475569;border-bottom:1.5px solid rgba(11,58,106,.08)}
 .tbl td{padding:11px 12px;border-bottom:1px solid rgba(11,58,106,.04);color:#0B3A6A}
 .tbl tr:hover td{background:rgba(29,78,216,.02)}
-.mono{font-family:'IBM Plex Mono',monospace;font-size:12px}
+.mono{font-family:var(--ff-mono);font-size:12px}
 /* Badges */
-.badge{display:inline-block;padding:2px 8px;font-size:11px;font-family:'IBM Plex Mono',monospace;text-transform:uppercase;letter-spacing:.06em}
+.badge{display:inline-block;padding:2px 8px;font-size:11px;font-family:var(--ff-mono);text-transform:uppercase;letter-spacing:.06em}
 .badge.community{background:rgba(11,58,106,.08);color:#0B3A6A}
 .badge.pro{background:rgba(29,78,216,.1);color:#1D4ED8}
 .badge.enterprise{background:rgba(178,255,63,.35);color:#2d5a00;font-weight:700}
 .badge.trial{background:rgba(245,158,11,.1);color:#b45309}
-.chip{font-family:'IBM Plex Mono',monospace;font-size:11px;text-transform:uppercase;letter-spacing:.06em}
+.chip{font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:.06em}
 .chip.active{color:#059669}.chip.pending{color:#d97706}.chip.none{color:#94a3b8}.chip.revoked{color:#dc2626}
 /* Filter bar */
 .fb{display:flex;gap:10px;margin-bottom:14px;flex-wrap:wrap;align-items:center}
-.fb input,.fb select{padding:7px 10px;border:1.5px solid rgba(11,58,106,.12);font-size:12px;font-family:'Inter',sans-serif;background:#fff;color:#0B3A6A;outline:none}
+.fb input,.fb select{padding:7px 10px;border:1.5px solid rgba(11,58,106,.12);font-size:12px;font-family:var(--ff-sans);background:#fff;color:#0B3A6A;outline:none}
 .fb input:focus,.fb select:focus{border-color:#1D4ED8}
 .sp{flex:1}
-.btn{padding:7px 14px;background:#0B3A6A;color:#F8FAFC;border:none;font-size:11px;font-family:'IBM Plex Mono',monospace;letter-spacing:.08em;text-transform:uppercase;cursor:pointer;transition:background .15s}
+.btn{padding:7px 14px;background:#0B3A6A;color:#F8FAFC;border:none;font-size:11px;font-family:var(--ff-mono);letter-spacing:.08em;text-transform:uppercase;cursor:pointer;transition:background .15s}
 .btn:hover{background:#1D4ED8}
 .btn.out{background:transparent;border:1.5px solid rgba(11,58,106,.2);color:#0B3A6A}
 .btn.out:hover{border-color:#1D4ED8;color:#1D4ED8;background:transparent}
 /* Relay strip */
 .rs{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-bottom:16px}
-.ri{padding:10px 12px;background:rgba(5,150,105,.08);border-left:3px solid #059669;font-family:'IBM Plex Mono',monospace;font-size:12px;color:#065f46}
+.ri{padding:10px 12px;background:rgba(5,150,105,.08);border-left:3px solid #059669;font-family:var(--ff-mono);font-size:12px;color:#065f46}
 .ri.offline{background:rgba(220,38,38,.06);border-left-color:#dc2626;color:#991b1b}
 .ri.loading{background:rgba(11,58,106,.04);border-left-color:#94a3b8;color:#475569}
 .ri-name{font-weight:700;margin-bottom:2px}
 .ri-det{font-size:10px;opacity:.8}
 /* Activity */
-.al{font-family:'IBM Plex Mono',monospace;font-size:11px}
+.al{font-family:var(--ff-mono);font-size:11px}
 .ai{display:flex;gap:12px;padding:5px 0;border-bottom:1px solid rgba(11,58,106,.04)}
 .ai .t{color:#475569;flex-shrink:0;width:80px}
 .ai .e{color:#1D4ED8;flex-shrink:0;width:160px}
 .ai .u{color:#0B3A6A;opacity:.6;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 /* Plan bars */
 .pb{display:flex;align-items:center;gap:10px;margin-bottom:8px}
-.pb .pl{width:90px;font-family:'IBM Plex Mono',monospace;font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:#475569}
+.pb .pl{width:90px;font-family:var(--ff-mono);font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:#475569}
 .pb .tr{flex:1;height:6px;background:rgba(11,58,106,.06);overflow:hidden}
 .pb .fi{height:100%;background:#1D4ED8;transition:width .5s}
-.pb .cn{width:28px;text-align:right;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#475569}
+.pb .cn{width:28px;text-align:right;font-family:var(--ff-mono);font-size:11px;color:#475569}
 /* Action menu */
 .amw{position:relative;display:inline-block}
-.amb{background:transparent;border:1px solid rgba(11,58,106,.12);color:#0B3A6A;padding:4px 10px;font-size:11px;font-family:'IBM Plex Mono',monospace;cursor:pointer}
+.amb{background:transparent;border:1px solid rgba(11,58,106,.12);color:#0B3A6A;padding:4px 10px;font-size:11px;font-family:var(--ff-mono);cursor:pointer}
 .amb:hover{background:rgba(11,58,106,.04)}
 .am{display:none;position:absolute;right:0;top:calc(100% + 4px);background:#fff;border:1px solid rgba(11,58,106,.15);z-index:20;min-width:190px;box-shadow:0 4px 16px rgba(11,58,106,.1)}
 .am.open{display:block}
@@ -109,13 +107,13 @@ button,input,select{font-family:inherit;font-size:inherit}
 .banner.stub{background:rgba(245,158,11,.08);border-left:3px solid #d97706;color:#92400e}
 .banner.info{background:rgba(29,78,216,.06);border-left:3px solid #1D4ED8;color:#1e3a8a}
 /* Toast */
-.toast{position:fixed;bottom:20px;right:20px;background:#0B3A6A;color:#F8FAFC;padding:10px 16px;font-size:12px;font-family:'IBM Plex Mono',monospace;z-index:999;max-width:320px}
+.toast{position:fixed;bottom:20px;right:20px;background:#0B3A6A;color:#F8FAFC;padding:10px 16px;font-size:12px;font-family:var(--ff-mono);z-index:999;max-width:320px}
 .toast.err{background:#dc2626}
 .toast.ok{background:#059669}
 /* Loading */
 .sp-icon{display:inline-block;width:14px;height:14px;border:2px solid rgba(11,58,106,.12);border-top-color:#1D4ED8;border-radius:50%;animation:spin .6s linear infinite;vertical-align:middle;margin-right:6px}
 @keyframes spin{to{transform:rotate(360deg)}}
-.empty{padding:32px;text-align:center;color:#94a3b8;font-family:'IBM Plex Mono',monospace;font-size:12px}
+.empty{padding:32px;text-align:center;color:#94a3b8;font-family:var(--ff-mono);font-size:12px}
 /* Accessibility */
 .skip-link{position:absolute;top:-40px;left:0;background:#0B3A6A;color:#F8FAFC;padding:8px 12px;text-decoration:none;z-index:200;font-size:13px}
 .skip-link:focus{top:0}
@@ -124,11 +122,11 @@ button,input,select{font-family:inherit;font-size:inherit}
 button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{outline:2px solid #1D4ED8;outline-offset:2px}
 /* Pagination */
 .pag{display:flex;align-items:center;gap:10px;padding:12px 0;border-top:1px solid rgba(11,58,106,.06);margin-top:4px}
-.pag button{padding:5px 12px;border:1.5px solid rgba(11,58,106,.15);background:#fff;color:#0B3A6A;cursor:pointer;font-size:12px;font-family:'IBM Plex Mono',monospace}
+.pag button{padding:5px 12px;border:1.5px solid rgba(11,58,106,.15);background:#fff;color:#0B3A6A;cursor:pointer;font-size:12px;font-family:var(--ff-mono)}
 .pag button:hover:not(:disabled){border-color:#1D4ED8;color:#1D4ED8}
 .pag button:disabled{opacity:.4;cursor:default}
-.pag select{padding:5px 8px;border:1.5px solid rgba(11,58,106,.15);background:#fff;color:#0B3A6A;font-size:12px;font-family:'IBM Plex Mono',monospace}
-.pag-info{font-size:12px;font-family:'IBM Plex Mono',monospace;color:#475569;flex:1;text-align:center}
+.pag select{padding:5px 8px;border:1.5px solid rgba(11,58,106,.15);background:#fff;color:#0B3A6A;font-size:12px;font-family:var(--ff-mono)}
+.pag-info{font-size:12px;font-family:var(--ff-mono);color:#475569;flex:1;text-align:center}
 /* Responsive */
 @media(max-width:900px){.sg,.rs,.g2,.g3{grid-template-columns:1fr 1fr}.tabs{overflow-x:auto}}
 @media(max-width:600px){.sg,.rs{grid-template-columns:1fr}.hdr{padding:0 12px}.main{padding:14px}.hdr-meta .lic{display:none}}
@@ -149,16 +147,16 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
 .mbody{padding:18px;overflow-y:auto;flex:1}
 .mc{margin-bottom:14px}
 .mc label{display:block;font-size:12px;color:#475569;margin-bottom:4px;font-weight:500}
-.mc select,.mc input[type=text]{width:100%;padding:7px 10px;border:1.5px solid rgba(11,58,106,.2);font-size:13px;font-family:'IBM Plex Mono',monospace;color:#0B3A6A;background:#fff;outline:none}
+.mc select,.mc input[type=text]{width:100%;padding:7px 10px;border:1.5px solid rgba(11,58,106,.2);font-size:13px;font-family:var(--ff-mono);color:#0B3A6A;background:#fff;outline:none}
 .mc select:focus,.mc input[type=text]:focus{border-color:#1D4ED8}
 .mfoot{padding:12px 18px;border-top:1px solid rgba(11,58,106,.1);display:flex;justify-content:flex-end;gap:8px}
 /* Email preview tabs */
 .ep-tabs{display:flex;gap:0;border-bottom:1px solid rgba(11,58,106,.1);margin-bottom:14px}
-.ep-tab{padding:7px 14px;border:none;background:transparent;font-size:12px;font-family:'IBM Plex Mono',monospace;cursor:pointer;color:#64748b;border-bottom:2px solid transparent;margin-bottom:-1px}
+.ep-tab{padding:7px 14px;border:none;background:transparent;font-size:12px;font-family:var(--ff-mono);cursor:pointer;color:#64748b;border-bottom:2px solid transparent;margin-bottom:-1px}
 .ep-tab.on{color:#1D4ED8;border-bottom-color:#1D4ED8}
-.ep-subj{font-size:12px;color:#475569;margin-bottom:10px;font-family:'IBM Plex Mono',monospace}
+.ep-subj{font-size:12px;color:#475569;margin-bottom:10px;font-family:var(--ff-mono)}
 .ep-content{font-size:12px;line-height:1.6;max-height:320px;overflow-y:auto}
-.ep-content pre{white-space:pre-wrap;word-break:break-word;font-family:'IBM Plex Mono',monospace}
+.ep-content pre{white-space:pre-wrap;word-break:break-word;font-family:var(--ff-mono)}
 .ep-content iframe{width:100%;border:none;height:340px}
 
 /* TOTP required badges */
@@ -199,12 +197,8 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
     </nav>
     <div class="hdr-meta">
       <span class="lic">v3.0.0 · Licensed</span>
-      <a class="lo-btn" href="/admin/settings.html" style="text-decoration:none">Settings</a>
-      <a class="lo-btn" href="/admin/cli.html" style="text-decoration:none">CLI</a>
-      <a class="lo-btn" data-toolhub href="/dashboard" style="text-decoration:none">Dashboard</a>
-      <a class="lo-btn" data-toolhub href="/ct-log" style="text-decoration:none">CT log</a>
-      <a class="lo-btn" data-toolhub href="/status" style="text-decoration:none">Status</a>
-      <a class="lo-btn" data-toolhub href="/docs#operator-scripts" style="text-decoration:none">Scripts</a>
+      <a class="lo-btn" href="/admin/settings.html">Settings</a>
+      <a class="lo-btn" href="/admin/cli.html">CLI</a>
       <button class="lo-btn" onclick="doLogout()">Sign out</button>
     </div>
   </header>
@@ -249,7 +243,7 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
       <button class="close-mo" onclick="closeModal('mo-plan')" aria-label="Close">&times;</button>
     </div>
     <div class="mbody">
-      <div class="mc"><label>Current plan</label><span id="cp-current" style="font-size:12px;font-family:'IBM Plex Mono',monospace;color:#475569"></span></div>
+      <div class="mc"><label>Current plan</label><span id="cp-current" style="font-size:12px;font-family:var(--ff-mono);color:#475569"></span></div>
       <div class="mc">
         <label for="cp-plan">New plan</label>
         <select id="cp-plan">

--- a/admin/public/settings.html
+++ b/admin/public/settings.html
@@ -4,41 +4,39 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Paramant Admin - Settings</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
 <style>
+  :root { --ff-sans:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; --ff-mono:'IBM Plex Mono',ui-monospace,'SF Mono','JetBrains Mono',Menlo,Consolas,'Liberation Mono',monospace; }
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background:#F8FAFC; color:#0B3A6A; font-family:'Inter',system-ui,sans-serif; font-size:14px; -webkit-font-smoothing:antialiased; min-height:100vh; }
+  body { background:#F8FAFC; color:#0B3A6A; font-family:var(--ff-sans); font-size:14px; -webkit-font-smoothing:antialiased; min-height:100vh; }
   button,input,select { font-family:inherit; font-size:inherit; }
-  .mono { font-family:'IBM Plex Mono',monospace; }
+  .mono { font-family:var(--ff-mono); }
   a { color:#0B3A6A; }
 
   /* header */
   header { display:flex; align-items:center; justify-content:space-between; padding:14px 24px; border-bottom:1.5px solid rgba(11,58,106,.1); background:#fff; position:sticky; top:0; z-index:10; }
-  .hdr-brand { font-family:'IBM Plex Mono',monospace; font-size:11px; letter-spacing:.14em; font-weight:700; text-transform:uppercase; }
-  .hdr-back { padding:6px 12px; background:transparent; border:1.5px solid rgba(11,58,106,.2); color:#0B3A6A; cursor:pointer; font-family:'IBM Plex Mono',monospace; font-size:11px; letter-spacing:.08em; text-transform:uppercase; text-decoration:none; }
+  .hdr-brand { font-family:var(--ff-mono); font-size:11px; letter-spacing:.14em; font-weight:700; text-transform:uppercase; }
+  .hdr-back { padding:6px 12px; background:transparent; border:1.5px solid rgba(11,58,106,.2); color:#0B3A6A; cursor:pointer; font-family:var(--ff-mono); font-size:11px; letter-spacing:.08em; text-transform:uppercase; text-decoration:none; }
 
   /* layout */
   .wrap { display:flex; max-width:1100px; margin:0 auto; padding:24px; gap:24px; align-items:flex-start; }
   .side { width:180px; flex:0 0 180px; position:sticky; top:80px; }
-  .side button { display:block; width:100%; text-align:left; background:transparent; border:none; border-left:2px solid transparent; padding:9px 12px; font-family:'IBM Plex Mono',monospace; font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:#475569; cursor:pointer; }
+  .side button { display:block; width:100%; text-align:left; background:transparent; border:none; border-left:2px solid transparent; padding:9px 12px; font-family:var(--ff-mono); font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:#475569; cursor:pointer; }
   .side button.active { border-left-color:#0B3A6A; color:#0B3A6A; background:rgba(11,58,106,.04); }
   .main { flex:1; min-width:0; }
 
   .field { padding:16px 0; border-bottom:1px solid rgba(11,58,106,.08); }
   .field.dirty { background:rgba(178,255,63,.12); margin:0 -12px; padding:16px 12px; }
   .f-top { display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:6px; }
-  .f-name { font-family:'IBM Plex Mono',monospace; font-size:12px; font-weight:500; }
+  .f-name { font-family:var(--ff-mono); font-size:12px; font-weight:500; }
   .f-desc { font-size:12px; color:#475569; margin-bottom:10px; line-height:1.4; }
-  .f-default { font-family:'IBM Plex Mono',monospace; font-size:10px; color:#94a3b8; }
+  .f-default { font-family:var(--ff-mono); font-size:10px; color:#94a3b8; }
 
-  .badge { display:inline-block; padding:2px 7px; font-size:10px; font-family:'IBM Plex Mono',monospace; text-transform:uppercase; letter-spacing:.06em; }
+  .badge { display:inline-block; padding:2px 7px; font-size:10px; font-family:var(--ff-mono); text-transform:uppercase; letter-spacing:.06em; }
   .badge-restart { background:rgba(234,179,8,.18); color:#854d0e; }
   .badge-admin { background:rgba(11,58,106,.1); color:#0B3A6A; }
   .badge-ro { background:rgba(148,163,184,.2); color:#475569; }
 
-  input[type=text], input[type=number], select { width:100%; max-width:420px; background:#fff; border:1.5px solid rgba(11,58,106,.15); padding:9px 11px; color:#0B3A6A; font-size:13px; outline:none; font-family:'IBM Plex Mono',monospace; }
+  input[type=text], input[type=number], select { width:100%; max-width:420px; background:#fff; border:1.5px solid rgba(11,58,106,.15); padding:9px 11px; color:#0B3A6A; font-size:13px; outline:none; font-family:var(--ff-mono); }
   input:focus, select:focus { border-color:#0B3A6A; }
   input[disabled] { background:#f1f5f9; color:#94a3b8; cursor:not-allowed; }
   .slider-row { display:flex; align-items:center; gap:12px; max-width:420px; }
@@ -54,25 +52,25 @@
   .toggle input:checked + .track:before { transform:translateX(18px); }
 
   .secret-row { display:flex; align-items:center; gap:10px; }
-  .secret-state { font-family:'IBM Plex Mono',monospace; font-size:12px; color:#475569; }
-  .replace-btn { padding:6px 12px; background:transparent; border:1.5px solid rgba(11,58,106,.2); color:#0B3A6A; cursor:pointer; font-family:'IBM Plex Mono',monospace; font-size:11px; text-transform:uppercase; letter-spacing:.06em; }
+  .secret-state { font-family:var(--ff-mono); font-size:12px; color:#475569; }
+  .replace-btn { padding:6px 12px; background:transparent; border:1.5px solid rgba(11,58,106,.2); color:#0B3A6A; cursor:pointer; font-family:var(--ff-mono); font-size:11px; text-transform:uppercase; letter-spacing:.06em; }
 
   /* footer bar */
   .footbar { position:sticky; bottom:0; background:#fff; border-top:1.5px solid rgba(11,58,106,.12); padding:14px 24px; display:flex; align-items:center; justify-content:space-between; gap:12px; }
-  .foot-info { font-family:'IBM Plex Mono',monospace; font-size:12px; color:#475569; }
-  .btn { padding:9px 16px; background:#0B3A6A; color:#F8FAFC; border:none; font-size:11px; font-family:'IBM Plex Mono',monospace; letter-spacing:.08em; text-transform:uppercase; cursor:pointer; }
+  .foot-info { font-family:var(--ff-mono); font-size:12px; color:#475569; }
+  .btn { padding:9px 16px; background:#0B3A6A; color:#F8FAFC; border:none; font-size:11px; font-family:var(--ff-mono); letter-spacing:.08em; text-transform:uppercase; cursor:pointer; }
   .btn[disabled] { opacity:.4; cursor:not-allowed; }
   .btn-ghost { background:transparent; border:1.5px solid rgba(11,58,106,.2); color:#0B3A6A; }
 
   .banner { display:none; background:rgba(234,179,8,.15); border-left:3px solid #ca8a04; padding:12px 16px; margin-bottom:18px; font-size:13px; color:#854d0e; }
   .banner.show { display:block; }
-  .banner code { font-family:'IBM Plex Mono',monospace; }
+  .banner code { font-family:var(--ff-mono); }
 
   /* audit */
-  .audit-row { padding:9px 0; border-bottom:1px solid rgba(11,58,106,.06); font-family:'IBM Plex Mono',monospace; font-size:12px; display:flex; gap:14px; }
+  .audit-row { padding:9px 0; border-bottom:1px solid rgba(11,58,106,.06); font-family:var(--ff-mono); font-size:12px; display:flex; gap:14px; }
   .audit-ts { color:#94a3b8; flex:0 0 130px; }
 
-  .empty { padding:40px; text-align:center; color:#94a3b8; font-family:'IBM Plex Mono',monospace; font-size:12px; }
+  .empty { padding:40px; text-align:center; color:#94a3b8; font-family:var(--ff-mono); font-size:12px; }
 
   /* toast */
   .toast { position:fixed; bottom:80px; left:50%; transform:translateX(-50%) translateY(20px); background:#0B3A6A; color:#fff; padding:11px 18px; font-size:13px; opacity:0; transition:opacity .2s, transform .2s; z-index:50; }
@@ -84,7 +82,7 @@
   .modal-bg { display:none; position:fixed; inset:0; background:rgba(11,58,106,.4); z-index:60; align-items:center; justify-content:center; }
   .modal-bg.show { display:flex; }
   .modal { background:#fff; padding:24px; width:min(440px,92vw); }
-  .modal h3 { font-family:'IBM Plex Mono',monospace; font-size:13px; text-transform:uppercase; letter-spacing:.08em; margin-bottom:12px; }
+  .modal h3 { font-family:var(--ff-mono); font-size:13px; text-transform:uppercase; letter-spacing:.08em; margin-bottom:12px; }
   .modal p { font-size:12px; color:#475569; margin-bottom:14px; line-height:1.5; }
   .modal-actions { display:flex; gap:10px; justify-content:flex-end; margin-top:18px; }
 </style>


### PR DESCRIPTION
## Summary
- Strip `Dashboard` / `CT log` / `Status` / `Scripts` links from the admin header. These pointed at the public site and yanked operators out of the admin context. The panel now only exposes admin-internal navigation: `Settings`, `CLI`, `Sign out`.
- Drop the Google Fonts `<link>` from `admin/public/index.html` and `admin/public/settings.html`. Replace inline font references with CSS variables (`--ff-sans`, `--ff-mono`) that prefer Inter / IBM Plex Mono if installed locally and fall back to native system fonts. No third-party font request from the admin panel. Addresses the 2026-05-27 site audit finding about admin Google Fonts vs EU-sovereignty.
- Light visual polish:
  - Header `52px -> 56px`, lighter border + subtle box-shadow.
  - Card/stat-card borders bumped `rgba(11,58,106,.08) -> .1` for definition.
  - Stat-card value `30px -> 28px`, licence chip slightly more subtle.

## What did NOT change
- No backend / `server.js` / `admin/lib/` changes.
- No public site frontend touched. `frontend/nav.css` and `frontend/nav.js` are unmodified.
- `admin/public/cli.html` unchanged (already self-contained, dark CLI theme).
- All existing admin functions (Users / Audit / Billing / Relay / Settings / CLI / Sign out) intact.

## Test plan
- [ ] Browse `/admin/` after merge + container rebuild. Header shows: brand, 5 tabs, licence chip, Settings, CLI, Sign out. No Dashboard / CT log / Status / Scripts buttons.
- [ ] Network tab: no requests to `fonts.googleapis.com` or `fonts.gstatic.com`.
- [ ] Login -> Overview / Users / Audit / Billing / Relay all render.
- [ ] `/admin/settings.html` renders, sticky save bar still works.
- [ ] `/admin/cli.html` still reachable via existing CLI link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)