### PR TITLE
fix(admin): mobile header so Users tab is reachable

### DIFF
--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -128,8 +128,15 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
 .pag select{padding:5px 8px;border:1.5px solid rgba(11,58,106,.15);background:#fff;color:#0B3A6A;font-size:12px;font-family:var(--ff-mono)}
 .pag-info{font-size:12px;font-family:var(--ff-mono);color:#475569;flex:1;text-align:center}
 /* Responsive */
-@media(max-width:900px){.sg,.rs,.g2,.g3{grid-template-columns:1fr 1fr}.tabs{overflow-x:auto}}
-@media(max-width:600px){.sg,.rs{grid-template-columns:1fr}.hdr{padding:0 12px}.main{padding:14px}.hdr-meta .lic{display:none}}
+@media(max-width:900px){.sg,.rs,.g2,.g3{grid-template-columns:1fr 1fr}
+  .hdr{flex-wrap:wrap;height:auto;min-height:56px;padding:8px 16px;gap:8px;row-gap:0}
+  .hdr-brand{order:1}
+  .hdr-meta{order:2;margin-left:auto;gap:6px}
+  .hdr-meta .lo-btn{padding:5px 10px;font-size:10px;letter-spacing:.06em}
+  .tabs{order:3;width:100%;border-top:1px solid rgba(11,58,106,.08);margin:0 -16px;padding:0 16px;-webkit-overflow-scrolling:touch}
+  .tabs button{padding:12px 14px 10px;font-size:13px}
+}
+@media(max-width:600px){.sg,.rs{grid-template-columns:1fr}.hdr{padding:8px 12px}.main{padding:14px}.hdr-meta .lic{display:none}.tabs{margin:0 -12px;padding:0 12px}}
 
 /* Action menu group labels */
 .ag-lbl{display:block;padding:4px 14px 2px;font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:#94a3b8;pointer-events:none;user-select:none}


### PR DESCRIPTION
## Problem
On mobile (<=900px) the admin header crammed brand + 5 tabs + meta buttons into a single 56px row. The tabs nav (Overview/Users/Audit/Billing/Relay) was squeezed between flex siblings and effectively hidden — Mick observed Users not being reachable on mobile, only on desktop.

## Fix
CSS-only. On `<=900px` the header wraps onto two rows:
- row 1: brand on the left, meta buttons (Settings/CLI/Sign out) on the right
- row 2: full-width tabs strip with a thin top divider; horizontal scroll if narrower than the 5 buttons

`hdr-meta .lo-btn` padding tightens on mobile so the meta row fits on small phones. `<=600px` adjusts the tabs row gutters.

No JS, no markup, no backend changes.

## Test plan
- [ ] Open `/admin/` on a phone (or DevTools mobile preview) — all 5 tabs visible on row 2.
- [ ] Tap `Users` — Users tab loads.
- [ ] Desktop (>900px) header unchanged: single row, brand left, tabs centre, meta right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)