### PR TITLE
feat(home): restore character via existing design-system tokens

### DIFF
--- a/frontend/components-parasign.css
+++ b/frontend/components-parasign.css
@@ -122,4 +122,35 @@ a.pcard:hover { border-color: var(--navy); transform: translateY(-2px); }
 .selfhost code { display:inline-block; padding: var(--space-2) var(--space-4); background: var(--bone); border:1px solid var(--ink-hair); border-radius:6px; font-family: var(--mono); font-size: var(--text-sm); }
 .home-center { text-align:center; }
 
-@media (max-width:600px){ .home-hero{padding: var(--space-6) var(--space-4);} .home-hero h1{font-size: var(--text-4xl);} .home-cta{flex-direction:column;align-items:stretch;} .home-cta .btn{width:100%;} }
+/* ---- Homepage section-dark inversion (tokens only) ---- */
+.section-dark .home-section { background: transparent; }
+.section-dark .home-section-head .eyebrow { color: var(--lime); }
+.section-dark .home-section-head h2 { color: var(--bone-on-navy); }
+.section-dark .home-section-head p  { color: var(--bone-on-navy-dim); }
+.section-dark .pcard { background: transparent; border-color: var(--bone-on-navy-hair); }
+.section-dark a.pcard:hover { border-color: var(--lime); transform: translateY(-2px); }
+.section-dark .pcard h3 { color: var(--bone-on-navy); }
+.section-dark .pcard p  { color: var(--bone-on-navy-dim); }
+.section-dark .pcard .ptag { background: var(--bone-on-navy-hair); color: var(--lime); }
+.section-dark .pcard .pcta { color: var(--lime); }
+
+/* Algorithm chip strip (tokens only) */
+.crypto-strip { display:flex; flex-wrap:wrap; gap: var(--space-3); list-style:none; padding:0; margin: 0 0 var(--space-6); justify-content:center; }
+.crypto-strip li { display:flex; flex-direction:column; gap: 4px; padding: var(--space-3) var(--space-4); border-left: 3px solid var(--lime); background: var(--bone-on-navy-hair); border-radius: 4px; }
+.crypto-strip .alg-tag { font-family: var(--mono); font-size: 10px; letter-spacing: .15em; text-transform: uppercase; color: var(--lime); }
+.crypto-strip strong { font-family: var(--mono); font-size: var(--text-sm); color: var(--bone-on-navy); font-weight: 600; letter-spacing: .02em; }
+
+/* Live CT-widget on dark section (uses existing .ct-widget tokens; just inverts text) */
+.section-dark .ct-widget { border-color: var(--bone-on-navy-hair); background: var(--bone-on-navy-hair); }
+.section-dark .ct-header { color: var(--bone-on-navy-dim); border-bottom-color: var(--bone-on-navy-hair); }
+.section-dark .ct-stats { border-bottom-color: var(--bone-on-navy-hair); }
+.section-dark .ct-stat { border-right-color: var(--bone-on-navy-hair); }
+.section-dark .ct-stat-label { color: var(--bone-on-navy-dim); }
+.section-dark .ct-stat-val { color: var(--lime); }
+.section-dark .ct-body { grid-template-columns: 1fr; }
+.section-dark .ct-root-panel { border-right: none; border-bottom: 1px solid var(--bone-on-navy-hair); }
+.section-dark .ct-feed-label { color: var(--bone-on-navy-dim); }
+.section-dark .ct-foot { border-top-color: var(--bone-on-navy-hair); color: var(--bone-on-navy-dim); }
+.section-dark .ct-widget .dot { display:inline-block; width:8px; height:8px; border-radius:50%; background: var(--ink-dim); }
+
+@media (max-width:600px){ .home-hero{padding: var(--space-6) var(--space-4);} .home-hero h1{font-size: var(--text-4xl);} .home-cta{flex-direction:column;align-items:stretch;} .home-cta .btn{width:100%;} .crypto-strip{justify-content:flex-start} }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -212,7 +212,7 @@
       <span class="ppp-label">Start here</span>
     </div>
     <div class="home-cta">
-      <a class="btn btn-primary" href="/dashboard">Open your dashboard</a>
+      <a class="btn btn-lime" href="/dashboard">Open your dashboard</a>
       <a class="btn btn-secondary" href="/signup">Create account</a>
       <a class="btn btn-tertiary" href="/docs#self-hosting">Self-host guide</a>
     </div>
@@ -265,21 +265,59 @@
     <li><h3>One-time download</h3><p>The recipient decrypts locally. On download the blob is overwritten in RAM.</p></li>
     <li><h3>Cryptographic proof</h3><p>The Merkle root updates. The transfer is provable without storing what was transferred.</p></li>
   </ol>
-</section>
-
-<section class="home-section alt" aria-labelledby="crypto-h">
-  <header class="home-section-head"><span class="eyebrow">Under the hood</span><h2 id="crypto-h">Post-quantum, hybrid, audited.</h2><p>Default core stack is ML-KEM-768 (FIPS 203) and ML-DSA-65 (FIPS 204), with ECDH P-256 hybrid. Extended algorithm sets are opt-in (ADR R006).</p></header>
-  <div class="pgrid">
-    <div class="pcard"><span class="ptag">kem</span><h3>ML-KEM-768</h3><p>FIPS 203 key encapsulation. Default in core mode, hybrid with ECDH P-256.</p></div>
-    <div class="pcard"><span class="ptag">signature</span><h3>ML-DSA-65</h3><p>FIPS 204 signatures. Relay identity, CT log STH, and ParaSign envelopes.</p></div>
-    <div class="pcard"><span class="ptag">crypto core</span><h3>paramant-core</h3><p>Audit-ready Rust binding the relay uses for all PQ primitives since v3.0.0 (M5b).</p></div>
-    <a class="pcard" href="/security"><span class="ptag">details</span><h3>Cryptography &amp; audits</h3><p>Full algorithm choices, threat model, and the independent security audits.</p><span class="pcta">Read the spec</span></a>
+  <div class="callout" role="note">
+    <h4>Burn-on-read</h4>
+    <p>The relay holds ciphertext in RAM only, never on disk. The moment a recipient downloads, the blob is overwritten and the slot is gone. There is no second copy to subpoena and nothing on disk for an operator or attacker to recover.</p>
   </div>
 </section>
 
-<section class="home-section" aria-labelledby="ct-h">
-  <header class="home-section-head"><span class="eyebrow">Verifiable</span><h2 id="ct-h">Public Merkle proof of every transfer.</h2><p>Every transfer is hashed into a public Merkle tree whose root updates on every write. Prove a transfer occurred without learning what it was.</p></header>
-  <div class="home-center"><a class="btn btn-primary" href="/ct-log">View live CT log</a> <a class="btn btn-tertiary" href="/hndl">Why post-quantum now</a></div>
+<section class="section-dark" aria-labelledby="crypto-h">
+  <div class="home-section">
+    <header class="home-section-head"><span class="eyebrow">Under the hood</span><h2 id="crypto-h">Post-quantum, hybrid, audited.</h2><p>Default core stack is ML-KEM-768 (FIPS 203) and ML-DSA-65 (FIPS 204), with ECDH P-256 hybrid. Extended algorithm sets are opt-in (ADR R006).</p></header>
+    <ul class="crypto-strip" aria-label="Algorithm stack">
+      <li><span class="alg-tag">FIPS 203</span><strong>ML-KEM-768</strong></li>
+      <li><span class="alg-tag">FIPS 204</span><strong>ML-DSA-65</strong></li>
+      <li><span class="alg-tag">Classical hybrid</span><strong>ECDH P-256</strong></li>
+      <li><span class="alg-tag">AEAD</span><strong>AES-256-GCM</strong></li>
+    </ul>
+    <div class="pgrid">
+      <div class="pcard"><span class="ptag">kem</span><h3>ML-KEM-768</h3><p>FIPS 203 key encapsulation. Default in core mode, hybrid with ECDH P-256.</p></div>
+      <div class="pcard"><span class="ptag">signature</span><h3>ML-DSA-65</h3><p>FIPS 204 signatures. Relay identity, CT log STH, and ParaSign envelopes.</p></div>
+      <div class="pcard"><span class="ptag">crypto core</span><h3>paramant-core</h3><p>Audit-ready Rust binding the relay uses for all PQ primitives since v3.0.0 (M5b).</p></div>
+      <a class="pcard" href="/security"><span class="ptag">details</span><h3>Cryptography &amp; audits</h3><p>Full algorithm choices, threat model, and the independent security audits.</p><span class="pcta">Read the spec</span></a>
+    </div>
+    <div class="callout" role="note">
+      <h4>Why post-quantum now</h4>
+      <p>Adversaries can capture ciphertext today and decrypt it later once a cryptographically relevant quantum computer arrives. Files that need to stay private past 2030 need post-quantum keys today. Paramant ships ML-KEM-768 + ML-DSA-65 in the default core stack, hybrid with ECDH P-256 so classical security is preserved.</p>
+    </div>
+  </div>
+</section>
+
+<section class="section-dark" aria-labelledby="ct-h">
+  <div class="home-section">
+    <header class="home-section-head"><span class="eyebrow">Verifiable</span><h2 id="ct-h">Public Merkle proof of every transfer.</h2><p>Every transfer is hashed into a public Merkle tree whose root updates on every write. Prove a transfer occurred without learning what it was.</p></header>
+    <div class="ct-widget" role="region" aria-label="Live CT log">
+      <div class="ct-header">
+        <span><span class="dot" id="ct-dot" aria-hidden="true"></span> Certificate Transparency &middot; live</span>
+        <a href="/ct-log" style="color:var(--lime);text-decoration:none;font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.06em">View all &rarr;</a>
+      </div>
+      <div class="ct-stats">
+        <div class="ct-stat"><div class="ct-stat-label">Log entries</div><div class="ct-stat-val" id="ct-transfers">&mdash;</div></div>
+        <div class="ct-stat"><div class="ct-stat-label">Registered relays</div><div class="ct-stat-val" id="ct-relays">&mdash;</div></div>
+        <div class="ct-stat"><div class="ct-stat-label">STH signature</div><div class="ct-stat-val" id="ct-sth-status" style="font-size:var(--text-lg)">checking&hellip;</div></div>
+      </div>
+      <div class="ct-body">
+        <div class="ct-root-panel">
+          <div class="ct-feed-label">Latest root</div>
+          <div id="ct-root" style="font-family:var(--mono);font-size:var(--text-sm);color:var(--bone-on-navy-dim);word-break:break-all;line-height:1.7">syncing&hellip;</div>
+        </div>
+      </div>
+      <div class="ct-foot">
+        <span>Signed with ML-DSA-65 (FIPS 204)</span>
+        <a class="btn btn-lime" href="/ct-log">View live CT log</a>
+      </div>
+    </div>
+  </div>
 </section>
 
 <section class="selfhost">
@@ -357,5 +395,6 @@
 </footer>
 <script src="/nav.js?v=12" defer></script>
 <script src="/js/nav-auth.js" defer></script>
+<script src="/ct-stats.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Why
A read-only audit (no changes) showed the homepage was reduced to a single ghost-tint stripe since `a11b417` (\"showcase\" rewrite, 814 -> 267 lines). Tokens that already exist in `frontend/design-system.css` and that `/docs.html` still uses (`section-dark`, `callout`, `ct-widget`, `btn-lime`) were never wired up on the homepage. This re-uses those tokens on the **current** content. No content rollback.

## What changed (HTML)
- **Hero primary CTA** -> `btn-lime` (was `btn-primary`). The dashboard CTA is now the clear visual anchor.
- **Under the hood** wrapped in `<section class=\"section-dark\">` (navy full-bleed) with an inner `home-section` so the 1140px content rhythm stays. Adds a `crypto-strip` chip list (ML-KEM-768 / ML-DSA-65 / ECDH P-256 / AES-256-GCM) plus a `\"Why post-quantum now\"` callout (HNDL framing). Callout inverts to lime accents inside `section-dark` (already in `design-system.css`).
- **Verifiable** replaced its lone CTA pair with a **live `ct-widget`** (all classes already defined in `design-system.css`). Wired to `/ct-stats.js` which fetches `tree_size` / `registered_relays` / STH / latest root from `https://health.paramant.app`. Foot has `btn-lime` View live CT log.
- **How it works** gets a `\"Burn-on-read\"` callout.

## What did NOT change
- All current content stays: workmodel (\"Your encrypted workspace\", \"How Paramant works\", \"Open your dashboard\"), sector showcase, ParaPear pointer, info-only (no `/send /parashare /drop /sign` tool links re-introduced), no anonymous claims.
- `nav.css` and `nav.js` untouched.
- No new hex colors: all dark/lime accents are `var(--navy)`, `var(--lime)`, `var(--bone-on-navy)`, `var(--bone-on-navy-dim)`, `var(--bone-on-navy-hair)`, `var(--ink-hair)`, `var(--ink-dim)`, `var(--cobalt)`, `var(--mono)` -- all already in `design-system.css`.
- CSP unchanged. `/ct-stats.js` is same-origin (matches `script-src 'self'`). Fetches to `https://health.paramant.app` are already in `connect-src`.

## What changed (CSS, additive only)
Added at the tail of `frontend/components-parasign.css`:
- `.section-dark .home-section-head .eyebrow/h2/p` inversion
- `.section-dark .pcard / .ptag / .pcta` inversion
- `.crypto-strip` + chip items (mono-caps, lime border-left, bone-on-navy-hair background)
- `.section-dark .ct-widget` and inner-class color/border inversion

## Test plan
- [ ] Open `paramant.app/` -> visible section-rhythm with two navy anchors (\"Under the hood\", \"Verifiable\"), not one flat grey field.
- [ ] Live `ct-widget`: \"Log entries\" + \"Registered relays\" + STH status populate within ~6s (fallback dot turns red on fetch fail, no broken layout).
- [ ] Hero CTA is the lime `btn-lime` button.
- [ ] Mobile (<=600px): crypto-strip wraps, ct-stats collapse 3 -> 1 column, ct-body single column (already in design-system breakpoints).
- [ ] No 3rd-party requests beyond `health.paramant.app` (already CSP-allowed).
- [ ] Content sanity: workmodel + dashboard CTA + no-anonymous still intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)