### PR TITLE
fix(home): make Merkle proof widget readable on dark section

### DIFF
--- a/frontend/components-parasign.css
+++ b/frontend/components-parasign.css
@@ -140,17 +140,26 @@ a.pcard:hover { border-color: var(--navy); transform: translateY(-2px); }
 .crypto-strip .alg-tag { font-family: var(--mono); font-size: 10px; letter-spacing: .15em; text-transform: uppercase; color: var(--lime); }
 .crypto-strip strong { font-family: var(--mono); font-size: var(--text-sm); color: var(--bone-on-navy); font-weight: 600; letter-spacing: .02em; }
 
-/* Live CT-widget on dark section (uses existing .ct-widget tokens; just inverts text) */
-.section-dark .ct-widget { border-color: var(--bone-on-navy-hair); background: var(--bone-on-navy-hair); }
-.section-dark .ct-header { color: var(--bone-on-navy-dim); border-bottom-color: var(--bone-on-navy-hair); }
-.section-dark .ct-stats { border-bottom-color: var(--bone-on-navy-hair); }
-.section-dark .ct-stat { border-right-color: var(--bone-on-navy-hair); }
-.section-dark .ct-stat-label { color: var(--bone-on-navy-dim); }
-.section-dark .ct-stat-val { color: var(--lime); }
-.section-dark .ct-body { grid-template-columns: 1fr; }
-.section-dark .ct-root-panel { border-right: none; border-bottom: 1px solid var(--bone-on-navy-hair); }
-.section-dark .ct-feed-label { color: var(--bone-on-navy-dim); }
-.section-dark .ct-foot { border-top-color: var(--bone-on-navy-hair); color: var(--bone-on-navy-dim); }
-.section-dark .ct-widget .dot { display:inline-block; width:8px; height:8px; border-radius:50%; background: var(--ink-dim); }
+/* Homepage live CT-widget (.ctw) -- base tokens only, designed to read on .section-dark */
+.ctw { max-width: 920px; margin: 0 auto; }
+.ctw-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-6); padding: var(--space-6) 0; border-top: 2px solid var(--lime); border-bottom: 1px solid var(--bone-on-navy-hair); }
+.ctw-stat { text-align: left; }
+.ctw-num { font-family: var(--mono); font-size: clamp(2.4rem, 5.5vw, 3.6rem); font-weight: 700; line-height: 1; color: var(--lime); font-variant-numeric: tabular-nums; letter-spacing: -.02em; margin-bottom: var(--space-3); }
+.ctw-num-sm { font-size: clamp(1.1rem, 2.4vw, 1.5rem); letter-spacing: .04em; }
+.ctw-lbl { font-family: var(--mono); font-size: var(--text-xs); letter-spacing: .15em; text-transform: uppercase; color: var(--bone-on-navy-dim); }
+.ctw-root { padding: var(--space-5) 0; border-bottom: 1px solid var(--bone-on-navy-hair); }
+.ctw-root-lbl { display: block; font-family: var(--mono); font-size: var(--text-xs); letter-spacing: .15em; text-transform: uppercase; color: var(--bone-on-navy-dim); margin-bottom: var(--space-2); }
+.ctw-root-val { font-family: var(--mono); font-size: var(--text-sm); color: var(--bone-on-navy); word-break: break-all; display: block; line-height: 1.7; background: transparent; padding: 0; }
+.ctw-foot { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-5) 0 0; flex-wrap: wrap; font-family: var(--mono); font-size: var(--text-xs); letter-spacing: .06em; color: var(--bone-on-navy-dim); }
+.ctw-status { display: inline-flex; align-items: center; gap: var(--space-2); }
+.ctw-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--bone-on-navy-dim); }
+@media (max-width: 700px) {
+  .ctw-stats { grid-template-columns: 1fr; gap: 0; padding: var(--space-2) 0; border-bottom: none; }
+  .ctw-stat { padding: var(--space-4) 0; border-bottom: 1px solid var(--bone-on-navy-hair); }
+  .ctw-stat:last-child { border-bottom: none; }
+  .ctw-num { font-size: clamp(2rem, 9vw, 3rem); }
+  .ctw-foot { flex-direction: column; align-items: flex-start; gap: var(--space-3); }
+  .ctw-foot .btn-lime { align-self: stretch; text-align: center; }
+}
 
 @media (max-width:600px){ .home-hero{padding: var(--space-6) var(--space-4);} .home-hero h1{font-size: var(--text-4xl);} .home-cta{flex-direction:column;align-items:stretch;} .home-cta .btn{width:100%;} .crypto-strip{justify-content:flex-start} }

--- a/frontend/ct-stats.js
+++ b/frontend/ct-stats.js
@@ -9,10 +9,10 @@
 
   function setDot(ok) {
     var dot = document.getElementById('ct-dot');
-    if (dot) dot.style.background = ok ? '#00cc33' : '#c84040';
+    if (dot) dot.style.background = ok ? '#B2FF3F' : '#FCA5A5';
   }
 
-  // /ct/feed — tree_size, root, last 50 entries with types
+  // /ct/feed -- tree_size, root, last 50 entries with types
   fetch(RELAY + '/ct/feed', {signal: AbortSignal.timeout(6000)})
     .then(function(r) { return r.json(); })
     .then(function(d) {
@@ -22,15 +22,18 @@
 
       var root = d.root;
       if (root && root !== '0'.repeat(64)) {
-        set('ct-root', root.slice(0, 16) + '...' + root.slice(-8));
+        set('ct-root', root.slice(0, 16) + ' ... ' + root.slice(-16));
       }
 
       if (d.entries) {
-        // Registered relays = device key registrations (no type or type='key_reg')
-        var keyRegCount = d.entries.filter(function(e) {
-          return !e.type || e.type === 'key_reg';
-        }).length;
-        set('ct-relays', keyRegCount.toLocaleString());
+        var sectors = {};
+        d.entries.forEach(function(e) {
+          if (e && (e.type === 'relay_reg' || e.type === 'key_reg' || !e.type) && e.s) {
+            sectors[e.s] = true;
+          }
+        });
+        var n = Object.keys(sectors).length;
+        if (n > 0) set('ct-relays', n.toLocaleString());
 
         var feedEl = document.getElementById('ct-feed');
         if (feedEl && d.entries.length) {
@@ -38,10 +41,10 @@
           var rows = last3.map(function(e) {
             var ts = new Date(e.t);
             var time = ts.toISOString().slice(11, 19);
-            var hash = e.h ? e.h.slice(0, 12) + '...' : '—';
+            var hash = e.h ? e.h.slice(0, 12) + '...' : '--';
             return '<div><span style="color:var(--quiet)">#' + e.i + '</span>'
-              + ' &nbsp;·&nbsp; ' + hash
-              + ' &nbsp;·&nbsp; <span style="color:var(--quiet)">' + time + ' UTC</span></div>';
+              + ' &nbsp;&middot;&nbsp; ' + hash
+              + ' &nbsp;&middot;&nbsp; <span style="color:var(--quiet)">' + time + ' UTC</span></div>';
           });
           feedEl.innerHTML = rows.join('');
         }
@@ -49,7 +52,7 @@
     })
     .catch(function() { setDot(false); });
 
-  // STH status — disk-backed, signed with ML-DSA-65
+  // STH status -- disk-backed, signed with ML-DSA-65
   fetch(RELAY + '/v2/sth', {signal: AbortSignal.timeout(5000)})
     .then(function(r) { return r.json(); })
     .then(function(d) {
@@ -57,10 +60,8 @@
       if (!el) return;
       if (d.ok && d.sth) {
         el.textContent = 'ML-DSA-65';
-        el.style.color = '#00cc33';
       } else {
         el.textContent = 'signed';
-        el.style.color = '#555';
       }
     })
     .catch(function() { set('ct-sth-status', 'offline'); });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
 <link rel="stylesheet" href="/parapear.css">
-<link rel="stylesheet" href="/components-parasign.css?v=2">
+<link rel="stylesheet" href="/components-parasign.css?v=3">
 <style>
 /* Hero pointing peer. Points at the primary 'Open your dashboard' CTA so
    the work-model is obvious: this is where you start. Tokens only. */
@@ -296,24 +296,27 @@
 <section class="section-dark" aria-labelledby="ct-h">
   <div class="home-section">
     <header class="home-section-head"><span class="eyebrow">Verifiable</span><h2 id="ct-h">Public Merkle proof of every transfer.</h2><p>Every transfer is hashed into a public Merkle tree whose root updates on every write. Prove a transfer occurred without learning what it was.</p></header>
-    <div class="ct-widget" role="region" aria-label="Live CT log">
-      <div class="ct-header">
-        <span><span class="dot" id="ct-dot" aria-hidden="true"></span> Certificate Transparency &middot; live</span>
-        <a href="/ct-log" style="color:var(--lime);text-decoration:none;font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.06em">View all &rarr;</a>
-      </div>
-      <div class="ct-stats">
-        <div class="ct-stat"><div class="ct-stat-label">Log entries</div><div class="ct-stat-val" id="ct-transfers">&mdash;</div></div>
-        <div class="ct-stat"><div class="ct-stat-label">Registered relays</div><div class="ct-stat-val" id="ct-relays">&mdash;</div></div>
-        <div class="ct-stat"><div class="ct-stat-label">STH signature</div><div class="ct-stat-val" id="ct-sth-status" style="font-size:var(--text-lg)">checking&hellip;</div></div>
-      </div>
-      <div class="ct-body">
-        <div class="ct-root-panel">
-          <div class="ct-feed-label">Latest root</div>
-          <div id="ct-root" style="font-family:var(--mono);font-size:var(--text-sm);color:var(--bone-on-navy-dim);word-break:break-all;line-height:1.7">syncing&hellip;</div>
+    <div class="ctw" role="region" aria-label="Live CT log">
+      <div class="ctw-stats">
+        <div class="ctw-stat">
+          <div class="ctw-num" id="ct-transfers">742</div>
+          <div class="ctw-lbl">Log entries</div>
+        </div>
+        <div class="ctw-stat">
+          <div class="ctw-num" id="ct-relays">5</div>
+          <div class="ctw-lbl">Registered relays</div>
+        </div>
+        <div class="ctw-stat">
+          <div class="ctw-num ctw-num-sm" id="ct-sth-status">ML-DSA-65</div>
+          <div class="ctw-lbl">STH signature</div>
         </div>
       </div>
-      <div class="ct-foot">
-        <span>Signed with ML-DSA-65 (FIPS 204)</span>
+      <div class="ctw-root">
+        <span class="ctw-root-lbl">Latest Merkle root (SHA3-256)</span>
+        <code class="ctw-root-val" id="ct-root">syncing&hellip;</code>
+      </div>
+      <div class="ctw-foot">
+        <span class="ctw-status"><span class="ctw-dot" id="ct-dot" aria-hidden="true"></span> Live &middot; Hetzner DE &middot; Signed with ML-DSA-65 (FIPS 204)</span>
         <a class="btn btn-lime" href="/ct-log">View live CT log</a>
       </div>
     </div>
@@ -395,6 +398,6 @@
 </footer>
 <script src="/nav.js?v=12" defer></script>
 <script src="/js/nav-auth.js" defer></script>
-<script src="/ct-stats.js" defer></script>
+<script src="/ct-stats.js?v=2" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Why
PR #112 inverted the design-system \`.ct-widget\` tokens with low-contrast overrides (\`rgba(248,250,252,.18)\` box on navy) and left placeholders that read as bare em-dashes. On mobile the stat grid collapsed into near-invisibility -- only the lime CTA button popped, the widget itself looked empty. Mick's screenshot showed exactly that.

## Fix
Rebuilds the homepage CT widget as a homepage-local \`.ctw\` component using only base design tokens (\`--lime\`, \`--bone-on-navy\`, \`--bone-on-navy-dim\`, \`--bone-on-navy-hair\`, \`--mono\`, \`--space-*\`, \`--text-*\`). No new hex colors.

- 2px lime top divider so the widget reads as a distinct block on the navy section.
- Stats render with \`clamp(2.4rem, 5.5vw, 3.6rem)\` lime numerals -- prominent even before JS data lands. Seeded with current live values (742 entries, 5 sectors, ML-DSA-65) so the widget never looks empty.
- Mobile: stats stack with bone-on-navy-hair separators; CTA button spans full width.
- Latest root row with its own label + mono 16...16 truncation.
- Footer with status dot (lime when live / salmon on fetch fail) + Hetzner DE + ML-DSA-65 attribution.

## ct-stats.js fixes (real bugs)
- **Relay-count filter was wrong.** Looked for \`type=key_reg\` but the actual entries are \`type=relay_reg\` / \`transfer\` -- count came out 0 every time. Now counts unique sector keys (\`s\` field) across \`relay_reg\`/\`key_reg\` entries. Currently yields 5 (health, finance, legal, iot, relay).
- Dot color switched from arbitrary \`#00cc33\` / \`#c84040\` to design-palette lime (\`#B2FF3F\`) / salmon (\`#FCA5A5\`).
- STH text-color removed inline overrides so CSS owns it.
- Root truncation widened from 16+8 to 16+16.

## Cache-busters
\`components-parasign.css?v=2 -> v=3\` and \`ct-stats.js?v=2\`.

## Test plan
- [ ] Open paramant.app on desktop -- Verifiable section shows lime divider + three big lime numerals + root row + status dot + lime CTA. Reads as a unit, not floating bits.
- [ ] Refresh -- numbers update via JS (relay_reg sector count should land at 5).
- [ ] Network tab: \`/ct/feed\` 200, \`/v2/sth\` 200, dot turns lime.
- [ ] Open on mobile (DevTools or phone) -- stats stack, separators visible, button spans full width.
- [ ] Throttle /ct/feed to fail (offline mode) -- dot turns salmon, seeded numerals stay visible (not broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)