### PR TITLE
feat(home): slim Products grid, add free Community pitch

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -236,12 +236,13 @@
 </aside>
 
 <section class="home-section" id="products" aria-labelledby="prod-h">
-  <header class="home-section-head"><span class="eyebrow">Products</span><h2 id="prod-h">Four ways to use Paramant.</h2><p>One relay, four endpoints. Each tuned for a different transfer pattern. All client-side encrypted, all burn-on-read.</p></header>
-  <div class="pgrid">
-    <a class="pcard" href="/dashboard"><span class="ptag">fast</span><h3>Send a file</h3><p>Drop a file from your dashboard, share the link, burns after one read. AES-256-GCM in-browser, bound to your account.</p><span class="pcta">Open your dashboard</span></a>
-    <a class="pcard" href="/dashboard"><span class="ptag">verified</span><h3>ParaShare</h3><p>End-to-end ML-KEM-768 hybrid with ML-DSA-65 signed receipts. Cryptographic proof of who sent what to whom.</p><span class="pcta">Open your dashboard</span></a>
-    <a class="pcard" href="/dashboard"><span class="ptag">device-to-device</span><h3>ParaDrop</h3><p>AirDrop alternative across iOS, Android, Windows, Linux. QR or 6-digit pairing. Encrypted in transit, burn on read.</p><span class="pcta">Open your dashboard</span></a>
-    <a class="pcard" href="/dashboard"><span class="ptag">new &middot; parasign</span><h3>Sign documents</h3><p>Post-quantum ML-DSA-65 signatures. Self-contained .psign envelope. CT-log backed.</p><span class="pcta">Open your dashboard</span></a>
+  <header class="home-section-head">
+    <span class="eyebrow">Products</span>
+    <h2 id="prod-h">Four ways to use Paramant.</h2>
+    <p>Send, ParaShare, ParaDrop, ParaSign &mdash; all from your dashboard, all client-side encrypted, all burn-on-read.</p>
+  </header>
+  <div class="home-center">
+    <a class="btn btn-lime" href="/dashboard">Open your dashboard</a>
   </div>
 </section>
 
@@ -338,6 +339,28 @@
     <a class="pcard" href="/docs#quickstart"><span class="ptag">javascript</span><h3>paramant-sdk (Node)</h3><p>Node 18+. Same wire format as the Python SDK. <code>npm install paramant-sdk</code></p><span class="pcta">Quick start</span></a>
     <a class="pcard" href="/docs#api"><span class="ptag">http api</span><h3>REST / WebSocket</h3><p>Full /v2 API: WebSocket push, signed receipts, DID-based device identity.</p><span class="pcta">API reference</span></a>
     <a class="pcard" href="https://github.com/Apolloccrypt/paramant-relay"><span class="ptag">source</span><h3>GitHub</h3><p>BUSL-1.1 source. Verify the code running on your relay against the public repo.</p><span class="pcta">View on GitHub</span></a>
+  </div>
+</section>
+
+<section class="home-section" aria-labelledby="free-h">
+  <header class="home-section-head">
+    <span class="eyebrow">Free</span>
+    <h2 id="free-h">Start free. Full Paramant.</h2>
+    <p>Same post-quantum cryptography, same zero-knowledge architecture, same EU jurisdiction. No stripped-down version. No credit card.</p>
+  </header>
+  <div style="max-width:72ch;margin:0 auto var(--space-5)">
+    <div class="callout" role="note" style="max-width:none;margin:0">
+      <h4>What you get on the free tier</h4>
+      <ul style="margin:0;padding-left:18px">
+        <li style="font-size:14px;line-height:1.6;color:var(--ink);margin-bottom:10px"><strong>Same crypto as paid tiers.</strong> ML-KEM-768 hybrid with ECDH P-256, ML-DSA-65 signed receipts, AES-256-GCM, all client-side. No encryption paywall.</li>
+        <li style="font-size:14px;line-height:1.6;color:var(--ink);margin-bottom:10px"><strong>Account-bound.</strong> Sign up with email and TOTP. Every transfer in your audit log. Recipients still need no account.</li>
+        <li style="font-size:14px;line-height:1.6;color:var(--ink);margin:0"><strong>Fair-use limits.</strong> 5 MB per file, 1-hour link expiry, 10 uploads per hour per IP, up to 5 registered devices for ParaShare. Full breakdown on the <a href="/pricing" style="color:var(--cobalt)">pricing page</a>.</li>
+      </ul>
+    </div>
+  </div>
+  <div class="home-center" style="display:flex;gap:var(--space-3);justify-content:center;flex-wrap:wrap">
+    <a class="btn btn-lime" href="/signup">Create your free account</a>
+    <a class="btn btn-tertiary" href="/pricing">See pricing</a>
   </div>
 </section>
 


### PR DESCRIPTION
## What
Homepage becomes pure storefront: drop the four-card Products grid that duplicated the dashboard tools, add an honest free-tier conversion pitch before the footer.

## Changes (\`frontend/index.html\` only, +29 / -6)

### 1. Products grid -> 1-liner + 1 CTA
The four pcards in the Products section all linked to \`/dashboard\` and described surfaces that already live on the dashboard. Removed. The section now reads:
- Eyebrow: **Products**
- Heading: **Four ways to use Paramant.**
- One line: "Send, ParaShare, ParaDrop, ParaSign -- all from your dashboard, all client-side encrypted, all burn-on-read."
- One CTA: lime **Open your dashboard**

The visitor still learns there are four tools, but the actual surface lives on the dashboard.

### 2. New Community / free-tier pitch (right before \`</main>\`)
Section with eyebrow **Free**, heading **Start free. Full Paramant.**, and an honest limits callout:
- **Same crypto as paid tiers** -- ML-KEM-768 hybrid with ECDH P-256, ML-DSA-65 signed receipts, AES-256-GCM, all client-side.
- **Account-bound** -- email + TOTP signup, every transfer in your audit log, recipients still need no account.
- **Fair-use limits** -- 5 MB per file, 1-hour link expiry, 10 uploads/hour/IP, up to 5 ParaShare devices. Link to \`/pricing\` for the full breakdown.

Two CTAs: lime **Create your free account** -> \`/signup\`, tertiary **See pricing** -> \`/pricing\`.

**Limits mirror the current live \`/pricing\` page exactly** so the homepage cannot contradict pricing. If you want different numbers on the homepage, update \`/pricing\` + relay enforcement first; otherwise this stays honest.

## What did NOT change
- Character sections preserved byte-identical: 2x \`.section-dark\`, 1x \`.crypto-strip\` (4 algorithm chips), 1x \`.ctw\` CT-widget (live), 2x existing \`.callout\` ("Burn-on-read" and "Why post-quantum now").
- nav.css / nav.js untouched.
- No new hex colours. Only \`var(--lime)\`, \`var(--cobalt)\`, \`var(--navy)\`, \`var(--ink)\`, \`var(--ink-dim)\`, \`var(--mono)\`, \`var(--space-*)\`, \`var(--text-*)\` -- all existing design-system tokens.
- All other showcase content (hero, How Paramant works, trust-bar, sector showcase, How it works, Under the hood, Verifiable CT, Self-host, For builders) byte-identical.
- CSP intact.

## Verifications (all PASS)
- pcard texts from removed Products section gone (\"Drop a file from your dashboard\", \"AirDrop alternative\", \"6-digit pairing\" -- 0 occurrences).
- Character markers unchanged: section-dark=2, crypto-strip=1, ctw-num=3, callout=3 (2 existing + 1 new pitch).
- btn-lime=4 (1 hero + 1 Products mini + 1 ctw-foot + 1 new pitch).
- No false claims ("unlimited free", "no limits") -> 0.
- Showcase keywords (post-quantum, zero-knowledge, FIPS, sector, self-host) -> 31.

## Test plan
- [ ] Open paramant.app on desktop and mobile.
- [ ] Products section reads as a one-liner with one lime CTA, not 4 cards.
- [ ] Scroll past Self-host and For builders -> Free pitch appears before footer.
- [ ] Free callout lists three honest bullets (same crypto / account-bound / fair-use limits).
- [ ] "Create your free account" -> /signup.
- [ ] "See pricing" -> /pricing.
- [ ] Pricing-page link inside the limits bullet works.
- [ ] Two navy section-dark anchors (Under the hood, Verifiable) still render.
- [ ] CT widget still hydrates live (tree_size, registered relays, ML-DSA-65, latest root).

## Note for Mick
Your brief mentioned "Community gratis: 500MB x10 transfers/maand, 2 signs/maand". The live \`/pricing\` page currently says **5 MB per file / 1-hour expiry / 10 uploads per hour per IP / 5 ParaShare devices**. To avoid the homepage contradicting /pricing, I used the live /pricing numbers. If the prompt numbers are the new policy, update /pricing + the relay enforcement code first, then a one-line follow-up will update this homepage callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)