### PR TITLE
docs: use placeholder path for backup key example

### DIFF
--- a/docs/ops/backup-restore-users-json.md
+++ b/docs/ops/backup-restore-users-json.md
@@ -36,7 +36,7 @@ Lose it and all backups are permanently unreadable.
 
 - Keep an OFFLINE copy of the private key (USB in a physical safe, or printed
   on paper). Retrieve it once with:
-  `ssh root@116.203.86.81 'cat /root/.config/paramant-backup/key.txt'`
+  `ssh root@<your-relay-host> 'cat /path/to/your/backup-key.txt'` (substitute host + path for your install)
 - NEVER commit the private key to any git repository, public or private.
 - The private key sitting next to the backups on the same box is fine for
   availability but means a full-host compromise exposes both — the offline


### PR DESCRIPTION
## Summary
- `docs/ops/backup-restore-users-json.md` L39 quoted a literal `ssh root@<prod-ip> 'cat <prod-key-path>'` — a reader of the public repo could paste it 1:1 against the live relay given SSH access.
- Substitute host + key path with angle-bracket placeholders so the recipe still teaches the shape without being copy-paste-ready.
- Single-line scope. L52 (script-run) and L61 (decrypt round-trip) describe operational checks rather than key-exfil and are left as-is.

## Test plan
- [x] `git diff` shows exactly one line changed in `docs/ops/backup-restore-users-json.md`.
- [ ] Markdown still renders cleanly (inline code + trailing parenthetical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)