### PR TITLE
homepage: dark + sharp-corner Integrate Paramant cards

### DIFF
--- a/frontend/components-parasign.css
+++ b/frontend/components-parasign.css
@@ -127,11 +127,12 @@ a.pcard:hover { border-color: var(--navy); transform: translateY(-2px); }
 .section-dark .home-section-head .eyebrow { color: var(--lime); }
 .section-dark .home-section-head h2 { color: var(--bone-on-navy); }
 .section-dark .home-section-head p  { color: var(--bone-on-navy-dim); }
-.section-dark .pcard { background: transparent; border-color: var(--bone-on-navy-hair); }
+.section-dark .pcard { background: transparent; border-color: var(--bone-on-navy-hair); border-radius: 0; border-top: 2px solid var(--lime); }
 .section-dark a.pcard:hover { border-color: var(--lime); transform: translateY(-2px); }
 .section-dark .pcard h3 { color: var(--bone-on-navy); }
 .section-dark .pcard p  { color: var(--bone-on-navy-dim); }
-.section-dark .pcard .ptag { background: var(--bone-on-navy-hair); color: var(--lime); }
+.section-dark .pcard code { font-family: var(--mono); font-size: 0.92em; color: var(--lime); background: var(--bone-on-navy-hair); padding: 1px 4px; }
+.section-dark .pcard .ptag { background: transparent; color: var(--lime); border-radius: 0; border-left: 2px solid var(--lime); padding-left: var(--space-2); }
 .section-dark .pcard .pcta { color: var(--lime); }
 
 /* Algorithm chip strip (tokens only) */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -332,13 +332,15 @@
   <div class="home-cta" style="margin-top:var(--space-4)"><a class="btn btn-secondary" href="/docs#self-hosting">Deploy guide</a><a class="btn btn-tertiary" href="/setup">Setup wizard</a></div>
 </section>
 
-<section class="home-section" aria-labelledby="dev-h">
-  <header class="home-section-head"><span class="eyebrow">For builders</span><h2 id="dev-h">Integrate Paramant.</h2><p>SDKs in Python and JavaScript, plus a direct HTTP/WebSocket API. Wire format v1, byte-compatible across implementations.</p></header>
-  <div class="pgrid">
-    <a class="pcard" href="/docs#quickstart"><span class="ptag">python</span><h3>paramant-sdk (Python)</h3><p>Python 3.10+. ML-KEM-768 + ML-DSA-65 by default. <code>pip install paramant-sdk</code></p><span class="pcta">Quick start</span></a>
-    <a class="pcard" href="/docs#quickstart"><span class="ptag">javascript</span><h3>paramant-sdk (Node)</h3><p>Node 18+. Same wire format as the Python SDK. <code>npm install paramant-sdk</code></p><span class="pcta">Quick start</span></a>
-    <a class="pcard" href="/docs#api"><span class="ptag">http api</span><h3>REST / WebSocket</h3><p>Full /v2 API: WebSocket push, signed receipts, DID-based device identity.</p><span class="pcta">API reference</span></a>
-    <a class="pcard" href="https://github.com/Apolloccrypt/paramant-relay"><span class="ptag">source</span><h3>GitHub</h3><p>BUSL-1.1 source. Verify the code running on your relay against the public repo.</p><span class="pcta">View on GitHub</span></a>
+<section class="section-dark" aria-labelledby="dev-h">
+  <div class="home-section">
+    <header class="home-section-head"><span class="eyebrow">For builders</span><h2 id="dev-h">Integrate Paramant.</h2><p>SDKs in Python and JavaScript, plus a direct HTTP/WebSocket API. Wire format v1, byte-compatible across implementations.</p></header>
+    <div class="pgrid">
+      <a class="pcard" href="/docs#quickstart"><span class="ptag">python</span><h3>paramant-sdk (Python)</h3><p>Python 3.10+. ML-KEM-768 + ML-DSA-65 by default. <code>pip install paramant-sdk</code></p><span class="pcta">Quick start</span></a>
+      <a class="pcard" href="/docs#quickstart"><span class="ptag">javascript</span><h3>paramant-sdk (Node)</h3><p>Node 18+. Same wire format as the Python SDK. <code>npm install paramant-sdk</code></p><span class="pcta">Quick start</span></a>
+      <a class="pcard" href="/docs#api"><span class="ptag">http api</span><h3>REST / WebSocket</h3><p>Full /v2 API: WebSocket push, signed receipts, DID-based device identity.</p><span class="pcta">API reference</span></a>
+      <a class="pcard" href="https://github.com/Apolloccrypt/paramant-relay"><span class="ptag">source</span><h3>GitHub</h3><p>BUSL-1.1 source. Verify the code running on your relay against the public repo.</p><span class="pcta">View on GitHub</span></a>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Wrap the Integrate Paramant SDK strip (Python / Node / REST / GitHub) in \`<section class=\"section-dark\">\` to match the Certificate Transparency strip aesthetic.
- On \`.section-dark .pcard\`: square corners (\`border-radius: 0\`), \`border-top: 2px solid var(--lime)\` echo of \`.ctw-stats\`, ptag pill → flat lime-left-accent (like \`.crypto-strip\`), and lime-mono treatment for \`<code>\` so install commands read as the CTA.
- Intentional side-effect: the Post-quantum cards (L285-288) already use \`.section-dark .pcard\`, so they pick up the same sharpening for free → the "everything square like CT log" consistency Mick wanted.
- \`.scard\` cards (industries) and the top banner cards left intact; only Mick's two flagged-grey sections move.

## Test plan
- [x] Markup balance: 10/10 \`<section>\`, 69/69 \`<div>\`, 124/124 CSS braces.
- [ ] Eyeball on staging or local preview: Integrate strip now navy + lime, Post-quantum strip now sharp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)