### PR TITLE
auth: close signup-timing + login-status enumeration oracles

### DIFF
--- a/admin/lib/email-templates.js
+++ b/admin/lib/email-templates.js
@@ -422,6 +422,55 @@ function signupVerificationEmail({ email, token, requestedAt, requestIP }) {
   return { ...wrap(text, html, { refId: 'verify-' + token.slice(0, 8) }), subject: 'Verify your Paramant account' };
 }
 
+// ── DUPLICATE SIGNUP ATTEMPT NOTICE ─────────────────────────────────────────
+// Sent to the existing account owner when someone tries to sign up using
+// their email. Required so the signup endpoint does the same kind of work
+// (Redis write + outbound mail) on the existing-email branch as on the
+// new-email branch, removing the ~50ms-vs-~500ms enumeration side-channel.
+function duplicateSignupAttemptEmail({ email, requestedAt, requestIP }) {
+  const dateStr = formatTS(requestedAt);
+  const maskedIp = maskIP(requestIP);
+  const loginUrl = `${BASE_URL}/auth/login`;
+
+  const preheader = 'Someone tried to create a Paramant account with your email.';
+  const text = [
+    'Signup attempt on your Paramant account',
+    '',
+    `Someone just attempted to create a Paramant account using ${email}.`,
+    'Your existing account was not changed and no new account was created.',
+    '',
+    'If this was you trying to sign in, use the login page instead:',
+    loginUrl,
+    '',
+    'If this was not you, ignore this email. The attempt was rate-limited.',
+    '',
+    `Attempt at: ${dateStr}${requestIP ? ' . IP: ' + maskedIp : ''}`,
+    '',
+    'Paramant',
+  ].join('\n');
+
+  const html = htmlShell(preheader, `
+    <h1 style="margin:0 0 16px 0;font-size:22px;font-weight:500;color:#0B3A6A;">Signup attempt on your account</h1>
+    <p style="margin:0 0 20px 0;line-height:1.6;">
+      Someone just tried to create a Paramant account with <strong>${email}</strong>. Your existing account was not changed and no new account was created.
+    </p>
+    <p style="margin:0 0 20px 0;line-height:1.6;">
+      If this was you trying to sign in, use the login page:
+    </p>
+    <div style="text-align:center;margin:0 0 28px 0;">
+      <a href="${loginUrl}" style="display:inline-block;background:#1D4ED8;color:#ffffff;font-size:15px;font-weight:600;padding:14px 32px;border-radius:6px;text-decoration:none;letter-spacing:0.01em;">Sign in to Paramant</a>
+    </div>
+    <div style="background:#F8FAFC;border:1px solid rgba(11,58,106,0.08);padding:12px 16px;margin:24px 0 0 0;border-radius:4px;">
+      <p style="margin:0;font-size:12px;color:#94A3B8;line-height:1.6;">
+        If this was not you, ignore this email. The attempt was rate-limited and no account was created.
+        <br>Attempt at ${dateStr}${requestIP ? ' . IP: ' + maskedIp : ''}.
+      </p>
+    </div>
+  `);
+
+  return { ...wrap(text, html, { refId: 'dup-' + Date.now().toString(36) }), subject: 'Signup attempt on your Paramant account' };
+}
+
 // ── BACKUP CODES RESET NOTIFICATION ─────────────────────────────────────────
 function backupCodesResetEmail({ email, requestedAt }) {
   const dateStr = formatTS(requestedAt);
@@ -504,6 +553,7 @@ module.exports = {
   backupCodesResetEmail,
   setupEmail,
   signupVerificationEmail,
+  duplicateSignupAttemptEmail,
   resetConfirmationEmail,
   welcomeEmail,
   billingConfirmationEmail,

--- a/admin/server.js
+++ b/admin/server.js
@@ -529,6 +529,21 @@ async function sendVerificationEmail(email, token, requestIP) {
   if (!res.ok) throw new Error(`Resend ${res.status}: ${await res.text().catch(() => '')}`);
 }
 
+// Send "someone tried to sign up with your email" notice to an existing
+// account owner. Called from the duplicate branch of /api/user/signup so
+// both branches do the same kind of outbound work (no timing oracle).
+async function sendDuplicateSignupAttempt(email, requestIP) {
+  const msg = emailTemplates.duplicateSignupAttemptEmail({ email, requestedAt: Date.now(), requestIP });
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) throw new Error('RESEND_API_KEY not set');
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ from: msg.from, replyTo: msg.replyTo, to: [email], subject: msg.subject, text: msg.text, html: msg.html, headers: msg.headers }),
+  });
+  if (!res.ok) throw new Error(`Resend ${res.status}: ${await res.text().catch(() => '')}`);
+}
+
 // Send TOTP reset confirmation email (step 1 of two-stage flow)
 async function sendResetConfirmEmail(email, confirmToken, maskedIp, requestedAt) {
   const msg = emailTemplates.resetConfirmationEmail({ confirmToken, requestedAt, requestIP: maskedIp });
@@ -643,32 +658,52 @@ api.post("/user/signup", async (req, res) => {
   if (emailCount === 1) await redis().expire(emailKey, 86400);
   if (emailCount > 10) return res.status(429).json({ error: "rate_limited", reason: "too_many_attempts_for_email" });
 
-  // 5. Already has an active account? — silent success to prevent enumeration
+  // 5. Both branches do the same kind of work (one Redis SET + one outbound
+  // mail enqueue) and return the same response, so the request cannot be
+  // used as an existence oracle through timing or response shape. The
+  // outbound mail is dispatched fire-and-forget via setImmediate so the
+  // Resend API latency (~200-500ms) is not in the response path.
   const existing = await findUserByEmail(norm);
-  if (existing) {
-    // Don't reveal whether email is registered — log silently and return same shape
-    console.log(`[signup] duplicate signup attempt for existing account: ${norm} from ${ip}`);
-    // Still send a "we sent you an email" response to prevent user enumeration
-    return res.json({ success: true, message: "verification_email_sent" });
-  }
-
-  // 6. Store pending signup in Redis (24h TTL), send verification email
   const verifyToken = crypto.randomBytes(32).toString("hex");
-  await redis().set(
-    `paramant:signup:pending:${verifyToken}`,
-    JSON.stringify({ email: norm, label: label || null, ip, requested_at: Date.now() }),
-    { EX: 86400 }
-  );
 
-  try {
-    await sendVerificationEmail(norm, verifyToken, ip);
-  } catch (err) {
-    console.error("[signup] verification email failed:", err.message);
-    await redis().del(`paramant:signup:pending:${verifyToken}`).catch(() => {});
-    return res.status(500).json({ error: "email_failed", message: "Could not send verification email. Please try again." });
+  if (existing) {
+    // Dummy token entry under an isolated namespace. Cannot be redeemed for
+    // signup (the verify route only reads paramant:signup:pending:*). Keeps
+    // the Redis I/O equivalent to the new-email branch.
+    await redis().set(
+      `paramant:signup:duplicate:${verifyToken}`,
+      JSON.stringify({ email_hash: emailHash, ip, attempted_at: Date.now() }),
+      { EX: 86400 }
+    );
+    // Fire-and-forget: tell the actual owner someone tried to claim their
+    // address. Only the real account holder can receive this mail, so it is
+    // not itself an oracle.
+    setImmediate(() => {
+      sendDuplicateSignupAttempt(norm, ip).catch(err =>
+        console.error("[signup] duplicate notice failed:", err.message));
+    });
+    console.log(`[signup] duplicate signup attempt: ${emailHash.slice(0, 8)} from ${ip}`);
+  } else {
+    // Real pending signup token.
+    await redis().set(
+      `paramant:signup:pending:${verifyToken}`,
+      JSON.stringify({ email: norm, label: label || null, ip, requested_at: Date.now() }),
+      { EX: 86400 }
+    );
+    // Fire-and-forget verification mail. On Resend failure we delete the
+    // pending token so the caller can retry the signup form. Per-email rate
+    // limit still applies, but a single Resend hiccup will not surface as a
+    // 500 to the user.
+    setImmediate(() => {
+      sendVerificationEmail(norm, verifyToken, ip).catch(err => {
+        console.error("[signup] verification email failed:", err.message);
+        redis().del(`paramant:signup:pending:${verifyToken}`).catch(() => {});
+      });
+    });
+    console.log(`[signup] pending signup for ${norm} from ${ip}`);
   }
 
-  console.log(`[signup] pending signup for ${norm} from ${ip}`);
+  // Identical response shape and timing in both branches.
   res.json({ success: true, message: "verification_email_sent" });
 });
 
@@ -847,9 +882,16 @@ api.post("/user/login", async (req, res) => {
           sendSetupEmail(um.email || user.email, setupToken).catch(e => console.error('[login/totp_required] email:', e.message));
         }
       }
-      return res.status(403).json({ error: "totp_setup_required", message: "Your administrator requires TOTP. Check your email for a setup link." });
+      // Setup mail is dispatched fire-and-forget above. Respond identically
+      // to "no such account" so the status code cannot be used as an
+      // enumeration oracle. Was: 403 totp_setup_required, which leaked the
+      // fact that the email belongs to a real account with admin-required
+      // TOTP not yet set up.
+      return res.status(401).json({ error: "invalid_credentials" });
     }
-    return res.status(403).json({ error: "totp_not_configured" });
+    // Same 401 for TOTP-not-configured so this branch also does not leak
+    // account existence. Was: 403 totp_not_configured.
+    return res.status(401).json({ error: "invalid_credentials" });
   }
 
   const verifyRes = await callRelay("/v2/user/verify-totp", { user_id: user.key, totp });


### PR DESCRIPTION
## Summary

Three audit findings on the public-facing auth endpoints, all closed in `admin/server.js`.

### 1. Signup timing side-channel (was L647-672)
Existing-email branch returned in ~50 ms (no I/O, no mail). New-email branch did one Redis SET + `await sendVerificationEmail` (Resend, ~200-500 ms). Response time was a reliable existence oracle.

**Fix:** both branches now perform one Redis SET (matching 24h TTL) + one outbound mail enqueued via `setImmediate`, then reach the same `res.json`. Resend round-trip is out of the response path. Duplicate branch writes under `paramant:signup:duplicate:*` (isolated namespace, not readable by the verify route) so the dummy entry cannot be redeemed.

### 2. Duplicate-signup notice mail (new)
The existing-email branch now fire-and-forgets a "someone tried to sign up with your email" notice to the actual owner. Supports the timing-equalize goal **and** is a product win on its own.

### 3. Login status oracle (was L850, L852)
`/api/user/login` returned three different status codes:
- `401 invalid_credentials` — email not found (or TOTP wrong)
- `403 totp_setup_required` — email exists, admin required TOTP
- `403 totp_not_configured` — email exists, no admin TOTP requirement

**Fix:** both 403 branches now return the same `401 invalid_credentials` body. The TOTP-setup-link mail in the admin-required branch is still dispatched fire-and-forget above the return, so a legit user still gets the setup link in their inbox.

## Preserved
- PoW check before any email lookup
- Per-IP rate limit (10/hour), per-email rate limit (10/24h, SHA256-hashed)
- 256-bit verification token
- Identical response body in both signup branches
- Login session flow on successful TOTP verify

## Side-effect
Resend hiccup on new-signup no longer surfaces as a 500. Pending Redis token is deleted in `.catch` so per-email rate limit still allows retry.

## Test plan
- [x] `node --check admin/server.js` and `node --check admin/lib/email-templates.js` pass
- [x] No remaining `await sendVerificationEmail` in the handler
- [x] No remaining `totp_setup_required` / `totp_not_configured` as active return values (only in `// Was:` comments)
- [x] PoW + per-IP + per-email rate-limits still present (6 matches)
- [x] Identical `verification_email_sent` response from both branches
- [ ] Post-merge: rebuild **admin** container only (relay backend untouched), verify `/auth/login` + `/signup` reachable, time signup with known-existing vs random-new email and confirm the gap closed.

## Rollout
- **Admin container needs rebuild.** Relay is untouched.
- Rollback: revert this commit + rebuild admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)