### PR TITLE
chore: retire dead prometheus admin-token from tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ CLAUDE.md
 package-lock.json.bak-*
 package.json.bak-*
 *.zip
+
+# Retired/rotated secrets — never re-commit
+deploy/token
+.env.bak*

--- a/deploy/prometheus-token
+++ b/deploy/prometheus-token
@@ -1,1 +1,0 @@
-Dusk7-Overlook0-Kinetic2-Remorse2


### PR DESCRIPTION
Tree-removal of deploy/prometheus-token (OLD admin token, confirmed dead — 401 vs live fleet) + .gitignore deploy/token & .env.bak*. Hygiene, not an acute fix. History purge (commit 55aab90) is a separate deliberate call; no force-push here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)