### PR TITLE
ParaSign v3 signing-activation: /sign + /co-sign passkey-PRF chain, cache-bust, 7-day invite TTL

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -1436,6 +1436,9 @@ api.post("/user/sign/activation", authUser, async (req, res) => {
   const sessionEmailHash = partyEmailHashAdmin(email);
   if (!env || env.doc_hash !== doc_hash) return res.status(403).json({ error: "doc_hash_mismatch" });
   if (!env.party || !sessionEmailHash || env.party.email_hash !== sessionEmailHash) return res.status(403).json({ error: "not_authorized" });
+  // Signing-invite window (7d from creation, != 30d record retention): fail here,
+  // before the client runs the passkey-PRF, when the invite is no longer signable.
+  if (env.sign_expires_at && Date.parse(env.sign_expires_at) < Date.now()) return res.status(410).json({ error: "invite_expired" });
 
   // ── ISSUE: one-shot record, server-side binding only, EX 300s.
   const activation_id = crypto.randomBytes(32).toString("base64url");

--- a/admin/server.js
+++ b/admin/server.js
@@ -1356,6 +1356,42 @@ api.get("/user/account/webauthn/credentials", authUser, async (req, res) => {
 });
 
 
+// POST /api/user/envelopes (authUser) — create a signing envelope SAME-ORIGIN
+// (replaces the old direct browser -> health.paramant.app POST, audit #2).
+// recipe_version 3 (domain-prefixed). Party 0 is the signer themselves (their
+// session email), so a self-sign (no recipients) still gets an envelope and
+// goes through the per-document activation gate (R018: every signature is a
+// passkey-PRF activation; no separate weaker self-sign route). The relay is
+// reached with the session's own pgp_ key as X-Api-Key.
+api.post("/user/envelopes", authUser, async (req, res) => {
+  const { user_id, email } = req.userSession;
+  const ip = req.headers["x-real-ip"] || req.socket?.remoteAddress || "unknown";
+  if (!(await webauthn.rateHit(redis(), `env:ip:${ip}`, 30, 900))) return res.status(429).json({ error: "rate_limited" });
+  const docHash = (req.body?.doc_hash || "").toString().trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(docHash)) return res.status(400).json({ error: "invalid_doc_hash" });
+  const recipients = Array.isArray(req.body?.recipients) ? req.body.recipients : [];
+  const originalFilename = (req.body?.original_filename || "").toString().slice(0, 200);
+  const creatorPublicKey = (req.body?.creator_public_key || "").toString();
+  // Party 0 = the signer (self), bound to their verified session email.
+  const parties = [{ label: ((req.body?.signer_label || "") + " (you)").trim(), email }];
+  for (const r of recipients) {
+    if (r && r.email) parties.push({ label: (r.label || "").toString().slice(0, 80), email: r.email.toString() });
+  }
+  try {
+    const rr = await fetch(`${SECTORS.health}/v2/envelopes`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Api-Key": user_id },
+      body: JSON.stringify({ doc_hash: docHash, parties, original_filename: originalFilename, binding_mode: "email", recipe_version: 3, creator_public_key: creatorPublicKey }),
+    });
+    const body = await rr.json().catch(() => ({}));
+    if (rr.status !== 200) return res.status(rr.status).json({ error: body.error || "envelope_create_failed" });
+    return res.json(body);   // { ok, envelope: { id, party_links:[{party_index, sign_path, invite_token}], ... } }
+  } catch (e) {
+    console.error("[user/envelopes POST]", e.message);
+    return res.status(502).json({ error: "relay_unreachable" });
+  }
+});
+
 // ── Per-document signing activation (R018: per-document PRF activation) ───────
 // A signature requires a fresh, server-issued, ONE-SHOT activation bound to
 // EXACTLY (account, envelope, party, doc-hash). Issuance authorizes BEFORE the
@@ -1676,6 +1712,27 @@ api.post("/user/account/signing-key", authUser, async (req, res) => {
     return res.status(relayRes.status).json(body);
   } catch (err) {
     console.error("[user/signing-key POST]", err.message);
+    return res.status(502).json({ error: "relay_unreachable" });
+  }
+});
+
+// POST /api/user/account/signing-key/tofu — TOFU enrol for a first-time invitee
+// (no TOTP), gated by an email-bound invite token instead. We forward the
+// SESSION's user_id (never a client-supplied id) + the invite context; the
+// relay self-verifies the token, that the party email == this account's email,
+// the one-shot, and the cross-account conflict. No invite context here means the
+// relay rejects — there is no TOTP-free enrol path without a valid invite.
+api.post("/user/account/signing-key/tofu", authUser, async (req, res) => {
+  const { user_id } = req.userSession;
+  const { pk_b64, label, envelope_id, party_index, invite_token } = req.body || {};
+  if (!pk_b64 || typeof pk_b64 !== "string") return res.status(400).json({ error: "missing_pk_b64" });
+  if (!envelope_id || !invite_token) return res.status(400).json({ error: "missing_invite_context" });
+  try {
+    const relayRes = await callRelay("/v2/user/signing-key/tofu", { user_id, pk_b64, label, envelope_id, party_index, invite_token }, "POST");
+    const body = await relayRes.json().catch(() => ({ error: "bad_relay_response" }));
+    return res.status(relayRes.status).json(body);
+  } catch (err) {
+    console.error("[user/signing-key/tofu POST]", err.message);
     return res.status(502).json({ error: "relay_unreachable" });
   }
 });

--- a/admin/server.js
+++ b/admin/server.js
@@ -1356,6 +1356,94 @@ api.get("/user/account/webauthn/credentials", authUser, async (req, res) => {
 });
 
 
+// ── Per-document signing activation (R018: per-document PRF activation) ───────
+// A signature requires a fresh, server-issued, ONE-SHOT activation bound to
+// EXACTLY (account, envelope, party, doc-hash). Issuance authorizes BEFORE the
+// client unlocks its key (no token -> no unlock). Consumption at submit is
+// ATOMIC via GETDEL, so two concurrent submits with the same token cannot both
+// pass (no TOCTOU). The relay never holds this token; the admin proxy verifies
+// + consumes it and forwards to the relay sign with PR-0's verified_email_hash.
+const SIGN_ACTIVATION_TTL = 300;   // 5 min: room for the human PRF gesture (Face ID, hesitation)
+
+// Canonical party-email hash — byte-identical to relay/envelope.js partyEmailHash.
+function partyEmailHashAdmin(email) {
+  const norm = (email || "").toString().trim().toLowerCase();
+  if (!norm) return "";
+  return crypto.createHash("sha3-256").update("paramant/party-email/v1\x00", "utf8").update(norm, "utf8").digest("hex");
+}
+
+// POST /api/user/sign/activation (authUser) — AUTHORIZE + ISSUE (pre-unlock gate).
+api.post("/user/sign/activation", authUser, async (req, res) => {
+  const { user_id, email } = req.userSession;          // identity from the session, never the client
+  const ip = req.headers["x-real-ip"] || req.socket?.remoteAddress || "unknown";
+  if (!(await webauthn.rateHit(redis(), `act:ip:${ip}`, 20, 900))) return res.status(429).json({ error: "rate_limited" });
+  if (!(await webauthn.rateHit(redis(), `act:acct:${webauthn.scopeHash(user_id)}`, 30, 900))) return res.status(429).json({ error: "rate_limited" });
+
+  const envelope_id = (req.body?.envelope_id || "").toString();
+  const party_index = parseInt(req.body?.party_index, 10);
+  const doc_hash = (req.body?.doc_hash || "").toString().trim().toLowerCase();
+  const invite_token = (req.body?.invite_token || "").toString();
+  if (!/^[A-Za-z0-9_-]{20,64}$/.test(envelope_id)) return res.status(400).json({ error: "invalid_envelope_id" });
+  if (!Number.isInteger(party_index) || party_index < 0) return res.status(400).json({ error: "invalid_party_index" });
+  if (!/^[0-9a-f]{64}$/.test(doc_hash)) return res.status(400).json({ error: "invalid_doc_hash" });
+
+  // ── AUTHORIZE before issuing (no token -> the client cannot proceed to unlock).
+  // The party view is token-gated (PR-0). Bind to: the invite capability (token),
+  // the signer's verified session email == the party's bound email, and the
+  // exact document hash == the envelope's doc_hash.
+  let env;
+  try {
+    const r = await callRelay(`/v2/envelopes/${encodeURIComponent(envelope_id)}?p=${party_index}&t=${encodeURIComponent(invite_token)}`, null, "GET");
+    if (r.status !== 200) return res.status(403).json({ error: "not_authorized" });
+    env = (await r.json()).envelope;
+  } catch (e) { return res.status(502).json({ error: "relay_unreachable" }); }
+  const sessionEmailHash = partyEmailHashAdmin(email);
+  if (!env || env.doc_hash !== doc_hash) return res.status(403).json({ error: "doc_hash_mismatch" });
+  if (!env.party || !sessionEmailHash || env.party.email_hash !== sessionEmailHash) return res.status(403).json({ error: "not_authorized" });
+
+  // ── ISSUE: one-shot record, server-side binding only, EX 300s.
+  const activation_id = crypto.randomBytes(32).toString("base64url");
+  await redis().set(`paramant:sign:activation:${activation_id}`,
+    JSON.stringify({ account_id: user_id, envelope_id, party_index, doc_hash, email_hash: sessionEmailHash, issued_at: Date.now() }),
+    { EX: SIGN_ACTIVATION_TTL });
+  res.json({ activation_id, email_hash: sessionEmailHash, recipe_version: env.recipe_version || 3, sign_domain: "paramant/parasign/doc/v1" });
+});
+
+// POST /api/user/sign/submit (authUser) — ATOMIC CONSUME + forward to relay sign.
+api.post("/user/sign/submit", authUser, async (req, res) => {
+  const { user_id } = req.userSession;
+  const { activation_id, signer_public_key, signature } = req.body || {};
+  if (!activation_id || typeof activation_id !== "string") return res.status(400).json({ error: "activation_id_required" });
+  if (!signer_public_key || !signature) return res.status(400).json({ error: "signature_required" });
+
+  // ── ATOMIC one-shot consume. GETDEL returns the record AND deletes it in one
+  // round-trip: of two concurrent submits with the same activation_id, exactly
+  // one receives the record; the other gets null and is rejected. No TOCTOU.
+  let raw;
+  try { raw = await redis().getDel(`paramant:sign:activation:${activation_id}`); }
+  catch (e) { return res.status(502).json({ error: "store_unavailable" }); }
+  if (!raw) return res.status(409).json({ error: "activation_invalid_or_used" });
+  let act; try { act = JSON.parse(raw); } catch { return res.status(409).json({ error: "activation_invalid_or_used" }); }
+
+  // The submit must come from the same account the activation was issued to.
+  if (act.account_id !== user_id) return res.status(403).json({ error: "account_mismatch" });
+
+  // Forward to the relay sign with PR-0's internal-auth email binding. The relay
+  // recomputes the v3 domain-prefixed message from its OWN stored envelope fields
+  // (doc_hash, party_index, email_hash) and verifies the ML-DSA-65 signature —
+  // doc/party/email are bound both by the consumed activation and by the message.
+  try {
+    const r = await callRelay(`/v2/envelopes/${encodeURIComponent(act.envelope_id)}/sign`, {
+      party_index: act.party_index, signer_public_key, signature, verified_email_hash: act.email_hash,
+    }, "POST");
+    const body = await r.json().catch(() => ({}));
+    if (r.status !== 200) return res.status(r.status).json({ error: body.error || "sign_failed" });
+    try { logAuditEvent("parasign_doc_signed", { account: String(user_id).slice(0, 12) + "…", envelope: String(act.envelope_id).slice(0, 10) + "…", party: act.party_index }); } catch {}
+    return res.json({ ok: true, signed_count: body.signed_count, party_count: body.party_count, status: body.status });
+  } catch (e) { return res.status(502).json({ error: "relay_unreachable" }); }
+});
+
+
 // POST /api/user/auth/request-totp-reset (public — two-stage: sends confirmation first)
 api.post("/user/auth/request-totp-reset", async (req, res) => {
   const { email, challenge_id, nonce } = req.body || {};

--- a/docs/adrs/R018-parasign-invite-webauthn.md
+++ b/docs/adrs/R018-parasign-invite-webauthn.md
@@ -201,6 +201,74 @@ Two lockout dimensions:
 Status: account-login guard + tests landed (this gate). The vault invariant is
 asserted within PR-B.
 
+## Signing-identity model (definitive — one level, per-document PRF activation)
+
+This is the binding acceptance criterion for the signing layer. It is distinct
+from the *login* factor model above: login authenticates a session; signing is a
+separate, per-document act.
+
+### Invariant
+Producing a ParaSign signature ALWAYS requires, together, every time, all four:
+1. a **verified email address** (the account, mailbox-proven);
+2. a **device-bound passkey** (WebAuthn, `userVerification: required`);
+3. a **per-document PRF activation** (fresh, for exactly this document); and
+4. an **ML-DSA-65** post-quantum signing key.
+
+There is NO email-only and NO TOTP-only signing path. **One strength level — no
+tiers** in signature strength.
+
+### Login ≠ signing (sole control; eIDAS SAP/SAM seam)
+A logged-in passkey *session* does NOT unlock the signing key. The key is
+activated only at the moment of deliberate signing, for exactly one document,
+and is **zeroized immediately after**. Authentication and signature-activation
+are distinct ceremonies; a session conveys no signing capability. This preserves
+the activation⇄key-use seam so an HSM-backed SAM can later sit between activation
+and key-use without reworking the flow.
+
+### Mail is a channel, not proof
+Invitations and per-document sign-requests are delivered by email (binding the
+request to an address), but email never authorizes a signature. The
+cryptographic activation is always the passkey-PRF for that specific document.
+
+### TOFU enrolment
+An invitee with no passkey registers one as part of the first signing: prove
+mailbox control (invite token) → register a passkey → that passkey-PRF activates
+the signature. No passkey ⇒ no signature.
+
+### Recovery / lockout (the vault-wrap invariant stays)
+The vault key carries two wraps: `passphrase` (PBKDF2, ALWAYS present) and
+`webauthn-prf` (added at passkey enrolment).
+- The signing *flow* is ALWAYS passkey-PRF-activation; the PRF wrap is what the
+  activation uses. The passphrase wrap is **not a second signing path**.
+- The passphrase is **break-glass for key material, not a weaker signature**: the
+  owner can always decrypt/export their own key bytes (sole control), so a
+  passkey/PRF failure on a device that still holds the vault never permanently
+  destroys the key. A signature produced that way is still full-strength
+  ML-DSA-65 — the model never weakens a signature, it only guarantees the owner
+  cannot lose their key.
+- **Device loss** (the IndexedDB vault is device-local): recover by importing the
+  passphrase-encrypted backup key file (downloadable at `/sign`) into the new
+  device's vault and re-wrapping with a new passkey; or enrol a fresh signing key
+  (new keypair + new passkey), with old signatures staying verifiable (revoke
+  keeps history — the user-signing.js model).
+- **Account/login recovery is separate** (another passkey, TOTP, or backup codes)
+  and never by itself yields a signature.
+- Forward: when the HSM-backed SAM lands, the key moves server-side under SAM
+  sole control; the client passphrase-export no longer applies and recovery
+  becomes SAM/operator-managed. The seam already accommodates that swap.
+
+### Build acceptance criteria (applied during implementation, not yet built)
+- `/v2/user/signing-key` use moves behind a **per-document PRF activation** (a
+  server-issued, one-shot, short-TTL activation token bound to doc-hash +
+  envelope-id + party-index + account_id), replacing pure-TOTP gating for the
+  *signing* act. (TOTP step-up remains for adding a login passkey.)
+- Every signed message carries a unique **domain-separation prefix**
+  (e.g. `paramant/parasign/doc/v1`), byte-identical across relay + SDK + core, to
+  close cross-context signature reuse (pentest H3).
+- **Enforce a strong passphrase at key enrolment**: the passphrase wrap is the
+  recovery floor, so the break-glass is only as strong as that passphrase. A weak
+  passphrase must be rejected at enrol time.
+
 ## Non-goals / boundary
 
 No HSM, no SAM, no SAP/SAD implementation, no eIDAS conformance work. This ADR

--- a/docs/adrs/R018-parasign-invite-webauthn.md
+++ b/docs/adrs/R018-parasign-invite-webauthn.md
@@ -269,6 +269,28 @@ The vault key carries two wraps: `passphrase` (PBKDF2, ALWAYS present) and
   recovery floor, so the break-glass is only as strong as that passphrase. A weak
   passphrase must be rejected at enrol time.
 
+### v3 sign-message wire format (BYTE-EXACT — relay + SDK + core MUST match)
+Any implementation that signs a ParaSign document MUST hash exactly these bytes,
+in this order, with NO separators other than the single NUL after the label.
+A one-byte deviation = a silent signature mismatch (cf. the SDK conformity
+report). Recipe v3:
+
+    message = SHA3-256(
+        utf8("paramant/parasign/doc/v1")   // domain label, 24 bytes, NO trailing slash/version drift
+      ‖ 0x00                                // single NUL separator
+      ‖ utf8(envelope_id)                   // base64url id string, as-is (NOT decoded)
+      ‖ hex_decode(doc_hash)                // 32 bytes (SHA3-256 of the document)
+      ‖ utf8(decimal(party_index))          // e.g. "0", "10" — ASCII decimal, no padding
+      ‖ hex_decode(party_email_hash)        // 32 bytes, or 0 bytes when the party has no email
+    )
+
+Reference implementations (this PR): `relay/envelope.js signMessageBytes(...,3)`
+and `frontend/js/parasign-signer.js buildDocSignMessage(...)` — verified to
+produce identical digests. `party_email_hash` itself is
+`SHA3-256("paramant/party-email/v1" ‖ 0x00 ‖ lower(trim(email)))` (see
+`partyEmailHash`). When the SDK/core gain signing, they take these two formats
+1:1; do not "improve" the byte layout.
+
 ## Non-goals / boundary
 
 No HSM, no SAM, no SAP/SAD implementation, no eIDAS conformance work. This ADR

--- a/docs/adrs/R018-parasign-invite-webauthn.md
+++ b/docs/adrs/R018-parasign-invite-webauthn.md
@@ -76,6 +76,15 @@ ActivatedSigner.dispose()                            // zeroize key material
   (32 random bytes). The emailed link is `/co-sign?env=<id>&p=<i>&t=<token>`.
   The token gates per-party detail and `markViewed`. Forwarding the email =
   forwarding the capability (documented residual risk, same as any e-sign link).
+- **Signing-invite TTL — 7 days, distinct from the 30-day record retention.** An
+  email-bound invite is *signable* only for `SIGN_INVITE_TTL_DAYS = 7` from the
+  envelope's `created_at` (≈ invite-send time). This is a separate, shorter window
+  than the 30-day envelope hash retention (`DEFAULT_TTL_DAYS`): the record stays
+  for 30d so a completed signature remains verifiable, but the *signable* window
+  closes at 7d. Enforced authoritatively in the relay `sign()` (`invite_expired`
+  → HTTP 410) and pre-checked in the admin activation gate via the
+  `sign_expires_at` field (fails before the passkey-PRF). Open/legacy envelopes
+  have no invite window — they are bounded only by the 30-day hash TTL.
 - **Authenticated-email binding (the ParaSign-grade layer):** the relay `/sign`
   endpoint is public and stateless, so it cannot know the caller's verified
   email. Binding-critical signs route through a new **admin proxy**

--- a/docs/adrs/R018-parasign-invite-webauthn.md
+++ b/docs/adrs/R018-parasign-invite-webauthn.md
@@ -291,6 +291,19 @@ produce identical digests. `party_email_hash` itself is
 `partyEmailHash`). When the SDK/core gain signing, they take these two formats
 1:1; do not "improve" the byte layout.
 
+### Non-ASCII canonicalization (cross-SDK signature safety)
+Surfaced by the SDK↔relay conformance suite: sdk-js serializes JSON strings as
+raw UTF-8 while sdk-py emits `\uXXXX` escapes, so any signed/canonicalized JSON
+payload containing non-ASCII (e.g. a signer label "José", "Müller") yields a
+**cross-SDK signature mismatch** — the same byte-identity class as the v3 domain
+prefix. Rule: anything that is signed or cross-SDK-canonicalized
+(sign-messages, receipts, envelope canonical forms) is **ASCII-only**, OR the
+single canonicalization divergence is resolved first. The v3 sign-message above
+is already safe by construction (it contains only the ASCII domain label, the
+base64url envelope id, ASCII decimal party index, and raw hash BYTES — never a
+raw name; emails are hashed, not embedded). Keep it that way: never fold a raw
+display string into a signed message; carry such fields outside the signature.
+
 ## Non-goals / boundary
 
 No HSM, no SAM, no SAP/SAD implementation, no eIDAS conformance work. This ADR

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -698,7 +698,7 @@
 </script>
 
 <script type="module">
-import { vaultAvailable, vaultList } from '/vendor/vault.js';
+import { vaultAvailable, vaultList } from '/vendor/vault.js?v=2';
 
 const escHtml = s => String(s == null ? '' : s)
   .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -126,18 +126,10 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   <div class="card">
     <div class="card-head"><div class="dot"></div><div class="card-head-title">Sign as <span id="me-label">party</span></div></div>
     <div class="card-body">
-      <div class="field">
-        <label class="label" for="signer-name">Your name (optional, baked into the signed acknowledgement)</label>
-        <input type="text" class="input" id="signer-name" maxlength="80" placeholder="e.g. Mick Beer" autocomplete="name">
-      </div>
-      <div class="field">
-        <label class="label" for="signer-key-src">Signing key</label>
-        <select class="select" id="signer-key-src">
-          <option value="ephemeral">Generate one-time key for this signature</option>
-        </select>
-      </div>
-      <button class="btn" id="sign-confirm" type="button" disabled>Sign acknowledgement</button>
+      <p class="sub" style="margin-bottom:12px">You sign with your passkey-protected ML-DSA-65 key - unlocked with Face ID / Touch ID / a security key the moment you sign, and never exported. The signature is bound to the email address this invite was sent to.</p>
       <div class="banner" id="sign-status" hidden></div>
+      <div id="sign-cta" style="margin-bottom:12px" hidden></div>
+      <button class="btn" id="sign-confirm" type="button" disabled>Sign this document</button>
     </div>
   </div>
 </div>
@@ -152,7 +144,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <dt>Envelope</dt><dd id="done-env-id">-</dd>
         <dt>Status</dt><dd id="done-status">-</dd>
         <dt>Progress</dt><dd id="done-progress">-</dd>
-        <dt>Your public key</dt><dd id="done-pk">-</dd>
+        <dt>Your key fingerprint</dt><dd id="done-pk">-</dd>
       </dl>
       <div style="margin-top:14px">
         <span class="tag green">Signed locally</span>
@@ -166,221 +158,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 
 </main>
 
-<script type="module" src="/vendor/parasign-bridge.js"></script>
-<script>
-const RELAY = 'https://health.paramant.app';
-
-// ---------- helpers ----------
-function $(id) { return document.getElementById(id); }
-function showStep(id) { document.querySelectorAll('.step').forEach(s => s.classList.remove('active')); $(id).classList.add('active'); }
-function showError(m) { $('error-msg').textContent = m; showStep('step-error'); }
-function toHex(u8) { let s=''; for (let i=0;i<u8.length;i++) s+=u8[i].toString(16).padStart(2,'0'); return s; }
-function toB64(u8) { let s=''; for (let i=0;i<u8.length;i++) s+=String.fromCharCode(u8[i]); return btoa(s); }
-function fromHex(s) { const out = new Uint8Array(s.length/2); for (let i=0;i<out.length;i++) out[i] = parseInt(s.slice(i*2,i*2+2),16); return out; }
-function escapeHtml(s){return String(s||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
-
-async function waitForParasign() {
-  if (window.__parasign) return window.__parasign;
-  return new Promise((resolve, reject) => {
-    const t = setTimeout(() => reject(new Error('Signing library failed to load')), 10000);
-    window.addEventListener('parasign:ready', () => { clearTimeout(t); resolve(window.__parasign); }, { once: true });
-  });
-}
-
-// ---------- state ----------
-let __envelope = null;
-let __partyIndex = -1;
-let __signerKey = null;
-let __hashMatches = null;
-
-// Reproduce the relay's sign-message: sha3_256(envelope.id || doc_hash || party_index_as_decimal)
-async function buildSignMessage(envId, docHash, partyIndex) {
-  const p = await waitForParasign();
-  const idBytes = new TextEncoder().encode(envId);
-  const hashBytes = fromHex(docHash);
-  const piBytes = new TextEncoder().encode(String(partyIndex));
-  const combined = new Uint8Array(idBytes.length + hashBytes.length + piBytes.length);
-  combined.set(idBytes, 0);
-  combined.set(hashBytes, idBytes.length);
-  combined.set(piBytes, idBytes.length + hashBytes.length);
-  return p.sha3_256(combined);
-}
-
-// ---------- boot ----------
-async function init() {
-  const params = new URLSearchParams(location.search);
-  const envId = (params.get('env') || '').trim();
-  const partyIndex = parseInt(params.get('p') || '', 10);
-  if (!envId || !Number.isInteger(partyIndex) || partyIndex < 0) {
-    return showError('Missing or invalid env / p query parameter.');
-  }
-  if (!/^[A-Za-z0-9_-]{20,64}$/.test(envId)) {
-    return showError('Envelope id is malformed.');
-  }
-  __partyIndex = partyIndex;
-
-  showStep('step-loading');
-  $('loading-msg').textContent = 'Fetching envelope...';
-
-  try {
-    const r = await fetch(RELAY + '/v2/envelopes/' + encodeURIComponent(envId));
-    if (r.status === 404) return showError('Envelope not found, expired, or already burned.');
-    if (r.status === 429) return showError('Rate-limited - too many requests from this address. Try again in a minute.');
-    if (!r.ok) return showError('Relay error: HTTP ' + r.status);
-    const data = await r.json();
-    __envelope = data.envelope;
-    if (__partyIndex >= __envelope.party_count) return showError('Party index out of range for this envelope.');
-
-    // Best-effort viewed-receipt; ignore failures so the rest of the page still loads.
-    try { await fetch(RELAY + '/v2/envelopes/' + encodeURIComponent(envId) + '/view', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ party_index: partyIndex }) }); } catch {}
-
-    renderEnvelope();
-    showStep('step-cosign');
-  } catch (e) {
-    showError(e.message || 'Network error');
-  }
-}
-
-function renderEnvelope() {
-  const e = __envelope;
-  $('env-id').textContent = e.id;
-  $('env-hash').textContent = e.doc_hash;
-  $('env-filename').textContent = e.original_filename || '(not provided)';
-  $('env-created').textContent = e.created_at || '-';
-  $('env-expires').textContent = e.expires_at || '-';
-  $('env-progress').textContent = e.signed_count + ' / ' + e.party_count + ' signed';
-  $('env-status').textContent = 'Status: ' + (e.status || '-');
-  const dot = $('env-status-dot');
-  dot.className = 'dot ' + (e.status === 'complete' ? '' : e.status === 'sent' ? 'amber' : '');
-
-  const list = $('parties-list');
-  list.innerHTML = '';
-  for (const p of e.parties) {
-    const row = document.createElement('div');
-    row.className = 'party-row' + (p.index === __partyIndex ? ' me' : '');
-    const label = escapeHtml(p.label || ('Party ' + (p.index + 1)));
-    const status = p.status === 'signed' ? 'SIGNED' : p.status === 'viewed' ? 'VIEWED' : 'PENDING';
-    row.innerHTML =
-      '<div class="party-idx">#' + p.index + '</div>' +
-      '<div class="party-label">' + label + (p.index === __partyIndex ? ' (you)' : '') + '</div>' +
-      '<div class="party-status ' + (p.status || 'pending') + '">' + status + '</div>';
-    list.appendChild(row);
-  }
-
-  const me = e.parties[__partyIndex] || {};
-  $('me-label').textContent = (me.label || 'party ' + (__partyIndex + 1));
-  if (me.status === 'signed') {
-    $('sign-status').hidden = false;
-    $('sign-status').className = 'banner ok';
-    $('sign-status').textContent = 'This slot has already been signed. Nothing to do.';
-    $('sign-confirm').disabled = true;
-    return;
-  }
-  $('sign-confirm').disabled = false;
-  $('sign-confirm').onclick = doSign;
-  $('verify-file').onchange = onVerifyFile;
-
-  // Populate vault keys if any.
-  populateVaultKeys().catch(() => {});
-}
-
-async function populateVaultKeys() {
-  const p = await waitForParasign();
-  if (!(await p.vaultAvailable())) return;
-  const items = await p.vaultList();
-  const sel = $('signer-key-src');
-  for (const it of items) {
-    const opt = document.createElement('option');
-    opt.value = 'vault:' + it.id;
-    opt.textContent = 'Vault: ' + (it.label || (it.pk_hash || '').slice(0, 12));
-    sel.appendChild(opt);
-  }
-}
-
-async function onVerifyFile(ev) {
-  const f = ev.target.files && ev.target.files[0];
-  if (!f) return;
-  const p = await waitForParasign();
-  const buf = new Uint8Array(await f.arrayBuffer());
-  const h = toHex(p.sha3_256(buf));
-  __hashMatches = (h === __envelope.doc_hash);
-  const b = $('verify-result');
-  b.hidden = false;
-  if (__hashMatches) {
-    b.className = 'banner ok';
-    b.textContent = 'Hash matches. This file is the same one the creator hashed.';
-  } else {
-    b.className = 'banner err';
-    b.textContent = 'Hash mismatch. The file you chose is different from the one in this envelope. Computed: ' + h.slice(0, 16) + '... Expected: ' + __envelope.doc_hash.slice(0, 16) + '...';
-  }
-}
-
-async function ensureSignerKey() {
-  const p = await waitForParasign();
-  const sel = $('signer-key-src').value;
-  if (sel === 'ephemeral') {
-    const seed = crypto.getRandomValues(new Uint8Array(32));
-    const kp = p.ml_dsa65.keygen(seed);
-    __signerKey = { secretKey: kp.secretKey, publicKey: kp.publicKey };
-    return __signerKey;
-  }
-  if (sel.startsWith('vault:')) {
-    const id = parseInt(sel.slice('vault:'.length), 10);
-    const pass = prompt('Passphrase to unlock the vault key:');
-    if (!pass) throw new Error('Vault unlock cancelled');
-    const unlocked = await p.vaultUnlock(id, pass);
-    __signerKey = { secretKey: unlocked.secretKey, publicKey: unlocked.publicKey };
-    return __signerKey;
-  }
-  throw new Error('Unsupported key source');
-}
-
-async function doSign() {
-  if (__hashMatches === false) {
-    if (!confirm('The file you uploaded does not match the envelope hash. Sign anyway? You will be signing a hash that does not match your local document.')) return;
-  }
-  $('sign-confirm').disabled = true;
-  $('sign-status').hidden = false;
-  $('sign-status').className = 'banner';
-  $('sign-status').textContent = 'Signing in browser...';
-
-  try {
-    const p = await waitForParasign();
-    const key = await ensureSignerKey();
-    const msg = await buildSignMessage(__envelope.id, __envelope.doc_hash, __partyIndex);
-    const signature = p.ml_dsa65.sign(key.secretKey, msg);
-
-    $('sign-status').textContent = 'Submitting signature to relay...';
-    const r = await fetch(RELAY + '/v2/envelopes/' + encodeURIComponent(__envelope.id) + '/sign', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        party_index: __partyIndex,
-        signer_public_key: toB64(key.publicKey),
-        signature: toB64(signature),
-      }),
-    });
-    const data = await r.json().catch(() => ({}));
-    if (r.status === 429) { throw new Error('Rate-limited. Wait a minute before retrying.'); }
-    if (r.status === 410) { throw new Error('Envelope is already complete; no more signatures accepted.'); }
-    if (r.status === 409) { throw new Error('This slot already holds a different signature.'); }
-    if (r.status === 400) { throw new Error(data.error || 'Bad request'); }
-    if (r.status === 404) { throw new Error('Envelope or party slot not found.'); }
-    if (!r.ok) { throw new Error('Relay error: HTTP ' + r.status); }
-
-    $('done-env-id').textContent = __envelope.id;
-    $('done-status').textContent = data.status + (data.idempotent ? ' (idempotent re-submit)' : '');
-    $('done-progress').textContent = data.signed_count + ' / ' + data.party_count + ' signed';
-    $('done-pk').textContent = toHex(p.sha3_256(key.publicKey)).slice(0, 32) + '...';
-    showStep('step-done');
-  } catch (e) {
-    $('sign-status').className = 'banner err';
-    $('sign-status').textContent = e.message || 'Signing failed';
-    $('sign-confirm').disabled = false;
-  }
-}
-
-init();
-</script>
+<script type="module" src="/co-sign.js?v=1"></script>
 </body>
 </html>

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -18,7 +18,7 @@
 // the view receipt. The signing path itself is same-origin via the admin
 // (/api/user/sign/*), bound to the logged-in invitee session.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey } from '/js/parasign-signer.js';
+import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=2';
 
 const RELAY_PUBLIC = 'https://health.paramant.app';
 

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -1,0 +1,244 @@
+// Co-sign flow on /co-sign — a recipient signs an existing multi-party envelope.
+//
+// v3-only. Co-sign goes through the SAME per-document passkey-PRF activation
+// chain as /sign's doSign() (ADR R018):
+//   resolvePasskeySigningKey()      public vault metadata, NO unlock
+//   -> requestSignActivation()      admin authorizes: invited email == party email,
+//                                   doc hash matches; mints a 300s one-shot token
+//   -> LocalVaultSigner.activate()  passkey-PRF unlock -> ActivatedSigner
+//   -> buildDocSignMessage() (v3)   domain-prefixed message, byte-identical to relay
+//      + signer.sign() + dispose()  the secret key lives ONLY in the signer; zeroized
+//   -> submitSignature()            admin consumes the activation atomically (GETDEL)
+//                                   + forwards to the relay sign with the email binding
+//
+// The plain-key / ephemeral / passphrase-vault path (and the audit-#1 parseInt
+// vault bug) is gone: the secret never exists outside the ActivatedSigner.
+//
+// The ONLY relay-host reference is the public, read-only envelope status fetch +
+// the view receipt. The signing path itself is same-origin via the admin
+// (/api/user/sign/*), bound to the logged-in invitee session.
+import { sha3_256 } from '/vendor/paramant-pqc.js';
+import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey } from '/js/parasign-signer.js';
+
+const RELAY_PUBLIC = 'https://health.paramant.app';
+
+// ---------- helpers ----------
+function $(id) { return document.getElementById(id); }
+function showStep(id) { document.querySelectorAll('.step').forEach((s) => s.classList.remove('active')); $(id).classList.add('active'); }
+function showError(m) { $('error-msg').textContent = m; showStep('step-error'); }
+function toHex(u8) { let s = ''; for (let i = 0; i < u8.length; i++) s += u8[i].toString(16).padStart(2, '0'); return s; }
+function toB64(u8) { let s = ''; for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]); return btoa(s); }
+function escapeHtml(s) { return String(s || '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])); }
+
+// ---------- state ----------
+let __envelope = null;
+let __partyIndex = -1;
+let __inviteToken = '';
+let __session = null;       // { email } when logged in as the invited recipient
+let __signKey = null;       // { vaultId, pk_b64, fingerprint } — PUBLIC metadata only
+let __hashMatches = null;
+
+// ---------- boot ----------
+async function init() {
+  const params = new URLSearchParams(location.search);
+  const envId = (params.get('env') || '').trim();
+  const partyIndex = parseInt(params.get('p') || '', 10);
+  __inviteToken = (params.get('t') || '').trim();
+  if (!envId || !Number.isInteger(partyIndex) || partyIndex < 0) {
+    return showError('Missing or invalid env / p query parameter.');
+  }
+  if (!/^[A-Za-z0-9_-]{20,64}$/.test(envId)) {
+    return showError('Envelope id is malformed.');
+  }
+  __partyIndex = partyIndex;
+
+  showStep('step-loading');
+  $('loading-msg').textContent = 'Fetching envelope...';
+
+  try {
+    const r = await fetch(RELAY_PUBLIC + '/v2/envelopes/' + encodeURIComponent(envId));
+    if (r.status === 404) return showError('Envelope not found, expired, or already burned.');
+    if (r.status === 429) return showError('Rate-limited - too many requests from this address. Try again in a minute.');
+    if (!r.ok) return showError('Relay error: HTTP ' + r.status);
+    const data = await r.json();
+    __envelope = data.envelope;
+    if (__partyIndex >= __envelope.party_count) return showError('Party index out of range for this envelope.');
+
+    // Best-effort viewed-receipt (token-gated for email-bound envelopes); ignore failures.
+    try {
+      await fetch(RELAY_PUBLIC + '/v2/envelopes/' + encodeURIComponent(envId) + '/view', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ party_index: partyIndex, token: __inviteToken }),
+      });
+    } catch {}
+
+    renderEnvelope();
+    await prepareSigning();
+    showStep('step-cosign');
+  } catch (e) {
+    showError(e.message || 'Network error');
+  }
+}
+
+function renderEnvelope() {
+  const e = __envelope;
+  $('env-id').textContent = e.id;
+  $('env-hash').textContent = e.doc_hash;
+  $('env-filename').textContent = e.original_filename || '(not provided)';
+  $('env-created').textContent = e.created_at || '-';
+  $('env-expires').textContent = e.expires_at || '-';
+  $('env-progress').textContent = e.signed_count + ' / ' + e.party_count + ' signed';
+  $('env-status').textContent = 'Status: ' + (e.status || '-');
+  const dot = $('env-status-dot');
+  dot.className = 'dot ' + (e.status === 'complete' ? '' : e.status === 'sent' ? 'amber' : '');
+
+  const list = $('parties-list');
+  list.innerHTML = '';
+  for (const p of e.parties) {
+    const row = document.createElement('div');
+    row.className = 'party-row' + (p.index === __partyIndex ? ' me' : '');
+    const label = escapeHtml(p.label || ('Party ' + (p.index + 1)));
+    const status = p.status === 'signed' ? 'SIGNED' : p.status === 'viewed' ? 'VIEWED' : 'PENDING';
+    row.innerHTML =
+      '<div class="party-idx">#' + p.index + '</div>' +
+      '<div class="party-label">' + label + (p.index === __partyIndex ? ' (you)' : '') + '</div>' +
+      '<div class="party-status ' + (p.status || 'pending') + '">' + status + '</div>';
+    list.appendChild(row);
+  }
+
+  const me = e.parties[__partyIndex] || {};
+  $('me-label').textContent = (me.label || 'party ' + (__partyIndex + 1));
+  $('verify-file').onchange = onVerifyFile;
+}
+
+// ---------- preconditions: the v3 chain needs a logged-in invitee + a passkey key ----------
+function setStatus(kind, msg) {
+  const b = $('sign-status');
+  b.hidden = false;
+  b.className = 'banner' + (kind ? ' ' + kind : '');
+  b.textContent = msg;
+}
+function showCta(html) {
+  const cta = $('sign-cta');
+  cta.hidden = false;
+  cta.innerHTML = html;
+}
+
+async function loadSession() {
+  try {
+    const r = await fetch('/api/user/account', { credentials: 'include' });
+    if (!r.ok) return null;
+    const d = await r.json().catch(() => null);
+    if (!d) return null;
+    const email = d.email || (d.account && d.account.email) || '';
+    return { email };
+  } catch { return null; }
+}
+
+async function prepareSigning() {
+  const me = __envelope.parties[__partyIndex] || {};
+  if (me.status === 'signed') {
+    setStatus('ok', 'This slot has already been signed. Nothing to do.');
+    return;
+  }
+
+  // GATE 1 — logged in. The activation endpoint enforces (server-side) that the
+  // session email equals THIS party's bound email; here we only route an invitee
+  // with no session to sign in first.
+  __session = await loadSession();
+  if (!__session) {
+    setStatus('warn', 'Sign in as the recipient this invite was sent to, then return here to sign.');
+    const ret = encodeURIComponent(location.pathname + location.search);
+    showCta('<a class="btn" href="/auth/login?return=' + ret + '">Sign in to continue</a>');
+    return;
+  }
+
+  // GATE 2 — has a passkey signing key (stuk 1). For a first-time invitee with no
+  // passkey, stuk 2 wires the inline TOFU enrol here; for now, point at /account.
+  try {
+    __signKey = await resolvePasskeySigningKey();
+  } catch (e) {
+    if (e && e.code === 'no_signing_passkey') {
+      setStatus('warn', 'Signed in as ' + escapeHtml(__session.email || 'your account') + ', but this device has no signing passkey yet. Set one up, then return to this link.');
+      showCta('<a class="btn btn-outline" href="/account">Set up a signing passkey</a>');
+    } else {
+      setStatus('err', e.message || 'Could not check your signing key.');
+    }
+    return;
+  }
+
+  setStatus('', 'Signed in as ' + escapeHtml(__session.email || 'your account') + '. You will sign with your passkey-protected key (fingerprint ' + escapeHtml(__signKey.fingerprint) + ').');
+  $('sign-confirm').disabled = false;
+  $('sign-confirm').onclick = doSign;
+}
+
+async function onVerifyFile(ev) {
+  const f = ev.target.files && ev.target.files[0];
+  if (!f) return;
+  const buf = new Uint8Array(await f.arrayBuffer());
+  const h = toHex(sha3_256(buf));
+  __hashMatches = (h === __envelope.doc_hash);
+  const b = $('verify-result');
+  b.hidden = false;
+  if (__hashMatches) {
+    b.className = 'banner ok';
+    b.textContent = 'Hash matches. This file is the same one the creator hashed.';
+  } else {
+    b.className = 'banner err';
+    b.textContent = 'Hash mismatch. The file you chose is different from the one in this envelope. Computed: ' + h.slice(0, 16) + '... Expected: ' + __envelope.doc_hash.slice(0, 16) + '...';
+  }
+}
+
+// ---------- the v3 passkey-PRF signing chain (same gate as /sign doSign) ----------
+async function doSign() {
+  if (__hashMatches === false) {
+    if (!confirm('The file you uploaded does not match the envelope hash. Sign anyway? You will be signing a hash that does not match your local document.')) return;
+  }
+  $('sign-confirm').disabled = true;
+  $('sign-cta').hidden = true;
+
+  try {
+    // 1) Per-document activation (authorize -> one-shot token). The admin checks
+    //    the invited email == this party's email and the doc hash, then mints a
+    //    300s one-shot activation. No token -> the client cannot proceed to unlock.
+    setStatus('', 'Requesting signing authorization...');
+    const act = await requestSignActivation({
+      envelopeId: __envelope.id,
+      partyIndex: __partyIndex,
+      docHash: __envelope.doc_hash,
+      inviteToken: __inviteToken,
+    });
+
+    // 2) Passkey-PRF unlock + sign of the v3 domain-prefixed message. The secret
+    //    key lives ONLY inside the ActivatedSigner and is zeroized by dispose().
+    setStatus('', 'Confirm with your passkey (Face ID / Touch ID / security key)...');
+    const signer = await new LocalVaultSigner().activate({ vaultId: __signKey.vaultId, rpId: location.hostname });
+    let sigB64;
+    try {
+      const message = buildDocSignMessage({ envelopeId: __envelope.id, docHash: __envelope.doc_hash, partyIndex: __partyIndex, emailHash: act.email_hash });
+      sigB64 = toB64(await signer.sign(message));
+    } finally {
+      signer.dispose();   // zeroize — the secret never outlives this block
+    }
+
+    // 3) Submit. The admin consumes the activation atomically (GETDEL) and
+    //    forwards to the relay sign with the verified email binding.
+    setStatus('', 'Recording your signature...');
+    const data = await submitSignature({ activationId: act.activation_id, signerPublicKey: signer.publicKey, signature: sigB64 });
+
+    $('done-env-id').textContent = __envelope.id;
+    $('done-status').textContent = data.status || '-';
+    $('done-progress').textContent = (data.signed_count != null ? data.signed_count : '?') + ' / ' + (data.party_count != null ? data.party_count : __envelope.party_count) + ' signed';
+    $('done-pk').textContent = __signKey.fingerprint;
+    showStep('step-done');
+  } catch (e) {
+    let msg = (e && e.message) ? e.message : String(e);
+    if (e && e.status === 401) msg = 'Your session expired. Sign in again as the invited recipient, then retry.';
+    else if (e && e.status === 403) msg = 'This invite is bound to a different email address. Sign in with the address the invite was sent to.';
+    else if (e && e.status === 409) msg = 'That signing authorization was already used or expired. Reload the page and try again.';
+    setStatus('err', msg);
+    $('sign-confirm').disabled = false;
+  }
+}
+
+init();

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -235,6 +235,7 @@ async function doSign() {
     let msg = (e && e.message) ? e.message : String(e);
     if (e && e.status === 401) msg = 'Your session expired. Sign in again as the invited recipient, then retry.';
     else if (e && e.status === 403) msg = 'This invite is bound to a different email address. Sign in with the address the invite was sent to.';
+    else if (e && e.status === 410) msg = 'This signing invite has expired (invites are valid for 7 days). Ask the sender for a new link.';
     else if (e && e.status === 409) msg = 'That signing authorization was already used or expired. Reload the page and try again.';
     setStatus('err', msg);
     $('sign-confirm').disabled = false;

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -5,7 +5,7 @@
 // Tomorrow a RemoteSamSigner (SAP -> HSM-backed SAM) drops in behind the same
 // interface without touching callers. Self-hosted deps only (CSP 'self').
 import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
-import { vaultGetPrfWrapInfo, vaultUnlockPrf } from '/vendor/vault.js';
+import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultStore, vaultAddPrfWrap } from '/vendor/vault.js';
 
 // Byte-identical to relay/envelope.js SIGN_DOMAIN_DOC (recipe v3). Keep in sync
 // across relay + SDK + core.
@@ -29,6 +29,16 @@ function b64urlToBytes(s) {
   const u = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) u[i] = bin.charCodeAt(i);
   return u;
+}
+function b64EncodeStd(u8) {
+  let s = '';
+  for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]);
+  return btoa(s);
+}
+function toHex(u8) {
+  let s = '';
+  for (let i = 0; i < u8.length; i++) s += u8[i].toString(16).padStart(2, '0');
+  return s;
 }
 
 // Reconstruct EXACTLY the relay's recipe-v3 sign-message:
@@ -109,4 +119,43 @@ export async function signDocumentWithPasskey({ vaultId, rpId, envelopeId, docHa
   } finally {
     active.dispose();
   }
+}
+
+// ── TOFU enrol-as-needed — a SEPARATE sub-step (ADR R018) ────────────────────
+// Runs ONCE for a first-time signer who has no passkey/PRF wrap yet, BEFORE the
+// per-document activation-gate. It is deliberately NOT fused with activate()/
+// sign(): this moment combines passkey registration + ML-DSA key enrolment, so
+// it must be auditable as one distinct block. Three explicit stages; the signing
+// of an actual document is a separate act (signDocumentWithPasskey) afterwards.
+//
+// WebAuthn create()/get() and the server enrol call are injected as callbacks so
+// the ceremony plumbing stays out of this orchestration:
+//   registerPasskey()              -> { credentialId }              (WebAuthn create + server store)
+//   evalNewPrf({credentialId,prfSalt}) -> Uint8Array prfOutput      (WebAuthn get, prf eval=salt)
+//   enrolPublicKey({pk_b64,pk_hash,label})                         (server: bind pubkey to account)
+export async function enrolSigningPasskey({ label, passphrase, registerPasskey, evalNewPrf, enrolPublicKey }) {
+  // ── stage 1: key material + recovery floor (passphrase wrap; enforced strong) ──
+  const seed = crypto.getRandomValues(new Uint8Array(32));
+  const kp = ml_dsa65.keygen(seed);
+  const pk_b64 = b64EncodeStd(kp.publicKey);
+  const pk_hash = toHex(sha3_256(kp.publicKey));
+  try {
+    await vaultStore({ alg: 'ML-DSA-65', label: label || null, pk_b64, pk_hash, secretKeyBytes: kp.secretKey, passphrase });
+
+    // ── stage 2: register the passkey, run PRF with a fresh salt, add prf wrap ──
+    const { credentialId } = await registerPasskey();
+    const prfSalt = crypto.getRandomValues(new Uint8Array(16));   // the eval salt; stored in the wrap
+    const prfOutput = await evalNewPrf({ credentialId, prfSalt });
+    try {
+      await vaultAddPrfWrap({ pk_hash, secretKeyBytes: kp.secretKey, credentialId, prfSalt, prfOutput });
+    } finally {
+      prfOutput.fill(0);
+    }
+
+    // ── stage 3: bind the public key to the account (server) ──
+    await enrolPublicKey({ pk_b64, pk_hash, label: label || null });
+  } finally {
+    kp.secretKey.fill(0);   // zeroize the plaintext key once both wraps + enrol are done
+  }
+  return { pk_hash, pk_b64 };
 }

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -5,7 +5,7 @@
 // Tomorrow a RemoteSamSigner (SAP -> HSM-backed SAM) drops in behind the same
 // interface without touching callers. Self-hosted deps only (CSP 'self').
 import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
-import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultStore, vaultAddPrfWrap, vaultAvailable, vaultList } from '/vendor/vault.js';
+import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultStore, vaultAddPrfWrap, vaultAvailable, vaultList } from '/vendor/vault.js?v=2';
 
 // Byte-identical to relay/envelope.js SIGN_DOMAIN_DOC (recipe v3). Keep in sync
 // across relay + SDK + core.

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -5,7 +5,7 @@
 // Tomorrow a RemoteSamSigner (SAP -> HSM-backed SAM) drops in behind the same
 // interface without touching callers. Self-hosted deps only (CSP 'self').
 import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
-import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultStore, vaultAddPrfWrap } from '/vendor/vault.js';
+import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultStore, vaultAddPrfWrap, vaultAvailable, vaultList } from '/vendor/vault.js';
 
 // Byte-identical to relay/envelope.js SIGN_DOMAIN_DOC (recipe v3). Keep in sync
 // across relay + SDK + core.
@@ -54,6 +54,27 @@ export function buildDocSignMessage({ envelopeId, docHash, partyIndex, emailHash
     enc.encode(String(partyIndex)),
     hexToBytes(emailHash || ''),
   ]));
+}
+
+// v3-only signing-key resolution — the SINGLE definition of "what a signing key
+// is", shared by /sign (self-sign) and /co-sign (recipient). The signing key is
+// the account's passkey-protected ML-DSA-65 key in the vault. We read its PUBLIC
+// half (pk_b64/pk_hash) from vault metadata WITHOUT unlocking; the secret is only
+// unlocked by the per-document passkey-PRF activation (LocalVaultSigner.activate,
+// the explicit step-2 action). No ephemeral/file/passphrase key source. If no
+// passkey signing key is enrolled, this throws with code 'no_signing_passkey' so
+// the caller can branch to the TOFU enrol sub-step (stuk 2 UI / enrolSigningPasskey).
+export async function resolvePasskeySigningKey() {
+  if (!(await vaultAvailable())) throw new Error('This browser cannot store signing keys (IndexedDB/WebCrypto unavailable).');
+  const keys = await vaultList();
+  const usable = keys.filter((k) => (k.kekSources || []).includes('webauthn-prf'));
+  if (usable.length === 0) {
+    const e = new Error('No passkey signing key on this device yet. Enrol a passkey for signing first.');
+    e.code = 'no_signing_passkey';
+    throw e;
+  }
+  const k = usable[0];   // single signing identity for now
+  return { vaultId: k.id, pk_b64: k.pk_b64, fingerprint: (k.pk_hash || '').slice(0, 16) };
 }
 
 // Reproduce the PRF output by running a WebAuthn get() with the SAME salt that
@@ -158,4 +179,26 @@ export async function enrolSigningPasskey({ label, passphrase, registerPasskey, 
     kp.secretKey.fill(0);   // zeroize the plaintext key once both wraps + enrol are done
   }
   return { pk_hash, pk_b64 };
+}
+
+// ── Same-origin admin calls for the per-document signing chain (R018) ────────
+async function _postJSON(url, body) {
+  const r = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body || {}), credentials: 'include' });
+  let data = null; try { data = await r.json(); } catch { /* non-JSON */ }
+  if (!r.ok) { const e = new Error((data && data.error) || ('http_' + r.status)); e.status = r.status; e.data = data; throw e; }
+  return data;
+}
+// Create the envelope (party 0 = self). Returns { envelope: { id, party_links, ... } }.
+export function createSigningEnvelope({ docHash, recipients, originalFilename, signerLabel, creatorPublicKey }) {
+  return _postJSON('/api/user/envelopes', { doc_hash: docHash, recipients: recipients || [], original_filename: originalFilename, signer_label: signerLabel, creator_public_key: creatorPublicKey });
+}
+// Authorize + issue the per-document activation (pre-unlock gate). Returns
+// { activation_id, email_hash, recipe_version }.
+export function requestSignActivation({ envelopeId, partyIndex, docHash, inviteToken }) {
+  return _postJSON('/api/user/sign/activation', { envelope_id: envelopeId, party_index: partyIndex, doc_hash: docHash, invite_token: inviteToken });
+}
+// Submit the signature; the admin consumes the activation atomically + forwards
+// to the relay. Returns { ok, signed_count, party_count, status }.
+export function submitSignature({ activationId, signerPublicKey, signature }) {
+  return _postJSON('/api/user/sign/submit', { activation_id: activationId, signer_public_key: signerPublicKey, signature });
 }

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -1,0 +1,112 @@
+// ParaSigner — the activation⇄key-use seam (ADR R018). The generic signing flow
+// only ever calls: activate() -> sign(message) -> dispose(). It NEVER sees the
+// raw ML-DSA secret key. Today this is LocalVaultSigner (a WebAuthn-PRF
+// activation unlocks the IndexedDB vault key, signs one document, zeroizes).
+// Tomorrow a RemoteSamSigner (SAP -> HSM-backed SAM) drops in behind the same
+// interface without touching callers. Self-hosted deps only (CSP 'self').
+import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
+import { vaultGetPrfWrapInfo, vaultUnlockPrf } from '/vendor/vault.js';
+
+// Byte-identical to relay/envelope.js SIGN_DOMAIN_DOC (recipe v3). Keep in sync
+// across relay + SDK + core.
+export const SIGN_DOMAIN_DOC = 'paramant/parasign/doc/v1';
+
+function hexToBytes(hex) {
+  const h = (hex || '').toString();
+  const out = new Uint8Array(h.length >> 1);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(h.substr(i * 2, 2), 16);
+  return out;
+}
+function concatBytes(parts) {
+  let n = 0; for (const p of parts) n += p.length;
+  const out = new Uint8Array(n); let o = 0;
+  for (const p of parts) { out.set(p, o); o += p.length; }
+  return out;
+}
+function b64urlToBytes(s) {
+  const t = (s || '').replace(/-/g, '+').replace(/_/g, '/');
+  const bin = atob(t + '='.repeat((4 - (t.length % 4)) % 4));
+  const u = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) u[i] = bin.charCodeAt(i);
+  return u;
+}
+
+// Reconstruct EXACTLY the relay's recipe-v3 sign-message:
+//   sha3_256("paramant/parasign/doc/v1" || 0x00 || envId || docHash || pi || emailHash)
+// This is what binds a signature to THIS document (doc_hash), party and email.
+export function buildDocSignMessage({ envelopeId, docHash, partyIndex, emailHash }) {
+  const enc = new TextEncoder();
+  return sha3_256(concatBytes([
+    enc.encode(SIGN_DOMAIN_DOC),
+    new Uint8Array([0]),
+    enc.encode(String(envelopeId)),
+    hexToBytes(docHash),
+    enc.encode(String(partyIndex)),
+    hexToBytes(emailHash || ''),
+  ]));
+}
+
+// Reproduce the PRF output by running a WebAuthn get() with the SAME salt that
+// was stored in the wrap at enrol (PRF output is deterministic per
+// (credential, salt), independent of the challenge).
+async function evalPrf({ rpId, credentialIdB64url, prfSaltB64url }) {
+  const assertion = await navigator.credentials.get({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      rpId,
+      allowCredentials: [{ type: 'public-key', id: b64urlToBytes(credentialIdB64url) }],
+      userVerification: 'required',
+      extensions: { prf: { eval: { first: b64urlToBytes(prfSaltB64url) } } },
+    },
+  });
+  const first = assertion.getClientExtensionResults()?.prf?.results?.first;
+  if (!first) throw new Error('passkey returned no PRF result (PRF unsupported on this authenticator)');
+  return new Uint8Array(first);
+}
+
+// One activated key. The raw secret lives ONLY in the private field and is
+// zeroized by dispose() immediately after signing — no key material lingers.
+class ActivatedSigner {
+  #sk; #pkB64;
+  constructor(secretKeyBytes, publicKeyB64) { this.#sk = secretKeyBytes; this.#pkB64 = publicKeyB64; }
+  get publicKey() { return this.#pkB64; }              // base64 (for signer_public_key)
+  async sign(message) {                                // KEY-USE — the replaceable step
+    if (!this.#sk) throw new Error('signer disposed');
+    return ml_dsa65.sign(this.#sk, message);
+  }
+  dispose() {                                          // zeroize
+    if (this.#sk) { this.#sk.fill(0); this.#sk = null; }
+  }
+}
+
+export class LocalVaultSigner {
+  // ACTIVATION — the replaceable step. WebAuthn-PRF unlocks the vault key.
+  // Returns an ActivatedSigner; the caller signs exactly one document then
+  // calls dispose(). The PRF output (key-deriving material) is wiped here.
+  async activate({ vaultId, rpId }) {
+    const info = await vaultGetPrfWrapInfo(vaultId);
+    if (!info) throw new Error('no passkey-PRF wrap on this key — enrol a passkey first');
+    const prfOutput = await evalPrf({ rpId, credentialIdB64url: info.credentialId, prfSaltB64url: info.prfSalt });
+    let unlocked;
+    try {
+      unlocked = await vaultUnlockPrf(vaultId, { prfOutput, credentialId: info.credentialId });
+    } finally {
+      prfOutput.fill(0);
+    }
+    return new ActivatedSigner(unlocked.secretKeyBytes, unlocked.pk_b64);
+  }
+}
+
+// Convenience: full per-document activation. activate -> sign(doc message) ->
+// dispose, returning the signature + public key for /api/user/sign/submit.
+// The raw key is never returned and is zeroized even if signing throws.
+export async function signDocumentWithPasskey({ vaultId, rpId, envelopeId, docHash, partyIndex, emailHash }) {
+  const active = await new LocalVaultSigner().activate({ vaultId, rpId });
+  try {
+    const message = buildDocSignMessage({ envelopeId, docHash, partyIndex, emailHash });
+    const signature = await active.sign(message);
+    return { signer_public_key: active.publicKey, signature };
+  } finally {
+    active.dispose();
+  }
+}

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -11,7 +11,7 @@
 // sign path. Signing goes through the passkey-PRF activation chain (LocalVaultSigner
 // in parasign-signer.js); sha3_256 stays for document hashing only.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey } from '/js/parasign-signer.js';
+import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=2';
 
 // Read-only public relay host, used ONLY for the "view envelope status" link on
 // the done screen. The signing path itself is same-origin via the admin

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -7,10 +7,16 @@
 // /vendor/pdfjs (preview render) and /vendor/pdf-lib (stamp baking). All
 // same-origin; CSP script-src 'self' remains intact.
 
-import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
-import { vaultAvailable, vaultList, vaultUnlock } from '/vendor/vault.js';
+// v3-only signing: ml_dsa65.sign + the passphrase vaultUnlock are GONE from the
+// sign path. Signing goes through the passkey-PRF activation chain (LocalVaultSigner
+// in parasign-signer.js); sha3_256 stays for document hashing only.
+import { sha3_256 } from '/vendor/paramant-pqc.js';
+import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey } from '/js/parasign-signer.js';
 
-const RELAY = 'https://health.paramant.app';
+// Read-only public relay host, used ONLY for the "view envelope status" link on
+// the done screen. The signing path itself is same-origin via the admin
+// (/api/user/sign/*, /api/user/envelopes) — no relay host hardcoded there.
+const RELAY_PUBLIC = 'https://health.paramant.app';
 
 // ====================================================================
 // State
@@ -27,9 +33,7 @@ const state = {
   stamp: null,           // PDF mode: bottom-left PDF points. Image mode: top-left image pixels.
   signer: {
     name: '',
-    keySrc: 'ephemeral',
-    key: null,           // { secretKey, publicKey }
-    apiKey: '',
+    fingerprint: '',       // public passkey-key fingerprint, resolved before sign (display only)
     sigStyle: 'typed',     // 'typed' | 'drawn' | 'image'
     sigImageBytes: null,   // Uint8Array (PNG for drawn, PNG/JPG for image)
     sigImageType: null,    // 'png' | 'jpg'
@@ -38,7 +42,7 @@ const state = {
   },
   recipients: [],        // [{label, email}]; if empty -> single-party local sign only
   envelope: null,        // populated when recipients.length > 0 after POST /v2/envelopes
-  result: null,          // { stampedBytes?, envelope, fingerprint, notary? }
+  result: null,          // { stampedBytes?, envelope, fingerprint }
 };
 
 // ====================================================================
@@ -316,19 +320,32 @@ async function initStepIdentity() {
   initDrawCanvas();
   initImageUpload();
 
-  // Populate vault keys if available.
+  // No key-source dropdown any more: signing is always the account's passkey-PRF
+  // key (resolved at sign time). Show the enrolled key's fingerprint (or a "set
+  // up a passkey" hint) so the signer knows which identity will sign.
+  showSigningIdentity().catch(() => {});
+}
+
+// Display the passkey signing identity in the identity step (read-only, public
+// metadata only — no unlock). If none is enrolled, point at the enrol path
+// (stuk 2 wires an inline enrol button here).
+async function showSigningIdentity() {
+  const el = $('ds-signing-identity');
+  if (!el) return;
   try {
-    if (await vaultAvailable()) {
-      const items = await vaultList();
-      const sel = $('ds-key-src');
-      for (const it of items) {
-        const opt = document.createElement('option');
-        opt.value = 'vault:' + it.id;
-        opt.textContent = 'Vault: ' + (it.label || (it.pk_hash || '').slice(0, 12));
-        sel.appendChild(opt);
-      }
+    const k = await resolvePasskeySigningKey();
+    state.signer.fingerprint = k.fingerprint;
+    el.className = 'ds-hint';
+    el.innerHTML = 'You will sign with your passkey-protected key (Face ID / Touch ID / security key). ' +
+      'Key fingerprint <code>' + escapeHtml(k.fingerprint) + '</code>.';
+  } catch (e) {
+    el.className = 'ds-hint';
+    if (e && e.code === 'no_signing_passkey') {
+      el.innerHTML = 'No signing passkey on this device yet. Set one up at <a href="/account">your account</a> before signing.';
+    } else {
+      el.textContent = (e && e.message) ? e.message : 'Could not check your signing key.';
     }
-  } catch {}
+  }
 }
 
 function refreshIdentityValid() {
@@ -445,46 +462,9 @@ function initImageUpload() {
   });
 }
 
-async function resolveSignerKey() {
-  const src = $('ds-key-src').value;
-  state.signer.keySrc = src;
-  if (src === 'ephemeral') {
-    const seed = crypto.getRandomValues(new Uint8Array(32));
-    const kp = ml_dsa65.keygen(seed);
-    return { secretKey: kp.secretKey, publicKey: kp.publicKey, kind: 'ephemeral' };
-  }
-  if (src === 'file') {
-    return await pickKeyFile();
-  }
-  if (src.startsWith('vault:')) {
-    const id = parseInt(src.slice('vault:'.length), 10);
-    const pass = prompt('Passphrase to unlock the vault key:');
-    if (!pass) throw new Error('Vault unlock cancelled');
-    const u = await vaultUnlock(id, pass);
-    return { secretKey: u.secretKey, publicKey: u.publicKey, kind: 'vault' };
-  }
-  throw new Error('Unknown key source');
-}
-
-function pickKeyFile() {
-  return new Promise((resolve, reject) => {
-    const inp = document.createElement('input');
-    inp.type = 'file';
-    inp.accept = '.json,application/json';
-    inp.onchange = async () => {
-      try {
-        const f = inp.files[0];
-        if (!f) return reject(new Error('No file picked'));
-        const d = JSON.parse(await f.text());
-        if (!d.secretKey || !d.publicKey) return reject(new Error('Invalid key file (missing secretKey/publicKey)'));
-        const secretKey = hexToBytes(d.secretKey);
-        const publicKey = hexToBytes(d.publicKey);
-        resolve({ secretKey, publicKey, kind: 'file' });
-      } catch (e) { reject(e); }
-    };
-    inp.click();
-  });
-}
+// resolvePasskeySigningKey() now lives in parasign-signer.js (the single
+// definition of "what a signing key is"), shared with /co-sign so the two flows
+// can never drift on key selection.
 
 function hexToBytes(s) {
   const out = new Uint8Array(s.length / 2);
@@ -511,30 +491,15 @@ function signedDocMime() {
   return 'application/octet-stream';
 }
 
-// Matches the recipe the relay's Lua script reproduces server-side
-// (see relay/envelope.js: signMessageBytes). Used to sign as party 0 when
-// the user creates a multi-party envelope, and read by /co-sign for parties
-// 1..N when they sign their own slot.
-function buildEnvelopeSignMessage(envId, docHashHex, partyIndex) {
-  const idBytes = new TextEncoder().encode(envId);
-  const hashBytes = hexToBytes(docHashHex);
-  const piBytes = new TextEncoder().encode(String(partyIndex));
-  const combined = new Uint8Array(idBytes.length + hashBytes.length + piBytes.length);
-  combined.set(idBytes, 0);
-  combined.set(hashBytes, idBytes.length);
-  combined.set(piBytes, idBytes.length + hashBytes.length);
-  return sha3_256(combined);
-}
+// (v2 buildEnvelopeSignMessage removed — the signed message is now the v3
+//  domain-prefixed buildDocSignMessage() in parasign-signer.js, byte-identical
+//  to relay/envelope.js signMessageBytes(...,3).)
 
 // ====================================================================
 // Step 4: review + sign
 // ====================================================================
 
 function fillReview() {
-  // Sync keySrc from the dropdown into state (was only set inside resolveSignerKey,
-  // which only runs after Sign is clicked - too late for the review card).
-  state.signer.keySrc = $('ds-key-src').value;
-
   $('ds-review-doc').textContent  = state.doc.name + ' (' + formatSize(state.doc.size) + ')';
   $('ds-review-mode').textContent =
     state.mode === 'pdf'   ? 'PDF with visual stamp on page ' + (state.stamp.pageIndex + 1) :
@@ -545,28 +510,19 @@ function fillReview() {
     state.signer.sigStyle === 'typed'  ? 'Typed name in the stamp' :
     state.signer.sigStyle === 'drawn'  ? 'Drawn signature (' + formatSize(state.signer.sigImageBytes.length) + ' PNG)' :
                                          'Uploaded image (' + formatSize(state.signer.sigImageBytes.length) + ' ' + state.signer.sigImageType.toUpperCase() + ')';
-  $('ds-review-key-src').textContent =
-    state.signer.keySrc === 'ephemeral' ? 'One-time key generated in this browser' :
-    state.signer.keySrc === 'file'      ? 'Key file from disk' :
-                                          'Saved key from this browser';
-  const apiKey = $('ds-api-key').value.trim();
-  state.signer.apiKey = apiKey;
-  $('ds-review-notary').textContent = apiKey
-    ? 'Yes - relay will counter-sign + write to CT log'
-    : 'No - envelope is self-contained (still verifiable)';
+  // Signing key: always the account's passkey-protected ML-DSA-65 key. The
+  // fingerprint is filled async (public vault metadata, no unlock) below.
+  $('ds-review-key-src').textContent = 'Passkey-protected ML-DSA-65 key';
 
-  // Recipients summary; warn if recipients but no API key (envelope creation will fail).
+  // Recipients summary. Multi-party envelopes are created same-origin via your
+  // logged-in session (no manual API key); each recipient signs at /co-sign
+  // with their own passkey.
   const recCell = $('ds-review-recipients');
   if (state.recipients.length === 0) {
     recCell.textContent = 'None - personal signature only';
   } else {
     const list = state.recipients.map(r => r.label + (r.email ? ' (' + r.email + ')' : '')).join(', ');
     recCell.innerHTML = state.recipients.length + ' co-signer' + (state.recipients.length === 1 ? '' : 's') + ': ' + escapeHtml(list);
-    if (!apiKey) {
-      recCell.innerHTML += '<br><span style="color:rgba(180,20,20,1);font-size:11px">Multi-party envelope needs your X-Api-Key in the Advanced section. Get one at <a href="/dashboard#api-keys" target="_blank" style="color:rgba(180,20,20,1);text-decoration:underline">Dashboard &gt; API Keys</a>.</span>';
-    } else if (!/^pgp_/.test(apiKey)) {
-      recCell.innerHTML += '<br><span style="color:rgba(180,20,20,1);font-size:11px">The API key in Advanced does not start with <code>pgp_</code>. Paramant keys look like <code>pgp_...</code> - check at <a href="/dashboard#api-keys" target="_blank" style="color:rgba(180,20,20,1);text-decoration:underline">Dashboard &gt; API Keys</a>.</span>';
-    }
   }
 
   // Cryptographic proof card: the mathematical evidence that backs the
@@ -574,38 +530,37 @@ function fillReview() {
   // the key source.
   const docHashHex = toHex(sha3_256(state.doc.bytes));
   $('ds-proof-doc-hash').textContent = docHashHex;
-  if (state.signer.key && state.signer.key.publicKey) {
-    $('ds-proof-fp').textContent = toHex(sha3_256(state.signer.key.publicKey));
-  } else if (state.signer.keySrc === 'ephemeral') {
-    $('ds-proof-fp').textContent = '(generated when you click Sign - the key never existed before this moment)';
-  } else {
-    $('ds-proof-fp').textContent = '(resolved when you click Sign)';
-  }
-  $('ds-proof-notary').textContent = state.signer.apiKey ? 'Yes (will fail-stop if the relay rejects the key)' : 'No (envelope is self-contained)';
-  $('ds-proof-version').textContent =
-    state.mode === 'pdf'   ? 'parasign-visual-1' :
-    state.mode === 'image' ? 'parasign-image-1'  :
-                             'parasign-hash-1';
+  $('ds-proof-fp').textContent = '(your passkey key fingerprint)';   // filled async below
+  $('ds-proof-version').textContent = 'parasign-doc-3 (recipe_version 3)';
 
-  // Envelope-structure preview (placeholders where post-sign data lives).
-  const previewEnv = state.mode === 'pdf' ? {
-    version: 'parasign-visual-1',
+  // Envelope-structure preview — the v3 .psign receipt (parasign-doc-3). The
+  // signed_message line shows the EXACT v3 domain-prefixed message the passkey
+  // will sign (byte-identical to relay/envelope.js signMessageBytes(...,3)), so
+  // the review reflects what is actually signed — not the old v2 message.
+  const previewEnv = (state.mode === 'pdf' || state.mode === 'image') ? {
+    version: 'parasign-doc-3',
+    recipe_version: 3,
+    sign_domain: 'paramant/parasign/doc/v1',
     algorithm: 'ML-DSA-65',
     hash_algorithm: 'SHA3-256',
     original_filename: state.doc.name,
-    stamped_filename: 'signed-' + state.doc.name,
+    stamped_filename: state.mode === 'image' ? '<signed image>' : 'signed-' + state.doc.name,
     original_hash: docHashHex,
-    stamped_hash: '<computed when the PDF is stamped>',
+    stamped_hash: '<computed when the document is stamped>',
     coords: { pageIndex: state.stamp.pageIndex, x: Math.round(state.stamp.x), y: Math.round(state.stamp.y), w: state.stamp.w, h: state.stamp.h, name: state.signer.name, date: '<set on sign>' },
     signature_style: state.signer.sigStyle,
     signature_image_hash: state.signer.sigImageBytes ? toHex(sha3_256(state.signer.sigImageBytes)) : null,
     signer_public_key: '<base64 of your ML-DSA-65 public key>',
     signer_pk_fingerprint: '<sha3_256(pubkey)[..16]>',
-    signature: '<base64 of ML-DSA-65 signature over (origHash || stampedHash || coords)>',
+    signed_message: 'sha3_256("paramant/parasign/doc/v1" || 0x00 || envelope_id || stamped_hash || party_index || party_email_hash)',
+    signature: '<base64 of ML-DSA-65 signature over signed_message>',
+    multiparty: { envelope_id: '<set on sign>', party_index: 0 },
     signed_at: '<set on sign>',
     disclaimer: 'Post-quantum, zero-knowledge. Not eIDAS-qualified.',
   } : {
-    version: 'parasign-hash-1',
+    version: 'parasign-doc-3',
+    recipe_version: 3,
+    sign_domain: 'paramant/parasign/doc/v1',
     algorithm: 'ML-DSA-65',
     hash_algorithm: 'SHA3-256',
     original_filename: state.doc.name,
@@ -613,7 +568,9 @@ function fillReview() {
     signer_name: state.signer.name,
     signer_public_key: '<base64 of your ML-DSA-65 public key>',
     signer_pk_fingerprint: '<sha3_256(pubkey)[..16]>',
-    signature: '<base64 of ML-DSA-65 signature over document_hash>',
+    signed_message: 'sha3_256("paramant/parasign/doc/v1" || 0x00 || envelope_id || document_hash || party_index || party_email_hash)',
+    signature: '<base64 of ML-DSA-65 signature over signed_message>',
+    multiparty: { envelope_id: '<set on sign>', party_index: 0 },
     signed_at: '<set on sign>',
     disclaimer: 'Post-quantum, zero-knowledge. Not eIDAS-qualified.',
   };
@@ -622,6 +579,22 @@ function fillReview() {
   // Render visual previews of doc + signature so the signer sees exactly
   // what they are about to commit to before clicking Sign now.
   renderReviewPreviews().catch(err => console.warn('review preview failed', err));
+  // Fill the passkey key fingerprint (async, public vault metadata only).
+  fillReviewKeyFingerprint().catch(() => {});
+}
+
+// Fill the signing-key fingerprint into the review card from PUBLIC vault
+// metadata (no unlock). On a device with no signing passkey, say so plainly.
+async function fillReviewKeyFingerprint() {
+  try {
+    const k = await resolvePasskeySigningKey();
+    state.signer.fingerprint = k.fingerprint;
+    const fpEl = $('ds-proof-fp'); if (fpEl) fpEl.textContent = k.fingerprint;
+    const ksEl = $('ds-review-key-src'); if (ksEl) ksEl.textContent = 'Passkey-protected ML-DSA-65 key (' + k.fingerprint + ')';
+  } catch (e) {
+    const fpEl = $('ds-proof-fp');
+    if (fpEl) fpEl.textContent = (e && e.code === 'no_signing_passkey') ? '(set up a signing passkey first)' : '(unavailable)';
+  }
 }
 
 async function renderReviewPreviews() {
@@ -751,9 +724,7 @@ function stampInnerHtml() {
 function stampMockupHtml() {
   const name = (state.signer.name || 'Signer').slice(0, 40);
   const dateStr = new Date().toISOString().slice(0, 16).replace('T', ' ');
-  const fp = (state.signer.key && state.signer.key.publicKey)
-    ? toHex(sha3_256(state.signer.key.publicKey)).slice(0, 8)
-    : 'pending';
+  const fp = state.signer.fingerprint ? state.signer.fingerprint.slice(0, 8) : 'pending';
   let mid = '';
   if (state.signer.sigStyle !== 'typed' && state.signer.sigImageDataUrl) {
     mid = `<img class="ds-sm-sig-img" src="${state.signer.sigImageDataUrl}" alt="">`;
@@ -962,190 +933,109 @@ async function buildStampedPdf(origBytes, stamp, signerName, dateStr, fingerprin
 }
 
 async function doSign() {
+  // STEP 2 of the two-step flow: this explicit action triggers the per-document
+  // passkey-PRF activation (the Face ID / Touch ID / security-key prompt fires
+  // here, bound to THIS document) — step 1 was the review/preview.
   $('ds-sign-now').disabled = true;
   $('ds-sign-status').hidden = false;
   $('ds-sign-status').className = 'ds-banner';
-  $('ds-sign-status').textContent = 'Resolving signing key...';
+  const status = (t) => { $('ds-sign-status').textContent = t; };
 
   try {
-    state.signer.key = await resolveSignerKey();
-    const fingerprint = toHex(sha3_256(state.signer.key.publicKey)).slice(0, 16);
+    // The signing key is the account's PASSKEY-protected ML-DSA-65 key. Read ONLY
+    // its public half from vault metadata here (for the stamp fingerprint); the
+    // secret is unlocked solely by the per-document PRF activation below.
+    status('Locating your passkey signing key...');
+    const signKey = await resolvePasskeySigningKey();   // { vaultId, pk_b64, fingerprint } — public only
+    const fingerprint = signKey.fingerprint;
     const dateStr = new Date().toISOString().slice(0, 19) + 'Z';
 
-    let stampedBytes = null;
-    let messageBytes;
-    let envelope;
-
+    // 1) STAMP (PDF/image) + HASH — unchanged. The stamp shows the PUBLIC fingerprint.
+    let stampedBytes = null, origHashHex = null, stampedHashHex = null, coords = null, docHashForEnvelope;
     if (state.mode === 'pdf' || state.mode === 'image') {
-      $('ds-sign-status').textContent = state.mode === 'pdf' ? 'Stamping PDF...' : 'Stamping image...';
+      status(state.mode === 'pdf' ? 'Stamping PDF...' : 'Stamping image...');
       stampedBytes = state.mode === 'pdf'
         ? await buildStampedPdf(state.doc.bytes, state.stamp, state.signer.name, dateStr, fingerprint)
         : await buildStampedImage(state.doc.bytes, state.stamp, state.signer.name, dateStr, fingerprint, state.imageType);
-      const origHash = sha3_256(state.doc.bytes);
-      const stampedHash = sha3_256(stampedBytes);
-      const coords = { pageIndex: state.stamp.pageIndex, x: state.stamp.x, y: state.stamp.y, w: state.stamp.w, h: state.stamp.h, name: state.signer.name, date: dateStr, isImage: !!state.stamp.isImage };
-      const coordsBytes = new TextEncoder().encode(JSON.stringify(coords));
-      messageBytes = new Uint8Array(origHash.length + stampedHash.length + coordsBytes.length);
-      messageBytes.set(origHash, 0);
-      messageBytes.set(stampedHash, origHash.length);
-      messageBytes.set(coordsBytes, origHash.length + stampedHash.length);
-      $('ds-sign-status').textContent = 'Signing in browser (ML-DSA-65)...';
-      const signature = ml_dsa65.sign(state.signer.key.secretKey, messageBytes);
-      const stampedName = state.mode === 'image' ? signedImageName() : 'signed-' + state.doc.name;
+      origHashHex = toHex(sha3_256(state.doc.bytes));
+      stampedHashHex = toHex(sha3_256(stampedBytes));
+      coords = { pageIndex: state.stamp.pageIndex, x: state.stamp.x, y: state.stamp.y, w: state.stamp.w, h: state.stamp.h, name: state.signer.name, date: dateStr, isImage: !!state.stamp.isImage };
+      docHashForEnvelope = stampedHashHex;
+    } else {
+      docHashForEnvelope = toHex(sha3_256(state.doc.bytes));
+    }
+
+    // 2) Create the signing envelope SAME-ORIGIN (party 0 = you; + any recipients),
+    //    recipe_version 3. A self-sign (no recipients) STILL gets an envelope, so
+    //    every signature goes through the per-document activation gate (R018) —
+    //    no separate weaker self-sign route.
+    status('Preparing this document for signing...');
+    const created = await createSigningEnvelope({
+      docHash: docHashForEnvelope,
+      recipients: state.recipients,
+      originalFilename: state.mode === 'pdf' ? 'signed-' + state.doc.name : state.doc.name,
+      signerLabel: state.signer.name,
+      creatorPublicKey: signKey.pk_b64,
+    });
+    const env = created.envelope;
+    state.envelope = env;
+    const myLink = (env.party_links || []).find((p) => p.party_index === 0) || {};
+
+    // 3) Per-document activation (authorize -> one-shot token), THEN the passkey-PRF
+    //    unlock + sign of the v3 domain-prefixed message, THEN submit. The secret
+    //    key lives ONLY inside the ActivatedSigner and is zeroized by dispose().
+    status('Requesting signing authorization...');
+    const act = await requestSignActivation({ envelopeId: env.id, partyIndex: 0, docHash: docHashForEnvelope, inviteToken: myLink.invite_token });
+
+    status('Confirm with your passkey (Face ID / Touch ID / security key)...');
+    const signer = await new LocalVaultSigner().activate({ vaultId: signKey.vaultId, rpId: location.hostname });
+    let sigB64;
+    try {
+      const message = buildDocSignMessage({ envelopeId: env.id, docHash: docHashForEnvelope, partyIndex: 0, emailHash: act.email_hash });
+      sigB64 = toB64(await signer.sign(message));
+    } finally {
+      signer.dispose();   // zeroize — the secret never outlives this block
+    }
+
+    status('Recording your signature...');
+    const submitted = await submitSignature({ activationId: act.activation_id, signerPublicKey: signer.publicKey, signature: sigB64 });
+
+    // 4) v3 .psign receipt. The authoritative, CT-logged signature record is the
+    //    relay envelope; this file points at it (envelope_id + party 0).
+    const mp = { envelope_id: env.id, party_index: 0, party_count: env.party_count, party_links: env.party_links, expires_at: env.expires_at, signed_count: submitted.signed_count };
+    let envelope;
+    if (state.mode === 'pdf' || state.mode === 'image') {
       envelope = {
-        version: state.mode === 'pdf' ? 'parasign-visual-1' : 'parasign-image-1',
-        algorithm: 'ML-DSA-65',
-        hash_algorithm: 'SHA3-256',
-        original_filename: state.doc.name,
-        stamped_filename: stampedName,
-        original_hash: toHex(origHash),
-        stamped_hash:  toHex(stampedHash),
-        coords,
+        version: 'parasign-doc-3', recipe_version: 3, sign_domain: 'paramant/parasign/doc/v1',
+        algorithm: 'ML-DSA-65', hash_algorithm: 'SHA3-256',
+        original_filename: state.doc.name, stamped_filename: state.mode === 'image' ? signedImageName() : 'signed-' + state.doc.name,
+        original_hash: origHashHex, stamped_hash: stampedHashHex, coords,
         signature_style: state.signer.sigStyle,
         signature_image_hash: state.signer.sigImageBytes ? toHex(sha3_256(state.signer.sigImageBytes)) : null,
-        signer_public_key: toB64(state.signer.key.publicKey),
-        signer_pk_fingerprint: fingerprint,
-        signature: toB64(signature),
-        signed_at: dateStr,
+        signer_public_key: signKey.pk_b64, signer_pk_fingerprint: fingerprint,
+        signature: sigB64, signed_at: dateStr, multiparty: mp,
         disclaimer: 'Post-quantum, zero-knowledge. Not eIDAS-qualified.',
       };
     } else {
-      // Hash-only path: sign the SHA3-256 of the original file.
-      const docHash = sha3_256(state.doc.bytes);
-      $('ds-sign-status').textContent = 'Signing in browser (ML-DSA-65)...';
-      const signature = ml_dsa65.sign(state.signer.key.secretKey, docHash);
       envelope = {
-        version: 'parasign-hash-1',
-        algorithm: 'ML-DSA-65',
-        hash_algorithm: 'SHA3-256',
-        original_filename: state.doc.name,
-        document_hash: toHex(docHash),
+        version: 'parasign-doc-3', recipe_version: 3, sign_domain: 'paramant/parasign/doc/v1',
+        algorithm: 'ML-DSA-65', hash_algorithm: 'SHA3-256',
+        original_filename: state.doc.name, document_hash: docHashForEnvelope,
         signer_name: state.signer.name,
-        signer_public_key: toB64(state.signer.key.publicKey),
-        signer_pk_fingerprint: fingerprint,
-        signature: toB64(signature),
-        signed_at: dateStr,
+        signer_public_key: signKey.pk_b64, signer_pk_fingerprint: fingerprint,
+        signature: sigB64, signed_at: dateStr, multiparty: mp,
         disclaimer: 'Post-quantum, zero-knowledge. Not eIDAS-qualified.',
       };
-    }
-
-    // Multi-party envelope: if the user added recipients, create the envelope
-    // on the relay with the (possibly stamped) document hash, then auto-sign
-    // as party 0. The recipients then sign via /co-sign?env=...&p=<i>.
-    // Requires an API key (the /v2/envelopes endpoint is auth-gated).
-    if (state.recipients.length > 0) {
-      if (!state.signer.apiKey) {
-        throw new Error('Adding recipients requires your Paramant X-Api-Key. Open the Advanced section in step 4 and paste it there. You can find or create one at Dashboard > API Keys (https://paramant.app/dashboard#api-keys). Alternatively, remove the recipients to sign only for yourself.');
-      }
-      if (!/^pgp_[A-Za-z0-9_-]{16,}$/.test(state.signer.apiKey)) {
-        throw new Error('The X-Api-Key you entered does not look like a Paramant API key (expected format: pgp_... with at least 16 chars after). Double-check the value at Dashboard > API Keys (https://paramant.app/dashboard#api-keys).');
-      }
-      $('ds-sign-status').textContent = 'Creating multi-party envelope on the relay...';
-      const docHashForEnvelope = state.mode === 'pdf' || state.mode === 'image' ? envelope.stamped_hash : envelope.document_hash;
-      const allParties = [{ label: state.signer.name + ' (sender)' }, ...state.recipients];
-      let createR, createBody;
-      try {
-        createR = await fetch(RELAY + '/v2/envelopes', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-Api-Key': state.signer.apiKey },
-          body: JSON.stringify({
-            doc_hash: docHashForEnvelope,
-            parties: allParties,
-            original_filename: state.mode === 'pdf' ? 'signed-' + state.doc.name : state.doc.name,
-            creator_public_key: envelope.signer_public_key,
-          }),
-        });
-        createBody = await createR.json().catch(() => null);
-      } catch (netErr) {
-        throw new Error('Envelope creation aborted: the relay was unreachable (' + (netErr.message || netErr) + ').');
-      }
-      if (!createR.ok) {
-        const reason = createR.status === 401
-          ? 'the API key was not accepted by the relay. Verify the value at Dashboard > API Keys (https://paramant.app/dashboard#api-keys), or remove recipients to sign only for yourself'
-          : createR.status === 429 ? 'the relay rate-limited envelope creation - try again in an hour'
-          : 'the relay returned HTTP ' + createR.status + (createBody && createBody.error ? ' (' + createBody.error + ')' : '');
-        throw new Error('Envelope creation aborted: ' + reason + '. No envelope was produced; recipients have not been notified.');
-      }
-      state.envelope = createBody.envelope;
-
-      // Auto-sign as party 0 with the same ML-DSA-65 key
-      $('ds-sign-status').textContent = 'Auto-signing as party 0 (sender)...';
-      const envMsg = buildEnvelopeSignMessage(state.envelope.id, docHashForEnvelope, 0);
-      const envSig = ml_dsa65.sign(state.signer.key.secretKey, envMsg);
-      let signR, signBody;
-      try {
-        signR = await fetch(RELAY + '/v2/envelopes/' + state.envelope.id + '/sign', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            party_index: 0,
-            signer_public_key: envelope.signer_public_key,
-            signature: toB64(envSig),
-          }),
-        });
-        signBody = await signR.json().catch(() => null);
-      } catch (netErr) {
-        throw new Error('Envelope ' + state.envelope.id + ' was created but auto-signing as party 0 failed (' + (netErr.message || netErr) + '). Recipients cannot proceed until this is resolved.');
-      }
-      if (!signR.ok) {
-        throw new Error('Envelope ' + state.envelope.id + ' was created but auto-signing as party 0 returned HTTP ' + signR.status + (signBody && signBody.error ? ' (' + signBody.error + ')' : '') + '. Recipients cannot proceed.');
-      }
-
-      // Bake multi-party info into the .psign envelope so recipients of the
-      // file can also see which envelope it belongs to.
-      envelope.multiparty = {
-        envelope_id: state.envelope.id,
-        party_count: state.envelope.party_count,
-        party_links: state.envelope.party_links,
-        expires_at: state.envelope.expires_at,
-        sender_signed_at: signBody.signed_count >= 1,
-      };
-    }
-
-    // Optional notary call (only when an API key was supplied). If the user
-    // explicitly asked for counter-signing, treat a failure as a HARD STOP:
-    // we will NOT hand back an envelope that says 'notary requested but
-    // failed', because that mixes two outcomes and quietly produces an
-    // unsigned-by-relay artefact the user thought was witnessed.
-    // The user stays in step-sign so they can fix the API key or clear it.
-    if (state.signer.apiKey) {
-      $('ds-sign-status').textContent = 'Requesting notary signature from relay...';
-      let r, body;
-      try {
-        const docHashForNotary = state.mode === 'pdf' ? toHex(sha3_256(stampedBytes)) : envelope.document_hash;
-        const sigForNotary = state.mode === 'pdf'
-          ? toB64(ml_dsa65.sign(state.signer.key.secretKey, sha3_256(stampedBytes)))
-          : envelope.signature;
-        r = await fetch(RELAY + '/v2/sign', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-Api-Key': state.signer.apiKey },
-          body: JSON.stringify({
-            document_hash: docHashForNotary,
-            signature: sigForNotary,
-            signer_public_key: envelope.signer_public_key,
-            signer_label: state.signer.name,
-          }),
-        });
-        body = await r.json().catch(() => null);
-      } catch (netErr) {
-        throw new Error('Counter-sign aborted: the relay was unreachable (' + (netErr.message || netErr) + '). Either fix your network or remove the API key under Advanced and sign locally.');
-      }
-      if (!r.ok) {
-        const reason =
-          r.status === 401 ? 'the API key was not accepted by the relay (check it under Advanced, or clear the field to sign without a counter-signature)' :
-          r.status === 403 ? 'the API key does not have notary permission on this relay' :
-          r.status === 429 ? 'the relay rate-limited the notary endpoint - retry in a minute' :
-          'the relay returned HTTP ' + r.status + (body && body.error ? ' (' + body.error + ')' : '');
-        throw new Error('Counter-sign aborted: ' + reason + '. No envelope was produced - the document was not signed.');
-      }
-      envelope.notary = body.envelope && body.envelope.notary ? body.envelope.notary : body.envelope;
     }
 
     state.result = { stampedBytes, envelope, fingerprint };
     showDone();
   } catch (e) {
     $('ds-sign-status').className = 'ds-banner err';
-    $('ds-sign-status').textContent = (e.message || String(e));
+    let msg = (e && e.message) ? e.message : String(e);
+    if (e && e.status === 401) msg = 'Please sign in to sign documents. Open /auth/login, then return here.';
+    else if (e && e.code === 'no_signing_passkey') msg = 'No signing passkey on this device yet. Set one up at /account, then sign.';
+    $('ds-sign-status').textContent = msg;
     $('ds-sign-now').disabled = false;
   }
 }
@@ -1163,9 +1053,8 @@ function showDone() {
   setActive('step-done');
   const r = state.result;
 
-  // Success banner: signature was produced locally regardless of the optional
-  // notary outcome. Soften the wording so a failed/skipped notary call does
-  // not look like 'signing failed'.
+  // Success banner: the signature was produced locally (the private key never
+  // left the browser); the relay only recorded the public signature + CT entry.
   const sb = $('ds-success-banner');
   if (sb) {
     sb.hidden = false;
@@ -1183,18 +1072,10 @@ function showDone() {
     state.mode === 'image' ? 'Image with visual stamp baked in (' + (state.imageType || '').toUpperCase() + ')' :
                              'Hash-only attestation (SHA3-256)';
 
-  // Notary line: only show when something happened, frame failure as
-  // 'optional step skipped' rather than an error.
-  if (r.envelope.notary) {
-    $('ds-done-notary').textContent = 'Yes - relay co-signed and added a CT-log entry';
-  } else if (r.envelope.notary_error) {
-    const reason = /401/.test(r.envelope.notary_error) ? 'API key was not accepted by the relay'
-                 : /403/.test(r.envelope.notary_error) ? 'API key has no notary permission'
-                 : 'relay was unreachable';
-    $('ds-done-notary').textContent = 'Skipped (' + reason + ') - the local signature is still fully valid';
-  } else {
-    $('ds-done-notary').textContent = 'Skipped (no API key provided) - the local signature is still fully valid';
-  }
+  // v3: the signature was submitted to the relay (same-origin, via the
+  // per-document activation) which recorded it on the envelope and wrote it to
+  // the public CT log. There is no optional "notary" step any more.
+  if ($('ds-done-notary')) $('ds-done-notary').textContent = 'Yes - recorded on the relay and the public CT log';
 
   const psignName = (state.mode === 'pdf' ? 'signed-' + state.doc.name : state.doc.name).replace(/\.[^.]+$/, '') + '.psign';
   $('ds-dl-psign').onclick = () => downloadBytes(new TextEncoder().encode(JSON.stringify(r.envelope, null, 2)), psignName, 'application/json');
@@ -1227,9 +1108,7 @@ function showDone() {
   }
   const notaryLine = $('ds-usage-notary-line');
   if (notaryLine) {
-    notaryLine.textContent = r.envelope.notary
-      ? 'Paramant\'s relay counter-signed the envelope, and the signature is logged in the public CT log - recipients see independent witness of when this signing happened.'
-      : 'No relay witness on this signature - that is fine for self-attestation but means there is no independent third-party timestamp.';
+    notaryLine.textContent = 'Your signature is recorded on the Paramant relay and written to the public CT log, so recipients get an independent witness of when this signing happened.';
   }
 
   // Multi-party: render share-links for the recipients (party 1..N).
@@ -1280,10 +1159,13 @@ function renderPartyLinks(mp) {
     list.appendChild(row);
   }
 
-  // Status-page link points at the relay's redacted envelope view.
+  // Status-page link points at the relay's redacted (public) envelope view.
+  // This is the ONLY relay-host reference left in the sign path, and it is a
+  // read-only status link; the signing itself routes same-origin via the admin
+  // (/api/user/sign/*). The relay GET /v2/envelopes/:id is public.
   const statusLink = $('ds-envelope-status-link');
   if (statusLink) {
-    statusLink.href = RELAY + '/v2/envelopes/' + mp.envelope_id;
+    statusLink.href = RELAY_PUBLIC + '/v2/envelopes/' + mp.envelope_id;
     statusLink.textContent = 'envelope ' + mp.envelope_id.slice(0, 10) + '... on the relay';
   }
 }

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -405,22 +405,10 @@
     </div>
 
     <div class="ds-field">
-      <label class="ds-label" for="ds-key-src">Cryptographic key (ML-DSA-65)</label>
-      <select class="ds-select" id="ds-key-src">
-        <option value="ephemeral">Generate a one-time key (simplest)</option>
-        <option value="file">Load a key file from disk</option>
-      </select>
-      <p class="ds-hint" style="margin-top:6px">Your signature style is what people see. The key is what cryptographically binds the signature - so it cannot be forged.</p>
+      <label class="ds-label">Cryptographic key (ML-DSA-65)</label>
+      <p class="ds-hint" id="ds-signing-identity">Checking your signing key...</p>
+      <p class="ds-hint" style="margin-top:6px">Your signature style is what people see. What cryptographically binds the signature is your passkey-protected ML-DSA-65 key - unlocked with Face ID / Touch ID / a security key the moment you sign, and never exported. Recipients you add sign at <code>/co-sign</code> with their own passkey.</p>
     </div>
-    <details class="ds-advanced">
-      <summary>Advanced: Paramant relay integration</summary>
-      <p>Optional for self-sign, <strong>required if you added recipients</strong>. With your Paramant API key, the relay (a) counter-signs the envelope and writes it to the public CT log, and (b) creates the multi-party envelope so co-signers can sign at <code>/co-sign?env=...</code>. Without a key your envelope is fully self-contained but recipients cannot use the co-sign flow.</p>
-      <div class="ds-field">
-        <label class="ds-label" for="ds-api-key">X-Api-Key (format: <code>pgp_...</code>)</label>
-        <input class="ds-input" type="password" id="ds-api-key" placeholder="pgp_..." autocomplete="off">
-        <p class="ds-hint" style="margin-top:6px">Find or create one at <a href="/dashboard#api-keys" target="_blank">Dashboard &gt; API Keys</a>. The key is sent only to the relay, never to other recipients.</p>
-      </div>
-    </details>
     <div class="ds-actions">
       <button class="btn btn-tertiary" id="ds-identity-back" type="button">Back</button>
       <button class="btn btn-primary" id="ds-identity-continue" type="button" disabled>Continue</button>
@@ -430,7 +418,7 @@
   <!-- Step 4: review + sign -->
   <section class="ds-step" id="step-sign" hidden>
     <h2>Review and sign</h2>
-    <p class="ds-sub">This is what you are about to sign. Check the document, your signature, and the metadata. The signature is created locally the moment you click Sign now.</p>
+    <p class="ds-sub">This is what you are about to sign. Check the document, your signature, and the metadata. When you click <strong>Sign this document</strong>, your passkey (Face ID / Touch ID / security key) unlocks the key for this one document and the signature is created locally.</p>
 
     <div class="ds-review-grid">
       <div class="ds-review-col">
@@ -447,13 +435,12 @@
 
     <div class="ds-proof-card">
       <h3 class="ds-proof-h">Cryptographic proof (.psign envelope)</h3>
-      <p class="ds-review-cap">The visual seal is supporting evidence. This envelope is the mathematical proof anyone can verify offline using only your public key. The signature itself is produced when you click Sign now.</p>
+      <p class="ds-review-cap">The visual seal is supporting evidence. This envelope is the mathematical proof anyone can verify offline using only your public key. The signature itself is produced when you click Sign this document.</p>
       <dl class="ds-proof-dl">
         <dt>Algorithm</dt>          <dd>ML-DSA-65 (FIPS 204, post-quantum)</dd>
         <dt>Hash algorithm</dt>     <dd>SHA3-256</dd>
         <dt>Document SHA3-256</dt>  <dd id="ds-proof-doc-hash">-</dd>
         <dt>Signer key fingerprint</dt><dd id="ds-proof-fp">-</dd>
-        <dt>Counter-signed by relay</dt><dd id="ds-proof-notary">-</dd>
         <dt>Envelope version</dt>   <dd id="ds-proof-version">-</dd>
       </dl>
       <details>
@@ -468,9 +455,8 @@
         <dt>Mode</dt>          <dd id="ds-review-mode">-</dd>
         <dt>Signer</dt>        <dd id="ds-review-name">-</dd>
         <dt>Signature style</dt><dd id="ds-review-sig">-</dd>
-        <dt>Key source</dt>    <dd id="ds-review-key-src">-</dd>
+        <dt>Signing key</dt>   <dd id="ds-review-key-src">-</dd>
         <dt>Recipients</dt>    <dd id="ds-review-recipients">-</dd>
-        <dt>Counter-sign</dt>  <dd id="ds-review-notary">-</dd>
       </dl>
     </div>
 
@@ -480,7 +466,7 @@
     </div>
     <div class="ds-actions">
       <button class="btn btn-tertiary" id="ds-sign-back" type="button">Back</button>
-      <button class="btn btn-primary" id="ds-sign-now" type="button">Sign now</button>
+      <button class="btn btn-primary" id="ds-sign-now" type="button">Sign this document</button>
     </div>
     <div class="ds-banner" id="ds-sign-status" hidden role="status" aria-live="polite"></div>
   </section>
@@ -498,7 +484,7 @@
         <dt>Document</dt>       <dd id="ds-done-name">-</dd>
         <dt>Mode</dt>           <dd id="ds-done-mode">-</dd>
         <dt>Key fingerprint</dt><dd id="ds-done-fingerprint">-</dd>
-        <dt>Counter-signed</dt> <dd id="ds-done-notary">-</dd>
+        <dt>Relay record</dt>   <dd id="ds-done-notary">-</dd>
       </dl>
     </div>
     <div class="ds-actions">
@@ -593,6 +579,6 @@
 <script src="/js/nav-auth.js" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js" defer></script>
-<script type="module" src="/sign-flow.js?v=9"></script>
+<script type="module" src="/sign-flow.js?v=10"></script>
 </body>
 </html>

--- a/frontend/vendor/vault.js
+++ b/frontend/vendor/vault.js
@@ -218,6 +218,85 @@ export async function vaultUnlock(id, passphrase) {
   };
 }
 
+// --- WebAuthn-PRF wrap (R018 / "PR 2"). The passkey's PRF output derives a KEK
+//     (HKDF-SHA256, domain-separated, per-wrap random salt) that unwraps the
+//     same ML-DSA secret key. ADDITIVE: the passphrase wrap is never touched, so
+//     it remains the recovery floor (lockout invariant). PRF is never the sole
+//     wrap. Per-wrap salt (not a fixed per-RP salt) so KEKs are independent.
+async function _deriveKekFromPrf(prfOutput, hkdfSalt) {
+  const ikm = await crypto.subtle.importKey('raw', prfOutput, { name: 'HKDF' }, false, ['deriveKey']);
+  return crypto.subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt: hkdfSalt, info: new TextEncoder().encode('paramant/parasign/vault-kek/v1') },
+    ikm,
+    { name: KEK_NAME, length: KEK_BITS },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+// Return the prf wrap's { credentialId, prfSalt(b64) } so the caller can run the
+// WebAuthn PRF eval with the SAME salt that was used at enrol (the PRF output is
+// only reproducible for an identical (credential, salt)). Null if no prf wrap.
+export async function vaultGetPrfWrapInfo(id, credentialId) {
+  if (!id) throw new Error('vaultGetPrfWrapInfo: id required');
+  const db = await vaultOpen();
+  const entry = await _toPromise(_tx(db, 'readonly').get(id));
+  db.close();
+  if (!entry) return null;
+  const matches = (entry.wraps || []).filter(w => w.kekSource === 'webauthn-prf' && (!credentialId || w.credentialId === credentialId));
+  if (!matches.length) return null;
+  const w = matches[matches.length - 1];
+  return { credentialId: w.credentialId, prfSalt: w.prfSalt };
+}
+
+// Add (or replace, per credential) a webauthn-prf wrap. Requires the unlocked
+// secretKeyBytes (caller obtained it during enrol or via a passphrase unlock)
+// AND the SAME prfSalt the caller fed to the WebAuthn PRF eval to obtain
+// prfOutput (the salt is stored so unlock can reproduce the PRF output).
+export async function vaultAddPrfWrap({ pk_hash, secretKeyBytes, credentialId, prfSalt, prfOutput }) {
+  if (!pk_hash || !(secretKeyBytes instanceof Uint8Array) || secretKeyBytes.length === 0) throw new Error('vaultAddPrfWrap: pk_hash + secretKeyBytes required');
+  if (!credentialId || !(prfOutput instanceof Uint8Array) || prfOutput.length < 16) throw new Error('vaultAddPrfWrap: credentialId + prfOutput required');
+  if (!(prfSalt instanceof Uint8Array) || prfSalt.length < 16) throw new Error('vaultAddPrfWrap: prfSalt (>=16 bytes, the WebAuthn PRF eval salt) required');
+  const iv      = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const kek     = await _deriveKekFromPrf(prfOutput, prfSalt);
+  const ct      = new Uint8Array(await crypto.subtle.encrypt({ name: KEK_NAME, iv }, kek, secretKeyBytes));
+  const wrap = {
+    kekSource: 'webauthn-prf', credentialId, hkdf: 'HKDF-SHA256',
+    info: 'paramant/parasign/vault-kek/v1',
+    prfSalt: b64Encode(prfSalt), iv: b64Encode(iv), ciphertext: b64Encode(ct),
+  };
+  const db = await vaultOpen();
+  const store = _tx(db, 'readwrite');
+  const entry = await _toPromise(store.get(pk_hash));
+  if (!entry) { db.close(); throw new Error('no such key'); }
+  entry.wraps = (entry.wraps || []).filter(w => !(w.kekSource === 'webauthn-prf' && w.credentialId === credentialId));
+  entry.wraps.push(wrap);   // passphrase wrap left intact
+  await _toPromise(store.put(entry));
+  db.close();
+  return { id: pk_hash, kekSources: entry.wraps.map(w => w.kekSource) };
+}
+
+// Unlock via the webauthn-prf wrap. Returns raw secretKeyBytes. The caller must
+// zeroize them after signing (see parasign-signer.js dispose()).
+export async function vaultUnlockPrf(id, { prfOutput, credentialId } = {}) {
+  if (!id) throw new Error('vaultUnlockPrf: id required');
+  if (!(prfOutput instanceof Uint8Array)) throw new Error('vaultUnlockPrf: prfOutput required');
+  const db = await vaultOpen();
+  const entry = await _toPromise(_tx(db, 'readonly').get(id));
+  if (!entry) { db.close(); throw new Error('no such key'); }
+  const matches = (entry.wraps || []).filter(w => w.kekSource === 'webauthn-prf' && (!credentialId || w.credentialId === credentialId));
+  if (!matches.length) { db.close(); throw new Error('no prf wrap'); }
+  const wrap = matches[matches.length - 1];
+  const kek = await _deriveKekFromPrf(prfOutput, b64Decode(wrap.prfSalt));
+  let plain;
+  try {
+    plain = new Uint8Array(await crypto.subtle.decrypt({ name: KEK_NAME, iv: b64Decode(wrap.iv) }, kek, b64Decode(wrap.ciphertext)));
+  } catch (e) { db.close(); throw new Error('prf unwrap failed'); }
+  try { const rw = _tx(db, 'readwrite'); const fresh = await _toPromise(rw.get(id)); if (fresh) { fresh.last_used_at = new Date().toISOString(); await _toPromise(rw.put(fresh)); } } catch {}
+  db.close();
+  return { secretKeyBytes: plain, pk_b64: entry.pk_b64, pk_hash: entry.pk_hash, label: entry.label };
+}
+
 // --- Delete an entry. Used when the user revokes locally (server-side
 //     revocation is a separate DELETE /api/user/account/signing-key call).
 export async function vaultDelete(id) {

--- a/frontend/vendor/vault.js
+++ b/frontend/vendor/vault.js
@@ -108,6 +108,25 @@ async function _deriveKekFromPassphrase(passphrase, salt) {
   return kek;
 }
 
+// Reject weak passphrases at enrol. The passphrase wrap is the recovery floor
+// (R018): the break-glass is only as strong as this passphrase, so enforce it
+// here, not just in the UI. >=12 chars; if <16, require >=3 character classes;
+// reject all-one-character and a small common-word blocklist. No external dep.
+export function assertStrongPassphrase(passphrase) {
+  const s = String(passphrase == null ? '' : passphrase);
+  if (s.length < 12) throw new Error('passphrase too weak: use at least 12 characters');
+  if (/^(.)\1+$/.test(s)) throw new Error('passphrase too weak: not all the same character');
+  const classes = [/[a-z]/, /[A-Z]/, /[0-9]/, /[^A-Za-z0-9]/].filter(re => re.test(s)).length;
+  if (s.length < 16 && classes < 3) {
+    throw new Error('passphrase too weak: use 16+ characters, or mix upper/lower/digits/symbols');
+  }
+  const lc = s.toLowerCase();
+  if (['password', 'paramant', '123456789012', 'qwertyuiop', 'aaaaaaaaaaaa'].some(w => lc.includes(w))) {
+    throw new Error('passphrase too weak: contains a common word/sequence');
+  }
+  return true;
+}
+
 // --- Store an entry. If id already exists, the new passphrase-wrap REPLACES
 //     the existing passphrase-wrap on that entry (so the user can change
 //     passphrases). Other wraps (e.g. PR 2's prf wrap) are left intact.
@@ -116,9 +135,7 @@ export async function vaultStore({ alg, label, pk_b64, pk_hash, secretKeyBytes, 
   if (!(secretKeyBytes instanceof Uint8Array) || secretKeyBytes.length === 0) {
     throw new Error('vaultStore: secretKeyBytes (Uint8Array) required');
   }
-  if (!passphrase || String(passphrase).length < 8) {
-    throw new Error('vaultStore: passphrase of at least 8 chars required');
-  }
+  assertStrongPassphrase(passphrase);   // recovery floor — fail closed on weak input
 
   const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
   const iv   = crypto.getRandomValues(new Uint8Array(IV_BYTES));

--- a/relay/envelope.js
+++ b/relay/envelope.js
@@ -26,6 +26,9 @@ const MAX_PARTIES = 20;          // sanity cap; CT-log/Redis can handle more
 const MAX_LABEL_LEN = 80;
 const DEFAULT_TTL_DAYS = 30;
 const MAX_TTL_DAYS = 365;
+// Domain-separation label for ParaSign document signatures (recipe v3, R018 /
+// pentest H3). MUST stay byte-identical across relay + SDK + core.
+const SIGN_DOMAIN_DOC = 'paramant/parasign/doc/v1';
 
 function newEnvelopeId() {
   return crypto.randomBytes(ID_BYTES).toString('base64url');
@@ -75,12 +78,21 @@ function safeTokenEqual(stored, provided) {
 // picks the recipe from the envelope's stored recipe_version. This only defines
 // the MESSAGE -- it is orthogonal to how the message is signed, so the
 // activation<->key-use seam (R018) is unaffected.
+//   recipeVersion 3 (per-document PRF activation, R018): a domain-separation
+//     label is PREPENDED so a ParaSign document signature can never be replayed
+//     as any other signed message (pentest H3). The label is byte-identical
+//     across relay + SDK + core; the NUL terminator delimits it from the id.
+//       sha3_256("paramant/parasign/doc/v1" || 0x00 || id || doc || pi || email_hash)
 function signMessageBytes(envelopeId, docHashHex, partyIndex, partyEmailHashHex, recipeVersion) {
-  const h = crypto.createHash('sha3-256')
-    .update(Buffer.from(envelopeId, 'utf8'))
-    .update(Buffer.from(docHashHex, 'hex'))
-    .update(Buffer.from(String(partyIndex), 'utf8'));
-  if (Number(recipeVersion) >= 2) {
+  const v = Number(recipeVersion) || 1;
+  const h = crypto.createHash('sha3-256');
+  if (v >= 3) {
+    h.update(Buffer.from(SIGN_DOMAIN_DOC, 'utf8')).update(Buffer.from([0]));
+  }
+  h.update(Buffer.from(envelopeId, 'utf8'))
+   .update(Buffer.from(docHashHex, 'hex'))
+   .update(Buffer.from(String(partyIndex), 'utf8'));
+  if (v >= 2) {
     // Decoded email-hash bytes: 32 bytes when present, 0 bytes when the party
     // has no email -- deterministic either way.
     h.update(Buffer.from(partyEmailHashHex || '', 'hex'));
@@ -380,4 +392,4 @@ class EnvelopeStore {
   }
 }
 
-module.exports = { EnvelopeStore, signMessageBytes, partyEmailHash, newEnvelopeId, MAX_PARTIES, DEFAULT_TTL_DAYS, MAX_TTL_DAYS };
+module.exports = { EnvelopeStore, signMessageBytes, partyEmailHash, newEnvelopeId, SIGN_DOMAIN_DOC, MAX_PARTIES, DEFAULT_TTL_DAYS, MAX_TTL_DAYS };

--- a/relay/envelope.js
+++ b/relay/envelope.js
@@ -153,7 +153,7 @@ class EnvelopeStore {
     return this._signScriptSha;
   }
 
-  async create({ creatorPkHash, creatorApiKeyHash, docHash, parties, originalFilename, expiresInDays, bindingMode }) {
+  async create({ creatorPkHash, creatorApiKeyHash, docHash, parties, originalFilename, expiresInDays, bindingMode, recipeVersion: recipeVersionArg }) {
     if (!this.available()) throw new Error('redis unavailable');
     if (!/^[0-9a-f]{64}$/.test(docHash)) throw new Error('doc_hash must be 64-char sha3-256 hex');
     if (!Array.isArray(parties) || parties.length === 0) throw new Error('parties required');
@@ -178,7 +178,12 @@ class EnvelopeStore {
     // signed via the trusted admin proxy (verified_email_hash + X-Internal-Auth);
     // 'open' = the legacy public flow (any holder of env_id+party_index signs).
     const mode = bindingMode === 'email' ? 'email' : 'open';
-    const recipeVersion = mode === 'email' ? 2 : 1;
+    // Explicit recipeVersion (1-3) wins; else default by binding mode. The
+    // per-document PRF activation flow (R018) creates v3 (domain-prefixed)
+    // envelopes; open=1, email=2 stay the defaults for existing flows.
+    const recipeVersion = (Number.isInteger(recipeVersionArg) && recipeVersionArg >= 1 && recipeVersionArg <= 3)
+      ? recipeVersionArg
+      : (mode === 'email' ? 2 : 1);
 
     const hash = {
       id,

--- a/relay/envelope.js
+++ b/relay/envelope.js
@@ -26,9 +26,31 @@ const MAX_PARTIES = 20;          // sanity cap; CT-log/Redis can handle more
 const MAX_LABEL_LEN = 80;
 const DEFAULT_TTL_DAYS = 30;
 const MAX_TTL_DAYS = 365;
+// Signing-invite window for EMAIL-bound envelopes (R018): how long an invite
+// link can actually be USED to sign, deliberately shorter than and independent
+// of the 30-day envelope record retention (DEFAULT_TTL_DAYS). Measured from the
+// envelope's created_at (= when the sender created it and sent the invites).
+// The record is still kept 30d for verification; only the signable window is 7d.
+const SIGN_INVITE_TTL_DAYS = 7;
 // Domain-separation label for ParaSign document signatures (recipe v3, R018 /
 // pentest H3). MUST stay byte-identical across relay + SDK + core.
 const SIGN_DOMAIN_DOC = 'paramant/parasign/doc/v1';
+
+// True when an email-bound invite's signing window (created_at + 7d) has closed.
+// Open/legacy envelopes have no invite window (only the 30d hash TTL), so callers
+// apply this in email mode only. Missing/unparseable created_at -> not closed
+// (real envelopes always store it; the 30d hash TTL remains the backstop).
+function signInviteClosed(createdAtIso, nowMs) {
+  const t = Date.parse(createdAtIso || '');
+  if (!Number.isFinite(t)) return false;
+  return (nowMs - t) > SIGN_INVITE_TTL_DAYS * 86400_000;
+}
+// ISO timestamp when an email-bound invite stops being signable, or null.
+function signInviteExpiresAt(createdAtIso) {
+  const t = Date.parse(createdAtIso || '');
+  if (!Number.isFinite(t)) return null;
+  return new Date(t + SIGN_INVITE_TTL_DAYS * 86400_000).toISOString();
+}
 
 function newEnvelopeId() {
   return crypto.randomBytes(ID_BYTES).toString('base64url');
@@ -303,6 +325,9 @@ class EnvelopeStore {
       binding_mode: mode,
       recipe_version: parseInt(h.recipe_version, 10) || 1,
       expires_at: h.expires_at,
+      // When this email-bound invite stops being signable (created_at + 7d);
+      // null for open envelopes. Lets the admin gate fail early before the PRF.
+      sign_expires_at: mode === 'email' ? signInviteExpiresAt(h.created_at) : null,
       party: {
         index: pi,
         label: h['p' + pi + '_label'] || null,
@@ -352,6 +377,10 @@ class EnvelopeStore {
     // so they can never fill an email-bound slot. Fail-closed: a party with no
     // bound email (empty hash) cannot be signed in email mode.
     if (mode === 'email') {
+      // Signing-invite window: an email-bound invite is signable for 7 days from
+      // creation, independent of the 30-day record retention. Past that, the
+      // slot is closed even though the envelope record still exists.
+      if (signInviteClosed(h.created_at, Date.now())) return { ok: false, code: 'invite_expired' };
       if (!opts.internalTrusted) return { ok: false, code: 'email_binding_required' };
       if (!safeHexEqual(opts.verifiedEmailHash, emailHash)) return { ok: false, code: 'email_mismatch' };
     }
@@ -397,4 +426,4 @@ class EnvelopeStore {
   }
 }
 
-module.exports = { EnvelopeStore, signMessageBytes, partyEmailHash, safeHexEqual, newEnvelopeId, SIGN_DOMAIN_DOC, MAX_PARTIES, DEFAULT_TTL_DAYS, MAX_TTL_DAYS };
+module.exports = { EnvelopeStore, signMessageBytes, partyEmailHash, safeHexEqual, newEnvelopeId, SIGN_DOMAIN_DOC, MAX_PARTIES, DEFAULT_TTL_DAYS, MAX_TTL_DAYS, SIGN_INVITE_TTL_DAYS };

--- a/relay/envelope.js
+++ b/relay/envelope.js
@@ -397,4 +397,4 @@ class EnvelopeStore {
   }
 }
 
-module.exports = { EnvelopeStore, signMessageBytes, partyEmailHash, newEnvelopeId, SIGN_DOMAIN_DOC, MAX_PARTIES, DEFAULT_TTL_DAYS, MAX_TTL_DAYS };
+module.exports = { EnvelopeStore, signMessageBytes, partyEmailHash, safeHexEqual, newEnvelopeId, SIGN_DOMAIN_DOC, MAX_PARTIES, DEFAULT_TTL_DAYS, MAX_TTL_DAYS };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -2445,6 +2445,74 @@ const server = http.createServer(async (req, res) => {
     }
   }
 
+  // POST /v2/user/signing-key/tofu — enrol a signing pubkey gated by an EMAIL-
+  // BOUND invite token + the account's own email, INSTEAD of TOTP, for a
+  // first-time (TOFU) invitee who has no TOTP. The relay self-verifies as
+  // strictly as the TOTP gate it replaces — it does NOT merely trust the caller:
+  //   GATE 1  the invite token must match this envelope party (PR-0, email-bound);
+  //   GATE 2  the party's bound email MUST equal THIS account's own email
+  //           (so a pubkey can only land on the account the invite was for —
+  //           no path to set a key on someone else's account);
+  //   GATE 3  one-shot per party slot (a single TOFU enrol per invite);
+  //   + the cross-account-conflict check inside storeSigningPk still applies.
+  // No valid invite token -> no enrol. Internal-auth only (admin proxy).
+  if (req.method === "POST" && path === "/v2/user/signing-key/tofu") {
+    if (!_internalOk()) return _internalReject();
+    try {
+      const { user_id, pk_b64, label, envelope_id, party_index, invite_token } = JSON.parse((await readBody(req, 16384)).toString());
+      if (!user_id) { res.writeHead(400); return res.end(J({ error: "missing_user_id" })); }
+      if (!pk_b64 || typeof pk_b64 !== "string") { res.writeHead(400); return res.end(J({ error: "missing_pk_b64" })); }
+      if (!envelope_id || !invite_token) { res.writeHead(400); return res.end(J({ error: "missing_invite_context" })); }
+      const pi = parseInt(party_index, 10);
+      if (!Number.isInteger(pi) || pi < 0) { res.writeHead(400); return res.end(J({ error: "invalid_party_index" })); }
+
+      const store = _envStore();
+      if (!store) { res.writeHead(503); return res.end(J({ error: "envelope_store_unavailable" })); }
+
+      // GATE 1 — invite token must match this envelope party (timing-safe, PR-0).
+      if (!(await store.checkInviteToken(envelope_id, pi, invite_token))) {
+        res.writeHead(403); return res.end(J({ error: "invalid_invite_token" }));
+      }
+      // GATE 2 — the party's bound email MUST equal THIS account's email.
+      const view = await store.getForParty(envelope_id, pi, invite_token);
+      const partyEmailHash = view && view.party ? (view.party.email_hash || "") : "";
+      let acctEmail = "";
+      try { acctEmail = (JSON.parse((await redisClient.get(`paramant:user:meta:${user_id}`)) || "{}").email) || ""; } catch {}
+      const acctEmailHash = envelopeMod.partyEmailHash(acctEmail);
+      // Timing-safe hex compare (the same helper envelope.js sign() uses) — for
+      // consistency, so the unsafe `!==` pattern is never copied to a spot where
+      // it would matter. safeHexEqual returns false for empty/length-mismatch too.
+      if (!envelopeMod.safeHexEqual(partyEmailHash, acctEmailHash)) {
+        res.writeHead(403); return res.end(J({ error: "account_email_mismatch" }));
+      }
+      // GATE 3 — one-shot per party slot (NX). Released on store failure below.
+      const enrolKey = `paramant:tofu_enrol:${envelope_id}:${pi}`;
+      const firstEnrol = await redisClient.set(enrolKey, String(user_id), { NX: true, EX: 30 * 86400 });
+      if (firstEnrol === null) { res.writeHead(409); return res.end(J({ error: "already_enrolled" })); }
+
+      // Store (server-side pk_hash; cross-account-conflict check inside).
+      let result;
+      try {
+        result = await userSigning.storeSigningPk(redisClient, user_id, { pk_b64, label });
+      } catch (e) {
+        await redisClient.del(enrolKey).catch(() => {});
+        res.writeHead(400, { "Content-Type": "application/json" });
+        return res.end(J({ error: e.message }));   // e.g. 'pubkey already enrolled to a different account'
+      }
+      const ctEntry = ctAppendSigningPkEvent("signing_pk_enrolled_tofu", user_id, result.entry.pk_hash_sha3);
+      log("info", "signing_pk_enrolled_tofu", {
+        user_id: String(user_id).slice(0, 12) + "…",
+        pk_hash: result.entry.pk_hash_sha3.slice(0, 16) + "…",
+        envelope: String(envelope_id).slice(0, 10) + "…", party: pi, ct_index: ctEntry.index,
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(J({ ok: true, pk_hash_sha3: result.entry.pk_hash_sha3, enrolled_at: result.entry.enrolled_at, ct_index: ctEntry.index }));
+    } catch (err) {
+      console.error("[user/signing-key/tofu]", err.message);
+      res.writeHead(500); return res.end(J({ error: "internal" }));
+    }
+  }
+
   // ── WebAuthn / passkey credential storage (ADR R018, PR-A) ───────────────────
   // Durable storage only. The WebAuthn ceremony (challenge issue + attestation/
   // assertion verification, rpId/origin checks) lives in the admin server and
@@ -4627,7 +4695,7 @@ python3 paramant-receiver.py \\
         ? crypto.createHash('sha3-256').update(Buffer.from(d.creator_public_key, 'base64')).digest('hex')
         : '';
       const creatorApiHash = crypto.createHash('sha3-256').update(apiKey).digest('hex');
-      const out = await store.create({ creatorPkHash, creatorApiKeyHash: creatorApiHash, docHash, parties, originalFilename: origFilename, expiresInDays: ttlDays, bindingMode: d.binding_mode });
+      const out = await store.create({ creatorPkHash, creatorApiKeyHash: creatorApiHash, docHash, parties, originalFilename: origFilename, expiresInDays: ttlDays, bindingMode: d.binding_mode, recipeVersion: d.recipe_version });
       log('info', 'envelope_created', { id: out.id, parties: out.party_count, binding_mode: out.binding_mode });
       res.writeHead(200, { 'Content-Type': 'application/json' });
       return res.end(J({ ok: true, envelope: out }));

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -4791,7 +4791,7 @@ python3 paramant-receiver.py \\
       if (!out.ok) {
         const code = out.code === 'not_found' ? 404
           : out.code === 'bad_signature' ? 400
-          : out.code === 'closed' ? 410
+          : (out.code === 'closed' || out.code === 'invite_expired') ? 410
           : (out.code === 'email_binding_required' || out.code === 'email_mismatch') ? 403
           : 409;
         res.writeHead(code, { 'Content-Type': 'application/json' });

--- a/relay/test/envelope-binding.test.js
+++ b/relay/test/envelope-binding.test.js
@@ -133,6 +133,39 @@ async function main() {
     assert.strictEqual(await store.checkInviteToken(ID, 0, 'nope'), false, 'checkInviteToken false on miss');
     ok('getForParty token gating + no token leak');
   }
+
+  // 9. sign(): the 7-day signing-invite window (email mode only). A fresh invite
+  //    still signs; one created >7d ago is rejected with 'invite_expired'; an
+  //    open/legacy envelope ignores the window (only the 30d hash TTL bounds it).
+  //    getForParty exposes sign_expires_at (created_at + 7d) for email mode.
+  {
+    const day = 86400_000;
+    const old = new Date(Date.now() - 8 * day).toISOString();
+    const fresh = new Date(Date.now() - 1 * day).toISOString();
+    const emailHashAt = (createdAt) => ({
+      id: ID, doc_hash: DOC, status: 'sent', binding_mode: 'email', recipe_version: '3',
+      party_count: '1', signed_count: '0', p0_email_hash: EMAIL_HASH, p0_status: 'pending', created_at: createdAt,
+    });
+    const opts = { internalTrusted: true, verifiedEmailHash: EMAIL_HASH };
+
+    const expired = new EnvelopeStore(fakeRedis(emailHashAt(old)), { sigVerify: () => true });
+    assert.strictEqual((await expired.sign(ID, 0, 'cHVi', 'c2ln', opts)).code, 'invite_expired', 'email invite past 7d rejected');
+
+    const within = new EnvelopeStore(fakeRedis(emailHashAt(fresh)), { sigVerify: () => true });
+    assert.strictEqual((await within.sign(ID, 0, 'cHVi', 'c2ln', opts)).ok, true, 'email invite within 7d still signs');
+
+    // open/legacy envelope with an OLD created_at is NOT subject to the invite window
+    const openOld = { id: ID, doc_hash: DOC, status: 'sent', party_count: '1', signed_count: '0', p0_email_hash: '', p0_status: 'pending', created_at: old };
+    const open = new EnvelopeStore(fakeRedis(openOld), { sigVerify: () => true });
+    assert.strictEqual((await open.sign(ID, 0, 'cHVi', 'c2ln')).ok, true, 'open/legacy envelope ignores the 7d invite window');
+
+    // getForParty exposes sign_expires_at for email mode (created_at + 7d), in the future for a fresh invite
+    const TOKEN = crypto.randomBytes(32).toString('base64url');
+    const vstore = new EnvelopeStore(fakeRedis({ ...emailHashAt(fresh), p0_invite_token: TOKEN }), {});
+    const view = await vstore.getForParty(ID, 0, TOKEN);
+    assert.ok(view.sign_expires_at && Date.parse(view.sign_expires_at) > Date.now(), 'sign_expires_at set + in the future for a fresh email invite');
+    ok('sign() enforces the 7-day signing-invite window (email mode; open unaffected)');
+  }
 }
 
 main()


### PR DESCRIPTION
## ParaSign v3 signing-activation (R018) — /sign + /co-sign on the passkey-PRF chain

6 commits, the full feature (never on main). Backend (admin + relay) + frontend.

### What
- **One signing path** for self-sign (`/sign`) and recipient co-sign (`/co-sign`): `resolvePasskeySigningKey` (public vault metadata, no unlock) → per-document activation token → WebAuthn-PRF unlock (`LocalVaultSigner`) → sign the v3 domain-prefixed message → `dispose()` zeroize → same-origin submit. The plain-key / ephemeral / passphrase-vault path is removed (incl. the audit-#1 `parseInt` vault bug in co-sign); the ML-DSA secret only ever lives inside the ActivatedSigner.
- **Self-sign goes through the same gate**: a single-party (party-0 = self) envelope, so there is no weaker self-sign route.
- **v3 wire format**: `sha3_256("paramant/parasign/doc/v1" ‖ 0x00 ‖ env ‖ docHash ‖ partyIndex ‖ emailHash)` — client `buildDocSignMessage` byte-identical to relay `signMessageBytes(...,3)`; v3 ≠ v2 ≠ v1 (domain separation, pentest H3).
- **TOFU enrol-gate** (`/v2/user/signing-key/tofu`): timing-safe email compare (`safeHexEqual`) + one-shot 30-day anti-re-enrol marker.
- **7-day signing-invite TTL** (email-bound), distinct from the 30-day record retention: relay-authoritative (`invite_expired` → 410) + admin early-fail via `sign_expires_at` (before the PRF). Open/legacy envelopes unaffected.
- **UI to v3**: removed the ephemeral/file/vault key-source dropdown + apiKey/notary "Advanced"; review shows the v3 signed message + passkey key fingerprint; two-step "Sign this document".
- **Cache-bust**: `vault.js → parasign-signer.js → entry` chain versioned `?v=2` (vault.js is served `immutable` on prod, already cached on devices).

### Verification
- `relay/test/envelope-binding.test.js` **9/9** (incl. the 7-day window: expired-rejected / fresh-accepted / open-unaffected / `sign_expires_at`).
- Cross-check: client v3 message ≡ relay `signMessageBytes(...,3)` byte-identical (3 vectors); v3≠v2≠v1.
- ESM/CJS syntax OK across all touched files.

### Deploy (post-merge)
Backend rebuild (admin + 5 sector relays) + frontend rsync to `/home/paramant/app`. Rollback net: git tag at `42040e1` + webroot backup + pre-build image tags. **FASE 4 gate: TOTP-login + passkey-login + signing-routes must all survive the admin rebuild** (any failure → rollback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)