### PR TITLE
feat(auth): land on /dashboard after login, not /account

### DIFF
--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -226,7 +226,7 @@
     });
 
     if (res.ok) {
-      window.location = '/account';
+      window.location = '/dashboard';
     } else {
       errorDiv.textContent = 'Invalid email or backup code.';
       errorDiv.classList.add('visible');

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -208,7 +208,7 @@
   const submitBtn = document.getElementById('submit-btn');
 
   const params = new URLSearchParams(window.location.search);
-  const returnUrl = params.get('return') || '/account';
+  const returnUrl = params.get('return') || '/dashboard';
 
   form.addEventListener('submit', async function(e) {
     e.preventDefault();

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -485,7 +485,7 @@
   });
 
   document.getElementById('finish-btn').addEventListener('click', function() {
-    window.location = '/account';
+    window.location = '/dashboard';
   });
 
   document.getElementById('start-btn').addEventListener('click', function() {

--- a/frontend/js/passkey.js
+++ b/frontend/js/passkey.js
@@ -84,7 +84,7 @@ function wireSetupPasskey() {
     document.querySelectorAll('section[id^="state-"]').forEach((s) => s.classList.add('hidden'));
     const section = document.getElementById('state-passkey-success');
     const grid = document.getElementById('passkey-backup-codes');
-    if (!section || !grid) { window.location = '/account'; return; }
+    if (!section || !grid) { window.location = '/dashboard'; return; }
     grid.innerHTML = '';
     codes.forEach((c) => {
       const d = document.createElement('div');
@@ -107,7 +107,7 @@ function wireSetupPasskey() {
       a.click();
     });
     const finishBtn = document.getElementById('passkey-finish-btn');
-    if (finishBtn) finishBtn.addEventListener('click', () => { window.location = '/account'; });
+    if (finishBtn) finishBtn.addEventListener('click', () => { window.location = '/dashboard'; });
   }
 }
 
@@ -124,7 +124,7 @@ function wireLoginPasskey() {
     return;
   }
 
-  const returnUrl = new URLSearchParams(window.location.search).get('return') || '/account';
+  const returnUrl = new URLSearchParams(window.location.search).get('return') || '/dashboard';
 
   btn.addEventListener('click', async () => {
     const email = (emailEl && emailEl.value || '').trim();


### PR DESCRIPTION
## What
Make `/dashboard` the post-login landing instead of `/account`. `/dashboard` is the real home (welcome, flagship *Send a file* / *Sign a document* cards, tools grid, account summary); `/account` stays for settings.

## Change (frontend-only, 6 redirect points across 4 files)
- email+TOTP login `returnUrl` default — `auth/login.html`
- passkey login `returnUrl` default — `js/passkey.js`
- passkey onboarding finish + missing-UI fallback — `js/passkey.js`
- TOTP setup completion — `auth/setup.html`
- backup-code login success — `auth/backup.html`

Unchanged: sign-out (→ `/`), auth guards (→ `/auth/login?next=…`), billing checkout (→ `/account`). An explicit `?return=` override still wins.

## Test
Log in via email+TOTP, passkey, or backup code → land on `/dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)