### PR TITLE
polish(parasign): make co-signing discoverable + actionable enrol CTA

### DIFF
--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -327,8 +327,8 @@ async function initStepIdentity() {
 }
 
 // Display the passkey signing identity in the identity step (read-only, public
-// metadata only — no unlock). If none is enrolled, point at the enrol path
-// (stuk 2 wires an inline enrol button here).
+// metadata only — no unlock). If none is enrolled, deep-link to the enrol
+// flow on /account (the "Set up a signing passkey" card).
 async function showSigningIdentity() {
   const el = $('ds-signing-identity');
   if (!el) return;
@@ -341,7 +341,7 @@ async function showSigningIdentity() {
   } catch (e) {
     el.className = 'ds-hint';
     if (e && e.code === 'no_signing_passkey') {
-      el.innerHTML = 'No signing passkey on this device yet. Set one up at <a href="/account">your account</a> before signing.';
+      el.innerHTML = 'You don\'t have a signing passkey on this device yet — you need one to sign. <a href="/account#signing-identity-section" class="btn btn-primary btn-small" style="margin-top:8px;display:inline-block">Set up a signing passkey →</a>';
     } else {
       el.textContent = (e && e.message) ? e.message : 'Could not check your signing key.';
     }

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -304,7 +304,7 @@
   <ol class="ds-stepper" aria-label="Sign progress">
     <li data-step="doc" class="active">Document</li>
     <li data-step="place">Place</li>
-    <li data-step="recipients">Recipients</li>
+    <li data-step="recipients">Co-signers</li>
     <li data-step="identity">Identity</li>
     <li data-step="sign">Sign</li>
   </ol>
@@ -351,8 +351,8 @@
 
   <!-- Step 2.5: recipients (optional - if empty, this is a personal sign) -->
   <section class="ds-step" id="step-recipients" hidden>
-    <h2>Recipients (optional)</h2>
-    <p class="ds-sub">If this is for someone else to co-sign or acknowledge, add them here. Each recipient gets their own co-sign link that you share with them out-of-band (you mail the signed PDF + their link separately). Leave empty to sign only for yourself.</p>
+    <h2>Add co-signers (optional)</h2>
+    <p class="ds-sub">Adding someone here makes this a multi-party signature. <strong>After you sign, you'll get a personal co-sign link for each person</strong> to send them yourself (along with the signed file). The email is a label for your reference only. Leave empty to sign just for yourself.</p>
 
     <div class="ds-recipients-list" id="ds-recipients-list"></div>
 
@@ -579,6 +579,6 @@
 <script src="/js/nav-auth.js" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js" defer></script>
-<script type="module" src="/sign-flow.js?v=10"></script>
+<script type="module" src="/sign-flow.js?v=11"></script>
 </body>
 </html>


### PR DESCRIPTION
Co-signing already worked (done-screen per-recipient links) but was easy to miss. Rename the /sign **Recipients** step to **Co-signers** + clarify the copy (each co-signer gets a personal link after you sign). Make the *no signing passkey* hint a primary-button CTA deep-linking to the new enrol card at `/account#signing-identity-section`. Cache-bust sign-flow.js v10→v11. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)