### PR TITLE
fix(onboarding): relabel finish buttons to 'Continue to dashboard'

### DIFF
--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -327,7 +327,7 @@
   </div>
 
   <button type="button" class="btn btn-primary mt-3" id="finish-btn" disabled>
-    Continue to account
+    Continue to dashboard
   </button>
 </section>
 
@@ -351,7 +351,7 @@
     <button type="button" class="btn btn-secondary" id="passkey-download-codes">Download .txt</button>
   </div>
 
-  <button type="button" class="btn btn-primary mt-3" id="passkey-finish-btn">Continue to account</button>
+  <button type="button" class="btn btn-primary mt-3" id="passkey-finish-btn">Continue to dashboard</button>
 </section>
 
 </main>


### PR DESCRIPTION
Follow-up to #128: the TOTP-setup and passkey-onboarding finish buttons still said *Continue to account* but now land on `/dashboard`. Relabel both to match. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)