### PR TITLE
polish(site): duplicate account section number, stale asset versions, compliance routes

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -419,7 +419,7 @@
 
 <section class="section">
   <div class="marker">
-    <div class="num">04</div>
+    <div class="num">05</div>
     <h2>Active sessions.</h2>
     <div class="tag">devices<br>signed in</div>
   </div>
@@ -435,7 +435,7 @@
 
 <section class="section" id="billing-section">
   <div class="marker">
-    <div class="num">05</div>
+    <div class="num">06</div>
     <h2>Plan &amp; billing.</h2>
     <div class="tag">subscription<br>and history</div>
   </div>
@@ -475,7 +475,7 @@
 
 <section class="section">
   <div class="marker">
-    <div class="num">06</div>
+    <div class="num">07</div>
     <h2>Session.</h2>
     <div class="tag">this browser<br>right now</div>
   </div>
@@ -488,7 +488,7 @@
 
 <section class="section">
   <div class="marker">
-    <div class="num">07</div>
+    <div class="num">08</div>
     <h2>Delete account.</h2>
     <div class="tag">permanent<br>cannot undo</div>
   </div>

--- a/frontend/billing/checkout.html
+++ b/frontend/billing/checkout.html
@@ -7,7 +7,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=16">
+<link rel="stylesheet" href="/design-system.css?v=19">
 <style>
   body { background: var(--bone); }
   .checkout-wrap { max-width: 480px; margin: var(--space-10) auto; padding: 0 var(--space-5); }

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -211,7 +211,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
 
 <div class="meta-bar" id="meta-bar"></div>
 <nav id="nav"></nav>
-<script src="/nav.js?v=10"></script>
+<script src="/nav.js?v=12"></script>
 
 <main id="main-content">
   <section class="page-hero">

--- a/frontend/pattern-library.html
+++ b/frontend/pattern-library.html
@@ -5,8 +5,8 @@
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Pattern Library — PARAMANT Design System v3</title>
-<link rel="stylesheet" href="/design-system.css?v=16">
-<link rel="stylesheet" href="/nav.css?v=10">
+<link rel="stylesheet" href="/design-system.css?v=19">
+<link rel="stylesheet" href="/nav.css?v=13">
 <style>
   /* Pattern-library-only styles — not part of design-system.css */
 

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -373,8 +373,8 @@ td{color:var(--cobalt)}
     <div class="card">
       <h3>Compliance pages</h3>
       <p style="font-size:13px">NIS2, NEN7510, IEC 62443 — detailed mapping.</p>
-      <a href="/compliance/nis2.html" class="dl-btn">NIS2 &rarr;</a>
-      <a href="/compliance/nen7510.html" class="dl-btn" style="margin-left:6px">NEN7510 &rarr;</a>
+      <a href="/compliance/nis2" class="dl-btn">NIS2 &rarr;</a>
+      <a href="/compliance/nen7510" class="dl-btn" style="margin-left:6px">NEN7510 &rarr;</a>
     </div>
   </div>
 

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -318,7 +318,7 @@
   </div>
 </footer>
 
-<script src="/nav.js?v=10"></script>
+<script src="/nav.js?v=12"></script>
 <script src="/nav.js?v=12" defer></script>
 <script src="/js/nav-auth.js" defer></script>
 </body>


### PR DESCRIPTION
Code-level site polish from a read-only audit (high-confidence, mechanical):
- **account.html** duplicate section number '04' (Active sessions) → renumber 05/06/07/08.
- **stale cache-bust** asset versions aligned to current (design-system v16→19, nav.css v10→13, nav.js v10→12 across checkout/pattern-library/changelog/request-key).
- **press.html** compliance links → clean /compliance/X routes.

Frontend-only. (Editorial/product items — Stripe stub banner, 'Pro coming soon', product-name casing — left for a product decision.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)