### PR TITLE
fix(sign): mobile touch polish — co-sign links, tab targets, draw canvas

### DIFF
--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -506,13 +506,15 @@ function initDrawCanvas() {
     }, 'image/png');
   }
 
+  // Pointer Events cover mouse, touch and pen on every modern browser (iOS 13+).
+  // Using ONLY pointer events avoids the double-fire you get when touch* and
+  // pointer* listeners both run on a touch device. The canvas has touch-action:none,
+  // so panning/zooming never hijacks a stroke.
   cv.addEventListener('pointerdown', start);
   cv.addEventListener('pointermove', move);
   cv.addEventListener('pointerup', end);
+  cv.addEventListener('pointercancel', end);
   cv.addEventListener('pointerleave', end);
-  cv.addEventListener('touchstart', start, { passive: false });
-  cv.addEventListener('touchmove',  move,  { passive: false });
-  cv.addEventListener('touchend',   end);
 
   $('ds-sig-clear').addEventListener('click', () => {
     ctx.fillStyle = '#ffffff';

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -72,7 +72,7 @@
 .ds-success-icon{flex:0 0 28px;height:28px;width:28px;background:var(--lime);color:var(--navy);border:1px solid var(--navy);display:flex;align-items:center;justify-content:center;font-size:16px;font-weight:700;border-radius:50%}
 #ds-signed-preview canvas{width:100%;height:auto;display:block;border:1px solid var(--ink-hair);margin-bottom:12px;background:#fff}
 .ds-sig-tabs{display:flex;gap:0;margin-bottom:14px;border-bottom:1px solid var(--ink-hair)}
-.ds-tab{padding:9px 16px;border:0;background:transparent;color:var(--ink-dim);font-family:var(--mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px}
+.ds-tab{padding:13px 18px;border:0;background:transparent;color:var(--ink-dim);font-family:var(--mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px}
 .ds-tab:hover{color:var(--navy)}
 .ds-tab.active{color:var(--cobalt);border-bottom-color:var(--cobalt)}
 .ds-sig-panel{padding:6px 0 0}
@@ -117,6 +117,7 @@
 .ds-party-link-row .ds-pl-copy{padding:6px 14px;background:var(--cobalt);color:#fff;border:0;font-family:var(--mono);font-size:10px;letter-spacing:.06em;cursor:pointer;font-weight:700}
 .ds-party-link-row .ds-pl-copy.copied{background:var(--lime);color:var(--navy)}
 @media(max-width:640px){.ds-recipient-row,.ds-party-link-row{grid-template-columns:1fr}}
+@media(max-width:640px){.ds-party-link-row .ds-pl-url{white-space:normal;overflow:visible;text-overflow:clip;word-break:break-all}.ds-party-link-row .ds-pl-copy{width:100%;padding:12px 14px}.ds-recipient-row .ds-rm{padding:10px 12px}}
 @media(max-width:640px){.ds-proof-dl{grid-template-columns:1fr}}
 @media(max-width:640px){.ds-review-grid{grid-template-columns:1fr}}
 @media(max-width:640px){
@@ -604,6 +605,6 @@
 <script src="/js/nav-auth.js" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js" defer></script>
-<script type="module" src="/sign-flow.js?v=12"></script>
+<script type="module" src="/sign-flow.js?v=13"></script>
 </body>
 </html>


### PR DESCRIPTION
Mechanical mobile fixes from the journey audit (no visual redesign — that's Mick's call):
- **Co-sign share links** (the handoff moment): URL no longer truncated on mobile (wraps, full URL visible), **Copy button full-width + ~44px** (was ~24px), bigger Remove button.
- **Signature tabs**: bigger touch target.
- **Draw canvas**: Pointer-Events-only (no double-fire from touch+pointer both running); +pointercancel.
- Cache-bust v12→v13. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)