### PR TITLE
polish(home+auth): flip ParaPear, compact /auth/login

### DIFF
--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -10,6 +10,17 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<style>
+/* Compact auth layout — existing design tokens only; design-system.css untouched. */
+.auth-wrap { max-width: 380px; margin: 0 auto; padding: var(--space-6) var(--space-4) var(--space-7); }
+.auth-head { text-align: center; margin-bottom: var(--space-4); }
+.auth-head .eyebrow { justify-content: center; }
+.auth-head h1 { font-size: clamp(24px, 5vw, 32px); line-height: 1.08; letter-spacing: -0.02em; color: var(--navy); margin: var(--space-2) 0 0; }
+.auth-card { margin: 0; }
+.auth-or { display: flex; align-items: center; gap: 10px; margin: var(--space-3) 0; color: var(--ink-dim); font-family: var(--mono); font-size: 10px; letter-spacing: .1em; text-transform: uppercase; }
+.auth-or::before, .auth-or::after { content: ""; flex: 1; height: 1px; background: var(--ink-hair); }
+.auth-foot { text-align: center; margin-top: var(--space-4); }
+</style>
 </head>
 <body>
 
@@ -160,42 +171,37 @@
   <a href="/help" class="nav-mobile-standalone">Help</a>
 </div>
 
-<main class="container-sm">
+<main class="auth-wrap">
 
-<section class="section-lg">
+<div class="auth-head">
   <div class="eyebrow"><span class="bar"></span>sign in</div>
   <h1>Welcome <em>back</em>.</h1>
-</section>
+</div>
 
-<section class="section">
-  <form id="login-form" class="form-card">
-    <label for="email">Email address</label>
-    <input type="email" id="email" name="email" required autocomplete="username"
-           autofocus>
+<form id="login-form" class="form-card auth-card">
+  <label for="email">Email address</label>
+  <input type="email" id="email" name="email" required autocomplete="username" autofocus>
 
-    <label for="totp" class="mt-3">6-digit code</label>
-    <input type="text" id="totp" name="totp" required inputmode="numeric"
-           pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code"
-           placeholder="&bull; &bull; &bull; &bull; &bull; &bull;">
+  <label for="totp" class="mt-3">6-digit code</label>
+  <input type="text" id="totp" name="totp" required inputmode="numeric"
+         pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code"
+         placeholder="&bull; &bull; &bull; &bull; &bull; &bull;">
 
-    <button type="submit" class="btn btn-primary mt-3" id="submit-btn">
-      Sign in
-    </button>
+  <button type="submit" class="btn btn-primary mt-3" id="submit-btn">Sign in</button>
 
-    <div id="error" class="error"></div>
-  </form>
+  <div id="error" class="error"></div>
 
-  <div class="cta-row mt-3">
-    <button type="button" class="btn btn-secondary" id="passkey-login-btn">Sign in with a passkey</button>
-  </div>
-  <p id="passkey-login-status" class="small" aria-live="polite"></p>
+  <div class="auth-or"><span>or</span></div>
 
-  <p class="footer-text mt-4">
-    Lost your authenticator? <a href="/auth/backup">Use a backup code</a><br>
-    No backup codes? <a href="/auth/request-reset">Request a reset email</a><br>
-    Don&rsquo;t have an account? <a href="/signup">Create one</a>
-  </p>
-</section>
+  <button type="button" class="btn btn-secondary" id="passkey-login-btn">Sign in with a passkey</button>
+  <p id="passkey-login-status" class="small" aria-live="polite" style="margin:8px 0 0"></p>
+</form>
+
+<p class="footer-text auth-foot">
+  Lost your authenticator? <a href="/auth/backup">Use a backup code</a><br>
+  No backup codes? <a href="/auth/request-reset">Request a reset email</a><br>
+  Don&rsquo;t have an account? <a href="/signup">Create one</a>
+</p>
 
 </main>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,7 +34,7 @@
 .path h2 { font-size: clamp(20px, 2.5vw, 27px); line-height: 1.12; letter-spacing: -0.015em; color: var(--navy); margin: 0 0 var(--space-3); max-width: 18ch; }
 .path > p { font-size: 15px; line-height: 1.55; color: var(--ink-dim); margin: 0 0 var(--space-4); max-width: 34ch; }
 .path-cta { margin-top: auto; }
-.path-pear { position: absolute; top: var(--space-4); right: var(--space-4); width: clamp(56px, 8vw, 84px); height: auto; opacity: .92; user-select: none; -webkit-user-drag: none; }
+.path-pear { position: absolute; top: var(--space-4); right: var(--space-4); width: clamp(56px, 8vw, 84px); height: auto; opacity: .92; transform: scaleX(-1); user-select: none; -webkit-user-drag: none; }
 @media (max-width: 760px) { .home-split { grid-template-columns: 1fr; } .path { min-height: 0; } }
 </style>
 </head>


### PR DESCRIPTION
- **Homepage**: ParaPear flipped to point inward (`transform: scaleX(-1)`).
- **/auth/login**: compacted to one centered ~380px card (heading + email/TOTP/Sign-in + passkey under an 'or' divider + footer links). Page-local tokens only; design-system/nav untouched; login flow + JS + routes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)