### PR TITLE
fix(login): cache-bust passkey.js (?v=2)

### DIFF
--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -261,7 +261,7 @@
   });
 })();
 </script>
-<script type="module" src="/js/passkey.js"></script>
+<script type="module" src="/js/passkey.js?v=2"></script>
 
 </body>
 </html>


### PR DESCRIPTION
`/js/passkey.js` is served `immutable` (1-year cache) with no version query, so returning visitors keep the old script and never receive the honest error message + cross-device button wiring from #138. Bumps the login page reference to `?v=2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)