### PR TITLE
fix(footer): add Privacy Policy link to homepage footer

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -257,6 +257,7 @@
       <div>
         <div class="footer-col-label">Legal</div>
         <div class="footer-links">
+          <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>


### PR DESCRIPTION
The privacy page was reachable from 55 pages but not the homepage footer — the most logical place a visitor looks. Adds it to the index.html Legal footer column, before DPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)