### PR TITLE
feat(site): ParaRules page — what Paramant stands for

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -98,6 +98,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -176,6 +177,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -152,6 +152,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -230,6 +231,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/anti-phishing.html
+++ b/frontend/anti-phishing.html
@@ -153,6 +153,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -231,6 +232,7 @@ section p+p{margin-top:14px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/apply-nav.py
+++ b/frontend/apply-nav.py
@@ -75,6 +75,7 @@ NEW_NAV = '''\
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -157,6 +158,7 @@ NEW_MOBILE = '''\
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -288,6 +288,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -366,6 +367,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -145,6 +145,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -223,6 +224,7 @@ section p+p{margin-top:14px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -76,6 +76,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -87,6 +87,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -76,6 +76,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -87,6 +87,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -77,6 +77,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -189,6 +189,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -267,6 +268,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -120,6 +120,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -198,6 +199,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/compliance/iec62443.html
+++ b/frontend/compliance/iec62443.html
@@ -223,6 +223,7 @@ pre{font-family:var(--mono)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/compliance/nen7510.html
+++ b/frontend/compliance/nen7510.html
@@ -222,6 +222,7 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/compliance/nis2.html
+++ b/frontend/compliance/nis2.html
@@ -222,6 +222,7 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -219,6 +219,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -297,6 +298,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -281,6 +281,7 @@ body { min-height:100vh; }
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -359,6 +360,7 @@ body { min-height:100vh; }
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -178,6 +178,7 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -256,6 +257,7 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -233,6 +233,7 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -311,6 +312,7 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -219,6 +219,7 @@ tr:last-child td{border-bottom:none}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -297,6 +298,7 @@ tr:last-child td{border-bottom:none}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -156,6 +156,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -234,6 +235,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -196,6 +196,7 @@ input:focus{border-color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -274,6 +275,7 @@ input:focus{border-color:var(--cobalt)}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/drop.html
+++ b/frontend/drop.html
@@ -262,6 +262,7 @@ select{background:var(--bone);border:1px solid var(--ink-hair);color:var(--ink);
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -340,6 +341,7 @@ select{background:var(--bone);border:1px solid var(--ink-hair);color:var(--ink);
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -214,6 +214,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -292,6 +293,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -245,6 +245,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -323,6 +324,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -145,6 +145,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -223,6 +224,7 @@ section p+p{margin-top:14px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -203,6 +203,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -189,6 +189,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -205,6 +205,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -207,6 +207,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -174,6 +174,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -202,6 +202,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -201,6 +201,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -207,6 +207,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -201,6 +201,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -204,6 +204,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -282,6 +283,7 @@ section p+p{margin-top:14px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -114,6 +114,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -192,6 +193,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -145,6 +145,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -223,6 +224,7 @@ section p+p{margin-top:14px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/legal.html
+++ b/frontend/legal.html
@@ -221,6 +221,7 @@ body {
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -299,6 +300,7 @@ body {
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -176,6 +176,7 @@ footer a{color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -254,6 +255,7 @@ footer a{color:var(--cobalt)}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -145,6 +145,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -223,6 +224,7 @@ section p+p{margin-top:14px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/one-pager.html
+++ b/frontend/one-pager.html
@@ -557,6 +557,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -635,6 +636,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -187,6 +187,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -265,6 +266,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/ot-vs-data-diodes.html
+++ b/frontend/ot-vs-data-diodes.html
@@ -158,6 +158,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -236,6 +237,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -218,6 +218,7 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -296,6 +297,7 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/pararules.html
+++ b/frontend/pararules.html
@@ -2,65 +2,51 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Set up your authenticator — PARAMANT Help</title>
-<meta name="description" content="How to set up your authenticator app for Paramant. About 3 minutes. Paramant requires a SHA-256 TOTP app: Raivo (iOS), Aegis (Android), 1Password, Bitwarden, Authy, Ente Auth, or 2FAS.">
+<title>ParaRules — What Paramant stands for</title>
+<meta name="description" content="The ParaRules — the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design. And how we build to keep them.">
+<meta property="og:title" content="ParaRules — What Paramant stands for">
+<meta property="og:description" content="The ParaRules — the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design. And how we build to keep them.">
+<meta property="og:url" content="https://paramant.app/pararules">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="ParaRules — What Paramant stands for">
+<meta name="twitter:description" content="The ParaRules — the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design. And how we build to keep them.">
+<link rel="canonical" href="https://paramant.app/pararules">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
-<style>
-*{box-sizing:border-box;margin:0;padding:0}
-html{scroll-behavior:smooth}
-main{max-width:780px;margin:0 auto;padding:80px 48px 120px}
-.breadcrumb{font-size:var(--text-xs);color:var(--ink-dim);margin-bottom:32px}
-.breadcrumb a{color:var(--cobalt);text-decoration:none}
-.breadcrumb a:hover{opacity:.7}
-.breadcrumb span{margin:0 8px;color:var(--ink-ghost)}
-h1{font-size:36px;font-weight:600;letter-spacing:-.03em;margin-bottom:12px}
-.lead{font-size:var(--text-base);color:var(--ink-dim);line-height:1.7;margin-bottom:48px;max-width:580px}
-h2{font-size:18px;font-weight:600;letter-spacing:-.01em;margin-bottom:12px;margin-top:48px}
-h3{font-size:var(--text-xs);font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:16px;margin-top:40px}
-p{color:var(--ink-dim);line-height:1.8;margin-bottom:16px;font-size:var(--text-base)}
-p strong{color:var(--ink)}
-a{color:var(--cobalt);text-decoration:none}
-a:hover{opacity:.7}
-em{color:var(--cobalt)}
-.step{display:flex;gap:20px;margin-bottom:32px;padding-bottom:32px;border-bottom:1px solid var(--ink-ghost)}
-.step:last-of-type{border-bottom:none}
-.step-num{width:32px;height:32px;background:var(--cobalt);color:#fff;font-size:14px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:2px}
-.step-body{flex:1}
-.step-body h2{margin-top:0}
-.app-list{list-style:none;margin:16px 0;display:flex;flex-direction:column;gap:8px}
-.app-list li{padding:10px 14px;border:1px solid var(--ink-hair);font-size:var(--text-sm);color:var(--ink-dim)}
-.app-list li strong{color:var(--ink)}
-.app-list li .tag{font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--cobalt);margin-left:8px;font-weight:600}
-.code-block{background:var(--ink);color:var(--bone);padding:14px 18px;font-family:var(--mono,ui-monospace);font-size:var(--text-sm);line-height:1.6;margin:16px 0;word-break:break-all}
-.tip{border-left:3px solid var(--cobalt);padding:12px 16px;margin:16px 0;background:var(--ink-ghost)}
-.tip p{margin:0;font-size:var(--text-sm)}
-.warn{border-left:3px solid var(--lime);padding:12px 16px;margin:16px 0;background:var(--ink-ghost)}
-.warn p{margin:0;font-size:var(--text-sm)}
-.divider{border:none;border-top:1px solid var(--ink-hair);margin:48px 0}
-.troubleshoot-item{margin-bottom:24px}
-.troubleshoot-item .q{font-size:var(--text-sm);font-weight:600;color:var(--ink);margin-bottom:6px}
-.troubleshoot-item .a{font-size:var(--text-sm);color:var(--ink-dim);line-height:1.7}
-.next-steps{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:24px}
-.next-step-card{border:1px solid var(--ink-hair);padding:18px 20px;text-decoration:none;color:inherit;display:block}
-.next-step-card:hover{border-color:var(--cobalt);opacity:1}
-.next-step-card h3{font-size:var(--text-sm);font-weight:600;color:var(--ink);margin:0 0 4px;text-transform:none;letter-spacing:0}
-.next-step-card p{font-size:var(--text-xs);color:var(--ink-dim);margin:0;line-height:1.5}
-footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:16px}
-@media(max-width:640px){
-  main{padding:48px 20px 80px}
-  h1{font-size:26px}
-  .next-steps{grid-template-columns:1fr}
-  footer{padding:32px 20px;flex-direction:column}
-}
-</style>
+
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+  <style>
+*{box-sizing:border-box;margin:0;padding:0}
+.content{max-width:800px;margin:80px auto;padding:0 48px}
+h1{font-size:32px;font-weight:600;letter-spacing:-.02em;margin-bottom:8px}
+.updated{font-size:var(--text-xs);color:var(--ink-dim);margin-bottom:40px}
+h2{font-size:18px;font-weight:600;margin:48px 0 16px;border-top:1px solid var(--ink-hair);padding-top:48px}
+h3{font-size:15px;font-weight:600;margin:30px 0 6px;color:var(--cobalt)}
+p{margin-bottom:16px;color:var(--ink-dim);font-size:var(--text-base);line-height:1.8}
+p strong{color:var(--cobalt)}
+p a{color:var(--cobalt)}
+table{width:100%;border-collapse:collapse;margin:24px 0}
+th,td{padding:12px 0;border-bottom:1px solid var(--ink-hair);text-align:left;vertical-align:top;font-size:var(--text-sm)}
+th{font-size:var(--text-xs);letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim)}
+td{color:var(--ink-dim)}
+td:first-child{color:var(--cobalt)}
+ul{margin-left:24px;color:var(--ink-dim)}
+li{margin-bottom:6px;font-size:var(--text-base);line-height:1.7}
+li strong{color:var(--cobalt)}
+code{font-size:var(--text-sm)}
+footer{border-top:1px solid var(--ink-hair);padding:32px 48px;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:20px;font-size:var(--text-xs);color:var(--ink-dim)}
+footer a{color:var(--ink);text-decoration:none}
+@media(max-width:900px){.content{padding:40px 24px}footer{padding:24px}}
+</style>
 <style>
 .nav-help {
   display: inline-flex;
@@ -125,27 +111,23 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </style>
 </head>
 <body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="meta-bar">
-  <span>build 3.0.0</span>
+  <span class="">build 3.0.0</span>
   <span class="sep">·</span>
-  <span>aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
+  <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
   <span class="sep">·</span>
-  <span>eu/de · ram only</span>
+  <span class="">eu/de · ram only</span>
 </div>
 <nav class="nav">
   <a href="/" class="nav-logo"><span class="logo-para">Para</span><span class="logo-mant">MANT</span></a>
 
   <ul class="nav-links">
 
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
-        <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
-      </ul>
-    </li>
+    <li><a href="/#products" class="nav-link">Products</a></li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
 
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
 
@@ -165,6 +147,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -204,6 +187,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
         <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>
@@ -224,14 +208,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
-    <div class="nav-mobile-group-items">
-      <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
-      <a href="/dashboard">Dashboard</a>
-    </div>
-  </div>
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
 
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
 
@@ -251,6 +230,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
+      <a href="/setup">Setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -284,6 +264,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <div class="nav-mobile-group-items">
       <a href="/status">Status</a>
       <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>
@@ -293,140 +274,63 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </div>
 
   <a href="/help" class="nav-mobile-standalone">Help</a>
-</div><main>
+</div>
 
-  <div class="breadcrumb">
-    <a href="/help">Help</a>
-    <span>/</span>
-    Set up your authenticator
-  </div>
+<div class="content">
 
-  <h1>Set up your <em>authenticator</em> app.</h1>
+<h1>ParaRules</h1>
+<p class="updated">What Paramant stands for &mdash; and how we build it.</p>
 
-<p class="lead">About 3 minutes. One-time setup. Paramant uses <strong>SHA-256</strong> TOTP &mdash; works with Raivo (iOS), Aegis (Android), 1Password, Bitwarden, Authy, Ente Auth, and 2FAS. <strong>Google Authenticator and Microsoft Authenticator do not work</strong> (SHA-1 only).</p>
+<p>These are the rules. Not marketing copy &mdash; the constraints we hold ourselves to, in the product and in the code. If we ever break one, hold us to it.</p>
 
-  <div class="step">
-    <div class="step-num">1</div>
-    <div class="step-body">
-      <h2>Install an authenticator app</h2>
-      <p>Pick one — all are free:</p>
-      <ul class="app-list">
-        <li><strong>Raivo</strong><span class="tag">recommended iOS</span> — open source, iCloud backup, single-device</li>
-        <li><strong>Aegis</strong><span class="tag">recommended Android</span> — open source, encrypted local backup</li>
-        <li><strong>1Password</strong> — syncs across devices, family and team plans available</li>
-        <li><strong>Bitwarden</strong> — free, open source, works on all platforms</li>
-        <li><strong>Authy</strong> — cloud backup, multi-device</li>
-        <li><strong>Ente Auth</strong> — open source, E2E-encrypted cloud backup</li>
-        <li><strong>2FAS</strong> — iOS/Android, browser extension companion</li>
-      </ul>
-      <p>Install on your phone before continuing.</p>
-    </div>
-  </div>
+<h2>What we guarantee</h2>
 
-  <div class="step">
-    <div class="step-num">2</div>
-    <div class="step-body">
-      <h2>Open your Paramant setup link</h2>
-      <p>You received a setup link in your welcome email. It looks like:</p>
-      <div class="code-block">https://paramant.app/auth/setup?token=XXXXXXXX</div>
-      <p>Click it on your computer. The link expires 14 days after issue.</p>
-      <div class="tip"><p>If your link has expired, request a new one at <a href="/auth/request-reset">paramant.app/auth/request-reset</a>.</p></div>
-    </div>
-  </div>
+<h3>1 &middot; We never had it</h3>
+<p>Files are encrypted in your browser before they reach us. The relay holds only ciphertext, in RAM, and burns it on read. We can&rsquo;t read it, can&rsquo;t leak it, and can&rsquo;t be compelled to hand over what we never had.</p>
 
-  <div class="step">
-    <div class="step-num">3</div>
-    <div class="step-body">
-      <h2>Scan the QR code</h2>
-      <p>Open your authenticator app on your phone and add a new entry:</p>
-      <ul class="app-list">
-        <li><strong>Raivo (iOS)</strong> — tap + &rarr; "Scan QR Code"</li>
-        <li><strong>Aegis (Android)</strong> — tap + &rarr; "Scan a QR code"</li>
-        <li><strong>1Password</strong> — tap + &rarr; "Scan QR Code"</li>
-        <li><strong>Bitwarden</strong> — Add item &rarr; Login &rarr; Authenticator key &rarr; Scan QR</li>
-        <li><strong>Authy</strong> — tap + &rarr; "Scan QR Code"</li>
-      </ul>
-      <p>Point the camera at the QR code on paramant.app. The app shows a 6-digit code that changes every 30 seconds.</p>
-    </div>
-  </div>
+<h3>2 &middot; Your browser talks only to us</h3>
+<p>No third-party requests. No Google fonts, no CDN, no analytics, no pixels, no embedded widgets. Open your network inspector on any page &mdash; every request goes to paramant.app and nowhere else.</p>
 
-  <div class="step">
-    <div class="step-num">4</div>
-    <div class="step-body">
-      <h2>Confirm it works</h2>
-      <p>Type the current 6-digit code from your app into the paramant.app setup page. Click <strong>Confirm setup</strong>.</p>
-      <div class="warn"><p>If it says "Invalid code", check that your phone's time is set automatically (Settings &rarr; General &rarr; Date &amp; Time &rarr; Set Automatically). TOTP depends on accurate time.</p></div>
-    </div>
-  </div>
+<h3>3 &middot; No surveillance</h3>
+<p>No tracking cookies, no fingerprinting, no ad tech. One functional session cookie after you sign in. That is the entire list.</p>
 
-  <div class="step">
-    <div class="step-num">5</div>
-    <div class="step-body">
-      <h2>Save your backup codes</h2>
-      <p>After confirming, you'll see 10 backup codes. Each can be used once if you lose access to your authenticator app.</p>
-      <p>Save them in at least one of these places:</p>
-      <ul class="app-list">
-        <li><strong>In your password manager</strong><span class="tag">recommended</span> — 1Password, Bitwarden, etc. as a secure note</li>
-        <li><strong>Printed copy</strong> — print and keep in a locked drawer or safe</li>
-        <li><strong>Encrypted file</strong> — password-protected ZIP or encrypted note</li>
-      </ul>
-      <div class="warn"><p>Don't store backup codes in plain text files, email, unencrypted cloud notes (iCloud Notes, Google Keep), or phone camera roll.</p></div>
-    </div>
-  </div>
+<h3>4 &middot; You own your keys</h3>
+<p>Keys are generated on your device and never leave it. Your passkey&rsquo;s private key is yours alone &mdash; we only ever see the public half.</p>
 
-  <hr class="divider">
+<h3>5 &middot; EU soil, EU law</h3>
+<p>Hosted in Germany, owned top to bottom in the EU. No US CLOUD Act reach over your data.</p>
 
-  <h2 style="margin-top:0">You're done</h2>
-  <p>From now on, sign in at <a href="/auth/login">paramant.app/auth/login</a> with your email and the current 6-digit code from your app. Sessions last 1 hour.</p>
+<h3>6 &middot; Quantum-ready by default</h3>
+<p>FIPS 203/204 &mdash; ML-KEM and ML-DSA &mdash; today, not &ldquo;soon&rdquo;. Harvest-now-decrypt-later is already happening; we encrypt for the decade, not the demo.</p>
 
-  <hr class="divider">
+<h3>7 &middot; Honest by design</h3>
+<p>No dark patterns. When something fails, we tell you what failed and how to recover &mdash; never a vague or misleading message to keep the UI looking tidy.</p>
 
-  <h3>Troubleshooting</h3>
+<h3>8 &middot; Verifiable, not trust-me</h3>
+<p>Open-core you can run yourself, a public Certificate Transparency log, and a relay that proves what it does. You don&rsquo;t have to trust us &mdash; you can check.</p>
 
-  <div class="troubleshoot-item">
-    <div class="q">"Invalid code" when I know it's correct</div>
-    <div class="a">
-      <p>Phone time drift is the most common cause. Enable automatic time on your phone (Settings &rarr; General &rarr; Date &amp; Time &rarr; Set Automatically).</p>
-      <p>Also possible: the code was already used in the last 90 seconds. Wait 30 seconds for a fresh code and try again.</p>
-    </div>
-  </div>
+<h3>9 &middot; Only what&rsquo;s required</h3>
+<p>An email to hold your account. No phone number, no IP logging beyond transit. Minimalism as a security property: data we don&rsquo;t hold can&rsquo;t be breached, subpoenaed, or sold.</p>
 
-  <div class="troubleshoot-item">
-    <div class="q">"Setup link expired"</div>
-    <div class="a">
-      <p>Request a new link at <a href="/auth/request-reset">paramant.app/auth/request-reset</a>.</p>
-    </div>
-  </div>
+<h2>How we build it</h2>
+<p>The same rules bind how we ship. The promises above are only credible if the engineering behind them is disciplined.</p>
 
-  <div class="troubleshoot-item">
-    <div class="q">"All backup codes used"</div>
-    <div class="a">
-      <p>Contact <a href="mailto:privacy@paramant.app">privacy@paramant.app</a> with your account details. We'll verify your identity and manually reset your authenticator setup.</p>
-    </div>
-  </div>
+<h3>We never deploy blind</h3>
+<p>Every change to production is preceded by a backup and a tagged rollback point, and verified on the live site afterwards. If we can&rsquo;t prove it works on the running service, it isn&rsquo;t done.</p>
 
-  <div class="troubleshoot-item">
-    <div class="q">I lost my phone / authenticator app</div>
-    <div class="a">
-      <p>Use one of your backup codes to sign in, then re-enroll a new authenticator app from your account settings. If you've used all backup codes, contact <a href="mailto:privacy@paramant.app">privacy@paramant.app</a>.</p>
-    </div>
-  </div>
+<h3>Reversible by default</h3>
+<p>Every deploy has a one-step rollback &mdash; a tagged image, a backup archive &mdash; captured before the change, not improvised after something breaks.</p>
 
-  <hr class="divider">
+<h3>The sign-in path is sacred</h3>
+<p>Authentication is never deployed casually. A rollback handle first, then every sign-in path is checked before and after the change. We would rather be slow than lock you out.</p>
 
-  <h3>Related</h3>
-  <div class="next-steps">
-    <a href="/help/backup-codes" class="next-step-card">
-      <h3>Backup codes</h3>
-      <p>What they are, when to use them, how to regenerate.</p>
-    </a>
-    <a href="/help/api-key-vs-totp" class="next-step-card">
-      <h3>API key or TOTP?</h3>
-      <p>When to use which authentication method.</p>
-    </a>
-  </div>
+<h3>We don&rsquo;t overwrite each other&rsquo;s work</h3>
+<p>Before any file is touched, we verify that what is live still matches what we expect. Surprises get flagged, not steamrolled.</p>
 
-</main>
+<h3>Honest errors over convenient lies</h3>
+<p>The same rule as the product: when a deploy or a check fails, we say so plainly &mdash; in our own logs and reports too &mdash; rather than paper over it.</p>
+
+</div>
 
 <footer>
   <div class="container-lg">
@@ -441,6 +345,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-links">
           <a href="/status">Status</a>
           <a href="/security">Security</a>
+          <a href="/trust">Trust</a>
+          <a href="/pararules">ParaRules</a>
           <a href="/ct-log">CT Log</a>
           <a href="/license">License</a>
           <a href="/press">Press kit</a>
@@ -459,6 +365,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
+          <a href="/setup">Setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -324,6 +324,7 @@ select:focus{border-color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -402,6 +403,7 @@ select:focus{border-color:var(--cobalt)}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -138,6 +138,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -216,6 +217,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -200,6 +200,7 @@ td{color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -278,6 +279,7 @@ td{color:var(--cobalt)}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -185,6 +185,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -263,6 +264,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -185,6 +185,7 @@ footer a{color:var(--ink);text-decoration:none}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -263,6 +264,7 @@ footer a{color:var(--ink);text-decoration:none}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/quantum-urgency.html
+++ b/frontend/quantum-urgency.html
@@ -158,6 +158,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -236,6 +237,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -144,6 +144,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -222,6 +223,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -208,6 +208,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -286,6 +287,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -100,6 +100,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -210,6 +210,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -288,6 +289,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -169,6 +169,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -247,6 +248,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -146,6 +146,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
         <li role="none"><a href="/license" role="menuitem">License</a></li>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -195,6 +195,7 @@ a:hover{opacity:.8}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -273,6 +274,7 @@ a:hover{opacity:.8}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -159,6 +159,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -237,6 +238,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -152,6 +152,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -230,6 +231,7 @@ section p+p{margin-top:14px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -208,6 +208,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -286,6 +287,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -223,6 +223,7 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -301,6 +302,7 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -89,6 +89,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -167,6 +168,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -158,6 +158,7 @@
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -236,6 +237,7 @@
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -145,6 +145,7 @@ section p+p{margin-top:14px}
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/status" role="menuitem">Status</a></li>
         <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
         <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
         <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
         <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
@@ -223,6 +224,7 @@ section p+p{margin-top:14px}
       <a href="/status">Status</a>
       <a href="/security">Security</a>
       <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
       <a href="/sla">SLA</a>
       <a href="/partners">Partners</a>
       <a href="/license">License</a>


### PR DESCRIPTION
A public manifesto at `/pararules`: 9 product guarantees + a "How we build it" section (the shipping discipline). Cloned from privacy.html for identical styling/nav/footer.

Discoverability: nav "About" dropdown link (desktop, all pages) + footer "Trust" column link; `apply-nav.py` updated (desktop + mobile) so the mobile nav link follows on the next regen.

Frontend-only, no backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)