### PR TITLE
style(pararules): remove all em-dashes

### DIFF
--- a/frontend/pararules.html
+++ b/frontend/pararules.html
@@ -4,16 +4,16 @@
 <meta charset="utf-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>ParaRules — What Paramant stands for</title>
-<meta name="description" content="The ParaRules — the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design. And how we build to keep them.">
-<meta property="og:title" content="ParaRules — What Paramant stands for">
-<meta property="og:description" content="The ParaRules — the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design. And how we build to keep them.">
+<title>ParaRules: What Paramant stands for</title>
+<meta name="description" content="The ParaRules: the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design, and how we build to keep them.">
+<meta property="og:title" content="ParaRules: What Paramant stands for">
+<meta property="og:description" content="The ParaRules: the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design, and how we build to keep them.">
 <meta property="og:url" content="https://paramant.app/pararules">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="ParaRules — What Paramant stands for">
-<meta name="twitter:description" content="The ParaRules — the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design. And how we build to keep them.">
+<meta name="twitter:title" content="ParaRules: What Paramant stands for">
+<meta name="twitter:description" content="The ParaRules: the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design, and how we build to keep them.">
 <link rel="canonical" href="https://paramant.app/pararules">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -279,9 +279,9 @@ footer a{color:var(--ink);text-decoration:none}
 <div class="content">
 
 <h1>ParaRules</h1>
-<p class="updated">What Paramant stands for &mdash; and how we build it.</p>
+<p class="updated">What Paramant stands for, and how we build it.</p>
 
-<p>These are the rules. Not marketing copy &mdash; the constraints we hold ourselves to, in the product and in the code. If we ever break one, hold us to it.</p>
+<p>These are the rules. Not marketing copy. They are the constraints we hold ourselves to, in the product and in the code. If we ever break one, hold us to it.</p>
 
 <h2>What we guarantee</h2>
 
@@ -289,25 +289,25 @@ footer a{color:var(--ink);text-decoration:none}
 <p>Files are encrypted in your browser before they reach us. The relay holds only ciphertext, in RAM, and burns it on read. We can&rsquo;t read it, can&rsquo;t leak it, and can&rsquo;t be compelled to hand over what we never had.</p>
 
 <h3>2 &middot; Your browser talks only to us</h3>
-<p>No third-party requests. No Google fonts, no CDN, no analytics, no pixels, no embedded widgets. Open your network inspector on any page &mdash; every request goes to paramant.app and nowhere else.</p>
+<p>No third-party requests. No Google fonts, no CDN, no analytics, no pixels, no embedded widgets. Open your network inspector on any page: every request goes to paramant.app and nowhere else.</p>
 
 <h3>3 &middot; No surveillance</h3>
 <p>No tracking cookies, no fingerprinting, no ad tech. One functional session cookie after you sign in. That is the entire list.</p>
 
 <h3>4 &middot; You own your keys</h3>
-<p>Keys are generated on your device and never leave it. Your passkey&rsquo;s private key is yours alone &mdash; we only ever see the public half.</p>
+<p>Keys are generated on your device and never leave it. Your passkey&rsquo;s private key is yours alone. We only ever see the public half.</p>
 
 <h3>5 &middot; EU soil, EU law</h3>
 <p>Hosted in Germany, owned top to bottom in the EU. No US CLOUD Act reach over your data.</p>
 
 <h3>6 &middot; Quantum-ready by default</h3>
-<p>FIPS 203/204 &mdash; ML-KEM and ML-DSA &mdash; today, not &ldquo;soon&rdquo;. Harvest-now-decrypt-later is already happening; we encrypt for the decade, not the demo.</p>
+<p>FIPS 203/204 (ML-KEM and ML-DSA) today, not &ldquo;soon&rdquo;. Harvest-now-decrypt-later is already happening; we encrypt for the decade, not the demo.</p>
 
 <h3>7 &middot; Honest by design</h3>
-<p>No dark patterns. When something fails, we tell you what failed and how to recover &mdash; never a vague or misleading message to keep the UI looking tidy.</p>
+<p>No dark patterns. When something fails, we tell you what failed and how to recover. Never a vague or misleading message to keep the UI looking tidy.</p>
 
 <h3>8 &middot; Verifiable, not trust-me</h3>
-<p>Open-core you can run yourself, a public Certificate Transparency log, and a relay that proves what it does. You don&rsquo;t have to trust us &mdash; you can check.</p>
+<p>Open-core you can run yourself, a public Certificate Transparency log, and a relay that proves what it does. You don&rsquo;t have to trust us. You can check it.</p>
 
 <h3>9 &middot; Only what&rsquo;s required</h3>
 <p>An email to hold your account. No phone number, no IP logging beyond transit. Minimalism as a security property: data we don&rsquo;t hold can&rsquo;t be breached, subpoenaed, or sold.</p>
@@ -319,7 +319,7 @@ footer a{color:var(--ink);text-decoration:none}
 <p>Every change to production is preceded by a backup and a tagged rollback point, and verified on the live site afterwards. If we can&rsquo;t prove it works on the running service, it isn&rsquo;t done.</p>
 
 <h3>Reversible by default</h3>
-<p>Every deploy has a one-step rollback &mdash; a tagged image, a backup archive &mdash; captured before the change, not improvised after something breaks.</p>
+<p>Every deploy has a one-step rollback (a tagged image, a backup archive) captured before the change, not improvised after something breaks.</p>
 
 <h3>The sign-in path is sacred</h3>
 <p>Authentication is never deployed casually. A rollback handle first, then every sign-in path is checked before and after the change. We would rather be slow than lock you out.</p>
@@ -328,7 +328,7 @@ footer a{color:var(--ink);text-decoration:none}
 <p>Before any file is touched, we verify that what is live still matches what we expect. Surprises get flagged, not steamrolled.</p>
 
 <h3>Honest errors over convenient lies</h3>
-<p>The same rule as the product: when a deploy or a check fails, we say so plainly &mdash; in our own logs and reports too &mdash; rather than paper over it.</p>
+<p>The same rule as the product: when a deploy or a check fails, we say so plainly, in our own logs and reports too, rather than paper over it.</p>
 
 </div>
 


### PR DESCRIPTION
Rewrites every em-dash sentence on /pararules to flow with colons, periods, or parentheses. No content change beyond punctuation/phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)