### PR TITLE
fix(csp): remove unused external hosts from frontend CSP

### DIFF
--- a/deploy/nginx-paramant-live.conf
+++ b/deploy/nginx-paramant-live.conf
@@ -13,7 +13,7 @@ server {
     add_header Permissions-Policy "geolocation=(), microphone=(), camera=(self)" always;
     # CSP: removed paramant-ghost-pipe.fly.dev (deprecated), ipapi.co,
     # esm.sh and cdnjs.cloudflare.com (libs now vendored locally).
-    add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://relay.paramant.app wss://relay.paramant.app https://health.paramant.app wss://health.paramant.app https://legal.paramant.app wss://legal.paramant.app https://finance.paramant.app wss://finance.paramant.app https://iot.paramant.app wss://iot.paramant.app; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://cdn.jsdelivr.net https://server.arcgisonline.com" always;
+    add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://relay.paramant.app wss://relay.paramant.app https://health.paramant.app wss://health.paramant.app https://legal.paramant.app wss://legal.paramant.app https://finance.paramant.app wss://finance.paramant.app https://iot.paramant.app wss://iot.paramant.app; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:" always;
 
     location = /admin/ {
         alias /home/paramant/app/admin.html;


### PR DESCRIPTION
## What

Removes four external origins from the **paramant.app frontend** `Content-Security-Policy` (`deploy/nginx-paramant-live.conf:16`). None are loaded at runtime anymore — assets are fully self-hosted.

| Directive | Removed |
|---|---|
| `style-src` | `https://fonts.googleapis.com` |
| `font-src` | `https://fonts.gstatic.com` |
| `img-src` | `https://cdn.jsdelivr.net` `https://server.arcgisonline.com` |

`default-src`, `connect-src` (own relay subdomains, https+wss), `script-src` (`'unsafe-inline'` + `'wasm-unsafe-eval'`) and `img-src data:` are **unchanged**.

## Why

The live CSP allowlisted four third-party hosts while `privacy.html` promises *"every byte your browser loads on paramant.app comes from paramant.app. No web fonts from Google, no JavaScript or CSS from a CDN … every request goes to one origin, and nowhere else."* The allowlist contradicted that machine-checkable claim. Tightening it both fixes the privacy-claim drift and hardens the CSP.

## Verification (read-only, before change)

- 0 real references to any of the 4 hosts in the webroot (`*.html`/`*.js`/`*.css`, excluding `.bak`) — globe textures now vendored locally, fonts are a system stack.
- Inline `<script>` blocks + 1084 inline `style=` attrs present → `'unsafe-inline'` retained.
- WASM (noble-mlkem) present → `'wasm-unsafe-eval'` retained.
- `data:` URIs present → `img-src data:` retained.
- Own-relay `wss://` connects retained in `connect-src`.

## Live status

Already applied to the live server (`/etc/nginx/sites-enabled/paramant.conf`), verified **byte-identical** to this repo line:
- `nginx -t` OK, reloaded (no restart).
- New header confirmed via `curl -sI`; the 4 hosts return 0 matches.
- `/`, `/privacy.html`, `/crypto-agility.html`, `/docs.html`, `/sign.html`, `/pricing.html` all return 200.
- Backup for revert: `/etc/nginx/backups/paramant.conf.pre-csp-tighten-20260530-195530`.

This PR brings the repo in sync so the next deploy doesn't reintroduce the old CSP.

## Out of scope (noted, not addressed here)

- The sector subdomains (`health/legal/finance/iot.paramant.app`) currently serve **no** CSP header — separate hardening to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)