### PR TITLE
fix(relay): correct misleading /health signature-fallback label

### DIFF
--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1935,7 +1935,7 @@ const server = http.createServer(async (req, res) => {
       webhooks: [...webhooks.values()].flat().length, stats,
       quantum_ready: true, protocol: 'ghost-pipe-v2',
       encryption: 'ML-KEM-768 + ECDH P-256 + AES-256-GCM',
-      signatures: mlDsa ? 'ML-DSA-65 (NIST FIPS 204)' : 'ECDSA P-256 (ML-DSA fallback)',
+      signatures: mlDsa ? 'ML-DSA-65 (NIST FIPS 204)' : 'ML-DSA-65 unavailable: signing disabled',
       audit: 'Merkle hash chain',
       storage: 'RAM-only, zero plaintext, burn-on-read',
       padding: '5MB fixed (DPI-masking)',


### PR DESCRIPTION
## What

One-line change to the full `/health` response in `relay/relay.js:1938`.

```diff
- signatures: mlDsa ? 'ML-DSA-65 (NIST FIPS 204)' : 'ECDSA P-256 (ML-DSA fallback)',
+ signatures: mlDsa ? 'ML-DSA-65 (NIST FIPS 204)' : 'ML-DSA-65 unavailable: signing disabled',
```

## Why

The old label implied a **silent downgrade to classical ECDSA** when the `@paramant/core` binding is missing. That downgrade does not exist:

- `crypto/impls/mldsa65.js` is a single `require("@paramant/core")` — no noble/ECDSA branch anywhere in the relay.
- The binding is `require()`d **eagerly and uncaught** (`relay.js:83 bootstrap()` → `bootstrap.js:19` → `mldsa65.js:7`). A missing/broken binding therefore **crashes the process at startup (fail-closed)** — the relay does not boot and does not serve.
- The `mlDsa===null` branch (and this string) is **dead code**: registration of sig `0x0002` is unconditional, so if bootstrap loaded, `mlDsa` is non-null.

So the relay never signs with ECDSA. The label promised a path that doesn't exist. Relabelled to describe the real (only-theoretical) state: signing disabled. Code and reported behaviour now match.

## Verification (live, read-only, 2026-05-30)

- All 5 relays: `@paramant/core` present, native sign+verify `ok`, `sig=3309` bytes (FIPS-204 size).
- `/v2/capabilities`: `ML-DSA-65 loaded:true`; `/v2/sth` returns a real ML-DSA signature.
- `node --check relay/relay.js` passes. No functional change.

Label uses `:` rather than an em-dash (user-facing JSON, per house style).

Out of scope (parked, not critical): (b) making fail-closed-at-boot vs. a real graceful-degrade explicit; (c) possibly-leftover `@noble/post-quantum` dep in `relay/package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)