### PR TITLE
docs: scrub remaining ParaDrop content mentions (relay)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Why a separate repo:
 - **Compliance:** 325 KAT vectors, 21 ADRs, byte-equivalence proven across three
   implementations (oqs server-side, RustCrypto browser-side, `@noble` reference).
 
-Browser-side crypto (parashare, paradrop, ontvang) lives vendored in
+Browser-side crypto (parashare, ontvang) lives vendored in
 [`crypto-wasm/`](crypto-wasm/) (RustCrypto, compiled to wasm32). It is validated
 against paramant-core via the cross-impl-validator crate there (ADR-0020,
 ADR-0021). See
@@ -128,7 +128,7 @@ Full set: [`docs/adrs/`](docs/adrs/) (R001–R011).
 | Outlook Add-in | Source in repo — server-side encryption path during client-side PQ migration ([architecture §08](https://paramant.app/architecture#components)) |
 | Thunderbird FileLink extension | Source in repo |
 
-**Zero-knowledge scope:** the relay-cannot-read guarantee applies to transfers from the official SDKs (`paramant-sdk` for Python and JavaScript), the WebApp tools (ParaShare, ParaDrop), and the anonymous `/send` flow. The Chromium and Outlook extensions currently take a server-side encryption path while their client-side hybrid crypto is being finished — until that lands, treat extension uploads as relay-side, not zero-knowledge.
+**Zero-knowledge scope:** the relay-cannot-read guarantee applies to transfers from the official SDKs (`paramant-sdk` for Python and JavaScript), the WebApp tools (ParaShare), and the anonymous `/send` flow. The Chromium and Outlook extensions currently take a server-side encryption path while their client-side hybrid crypto is being finished — until that lands, treat extension uploads as relay-side, not zero-knowledge.
 
 ---
 

--- a/docs/businessmodel.md
+++ b/docs/businessmodel.md
@@ -45,7 +45,6 @@ For professionals who send sensitive documents regularly.
 - Send history (last 30 transfers)
 - Custom expiry message
 - Delivery confirmation email to sender
-- ParaDrop included
 
 **OT kant:**
 - Unlimited transfers
@@ -134,15 +133,6 @@ Paramant is published under BUSL-1.1. If the managed service shuts down, every s
 ### OT pricing rationale
 OT customers (regulated industrial) buy Enterprise — dedicated relay, compliance docs, human contact.
 Free + Pro OT tiers exist for engineer evaluation before procurement.
-
----
-
-## ParaDrop
-
-ParaDrop is the AirDrop alternative product.
-Encrypted local transfer. No Apple, no cloud, no account.
-Share files with nearby devices over your local network. Burn-on-read.
-Available on Pro and above via /drop.
 
 ---
 

--- a/docs/cross-repo-coordination.md
+++ b/docs/cross-repo-coordination.md
@@ -21,7 +21,7 @@ paramant-core/docs/ARCHITECTURE.md (the authoritative cross-repo overview).
 | Crypto primitives + KATs        | core       | relay      | core ADR-0005/12 |
 | Wire format (bytes on the wire) | relay      | core       | core ADR-0014    |
 | Algorithm registry / IDs        | core       | relay      | core ADR-0007    |
-| Send/ParaShare/ParaDrop envel.  | core       | relay      | core envelope-*  |
+| Send/ParaShare envel.  | core       | relay      | core envelope-*  |
 | Operator tooling / deployment   | relay      | --         | R009             |
 
 Rule of thumb: anything that is "what bytes does a client see" is decided in the

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -735,7 +735,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
   <div class="arch-inner">
     <div class="section-num">08</div>
     <h2 class="section-title">Components</h2>
-    <p class="section-desc">The relay is one piece. Around it sit official SDKs, two browser extensions, and the WebApp tools (ParaShare, ParaDrop). Each surface is at a different stage of the wire-format-v1 migration. Here is the honest state today.</p>
+    <p class="section-desc">The relay is one piece. Around it sit official SDKs, two browser extensions, and the WebApp tools (ParaShare). Each surface is at a different stage of the wire-format-v1 migration. Here is the honest state today.</p>
 
     <table class="modes-table">
       <thead>
@@ -765,11 +765,6 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
           <td><strong>ParaShare (webapp)</strong></td>
           <td>Verified, authenticated transfers from the browser.</td>
           <td>Hybrid ML-KEM-768 + ECDH P-256 + AES-256-GCM via WASM, client-side. Pre-v1 blob layout. Migration to v1 in progress.</td>
-        </tr>
-        <tr>
-          <td><strong>ParaDrop (webapp)</strong></td>
-          <td>Device-to-device transfer over the relay, browser-to-browser.</td>
-          <td>Same WASM bridge as ParaShare. Pre-v1 layout. Migration to v1 in progress.</td>
         </tr>
         <tr>
           <td><strong>Chromium extension</strong></td>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -316,7 +316,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
   <div class="card" style="margin-top:14px;border-left:3px solid var(--cobalt)">
     <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px">Where the zero-knowledge guarantee holds today</div>
-    <p style="margin:0;line-height:1.75;font-size:var(--text-sm)">The guarantee above applies to transfers from the official SDKs (sdk-py 3.0.0, sdk-js 3.0.0) and the WebApp tools (ParaShare, ParaDrop), each of which encrypts in the client before bytes leave the device. The Chromium and Outlook extensions currently take a server-side encryption path while their client-side crypto is being finished; until that migration lands, treat extension uploads as relay-side, not zero-knowledge. Per-client status: <a href="/crypto-agility#06">crypto-agility § 06</a>.</p>
+    <p style="margin:0;line-height:1.75;font-size:var(--text-sm)">The guarantee above applies to transfers from the official SDKs (sdk-py 3.0.0, sdk-js 3.0.0) and the WebApp tools (ParaShare), each of which encrypts in the client before bytes leave the device. The Chromium and Outlook extensions currently take a server-side encryption path while their client-side crypto is being finished; until that migration lands, treat extension uploads as relay-side, not zero-knowledge. Per-client status: <a href="/crypto-agility#06">crypto-agility § 06</a>.</p>
   </div>
 
   <p style="font-size:var(--text-sm);color:var(--ink-dim)">For the full audit history, patch timeline, and cryptographic architecture, see the <a href="/architecture">architecture page</a>.</p>


### PR DESCRIPTION
Follow-up to #150 (ParaDrop feature removal). Removes the remaining ParaDrop *content* mentions so the site/docs stop describing a removed product.

- architecture.html (blurb + modes-table row), security.html, README.md (zero-knowledge scope + browser-crypto line), cross-repo-coordination.md (envelope row), businessmodel.md (ParaDrop product section + Pro-tier bullet).

Out of scope (separate tracks): the `/drop` **nav links** (~60 pages, after the nav sessions) and historical audit-reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)