### PR TITLE
chore(nav): remove ParaDrop links from nav + dashboard

### DIFF
--- a/frontend/apply-nav.py
+++ b/frontend/apply-nav.py
@@ -14,7 +14,6 @@ NEW_NAV = '''\
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -102,7 +101,6 @@ NEW_MOBILE = '''\
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/compliance/iec62443.html
+++ b/frontend/compliance/iec62443.html
@@ -162,7 +162,6 @@ pre{font-family:var(--mono)}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -248,7 +247,6 @@ pre{font-family:var(--mono)}
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/compliance/nen7510.html
+++ b/frontend/compliance/nen7510.html
@@ -161,7 +161,6 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -247,7 +246,6 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/compliance/nis2.html
+++ b/frontend/compliance/nis2.html
@@ -161,7 +161,6 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -247,7 +246,6 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -316,7 +316,6 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
     <section class="dh-tools" aria-label="More tools">
       <a class="dh-tool" href="/get"><h3>Receive a file</h3><p>Open a secure link someone sent you. Decryption happens locally.</p></a>
       <a class="dh-tool" href="/parashare"><h3>ParaShare</h3><p>Verified, signed delivery with receipts. Multi-recipient. Sector audit log.</p></a>
-      <a class="dh-tool" href="/drop"><h3>ParaDrop</h3><p>Device-to-device transfer. Six-digit pairing code. End-to-end encrypted.</p></a>
       <a class="dh-tool" href="/verify"><h3>Verify a signature</h3><p>Check a .psign envelope against its document. Local hash, relay-side math.</p></a>
     </section>
 

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -142,7 +142,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -228,7 +227,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -128,7 +128,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -214,7 +213,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -142,7 +142,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -228,7 +227,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -144,7 +144,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -230,7 +229,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -146,7 +146,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -232,7 +231,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -113,7 +113,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -199,7 +198,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -141,7 +141,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -227,7 +226,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -140,7 +140,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -226,7 +225,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -146,7 +146,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -232,7 +231,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -140,7 +140,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -226,7 +225,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -39,7 +39,6 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -125,7 +124,6 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -85,7 +85,6 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Products</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/parashare" role="menuitem">ParaShare</a></li>
-        <li role="none"><a href="/drop" role="menuitem">ParaDrop</a></li>
         <li role="none"><a href="/dashboard" role="menuitem">Dashboard</a></li>
       </ul>
     </li>
@@ -171,7 +170,6 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Products</button>
     <div class="nav-mobile-group-items">
       <a href="/parashare">ParaShare</a>
-      <a href="/drop">ParaDrop</a>
       <a href="/dashboard">Dashboard</a>
     </div>
   </div>


### PR DESCRIPTION
Last UI references to the removed ParaDrop `/drop` page (companion to #150/#151). Without this they 404 once drop.html is gone.

- `apply-nav.py`: ParaDrop entry out of the desktop About dropdown + mobile nav (template source).
- 15 pages with the generated /drop nav link (compliance/*, help/*, security/acknowledgements, signup/verified): desktop + mobile removed.
- `dashboard.html`: ParaDrop tool card removed from 'More tools'.

apply-nav.py edit is in the nav-`<li>` region (lines 17/105), non-overlapping with PR #147's EXCLUDE-list change. Homepage already had no /drop link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)