### PR TITLE
feat(relay): additive account-split schema (stap 1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,3 +56,30 @@ jobs:
       - name: Relay crypto suite
         working-directory: relay
         run: node --test $(find crypto -name '*.test.js')
+
+  relay-unit-tests:
+    name: relay - unit suite (no native deps)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      # Pure-JS units: account-split schema (keys-table), static-serve, envelope
+      # binding, webauthn helpers. No @paramant/core build and no Redis, so the
+      # relay/test suite that previously had zero CI coverage now gates here.
+      - name: Relay unit suite
+        working-directory: relay
+        run: node --test test/*.test.js
+
+  admin-unit-tests:
+    name: admin - unit suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Admin unit suite
+        working-directory: admin
+        run: node --test test/*.test.js

--- a/deploy/migrate-users-v2.mjs
+++ b/deploy/migrate-users-v2.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Idempotent users.json v1 -> v2 migration (additive account-split schema).
+//
+//   node deploy/migrate-users-v2.mjs [path-to-users.json]
+//
+// Safe to run on a live file: it backs up first, writes atomically (tmp+rename),
+// and is a no-op when the file is already schema_version >= 2. The relay also
+// tolerates a v1 file at runtime (loadUsers defaults account_id = key), so this
+// script is only needed when you want the on-disk file to carry the v2 shape.
+//
+// Rollback: restore the printed `.v1.bak.<stamp>` over users.json and reload.
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+const require_ = createRequire(import.meta.url);
+const { migrateUsersV2 } = require_('../relay/lib/keys-table.js');
+
+const file = process.argv[2] || process.env.USERS_FILE || './users.json';
+
+let raw;
+try { raw = fs.readFileSync(file, 'utf8'); }
+catch (e) { console.error(`[migrate] cannot read ${file}: ${e.message}`); process.exit(1); }
+
+let data;
+try { data = JSON.parse(raw); }
+catch (e) { console.error(`[migrate] ${file} is not valid JSON: ${e.message}`); process.exit(1); }
+
+if ((data.schema_version | 0) >= 2) {
+  console.log(`[migrate] ${file} already schema_version >= 2 — no-op.`);
+  process.exit(0);
+}
+
+let out;
+try { out = migrateUsersV2(data); }
+catch (e) { console.error(`[migrate] refused: ${e.message}`); process.exit(1); }
+
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const bak = `${file}.v1.bak.${stamp}`;
+fs.copyFileSync(file, bak);
+
+const tmp = `${file}.tmp.${process.pid}.${stamp}`;
+fs.writeFileSync(tmp, JSON.stringify(out, null, 2));
+fs.renameSync(tmp, file);
+
+console.log(`[migrate] ${file}: v1 -> v2  (${out.api_keys.length} keys, ${Object.keys(out.accounts).length} accounts)`);
+console.log(`[migrate] backup: ${bak}`);

--- a/relay/lib/keys-table.js
+++ b/relay/lib/keys-table.js
@@ -1,0 +1,96 @@
+'use strict';
+// Account-split schema helpers (stap 1: additive, behaviour-neutral).
+//
+// Today one string means three things: session.user_id == "pgp_..." ==
+// apiKeys.get(key). This module introduces the additive account layer that
+// lets account_id, primary_api_key and N per-account keys diverge later,
+// WITHOUT changing current behaviour: for an existing key the defaults make
+// account_id == the key itself (1:1), so every downstream lookup is identical.
+//
+// Pure module: no I/O, no globals. Unit-tested in test/keys-table.test.js.
+const crypto = require('crypto');
+
+// Scopes are reserved now (every key is "full"); the relay does not yet gate on
+// them. Kept as an allow-list so the enum stays stable for a non-breaking
+// future migration to composite grants.
+const VALID_SCOPES = new Set(['full', 'send-only', 'sign-only', 'read-only']);
+
+// Non-secret, stable key identifier for URLs/listings (never the raw pgp_ key).
+// 48 bits of SHA3-free SHA-256 prefix: collision-safe well past 10M keys.
+function computeKid(key) {
+  return 'k_' + crypto.createHash('sha256').update(String(key)).digest('hex').slice(0, 12);
+}
+
+// Parse the additive account fields off a raw users.json key record, with
+// backward-compatible defaults. A record with no explicit account_id is its own
+// account (account_id = key), is its own primary, full scope, and — being a
+// seeded primary — stays re-revealable until the user rotates it.
+function parseAccountFields(rawKey) {
+  const hasAccountId = rawKey.account_id != null && rawKey.account_id !== '';
+  const account_id = hasAccountId ? rawKey.account_id : rawKey.key;
+  const is_primary = (rawKey.is_primary !== undefined) ? !!rawKey.is_primary : !hasAccountId;
+  const scope = VALID_SCOPES.has(rawKey.scope) ? rawKey.scope : 'full';
+  const legacy_revealable = (rawKey.legacy_revealable !== undefined)
+    ? !!rawKey.legacy_revealable
+    : (!hasAccountId && is_primary);
+  return { account_id, is_primary, scope, legacy_revealable };
+}
+
+// Pick a kid not already present in `taken` (anything with a .has(kid) method:
+// the live kidIndex Map, or a Set in tests). On the astronomically-unlikely
+// 48-bit prefix collision at LOAD time we cannot regenerate an existing key, so
+// we suffix the kid and warn. (At CREATE time the caller regenerates the key
+// instead — see assignKid usage notes; not wired in stap 1.)
+function assignKid(taken, key, log) {
+  const base = computeKid(key);
+  if (!taken.has(base)) return base;
+  let n = 1, alt = `${base}_${n}`;
+  while (taken.has(alt) && n < 1000) { n += 1; alt = `${base}_${n}`; }
+  if (log) log('warn', 'kid_collision', { kid: base, resolved: alt, key_prefix: String(key).slice(0, 8) });
+  return alt;
+}
+
+// Full rebuild of the account/index Maps from the live apiKeys Map. Idempotent:
+// clears and re-derives on every call (used after load, trial-load and the
+// reload atomic swap). Each apiKeys value must already carry account_id/
+// is_primary/scope (set via parseAccountFields at load). Assigns each value a
+// stable `kid`. First-writer fills the account record; an explicit primary key
+// always wins primary_api_key.
+function rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex, log) {
+  accounts.clear();
+  accountKeys.clear();
+  kidIndex.clear();
+  for (const [key, v] of apiKeys) {
+    const account_id = v.account_id || key;
+    if (!accounts.has(account_id)) {
+      accounts.set(account_id, { account_id, plan: v.plan, email: v.email || '', primary_api_key: null, label: v.label || '' });
+    }
+    const acct = accounts.get(account_id);
+    if (v.is_primary || !acct.primary_api_key) acct.primary_api_key = v.is_primary ? key : (acct.primary_api_key || key);
+    if (!accountKeys.has(account_id)) accountKeys.set(account_id, new Set());
+    accountKeys.get(account_id).add(key);
+    const kid = assignKid(kidIndex, key, log);
+    v.kid = kid;
+    kidIndex.set(kid, key);
+  }
+  return { accounts, accountKeys, kidIndex };
+}
+
+// users.json v1 -> v2 migration. Pure: returns a NEW object, never mutates the
+// input. Idempotent: a v2 input (schema_version >= 2) is returned unchanged, so
+// running it twice is a no-op. Seeds account_id = key for every existing key.
+function migrateUsersV2(data) {
+  if (!data || !Array.isArray(data.api_keys)) throw new Error('invalid users.json: missing api_keys array');
+  if ((data.schema_version | 0) >= 2) return data;
+  const accounts = {};
+  const api_keys = data.api_keys.map((k) => {
+    const fields = parseAccountFields(k);
+    const a = accounts[fields.account_id]
+      || (accounts[fields.account_id] = { account_id: fields.account_id, plan: k.plan, email: k.email || '', primary_api_key: null, label: k.label || '' });
+    if (fields.is_primary || !a.primary_api_key) a.primary_api_key = fields.is_primary ? k.key : (a.primary_api_key || k.key);
+    return { ...k, ...fields };
+  });
+  return { ...data, schema_version: 2, accounts, api_keys };
+}
+
+module.exports = { VALID_SCOPES, computeKid, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2 };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -31,6 +31,7 @@ const userSigning   = require('./lib/user-signing');
 const userWebauthn  = require('./lib/user-webauthn');
 const tiers         = require('./lib/tiers');
 const quota         = require('./lib/quota');
+const keysTable     = require('./lib/keys-table');
 
 const VERSION    = '3.0.0';
 // Per-restart nonce: stream-next hashes non-precomputable even if API key is known
@@ -1315,7 +1316,10 @@ setInterval(() => {
 
 // ── RAM_GUARD marker
 // ── RAM-only stores ───────────────────────────────────────────────────────────
-const apiKeys    = new Map();  // key → {plan, active, label, dsa_pub}
+const apiKeys    = new Map();  // key → {plan, active, label, dsa_pub, account_id, is_primary, scope, kid}
+const accounts   = new Map();  // account_id → {account_id, plan, email, primary_api_key, label}  (stap 1: account_id == key)
+const accountKeys = new Map(); // account_id → Set<api_key>  (reverse index for per-account cap + listing)
+const kidIndex   = new Map();  // kid → api_key  (non-secret key id for URLs/listings)
 const blobStore  = new Map();  // hash → {blob, ts, ttl, size, sig?}
 
 // Trial key request rate limiting (in-memory)
@@ -1558,7 +1562,7 @@ function _mutateUsersJson(fn) {
 
 function loadUsers() {
   if (process.env.USERS_JSON) {
-    try { const d = JSON.parse(process.env.USERS_JSON); (d.api_keys||[]).forEach(k => { if(k.active) apiKeys.set(k.key,{plan:k.plan,label:k.label||"",email:k.email||"",active:true}); }); log("info","users_loaded",{count:apiKeys.size,source:"env"}); return; } catch(e) { log("error","users_json_parse",{err:e.message}); }
+    try { const d = JSON.parse(process.env.USERS_JSON); (d.api_keys||[]).forEach(k => { if(k.active) apiKeys.set(k.key,{plan:k.plan,label:k.label||"",email:k.email||"",active:true,...keysTable.parseAccountFields(k)}); }); keysTable.rebuildKeyIndexes(apiKeys,accounts,accountKeys,kidIndex,log); log("info","users_loaded",{count:apiKeys.size,source:"env"}); return; } catch(e) { log("error","users_json_parse",{err:e.message}); }
   }
   try {
     const d = JSON.parse(fs.readFileSync(USERS_FILE, 'utf8'));
@@ -1569,8 +1573,10 @@ function loadUsers() {
         is_trial: !!(k.plan === 'community' && k.trial_metadata),
         trial_created: k.created ? new Date(k.created).getTime() : null,
         uploads_today: 0, last_upload_day: '',
+        ...keysTable.parseAccountFields(k),
       });
     });
+    keysTable.rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex, log);
     log('info', 'users_loaded', { count: apiKeys.size, sector: SECTOR });
   } catch(e) { log('warn', 'no_users_file'); }
 }
@@ -1590,12 +1596,13 @@ function loadTrialKeys() {
             daily_uploads: 0, daily_reset_ts: Date.now() + 86_400_000,
             is_trial: true, trial_created: k.created || Date.now(),
             uploads_today: 0, last_upload_day: '',
+            ...keysTable.parseAccountFields(k),
           });
           loaded++;
         }
       } catch {}
     }
-    if (loaded > 0) log('info', 'trial_keys_loaded', { count: loaded });
+    if (loaded > 0) { keysTable.rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex, log); log('info', 'trial_keys_loaded', { count: loaded }); }
   } catch(e) { /* file may not exist yet */ }
 }
 
@@ -3356,6 +3363,7 @@ session = client.create_session('recipient@example.com')</pre>
         is_trial: !!(k.plan === 'community' && k.trial_metadata),
         trial_created: k.created ? new Date(k.created).getTime() : null,
         uploads_today: 0, last_upload_day: '',
+        ...keysTable.parseAccountFields(k),
       });
     }
 
@@ -3369,6 +3377,7 @@ session = client.create_session('recipient@example.com')</pre>
     // Atomic swap.
     apiKeys.clear();
     candidate.forEach((v, k) => apiKeys.set(k, v));
+    keysTable.rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex, log);
 
     applyKeyLimitEnforcement();
     log('info', 'reload_users', { prev: prevCount, now: apiKeys.size, delta: apiKeys.size - prevCount });

--- a/relay/test/keys-table.test.js
+++ b/relay/test/keys-table.test.js
@@ -1,0 +1,127 @@
+'use strict';
+// Unit tests for the additive account-split schema (stap 1). Pure: imports the
+// helper module only, never starts the relay server.
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const kt = require('../lib/keys-table');
+
+test('computeKid is deterministic and well-formed', () => {
+  const a = kt.computeKid('pgp_deadbeef');
+  assert.equal(a, kt.computeKid('pgp_deadbeef'));            // deterministic
+  assert.match(a, /^k_[0-9a-f]{12}$/);                       // k_ + 48-bit hex
+  assert.notEqual(a, kt.computeKid('pgp_other'));            // distinct inputs differ
+});
+
+test('parseAccountFields: v1 record (no account_id) is its own account+primary', () => {
+  const f = kt.parseAccountFields({ key: 'pgp_seed', plan: 'community', email: 'a@b.c', active: true });
+  assert.equal(f.account_id, 'pgp_seed');     // 1:1 — the behaviour-neutral guarantee
+  assert.equal(f.is_primary, true);
+  assert.equal(f.scope, 'full');
+  assert.equal(f.legacy_revealable, true);    // seed primary stays re-revealable until rotated
+});
+
+test('parseAccountFields: v2 record preserves explicit fields', () => {
+  const f = kt.parseAccountFields({ key: 'pgp_x', account_id: 'acct_1', is_primary: false, scope: 'send-only' });
+  assert.equal(f.account_id, 'acct_1');
+  assert.equal(f.is_primary, false);
+  assert.equal(f.scope, 'send-only');
+  assert.equal(f.legacy_revealable, false);   // not a seeded primary
+});
+
+test('parseAccountFields: unknown scope falls back to full', () => {
+  assert.equal(kt.parseAccountFields({ key: 'pgp_x', scope: 'root' }).scope, 'full');
+  assert.equal(kt.parseAccountFields({ key: 'pgp_x', scope: '' }).scope, 'full');
+});
+
+test('assignKid: no collision returns the base kid', () => {
+  const kid = kt.assignKid(new Set(), 'pgp_a');
+  assert.equal(kid, kt.computeKid('pgp_a'));
+});
+
+test('assignKid: collision suffixes and warns (load-time, never regenerates the key)', () => {
+  const base = kt.computeKid('pgp_a');
+  const events = [];
+  const kid = kt.assignKid(new Set([base]), 'pgp_a', (lvl, ev, data) => events.push([lvl, ev, data]));
+  assert.equal(kid, base + '_1');
+  assert.equal(events.length, 1);
+  assert.equal(events[0][1], 'kid_collision');
+});
+
+test('rebuildKeyIndexes: groups keys per account, resolves primary, indexes kids', () => {
+  const apiKeys = new Map();
+  const set = (key, raw) => apiKeys.set(key, { plan: raw.plan || 'community', label: raw.label || '', email: raw.email || '', active: true, ...kt.parseAccountFields({ ...raw, key }) });
+  set('pgp_primary', { account_id: 'acct_1', is_primary: true, plan: 'pro', email: 'a@b.c' });
+  set('pgp_second',  { account_id: 'acct_1', is_primary: false });
+  set('pgp_solo',    {});                                   // v1-style: its own account
+
+  const accounts = new Map(), accountKeys = new Map(), kidIndex = new Map();
+  kt.rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex);
+
+  assert.equal(accounts.get('acct_1').primary_api_key, 'pgp_primary');
+  assert.deepEqual([...accountKeys.get('acct_1')].sort(), ['pgp_primary', 'pgp_second']);
+  assert.equal(accounts.get('pgp_solo').primary_api_key, 'pgp_solo');
+  assert.equal(kidIndex.size, 3);                          // bijective: one kid per key
+  assert.equal(kidIndex.get(apiKeys.get('pgp_solo').kid), 'pgp_solo');
+  assert.equal(apiKeys.get('pgp_primary').kid, kt.computeKid('pgp_primary'));
+});
+
+test('rebuildKeyIndexes is idempotent (safe on reload)', () => {
+  const apiKeys = new Map([
+    ['pgp_a', { plan: 'community', ...kt.parseAccountFields({ key: 'pgp_a' }) }],
+    ['pgp_b', { plan: 'community', ...kt.parseAccountFields({ key: 'pgp_b' }) }],
+  ]);
+  const accounts = new Map(), accountKeys = new Map(), kidIndex = new Map();
+  kt.rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex);
+  const firstKids = [...kidIndex.keys()].sort();
+  kt.rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex);   // run again
+  assert.equal(accounts.size, 2);
+  assert.equal(kidIndex.size, 2);
+  assert.deepEqual([...kidIndex.keys()].sort(), firstKids);
+});
+
+test('migrateUsersV2: v1 -> v2, additive, original fields preserved, input not mutated', () => {
+  const v1 = { api_keys: [{ key: 'pgp_a', plan: 'community', label: 'Alice', email: 'a@b.c', active: true }] };
+  const v2 = kt.migrateUsersV2(v1);
+  assert.equal(v2.schema_version, 2);
+  assert.equal(v2.api_keys[0].account_id, 'pgp_a');
+  assert.equal(v2.api_keys[0].is_primary, true);
+  assert.equal(v2.api_keys[0].scope, 'full');
+  assert.equal(v2.api_keys[0].legacy_revealable, true);
+  assert.equal(v2.api_keys[0].plan, 'community');          // original preserved
+  assert.equal(v2.api_keys[0].label, 'Alice');
+  assert.equal(v2.accounts['pgp_a'].primary_api_key, 'pgp_a');
+  assert.equal(v1.api_keys[0].account_id, undefined);      // pure: input untouched
+  assert.equal(v1.schema_version, undefined);
+});
+
+test('migrateUsersV2 is idempotent (second run is a no-op)', () => {
+  const v1 = { api_keys: [{ key: 'pgp_a', plan: 'pro', active: true }] };
+  const once = kt.migrateUsersV2(v1);
+  const twice = kt.migrateUsersV2(once);
+  assert.deepEqual(twice, once);
+  assert.equal(twice.schema_version, 2);
+});
+
+test('migrateUsersV2 rejects malformed input', () => {
+  assert.throws(() => kt.migrateUsersV2({}), /missing api_keys/);
+  assert.throws(() => kt.migrateUsersV2(null), /missing api_keys/);
+});
+
+test('integration: migrate v1 file -> load -> rebuild produces consistent indexes', () => {
+  const v1 = { api_keys: [
+    { key: 'pgp_alice', plan: 'pro', email: 'alice@x.io', active: true },
+    { key: 'pgp_bob',   plan: 'community', email: 'bob@x.io', active: true },
+  ] };
+  const v2 = kt.migrateUsersV2(v1);
+
+  // simulate loadUsers: apiKeys carries the parsed fields
+  const apiKeys = new Map();
+  for (const k of v2.api_keys) apiKeys.set(k.key, { plan: k.plan, email: k.email, active: true, ...kt.parseAccountFields(k) });
+  const accounts = new Map(), accountKeys = new Map(), kidIndex = new Map();
+  kt.rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex);
+
+  assert.equal(accounts.size, 2);                          // each key is its own account (1:1)
+  assert.equal(accounts.get('pgp_alice').primary_api_key, 'pgp_alice');
+  assert.equal(kidIndex.size, 2);
+  assert.equal(apiKeys.get('pgp_bob').account_id, 'pgp_bob');
+});


### PR DESCRIPTION
**Stap 1 van 5** in de `account_id ≠ api_key`-splitsing. Puur **additief** en **gedrags-neutraal**: voor elke bestaande key maken de defaults `account_id == de key zelf` (1:1), dus alle downstream-lookups zijn byte-identiek. Geen forced logout, geen Redis-herkey.

### Wat dit toevoegt
- **`relay/lib/keys-table.js`** — pure, geteste helpers: `parseAccountFields`, `computeKid` (`k_`+48-bit), `assignKid` (load-time botsings-suffix), `rebuildKeyIndexes`, `migrateUsersV2`. Geen I/O, geen globals.
- **`relay.js`** — `loadUsers` (env+file), `loadTrialKeys` en de `/v2/reload-users` atomic-swap taggen elke key met `account_id / is_primary / scope / legacy_revealable` en herbouwen `accounts` + `accountKeys` + `kidIndex`. **Regel 1857 onaangeroerd** (account_id staat nu al bij load, == key).
- **`deploy/migrate-users-v2.mjs`** — idempotente v1→v2 bestandsmigratie; backup vóór atomic `tmp+rename`; no-op bij `schema_version >= 2`.
- **`.github/workflows/test.yml`** — nieuwe `relay-unit` + `admin-unit` jobs draaien de `relay/test`- en `admin/test`-suites die **voorheen geen CI-dekking** hadden (de nieuwe keys-table-suite gate't hier).
- **`relay/test/keys-table.test.js`** — 12 unit-tests.

### Envelope-discipline
Geen wijzigingen aan `admin/server.js`, de SDK, of auth/device/cap-logica. Die komen in stap 2-5.

### Test
- `relay/test`: 15 pass / 0 fail · `admin/test`: 2 pass / 0 fail · nieuwe keys-table: 12 pass.
- Migratie geverifieerd v1→v2 additief, 2e run no-op, backup gemaakt.

### Rollback
Image-revert volstaat (de v2-`users.json` is voor-én-achterwaarts leesbaar; oude `loadUsers` negeert de extra velden), of herstel de `.v1.bak.<stamp>`-backup van het migratie-script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)