### PR TITLE
feat: gated /developer dashboard access path (single-account)

### DIFF
--- a/admin/lib/developer-gate.js
+++ b/admin/lib/developer-gate.js
@@ -1,0 +1,28 @@
+'use strict';
+// Email allowlist for the hidden /developer dashboard. Pure + env-injectable so
+// the gate can be unit-tested without booting the admin server (same pattern as
+// lib/webauthn.js and lib/account-recovery.js).
+//
+// Rules:
+//   - the allowlist comes from env.DEVELOPER_ALLOWLIST (comma-separated) — never
+//     hardcoded in the code;
+//   - empty allowlist + NODE_ENV=development  => open (local dev/test only);
+//   - empty allowlist otherwise (incl. production, where NODE_ENV is unset)
+//     => closed for everyone, so access always requires an explicit entry.
+
+function developerAllowlist(env) {
+  env = env || process.env;
+  return String(env.DEVELOPER_ALLOWLIST || '')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function isDeveloper(email, env) {
+  env = env || process.env;
+  const list = developerAllowlist(env);
+  if (list.length === 0) return env.NODE_ENV === 'development';
+  return list.includes(String(email || '').trim().toLowerCase());
+}
+
+module.exports = { developerAllowlist, isDeveloper };

--- a/admin/server.js
+++ b/admin/server.js
@@ -598,6 +598,36 @@ async function authUser(req, res, next) {
   }
 }
 
+// ── Developer dashboard allowlist ───────────────────────────────────────────
+// Extra gate ON TOP OF authUser for the hidden /developer dashboard. The email
+// allowlist comes from env only (DEVELOPER_ALLOWLIST, comma-separated) — never
+// hardcoded. The pure logic lives in ./lib/developer-gate (unit-tested in
+// admin/test/developer-gate.test.js).
+const { isDeveloper } = require("./lib/developer-gate");
+// Gate for /api/user/developer/* data endpoints. Runs after authUser (which
+// 401s on no session). A valid session that is not on the allowlist gets a
+// 404 — indistinguishable from "this route does not exist", so the developer
+// surface stays hidden from logged-in non-developers (never 403).
+function developerGate(req, res, next) {
+  if (!isDeveloper(req.userSession && req.userSession.email))
+    return res.status(404).json({ error: "not_found" });
+  next();
+}
+// Provisional CLI catalogue surfaced by /api/user/developer/tools. Source of
+// truth for the descriptions is paramant-solutions/tools/. WIP — not published.
+const DEVELOPER_TOOLS = [
+  { name: "paramant-dev-transfer",  tagline: "WeTransfer for the terminal — send a file, get a token." },
+  { name: "paramant-s3-migrate",    tagline: "Move an S3 object to a device, encrypted, no copy left behind." },
+  { name: "paramant-db-backup",     tagline: "Off-site database backups, encrypted before they leave the box." },
+  { name: "paramant-git-archive",   tagline: "Send a repo snapshot at any ref, encrypted, without a remote." },
+  { name: "paramant-docker-migrate",tagline: "Move a Docker volume to another host, encrypted." },
+  { name: "paramant-secrets-sync",  tagline: "Team secrets sync without a cloud vault." },
+  { name: "paramant-ci-artifact",   tagline: "Ship CI/CD build artifacts, encrypted, from the pipeline." },
+  { name: "paramant-log-ship",      tagline: "Tamper-evident log shipping — ML-DSA-65-signed batches to the SIEM." },
+  { name: "paramant-package-sign",  tagline: "Code-sign a release artifact with post-quantum ML-DSA-65." },
+  { name: "paramant-db-replicate",  tagline: "Cross-region database replication, post-quantum encrypted." },
+];
+
 // Session cookie is SameSite=Lax (was Strict). Deliberate choice (ADR R018):
 // the invite/co-sign flow lands a recipient via a top-level navigation from an
 // emailed link (cross-site, from their mail client). A Strict cookie is NOT
@@ -1715,6 +1745,26 @@ api.get("/user/dashboard-fragment", (req, res) => {
 // and returns 401 on miss; this handler only fires on hit.
 api.get("/user/check", authUser, (req, res) => {
   res.status(200).end();
+});
+
+// GET /api/user/developer/check
+// nginx auth_request probe for the /developer page (mirrors /user/check, with
+// the allowlist layer). authUser returns 401 on no session -> nginx redirects
+// to login. A valid session that is NOT on the developer allowlist gets 403,
+// which nginx remaps to 404 so the page's existence stays hidden. Allowlisted
+// session -> 200 and nginx serves /developer.html.
+api.get("/user/developer/check", authUser, (req, res) => {
+  if (!isDeveloper(req.userSession.email)) return res.status(403).end();
+  res.status(200).end();
+});
+
+// GET /api/user/developer/tools
+// Developer-only data endpoint behind authUser + developerGate (404 for
+// non-allowlisted). Provisional: the page renders the tool list statically;
+// this endpoint exists so the gated /api/user/developer/* surface is wired and
+// testable from day one.
+api.get("/user/developer/tools", authUser, developerGate, (req, res) => {
+  res.json({ status: "wip", tools: DEVELOPER_TOOLS });
 });
 
 // GET /api/user/account

--- a/admin/test/developer-gate.test.js
+++ b/admin/test/developer-gate.test.js
@@ -1,0 +1,51 @@
+'use strict';
+// Unit test for admin/lib/developer-gate.js: the email allowlist parsing and
+// the open/closed rules for the hidden /developer dashboard.
+// Run: node admin/test/developer-gate.test.js (no deps, non-zero exit on fail).
+
+const assert = require('assert');
+const { developerAllowlist, isDeveloper } = require('../lib/developer-gate');
+
+let passed = 0;
+const ok = (n) => { passed++; console.log('  ok -', n); };
+
+// developerAllowlist parsing
+assert.deepStrictEqual(developerAllowlist({ DEVELOPER_ALLOWLIST: '' }), [], 'empty => []');
+assert.deepStrictEqual(developerAllowlist({}), [], 'missing => []');
+assert.deepStrictEqual(
+  developerAllowlist({ DEVELOPER_ALLOWLIST: 'a@x.com, B@Y.COM ,,c@z.com' }),
+  ['a@x.com', 'b@y.com', 'c@z.com'],
+  'split, trim, lowercase, drop blanks');
+ok('developerAllowlist parsing');
+
+// Allowlisted email => allowed (case/space-insensitive)
+const prodEnv = { DEVELOPER_ALLOWLIST: 'mickbr@protonmail.com' };
+assert.strictEqual(isDeveloper('mickbr@protonmail.com', prodEnv), true, 'exact match allowed');
+assert.strictEqual(isDeveloper('  MickBr@Protonmail.com ', prodEnv), true, 'case/space-insensitive');
+ok('allowlisted email allowed');
+
+// Non-allowlisted email => denied (this is the "/developer 404" case)
+assert.strictEqual(isDeveloper('someone@else.com', prodEnv), false, 'other account denied');
+assert.strictEqual(isDeveloper('', prodEnv), false, 'empty email denied');
+assert.strictEqual(isDeveloper(null, prodEnv), false, 'null email denied');
+assert.strictEqual(isDeveloper(undefined, prodEnv), false, 'undefined email denied');
+ok('non-allowlisted email denied');
+
+// Empty allowlist in production (NODE_ENV unset) => closed for everyone
+assert.strictEqual(isDeveloper('mickbr@protonmail.com', { DEVELOPER_ALLOWLIST: '' }), false,
+  'empty allowlist, no NODE_ENV => closed');
+assert.strictEqual(isDeveloper('mickbr@protonmail.com', { DEVELOPER_ALLOWLIST: '', NODE_ENV: 'production' }), false,
+  'empty allowlist in production => closed');
+ok('empty allowlist closed in production');
+
+// Empty allowlist + NODE_ENV=development => open (local dev/test bypass)
+assert.strictEqual(isDeveloper('anyone@dev.local', { NODE_ENV: 'development' }), true,
+  'empty allowlist + development => open');
+// ...but an explicit allowlist still wins even in development
+assert.strictEqual(isDeveloper('anyone@dev.local', { NODE_ENV: 'development', DEVELOPER_ALLOWLIST: 'only@me.com' }), false,
+  'explicit allowlist overrides dev bypass');
+assert.strictEqual(isDeveloper('only@me.com', { NODE_ENV: 'development', DEVELOPER_ALLOWLIST: 'only@me.com' }), true,
+  'allowlisted in development allowed');
+ok('development bypass only when allowlist empty');
+
+console.log(`\n${passed} groups passed.`);

--- a/deploy/nginx-paramant-live.conf
+++ b/deploy/nginx-paramant-live.conf
@@ -50,6 +50,24 @@ server {
     # with the internal :8080 port, which is unreachable from outside.
     location @login_redirect { return 302 https://$host/auth/login?next=$uri; }
 
+    # ── Developer dashboard: gated AND hidden ───────────────────────────────
+    # auth_request /api/user/developer/check returns:
+    #   200  allowlisted developer   -> serve /developer.html
+    #   401  no session              -> @login_redirect
+    #   403  logged in, not a dev    -> remap to 404 (@developer_hidden) so a
+    #                                   logged-in non-developer cannot tell the
+    #                                   page exists.
+    # /developer.html is force-404'd so the static file can only be reached
+    # through the gated /developer route, never directly.
+    location = /developer {
+        auth_request /api/user/developer/check;
+        error_page 401 = @login_redirect;
+        error_page 403 = @developer_hidden;
+        try_files /developer.html =404;
+    }
+    location = /developer.html { return 404; }
+    location @developer_hidden { return 404; }
+
     location = /signup { try_files /signup.html =404; }
     location = /signup/verified { try_files /signup/verified.html =404; }
     location = /account { try_files /account.html =404; }
@@ -77,6 +95,16 @@ server {
     location = /api/user/check {
         internal;
         proxy_pass http://127.0.0.1:4200/admin/api/user/check;
+        proxy_set_header Host $host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+    }
+
+    location = /api/user/developer/check {
+        internal;
+        proxy_pass http://127.0.0.1:4200/admin/api/user/developer/check;
         proxy_set_header Host $host;
         proxy_set_header Cookie $http_cookie;
         proxy_set_header X-Original-URI $request_uri;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,6 +291,10 @@ services:
       INTERNAL_AUTH_TOKEN: "${INTERNAL_AUTH_TOKEN:-}"
       SITE_URL: "${SITE_URL:-https://paramant.app}"
       ENABLE_USER_TOTP: "${ENABLE_USER_TOTP:-false}"
+      # Comma-separated emails allowed into the hidden /developer dashboard.
+      # Empty by default; set in the production env-file. Empty allowlist with
+      # no NODE_ENV=development keeps the door closed for everyone.
+      DEVELOPER_ALLOWLIST: "${DEVELOPER_ALLOWLIST:-}"
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:4200/admin/ > /dev/null || exit 1"]
       interval: 30s

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Developer dashboard — Paramant</title>
+<meta name="robots" content="noindex, nofollow">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0B3A6A">
+<link rel="stylesheet" href="/design-system.css?v=19">
+<link rel="stylesheet" href="/nav.css?v=13">
+<link rel="canonical" href="https://paramant.app/developer">
+<style>
+.dev-top { display: flex; align-items: center; justify-content: space-between; max-width: 1040px; margin: 0 auto; padding: 18px var(--space-4); border-bottom: 1px solid var(--ink-hair); }
+.dev-top a.brand { font-weight: 700; letter-spacing: -0.02em; color: var(--navy); text-decoration: none; font-size: 18px; }
+.dev-top .dev-top-links a { font-size: 13px; color: var(--ink-dim); text-decoration: none; margin-left: 18px; }
+.dev-top .dev-top-links a:hover { color: var(--navy); text-decoration: underline; }
+.dev-wrap { max-width: 1040px; margin: var(--space-5) auto var(--space-6); padding: 0 var(--space-4); }
+.dev-wrap h1 { font-size: clamp(26px, 3.4vw, 38px); line-height: 1.1; letter-spacing: -0.02em; color: var(--navy); margin: 0 0 var(--space-2); }
+.dev-wrap .lede { font-size: 16px; line-height: 1.55; color: var(--ink-dim); max-width: 60ch; margin: 0 0 var(--space-4); }
+.wip { display: inline-flex; align-items: center; gap: 8px; font-family: var(--mono, IBM Plex Mono, monospace); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: #92400E; background: #FEF3C7; border: 1px solid #FDE68A; border-radius: 999px; padding: 6px 13px; margin-bottom: var(--space-4); }
+.dev-note { border-left: 3px solid var(--ink-hair); padding: 4px 0 4px 16px; color: var(--ink-dim); font-size: 14px; line-height: 1.6; margin: 0 0 var(--space-5); max-width: 70ch; }
+.dev-auth { background: var(--bone, #F1F5F9); border: 1px solid var(--ink-hair); padding: var(--space-4); margin: 0 0 var(--space-5); }
+.dev-auth h2 { font-size: 15px; margin: 0 0 10px; color: var(--navy); letter-spacing: -0.01em; }
+pre.code { background: #0B1B2B; color: #E2E8F0; font-family: var(--mono, IBM Plex Mono, monospace); font-size: 13px; line-height: 1.55; padding: 14px 16px; overflow-x: auto; margin: 0; border-radius: 4px; }
+.tools { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); }
+.tool { border: 1px solid var(--ink-hair); background: #fff; padding: var(--space-4); display: flex; flex-direction: column; }
+.tool h3 { font-family: var(--mono, IBM Plex Mono, monospace); font-size: 15px; color: var(--navy); margin: 0 0 6px; }
+.tool p { font-size: 13px; line-height: 1.5; color: var(--ink-dim); margin: 0 0 12px; }
+.tool pre.code { font-size: 12px; margin-top: auto; }
+.dev-foot { margin-top: var(--space-6); padding-top: var(--space-4); border-top: 1px solid var(--ink-hair); font-size: 13px; color: var(--ink-dim); }
+.dev-foot a { color: var(--navy); }
+@media (max-width: 760px) { .tools { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+
+<a class="skip-link" href="#main-content">Skip to content</a>
+
+<header class="dev-top">
+  <a class="brand" href="/">Paramant</a>
+  <nav class="dev-top-links" aria-label="Developer">
+    <a href="/dashboard">Dashboard</a>
+    <a href="/docs">Docs</a>
+    <a href="/account">Account</a>
+  </nav>
+</header>
+
+<main id="main-content" class="dev-wrap">
+  <span class="wip">⚠ Work in progress</span>
+  <h1>Developer dashboard</h1>
+  <p class="lede">Command-line tools that ship their result through the Paramant post-quantum relay
+  (ML-KEM-768 + ML-DSA-65, ciphertext-only, burn-on-read) using only the public
+  <code>paramant-sdk</code> API.</p>
+
+  <p class="dev-note">This page is provisional. The tools below are starter / POC and are not yet
+  published to a package index. The install and usage lines are placeholders that mirror the
+  intended shape (one-line install, three-line usage) and will be replaced as each tool ships.</p>
+
+  <section class="dev-auth">
+    <h2>Authenticate once</h2>
+    <pre class="code"># 1. https://paramant.app/signup  →  2. Dashboard → Developer → copy pgp_ key
+export PARAMANT_API_KEY=pgp_...
+export PARAMANT_DEVICE=my-laptop          # optional, stable device id</pre>
+  </section>
+
+  <div class="tools">
+    <article class="tool">
+      <h3>paramant-dev-transfer</h3>
+      <p>WeTransfer for the terminal. Send a file, get a token; the other side receives it by token. The relay only ever holds ciphertext, in RAM, and burns it on first read.</p>
+      <pre class="code">pipx install paramant-dev-transfer
+paramant-dev-transfer ./build.zip
+# → token: pdt_… (share it)</pre>
+    </article>
+
+    <article class="tool">
+      <h3>paramant-s3-migrate</h3>
+      <p>Move an S3 object to a device, encrypted, without leaving a copy behind. Bytes are encrypted on your machine; the relay holds only ciphertext.</p>
+      <pre class="code">pipx install paramant-s3-migrate
+paramant-s3-migrate s3://bucket/key --to ops@host</pre>
+    </article>
+
+    <article class="tool">
+      <h3>paramant-db-backup</h3>
+      <p>One-command off-site database backups that are encrypted before they leave the box. Hands a <code>pg_dump</code>/<code>mysqldump</code> straight to the relay.</p>
+      <pre class="code">pipx install paramant-db-backup
+paramant-db-backup --pg "postgres://…" --to backup@vault</pre>
+    </article>
+
+    <article class="tool">
+      <h3>paramant-git-archive</h3>
+      <p>Send a snapshot of a repo at any ref, encrypted, without a remote. <code>git archive</code> the tree; the other side picks it up by hash.</p>
+      <pre class="code">pipx install paramant-git-archive
+paramant-git-archive HEAD --to teammate@laptop</pre>
+    </article>
+
+    <article class="tool">
+      <h3>paramant-docker-migrate</h3>
+      <p>Move a Docker volume to another host, encrypted, without a shared registry or a cleartext SSH pipe. Export, ship, untar on the far side.</p>
+      <pre class="code">pipx install paramant-docker-migrate
+paramant-docker-migrate my-volume --to operator@host2</pre>
+    </article>
+
+    <article class="tool">
+      <h3>paramant-secrets-sync</h3>
+      <p>Team secrets sync without a cloud vault. Push <code>.env.prod</code> to a teammate; they pull it back by hash. Burned on first read.</p>
+      <pre class="code">pipx install paramant-secrets-sync
+paramant-secrets-sync push .env.prod --to alice@laptop</pre>
+    </article>
+
+    <article class="tool">
+      <h3>paramant-ci-artifact</h3>
+      <p>Ship CI/CD build artifacts to a destination, encrypted, straight from the pipeline. No public artifact store, no plaintext copy in a bucket.</p>
+      <pre class="code">pipx install paramant-ci-artifact
+paramant-ci-artifact ./dist --to deploy@prod</pre>
+    </article>
+
+    <article class="tool">
+      <h3>paramant-log-ship</h3>
+      <p>Tamper-evident log shipping for the SOC. Tail a log and ship each batch to your SIEM as an ML-DSA-65-signed blob the auditor can verify.</p>
+      <pre class="code">pipx install paramant-log-ship
+paramant-log-ship /var/log/app.log --to siem@collector</pre>
+    </article>
+
+    <article class="tool">
+      <h3>paramant-package-sign</h3>
+      <p>Code-sign a release artifact with post-quantum ML-DSA-65, and catch a swap. Produces a detached <code>.psign</code> sidecar (SHA-256 + signature + public key).</p>
+      <pre class="code">pipx install paramant-package-sign
+paramant-package-sign dist/app-1.0.tar.gz
+# → dist/app-1.0.tar.gz.psign</pre>
+    </article>
+
+    <article class="tool">
+      <h3>paramant-db-replicate</h3>
+      <p>Cross-region database replication, post-quantum encrypted. Continuously feed new rows of a Postgres table to another region as encrypted batches.</p>
+      <pre class="code">pipx install paramant-db-replicate
+paramant-db-replicate --table orders --to eu-west@replica</pre>
+    </article>
+  </div>
+
+  <p class="dev-foot">Tools are documented in <code>paramant-solutions/tools/</code>. Each ships only
+  ciphertext through the relay and uses the public <a href="/docs#api">paramant-sdk</a> API.
+  Questions: <a href="/docs">read the docs</a>.</p>
+</main>
+
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,6 +34,8 @@
 .path h2 { font-size: clamp(20px, 2.5vw, 27px); line-height: 1.12; letter-spacing: -0.015em; color: var(--navy); margin: 0 0 var(--space-3); max-width: 18ch; }
 .path > p { font-size: 15px; line-height: 1.55; color: var(--ink-dim); margin: 0 0 var(--space-4); max-width: 34ch; }
 .path-cta { margin-top: auto; }
+.path-cta-sub { display: inline-block; margin-top: var(--space-2); font-size: 13px; color: var(--ink-dim); text-decoration: underline; }
+.path-cta-sub:hover { color: var(--navy); }
 .path-pear { position: absolute; top: var(--space-4); right: var(--space-4); width: clamp(56px, 8vw, 84px); height: auto; opacity: .92; transform: scaleX(-1); user-select: none; -webkit-user-drag: none; }
 @media (max-width: 760px) { .home-split { grid-template-columns: 1fr; } .path { min-height: 0; } }
 </style>
@@ -231,7 +233,8 @@
     <h2>For builders who don&rsquo;t trust servers either.</h2>
     <p>Post-quantum encryption and signing as a pipe. Drop it into your stack, or self-host the whole thing.</p>
     <div class="path-cta">
-      <a class="btn btn-lime" href="/docs">Read the docs</a>
+      <a class="btn btn-lime" href="/developer">Open developer dashboard</a>
+      <a class="path-cta-sub" href="/docs">or read the docs</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## What

A hidden **developer-dashboard door** on paramant.app, gated to a single account (Mick) via an email allowlist on top of the existing passkey/`authUser` session. **No merge, no deploy** — review only.

## Changes

**1. Homepage** (`frontend/index.html`) — the right "For builders who don't trust servers either" box now mirrors the left box: a primary lime **`Open developer dashboard`** button (`/developer`) + a small secondary **`or read the docs`** text link. The old "Read the docs" button becomes that secondary link; `/docs` target unchanged.

**2. `/developer` page** (`frontend/developer.html`, new) — provisional WIP placeholder: "Developer dashboard" header + work-in-progress notice + the 10 `paramant-solutions` CLIs (paramant-dev-transfer, -s3-migrate, -db-backup, -git-archive, -docker-migrate, -secrets-sync, -ci-artifact, -log-ship, -package-sign, -db-replicate) with provisional install/usage. Content is explicitly marked provisional.

**3. Access control — extra layer on `authUser`:**
- `admin/lib/developer-gate.js` (new, pure + env-injectable, unit-tested): allowlist from `DEVELOPER_ALLOWLIST` (comma-separated). Empty allowlist + `NODE_ENV=development` ⇒ open (local dev/test); empty otherwise (incl. production, where `NODE_ENV` is unset) ⇒ **closed for everyone**.
- `admin/server.js`: `GET /api/user/developer/check` (nginx `auth_request` probe) → 401 no-session / 403 logged-in-not-dev / 200 allowlisted; `GET /api/user/developer/tools` behind `authUser` + `developerGate` (**404** for non-allowlisted, never 403, so the API surface looks non-existent).
- `deploy/nginx-paramant-live.conf`: `/developer` uses `auth_request` (same pattern as `/send`, `/sign`). `error_page 401 = @login_redirect`; **`error_page 403 = @developer_hidden` (404)** so a logged-in non-developer cannot tell the page exists. `/developer.html` is force-404'd (only reachable via the gated `/developer`).

**4. Production config** — `DEVELOPER_ALLOWLIST` wired into the admin service env in `docker-compose.yml` with an **empty default**. Value is **not hardcoded**.

## ⚠️ Action for Mick at deploy

Set in the production env-file (e.g. `.env`), then restart the admin service:
```
DEVELOPER_ALLOWLIST=mickbr@protonmail.com
```
Without this, `/developer` returns 404 for everyone in production (closed-by-default).

## Verification (local, sandbox)

- `node admin/test/developer-gate.test.js` → **5 groups pass** (allowlist rules, case/space-insensitive, prod-closed, dev-bypass-only-when-empty).
- `node --check` clean on `server.js` + `developer-gate.js`.
- HTTP-level integration smoke (real `developer-gate.js`, handlers wired as in `server.js`, in-memory session store):
  - no session → **401** (→ login redirect)
  - `mickbr@protonmail.com` → **200** (→ serves `/developer.html`)
  - other account → **403** at the probe (→ nginx remaps to **404**); `/api/user/developer/tools` → **404**
- nginx config: brace-balanced; `/developer` block mirrors the proven `/send` `auth_request` pattern. **`nginx -t` not run** (nginx not installed in sandbox).
- HTML: structural tags balanced for both pages. **Screenshots not captured** (no browser/playwright in sandbox).

## Not touched

Account-schema work (#153), existing `/account` flow, SDK, `paramant-solutions`, production.