### PR TITLE
feat(developer): rebuild /developer as a live operations dashboard

### DIFF
--- a/admin/lib/developer-snapshot.js
+++ b/admin/lib/developer-snapshot.js
@@ -1,0 +1,54 @@
+'use strict';
+// Builds the initial-render snapshot for the /developer operations dashboard.
+// Dependencies (redis client, getAuditEvents, resolved plan) are injected so it
+// unit-tests without booting the admin server.
+
+const { DEVELOPER_TOOLS, toolsStatusFromAudit } = require('./developer-tools');
+
+// Per-account monthly caps. Mirrors relay/lib/tiers.js — duplicated honestly
+// here because the admin Docker image does not ship the relay package.
+const TIER_CAPS = {
+  community:  { transfers: 10,  signs: 2 },
+  pro:        { transfers: 500, signs: 100 },
+  enterprise: { transfers: Infinity, signs: Infinity },
+};
+function normalisePlan(p) {
+  p = String(p || '').toLowerCase();
+  if (p === 'free' || p === 'dev') return 'community';
+  if (p === 'licensed') return 'enterprise';
+  return (p === 'pro' || p === 'enterprise') ? p : 'community';
+}
+function ymKey(d) { return d.toISOString().slice(0, 7); }            // YYYY-MM
+function maskKey(k) { k = String(k || ''); return k.length <= 12 ? k : k.slice(0, 8) + '…' + k.slice(-4); }
+const capOut = (n) => (n === Infinity ? null : n);                   // null = unlimited (JSON-safe)
+
+// deps: { redis: () => client, getAuditEvents, plan, now? }
+async function buildSnapshot(deps, userSession) {
+  const uid = userSession.user_id;        // == pgp_ key == account_id (1:1 today)
+  const email = userSession.email;
+  const r = deps.redis();
+  const np = normalisePlan(deps.plan);
+  const caps = TIER_CAPS[np];
+
+  const ym = ymKey(deps.now || new Date());
+  const num = async (k) => { try { return parseInt((await r.get(k)) || '0', 10) || 0; } catch { return 0; } };
+  const transfers = await num(`paramant:quota:transfers:${uid}:${ym}`);
+  const signs = await num(`paramant:quota:signs:${uid}:${ym}`);
+
+  let audit = [];
+  try { audit = await deps.getAuditEvents(uid, { limit: 50 }); } catch {}
+
+  return {
+    email,
+    plan: np,
+    key_masked: maskKey(uid),
+    quota: {
+      transfers, signs,
+      caps: { transfers: capOut(caps.transfers), signs: capOut(caps.signs) },
+    },
+    audit,
+    tools_status: toolsStatusFromAudit(DEVELOPER_TOOLS, audit),
+  };
+}
+
+module.exports = { buildSnapshot, TIER_CAPS, normalisePlan, maskKey, ymKey };

--- a/admin/lib/developer-tools.js
+++ b/admin/lib/developer-tools.js
@@ -1,0 +1,71 @@
+'use strict';
+// Catalogue for the /developer operations dashboard. Source of truth for the
+// descriptions is paramant-solutions/tools/. Pure data + a couple of pure
+// helpers so it is unit-testable without booting the server. The tools are not
+// on PyPI yet (known-issue C9): `install` reflects that honestly.
+//
+// `usage` carries a {KEY} placeholder the frontend fills with the developer's
+// real pgp_ key (already revealable via /api/user/account/key, behind the gate).
+
+const SOURCE_BASE = 'https://github.com/Apolloccrypt/paramant-solutions/tree/main/tools';
+
+const DEVELOPER_TOOLS = [
+  { name: 'paramant-dev-transfer',  category: 'transfer', tagline: 'WeTransfer for the terminal — send a file, get a token.',
+    usage: 'PARAMANT_API_KEY={KEY} paramant-dev-transfer send report.pdf' },
+  { name: 'paramant-s3-migrate',    category: 'migrate',  tagline: 'Move an S3 object to a device, encrypted, no copy left behind.',
+    usage: 'PARAMANT_API_KEY={KEY} paramant-s3-migrate s3://bucket/key --to bob' },
+  { name: 'paramant-db-backup',     category: 'backup',   tagline: 'Off-site database backups, encrypted before they leave the box.',
+    usage: 'PARAMANT_API_KEY={KEY} paramant-db-backup --pg mydb --to backups' },
+  { name: 'paramant-git-archive',   category: 'archive',  tagline: 'Send a repo snapshot at any ref, encrypted, without a remote.',
+    usage: 'PARAMANT_API_KEY={KEY} paramant-git-archive HEAD --to teammate' },
+  { name: 'paramant-docker-migrate',category: 'migrate',  tagline: 'Move a Docker volume to another host, encrypted.',
+    usage: 'PARAMANT_API_KEY={KEY} paramant-docker-migrate my-volume --to host2' },
+  { name: 'paramant-secrets-sync',  category: 'sync',     tagline: 'Team secrets sync without a cloud vault.',
+    usage: 'PARAMANT_API_KEY={KEY} paramant-secrets-sync push .env --to team' },
+  { name: 'paramant-ci-artifact',   category: 'ship',     tagline: 'Ship CI/CD build artifacts, encrypted, from the pipeline.',
+    usage: 'PARAMANT_API_KEY={KEY} paramant-ci-artifact dist/ --to release' },
+  { name: 'paramant-log-ship',      category: 'ship',     tagline: 'Tamper-evident log shipping — ML-DSA-65-signed batches to the SIEM.',
+    usage: 'PARAMANT_API_KEY={KEY} paramant-log-ship /var/log/app.log --to siem' },
+  { name: 'paramant-package-sign',  category: 'sign',     tagline: 'Code-sign a release artifact with post-quantum ML-DSA-65.',
+    usage: 'PARAMANT_API_KEY={KEY} paramant-package-sign app-1.0.tgz' },
+  { name: 'paramant-db-replicate',  category: 'replicate',tagline: 'Cross-region database replication, post-quantum encrypted.',
+    usage: 'PARAMANT_API_KEY={KEY} paramant-db-replicate --pg mydb --to dr-region' },
+].map((t) => ({
+  ...t,
+  // Honest install: not published to PyPI yet (C9) — clone + editable install.
+  install: `git clone https://github.com/Apolloccrypt/paramant-solutions && pip install -e paramant-solutions/tools/${t.name}`,
+  source: `${SOURCE_BASE}/${t.name}`,
+}));
+
+// Audit-event types this dashboard treats as a "tool run" for status/stats.
+// None are emitted yet (tools are not wired to the per-user audit) — so every
+// tool reads as "never used" today. Honest: stats appear once runs are logged.
+const TOOL_RUN_TYPES = new Set(['tool_run', 'transfer_sent', 'sign_completed']);
+
+function isToolEvent(ev) {
+  return ev && (TOOL_RUN_TYPES.has(ev.event_type) || (ev.metadata && ev.metadata.tool));
+}
+
+// Per-tool status from the account's audit events. Pure.
+function toolsStatusFromAudit(tools, audit) {
+  const out = {};
+  const weekAgo = 7 * 24 * 3600 * 1000;
+  const nowTsFromAudit = audit.length ? Math.max(...audit.map((e) => e.ts || 0)) : 0;
+  for (const t of tools) {
+    const runs = audit.filter((e) => isToolEvent(e) && (e.metadata?.tool === t.name || e.event_type === t.name));
+    if (!runs.length) { out[t.name] = { state: 'never_used', last_run: null, runs_week: 0, success_rate: null, avg_ms: null }; continue; }
+    const week = runs.filter((e) => nowTsFromAudit - (e.ts || 0) <= weekAgo);
+    const ok = week.filter((e) => e.metadata?.result !== 'fail').length;
+    const durs = week.map((e) => e.metadata?.duration_ms).filter((n) => typeof n === 'number');
+    out[t.name] = {
+      state: 'idle',
+      last_run: Math.max(...runs.map((e) => e.ts || 0)),
+      runs_week: week.length,
+      success_rate: week.length ? Math.round((ok / week.length) * 100) : null,
+      avg_ms: durs.length ? Math.round(durs.reduce((a, b) => a + b, 0) / durs.length) : null,
+    };
+  }
+  return out;
+}
+
+module.exports = { DEVELOPER_TOOLS, isToolEvent, toolsStatusFromAudit, SOURCE_BASE };

--- a/admin/server.js
+++ b/admin/server.js
@@ -613,20 +613,11 @@ function developerGate(req, res, next) {
     return res.status(404).json({ error: "not_found" });
   next();
 }
-// Provisional CLI catalogue surfaced by /api/user/developer/tools. Source of
-// truth for the descriptions is paramant-solutions/tools/. WIP — not published.
-const DEVELOPER_TOOLS = [
-  { name: "paramant-dev-transfer",  tagline: "WeTransfer for the terminal — send a file, get a token." },
-  { name: "paramant-s3-migrate",    tagline: "Move an S3 object to a device, encrypted, no copy left behind." },
-  { name: "paramant-db-backup",     tagline: "Off-site database backups, encrypted before they leave the box." },
-  { name: "paramant-git-archive",   tagline: "Send a repo snapshot at any ref, encrypted, without a remote." },
-  { name: "paramant-docker-migrate",tagline: "Move a Docker volume to another host, encrypted." },
-  { name: "paramant-secrets-sync",  tagline: "Team secrets sync without a cloud vault." },
-  { name: "paramant-ci-artifact",   tagline: "Ship CI/CD build artifacts, encrypted, from the pipeline." },
-  { name: "paramant-log-ship",      tagline: "Tamper-evident log shipping — ML-DSA-65-signed batches to the SIEM." },
-  { name: "paramant-package-sign",  tagline: "Code-sign a release artifact with post-quantum ML-DSA-65." },
-  { name: "paramant-db-replicate",  tagline: "Cross-region database replication, post-quantum encrypted." },
-];
+// Operations-dashboard data libs (CLI catalogue + snapshot builder). Source of
+// truth for the descriptions is paramant-solutions/tools/. Unit-tested in
+// admin/test/developer-snapshot.test.js.
+const { DEVELOPER_TOOLS } = require('./lib/developer-tools');
+const { buildSnapshot } = require('./lib/developer-snapshot');
 
 // Session cookie is SameSite=Lax (was Strict). Deliberate choice (ADR R018):
 // the invite/co-sign flow lands a recipient via a top-level navigation from an
@@ -1764,7 +1755,57 @@ api.get("/user/developer/check", authUser, (req, res) => {
 // this endpoint exists so the gated /api/user/developer/* surface is wired and
 // testable from day one.
 api.get("/user/developer/tools", authUser, developerGate, (req, res) => {
-  res.json({ status: "wip", tools: DEVELOPER_TOOLS });
+  res.json({ status: "live", tools: DEVELOPER_TOOLS });
+});
+
+// GET /api/user/developer/snapshot — one call for the initial dashboard render:
+// {email, plan, key_masked, quota:{transfers,signs,caps}, audit:[last 50],
+//  tools_status:{per tool}}. 3s in-memory cache per account so a refresh storm
+// cannot hammer Redis.
+const _snapCache = new Map(); // uid -> { at, data }
+api.get("/user/developer/snapshot", authUser, developerGate, async (req, res) => {
+  const uid = req.userSession.user_id;
+  const hit = _snapCache.get(uid);
+  if (hit && Date.now() - hit.at < 3000) return res.json(hit.data);
+  let plan = "community";
+  try { const u = await findUserByEmail(req.userSession.email); if (u && u.plan) plan = u.plan; } catch {}
+  try {
+    const data = await buildSnapshot({ redis, getAuditEvents, plan }, req.userSession);
+    _snapCache.set(uid, { at: Date.now(), data });
+    if (_snapCache.size > 500) _snapCache.clear();
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ error: "snapshot_failed" });
+  }
+});
+
+// GET /api/user/developer/stream — Server-Sent Events. Pushes new audit events
+// for this account as they land. SSE (not WebSocket): simpler, rides the
+// existing HTTP/auth/cookie stack, no upgrade handshake. Server-side 2s poll of
+// the account's audit zset; pushes deltas + a heartbeat. Closes on disconnect.
+api.get("/user/developer/stream", authUser, developerGate, async (req, res) => {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache, no-transform",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+  });
+  res.write("retry: 4000\n");
+  res.write('event: hello\ndata: {"ok":true}\n\n');
+  const uid = req.userSession.user_id;
+  let lastTs = Date.now();
+  let alive = true;
+  const tick = async () => {
+    if (!alive) return;
+    try {
+      const events = await getAuditEvents(uid, { limit: 20 });
+      const fresh = events.filter((e) => (e.ts || 0) > lastTs).sort((a, b) => (a.ts || 0) - (b.ts || 0));
+      for (const ev of fresh) { lastTs = Math.max(lastTs, ev.ts || 0); res.write(`event: audit\ndata: ${JSON.stringify(ev)}\n\n`); }
+      res.write(`event: ping\ndata: ${Date.now()}\n\n`);
+    } catch {}
+  };
+  const iv = setInterval(tick, 2000);
+  req.on("close", () => { alive = false; clearInterval(iv); try { res.end(); } catch {} });
 });
 
 // GET /api/user/account

--- a/admin/test/developer-snapshot.test.js
+++ b/admin/test/developer-snapshot.test.js
@@ -1,0 +1,80 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { buildSnapshot, normalisePlan, maskKey, ymKey, TIER_CAPS } = require('../lib/developer-snapshot');
+const { DEVELOPER_TOOLS, toolsStatusFromAudit, isToolEvent } = require('../lib/developer-tools');
+
+function fakeRedis(map) { return () => ({ get: async (k) => (k in map ? String(map[k]) : null) }); }
+
+test('catalogue: 10 tools, each with category/install/usage/source', () => {
+  assert.equal(DEVELOPER_TOOLS.length, 10);
+  for (const t of DEVELOPER_TOOLS) {
+    assert.ok(t.name && t.tagline && t.category, 'core fields ' + t.name);
+    assert.match(t.install, /git clone .*paramant-solutions/);
+    assert.match(t.usage, /\{KEY\}/, 'usage carries a {KEY} placeholder');
+    assert.match(t.source, /github\.com\/Apolloccrypt\/paramant-solutions\/tree\/main\/tools\//);
+  }
+});
+
+test('maskKey / normalisePlan / ymKey', () => {
+  assert.equal(maskKey('pgp_' + 'a'.repeat(40)), 'pgp_aaaa…aaaa');
+  assert.equal(maskKey('short'), 'short');
+  assert.equal(normalisePlan('free'), 'community');
+  assert.equal(normalisePlan('licensed'), 'enterprise');
+  assert.equal(normalisePlan('PRO'), 'pro');
+  assert.equal(normalisePlan('whatever'), 'community');
+  assert.equal(ymKey(new Date('2026-05-31T12:00:00Z')), '2026-05');
+});
+
+test('toolsStatusFromAudit: never_used when no tool events', () => {
+  const st = toolsStatusFromAudit(DEVELOPER_TOOLS, [{ event_type: 'webauthn_login', ts: Date.now() }]);
+  for (const t of DEVELOPER_TOOLS) assert.equal(st[t.name].state, 'never_used');
+});
+
+test('toolsStatusFromAudit: idle + stats when a tool event exists', () => {
+  const now = Date.now();
+  const audit = [
+    { event_type: 'tool_run', ts: now - 1000, metadata: { tool: 'paramant-s3-migrate', result: 'ok', duration_ms: 1200 } },
+    { event_type: 'tool_run', ts: now - 2000, metadata: { tool: 'paramant-s3-migrate', result: 'fail', duration_ms: 800 } },
+  ];
+  const st = toolsStatusFromAudit(DEVELOPER_TOOLS, audit);
+  assert.equal(st['paramant-s3-migrate'].state, 'idle');
+  assert.equal(st['paramant-s3-migrate'].runs_week, 2);
+  assert.equal(st['paramant-s3-migrate'].success_rate, 50);
+  assert.equal(st['paramant-s3-migrate'].avg_ms, 1000);
+  assert.equal(st['paramant-db-backup'].state, 'never_used');
+});
+
+test('isToolEvent', () => {
+  assert.ok(isToolEvent({ event_type: 'tool_run' }));
+  assert.ok(isToolEvent({ event_type: 'x', metadata: { tool: 'paramant-x' } }));
+  assert.ok(!isToolEvent({ event_type: 'webauthn_login' }));
+});
+
+test('buildSnapshot: full shape, caps, masked key, no key leak', async () => {
+  const uid = 'pgp_' + 'b'.repeat(60);
+  const redis = fakeRedis({
+    [`paramant:quota:transfers:${uid}:2026-05`]: '7',
+    [`paramant:quota:signs:${uid}:2026-05`]: '1',
+  });
+  const getAuditEvents = async () => [{ event_type: 'webauthn_login', ts: Date.parse('2026-05-31T10:00:00Z'), metadata: {} }];
+  const snap = await buildSnapshot({ redis, getAuditEvents, plan: 'community', now: new Date('2026-05-31T12:00:00Z') }, { user_id: uid, email: 'dev@x.io' });
+
+  assert.equal(snap.email, 'dev@x.io');
+  assert.equal(snap.plan, 'community');
+  assert.equal(snap.key_masked, 'pgp_bbbb…bbbb');
+  assert.ok(!snap.key_masked.includes(uid), 'full key never returned');
+  assert.equal(snap.quota.transfers, 7);
+  assert.equal(snap.quota.signs, 1);
+  assert.equal(snap.quota.caps.transfers, 10);
+  assert.equal(snap.quota.caps.signs, 2);
+  assert.equal(snap.audit.length, 1);
+  assert.equal(Object.keys(snap.tools_status).length, 10);
+});
+
+test('buildSnapshot: enterprise caps = unlimited (null), missing counters = 0', async () => {
+  const snap = await buildSnapshot({ redis: fakeRedis({}), getAuditEvents: async () => [], plan: 'enterprise', now: new Date('2026-05-31T00:00:00Z') }, { user_id: 'pgp_x', email: 'e@x.io' });
+  assert.equal(snap.quota.transfers, 0);
+  assert.equal(snap.quota.caps.transfers, null);
+  assert.equal(snap.quota.caps.signs, null);
+});

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -2,147 +2,186 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Developer dashboard — Paramant</title>
-<meta name="robots" content="noindex, nofollow">
+<meta name="robots" content="noindex,nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
-<link rel="canonical" href="https://paramant.app/developer">
 <style>
-.dev-top { display: flex; align-items: center; justify-content: space-between; max-width: 1040px; margin: 0 auto; padding: 18px var(--space-4); border-bottom: 1px solid var(--ink-hair); }
-.dev-top a.brand { font-weight: 700; letter-spacing: -0.02em; color: var(--navy); text-decoration: none; font-size: 18px; }
-.dev-top .dev-top-links a { font-size: 13px; color: var(--ink-dim); text-decoration: none; margin-left: 18px; }
-.dev-top .dev-top-links a:hover { color: var(--navy); text-decoration: underline; }
-.dev-wrap { max-width: 1040px; margin: var(--space-5) auto var(--space-6); padding: 0 var(--space-4); }
-.dev-wrap h1 { font-size: clamp(26px, 3.4vw, 38px); line-height: 1.1; letter-spacing: -0.02em; color: var(--navy); margin: 0 0 var(--space-2); }
-.dev-wrap .lede { font-size: 16px; line-height: 1.55; color: var(--ink-dim); max-width: 60ch; margin: 0 0 var(--space-4); }
-.wip { display: inline-flex; align-items: center; gap: 8px; font-family: var(--mono, IBM Plex Mono, monospace); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: #92400E; background: #FEF3C7; border: 1px solid #FDE68A; border-radius: 999px; padding: 6px 13px; margin-bottom: var(--space-4); }
-.dev-note { border-left: 3px solid var(--ink-hair); padding: 4px 0 4px 16px; color: var(--ink-dim); font-size: 14px; line-height: 1.6; margin: 0 0 var(--space-5); max-width: 70ch; }
-.dev-auth { background: var(--bone, #F1F5F9); border: 1px solid var(--ink-hair); padding: var(--space-4); margin: 0 0 var(--space-5); }
-.dev-auth h2 { font-size: 15px; margin: 0 0 10px; color: var(--navy); letter-spacing: -0.01em; }
-pre.code { background: #0B1B2B; color: #E2E8F0; font-family: var(--mono, IBM Plex Mono, monospace); font-size: 13px; line-height: 1.55; padding: 14px 16px; overflow-x: auto; margin: 0; border-radius: 4px; }
-.tools { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); }
-.tool { border: 1px solid var(--ink-hair); background: #fff; padding: var(--space-4); display: flex; flex-direction: column; }
-.tool h3 { font-family: var(--mono, IBM Plex Mono, monospace); font-size: 15px; color: var(--navy); margin: 0 0 6px; }
-.tool p { font-size: 13px; line-height: 1.5; color: var(--ink-dim); margin: 0 0 12px; }
-.tool pre.code { font-size: 12px; margin-top: auto; }
-.dev-foot { margin-top: var(--space-6); padding-top: var(--space-4); border-top: 1px solid var(--ink-hair); font-size: 13px; color: var(--ink-dim); }
-.dev-foot a { color: var(--navy); }
-@media (max-width: 760px) { .tools { grid-template-columns: 1fr; } }
+*{box-sizing:border-box}
+main.dev{max-width:1180px;margin:0 auto;padding:var(--space-5) var(--space-4) var(--space-7)}
+.dev-h{font-family:var(--sans);font-size:clamp(24px,3vw,32px);font-weight:600;letter-spacing:-.02em;color:var(--ink);margin:0}
+.dev-sec{margin-top:var(--space-7)}
+.dev-sec:first-of-type{margin-top:var(--space-4)}
+.dev-eyebrow{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-dim);margin:0 0 var(--space-3)}
+.dev-card{background:var(--bone);border:1px solid rgba(11,58,106,.08);border-radius:14px;box-shadow:0 1px 2px rgba(11,58,106,.04)}
+.mono{font-family:var(--mono)}
+.dim{color:var(--ink-dim)}
+
+/* Section 1: Pulse */
+.pulse{display:grid;grid-template-columns:minmax(220px,1fr) 2fr;gap:var(--space-4);align-items:stretch}
+.pulse-id{padding:var(--space-5)}
+.pulse-id .email{font-family:var(--mono);font-size:13px;color:var(--ink);word-break:break-all}
+.plan-badge{display:inline-flex;align-items:center;gap:7px;margin-top:var(--space-3);font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--ink-dim);border:1px solid var(--ink-hair);border-radius:999px;padding:5px 12px}
+.plan-badge strong{color:var(--ink);font-weight:600}
+.heartbeat{display:flex;align-items:center;gap:8px;margin-top:var(--space-4);font-family:var(--mono);font-size:11px;color:var(--ink-dim)}
+.hb-dot{width:8px;height:8px;border-radius:50%;background:#9aa7b5}
+.hb-dot.up{background:#5fbf3f;animation:hb 2s ease-out infinite}
+.hb-dot.poll{background:#e8a33d}.hb-dot.down{background:#d7483b}
+@keyframes hb{0%{box-shadow:0 0 0 0 rgba(95,191,63,.5)}70%{box-shadow:0 0 0 7px rgba(95,191,63,0)}100%{box-shadow:0 0 0 0 rgba(95,191,63,0)}}
+.feed{padding:var(--space-4) var(--space-5);overflow:hidden}
+.feed h3{font-family:var(--mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--ink-dim);margin:0 0 10px}
+.feed-row{display:grid;grid-template-columns:auto auto 1fr auto;gap:10px;align-items:baseline;font-family:var(--mono);font-size:11.5px;padding:5px 0;border-bottom:1px solid var(--ink-hair);transition:opacity .4s}
+.feed-row:last-child{border-bottom:0}
+.feed-row .t{color:var(--ink-dim);font-size:10px;white-space:nowrap}
+.feed-row .ev{color:var(--ink);font-weight:600}
+.feed-row .tg{color:var(--ink-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.feed-row .rs{font-size:10px;letter-spacing:.06em;text-transform:uppercase}
+.feed-row .rs.ok{color:#1D4ED8}.feed-row .rs.fail{color:#d7483b}
+.feed-row.fresh{animation:slidein .45s ease}
+@keyframes slidein{from{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:none}}
+
+/* Section 2: Flow */
+.flow{padding:var(--space-5)}
+.flow svg{display:block;width:100%;height:auto;max-height:140px}
+.flow-node rect{fill:#fff;stroke:var(--ink-hair);stroke-width:1.4;transition:stroke .35s,fill .35s}
+.flow-node text{font-family:var(--mono);font-size:9px;fill:var(--ink-dim);transition:fill .35s}
+.flow-node.on rect{stroke:#B2FF3F;fill:#0a1626}
+.flow-node.on text{fill:#B2FF3F}
+.flow-arrow{stroke:var(--ink-hair);stroke-width:1.6;transition:stroke .35s}
+.flow-arrow.on{stroke:#B2FF3F}
+.flow-lbl{font-family:var(--mono);font-size:8px;fill:var(--ink-dim)}
+.flow-cap{font-family:var(--mono);font-size:11px;color:var(--ink-dim);margin-top:10px;text-align:center}
+.flow-cap b{color:var(--ink)}
+
+/* Section 3: Tools */
+.tools{display:grid;grid-template-columns:repeat(auto-fill,minmax(290px,1fr));gap:var(--space-4)}
+.tool{padding:var(--space-4) var(--space-5);display:flex;flex-direction:column;gap:8px}
+.tool-top{display:flex;align-items:flex-start;gap:12px}
+.tool-icon{width:34px;height:34px;flex-shrink:0;border-radius:9px;background:#0a1626;display:flex;align-items:center;justify-content:center}
+.tool-icon svg{width:18px;height:18px;stroke:#B2FF3F;fill:none;stroke-width:1.6;stroke-linecap:round;stroke-linejoin:round}
+.tool-name{font-family:var(--mono);font-size:13px;font-weight:600;color:var(--ink)}
+.tool-tag{font-family:var(--sans);font-size:12.5px;line-height:1.5;color:var(--ink-dim);margin:0}
+.tool-status{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:10px;letter-spacing:.06em;text-transform:uppercase}
+.tool-status .sd{width:6px;height:6px;border-radius:50%;background:#9aa7b5}
+.tool-status.idle .sd{background:#5fbf3f}.tool-status.running .sd{background:#e8a33d}
+.tool-stats{display:flex;gap:14px;font-family:var(--mono);font-size:10px;color:var(--ink-dim);flex-wrap:wrap}
+.tool-stats b{color:var(--ink);font-weight:600}
+.tool-install summary{font-family:var(--mono);font-size:11px;color:#1D4ED8;cursor:pointer;list-style:none}
+.tool-install summary::-webkit-details-marker{display:none}
+.tool-install pre{font-family:var(--mono);font-size:10px;line-height:1.5;color:#cfe0f2;background:#0a1626;border-radius:8px;padding:9px 10px;margin:8px 0 0;overflow-x:auto;white-space:pre-wrap;word-break:break-all}
+.tool-actions{display:flex;gap:8px;margin-top:auto;padding-top:8px;flex-wrap:wrap;align-items:center}
+.dev-btn{font-family:var(--mono);font-size:11px;padding:7px 12px;border-radius:8px;border:1px solid var(--ink-hair);background:transparent;color:var(--ink-dim);cursor:not-allowed}
+.dev-btn[disabled]{opacity:.6}
+.dev-link{font-family:var(--mono);font-size:11px;color:#1D4ED8;text-decoration:none}
+.dev-link:hover{text-decoration:underline}
+
+/* Section 4: Operations */
+.ops{display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-4);align-items:start}
+.ops-card{padding:var(--space-4) var(--space-5)}
+.ops-card h3{font-family:var(--mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--ink-dim);margin:0 0 12px}
+.key-row{font-family:var(--mono);font-size:11.5px;color:var(--ink);display:flex;justify-content:space-between;gap:8px;padding:7px 0;border-bottom:1px solid var(--ink-hair)}
+.bar{height:7px;border-radius:999px;background:var(--ink-ghost);overflow:hidden;margin:5px 0 2px}
+.bar > i{display:block;height:100%;background:#1D4ED8;border-radius:999px;transition:width .5s}
+.bar.warn > i{background:#B2FF3F}
+.usage-row{margin-bottom:14px}
+.usage-row .lab{display:flex;justify-content:space-between;font-family:var(--mono);font-size:11px;color:var(--ink-dim)}
+.usage-row .lab b{color:var(--ink)}
+.upsell{margin-top:6px;font-family:var(--mono);font-size:10px;color:#0B3A6A;background:#B2FF3F;border-radius:6px;padding:5px 9px;display:inline-block}
+.tl-filter{width:100%;font-family:var(--mono);font-size:11px;padding:8px 10px;border:1px solid var(--ink-hair);border-radius:8px;background:#fff;color:var(--ink);margin-bottom:10px}
+.tl{max-height:260px;overflow-y:auto}
+.tl-row{font-family:var(--mono);font-size:10.5px;display:flex;gap:8px;padding:5px 0;border-bottom:1px solid var(--ink-hair)}
+.tl-row .t{color:var(--ink-dim);white-space:nowrap}.tl-row .e{color:var(--ink)}
+
+/* Section 5: WIP strip */
+.wip{margin-top:var(--space-7);padding:var(--space-4) var(--space-5);border:1px dashed var(--ink-hair);border-radius:12px;font-family:var(--mono);font-size:11px;line-height:1.7;color:var(--ink-dim)}
+.wip b{color:var(--ink)}.wip a{color:#1D4ED8}
+
+@media(max-width:880px){.pulse{grid-template-columns:1fr}.ops{grid-template-columns:1fr}}
+@media(prefers-reduced-motion:reduce){.feed-row.fresh{animation:none}.hb-dot.up{animation:none}*{transition:none !important}}
 </style>
 </head>
 <body>
+<a href="#main" class="skip-link">Skip to main content</a>
+<nav class="nav">
+  <a href="/" class="nav-logo"><span class="logo-para">Para</span><span class="logo-mant">MANT</span></a>
+  <ul class="nav-links">
+    <li><a href="/dashboard" class="nav-link">Dashboard</a></li>
+    <li><a href="/developer" class="nav-link nav-link-strong">Developer</a></li>
+    <li><a href="/docs" class="nav-link">Docs</a></li>
+  </ul>
+  <div class="nav-auth"><a href="/account" class="nav-signin">Account</a></div>
+</nav>
 
-<a class="skip-link" href="#main-content">Skip to content</a>
+<main id="main" class="dev">
+  <p class="dev-eyebrow">Operations dashboard · read-only</p>
+  <h1 class="dev-h">What happens when you ship.</h1>
 
-<header class="dev-top">
-  <a class="brand" href="/">Paramant</a>
-  <nav class="dev-top-links" aria-label="Developer">
-    <a href="/dashboard">Dashboard</a>
-    <a href="/docs">Docs</a>
-    <a href="/account">Account</a>
-  </nav>
-</header>
-
-<main id="main-content" class="dev-wrap">
-  <span class="wip">⚠ Work in progress</span>
-  <h1>Developer dashboard</h1>
-  <p class="lede">Command-line tools that ship their result through the Paramant post-quantum relay
-  (ML-KEM-768 + ML-DSA-65, ciphertext-only, burn-on-read) using only the public
-  <code>paramant-sdk</code> API.</p>
-
-  <p class="dev-note">This page is provisional. The tools below are starter / POC and are not yet
-  published to a package index. The install and usage lines are placeholders that mirror the
-  intended shape (one-line install, three-line usage) and will be replaced as each tool ships.</p>
-
-  <section class="dev-auth">
-    <h2>Authenticate once</h2>
-    <pre class="code"># 1. https://paramant.app/signup  →  2. Dashboard → Developer → copy pgp_ key
-export PARAMANT_API_KEY=pgp_...
-export PARAMANT_DEVICE=my-laptop          # optional, stable device id</pre>
+  <section class="dev-sec pulse" aria-label="Pulse">
+    <div class="dev-card pulse-id">
+      <div class="email" data-dv="email">—</div>
+      <span class="plan-badge"><strong data-dv="plan">—</strong><span>plan</span></span>
+      <div class="heartbeat"><span class="hb-dot" id="hb"></span><span id="hb-label">connecting…</span></div>
+    </div>
+    <div class="dev-card feed">
+      <h3>Live activity · newest first</h3>
+      <div id="feed"><div class="feed-row"><span class="t dim">—</span><span class="ev dim">waiting for events…</span><span class="tg"></span><span class="rs"></span></div></div>
+    </div>
   </section>
 
-  <div class="tools">
-    <article class="tool">
-      <h3>paramant-dev-transfer</h3>
-      <p>WeTransfer for the terminal. Send a file, get a token; the other side receives it by token. The relay only ever holds ciphertext, in RAM, and burns it on first read.</p>
-      <pre class="code">pipx install paramant-dev-transfer
-paramant-dev-transfer ./build.zip
-# → token: pdt_… (share it)</pre>
-    </article>
+  <section class="dev-sec" aria-label="Transfer flow">
+    <p class="dev-eyebrow">What happens to a transfer</p>
+    <div class="dev-card flow">
+      <svg viewBox="0 0 640 90" role="img" aria-label="device, encrypt, relay RAM, deliver, recipient, read, burned">
+        <g class="flow-node" id="fn-device"><rect x="6" y="26" width="96" height="38" rx="7"/><text x="54" y="49" text-anchor="middle">device</text></g>
+        <line class="flow-arrow" id="fa-1" x1="104" y1="45" x2="178" y2="45"/><text class="flow-lbl" x="141" y="38" text-anchor="middle">encrypt</text>
+        <g class="flow-node" id="fn-relay"><rect x="180" y="26" width="110" height="38" rx="7"/><text x="235" y="49" text-anchor="middle">relay · RAM</text></g>
+        <line class="flow-arrow" id="fa-2" x1="292" y1="45" x2="366" y2="45"/><text class="flow-lbl" x="329" y="38" text-anchor="middle">deliver</text>
+        <g class="flow-node" id="fn-recv"><rect x="368" y="26" width="104" height="38" rx="7"/><text x="420" y="49" text-anchor="middle">recipient</text></g>
+        <line class="flow-arrow" id="fa-3" x1="474" y1="45" x2="548" y2="45"/><text class="flow-lbl" x="511" y="38" text-anchor="middle">read</text>
+        <g class="flow-node" id="fn-burn"><rect x="550" y="26" width="84" height="38" rx="7"/><text x="592" y="49" text-anchor="middle">burned</text></g>
+      </svg>
+      <div class="flow-cap" id="flow-cap">Idle — the last event animates here.</div>
+    </div>
+  </section>
 
-    <article class="tool">
-      <h3>paramant-s3-migrate</h3>
-      <p>Move an S3 object to a device, encrypted, without leaving a copy behind. Bytes are encrypted on your machine; the relay holds only ciphertext.</p>
-      <pre class="code">pipx install paramant-s3-migrate
-paramant-s3-migrate s3://bucket/key --to ops@host</pre>
-    </article>
+  <section class="dev-sec" aria-label="Tools">
+    <p class="dev-eyebrow">Tools · status from your activity</p>
+    <div class="tools" id="tools"><div class="dim mono" style="font-size:12px">Loading tools…</div></div>
+  </section>
 
-    <article class="tool">
-      <h3>paramant-db-backup</h3>
-      <p>One-command off-site database backups that are encrypted before they leave the box. Hands a <code>pg_dump</code>/<code>mysqldump</code> straight to the relay.</p>
-      <pre class="code">pipx install paramant-db-backup
-paramant-db-backup --pg "postgres://…" --to backup@vault</pre>
-    </article>
+  <section class="dev-sec" aria-label="Operations">
+    <p class="dev-eyebrow">Operations</p>
+    <div class="ops">
+      <div class="dev-card ops-card">
+        <h3>API keys</h3>
+        <div id="keys"><div class="key-row"><span>—</span><span class="dim">loading</span></div></div>
+        <div class="tool-actions"><button class="dev-btn" disabled title="Available with self-service keys (coming)">+ New key</button></div>
+      </div>
+      <div class="dev-card ops-card">
+        <h3>Usage · this month</h3>
+        <div id="usage"><div class="dim mono" style="font-size:11px">loading…</div></div>
+      </div>
+      <div class="dev-card ops-card">
+        <h3>Activity timeline</h3>
+        <input class="tl-filter mono" id="tl-filter" placeholder="filter events…" aria-label="Filter activity">
+        <div class="tl" id="timeline"></div>
+        <div class="tool-actions"><button class="dev-btn" disabled title="Available with self-service keys (coming)">View all</button></div>
+      </div>
+    </div>
+  </section>
 
-    <article class="tool">
-      <h3>paramant-git-archive</h3>
-      <p>Send a snapshot of a repo at any ref, encrypted, without a remote. <code>git archive</code> the tree; the other side picks it up by hash.</p>
-      <pre class="code">pipx install paramant-git-archive
-paramant-git-archive HEAD --to teammate@laptop</pre>
-    </article>
-
-    <article class="tool">
-      <h3>paramant-docker-migrate</h3>
-      <p>Move a Docker volume to another host, encrypted, without a shared registry or a cleartext SSH pipe. Export, ship, untar on the far side.</p>
-      <pre class="code">pipx install paramant-docker-migrate
-paramant-docker-migrate my-volume --to operator@host2</pre>
-    </article>
-
-    <article class="tool">
-      <h3>paramant-secrets-sync</h3>
-      <p>Team secrets sync without a cloud vault. Push <code>.env.prod</code> to a teammate; they pull it back by hash. Burned on first read.</p>
-      <pre class="code">pipx install paramant-secrets-sync
-paramant-secrets-sync push .env.prod --to alice@laptop</pre>
-    </article>
-
-    <article class="tool">
-      <h3>paramant-ci-artifact</h3>
-      <p>Ship CI/CD build artifacts to a destination, encrypted, straight from the pipeline. No public artifact store, no plaintext copy in a bucket.</p>
-      <pre class="code">pipx install paramant-ci-artifact
-paramant-ci-artifact ./dist --to deploy@prod</pre>
-    </article>
-
-    <article class="tool">
-      <h3>paramant-log-ship</h3>
-      <p>Tamper-evident log shipping for the SOC. Tail a log and ship each batch to your SIEM as an ML-DSA-65-signed blob the auditor can verify.</p>
-      <pre class="code">pipx install paramant-log-ship
-paramant-log-ship /var/log/app.log --to siem@collector</pre>
-    </article>
-
-    <article class="tool">
-      <h3>paramant-package-sign</h3>
-      <p>Code-sign a release artifact with post-quantum ML-DSA-65, and catch a swap. Produces a detached <code>.psign</code> sidecar (SHA-256 + signature + public key).</p>
-      <pre class="code">pipx install paramant-package-sign
-paramant-package-sign dist/app-1.0.tar.gz
-# → dist/app-1.0.tar.gz.psign</pre>
-    </article>
-
-    <article class="tool">
-      <h3>paramant-db-replicate</h3>
-      <p>Cross-region database replication, post-quantum encrypted. Continuously feed new rows of a Postgres table to another region as encrypted batches.</p>
-      <pre class="code">pipx install paramant-db-replicate
-paramant-db-replicate --table orders --to eu-west@replica</pre>
-    </article>
+  <div class="wip">
+    <b>Operations dashboard · read-only.</b> Action capabilities (run, configure, new keys) arrive with self-service keys (account-schema steps 4&ndash;5).
+    Tools show live status from your activity; per-run stats appear once tool runs are logged to your audit trail.
+    Source: <a href="https://github.com/Apolloccrypt/paramant-solutions" target="_blank" rel="noopener">github.com/Apolloccrypt/paramant-solutions</a>
   </div>
-
-  <p class="dev-foot">Tools are documented in <code>paramant-solutions/tools/</code>. Each ships only
-  ciphertext through the relay and uses the public <a href="/docs#api">paramant-sdk</a> API.
-  Questions: <a href="/docs">read the docs</a>.</p>
 </main>
 
+<script src="/nav.js?v=12" defer></script>
+<script src="/js/developer.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/js/developer.js
+++ b/frontend/js/developer.js
@@ -1,0 +1,175 @@
+/* Operations dashboard for /developer. Vanilla JS, no libraries (CSP). Reads
+ * /api/user/developer/{snapshot,tools} and streams new audit events over SSE
+ * (/api/user/developer/stream), with a polling fallback. All action controls are
+ * UI-prepared but disabled with an honest tooltip until self-service keys land. */
+(function () {
+  'use strict';
+  var $ = function (s, r) { return (r || document).querySelector(s); };
+  var elFeed = $('#feed'), elTools = $('#tools'), elKeys = $('#keys'),
+      elUsage = $('#usage'), elTimeline = $('#timeline'), elHb = $('#hb'),
+      elHbLabel = $('#hb-label'), elFlowCap = $('#flow-cap');
+
+  function esc(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) { return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]; }); }
+  function pad(n) { return (n < 10 ? '0' : '') + n; }
+  function fmtTs(ts) { if (!ts) return '--:--:--'; var d = new Date(ts); return pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds()); }
+  function fmtDur(ms) { if (ms == null) return '—'; return ms < 1000 ? ms + 'ms' : (ms / 1000).toFixed(1) + 's'; }
+  function fmtAgo(ts) { if (!ts) return 'never'; var s = Math.round((Date.now() - ts) / 1000); if (s < 60) return s + 's ago'; if (s < 3600) return Math.round(s / 60) + 'm ago'; if (s < 86400) return Math.round(s / 3600) + 'h ago'; return Math.round(s / 86400) + 'd ago'; }
+
+  // line-icons per tool category
+  var ICONS = {
+    transfer: 'M3 12h14M12 7l5 5-5 5', backup: 'M4 6c0-1.1 3.6-2 8-2s8 .9 8 2-3.6 2-8 2-8-.9-8-2zM4 6v12c0 1.1 3.6 2 8 2s8-.9 8-2V6',
+    sign: 'M4 17l5-5 3 3 7-8M16 7l3-1-1 3', sync: 'M4 9a8 8 0 0 1 13-3l3 3M20 15a8 8 0 0 1-13 3l-3-3M17 6V3M7 18v3',
+    ship: 'M12 3v10M8 7l4-4 4 4M4 14v5h16v-5', migrate: 'M3 8h10M9 4l4 4-4 4M14 12h6v8h-6', archive: 'M3 6h18v3H3zM5 9v11h14V9M9 13h6',
+    replicate: 'M8 8h11v11H8zM5 5h11v3M5 5v11h3'
+  };
+  function toolIcon(cat) { return '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="' + (ICONS[cat] || ICONS.transfer) + '"/></svg>'; }
+
+  var STATE = { tools: [], status: {}, key: '', filter: '', feed: [] };
+
+  /* ---------- render ---------- */
+  function renderHeader(d) {
+    var e = document.querySelector('[data-dv="email"]'); if (e) e.textContent = d.email || '—';
+    var p = document.querySelector('[data-dv="plan"]'); if (p) p.textContent = (d.plan || '—');
+  }
+  function renderKeys(d) {
+    elKeys.innerHTML =
+      '<div class="key-row"><span>' + esc(d.key_masked || '—') + '</span><span class="dim">primary</span></div>' +
+      '<div class="key-row"><span class="dim">last used</span><span class="dim">tracked via activity</span></div>' +
+      '<div class="key-row"><span class="dim">request rate</span><span class="dim">live with keys (coming)</span></div>';
+  }
+  function bar(used, cap) {
+    var unlimited = cap == null;
+    var pct = unlimited ? 4 : Math.min(100, Math.round((used / Math.max(1, cap)) * 100));
+    var warn = !unlimited && pct >= 80;
+    return { pct: pct, warn: warn, unlimited: unlimited };
+  }
+  function renderUsage(d) {
+    var q = d.quota || { transfers: 0, signs: 0, caps: {} };
+    function row(label, used, cap) {
+      var b = bar(used, cap);
+      var capTxt = b.unlimited ? '∞' : cap;
+      return '<div class="usage-row"><div class="lab"><span>' + label + '</span><span><b>' + used + '</b> / ' + capTxt + '</span></div>' +
+        '<div class="bar' + (b.warn ? ' warn' : '') + '"><i style="width:' + b.pct + '%"></i></div>' +
+        (b.warn ? '<a class="upsell" href="/pricing">▲ Upgrade to Pro</a>' : '') + '</div>';
+    }
+    elUsage.innerHTML = row('Transfers', q.transfers || 0, q.caps && q.caps.transfers) +
+      row('Signings', q.signs || 0, q.caps && q.caps.signs) +
+      '<div class="dim mono" style="font-size:10px">live · refreshes every 5s · source: relay quota counters</div>';
+  }
+  function renderTools() {
+    if (!STATE.tools.length) { elTools.innerHTML = '<div class="dim mono" style="font-size:12px">No tools.</div>'; return; }
+    elTools.innerHTML = STATE.tools.map(function (t) {
+      var st = STATE.status[t.name] || { state: 'never_used' };
+      var statusTxt = st.state === 'never_used' ? 'never used' : st.state;
+      var statsHtml = st.state === 'never_used'
+        ? '<details class="tool-install"><summary>Install &amp; run ▸</summary><pre>' +
+            esc(t.install) + '\n\n' + esc((t.usage || '').replace('{KEY}', STATE.key || 'pgp_…')) + '</pre></details>'
+        : '<div class="tool-stats"><span>last <b>' + fmtAgo(st.last_run) + '</b></span>' +
+            (st.success_rate != null ? '<span><b>' + st.success_rate + '%</b> ok/wk</span>' : '') +
+            (st.avg_ms != null ? '<span>avg <b>' + fmtDur(st.avg_ms) + '</b></span>' : '') + '</div>';
+      return '<div class="dev-card tool">' +
+        '<div class="tool-top"><div class="tool-icon">' + toolIcon(t.category) + '</div>' +
+        '<div><div class="tool-name">' + esc(t.name) + '</div>' +
+        '<span class="tool-status ' + (st.state === 'never_used' ? '' : st.state) + '"><span class="sd"></span>' + statusTxt + '</span></div></div>' +
+        '<p class="tool-tag">' + esc(t.tagline) + '</p>' + statsHtml +
+        '<div class="tool-actions">' +
+          '<button class="dev-btn" disabled title="Available with self-service keys (coming)">Run in browser</button>' +
+          '<button class="dev-btn" disabled title="Available with self-service keys (coming)">Configure</button>' +
+          '<a class="dev-link" href="' + esc(t.source) + '" target="_blank" rel="noopener">View source ↗</a>' +
+        '</div></div>';
+    }).join('');
+  }
+  function timelineRow(ev) {
+    return '<div class="tl-row" data-ev="' + esc((ev.event_type || '') + ' ' + JSON.stringify(ev.metadata || {})) + '">' +
+      '<span class="t">' + fmtTs(ev.ts) + '</span><span class="e">' + esc(ev.event_type || 'event') + '</span></div>';
+  }
+  function renderTimeline(events) {
+    var f = STATE.filter.toLowerCase();
+    var rows = events.filter(function (ev) { return !f || (ev.event_type || '').toLowerCase().indexOf(f) >= 0 || JSON.stringify(ev.metadata || {}).toLowerCase().indexOf(f) >= 0; });
+    elTimeline.innerHTML = rows.length ? rows.map(timelineRow).join('') : '<div class="dim mono" style="font-size:11px;padding:6px 0">No events' + (f ? ' match "' + esc(STATE.filter) + '"' : ' yet') + '.</div>';
+  }
+
+  /* ---------- live feed + flow ---------- */
+  function feedRow(ev, fresh) {
+    var meta = ev.metadata || {};
+    var target = meta.target || meta.tool || meta.email || meta.device || '';
+    var result = meta.result || (/(_failed|_error|regression)$/.test(ev.event_type || '') ? 'fail' : 'ok');
+    return '<div class="feed-row' + (fresh ? ' fresh' : '') + '"><span class="t">' + fmtTs(ev.ts) + '</span>' +
+      '<span class="ev">' + esc(ev.event_type || 'event') + '</span>' +
+      '<span class="tg">' + esc(target) + '</span>' +
+      '<span class="rs ' + (result === 'fail' ? 'fail' : 'ok') + '">' + esc(result) + '</span></div>';
+  }
+  function pushFeed(ev, fresh) {
+    STATE.feed.unshift(ev); STATE.feed = STATE.feed.slice(0, 10);
+    elFeed.innerHTML = STATE.feed.map(function (e, i) { return feedRow(e, fresh && i === 0); }).join('');
+    var rows = elFeed.children;
+    for (var i = 0; i < rows.length; i++) rows[i].style.opacity = String(Math.max(0.35, 1 - i * 0.07));
+    if (fresh) playFlow(ev);
+  }
+  var FLOW = ['fn-device', 'fa-1', 'fn-relay', 'fa-2', 'fn-recv', 'fa-3', 'fn-burn'];
+  var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  function playFlow(ev) {
+    if (elFlowCap) elFlowCap.innerHTML = '<b>' + esc(ev.event_type || 'event') + '</b> · ' + fmtTs(ev.ts);
+    if (reduce) { FLOW.forEach(function (id) { var n = document.getElementById(id); if (n) n.classList.add('on'); }); return; }
+    FLOW.forEach(function (id) { var n = document.getElementById(id); if (n) n.classList.remove('on'); });
+    FLOW.forEach(function (id, i) { setTimeout(function () { var n = document.getElementById(id); if (n) n.classList.add('on'); }, i * 230); });
+  }
+
+  /* ---------- heartbeat ---------- */
+  function heartbeat(state) {
+    elHb.className = 'hb-dot ' + state;
+    elHbLabel.textContent = state === 'up' ? 'relay reachable · streaming' : state === 'poll' ? 'polling fallback' : 'disconnected';
+  }
+
+  /* ---------- data flow ---------- */
+  function applySnapshot(d) {
+    renderHeader(d); renderKeys(d); renderUsage(d); STATE.status = d.tools_status || {};
+    renderTimeline(d.audit || []);
+    if (d.audit && d.audit.length && !STATE.feed.length) { STATE.feed = d.audit.slice(0, 10).slice().reverse(); STATE.feed.forEach(function () {}); STATE.feed = d.audit.slice(0, 10); elFeed.innerHTML = STATE.feed.map(function (e) { return feedRow(e, false); }).join(''); }
+    renderTools();
+  }
+  function getJSON(url) { return fetch(url, { credentials: 'include', headers: { Accept: 'application/json' }, cache: 'no-store' }).then(function (r) { if (!r.ok) throw new Error('http ' + r.status); return r.json(); }); }
+
+  function refreshSnapshot() { return getJSON('/api/user/developer/snapshot').then(applySnapshot); }
+
+  /* SSE with polling fallback */
+  var lastPing = 0, pollTimer = null, es = null;
+  function startPolling() {
+    if (pollTimer) return;
+    heartbeat('poll');
+    pollTimer = setInterval(function () { refreshSnapshot().then(function () { heartbeat('poll'); }).catch(function () { heartbeat('down'); }); }, 5000);
+  }
+  function stopPolling() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
+  function connectSSE() {
+    if (!window.EventSource) { startPolling(); return; }
+    try { es = new EventSource('/api/user/developer/stream'); } catch (e) { startPolling(); return; }
+    es.addEventListener('hello', function () { lastPing = Date.now(); heartbeat('up'); stopPolling(); });
+    es.addEventListener('ping', function () { lastPing = Date.now(); heartbeat('up'); });
+    es.addEventListener('audit', function (m) {
+      try { var ev = JSON.parse(m.data); pushFeed(ev, true); STATE.status = STATE.status || {}; renderTimeline([ev].concat(STATE.feed.slice(1))); } catch (e) {}
+    });
+    es.onerror = function () { heartbeat('poll'); startPolling(); };
+  }
+  // quota stays fresh even over SSE: light snapshot poll every 5s
+  setInterval(function () { refreshSnapshot().catch(function () {}); }, 5000);
+  // watchdog: if no ping for 8s, mark polling
+  setInterval(function () { if (es && Date.now() - lastPing > 8000) { heartbeat('poll'); startPolling(); } }, 4000);
+
+  /* filter */
+  var fi = $('#tl-filter'); if (fi) fi.addEventListener('input', function () { STATE.filter = fi.value; getJSON('/api/user/developer/snapshot').then(function (d) { renderTimeline(d.audit || []); }).catch(function () {}); });
+
+  /* ---------- boot ---------- */
+  function boot() {
+    heartbeat('poll');
+    Promise.all([
+      getJSON('/api/user/developer/snapshot'),
+      getJSON('/api/user/developer/tools').catch(function () { return { tools: [] }; }),
+      getJSON('/api/user/account/key').then(function (k) { return k.api_key || ''; }).catch(function () { return ''; })
+    ]).then(function (res) {
+      STATE.tools = res[1].tools || []; STATE.key = res[2];
+      applySnapshot(res[0]);
+      connectSSE();
+    }).catch(function () { heartbeat('down'); elTools.innerHTML = '<div class="dim mono" style="font-size:12px">Could not load dashboard data.</div>'; });
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot); else boot();
+})();


### PR DESCRIPTION
## Wat

Vervangt de statische install-instructiepagina op `/developer` door een echte, **read-only operations dashboard** — live data, geen nep-actieknoppen, en een visualisatie van wát er gebeurt bij elke transfer/sign.

## Frontend — `frontend/developer.html` + `js/developer.js`

Eén scrollende pagina, vijf secties (whitespace-gescheiden):

1. **Pulse** — e-mail + plan-badge links; live event-feed rechts (laatste 10: `tijd · event · target · resultaat`); heartbeat groen/oranje/rood.
2. **Flow-viz** — `device → encrypt → relay·RAM → deliver → recipient → read → burned`, pure SVG/CSS. Per event licht één node lime op; idle = laatste statische frame.
3. **Tools** — agents-stijl kaart per CLI-tool: status `idle/running/never-used` (live uit audit), stats indien ooit gedraaid, en voor never-used een uitklapbare install+usage-flow met de **echte** API-key ingevuld. "View source" → GitHub. Actieknoppen disabled.
4. **Operations** — gemaskeerde API-keys; live usage-bars transfers/signs `x/cap` (poll 5s, ≥80% → "Upgrade to Pro"); filterbare activity-timeline (laatste 50).
5. **WIP-strip** footer.

Live via **SSE** (`/api/user/developer/stream`) met 5s polling-fallback; heartbeat volgt stream-gezondheid. `prefers-reduced-motion` → statisch eindframe; ops-grid klapt naar 1 kolom op mobiel.

**Alle** actiecontrols (Run in browser, Configure, +New key, View all) zijn aanwezig maar `disabled` met eerlijke tooltip *"Available with self-service keys (coming)"*. Geen nep-acties.

## Backend — `admin/server.js` + `admin/lib/`

Achter `authUser + developerGate` (404 voor niet-allowlisted):

- `GET /api/user/developer/snapshot` → `{email, plan, key_masked, quota:{transfers,signs,caps}, audit[50], tools_status}`, 3s per-account cache.
- `GET /api/user/developer/tools` → statische catalogus.
- `GET /api/user/developer/stream` → SSE, server-side 2s audit-poll, pusht deltas + heartbeat, sluit netjes op disconnect.
- `developer-snapshot.js` / `developer-tools.js` — pure, dependency-injected builders (self-contained tier-caps; admin-image bevat `relay/` niet).

## Tests

- `admin/test/developer-snapshot.test.js` — **7/7** unit (shape, caps, masked-key lekt nooit de volledige sleutel, tool-status uit audit).
- Integratie-render (mock-backend + SSE) — **13/13**: vijf secties aanwezig, live event in feed <2s, heartbeat up, mobiel 1-koloms, reduced-motion statisch.

## Grenzen

Read-only. Geen relay-mutaties. Alleen endpoints onder `/api/user/developer/*`. Niet mergen/deployen in deze PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)