### PR TITLE
fix(auth): honour ?next= return-url after login (gated pages landed on /dashboard)

### DIFF
--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -230,7 +230,10 @@
   const submitBtn = document.getElementById('submit-btn');
 
   const params = new URLSearchParams(window.location.search);
-  const returnUrl = params.get('return') || '/dashboard';
+  // Honour both the nginx gate's ?next= and legacy ?return= links. Local paths
+  // only (leading single slash, no // or /\) so it can't become an open redirect.
+  const _rv = params.get('next') || params.get('return') || '/dashboard';
+  const returnUrl = /^\/(?![\/\\])/.test(_rv) ? _rv : '/dashboard';
 
   form.addEventListener('submit', async function(e) {
     e.preventDefault();

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -293,7 +293,7 @@
   }
 })();
 </script>
-<script type="module" src="/js/passkey.js?v=2"></script>
+<script type="module" src="/js/passkey.js?v=3"></script>
 
 </body>
 </html>

--- a/frontend/js/passkey.js
+++ b/frontend/js/passkey.js
@@ -144,7 +144,9 @@ function wireLoginPasskey() {
     return;
   }
 
-  const returnUrl = new URLSearchParams(window.location.search).get('return') || '/dashboard';
+  const _rp = new URLSearchParams(window.location.search), _rv = _rp.get('next') || _rp.get('return') || '/dashboard';
+  // Local paths only (leading single slash) — never an off-site open redirect.
+  const returnUrl = /^\/(?![\/\\])/.test(_rv) ? _rv : '/dashboard';
 
   btn.addEventListener('click', async () => {
     const email = (emailEl && emailEl.value || '').trim();
@@ -271,7 +273,9 @@ function wireDiscoverablePasskey() {
 
   if (!browserSupportsWebAuthn()) { btn.disabled = true; return; }
 
-  const returnUrl = new URLSearchParams(window.location.search).get('return') || '/dashboard';
+  const _rp = new URLSearchParams(window.location.search), _rv = _rp.get('next') || _rp.get('return') || '/dashboard';
+  // Local paths only (leading single slash) — never an off-site open redirect.
+  const returnUrl = /^\/(?![\/\\])/.test(_rv) ? _rv : '/dashboard';
 
   btn.addEventListener('click', async () => {
     btn.disabled = true;


### PR DESCRIPTION
## Bug

Inloggen via een gated pagina zette je daarna door naar **`/dashboard`** i.p.v. terug naar waar je heen wilde (bv. `/developer`).

**Oorzaak — parameter-mismatch:**
- De nginx `auth_request`-gate redirect naar `…/auth/login?**next**=<pad>` (bv. `?next=/developer`).
- `login.html` en de passkey-handlers lazen alleen `?**return**=` → afwezig → fallback `/dashboard`.

Dit raakte **elke** auth_request-gated pagina: `/developer`, `/parashare`, `/drop`, `/sign`.

## Fix

In alle drie de inlog-paden eerst `?next=` lezen, dan `?return=` (legacy co-sign/pricing-links):
- `frontend/auth/login.html` — TOTP-pad
- `frontend/js/passkey.js` — e-mail-first passkey (`wireLoginPasskey`) + cross-device passkey (`wireDiscoverablePasskey`)

Plus een **open-redirect-guard**: alleen lokale paden (leidende enkele `/`, geen `//` of `/\`), anders `/dashboard`. Dat dekt meteen de latente open-redirect die er al zat op `?return=`.

## Verificatie
- `node --check` op passkey.js ✓ · inline-script login.html syntaxisvrij ✓
- Guard-logica **8/8**: `next=/developer→/developer`, `return=/parashare→/parashare`, `next=//evil.com → /dashboard`, `next=https://evil.com → /dashboard`, `next` wint van `return`.

Frontend-only, geen backend/relay-mutatie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)