### PR TITLE
fix(parasign): break the signing-passkey enrol loop (PRF fallback + cross-device hint)

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -757,7 +757,7 @@ loadVaultStatus();
 document.addEventListener('signing-key-enrolled', () => { loadEnrolledKeys(); loadVaultStatus(); });
 </script>
 <script type="module" src="/js/passkey.js"></script>
-<script type="module" src="/js/signing-enrol.js?v=2"></script>
+<script type="module" src="/js/signing-enrol.js?v=3"></script>
 
 </body>
 </html>

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -169,6 +169,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 </main>
 
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js"></script>
-<script type="module" src="/co-sign.js?v=2"></script>
+<script type="module" src="/co-sign.js?v=3"></script>
 </body>
 </html>

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -18,7 +18,7 @@
 // the view receipt. The signing path itself is same-origin via the admin
 // (/api/user/sign/*), bound to the logged-in invitee session.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=2';
+import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=3';
 
 const RELAY_PUBLIC = 'https://health.paramant.app';
 

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -163,12 +163,30 @@ export async function enrolSigningPasskey({ label, passphrase, registerPasskey, 
   try {
     await vaultStore({ alg: 'ML-DSA-65', label: label || null, pk_b64, pk_hash, secretKeyBytes: kp.secretKey, passphrase });
 
-    // ── stage 2: register the passkey, run PRF with a fresh salt, add prf wrap ──
-    const { credentialId } = await registerPasskey();
+    // ── stage 2: obtain a passkey-PRF output, with a one-shot fallback ──────────
+    // registerPasskey() may REUSE an existing PRF-capable passkey (fast path, no
+    // new credential). But a credential the server flagged prfSupported can still
+    // fail to actually produce a PRF result here (it was created before PRF, or
+    // the platform won't eval it) — that is the loop users hit: the enrolment
+    // dies, the orphan is swept, /sign keeps asking to "set up a signing passkey".
+    // So when PRF fails on a REUSED credential we don't give up: we mint a FRESH
+    // PRF-capable passkey and try once more. Only a FRESH passkey that STILL can't
+    // PRF is a genuine device/browser limitation (surfaced to the user).
     const prfSalt = crypto.getRandomValues(new Uint8Array(16));   // the eval salt; stored in the wrap
-    const prfOutput = await evalNewPrf({ credentialId, prfSalt });
+    let reg = await registerPasskey({ forceFresh: false });
+    let prfOutput;
     try {
-      await vaultAddPrfWrap({ pk_hash, secretKeyBytes: kp.secretKey, credentialId, prfSalt, prfOutput });
+      prfOutput = await evalNewPrf({ credentialId: reg.credentialId, prfSalt });
+    } catch (e) {
+      if (reg && reg.reused && e && e.code === 'no_prf') {
+        reg = await registerPasskey({ forceFresh: true });
+        prfOutput = await evalNewPrf({ credentialId: reg.credentialId, prfSalt });
+      } else {
+        throw e;
+      }
+    }
+    try {
+      await vaultAddPrfWrap({ pk_hash, secretKeyBytes: kp.secretKey, credentialId: reg.credentialId, prfSalt, prfOutput });
     } finally {
       prfOutput.fill(0);
     }

--- a/frontend/js/signing-enrol.js
+++ b/frontend/js/signing-enrol.js
@@ -5,7 +5,7 @@
 // (registerPasskey / evalNewPrf / enrolPublicKey), then proves the result is
 // resolvable so /sign can find it. Self-hosted deps only (CSP script-src
 // 'self'); no-ops if the page lacks the enrol elements.
-import { enrolSigningPasskey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=2';
+import { enrolSigningPasskey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=3';
 import { startRegistration, browserSupportsWebAuthn } from '/vendor/simplewebauthn-browser/index.js';
 import { vaultList, vaultDelete } from '/vendor/vault.js?v=2';
 
@@ -96,14 +96,19 @@ function wireSigningEnrol() {
         //     extensions.prf, and we strip excludeCredentials client-side so the
         //     device will mint a PRF-capable passkey even when a pre-PRF passkey
         //     already exists for this account (TOTP step-up still gates it).
-        registerPasskey: async () => {
-          let list = [];
-          try {
-            const cr = await fetch('/api/user/account/webauthn/credentials', { credentials: 'include' });
-            if (cr.ok) list = (await cr.json()).passkeys || [];
-          } catch { /* treat as no usable passkey */ }
-          const prfCapable = list.find(c => c.prfSupported && c.credId);
-          if (prfCapable) return { credentialId: prfCapable.credId };
+        registerPasskey: async ({ forceFresh } = {}) => {
+          // Fast path: reuse an existing PRF-capable passkey — UNLESS the caller
+          // forces a fresh one (the fallback when a reused credential turned out
+          // not to actually produce a PRF result, which is what caused the loop).
+          if (!forceFresh) {
+            let list = [];
+            try {
+              const cr = await fetch('/api/user/account/webauthn/credentials', { credentials: 'include' });
+              if (cr.ok) list = (await cr.json()).passkeys || [];
+            } catch { /* treat as no usable passkey */ }
+            const prfCapable = list.find(c => c.prfSupported && c.credId);
+            if (prfCapable) return { credentialId: prfCapable.credId, reused: true };
+          }
 
           const totp = askTotp('Add a signing passkey — enter your current 6-digit authenticator code:');
           setStatus('Verifying code, then follow your device prompt to create the passkey…', false);
@@ -122,7 +127,7 @@ function wireSigningEnrol() {
           }
           const ver = await postJSON('/api/user/account/webauthn/register/verify', { flowId: opt.data.flowId, response: attResp, label });
           if (!ver.ok) throw new Error((ver.data && ver.data.error) || ('register_verify_failed_' + ver.status));
-          return { credentialId: attResp.id };
+          return { credentialId: attResp.id, reused: false };
         },
 
         // (2) Evaluate the passkey PRF with the per-wrap salt. This is the SAME
@@ -140,7 +145,11 @@ function wireSigningEnrol() {
             },
           });
           const first = assertion.getClientExtensionResults()?.prf?.results?.first;
-          if (!first) throw new Error('This passkey can’t produce a PRF result. Use a device/browser with passkey-PRF (iOS 18+ or a recent Chrome), or remove an old non-PRF passkey for this site and retry.');
+          if (!first) {
+            const e = new Error('This passkey can’t produce a PRF result. Use a device/browser with passkey-PRF (iOS 18+ or a recent Chrome), or remove an old non-PRF passkey for this site and retry.');
+            e.code = 'no_prf';   // signals enrolSigningPasskey to retry with a FRESH passkey when this one was reused
+            throw e;
+          }
           return new Uint8Array(first);
         },
 

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -11,7 +11,7 @@
 // sign path. Signing goes through the passkey-PRF activation chain (LocalVaultSigner
 // in parasign-signer.js); sha3_256 stays for document hashing only.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=2';
+import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=3';
 
 // Read-only public relay host, used ONLY for the "view envelope status" link on
 // the done screen. The signing path itself is same-origin via the admin
@@ -411,6 +411,22 @@ async function initStepIdentity() {
   showSigningIdentity().catch(() => {});
 }
 
+// Does this ACCOUNT have a signing key bound on the server, even though THIS
+// browser's vault has none? The signing key's private half + PRF wrap live
+// per-browser in IndexedDB; the server only holds the public binding. A key
+// enrolled on your phone is therefore NOT usable in a desktop browser — each
+// browser enrols once. This lets the hint say "set it up on this device too"
+// instead of the misleading "you don't have a signing passkey", which is what
+// made it feel like a loop when signing across devices.
+async function serverHasSigningKey() {
+  try {
+    const r = await fetch('/api/user/account/signing-key', { credentials: 'include' });
+    if (!r.ok) return false;
+    const body = await r.json().catch(() => ({}));
+    return Array.isArray(body.keys) && body.keys.some((k) => !k.revoked_at);
+  } catch { return false; }
+}
+
 // Display the passkey signing identity in the identity step (read-only, public
 // metadata only — no unlock). If none is enrolled, deep-link to the enrol
 // flow on /account (the "Set up a signing passkey" card).
@@ -426,7 +442,11 @@ async function showSigningIdentity() {
   } catch (e) {
     el.className = 'ds-hint';
     if (e && e.code === 'no_signing_passkey') {
-      el.innerHTML = 'You don\'t have a signing passkey on this device yet — you need one to sign. <a href="/account#signing-identity-section" class="btn btn-primary btn-small" style="margin-top:8px;display:inline-block">Set up a signing passkey →</a>';
+      const elsewhere = await serverHasSigningKey();
+      el.innerHTML = (elsewhere
+        ? 'Your signing key was set up in another browser or on another device. Signing keys live in the browser where you create them, so set one up here too. '
+        : 'You don\'t have a signing passkey on this device yet — you need one to sign. ') +
+        '<a href="/account#signing-identity-section" class="btn btn-primary btn-small" style="margin-top:8px;display:inline-block">Set up a signing passkey →</a>';
     } else {
       el.textContent = (e && e.message) ? e.message : 'Could not check your signing key.';
     }

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -608,6 +608,6 @@
 <script src="/js/nav-auth.js" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js" defer></script>
-<script type="module" src="/sign-flow.js?v=13"></script>
+<script type="module" src="/sign-flow.js?v=14"></script>
 </body>
 </html>


### PR DESCRIPTION
## Bug

Op **alle** devices (iPhone + desktop), signing-passkey **2x aangemaakt**, en `/sign` blijft "set up a signing passkey" tonen → loop.

## Oorzaak

De signing-key leeft in een **per-browser IndexedDB-vault** met een `webauthn-prf`-wrap. De enrol **hergebruikte** elke passkey die de server als `prfSupported` markeerde en eiste daar een PRF-resultaat van. Een credential die in werkelijkheid **geen PRF kan eval'en** (ooit aangemaakt zónder PRF, of platform weigert) liet `evalNewPrf` fataal gooien — **zonder fallback**. De half-gemaakte vault-entry werd geveegd door `cleanupOrphans`, en `/sign` bleef om een signing-passkey vragen. Dezelfde falende credential op elk device → permanente loop.

## Fix (frontend-only)

- **`enrolSigningPasskey` (parasign-signer.js):** faalt PRF op een **hergebruikte** credential → mint alsnog een **verse PRF-capabele passkey** en probeer één keer opnieuw. Alleen een vérse passkey die nóg geen PRF kan is een echte device/browser-limiet (nu netjes getoond i.p.v. stil terugsturen). `registerPasskey` krijgt `{forceFresh}` + geeft `{credentialId, reused}`; `evalNewPrf` tagt de geen-PRF-fout `code:'no_prf'` zodat de fallback 'm onderscheidt van een annulering.
- **Cross-device-hint (sign-flow.js):** heeft deze browser geen vault-key maar de **server** wél een signing-key → "set it up on this device too" i.p.v. het misleidende "you don't have a signing passkey". Signing-keys zijn per-browser; enrol je op je telefoon, dan moet je desktop apart.
- **Cache-bust:** `parasign-signer` v2→v3 (3 importers), `signing-enrol`/`co-sign` v2→v3, `sign-flow` v13→v14.

## Verificatie
- `node --check` op alle 4 gewijzigde modules ✓
- Fallback-control-flow **4/4**: hergebruik+PRF-ok (geen fallback), hergebruik+PRF-faalt → verse passkey + slaagt, verse+PRF-faalt → gooit door, annulering → geen fallback-spam.

Geen relay/server-mutatie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)