### PR TITLE
help: remove em-dashes from the help index

### DIFF
--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Help — PARAMANT</title>
+<title>Help · PARAMANT</title>
 <meta name="description" content="Help and documentation for PARAMANT. API keys, TOTP, integrations, and troubleshooting.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -265,7 +265,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </div><main>
 
   <h1>Help</h1>
-  <p class="lead">Answers to the most common questions about Paramant &mdash; authentication, integrations, and troubleshooting.</p>
+  <p class="lead">Answers to the most common questions about Paramant: authentication, integrations, and troubleshooting.</p>
 
   <aside class="parapear-block" aria-label="A friendly note">
     <img class="parapear-img" src="/assets/parapear/parapear-help.png" alt="" aria-hidden="true" loading="lazy" decoding="async" width="120" height="120">
@@ -279,7 +279,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <div class="help-grid">
 
     <a href="/help/api-key-vs-totp" class="help-card">
-      <div class="help-card-title">API key vs TOTP — what's the difference?</div>
+      <div class="help-card-title">API key vs TOTP: what's the difference?</div>
       <div class="help-card-desc">When you need just the key, when you need both, and how to set up your authenticator app.</div>
       <span class="help-card-arrow">Read &rarr;</span>
     </a>
@@ -303,7 +303,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
     <a href="/help/iot-integration" class="help-card">
       <div class="help-card-title">IoT &amp; embedded devices</div>
-      <div class="help-card-desc">How to use the Paramant API on constrained devices — Pi Zero, ESP32, OT gateway. Static key, no TOTP required.</div>
+      <div class="help-card-desc">How to use the Paramant API on constrained devices: Pi Zero, ESP32, OT gateway. Static key, no TOTP required.</div>
       <span class="help-card-arrow">Read &rarr;</span>
     </a>
 
@@ -338,7 +338,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
     <a href="mailto:privacy@paramant.app" class="help-card">
       <div class="help-card-title">Contact support</div>
-      <div class="help-card-desc">Can't find what you need? Email privacy@paramant.app — we respond within 48 hours.</div>
+      <div class="help-card-desc">Can't find what you need? Email privacy@paramant.app. We respond within 48 hours.</div>
       <span class="help-card-arrow">Email &rarr;</span>
     </a>
 


### PR DESCRIPTION
Content-only cleanup of `frontend/help/index.html`: removes the 5 em-dashes from the `/help` index, replacing them with plain punctuation per the Paramant no-em-dash style. No structural, link, version, or auth-model change.

## Em-dash removals (before → after)

1. **Page `<title>`**: `Help — PARAMANT` → `Help · PARAMANT` (middot)
2. **Lead paragraph**: `...about Paramant &mdash; authentication, integrations...` → `...about Paramant: authentication, integrations...` (colon)
3. **Card title (API key vs TOTP)**: `API key vs TOTP — what's the difference?` → `API key vs TOTP: what's the difference?` (colon)
4. **IoT card description**: `...on constrained devices — Pi Zero, ESP32...` → `...on constrained devices: Pi Zero, ESP32...` (colon)
5. **Contact support card**: `Email privacy@paramant.app — we respond within 48 hours.` → `Email privacy@paramant.app. We respond within 48 hours.` (two sentences)

`git diff --cached --stat`: 1 file changed, 5 insertions(+), 5 deletions(-).

## Verified, left for later

- **No dead `/help/*` links**: all sub-article links on the index return 200; nothing removed.
- **Gmail-extension / Outlook-add-in cards**: point at live pages, but no public store listing could be found. Flagged as a content decision, not removed (not a dead link).
- **Passkey/WebAuthn**: the page is still entirely API-key/TOTP with no passkey/WebAuthn mention. Content update deferred until the passkey flow is stable.
- **`build 3.0.0` string**: left untouched.
- **Two orphan files noted**: `authenticator-apps.html` and `authenticator-setup.html` (not linked from the index; not part of this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)