### PR TITLE
feat(dashboard): add the Operations block to the normal user dashboard

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -1856,6 +1856,28 @@ api.get("/user/account/key", authUser, async (req, res) => {
   res.json({ api_key: req.userSession.user_id });
 });
 
+// GET /api/user/dashboard/overview — read-only Operations data for the normal
+// (non-developer) dashboard: plan, masked key, this-month quota, recent audit.
+// authUser only (NO developer gate). Reuses buildSnapshot minus the tools
+// catalogue. 3s per-account cache so the dashboard's 5s poll can't hammer Redis.
+const _ovCache = new Map(); // uid -> { at, data }
+api.get("/user/dashboard/overview", authUser, async (req, res) => {
+  const uid = req.userSession.user_id;
+  const hit = _ovCache.get(uid);
+  if (hit && Date.now() - hit.at < 3000) return res.json(hit.data);
+  let plan = "community";
+  try { const u = await findUserByEmail(req.userSession.email); if (u && u.plan) plan = u.plan; } catch {}
+  try {
+    const snap = await buildSnapshot({ redis, getAuditEvents, plan }, req.userSession);
+    const data = { plan: snap.plan, key_masked: snap.key_masked, quota: snap.quota, audit: snap.audit };
+    _ovCache.set(uid, { at: Date.now(), data });
+    if (_ovCache.size > 500) _ovCache.clear();
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ error: "overview_failed" });
+  }
+});
+
 // ── Account-bound signing identity (proxies to relay /v2/user/signing-key) ──
 // The browser talks to admin (session-cookie); admin forwards to relay with
 // the internal-auth token. user_id is taken from the session, never from the

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -115,6 +115,33 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
 .dh-pm-item span { display: block; font-family: var(--sans); font-size: 13px; line-height: 1.5; color: var(--ink-dim); }
 .dh-modal-dismiss { margin-top: var(--space-2); background: transparent; border: none; font-family: var(--sans); font-size: 13px; color: var(--ink-dim); cursor: pointer; padding: 8px 10px; border-radius: 8px; }
 .dh-modal-dismiss:hover { color: var(--ink); background: var(--ink-ghost); }
+
+/* Operations -- read-only live cards (keys, usage, activity) */
+.dh-ops { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: var(--space-3); margin-bottom: var(--space-3); }
+.dh-ops-card { display: flex; flex-direction: column; gap: var(--space-3); padding: var(--space-4); border-radius: 14px; background: var(--bone); border: 1px solid rgba(11,58,106,0.06); box-shadow: 0 1px 2px rgba(11,58,106,0.03); }
+.dh-ops-h { font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: var(--ink-dim); }
+.dh-ops-dim { font-family: var(--mono); font-size: 12px; color: var(--ink-dim); }
+.dh-ops-row { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; padding: 5px 0; border-bottom: 1px solid var(--ink-hair); }
+.dh-ops-row:last-child { border-bottom: none; }
+.dh-ops-row .mono { font-family: var(--mono); font-size: 12px; color: var(--ink); word-break: break-all; }
+.dh-ops-row .dim { font-family: var(--mono); font-size: 11px; color: var(--ink-dim); flex: 0 0 auto; }
+.dh-usage-row { margin-bottom: var(--space-3); }
+.dh-usage-lab { display: flex; justify-content: space-between; font-family: var(--mono); font-size: 12px; color: var(--ink); margin-bottom: 6px; }
+.dh-bar { height: 6px; border-radius: 999px; background: var(--ink-hair); overflow: hidden; }
+.dh-bar > i { display: block; height: 100%; width: 0; background: var(--cobalt, #0B3A6A); border-radius: 999px; transition: width .4s ease; }
+.dh-bar.warn > i { background: var(--lime); }
+.dh-usage-upsell { display: inline-block; margin-top: 6px; font-family: var(--mono); font-size: 11px; color: var(--cobalt, #0B3A6A); text-decoration: none; }
+.dh-usage-upsell:hover { text-decoration: underline; }
+.dh-ops-filter { width: 100%; box-sizing: border-box; padding: 8px 10px; border: 1px solid var(--ink-hair); border-radius: 8px; font-family: var(--mono); font-size: 12px; background: var(--bone); color: var(--ink); }
+.dh-ops-filter:focus { outline: none; border-color: var(--cobalt, #0B3A6A); }
+.dh-ops-tl { display: flex; flex-direction: column; max-height: 196px; overflow-y: auto; }
+.dh-tl-row { display: flex; gap: 10px; align-items: baseline; padding: 5px 0; border-bottom: 1px solid var(--ink-hair); }
+.dh-tl-row:last-child { border-bottom: none; }
+.dh-tl-row .t { font-family: var(--mono); font-size: 11px; color: var(--ink-dim); flex: 0 0 auto; }
+.dh-tl-row .e { font-family: var(--mono); font-size: 11px; color: var(--ink); word-break: break-all; }
+.dh-ops-note { font-family: var(--sans); font-size: 12px; line-height: 1.55; color: var(--ink-dim); border: 1px dashed var(--ink-hair); border-radius: 12px; padding: var(--space-3) var(--space-4); margin-bottom: var(--space-7); }
+.dh-ops-note strong { color: var(--ink); }
+@media (prefers-reduced-motion: reduce) { .dh-bar > i { transition: none; } }
 </style>
 </head>
 <body>
@@ -332,6 +359,26 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
       <a class="dh-tool" href="/parashare"><h3>ParaShare</h3><p>Verified, signed delivery with receipts. Multi-recipient. Sector audit log.</p></a>
       <a class="dh-tool" href="/verify"><h3>Verify a signature</h3><p>Check a .psign envelope against its document. Local hash, relay-side math.</p></a>
     </section>
+
+    <div class="dh-tools-head"><h2>Operations</h2></div>
+    <section class="dh-ops" id="dh-ops" aria-label="Operations">
+      <div class="dh-ops-card">
+        <div class="dh-ops-h">API keys</div>
+        <div id="dh-ops-keys"><div class="dh-ops-dim">Loading...</div></div>
+        <div><button type="button" class="dh-btn" disabled title="Available with self-service keys (coming)">+ New key</button></div>
+      </div>
+      <div class="dh-ops-card">
+        <div class="dh-ops-h">Usage &middot; this month</div>
+        <div id="dh-ops-usage"><div class="dh-ops-dim">Loading...</div></div>
+      </div>
+      <div class="dh-ops-card">
+        <div class="dh-ops-h">Activity timeline</div>
+        <input id="dh-ops-filter" class="dh-ops-filter" type="text" placeholder="Filter events..." aria-label="Filter activity">
+        <div id="dh-ops-timeline" class="dh-ops-tl"><div class="dh-ops-dim">Loading...</div></div>
+        <div><button type="button" class="dh-btn" disabled title="Full history coming soon">View all</button></div>
+      </div>
+    </section>
+    <p class="dh-ops-note"><strong>Operations &middot; read-only.</strong> Live usage and activity from your account. Action controls (new keys, run, configure) arrive with self-service keys.</p>
 
     <details class="dh-acct" aria-label="Account details">
       <summary class="dh-acct-head" id="dh-acct-toggle">

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -104,6 +104,7 @@
     root.classList.add('dh-loaded');
 
     checkKeySetup();
+    loadOperations();
   }
 
   function wireActions() {
@@ -189,6 +190,69 @@
       modal.addEventListener('click', function (ev) { if (ev.target === modal) dismiss(); });
       document.addEventListener('keydown', function (ev) { if (ev.key === 'Escape' && !modal.hidden) dismiss(); });
     });
+  }
+
+  // ---- Operations: read-only live keys / usage / activity cards ----
+  // Fed by GET /api/user/dashboard/overview (authUser). Polled every 5s so the
+  // usage bars stay current; the audit feed and key are refreshed on the same tick.
+  var opsAudit = [], opsFilter = '', opsPollTimer = 0;
+  function esc(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) { return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]; }); }
+  function fmtTime(ts) { if (!ts) return '--:--:--'; var d = new Date(ts); function p(n) { return (n < 10 ? '0' : '') + n; } return p(d.getHours()) + ':' + p(d.getMinutes()) + ':' + p(d.getSeconds()); }
+  function opsBar(used, cap) {
+    var unlimited = (cap == null);
+    var pct = unlimited ? 4 : Math.min(100, Math.round(((used || 0) / Math.max(1, cap)) * 100));
+    return { pct: pct, warn: !unlimited && pct >= 80, capTxt: unlimited ? '&#8734;' : String(cap) };
+  }
+  function renderOpsTimeline() {
+    var el = document.getElementById('dh-ops-timeline');
+    if (!el) return;
+    var f = (opsFilter || '').toLowerCase();
+    var rows = opsAudit.filter(function (ev) {
+      if (!f) return true;
+      return (ev.event_type || '').toLowerCase().indexOf(f) >= 0 ||
+             JSON.stringify(ev.metadata || {}).toLowerCase().indexOf(f) >= 0;
+    });
+    el.innerHTML = rows.length
+      ? rows.slice(0, 50).map(function (ev) {
+          return '<div class="dh-tl-row"><span class="t">' + fmtTime(ev.ts) + '</span><span class="e">' + esc(ev.event_type || 'event') + '</span></div>';
+        }).join('')
+      : '<div class="dh-ops-dim">No activity' + (f ? ' matches "' + esc(opsFilter) + '"' : ' yet') + '.</div>';
+  }
+  function renderOps(d) {
+    var keysEl = document.getElementById('dh-ops-keys');
+    if (keysEl) {
+      keysEl.innerHTML =
+        '<div class="dh-ops-row"><span class="mono">' + esc(d.key_masked || '--') + '</span><span class="dim">primary</span></div>' +
+        '<div class="dh-ops-row"><span class="dim">last used</span><span class="dim">tracked via activity</span></div>';
+    }
+    var q = d.quota || { transfers: 0, signs: 0, caps: {} };
+    var caps = q.caps || {};
+    function usageRow(label, used, cap) {
+      var b = opsBar(used, cap);
+      return '<div class="dh-usage-row"><div class="dh-usage-lab"><span>' + label + '</span><span><b>' + (used || 0) + '</b> / ' + b.capTxt + '</span></div>' +
+        '<div class="dh-bar' + (b.warn ? ' warn' : '') + '"><i style="width:' + b.pct + '%"></i></div>' +
+        (b.warn ? '<a class="dh-usage-upsell" href="/pricing">Upgrade to Pro</a>' : '') + '</div>';
+    }
+    var usageEl = document.getElementById('dh-ops-usage');
+    if (usageEl) {
+      usageEl.innerHTML = usageRow('Transfers', q.transfers, caps.transfers) + usageRow('Signings', q.signs, caps.signs) +
+        '<div class="dh-ops-dim" style="font-size:10px">Live, refreshes every 5s.</div>';
+    }
+    opsAudit = d.audit || [];
+    renderOpsTimeline();
+  }
+  function loadOperations() {
+    if (!document.getElementById('dh-ops')) return;
+    var fi = document.getElementById('dh-ops-filter');
+    if (fi && !fi._wired) { fi._wired = 1; fi.addEventListener('input', function () { opsFilter = fi.value; renderOpsTimeline(); }); }
+    function pull() {
+      return fetch('/api/user/dashboard/overview', { credentials: 'include', headers: { 'Accept': 'application/json' }, cache: 'no-store' })
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (d) { if (d) renderOps(d); })
+        .catch(function () {});
+    }
+    pull();
+    if (!opsPollTimer) opsPollTimer = setInterval(pull, 5000);
   }
 
   function start() {


### PR DESCRIPTION
## Wat
Het developer-dashboard had een **Operations**-blok (API keys · usage deze maand · activity timeline) dat het normale dashboard miste. Dit voegt hetzelfde **read-only** blok toe aan `/dashboard`.

## Backend
`GET /api/user/dashboard/overview` (`authUser`, **géén** developer-gate) → `{plan, key_masked, quota, audit}`. Hergebruikt de geteste `buildSnapshot` (zonder de tools-catalogus), met 3s per-account cache zodat de 5s-poll Redis niet hamert.

## Frontend
Een Operations-sectie tussen **More tools** en **Manage account**, in de bestaande `dh-`-stijl:
- **API keys** — gemaskeerde primary key (+ `+ New key`, disabled).
- **Usage · this month** — live transfers/signings-bars `x/cap`; bij ≥80% een **Upgrade to Pro**-CTA. Ververst elke 5s.
- **Activity timeline** — laatste 50 audit-events, filterbaar (+ `View all`, disabled).
- Read-only WIP-note onderaan; alle actie-knoppen disabled met eerlijke tooltip.

## Verificatie
Headless render **14/14**: 3 kaarten, gemaskeerde key, 2 usage-bars + ≥80%-upsell, timeline met events + werkende filter, disabled actie-knoppen met tooltip, mobiel 1-koloms, geen page-errors. `buildSnapshot` unit-tests 7/7 (uit #161).

Vanilla JS (ASCII-only, matcht dashboard.js), geen libs, geen relay-mutatie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)