### PR TITLE
ux: homepage badges + human CTA, docs quickstart + anchors

### DIFF
--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -404,12 +404,13 @@ npm install paramant-sdk</pre>
       <pre>from paramant_sdk import GhostPipe
 
 gp = GhostPipe(api_key="pgp_your_key", device="laptop-01")
+gp.receive_setup()  <span class="cm"># register this device's keys (once)</span>
 
-<span class="cm"># Send — returns blob hash; share with receiver</span>
-hash_ = gp.send(open("document.pdf", "rb").read(), ttl=3600)
+<span class="cm"># Send: returns (blob hash, inclusion proof). Share the hash with the receiver.</span>
+hash_, proof = gp.send(open("document.pdf", "rb").read(), ttl=3600)
 
-<span class="cm"># Receive — burn-on-read, one download only</span>
-data = gp.receive(hash_)</pre>
+<span class="cm"># Receive: burn-on-read, one download only.</span>
+data, proof = gp.receive(hash_)</pre>
     </div>
 
     <p>Or use the direct HTTP API — no SDK needed:</p>
@@ -485,7 +486,7 @@ data = gp.receive(hash_)</pre>
     <pre><span class="cm"># Send DICOM scan to specialist</span>
 from paramant_sdk import GhostPipe
 gp = GhostPipe(api_key="pgp_xxx", device="mri-001", sector="health")
-hash_ = gp.send(open("scan.dcm","rb").read(), ttl=3600)</pre></div>
+hash_, proof = gp.send(open("scan.dcm","rb").read(), ttl=3600)</pre></div>
     <p><a href="/compliance/nen7510" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">NEN 7510 compliance page →</a></p>
 
     <h3><span class="sector-badge">legal</span>Legal &amp; Notary — eIDAS, KNB</h3>
@@ -494,7 +495,7 @@ hash_ = gp.send(open("scan.dcm","rb").read(), ttl=3600)</pre></div>
     <pre><span class="cm"># Signed deed — burn-on-read, CT log entry as proof of delivery</span>
 from paramant_sdk import GhostPipe
 gp = GhostPipe(api_key="pgp_xxx", device="notary-01", sector="legal")
-hash_, receipt = gp.send_with_receipt(open("deed.pdf","rb").read())
+hash_, receipt = gp.send(open("deed.pdf","rb").read())
 gp.verify_receipt(receipt)  <span class="cm"># ML-DSA-65 signed</span></pre></div>
 
     <h3><span class="sector-badge">iot</span>Industrial IoT — IEC 62443</h3>
@@ -514,10 +515,11 @@ while True:
     <pre><span class="cm"># Send ISO 20022 payment file with CT proof for DORA audit</span>
 from paramant_sdk import GhostPipe
 gp = GhostPipe(api_key="pgp_xxx", device="bank-nl-01", sector="finance")
-hash_, receipt = gp.send_with_receipt(open("pacs008.xml","rb").read())
+hash_, receipt = gp.send(open("pacs008.xml","rb").read())
 <span class="cm"># receipt → tree_size, sha3_root, ML-DSA-65 signature</span></pre></div>
 
     <!-- ── API Reference ──────────────────────────────────────── -->
+    <span id="api" style="display:block;scroll-margin-top:90px" aria-hidden="true"></span>
     <h2 id="endpoints">All endpoints</h2>
     <table>
       <tr><th>Method</th><th>Endpoint</th><th>Description</th><th>Auth</th></tr>
@@ -607,6 +609,7 @@ ws.onmessage = e => {
 }</span></pre>
 
     <!-- ── Self-hosting ─────────────────────────────────────────── -->
+    <span id="self-hosting" style="display:block;scroll-margin-top:90px" aria-hidden="true"></span>
     <h2 id="selfhost-docker">Self-hosting — Docker Compose</h2>
     <p>Community Edition is free forever for up to 5 users. One <code>docker compose up</code> starts 6 containers: five sector relays and an admin panel.</p>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,6 +28,9 @@
 .home-hero .lede { font-size: 16px; line-height: 1.55; color: var(--ink-dim); max-width: 58ch; margin: 0 auto; }
 .hero-badges { list-style: none; display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; padding: 0; margin: var(--space-4) 0 0; }
 .hero-badges li { font-family: var(--mono); font-size: 10px; letter-spacing: .1em; text-transform: uppercase; color: var(--ink-dim); border: 1px solid var(--ink-hair); border-radius: 999px; padding: 5px 11px; background: var(--bone); }
+.hero-badges a { display: block; margin: -5px -11px; padding: 5px 11px; border-radius: 999px; color: inherit; text-decoration: none; }
+.hero-badges li:hover { border-color: var(--navy); }
+.hero-badges li:hover a { color: var(--navy); }
 .home-split { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); max-width: 1040px; margin: var(--space-5) auto var(--space-6); padding: 0 var(--space-4); }
 .path { position: relative; display: flex; flex-direction: column; border: 1px solid var(--ink-hair); background: #fff; padding: var(--space-5); min-height: 220px; }
 .path-dev { background: var(--bone); }
@@ -304,11 +307,11 @@
   <h1>Sign it. Send it. We never even had it.</h1>
   <p class="lede">Post-quantum signatures and encrypted transfers, held in memory and gone after read. The server is blind by design, not by promise.</p>
   <ul class="hero-badges" aria-label="At a glance">
-    <li>Open source</li>
-    <li>Free</li>
-    <li>Fully auditable</li>
-    <li>EU-sovereign</li>
-    <li>Post-quantum</li>
+    <li><a href="https://github.com/Apolloccrypt/paramant-relay">Open source</a></li>
+    <li><a href="/pricing">Free</a></li>
+    <li><a href="/security">Fully auditable</a></li>
+    <li><a href="/sovereignty">EU-sovereign</a></li>
+    <li><a href="/crypto-agility">Post-quantum</a></li>
   </ul>
 </section>
 
@@ -348,7 +351,7 @@
       </svg>
     </div>
     <div class="path-cta">
-      <a class="btn btn-lime" href="/dashboard">Open your dashboard</a>
+      <a class="btn btn-lime" href="/signup?next=%2Fdashboard">Open your dashboard</a>
     </div>
   </div>
   <div class="path path-dev">


### PR DESCRIPTION
From the live UX audit (top-priority, low-risk frontend fixes):

**Homepage (`frontend/index.html`)**
- Human-door CTA now routes new visitors to `/signup?next=%2Fdashboard` instead of the sign-in screen (dev-door unchanged at `/developer`).
- The five hero trust badges are now links to their proof pages: GitHub, `/pricing`, `/security`, `/sovereignty`, `/crypto-agility`. Added `.hero-badges a` styling.

**Docs (`frontend/docs.html`)**
- Corrected the Python quickstart to the published SDK 3.0.0 API: `receive_setup()` first; `send()`/`receive()` return tuples (`hash_, proof = gp.send(...)`, `data, proof = gp.receive(hash_)`).
- Removed the non-existent `send_with_receipt()` from the legal/finance examples.
- Added `id="api"` / `id="self-hosting"` anchor aliases so the global-nav "API reference" / "Deploy guide" links resolve.

Frontend-only, deployed via webroot rsync. Headless render verified: no new console errors, both DOM anchors present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)