### PR TITLE
refactor(parasign): disambiguate passkey labels (sign-in vs signing key) [re-land #166]

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -366,10 +366,10 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
   </div>
   <hr class="acct-divider">
   <div class="acct-block">
-    <h3>Set up a signing passkey</h3>
+    <h3>Set up your signing key</h3>
     <p class="small">
-      Creates your ML-DSA-65 signing key in this browser, protected by your passkey
-      (Face ID / Touch ID / security key). The passphrase is your recovery floor &mdash;
+      Creates your ML-DSA-65 signing key in this browser, unlocked with Face ID /
+      Touch ID / a security key when you sign. The passphrase is your recovery floor &mdash;
       we never see it and cannot reset it, so store it safely. Adding a signing key needs
       your authenticator code.
     </p>
@@ -378,7 +378,7 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
       <input type="password" id="signing-enrol-pass" placeholder="Recovery passphrase (min 12 characters)" autocomplete="new-password">
       <input type="password" id="signing-enrol-pass2" placeholder="Confirm passphrase" autocomplete="new-password">
       <div>
-        <button type="button" class="btn btn-primary btn-small" id="signing-enrol-btn">Set up signing passkey</button>
+        <button type="button" class="btn btn-primary btn-small" id="signing-enrol-btn">Set up signing</button>
       </div>
     </div>
     <p id="signing-enrol-status" class="small" aria-live="polite" style="margin-top:8px"></p>
@@ -684,7 +684,7 @@ async function loadEnrolledKeys() {
     const data = await res.json();
     const keys = (data.keys || []);
     if (!keys.length) {
-      emptyEl.textContent = 'No signing keys enrolled yet. Use "Set up a signing passkey" below to create one.';
+      emptyEl.textContent = 'No signing keys enrolled yet. Use "Set up your signing key" below to create one.';
       listEl.innerHTML = '';
       return;
     }
@@ -739,7 +739,7 @@ async function loadVaultStatus() {
   try {
     const list = await vaultList();
     if (!list.length) {
-      el.textContent = 'No signing key in this browser yet. Use "Set up a signing passkey" below.';
+      el.textContent = 'No signing key in this browser yet. Use "Set up your signing key" below.';
       return;
     }
     const fmt = e => (e.label ? e.label : '(no label)') + ' [' + (e.pk_hash || '').slice(0, 12) + '...]';
@@ -757,7 +757,7 @@ loadVaultStatus();
 document.addEventListener('signing-key-enrolled', () => { loadEnrolledKeys(); loadVaultStatus(); });
 </script>
 <script type="module" src="/js/passkey.js"></script>
-<script type="module" src="/js/signing-enrol.js?v=3"></script>
+<script type="module" src="/js/signing-enrol.js?v=4"></script>
 
 </body>
 </html>

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -135,7 +135,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   <div class="card">
     <div class="card-head"><div class="dot"></div><div class="card-head-title">Sign as <span id="me-label">party</span></div></div>
     <div class="card-body">
-      <p class="sub" style="margin-bottom:12px">You sign with your passkey-protected ML-DSA-65 key - unlocked with Face ID / Touch ID / a security key the moment you sign, and never exported. The signature is bound to the email address this invite was sent to.</p>
+      <p class="sub" style="margin-bottom:12px">You sign with your signing key (ML-DSA-65) — unlocked with Face ID / Touch ID / a security key the moment you sign, and never exported. The signature is bound to the email address this invite was sent to.</p>
       <div class="banner" id="sign-status" hidden></div>
       <div id="sign-cta" style="margin-bottom:12px" hidden></div>
       <button class="btn" id="sign-confirm" type="button" disabled>Sign this document</button>
@@ -169,6 +169,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 </main>
 
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js"></script>
-<script type="module" src="/co-sign.js?v=3"></script>
+<script type="module" src="/co-sign.js?v=4"></script>
 </body>
 </html>

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -186,15 +186,15 @@ async function prepareSigning() {
     __signKey = await resolvePasskeySigningKey();
   } catch (e) {
     if (e && e.code === 'no_signing_passkey') {
-      setStatus('warn', 'Signed in as ' + escapeHtml(__session.email || 'your account') + ', but this device has no signing passkey yet. Set one up, then return to this link.');
-      showCta('<a class="btn btn-outline" href="/account">Set up a signing passkey</a>');
+      setStatus('warn', 'Signed in as ' + escapeHtml(__session.email || 'your account') + ', but signing isn\'t set up on this device yet. Set it up, then return to this link.');
+      showCta('<a class="btn btn-outline" href="/account">Set up your signing key</a>');
     } else {
       setStatus('err', e.message || 'Could not check your signing key.');
     }
     return;
   }
 
-  setStatus('', 'Signed in as ' + escapeHtml(__session.email || 'your account') + '. You will sign with your passkey-protected key (fingerprint ' + escapeHtml(__signKey.fingerprint) + ').');
+  setStatus('', 'Signed in as ' + escapeHtml(__session.email || 'your account') + '. You\'ll sign with your signing key (fingerprint ' + escapeHtml(__signKey.fingerprint) + ').');
   $('sign-confirm').onclick = doSign;
   refreshSignGate();   // stays disabled until the document has been reviewed (or blind-signing is acknowledged)
 }
@@ -335,7 +335,7 @@ async function doSign() {
 
     // 2) Passkey-PRF unlock + sign of the v3 domain-prefixed message. The secret
     //    key lives ONLY inside the ActivatedSigner and is zeroized by dispose().
-    setStatus('', 'Confirm with your passkey (Face ID / Touch ID / security key)...');
+    setStatus('', 'Confirm to sign (Face ID / Touch ID / security key)...');
     const signer = await new LocalVaultSigner().activate({ vaultId: __signKey.vaultId, rpId: location.hostname });
     let sigB64;
     try {

--- a/frontend/js/signing-enrol.js
+++ b/frontend/js/signing-enrol.js
@@ -1,4 +1,4 @@
-// Signing-passkey enrolment — wires the "Set up signing passkey" action on
+// Signing-key enrolment — wires the "Set up your signing key" action on
 // /account (ADR R018, the deferred "stuk 2"). This is the ONE place a signing
 // key is created; /sign points here. It runs the shared enrolSigningPasskey()
 // orchestration (parasign-signer.js) with the three ceremony callbacks
@@ -110,8 +110,8 @@ function wireSigningEnrol() {
             if (prfCapable) return { credentialId: prfCapable.credId, reused: true };
           }
 
-          const totp = askTotp('Add a signing passkey — enter your current 6-digit authenticator code:');
-          setStatus('Verifying code, then follow your device prompt to create the passkey…', false);
+          const totp = askTotp('Set up your signing key — enter your current 6-digit authenticator code:');
+          setStatus('Verifying code, then follow your device prompt…', false);
           const opt = await postJSON('/api/user/account/webauthn/register/options', { totp });
           if (opt.status === 403) throw new Error('That authenticator code was not accepted.');
           if (!opt.ok) throw new Error((opt.data && opt.data.error) || ('register_options_failed_' + opt.status));
@@ -134,7 +134,7 @@ function wireSigningEnrol() {
         //     get()+prf.eval that LocalVaultSigner.activate() runs at sign time,
         //     so a successful enrol guarantees a successful unlock later.
         evalNewPrf: async ({ credentialId, prfSalt }) => {
-          setStatus('Confirm with your passkey (Face ID / Touch ID / security key)…', false);
+          setStatus('Confirm with Face ID / Touch ID / your security key…', false);
           const assertion = await navigator.credentials.get({
             publicKey: {
               challenge: crypto.getRandomValues(new Uint8Array(32)),
@@ -170,13 +170,13 @@ function wireSigningEnrol() {
       // If it returns here, the vault now holds a webauthn-prf-wrapped key under
       // id = pk_hash, and /sign will find it. Show the fingerprint as proof.
       const k = await resolvePasskeySigningKey();
-      setStatus('Signing passkey ready — fingerprint ' + (k.fingerprint || pk_hash.slice(0, 16)) + '. You can now sign at /sign.', false);
+      setStatus('Signing key ready — fingerprint ' + (k.fingerprint || pk_hash.slice(0, 16)) + '. You can now sign at /sign.', false);
       if (passEl) passEl.value = '';
       if (pass2El) pass2El.value = '';
       document.dispatchEvent(new CustomEvent('signing-key-enrolled'));
     } catch (e) {
       await cleanupOrphans();   // don't leave a half-finished passphrase-only entry behind
-      setStatus((e && e.message) ? e.message : 'Could not set up signing passkey.', true);
+      setStatus((e && e.message) ? e.message : 'Could not set up your signing key.', true);
     } finally {
       btn.disabled = false;
     }

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -437,7 +437,7 @@ async function showSigningIdentity() {
     const k = await resolvePasskeySigningKey();
     state.signer.fingerprint = k.fingerprint;
     el.className = 'ds-hint';
-    el.innerHTML = 'You will sign with your passkey-protected key (Face ID / Touch ID / security key). ' +
+    el.innerHTML = 'You\'ll sign with your signing key — unlocked with Face ID / Touch ID / a security key. ' +
       'Key fingerprint <code>' + escapeHtml(k.fingerprint) + '</code>.';
   } catch (e) {
     el.className = 'ds-hint';
@@ -445,8 +445,8 @@ async function showSigningIdentity() {
       const elsewhere = await serverHasSigningKey();
       el.innerHTML = (elsewhere
         ? 'Your signing key was set up in another browser or on another device. Signing keys live in the browser where you create them, so set one up here too. '
-        : 'You don\'t have a signing passkey on this device yet — you need one to sign. ') +
-        '<a href="/account#signing-identity-section" class="btn btn-primary btn-small" style="margin-top:8px;display:inline-block">Set up a signing passkey →</a>';
+        : 'You haven\'t set up signing on this device yet — you need to before you can sign. ') +
+        '<a href="/account#signing-identity-section" class="btn btn-primary btn-small" style="margin-top:8px;display:inline-block">Set up your signing key →</a>';
     } else {
       el.textContent = (e && e.message) ? e.message : 'Could not check your signing key.';
     }
@@ -619,7 +619,7 @@ function fillReview() {
                                          'Uploaded image (' + formatSize(state.signer.sigImageBytes.length) + ' ' + state.signer.sigImageType.toUpperCase() + ')';
   // Signing key: always the account's passkey-protected ML-DSA-65 key. The
   // fingerprint is filled async (public vault metadata, no unlock) below.
-  $('ds-review-key-src').textContent = 'Passkey-protected ML-DSA-65 key';
+  $('ds-review-key-src').textContent = 'Your signing key (ML-DSA-65)';
 
   // Recipients summary. Multi-party envelopes are created same-origin via your
   // logged-in session (no manual API key); each recipient signs at /co-sign
@@ -637,7 +637,7 @@ function fillReview() {
   // the key source.
   const docHashHex = toHex(sha3_256(state.doc.bytes));
   $('ds-proof-doc-hash').textContent = docHashHex;
-  $('ds-proof-fp').textContent = '(your passkey key fingerprint)';   // filled async below
+  $('ds-proof-fp').textContent = '(your signing key fingerprint)';   // filled async below
   $('ds-proof-version').textContent = 'parasign-doc-3 (recipe_version 3)';
 
   // Envelope-structure preview — the v3 .psign receipt (parasign-doc-3). The
@@ -697,10 +697,10 @@ async function fillReviewKeyFingerprint() {
     const k = await resolvePasskeySigningKey();
     state.signer.fingerprint = k.fingerprint;
     const fpEl = $('ds-proof-fp'); if (fpEl) fpEl.textContent = k.fingerprint;
-    const ksEl = $('ds-review-key-src'); if (ksEl) ksEl.textContent = 'Passkey-protected ML-DSA-65 key (' + k.fingerprint + ')';
+    const ksEl = $('ds-review-key-src'); if (ksEl) ksEl.textContent = 'Your signing key (' + k.fingerprint + ')';
   } catch (e) {
     const fpEl = $('ds-proof-fp');
-    if (fpEl) fpEl.textContent = (e && e.code === 'no_signing_passkey') ? '(set up a signing passkey first)' : '(unavailable)';
+    if (fpEl) fpEl.textContent = (e && e.code === 'no_signing_passkey') ? '(set up your signing key first)' : '(unavailable)';
   }
 }
 
@@ -1052,7 +1052,7 @@ async function doSign() {
     // The signing key is the account's PASSKEY-protected ML-DSA-65 key. Read ONLY
     // its public half from vault metadata here (for the stamp fingerprint); the
     // secret is unlocked solely by the per-document PRF activation below.
-    status('Locating your passkey signing key...');
+    status('Locating your signing key...');
     const signKey = await resolvePasskeySigningKey();   // { vaultId, pk_b64, fingerprint } — public only
     const fingerprint = signKey.fingerprint;
     const dateStr = new Date().toISOString().slice(0, 19) + 'Z';
@@ -1094,7 +1094,7 @@ async function doSign() {
     status('Requesting signing authorization...');
     const act = await requestSignActivation({ envelopeId: env.id, partyIndex: 0, docHash: docHashForEnvelope, inviteToken: myLink.invite_token });
 
-    status('Confirm with your passkey (Face ID / Touch ID / security key)...');
+    status('Confirm to sign (Face ID / Touch ID / security key)...');
     const signer = await new LocalVaultSigner().activate({ vaultId: signKey.vaultId, rpId: location.hostname });
     let sigB64;
     try {
@@ -1141,7 +1141,7 @@ async function doSign() {
     $('ds-sign-status').className = 'ds-banner err';
     let msg = (e && e.message) ? e.message : String(e);
     if (e && e.status === 401) msg = 'Please sign in to sign documents. Open /auth/login, then return here.';
-    else if (e && e.code === 'no_signing_passkey') msg = 'No signing passkey on this device yet. Set one up at /account, then sign.';
+    else if (e && e.code === 'no_signing_passkey') msg = 'Signing isn\'t set up on this device yet. Set it up at /account, then sign.';
     $('ds-sign-status').textContent = msg;
     $('ds-sign-now').disabled = false;
   }

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -435,7 +435,7 @@
     <div class="ds-field">
       <label class="ds-label">Cryptographic key (ML-DSA-65)</label>
       <p class="ds-hint" id="ds-signing-identity">Checking your signing key...</p>
-      <p class="ds-hint" style="margin-top:6px">Your signature style is what people see. What cryptographically binds the signature is your passkey-protected ML-DSA-65 key - unlocked with Face ID / Touch ID / a security key the moment you sign, and never exported. Recipients you add sign at <code>/co-sign</code> with their own passkey.</p>
+      <p class="ds-hint" style="margin-top:6px">Your signature style is what people see. What cryptographically binds the signature is your signing key (ML-DSA-65) — unlocked with Face ID / Touch ID / a security key the moment you sign, and never exported. Recipients you add sign at <code>/co-sign</code> with their own signing key.</p>
     </div>
     <div class="ds-actions">
       <button class="btn btn-tertiary" id="ds-identity-back" type="button">Back</button>
@@ -446,7 +446,7 @@
   <!-- Step 4: review + sign -->
   <section class="ds-step" id="step-sign" hidden>
     <h2>Review and sign</h2>
-    <p class="ds-sub">This is what you are about to sign. Check the document, your signature, and the metadata. When you click <strong>Sign this document</strong>, your passkey (Face ID / Touch ID / security key) unlocks the key for this one document and the signature is created locally.</p>
+    <p class="ds-sub">This is what you are about to sign. Check the document, your signature, and the metadata. When you click <strong>Sign this document</strong>, you confirm with Face ID / Touch ID / your security key — that unlocks your signing key for this one document and the signature is created locally.</p>
 
     <div class="ds-review-grid">
       <div class="ds-review-col">
@@ -608,6 +608,6 @@
 <script src="/js/nav-auth.js" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js" defer></script>
-<script type="module" src="/sign-flow.js?v=14"></script>
+<script type="module" src="/sign-flow.js?v=15"></script>
 </body>
 </html>


### PR DESCRIPTION
Her-landt de naamgeving van **#166**, die per ongeluk in zijn gestackte base-branch (`fix/signing-passkey-loop`) mergede i.p.v. main en dus nooit in main/prod kwam.

Bevat **alleen** de user-facing label-wijzigingen bovenop de huidige main (de #164-signing-fix zit al in main via de squash, dus deze diff = puur de labels): "passkey" alleen voor inloggen; de signing-flow leest nu **"your signing key"** + **"Confirm to sign"**.

6 bestanden, 32/32 (pure herlabeling), geen logica/IDs/backend. Cache-bust: sign-flow v14→v15, signing-enrol v3→v4, co-sign v3→v4. `node --check` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)