### PR TITLE
fix(home): restore the human "Open your dashboard" CTA to /dashboard

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -351,7 +351,7 @@
       </svg>
     </div>
     <div class="path-cta">
-      <a class="btn btn-lime" href="/signup?next=%2Fdashboard">Open your dashboard</a>
+      <a class="btn btn-lime" href="/dashboard">Open your dashboard</a>
     </div>
   </div>
   <div class="path path-dev">


### PR DESCRIPTION
## Regression: the human dashboard button is broken for every signed-in visitor

The left hero CTA **"Open your dashboard"** stopped working. Earlier it was the *developer* button that was broken and the human one worked; that reversal pointed at a recent frontend deploy.

### Diagnosis (read-only)

The two hero buttons:

| Button | href (before) | State |
|---|---|---|
| LEFT "Open your dashboard" | `/signup?next=%2Fdashboard` | **broken** |
| RIGHT "Open developer dashboard" | `/developer` | works |

Live route behavior (logged-out, verified with `curl`):

| Route | Status | Result |
|---|---|---|
| `/dashboard` | 200 | served; `dashboard.js` client-gate → `/auth/login?next=%2Fdashboard` |
| `/developer` | 302 | → `/auth/login?next=/developer` (nginx gate) |
| `/signup?next=%2Fdashboard` | 200 | signup page; **`next` ignored** |
| `/auth/login?next=%2Fdashboard` | 200 | login; **honours `next`** (#162) |

**Root cause — not a shared code path, two independent commits in the same recent wave:**

1. **Developer button repaired by #162** (`8189ec0`) — login.html now honours `?next=`. Before it, login always went to `/dashboard`, so the gated `/developer` round-trip dumped you on the normal dashboard. After #162, `/developer` → `login?next=/developer` → lands on `/developer`. ✓
2. **Human button broken by #168** (`1e76d1c`) — it re-pointed the CTA:
   ```diff
   -      <a class="btn btn-lime" href="/dashboard">Open your dashboard</a>
   +      <a class="btn btn-lime" href="/signup?next=%2Fdashboard">Open your dashboard</a>
   ```
   - A **signed-in** visitor clicking "Open your dashboard" now lands on the **signup page** ("You are already signed in as X … go to your account or sign out first"), not their dashboard.
   - The `next=%2Fdashboard` is **dead**: `signup.html` never reads `next`, and the signup flow runs through email verification + authenticator setup, so it can never honour a `/dashboard` return.

So the "reversal" is real but it is two separate commits (#162 fixed dev, #168 broke human), **not one shared toggle**.

### Fix

One line — point the human CTA back at `/dashboard`, the symmetric counterpart to the developer CTA's `/developer`:

- **logged out:** `/dashboard` (200) → `dashboard.js` gate → 401 → `/auth/login?next=%2Fdashboard` → login honours `next` → lands on `/dashboard`
- **logged in:** `/dashboard` renders directly

The developer CTA (`/developer`, gated server-side by nginx) already satisfies both states and is **left untouched on purpose** — touching it is the "fix one, break the other" trap.

### Verification (live, after fix)

```
HUMAN  GET /dashboard                    -> 200   (then client gate -> /auth/login?next=%2Fdashboard)
       GET /auth/login?next=%2Fdashboard -> 200   (honours next; lands /dashboard after login)
DEV    GET /developer                    -> 302 -> /auth/login?next=/developer -> 200
```
- Both hero CTAs now: `/dashboard` and `/developer`.
- No stray `/signup?next` refs remain in `frontend/`.
- Logged-in paths code-traced (curl can't auth): `/dashboard` 200 → `dashboard.js` renders; `/developer` 200 (dev) → nginx serves.

**Frontend-only.** No relay/admin changes. For review — please do not merge until you've looked it over.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)