### PR TITLE
chore(seo): drop em-dashes from og:title / twitter:title site-wide

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -11,13 +11,13 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
-<meta property="og:title" content="Your account — Paramant">
+<meta property="og:title" content="Your account · Paramant">
 <meta property="og:description" content="Your account — Paramant">
 <meta property="og:url" content="https://paramant.app/account">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Your account — Paramant">
+<meta name="twitter:title" content="Your account · Paramant">
 <meta name="twitter:description" content="Your account — Paramant">
 <link rel="canonical" href="https://paramant.app/account">
 <style>

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Architecture — PARAMANT</title>
 <meta name="description" content="How Paramant works: browser-side encryption, RAM-only relay, burn-on-read, URL fragment key delivery. Shown, not told.">
-<meta property="og:title" content="Architecture — PARAMANT">
+<meta property="og:title" content="Architecture · PARAMANT">
 <meta property="og:description" content="How Paramant works: browser-side encryption, RAM-only relay, burn-on-read, URL fragment key delivery. Shown, not told.">
 <meta property="og:url" content="https://paramant.app/architecture">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Architecture — PARAMANT">
+<meta name="twitter:title" content="Architecture · PARAMANT">
 <meta name="twitter:description" content="How Paramant works: browser-side encryption, RAM-only relay, burn-on-read, URL fragment key delivery. Shown, not told.">
 <link rel="canonical" href="https://paramant.app/architecture">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT - GDPR audit log export with chain of custody</title>
 <meta name="description" content="Deliver GDPR Article 30 audit evidence to DPAs and auditors without creating new exposure. Burn-on-read delivery with ML-DSA-65 signed receipts for chain-of-custody.">
-<meta property="og:title" content="PARAMANT - GDPR audit log export, chain of custody">
+<meta property="og:title" content="PARAMANT · GDPR audit log export, chain of custody">
 <meta property="og:description" content="Send audit logs to investigators and auditors over ML-KEM-768 encrypted, burn-on-read channels. The signed receipt is your chain-of-custody record.">
 <meta property="og:url" content="https://paramant.app/audit-log-export">
 <meta property="og:type" content="website">

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -42,13 +42,13 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
 .tag{display:inline-block;font-size:9px;padding:3px 8px;border:1px solid var(--ink-hair);letter-spacing:.06em;margin:2px;color:var(--ink-dim)}
 @media(max-width:640px){.grid2,.grid3{grid-template-columns:1fr}}
 </style>
-<meta property="og:title" content="PARAMANT voor Banken & Finance — Post-Quantum Settlement">
+<meta property="og:title" content="PARAMANT voor Banken & Finance · Post-Quantum Settlement">
 <meta property="og:description" content="PARAMANT voor Banken & Finance — Post-Quantum Settlement">
 <meta property="og:url" content="https://paramant.app/banken">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT voor Banken & Finance — Post-Quantum Settlement">
+<meta name="twitter:title" content="PARAMANT voor Banken & Finance · Post-Quantum Settlement">
 <meta name="twitter:description" content="PARAMANT voor Banken & Finance — Post-Quantum Settlement">
 <link rel="canonical" href="https://paramant.app/banken">
 <style>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Changelog — Paramant</title>
 <meta name="description" content="Paramant release history — what changed, when, and why.">
-<meta property="og:title" content="Changelog — Paramant">
+<meta property="og:title" content="Changelog · Paramant">
 <meta property="og:description" content="Paramant release history — what changed, when, and why.">
 <meta property="og:url" content="https://paramant.app/changelog">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Changelog — Paramant">
+<meta name="twitter:title" content="Changelog · Paramant">
 <meta name="twitter:description" content="Paramant release history — what changed, when, and why.">
 <link rel="canonical" href="https://paramant.app/changelog">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/compliance/iec62443.html
+++ b/frontend/compliance/iec62443.html
@@ -5,13 +5,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT — IEC 62443 Compliance (Industrial IoT)</title>
 <meta name="description" content="How paramant supports IEC 62443 compliance for industrial control systems — quantum-safe communications, zone isolation, and data integrity for OT environments.">
-<meta property="og:title" content="PARAMANT — IEC 62443 Compliance (Industrial IoT)">
+<meta property="og:title" content="PARAMANT · IEC 62443 Compliance (Industrial IoT)">
 <meta property="og:description" content="How paramant supports IEC 62443 compliance for industrial control systems — quantum-safe communications, zone isolation, and data integrity for OT environments.">
 <meta property="og:url" content="https://paramant.app/compliance/iec62443">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT — IEC 62443 Compliance (Industrial IoT)">
+<meta name="twitter:title" content="PARAMANT · IEC 62443 Compliance (Industrial IoT)">
 <meta name="twitter:description" content="How paramant supports IEC 62443 compliance for industrial control systems — quantum-safe communications, zone isolation, and data integrity for OT environments.">
 <link rel="canonical" href="https://paramant.app/compliance/iec62443">
 <style>

--- a/frontend/compliance/nen7510.html
+++ b/frontend/compliance/nen7510.html
@@ -5,13 +5,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT — NEN 7510 Compliance (Healthcare Information Security)</title>
 <meta name="description" content="How paramant helps comply with NEN 7510 for confidentiality, availability and integrity of medical data. DICOM transport, burn-on-read, EU/DE jurisdiction.">
-<meta property="og:title" content="PARAMANT — NEN 7510 Compliance (Healthcare Information Security)">
+<meta property="og:title" content="PARAMANT · NEN 7510 Compliance (Healthcare Information Security)">
 <meta property="og:description" content="How paramant helps comply with NEN 7510 for confidentiality, availability and integrity of medical data. DICOM transport, burn-on-read, EU/DE jurisdiction.">
 <meta property="og:url" content="https://paramant.app/compliance/nen7510">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT — NEN 7510 Compliance (Healthcare Information Security)">
+<meta name="twitter:title" content="PARAMANT · NEN 7510 Compliance (Healthcare Information Security)">
 <meta name="twitter:description" content="How paramant helps comply with NEN 7510 for confidentiality, availability and integrity of medical data. DICOM transport, burn-on-read, EU/DE jurisdiction.">
 <link rel="canonical" href="https://paramant.app/compliance/nen7510">
 <style>

--- a/frontend/compliance/nis2.html
+++ b/frontend/compliance/nis2.html
@@ -5,13 +5,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT — NIS2 Compliance (EU 2022/2555)</title>
 <meta name="description" content="How paramant helps organizations comply with NIS2 Directive obligations on cybersecurity measures, incident reporting, and accountability.">
-<meta property="og:title" content="PARAMANT — NIS2 Compliance (EU 2022/2555)">
+<meta property="og:title" content="PARAMANT · NIS2 Compliance (EU 2022/2555)">
 <meta property="og:description" content="How paramant helps organizations comply with NIS2 Directive obligations on cybersecurity measures, incident reporting, and accountability.">
 <meta property="og:url" content="https://paramant.app/compliance/nis2">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT — NIS2 Compliance (EU 2022/2555)">
+<meta name="twitter:title" content="PARAMANT · NIS2 Compliance (EU 2022/2555)">
 <meta name="twitter:description" content="How paramant helps organizations comply with NIS2 Directive obligations on cybersecurity measures, incident reporting, and accountability.">
 <link rel="canonical" href="https://paramant.app/compliance/nis2">
 <style>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -11,7 +11,7 @@
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT — Crypto Agility">
+<meta name="twitter:title" content="PARAMANT · Crypto Agility">
 <meta name="twitter:description" content="Paramant's crypto agility: 3 KEMs and 18 signatures from NIST FIPS 203, 204, 205, 206 loaded in production. Clients pick, the relay validates, nothing is hardcoded.">
 <link rel="canonical" href="https://paramant.app/crypto-agility">
 <link rel="stylesheet" href="/design-system.css?v=19">

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -14,13 +14,13 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
-<meta property="og:title" content="PARAMANT — Certificate Transparency Log">
+<meta property="og:title" content="PARAMANT · Certificate Transparency Log">
 <meta property="og:description" content="PARAMANT — Certificate Transparency Log">
 <meta property="og:url" content="https://paramant.app/ct-log">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT — Certificate Transparency Log">
+<meta name="twitter:title" content="PARAMANT · Certificate Transparency Log">
 <meta name="twitter:description" content="PARAMANT — Certificate Transparency Log">
 <link rel="canonical" href="https://paramant.app/ct-log">
   <style>

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>DICOM via Paramant — NEN 7510 compliant file relay for healthcare</title>
 <meta name="description" content="Send DICOM files with post-quantum encryption. Burn-on-read relay, zero storage, Merkle audit trail. NEN 7510 · GDPR · EU only.">
-<meta property="og:title" content="DICOM via Paramant — NEN 7510 compliant file relay for healthcare">
+<meta property="og:title" content="DICOM via Paramant · NEN 7510 compliant file relay for healthcare">
 <meta property="og:description" content="Send DICOM files with post-quantum encryption. Burn-on-read relay, zero storage, Merkle audit trail. NEN 7510 · GDPR · EU only.">
 <meta property="og:url" content="https://paramant.app/dicom">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="DICOM via Paramant — NEN 7510 compliant file relay for healthcare">
+<meta name="twitter:title" content="DICOM via Paramant · NEN 7510 compliant file relay for healthcare">
 <meta name="twitter:description" content="Send DICOM files with post-quantum encryption. Burn-on-read relay, zero storage, Merkle audit trail. NEN 7510 · GDPR · EU only.">
 <link rel="canonical" href="https://paramant.app/dicom">
 

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT — Documentation</title>
 <meta name="description" content="API reference, SDK guide, self-hosting, and compliance docs for PARAMANT Ghost Pipe v2.">
-<meta property="og:title" content="PARAMANT — Documentation">
+<meta property="og:title" content="PARAMANT · Documentation">
 <meta property="og:description" content="API reference, SDK guide, self-hosting, and compliance docs for PARAMANT Ghost Pipe v2.">
 <meta property="og:url" content="https://paramant.app/docs">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT — Documentation">
+<meta name="twitter:title" content="PARAMANT · Documentation">
 <meta name="twitter:description" content="API reference, SDK guide, self-hosting, and compliance docs for PARAMANT Ghost Pipe v2.">
 <link rel="canonical" href="https://paramant.app/docs">
 

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Data Processing Agreement — PARAMANT</title>
 <meta name="description" content="PARAMANT GDPR Art. 28 Data Processing Agreement. Sign electronically. EU/DE jurisdiction.">
-<meta property="og:title" content="Data Processing Agreement — PARAMANT">
+<meta property="og:title" content="Data Processing Agreement · PARAMANT">
 <meta property="og:description" content="PARAMANT GDPR Art. 28 Data Processing Agreement. Sign electronically. EU/DE jurisdiction.">
 <meta property="og:url" content="https://paramant.app/dpa">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Data Processing Agreement — PARAMANT">
+<meta name="twitter:title" content="Data Processing Agreement · PARAMANT">
 <meta name="twitter:description" content="PARAMANT GDPR Art. 28 Data Processing Agreement. Sign electronically. EU/DE jurisdiction.">
 <link rel="canonical" href="https://paramant.app/dpa">
 <link rel="stylesheet" href="/design-system.css?v=19">

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT — Post-Quantum File Transfer for Government</title>
 <meta name="description" content="71% of Dutch government organisations have no post-quantum plan (Court of Audit, Feb 2026). NIS2 requires documented cryptographic controls by end of 2026. Paramant is open source, self-hostable, and deployable in days.">
-<meta property="og:title" content="PARAMANT — Post-Quantum File Transfer for Government">
+<meta property="og:title" content="PARAMANT · Post-Quantum File Transfer for Government">
 <meta property="og:description" content="71% of Dutch government organisations have no post-quantum plan (Court of Audit, Feb 2026). NIS2 requires documented cryptographic controls by end of 2026. Paramant is open source, self-hostable, and ">
 <meta property="og:url" content="https://paramant.app/government">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT — Post-Quantum File Transfer for Government">
+<meta name="twitter:title" content="PARAMANT · Post-Quantum File Transfer for Government">
 <meta name="twitter:description" content="71% of Dutch government organisations have no post-quantum plan (Court of Audit, Feb 2026). NIS2 requires documented cryptographic controls by end of 2026. Paramant is open source, self-hostable, and ">
 <link rel="canonical" href="https://paramant.app/government">
 <link rel="stylesheet" href="/design-system.css?v=19">

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT - Healthcare data delivery, NEN 7510</title>
 <meta name="description" content="NEN 7510-compliant patient data transfer with ML-KEM-768 encryption, burn-on-read delivery, and ML-DSA-65 signed receipts. EU/DE hosting, no US CLOUD Act.">
-<meta property="og:title" content="PARAMANT - Healthcare data delivery, NEN 7510 compliant">
+<meta property="og:title" content="PARAMANT · Healthcare data delivery, NEN 7510 compliant">
 <meta property="og:description" content="Deliver patient records, lab results, and imaging studies over ML-KEM-768 encrypted, burn-on-read channels with NEN 7510-compliant audit trails.">
 <meta property="og:url" content="https://paramant.app/healthcare">
 <meta property="og:type" content="website">

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT — Harvest Now, Decrypt Later</title>
 <meta name="description" content="Harvest Now, Decrypt Later: why encrypted data collected today can be decrypted by quantum computers tomorrow, and how RAM-only post-quantum transfer removes the target entirely.">
-<meta property="og:title" content="PARAMANT — Harvest Now, Decrypt Later">
+<meta property="og:title" content="PARAMANT · Harvest Now, Decrypt Later">
 <meta property="og:description" content="Harvest Now, Decrypt Later: why encrypted data collected today can be decrypted by quantum computers tomorrow, and how RAM-only post-quantum transfer removes the target entirely.">
 <meta property="og:url" content="https://paramant.app/hndl">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT — Harvest Now, Decrypt Later">
+<meta name="twitter:title" content="PARAMANT · Harvest Now, Decrypt Later">
 <meta name="twitter:description" content="Harvest Now, Decrypt Later: why encrypted data collected today can be decrypted by quantum computers tomorrow, and how RAM-only post-quantum transfer removes the target entirely.">
 <link rel="canonical" href="https://paramant.app/hndl">
 <link rel="stylesheet" href="/design-system.css?v=19">

--- a/frontend/iot.html
+++ b/frontend/iot.html
@@ -6,13 +6,13 @@
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <link rel="canonical" href="/ot">
 <title>PARAMANT IoT / OT &mdash; redirecting…</title>
-<meta property="og:title" content="PARAMANT IoT / OT &mdash; redirecting…">
+<meta property="og:title" content="PARAMANT IoT / OT · redirecting…">
 <meta property="og:description" content="PARAMANT IoT / OT &mdash; redirecting…">
 <meta property="og:url" content="https://paramant.app/iot">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT IoT / OT &mdash; redirecting…">
+<meta name="twitter:title" content="PARAMANT IoT / OT · redirecting…">
 <meta name="twitter:description" content="PARAMANT IoT / OT &mdash; redirecting…">
 
 <style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT - Legal discovery, attorney-client privileged delivery</title>
 <meta name="description" content="E-discovery document production over ML-KEM-768 encrypted, burn-on-read channels. ML-DSA-65 signed receipts for chain of custody. Zero-knowledge relay.">
-<meta property="og:title" content="PARAMANT - Legal discovery delivery, privilege intact">
+<meta property="og:title" content="PARAMANT · Legal discovery delivery, privilege intact">
 <meta property="og:description" content="Deliver discovery production sets to opposing counsel with cryptographic receipts. Zero-knowledge relay eliminates new custodian arguments. EU/DE hosting.">
 <meta property="og:url" content="https://paramant.app/legal-discovery">
 <meta property="og:type" content="website">

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>License — PARAMANT</title>
 <meta name="description" content="PARAMANT Ghost Pipe Protocol — Business Source License 1.1. Free for personal use, MIT on 2030-01-01.">
-<meta property="og:title" content="License — PARAMANT">
+<meta property="og:title" content="License · PARAMANT">
 <meta property="og:description" content="PARAMANT Ghost Pipe Protocol — Business Source License 1.1. Free for personal use, MIT on 2030-01-01.">
 <meta property="og:url" content="https://paramant.app/license">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="License — PARAMANT">
+<meta name="twitter:title" content="License · PARAMANT">
 <meta name="twitter:description" content="PARAMANT Ghost Pipe Protocol — Business Source License 1.1. Free for personal use, MIT on 2030-01-01.">
 <link rel="canonical" href="https://paramant.app/license">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT - M&A due diligence, EU-sovereign deal rooms</title>
 <meta name="description" content="EU-sovereign document delivery for mergers and acquisitions. No US CLOUD Act exposure. ML-KEM-768 encryption, burn-on-read, ML-DSA-65 signed receipts.">
-<meta property="og:title" content="PARAMANT - M&A due diligence, EU-sovereign">
+<meta property="og:title" content="PARAMANT · M&A due diligence, EU-sovereign">
 <meta property="og:description" content="Your deal room cannot be a US-hosted SaaS. Paramant delivers M&A documents with ML-KEM-768 encryption and EU/DE hosting — no CLOUD Act production orders.">
 <meta property="og:url" content="https://paramant.app/ma-due-diligence">
 <meta property="og:type" content="website">

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>PARAMANT for Industrial OT — IEC 62443 quantum-safe conduit</title>
 <meta name="description" content="Ghost Pipe as a quantum-safe data conduit for OT environments. PLC → Ghost Pipe → SCADA. No VPN, no network changes, no persistent connection. IEC 62443 aligned.">
-<meta property="og:title" content="PARAMANT for Industrial OT — IEC 62443 quantum-safe conduit">
+<meta property="og:title" content="PARAMANT for Industrial OT · IEC 62443 quantum-safe conduit">
 <meta property="og:description" content="Ghost Pipe as a quantum-safe data conduit for OT environments. PLC → Ghost Pipe → SCADA. No VPN, no network changes, no persistent connection. IEC 62443 aligned.">
 <meta property="og:url" content="https://paramant.app/ot">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT for Industrial OT — IEC 62443 quantum-safe conduit">
+<meta name="twitter:title" content="PARAMANT for Industrial OT · IEC 62443 quantum-safe conduit">
 <meta name="twitter:description" content="Ghost Pipe as a quantum-safe data conduit for OT environments. PLC → Ghost Pipe → SCADA. No VPN, no network changes, no persistent connection. IEC 62443 aligned.">
 <link rel="canonical" href="https://paramant.app/ot">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>In the wild — PARAMANT</title>
 <meta name="description" content="Organisations that have publicly stated they use Paramant in production. Observed deployments in compliance, sovereign infrastructure, and security engagements.">
-<meta property="og:title" content="In the wild — PARAMANT">
+<meta property="og:title" content="In the wild · PARAMANT">
 <meta property="og:description" content="Organisations that have publicly stated they use Paramant in production.">
 <meta property="og:url" content="https://paramant.app/partners">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="In the wild — PARAMANT">
+<meta name="twitter:title" content="In the wild · PARAMANT">
 <meta name="twitter:description" content="Organisations that have publicly stated they use Paramant in production.">
 <link rel="canonical" href="https://paramant.app/partners">
 

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Press Kit — PARAMANT</title>
 <meta name="description" content="PARAMANT press kit — post-quantum encrypted file relay. Blurbs, key facts, brand assets, and press contact.">
-<meta property="og:title" content="Press Kit — PARAMANT">
+<meta property="og:title" content="Press Kit · PARAMANT">
 <meta property="og:description" content="PARAMANT press kit — post-quantum encrypted file relay. Blurbs, key facts, brand assets, and press contact.">
 <meta property="og:url" content="https://paramant.app/press">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Press Kit — PARAMANT">
+<meta name="twitter:title" content="Press Kit · PARAMANT">
 <meta name="twitter:description" content="PARAMANT press kit — post-quantum encrypted file relay. Blurbs, key facts, brand assets, and press contact.">
 <link rel="canonical" href="https://paramant.app/press">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Pricing — PARAMANT</title>
 <meta name="description" content="PARAMANT pricing. Free forever: AES-256-GCM, 5 MB, RAM-only. Pro coming soon. Enterprise: dedicated relay, ML-KEM-768, 7-day TTL, SLA.">
-<meta property="og:title" content="Pricing — PARAMANT">
+<meta property="og:title" content="Pricing · PARAMANT">
 <meta property="og:description" content="PARAMANT pricing. Free forever: AES-256-GCM, 5 MB, RAM-only. Pro coming soon. Enterprise: dedicated relay, ML-KEM-768, 7-day TTL, SLA.">
 <meta property="og:url" content="https://paramant.app/pricing">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Pricing — PARAMANT">
+<meta name="twitter:title" content="Pricing · PARAMANT">
 <meta name="twitter:description" content="PARAMANT pricing. Free forever: AES-256-GCM, 5 MB, RAM-only. Pro coming soon. Enterprise: dedicated relay, ML-KEM-768, 7-day TTL, SLA.">
 <link rel="canonical" href="https://paramant.app/pricing">
 <link rel="stylesheet" href="/design-system.css?v=19">

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Privacy Policy — PARAMANT</title>
 <meta name="description" content="PARAMANT privacy policy. No personal data collected. RAM-only storage. GDPR/EU. No US CLOUD Act.">
-<meta property="og:title" content="Privacy Policy — PARAMANT">
+<meta property="og:title" content="Privacy Policy · PARAMANT">
 <meta property="og:description" content="PARAMANT privacy policy. No personal data collected. RAM-only storage. GDPR/EU. No US CLOUD Act.">
 <meta property="og:url" content="https://paramant.app/privacy">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Privacy Policy — PARAMANT">
+<meta name="twitter:title" content="Privacy Policy · PARAMANT">
 <meta name="twitter:description" content="PARAMANT privacy policy. No personal data collected. RAM-only storage. GDPR/EU. No US CLOUD Act.">
 <link rel="canonical" href="https://paramant.app/privacy">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Security — PARAMANT</title>
 <meta name="description" content="How PARAMANT approaches security: post-quantum crypto, independent audit, responsible disclosure, relay architecture.">
-<meta property="og:title" content="Security — PARAMANT">
+<meta property="og:title" content="Security · PARAMANT">
 <meta property="og:description" content="How PARAMANT approaches security: post-quantum crypto, independent audit, responsible disclosure, relay architecture.">
 <meta property="og:url" content="https://paramant.app/security">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Security — PARAMANT">
+<meta name="twitter:title" content="Security · PARAMANT">
 <meta name="twitter:description" content="How PARAMANT approaches security: post-quantum crypto, independent audit, responsible disclosure, relay architecture.">
 <link rel="canonical" href="https://paramant.app/security">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Create account — Paramant</title>
 <meta name="description" content="Create a Paramant account. No password. Authenticator app required.">
-<meta property="og:title" content="Create account — Paramant">
+<meta property="og:title" content="Create account · Paramant">
 <meta property="og:description" content="Create a Paramant account. No password. Authenticator app required.">
 <meta property="og:url" content="https://paramant.app/signup">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Create account — Paramant">
+<meta name="twitter:title" content="Create account · Paramant">
 <meta name="twitter:description" content="Create a Paramant account. No password. Authenticator app required.">
 <link rel="canonical" href="https://paramant.app/signup">
 <meta name="robots" content="index, follow">

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Service Level Agreement — PARAMANT</title>
 <meta name="description" content="PARAMANT SLA: uptime commitments, credits policy, and support tiers for community, professional, and enterprise plans.">
-<meta property="og:title" content="Service Level Agreement — PARAMANT">
+<meta property="og:title" content="Service Level Agreement · PARAMANT">
 <meta property="og:description" content="PARAMANT SLA: uptime commitments, credits policy, and support tiers for community, professional, and enterprise plans.">
 <meta property="og:url" content="https://paramant.app/sla">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Service Level Agreement — PARAMANT">
+<meta name="twitter:title" content="Service Level Agreement · PARAMANT">
 <meta name="twitter:description" content="PARAMANT SLA: uptime commitments, credits policy, and support tiers for community, professional, and enterprise plans.">
 <link rel="canonical" href="https://paramant.app/sla">
 

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT - SSH key delivery, post-quantum</title>
 <meta name="description" content="OpenSSH 10.0 encrypts your session with ML-KEM. Paramant encrypts the delivery of the key itself, with burn-on-read delivery and ML-DSA-65 signed receipts.">
-<meta property="og:title" content="PARAMANT - SSH key delivery, post-quantum">
+<meta property="og:title" content="PARAMANT · SSH key delivery, post-quantum">
 <meta property="og:description" content="Post-quantum SSH bootstrap: deliver authorized_keys and keypairs through ML-KEM-768 encrypted, burn-on-read channels with cryptographic receipts.">
 <meta property="og:url" content="https://paramant.app/ssh-key-delivery">
 <meta property="og:type" content="website">

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>System Status — PARAMANT</title>
 <meta name="description" content="Real-time status of all PARAMANT relay sectors.">
-<meta property="og:title" content="System Status — PARAMANT">
+<meta property="og:title" content="System Status · PARAMANT">
 <meta property="og:description" content="Real-time status of all PARAMANT relay sectors.">
 <meta property="og:url" content="https://paramant.app/status">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="System Status — PARAMANT">
+<meta name="twitter:title" content="System Status · PARAMANT">
 <meta name="twitter:description" content="Real-time status of all PARAMANT relay sectors.">
 <link rel="canonical" href="https://paramant.app/status">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -6,13 +6,13 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Trust &amp; Transparency — PARAMANT</title>
 <meta name="description" content="How Paramant works with your relay: how license-check is specified, what we can see, how to verify your deployment, and what we can and cannot do remotely. Open-core, customer-verifiable.">
-<meta property="og:title" content="Trust &amp; Transparency — PARAMANT">
+<meta property="og:title" content="Trust &amp; Transparency · PARAMANT">
 <meta property="og:description" content="How Paramant works with your relay: how license-check is specified, what we can see, how to verify your deployment, and what we can and cannot do remotely. Open-core, customer-verifiable.">
 <meta property="og:url" content="https://paramant.app/trust">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Trust &amp; Transparency — PARAMANT">
+<meta name="twitter:title" content="Trust &amp; Transparency · PARAMANT">
 <meta name="twitter:description" content="How Paramant works with your relay: how license-check is specified, what we can see, how to verify your deployment, and what we can and cannot do remotely. Open-core, customer-verifiable.">
 <link rel="canonical" href="https://paramant.app/trust">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT - Whistleblower channel, EU Directive 2019/1937</title>
 <meta name="description" content="EU Directive 2019/1937 compliant internal reporting channel. Burn-on-read delivery, zero-knowledge relay, no sender logging. Technical confidentiality as required by Recital 85.">
-<meta property="og:title" content="PARAMANT - Whistleblower channel, EU Directive 2019/1937">
+<meta property="og:title" content="PARAMANT · Whistleblower channel, EU Directive 2019/1937">
 <meta property="og:description" content="Run a technically confidential whistleblower channel compliant with EU Directive 2019/1937. Burn-on-read delivery. No sender identity logged. ML-KEM-768 encryption.">
 <meta property="og:url" content="https://paramant.app/whistleblower-channel">
 <meta property="og:type" content="website">


### PR DESCRIPTION
## Site-wide og:title / twitter:title dedash

Mechanical follow-up to **#171** (shareable-link previews). The dash audit there surfaced **32 more pages** (marketing/content) still carrying an em-dash / hyphen separator in their preview title, e.g. `License — PARAMANT`, `PARAMANT — Documentation`, `Pricing — PARAMANT`. Em-dashes read as an AI-tell and are house-style to avoid.

This replaces the separator with `·` in **og:title and twitter:title only**:

```
License — PARAMANT            ->  License · PARAMANT
PARAMANT — Documentation      ->  PARAMANT · Documentation
PARAMANT IoT / OT &mdash; …   ->  PARAMANT IoT / OT · …
PARAMANT - M&A due diligence  ->  PARAMANT · M&A due diligence
```

### Scope / safety
- **32 files**, 57 lines, pure 1:1 separator swaps (57+/57-).
- Touches **only** `og:title` / `twitter:title` meta lines — verified no `<title>`, no descriptions, no other content changed.
- **No casing changes**: kept each page's existing `PARAMANT` / `Paramant` casing.
- `&amp;` (Trust &amp; Transparency), `/` (IoT / OT), `&` (M&A) all preserved — only dashes touched.
- **Disjoint** from the 9 pages in #171 (co-sign, sign, verify, parashare, ontvang, get, download, index, auth/login), so #171 and this merge independently in any order.

Pages: account, architecture, audit-log-export, banken, changelog, compliance/{iec62443,nen7510,nis2}, crypto-agility, ct-log, dicom, docs, dpa, government, healthcare, hndl, iot, legal-discovery, license, ma-due-diligence, ot, partners, press, pricing, privacy, security, signup, sla, ssh-key-delivery, status, trust, whistleblower-channel.

**For review — not merged, not deployed.** Frontend-only.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)