### PR TITLE
feat(admin): account-split stap 3 — primary_api_key in the session

### DIFF
--- a/admin/lib/account-keys.js
+++ b/admin/lib/account-keys.js
@@ -1,0 +1,46 @@
+'use strict';
+// Account-split, admin side (stap 3). One place decides which api-key the admin
+// plane uses on a logged-in user's behalf, so the SESSION — not the raw user_id
+// — is the source of truth for relay auth (X-Api-Key) and the /account/key
+// reveal.
+//
+// Backward-compatible by construction (mirrors relay/lib/keys-table.js
+// parseAccountFields): today a session's user_id IS the account's primary,
+// re-revealable api-key (the 1:1 seed account_id == key), so every function here
+// is behaviour-neutral right now. The point is the plumbing: once stap 5 mints
+// sessions whose identity (account_id, eventually acct_…) differs from a usable
+// api-key, these call sites already read primary_api_key and keep working,
+// untouched.
+//
+// Distinction this module enforces:
+//   • X-Api-Key (a relay AUTH credential)  -> must be a real api-key  -> proxyApiKey()
+//   • user_id in a request BODY (an account IDENTIFIER, e.g. signing-key enrol)
+//     stays user_id and is NOT routed through here.
+
+// Fields a freshly-minted session carries. `key` is the api-key the user just
+// authenticated with — its account's primary today. legacy_revealable mirrors
+// the seeded-primary default (a seeded primary stays revealable until the user
+// rotates it); stap 5 will pass the real per-key flag here.
+function sessionKeyFields(key) {
+  return { primary_api_key: key, legacy_revealable: true };
+}
+
+// The api-key the admin plane presents to a relay on this session's behalf
+// (X-Api-Key). primary_api_key when the session carries it (stap 3+), else the
+// legacy user_id so sessions minted before stap 3 keep authenticating.
+function proxyApiKey(session) {
+  if (!session) return null;
+  return session.primary_api_key || session.user_id || null;
+}
+
+// The GET /account/key reveal decision. The raw key is returned ONLY when the
+// account is legacy_revealable; a non-revealable key (a future acct_/non-primary
+// key) yields no secret. A session without the field (minted before stap 3) is
+// treated as revealable, so existing sessions still see their key.
+function revealKey(session) {
+  const revealable = !!session && session.legacy_revealable !== false;
+  if (!revealable) return { api_key: null, revealable: false };
+  return { api_key: proxyApiKey(session), revealable: true };
+}
+
+module.exports = { sessionKeyFields, proxyApiKey, revealKey };

--- a/admin/server.js
+++ b/admin/server.js
@@ -1469,7 +1469,7 @@ api.post("/user/envelopes", authUser, async (req, res) => {
   try {
     const rr = await fetch(`${SECTORS.health}/v2/envelopes`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", "X-Api-Key": user_id },
+      headers: { "Content-Type": "application/json", "X-Api-Key": proxyApiKey(req.userSession) },
       body: JSON.stringify({ doc_hash: docHash, parties, original_filename: originalFilename, binding_mode: "email", recipe_version: 3, creator_public_key: creatorPublicKey }),
     });
     const body = await rr.json().catch(() => ({}));

--- a/admin/server.js
+++ b/admin/server.js
@@ -13,6 +13,7 @@ const cliAudit = require('./lib/cli-audit');
 const cliRate = require('./lib/cli-ratelimit');
 const configStore = require('./lib/config-store');
 const webauthn = require('./lib/webauthn');
+const { sessionKeyFields, proxyApiKey, revealKey } = require('./lib/account-keys');
 const { generateAuthenticationOptions, verifyAuthenticationResponse, generateRegistrationOptions, verifyRegistrationResponse } = require('@simplewebauthn/server');
 
 const PORT        = parseInt(process.env.PORT || '4200', 10);
@@ -898,7 +899,7 @@ api.post("/user/setup/:token/confirm", async (req, res) => {
   const sessionToken = crypto.randomBytes(32).toString("hex");
   await redis().set(
     `paramant:user:session:${sessionToken}`,
-    JSON.stringify({ user_id, email, created_at: Date.now(), ip: req.headers["x-real-ip"] || "unknown", ua: req.get("user-agent") || "" }),
+    JSON.stringify({ user_id, email, created_at: Date.now(), ip: req.headers["x-real-ip"] || "unknown", ua: req.get("user-agent") || "", ...sessionKeyFields(user_id) }),
     { EX: 3600 }
   );
 
@@ -959,7 +960,7 @@ api.post("/user/login", async (req, res) => {
   const sessionToken = crypto.randomBytes(32).toString("hex");
   await redis().set(
     `paramant:user:session:${sessionToken}`,
-    JSON.stringify({ user_id: user.key, email: user.email, created_at: Date.now(), ip, ua: req.get("user-agent") || "" }),
+    JSON.stringify({ user_id: user.key, email: user.email, created_at: Date.now(), ip, ua: req.get("user-agent") || "", ...sessionKeyFields(user.key) }),
     { EX: 3600 }
   );
 
@@ -990,7 +991,7 @@ api.post("/user/login-with-backup", async (req, res) => {
   const sessionToken = crypto.randomBytes(32).toString("hex");
   await redis().set(
     `paramant:user:session:${sessionToken}`,
-    JSON.stringify({ user_id: user.key, email: user.email, created_at: Date.now(), ip: req.headers["x-real-ip"] || "unknown", ua: req.get("user-agent") || "", via: "backup_code" }),
+    JSON.stringify({ user_id: user.key, email: user.email, created_at: Date.now(), ip: req.headers["x-real-ip"] || "unknown", ua: req.get("user-agent") || "", via: "backup_code", ...sessionKeyFields(user.key) }),
     { EX: 3600 }
   );
 
@@ -1170,7 +1171,7 @@ api.post("/user/auth/webauthn/login/verify", async (req, res) => {
   const sessionToken = crypto.randomBytes(32).toString("hex");
   await redis().set(
     `paramant:user:session:${sessionToken}`,
-    JSON.stringify({ user_id: authedUserId, email: authedEmail, created_at: Date.now(), ip, ua: req.get("user-agent") || "", via: flow.discoverable ? "webauthn_xdev" : "webauthn" }),
+    JSON.stringify({ user_id: authedUserId, email: authedEmail, created_at: Date.now(), ip, ua: req.get("user-agent") || "", via: flow.discoverable ? "webauthn_xdev" : "webauthn", ...sessionKeyFields(authedUserId) }),
     { EX: 3600 }
   );
   setUserCookie(res, sessionToken);
@@ -1337,7 +1338,7 @@ api.post("/user/auth/webauthn/register/verify", async (req, res) => {
   const sessionToken = crypto.randomBytes(32).toString("hex");
   await redis().set(
     `paramant:user:session:${sessionToken}`,
-    JSON.stringify({ user_id: flow.user_id, email: flow.email, created_at: Date.now(), ip, ua: req.get("user-agent") || "", via: "webauthn-register" }),
+    JSON.stringify({ user_id: flow.user_id, email: flow.email, created_at: Date.now(), ip, ua: req.get("user-agent") || "", via: "webauthn-register", ...sessionKeyFields(flow.user_id) }),
     { EX: 3600 }
   );
   setUserCookie(res, sessionToken);
@@ -1853,7 +1854,10 @@ function maskIp(ip) {
 
 // GET /api/user/account/key
 api.get("/user/account/key", authUser, async (req, res) => {
-  res.json({ api_key: req.userSession.user_id });
+  // stap 3: reveal the account's PRIMARY api-key (== user_id today), and only
+  // when the account is legacy_revealable. The `revealable` field is additive;
+  // existing callers read `.api_key`, unchanged while every account is 1:1.
+  res.json(revealKey(req.userSession));
 });
 
 // GET /api/user/dashboard/overview — read-only Operations data for the normal
@@ -2033,7 +2037,7 @@ api.all("/relay/:sector/*path", authUser, async (req, res) => {
   const fetchOpts = {
     method: req.method,
     headers: {
-      "X-Api-Key": req.userSession.user_id,
+      "X-Api-Key": proxyApiKey(req.userSession),
       "Content-Type": "application/json",
     },
   };

--- a/admin/test/keys-session.test.js
+++ b/admin/test/keys-session.test.js
@@ -1,0 +1,79 @@
+'use strict';
+// Account-split stap 3 (admin side): the session carries the account's primary
+// api-key, and admin-side relay auth + the /account/key reveal read it instead
+// of the raw user_id. Pure-logic unit test for admin/lib/account-keys.js.
+// Run: node admin/test/keys-session.test.js (no deps, non-zero exit on fail).
+
+const assert = require('assert');
+const { sessionKeyFields, proxyApiKey, revealKey } = require('../lib/account-keys');
+
+let passed = 0;
+const ok = (n) => { passed++; console.log('  ok -', n); };
+
+// ── 1. login → the minted session carries primary_api_key ──────────────────────
+// Every session-write site embeds sessionKeyFields(<authenticating key>). Today
+// that key IS the account's primary, revealable api-key (1:1 seed), so the
+// fields are behaviour-neutral.
+assert.deepStrictEqual(
+  sessionKeyFields('pgp_alice'),
+  { primary_api_key: 'pgp_alice', legacy_revealable: true },
+  'session carries primary_api_key + legacy_revealable');
+ok('login: session carries primary_api_key (== user_id today)');
+
+// A realistic minted session: user_id + the stap-3 fields spread in, exactly as
+// the JSON.stringify call sites build it.
+const freshSession = { user_id: 'pgp_alice', email: 'a@b.com', ...sessionKeyFields('pgp_alice') };
+assert.strictEqual(freshSession.primary_api_key, 'pgp_alice', 'primary mirrors user_id at mint');
+assert.strictEqual(freshSession.legacy_revealable, true, 'fresh session is revealable');
+ok('login: minted session shape is correct');
+
+// ── 2. GET /account/key returns the primary key, honouring legacy_revealable ────
+assert.deepStrictEqual(
+  revealKey(freshSession),
+  { api_key: 'pgp_alice', revealable: true },
+  'revealable session reveals the primary key');
+ok('/account/key: reveals primary key for a revealable account');
+
+// A session minted BEFORE stap 3 has no primary_api_key/legacy_revealable: must
+// still reveal, falling back to user_id (no forced re-login).
+assert.deepStrictEqual(
+  revealKey({ user_id: 'pgp_legacy', email: 'l@b.com' }),
+  { api_key: 'pgp_legacy', revealable: true },
+  'pre-stap3 session falls back to user_id and stays revealable');
+ok('/account/key: legacy session falls back to user_id');
+
+// A non-revealable account (future acct_/non-primary key) yields no secret.
+assert.deepStrictEqual(
+  revealKey({ user_id: 'acct_bob', primary_api_key: 'pgp_bob', legacy_revealable: false }),
+  { api_key: null, revealable: false },
+  'non-revealable account returns no raw key');
+ok('/account/key: non-revealable account is refused (no secret leak)');
+
+// Null/garbage session never throws and never leaks.
+assert.deepStrictEqual(revealKey(null), { api_key: null, revealable: false }, 'null session => no key');
+assert.deepStrictEqual(revealKey(undefined), { api_key: null, revealable: false }, 'undefined session => no key');
+ok('/account/key: null/undefined session is safe');
+
+// ── 3. sector-proxy authenticates with the session's api-key (X-Api-Key) ────────
+assert.strictEqual(proxyApiKey(freshSession), 'pgp_alice', 'proxy uses primary_api_key');
+assert.strictEqual(
+  proxyApiKey({ user_id: 'pgp_legacy' }), 'pgp_legacy',
+  'pre-stap3 session falls back to user_id so the proxy keeps authenticating');
+assert.strictEqual(proxyApiKey(null), null, 'null session => null (caller/relay rejects)');
+assert.strictEqual(proxyApiKey({}), null, 'empty session => null');
+ok('sector-proxy: X-Api-Key = primary_api_key || user_id');
+
+// ── 4. the WHOLE point — stap 5 divergence: identity != usable api-key ──────────
+// Once a session's user_id becomes an account id (acct_…) that the relay will
+// NOT accept as an api-key, the proxy and the reveal must use primary_api_key.
+// These assertions prove the call sites are already correct for that future.
+const stap5Session = { user_id: 'acct_carol', primary_api_key: 'pgp_carol_real', legacy_revealable: true };
+assert.strictEqual(proxyApiKey(stap5Session), 'pgp_carol_real',
+  'proxy sends the real api-key, NOT the acct_ identity');
+assert.notStrictEqual(proxyApiKey(stap5Session), stap5Session.user_id,
+  'proxy must not send acct_ as X-Api-Key');
+assert.deepStrictEqual(revealKey(stap5Session), { api_key: 'pgp_carol_real', revealable: true },
+  'reveal returns the real api-key, not the acct_ identity');
+ok('stap5-ready: identity (acct_) and api-key diverge cleanly');
+
+console.log(`\nkeys-session: ${passed} groups passed`);


### PR DESCRIPTION
## Stap 3 of the account_id ≠ api_key split (admin-only)

Threads the account's **primary api-key through the session** so the admin plane stops using the raw `user_id` as a relay credential / reveal value. Depends only on stap 1's additive schema; **does not touch the relay** (that's stap 4).

**Behaviour-neutral today.** Every account is still the 1:1 seed (`account_id == key`, `is_primary`, `legacy_revealable` — see `relay/lib/keys-table.js parseAccountFields`), so `primary_api_key == user_id` everywhere and the reveal stays revealable. The value is the plumbing: when stap 5 makes the session identity (`account_id`, eventually `acct_…`) diverge from a usable api-key, these call sites already read `primary_api_key` and keep working untouched.

### Changes
- **`admin/lib/account-keys.js`** (new, pure, unit-tested): `sessionKeyFields` / `proxyApiKey` / `revealKey`, each with a **`|| user_id` fallback** so sessions minted before stap 3 keep working — **no forced logout**.
- **All 5 session-mint sites** embed `primary_api_key` + `legacy_revealable`: setup-confirm, login (TOTP), backup-code, webauthn login, webauthn register. *(The plan listed 4; there are 5 mint sites in current `main` — all covered.)*
- **`GET /account/key`** → returns `primary_api_key || user_id`, honouring `legacy_revealable`. Additive `revealable` field; existing callers read `.api_key` and are unchanged while every account is 1:1.
- **Sector proxy** (`/relay/:sector/*`) → `X-Api-Key = primary_api_key || user_id`.

### Distinction kept (the core of the whole refactor)
- **X-Api-Key** (a relay AUTH credential) → must be a real api-key → routed through `proxyApiKey()`.
- **`user_id` as an account IDENTIFIER in a request body** (signing-key enrol, regenerate-backup, …) → left untouched; it identifies *which account*, and in stap 5 that identity IS `user_id`.

### ⚠️ One change beyond the literal site list — review it explicitly (commit `36dcfc7`, separate so you can drop it)
`POST /user/envelopes` proxies to the relay with `X-Api-Key = user_id` — the **same** session→relay auth pattern as the sector proxy, just not in the original stap-3 list. I converted it too: leaving it on raw `user_id` would be a **stap-5 landmine** (envelope creation breaks the moment `account_id` diverges). Behaviour-neutral today. If you'd rather keep stap 3 to the literal two sites, revert `36dcfc7`.

### Tests / verification
- `admin/test/keys-session.test.js` (new): the three plan assertions (session carries `primary_api_key`; `/account/key` returns it & honours `legacy_revealable`; sector-proxy authenticates) **+ a stap-5 divergence case** (`acct_` identity vs real api-key) + null-safety.
- Full admin unit suite, CI-equivalent `node --test test/*.test.js`: **11/11 pass, 0 fail**.
- `node --check admin/server.js`: clean. Relay/crypto CI jobs untouched (admin-only change).

### Security notes
- No new secret exposure: the session already held `user_id` (== the api-key today); `primary_api_key` is the same value, stored server-side in Redis, never sent to the client.
- `/account/key` for a non-revealable account now returns **no** raw key (`api_key: null`) — strictly more conservative than before.
- Login/enumeration/TOCTOU decision logic is unchanged; only what a session carries *after* successful auth changed.

---
**Do not merge / do not deploy** — delivered for review. Per the plan I stop here and wait for your go before building stap 4 (self-service endpoints, which DO touch the relay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
