### PR TITLE
fix: CACHE-01 — HTML always-revalidate + consistent ?v= busting (C1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,14 @@ jobs:
           | xargs -0 -n1 bash -n
           echo "All shell scripts parse OK."
 
+  frontend-cache-bust:
+    name: frontend — cache-bust guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: All local css/js links must carry a single ?v= cache-bust
+        run: scripts/check-cache-bust.sh
+
   relay-crypto-tests:
     name: relay - crypto suite (@paramant/core)
     runs-on: ubuntu-latest

--- a/deploy/nginx-paramant-live.conf
+++ b/deploy/nginx-paramant-live.conf
@@ -5,15 +5,17 @@ server {
     access_log off;
     set_real_ip_from 127.0.0.1;
     real_ip_header CF-Connecting-IP;
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "no-referrer" always;
-    # camera=(self) required for QR scanner on /drop
-    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(self)" always;
-    # CSP: removed paramant-ghost-pipe.fly.dev (deprecated), ipapi.co,
-    # esm.sh and cdnjs.cloudflare.com (libs now vendored locally).
-    add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://relay.paramant.app wss://relay.paramant.app https://health.paramant.app wss://health.paramant.app https://legal.paramant.app wss://legal.paramant.app https://finance.paramant.app wss://finance.paramant.app https://iot.paramant.app wss://iot.paramant.app; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:" always;
+    # Security headers — single source of truth (deploy/nginx/snippets/). Also
+    # re-included in any location that sets its own add_header (the static-asset
+    # block below), because nginx add_header does not inherit once a location
+    # defines its own — so CSP/HSTS can never be silently dropped from a response.
+    include snippets/paramant-security-headers.conf;
+    # HTML and every other non-asset response: cacheable but ALWAYS revalidated
+    # (a cheap 304 via ETag), so a new deploy's HTML — nav links, hero CTAs — is
+    # visible immediately instead of being served stale from the browser's
+    # heuristic cache (root cause of the "ParaRules vanished" / dashboard-button
+    # confusion). The versioned static-asset block overrides this with immutable.
+    add_header Cache-Control "no-cache" always;
 
     location = /admin/ {
         alias /home/paramant/app/admin.html;
@@ -153,11 +155,15 @@ server {
     location = /compliance/nen7510 { try_files /compliance/nen7510.html =404; }
 location = /users.json { deny all; return 404; }    location ~ /.env { deny all; return 404; }    location ~ /.git { deny all; return 404; }
 
-    # Long-lived cache for versioned static assets
+    # Long-lived cache for VERSIONED static assets (links carry ?v=N — enforced by
+    # scripts/check-cache-bust.sh). immutable = the browser never revalidates;
+    # safe ONLY because a content change ships under a new ?v= URL. Re-includes the
+    # security headers (this location sets its own add_header, which would
+    # otherwise drop the server-level set). Single Cache-Control now: the old
+    # `expires 1y` emitted a second, redundant Cache-Control header.
     location ~* \.(css|js|woff2|woff|ttf|otf|svg|png|jpg|jpeg|gif|webp|ico)$ {
-        expires 1y;
-        add_header Cache-Control "public, max-age=31536000, immutable";
-        add_header X-Content-Type-Options nosniff;
+        include snippets/paramant-security-headers.conf;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
         access_log off;
         try_files $uri =404;
     }

--- a/deploy/nginx/snippets/paramant-security-headers.conf
+++ b/deploy/nginx/snippets/paramant-security-headers.conf
@@ -1,0 +1,19 @@
+# Shared security headers for the paramant.app main vhost (127.0.0.1:8080).
+# Deploys to /etc/nginx/snippets/paramant-security-headers.conf and is pulled in
+# with `include snippets/paramant-security-headers.conf;`.
+#
+# Included BOTH at server level AND inside every location that sets its own
+# add_header (the static-asset block sets Cache-Control). nginx add_header does
+# NOT inherit into a location that defines any add_header of its own, so without
+# re-including these that location's responses lose every header below. That is
+# exactly how /*.css and /*.js were served WITHOUT CSP / X-Frame-Options /
+# Referrer-Policy / Permissions-Policy before this snippet existed (HSTS still
+# appeared because the Caddy edge adds it independently).
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "no-referrer" always;
+# camera=(self) required for the QR scanner
+add_header Permissions-Policy "geolocation=(), microphone=(), camera=(self)" always;
+# CSP: libs are vendored locally (no esm.sh / cdnjs); ghost-pipe.fly.dev & ipapi.co removed.
+add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://relay.paramant.app wss://relay.paramant.app https://health.paramant.app wss://health.paramant.app https://legal.paramant.app wss://legal.paramant.app https://finance.paramant.app wss://finance.paramant.app https://iot.paramant.app wss://iot.paramant.app; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:" always;

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -25,7 +25,7 @@
 <style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
-<link rel="stylesheet" href="/parapear.css">
+<link rel="stylesheet" href="/parapear.css?v=1">
 <style>
   main .wrap .parapear-block { max-width: 560px; margin: 0 auto 28px; text-align: left; }
 </style>
@@ -265,6 +265,6 @@
     </div>
   </div>
 </footer>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -447,7 +447,7 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
 </main>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 <script>
 (function() {
   function show(id) {
@@ -756,7 +756,7 @@ loadEnrolledKeys();
 loadVaultStatus();
 document.addEventListener('signing-key-enrolled', () => { loadEnrolledKeys(); loadVaultStatus(); });
 </script>
-<script type="module" src="/js/passkey.js"></script>
+<script type="module" src="/js/passkey.js?v=3"></script>
 <script type="module" src="/js/signing-enrol.js?v=4"></script>
 
 </body>

--- a/frontend/all-systems-go.html
+++ b/frontend/all-systems-go.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Paramant - All systems</title>
-  <link rel="stylesheet" href="/design-system.css">
-  <link rel="stylesheet" href="/nav.css">
+  <link rel="stylesheet" href="/design-system.css?v=19">
+  <link rel="stylesheet" href="/nav.css?v=13">
   <style>
     .asg { max-width: 560px; margin: 64px auto; padding: 0 24px; }
     .asg-hero { text-align: center; margin-bottom: 40px; }

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -854,6 +854,6 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -354,6 +354,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -206,7 +206,7 @@
 </main>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 <script>
 (function() {
   const form = document.getElementById('backup-form');

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -234,7 +234,7 @@
 </main>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 <script>
 (function() {
   const form = document.getElementById('login-form');

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -184,9 +184,9 @@
 </section>
 </main>
 
-<script src="/js/pow-captcha.js"></script>
+<script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 <script>
 (function() {
   const form = document.getElementById('reset-form');

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -208,7 +208,7 @@
 </main>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 <script>
 (function() {
   const token = window.location.pathname.split('/').pop();

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -10,7 +10,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
-<script src="/js/qrcode.min.js"></script>
+<script src="/js/qrcode.min.js?v=1"></script>
 </head>
 <body>
 
@@ -358,7 +358,7 @@
 </main>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 <script>
 (function() {
   const token = window.location.pathname.split('/').pop();
@@ -495,7 +495,7 @@
   });
 })();
 </script>
-<script type="module" src="/js/passkey.js"></script>
+<script type="module" src="/js/passkey.js?v=3"></script>
 
 </body>
 </html>

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -438,5 +438,5 @@ async function demoKeygen(){
 }
 </script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body></html>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -394,6 +394,6 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -180,7 +180,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 
 </main>
 
-<script type="module" src="/vendor/pdfjs/pdfjs-loader.js"></script>
+<script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=1"></script>
 <script type="module" src="/co-sign.js?v=4"></script>
 </body>
 </html>

--- a/frontend/compliance/iec62443.html
+++ b/frontend/compliance/iec62443.html
@@ -656,6 +656,6 @@ Level 1  Field devices     ─────────────────�
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/compliance/nen7510.html
+++ b/frontend/compliance/nen7510.html
@@ -535,6 +535,6 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/compliance/nis2.html
+++ b/frontend/compliance/nis2.html
@@ -535,6 +535,6 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -672,6 +672,6 @@ FLAGS    1 byte    reserved for future features</pre>
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -782,6 +782,6 @@ setInterval(load, 30000);
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -8,9 +8,9 @@
 <meta name="theme-color" content="#0B1622">
 <link rel="icon" type="image/svg+xml" href="/assets/paramant-icon.svg">
 <link rel="preconnect" href="https://relay.paramant.app">
-<link rel="stylesheet" href="/design-system.css">
-<link rel="stylesheet" href="/nav.css">
-<link rel="stylesheet" href="/parapear.css">
+<link rel="stylesheet" href="/design-system.css?v=19">
+<link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/parapear.css?v=1">
 <noscript><meta http-equiv="refresh" content="0;url=/auth/login?next=/dashboard"></noscript>
 <style>
 /* Dashboard. Client-side rendered from /api/user/me JSON. Auth-gate stays
@@ -479,8 +479,8 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
   </div>
 </footer>
 
-<script src="/nav.js" defer></script>
-<script src="/js/nav-auth.js" defer></script>
-<script src="/js/dashboard.js" defer></script>
+<script src="/nav.js?v=12" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/dashboard.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -633,6 +633,6 @@ paramant-receiver.py \
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -1021,7 +1021,7 @@ window.addEventListener('scroll', () => {
 }, { passive: true });
 </script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 <footer>
   <div class="container-lg">
     <div class="footer-grid">

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -536,6 +536,6 @@ input:focus{border-color:var(--cobalt)}
 }());
 </script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -508,10 +508,10 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
-<script type="module" src="/vendor/pdfjs/pdfjs-loader.js"></script>
-<script type="module" src="/vendor/parasign-bridge.js"></script>
-<script src="/vendor/pdf-lib/pdf-lib.min.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
+<script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=1"></script>
+<script type="module" src="/vendor/parasign-bridge.js?v=1"></script>
+<script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script>
 const RELAY = 'https://health.paramant.app';
 

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -643,6 +643,6 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -357,6 +357,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -446,6 +446,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -380,6 +380,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -481,6 +481,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -453,6 +453,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -487,6 +487,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -31,7 +31,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
-<link rel="stylesheet" href="/parapear.css">
+<link rel="stylesheet" href="/parapear.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;
@@ -406,6 +406,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -468,6 +468,6 @@ print(resp.json()["url"])</div>
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -439,6 +439,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -475,6 +475,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -441,6 +441,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -543,6 +543,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,7 +23,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
-<link rel="stylesheet" href="/parapear.css">
+<link rel="stylesheet" href="/parapear.css?v=1">
 <link rel="stylesheet" href="/components-parasign.css?v=3">
 <style>
 /* Homepage — compact 50/50 launchpad. Existing design tokens + classes only;
@@ -446,6 +446,6 @@
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -344,6 +344,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -392,6 +392,6 @@ Website: https://paramant.app</div>
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -345,6 +345,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -781,6 +781,6 @@ window.addEventListener('mlkem-ready', () => {
 });
 </script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/ot-vs-data-diodes.html
+++ b/frontend/ot-vs-data-diodes.html
@@ -575,7 +575,7 @@
 </section>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 
 <footer>
   <div class="container-lg">

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -550,6 +550,6 @@ Level 1  Field devices  ──────────────────�
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/pararules.html
+++ b/frontend/pararules.html
@@ -390,6 +390,6 @@ footer a{color:var(--ink);text-decoration:none}
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -13,7 +13,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
-<link rel="stylesheet" href="/parapear.css">
+<link rel="stylesheet" href="/parapear.css?v=1">
 <style>
 /* Page: parashare — transfer UI */
 
@@ -660,7 +660,7 @@ select:focus{border-color:var(--cobalt)}
   </div>
 </div>
 
-<script src="./vendor/qrcode.min.js"></script>
+<script src="./vendor/qrcode.min.js?v=1"></script>
 <script type="module">
 import { initCrypto, encryptBlob as _eb } from './crypto-bridge.js?v=4';
 window._cryptoBridge = { encryptBlob: _eb };
@@ -1486,7 +1486,7 @@ function updateGlobeTransfer(userLat, userLng) {
 }
 </script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 <footer style="border-top:1px solid var(--ink-hair);padding:var(--space-12) var(--space-8);position:relative;z-index:10">
   <div class="footer-grid">
     <div>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -326,6 +326,6 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -447,6 +447,6 @@ td{color:var(--cobalt)}
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -500,7 +500,7 @@
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 <script>
 (function() {
   async function initUpgrade() {

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -412,6 +412,6 @@ footer a{color:var(--ink);text-decoration:none}
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/quantum-urgency.html
+++ b/frontend/quantum-urgency.html
@@ -446,7 +446,7 @@
 </section>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 
 <footer>
   <div class="container-lg">

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -323,6 +323,6 @@
 
 <script src="/nav.js?v=12"></script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -577,6 +577,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -262,6 +262,6 @@
   </div>
 </footer>
 
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Paramant - First-time setup</title>
-  <link rel="stylesheet" href="/design-system.css">
-  <link rel="stylesheet" href="/nav.css">
+  <link rel="stylesheet" href="/design-system.css?v=19">
+  <link rel="stylesheet" href="/nav.css?v=13">
 </head>
 <body>
   <main class="setup-wizard" style="max-width:640px;margin:48px auto;padding:0 20px">
@@ -105,6 +105,6 @@
     </div>
   </main>
 
-  <script src="/setup.js"></script>
+  <script src="/setup.js?v=1"></script>
 </body>
 </html>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -22,7 +22,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
-<link rel="stylesheet" href="/components-parasign.css?v=2">
+<link rel="stylesheet" href="/components-parasign.css?v=3">
 <style>
 .ds-wrap{max-width:880px;margin:48px auto;padding:0 24px}
 .ds-head{margin-bottom:28px}
@@ -616,9 +616,9 @@
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
-<script type="module" src="/vendor/pdfjs/pdfjs-loader.js"></script>
-<script src="/vendor/pdf-lib/pdf-lib.min.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
+<script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=1"></script>
+<script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script type="module" src="/sign-flow.js?v=15"></script>
 </body>
 </html>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -402,9 +402,9 @@
 
 </main>
 
-<script src="/js/pow-captcha.js"></script>
+<script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 <script>
 (function() {
   const form = document.getElementById('signup-form');

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/design-system.css?v=19">
   <link rel="stylesheet" href="/nav.css?v=13">
   <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
   <style>
     body { background: #F8FAFC; }
     .vwrap { max-width: 620px; margin: 48px auto; padding: 0 20px; }

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -474,6 +474,6 @@ a:hover{opacity:.8}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -550,7 +550,7 @@
 </section>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 
 <footer>
   <div class="container-lg">

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -458,6 +458,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -517,6 +517,6 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
 }());
 </script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -530,6 +530,6 @@ docker compose build   # build locally instead of pulling the published image</c
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -22,7 +22,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
-<link rel="stylesheet" href="/components-parasign.css?v=2">
+<link rel="stylesheet" href="/components-parasign.css?v=3">
 </head>
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -289,7 +289,7 @@
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 <script type="module" src="/parasign-verify.js?v=2"></script>
 </body>
 </html>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -552,7 +552,7 @@
 </section>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 
 <footer>
   <div class="container-lg">

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -361,6 +361,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js" defer></script>
+<script src="/js/nav-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/scripts/check-cache-bust.sh
+++ b/scripts/check-cache-bust.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Cache-bust guard (CACHE-01). The nginx static-asset block serves /*.css /*.js
+# with `Cache-Control: immutable, max-age=1y` — the browser never revalidates.
+# That is only safe when every reference carries a ?v=N cache-bust, so a content
+# change ships under a NEW url. This guard fails the build when that invariant
+# breaks, so stale-after-deploy assets can't silently creep back in.
+#
+# Two checks over frontend/**/*.html, for LOCAL .css/.js/.mjs only (external
+# https:// and protocol-relative // links are ignored — they aren't ours to bust):
+#   1. MISSING  — a local asset link with no ?v=N at all.
+#   2. SPLIT    — the same asset referenced with >1 distinct ?v= value
+#                 (two cache keys for one file; the "double-key" bug).
+#
+# Run: scripts/check-cache-bust.sh   (exit 0 = clean, 1 = violations)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIR="$ROOT/frontend"
+fail=0
+
+# All local .css/.js/.mjs references (value starts with "/" or "./", never "//"
+# or a scheme). Emits: "<file>:<line>\t<asset-path>\t<version-or-NONE>".
+refs="$(grep -rnoE '(href|src)="(\.?/[^"/][^"]*)\.(css|js|mjs)(\?v=[0-9]+)?"' "$DIR" --include='*.html' \
+  | sed -E 's#^([^:]+:[0-9]+):.*"(\.?/[^"]+\.(css|js|mjs))(\?v=([0-9]+))?"#\1\t\2\t\5#' || true)"
+
+# ── Check 1: MISSING ?v= ──────────────────────────────────────────────────────
+missing="$(printf '%s\n' "$refs" | awk -F'\t' 'NF>=3 && $3=="" {print "  "$1"  ->  "$2}')"
+if [ -n "$missing" ]; then
+  echo "FAIL: local asset links WITHOUT a ?v= cache-bust (immutable-cached => stale after deploy):"
+  printf '%s\n' "$missing"
+  fail=1
+fi
+
+# ── Check 2: SPLIT version (same asset, >1 distinct ?v=) ──────────────────────
+split="$(printf '%s\n' "$refs" | awk -F'\t' '$3!="" {seen[$2 SUBSEP $3]=1} END{for(k in seen){split(k,a,SUBSEP); c[a[1]]++; vs[a[1]]=vs[a[1]]" v"a[2]} for(p in c) if(c[p]>1) print "  "p"  ->" vs[p]}')"
+if [ -n "$split" ]; then
+  echo "FAIL: assets referenced with more than one ?v= version (one file, two cache keys — unify them):"
+  printf '%s\n' "$split"
+  fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  n="$(printf '%s\n' "$refs" | grep -c . || true)"
+  echo "cache-bust guard: OK — $n local css/js/mjs link(s), all carry a single consistent ?v="
+fi
+exit "$fail"


### PR DESCRIPTION
## CACHE-01 — fix stale-after-deploy content (option C1)

Read-only diagnosis confirmed: **the "ParaRules vanished" and dashboard-button mysteries were never code regressions — they were the browser serving stale HTML.** This is the build of the approved **C1** design (HTML always-revalidate + consistent `?v=` busting + a deploy-guard). C2 (content-hash filenames) is parked until there's a build step.

> ⛔ **Not deployed. Review the nginx diff before anything reaches the edge** — a dropped CSP/HSTS is exactly the silent failure to catch here. Deploy plan + drift caveat below.

### Root cause (evidence)
`/etc/nginx/sites-enabled/paramant.conf` (:8080 static vhost, behind the Caddy PQC edge):
- **HTML** is served with **no `Cache-Control`** (only ETag/Last-Modified) → browsers apply heuristic freshness and serve a stale pre-deploy `index.html` (old nav, old hero CTA) **without revalidating**. → ParaRules link "gone", dashboard CTA nondeterministic.
- **The asset block sets `immutable, max-age=1y` by file extension** — regardless of whether the link is versioned. ~88 links (notably `/js/nav-auth.js` ×62) carried **no `?v=`** → a changed file can never reach returning visitors.
- **The `add_header` inheritance trap is already biting:** because the asset `location` sets its own `add_header`, `/*.css` and `/*.js` were served **without CSP / X-Frame-Options / Referrer-Policy / Permissions-Policy** (verified live; HTML had them, assets didn't). Two `Cache-Control` headers were also emitted (`expires 1y` + the explicit one).

### The fix — 3 commits
1. **`8390a32` nginx** — HTML/non-asset → `Cache-Control: no-cache` (store, always revalidate via ETag → cheap 304). Assets keep `immutable, 1y`. Security headers moved to **one shared snippet** (`deploy/nginx/snippets/paramant-security-headers.conf`) **included at server level AND in the asset block**, so CSP/HSTS can never be silently dropped — and assets now *regain* the 4 missing headers. Dropped the redundant `expires 1y`.
2. **`b20f982` frontend** — `?v=` on every previously-unbusted local css/js link (65 pages); bare refs unified to live versions (`nav.css?v=13`, `design-system.css?v=19`, `nav.js?v=12`); split-version "double key" fixed (`passkey.js` & `components-parasign.css` were both `?v=2` *and* `?v=3` → unified to `?v=3`).
3. **`e975ad0` guard + CI** — `scripts/check-cache-bust.sh` fails on any local css/js link that (1) lacks `?v=` or (2) has >1 version. New CI job `frontend — cache-bust guard`. Verified: passes on the busted tree (291 links); fails+names offenders on injected violations.

**End state per layer:** HTML → `no-cache` + all 6 security headers; assets → `immutable, 1y` + all 6 security headers (single `Cache-Control`); every css/js link carries one consistent `?v=`.

### ✅ Verification plan (run on-box after applying — NOT yet done)
```sh
nginx -t && systemctl reload nginx                 # graceful, no dropped conns
# HTML revalidates:
curl -sI http://127.0.0.1:8080/ | grep -i cache-control          # => no-cache
# 304 proof (revalidation works, cheap):
ETAG=$(curl -sI http://127.0.0.1:8080/ | awk 'tolower($1)=="etag:"{print $2}' | tr -d '\r')
curl -s -o /dev/null -w '%{http_code}\n' -H "If-None-Match: $ETAG" http://127.0.0.1:8080/   # => 304
# assets still immutable AND now carry CSP/XFO/Referrer/Permissions:
curl -sI 'http://127.0.0.1:8080/design-system.css?v=19' | grep -iE 'cache-control|content-security|x-frame|referrer|permissions'
# security headers intact on HTML, asset AND an API response (the add_header trap):
for u in / '/design-system.css?v=19' /v2/health; do curl -sI "http://127.0.0.1:8080$u" | grep -iE 'strict-transport|content-security'; done
# incognito (clean cache) public check via the Caddy edge: ParaRules link present in the nav
```
**Rollback criterion:** any 5xx rise, or any missing HSTS/CSP on any response → restore backup + reload (seconds).

### Deploy plan + safety net (for when you approve)
1. `cp /etc/nginx/sites-enabled/paramant.conf /etc/nginx/backups/paramant.conf.pre-cache01-$(date +%Y%m%d-%H%M%S)`
2. Place the snippet at `/etc/nginx/snippets/paramant-security-headers.conf`.
3. **Apply the two edits surgically to the live file — do NOT copy the repo file over it.** ⚠️ **`deploy/nginx-paramant-live.conf` has drifted from live** (repo still has `/send`+`/drop`, which live removed; live has a `/api/user/developer/check` internal block the repo lacks). A wholesale copy would resurrect ParaDrop routes and **break the `/developer` gate**. The PR diff is the *spec* for the two edits. (Reconciling the repo↔live drift is worth a separate housekeeping pass — flagged, out of scope here.)
4. Deploy the frontend `?v=` changes via the usual webroot rsync (`/home/paramant/app`), together with / before the nginx change so HTML references the busted URLs.
5. `nginx -t` → `systemctl reload nginx` → run the verification block above.

### Accepted limitation
This prevents **future** staleness. **Already-poisoned caches** (visitors who cached an unversioned asset under `immutable`) are only fixed by changing the URL — which the `?v=` additions in commit 2 do as a one-time side benefit. Inherent to immutable caching, not a gap in the fix.

### Scope notes (honest)
- Busting + guard cover **`.css/.js/.mjs`** (executable assets, where staleness = behavioural bugs). Images/fonts keep `immutable`; bump `?v=` or rename on the rare change — not auto-busted to avoid churn. Say the word to extend the guard to images.
- `location = /outlook/taskpane` also sets its own `add_header` (ACAO) and thus already drops the security headers — pre-existing, left as-is; could take the snippet in a follow-up.
- Only the **`:8080` main vhost** is touched. Sector frontends proxy to relays and are unaffected.
- `nginx -t` is the real syntax gate (runs on-box); locally I confirmed brace balance (108/108) and that no inline security header is left stranded at server level.

---
**Do not merge / do not deploy** — delivered for your review of the config diff first, per your instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

