### PR TITLE
feat(site): relay-pulse — a site-wide connective animation

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -25,6 +25,7 @@
 <style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <style>
   main .wrap .parapear-block { max-width: 560px; margin: 0 auto 28px; text-align: left; }

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -11,6 +11,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta property="og:title" content="Your account · Paramant">
 <meta property="og:description" content="Your account — Paramant">
 <meta property="og:url" content="https://paramant.app/account">

--- a/frontend/all-systems-go.html
+++ b/frontend/all-systems-go.html
@@ -6,6 +6,7 @@
   <title>Paramant - All systems</title>
   <link rel="stylesheet" href="/design-system.css?v=19">
   <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
     .asg { max-width: 560px; margin: 64px auto; padding: 0 24px; }
     .asg-hero { text-align: center; margin-bottom: 40px; }

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -24,6 +24,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -15,6 +15,7 @@
 <link rel="canonical" href="https://paramant.app/audit-log-export">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}
 a:hover{opacity:.7}

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -10,6 +10,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 </head>
 <body>
 

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -22,6 +22,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 /* Compact auth layout — existing design tokens only; design-system.css untouched. */
 .auth-wrap { max-width: 380px; margin: 0 auto; padding: var(--space-6) var(--space-4) var(--space-7); }

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -10,6 +10,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 </head>
 <body>
 

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -10,6 +10,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
   .warning-box {
     background: #fffbeb;

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -10,6 +10,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <script src="/js/qrcode.min.js?v=1"></script>
 </head>
 <body>

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -6,6 +6,7 @@
 <title>PARAMANT voor Banken & Finance — Post-Quantum Settlement</title>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{background:var(--bone);color:var(--ink);font-family:var(--mono)}

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -21,6 +21,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -24,6 +24,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{background:var(--bone);color:var(--ink);font-family:var(--sans);min-height:100vh}

--- a/frontend/compliance/iec62443.html
+++ b/frontend/compliance/iec62443.html
@@ -80,6 +80,7 @@ pre{font-family:var(--mono)}
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/compliance/nen7510.html
+++ b/frontend/compliance/nen7510.html
@@ -79,6 +79,7 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/compliance/nis2.html
+++ b/frontend/compliance/nis2.html
@@ -79,6 +79,7 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -16,6 +16,7 @@
 <link rel="canonical" href="https://paramant.app/crypto-agility">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}
 a:hover{opacity:.7}

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -14,6 +14,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta property="og:title" content="PARAMANT · Certificate Transparency Log">
 <meta property="og:description" content="PARAMANT — Certificate Transparency Log">
 <meta property="og:url" content="https://paramant.app/ct-log">

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -10,6 +10,7 @@
 <link rel="preconnect" href="https://relay.paramant.app">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <noscript><meta http-equiv="refresh" content="0;url=/auth/login?next=/dashboard"></noscript>
 <style>

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -10,6 +10,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 *{box-sizing:border-box}
 main.dev{max-width:1180px;margin:0 auto;padding:var(--space-5) var(--space-4) var(--space-7)}

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -18,6 +18,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -18,6 +18,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}
 a{color:var(--ink);text-decoration:none}

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -90,6 +90,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
 <style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 </head>
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -17,6 +17,7 @@
 <link rel="canonical" href="https://paramant.app/dpa">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-hair)}
 a:hover{opacity:.7}

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -28,6 +28,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{background:var(--bone);color:var(--ink);font-family:var(--sans);min-height:100vh}

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -17,6 +17,7 @@
 <link rel="canonical" href="https://paramant.app/government">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}
 a:hover{opacity:.7}

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -15,6 +15,7 @@
 <link rel="canonical" href="https://paramant.app/healthcare">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}
 a:hover{opacity:.7}

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -61,6 +61,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -47,6 +47,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -61,6 +61,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -63,6 +63,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -65,6 +65,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -31,6 +31,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <style>
 .nav-help {

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -60,6 +60,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -59,6 +59,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -65,6 +65,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -59,6 +59,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -17,6 +17,7 @@
 <link rel="canonical" href="https://paramant.app/hndl">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}
 a:hover{opacity:.7}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,6 +23,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <link rel="stylesheet" href="/components-parasign.css?v=3">
 <style>

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -15,6 +15,7 @@
 <link rel="canonical" href="https://paramant.app/legal-discovery">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}
 a:hover{opacity:.7}

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -24,6 +24,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 main{max-width:760px;margin:64px auto;padding:0 24px 80px}

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -15,6 +15,7 @@
 <link rel="canonical" href="https://paramant.app/ma-due-diligence">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}
 a:hover{opacity:.7}

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -7,6 +7,7 @@
 <title>Receive a file · Paramant</title>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta name="description" content="A secure file is waiting for you. It decrypts in your browser and burns after one download.">
 <meta property="og:title" content="A secure file is waiting · Paramant">
 <meta property="og:description" content="A secure file is waiting for you. It decrypts in your browser and burns after one download. Nothing is stored on the server.">

--- a/frontend/ot-vs-data-diodes.html
+++ b/frontend/ot-vs-data-diodes.html
@@ -18,6 +18,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>
 .nav-help {

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -24,6 +24,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{padding-top:56px}

--- a/frontend/pararules.html
+++ b/frontend/pararules.html
@@ -24,6 +24,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 .content{max-width:800px;margin:80px auto;padding:0 48px}

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -13,6 +13,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <style>
 /* Page: parashare — transfer UI */

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -18,6 +18,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 
 <style>
 *{margin:0;padding:0;box-sizing:border-box}

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -24,6 +24,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 :root{

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -17,6 +17,7 @@
 <link rel="canonical" href="https://paramant.app/pricing">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .tier-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--ink-hair)}
 .tier-card{padding:var(--space-7) var(--space-6);background:var(--bone);min-height:440px;display:flex;flex-direction:column}

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -24,6 +24,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 .content{max-width:800px;margin:80px auto;padding:0 48px}

--- a/frontend/quantum-urgency.html
+++ b/frontend/quantum-urgency.html
@@ -18,6 +18,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>
 .nav-help {

--- a/frontend/relay-pulse.css
+++ b/frontend/relay-pulse.css
@@ -1,0 +1,49 @@
+/* relay-pulse.css  ·  site-wide "relay signal"
+ *
+ * One lime pulse glides across the very top edge of every page on a slow loop:
+ * the signal passing through the relay, tying the whole site together. It is the
+ * connective motif that echoes the lime beats in the homepage panel animations.
+ *
+ * Self-contained on purpose: nav.css and design-system.css are NOT touched. The
+ * effect lives entirely on body::after, is fixed + 2px tall + pointer-events:none
+ * (zero layout impact), and is transform-driven (no layout thrash). It honours
+ * prefers-reduced-motion by disappearing entirely. Tunable in one place: the
+ * --rp-* custom properties below.
+ */
+:root {
+  --rp-lime: #B2FF3F;   /* brand lime */
+  --rp-width: 280px;    /* length of the travelling pulse */
+  --rp-period: 7s;      /* one pulse every N seconds */
+  --rp-thickness: 2px;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: var(--rp-width);
+  height: var(--rp-thickness);
+  z-index: 100;
+  pointer-events: none;
+  background: linear-gradient(90deg,
+    rgba(178, 255, 63, 0) 0%,
+    var(--rp-lime) 50%,
+    rgba(178, 255, 63, 0) 100%);
+  transform: translateX(-320px);
+  animation: relay-pulse var(--rp-period) ease-in-out 0.5s infinite;
+  will-change: transform, opacity;
+}
+
+/* travel left -> right across the viewport, then rest off-screen until the next
+   beat. translateX(100vw) clears the right edge on any width; the gap between
+   16% and 100% is the quiet interval. */
+@keyframes relay-pulse {
+  0%        { transform: translateX(-320px); opacity: 1; }
+  16%       { transform: translateX(100vw);  opacity: 1; }
+  17%, 100% { transform: translateX(100vw);  opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body::after { animation: none; display: none; }
+}

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -11,6 +11,7 @@
 <link rel="canonical" href="https://paramant.app/signup">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>
 .nav-help {

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -24,6 +24,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -28,6 +28,7 @@
   </style>
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 </head>
 <body>
 <nav class="nav">

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -6,6 +6,7 @@
   <title>Paramant - First-time setup</title>
   <link rel="stylesheet" href="/design-system.css?v=19">
   <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 </head>
 <body>
   <main class="setup-wizard" style="max-width:640px;margin:48px auto;padding:0 20px">

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -22,6 +22,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/components-parasign.css?v=3">
 <style>
 .ds-wrap{max-width:880px;margin:48px auto;padding:0 24px}

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -23,6 +23,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
   display: inline-flex;

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -6,6 +6,7 @@
   <title>Email verified &mdash; check your inbox &mdash; Paramant</title>
   <link rel="stylesheet" href="/design-system.css?v=19">
   <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <script src="/nav.js?v=12" defer></script>
 <script src="/js/nav-auth.js?v=1" defer></script>
   <style>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -18,6 +18,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{

--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -18,6 +18,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>
 .nav-help {

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -15,6 +15,7 @@
 <link rel="canonical" href="https://paramant.app/ssh-key-delivery">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}
 a:hover{opacity:.7}

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -23,6 +23,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{background:var(--bone);color:var(--ink);font-family:var(--mono);font-size:15px;line-height:1.6;min-height:100vh}

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -24,6 +24,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -22,6 +22,7 @@
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/components-parasign.css?v=3">
 </head>
 <body>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -18,6 +18,7 @@
 
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>
 .nav-help {

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -15,6 +15,7 @@
 <link rel="canonical" href="https://paramant.app/whistleblower-channel">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}
 a:hover{opacity:.7}


### PR DESCRIPTION
## Relay-pulse — the connective site-wide animation

Per the agreed direction ("Relay-puls"): one lime pulse glides across the top edge of **every page** on a slow 7s loop. The signal moving through the relay, the motif that ties the whole site together and echoes the lime beats in the homepage panel animations.

### How
- **One new file** `relay-pulse.css`, linked site-wide after `nav.css` (67 pages). **`nav.css` and `design-system.css` are untouched** (you flagged them sacred).
- The effect is `body::after` only: `position:fixed`, 2px tall, `pointer-events:none` → **zero layout impact**, transform-driven.
- **`prefers-reduced-motion`** → the pulse disappears entirely.
- New asset → cache-fresh (no `?v=` bump of an existing file; CACHE-01 fix #175 already landed).

### Tunable in one place (live-iterate friendly)
`:root { --rp-lime; --rp-width:280px; --rp-period:7s; --rp-thickness:2px; }` — say the word and I retune speed/length/frequency, or move it from the top edge to the nav hairline.

Frontend-only: 67 HTML link-adds + 1 new CSS. Deploy = surgical rsync of those 68 files (incl. `relay-pulse.css`).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)