### PR TITLE
feat(relay): stap 4 foundation — account-aware keys list + primary-key endpoint

### DIFF
--- a/relay/lib/keys-table.js
+++ b/relay/lib/keys-table.js
@@ -140,4 +140,29 @@ function computeOverLimit(apiKeys, accounts, accountKeys, opts) {
   return over;
 }
 
-module.exports = { VALID_SCOPES, computeKid, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2, computeOverLimit };
+// Designate `key` as the primary api-key of account `accountId` (stap 4). Mutates
+// the live Maps in place: promotes the chosen key (is_primary=true), demotes every
+// other member of the account, and repoints accounts[accountId].primary_api_key.
+// Pure w.r.t. I/O — the caller persists to users.json and reads no globals.
+// Throws (caller maps to 4xx) when the key is unknown, inactive, or not a member
+// of the account, so a mismatched account_id can never silently move a primary.
+// Returns { previous, current } (previous may be null on a fresh account).
+function designatePrimary(apiKeys, accounts, accountKeys, accountId, key) {
+  const v = apiKeys.get(key);
+  if (!v) { const e = new Error('key_not_found'); e.code = 'key_not_found'; throw e; }
+  if (v.active === false) { const e = new Error('key_inactive'); e.code = 'key_inactive'; throw e; }
+  const acctOf = v.account_id || key;
+  if (acctOf !== accountId) { const e = new Error('key_account_mismatch'); e.code = 'key_account_mismatch'; throw e; }
+  const members = accountKeys.get(accountId) || new Set([key]);
+  const previous = (accounts.get(accountId) && accounts.get(accountId).primary_api_key) || null;
+  for (const m of members) { const mv = apiKeys.get(m); if (mv) mv.is_primary = (m === key); }
+  v.is_primary = true;
+  if (!accounts.has(accountId)) {
+    accounts.set(accountId, { account_id: accountId, plan: v.plan, email: v.email || '', primary_api_key: key, label: v.label || '' });
+  } else {
+    accounts.get(accountId).primary_api_key = key;
+  }
+  return { previous, current: key };
+}
+
+module.exports = { VALID_SCOPES, computeKid, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2, computeOverLimit, designatePrimary };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -4205,8 +4205,12 @@ session = client.create_session('recipient@example.com')</pre>
 
   // ── GET /v2/admin/keys ────────────────────────────────────────────────────
   if (path === '/v2/admin/keys' && req.method === 'GET') {
+    // Account fields (kid/account_id/is_primary/scope/created) are ADDITIVE —
+    // existing consumers read key/plan/label/email/active; stap-4 self-service
+    // and the account-aware admin view use the account grouping.
     const keys = [...apiKeys.entries()].map(([k, v]) => ({
-      key: k, plan: v.plan, label: v.label, email: v.email || null, active: v.active, over_limit: v.over_limit || false
+      key: k, plan: v.plan, label: v.label, email: v.email || null, active: v.active, over_limit: v.over_limit || false,
+      kid: v.kid || null, account_id: v.account_id || k, is_primary: !!v.is_primary, scope: v.scope || 'full', created: v.created || null
     }));
     const licenseInfo = { edition: EDITION, active_keys: keys.length, key_limit: LICENSE_MAX_KEYS === Infinity ? null : LICENSE_MAX_KEYS, ...(LICENSE_PAYLOAD ? { license_expires: LICENSE_PAYLOAD.expires_at } : {}) };
     res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -4312,6 +4316,47 @@ session = client.create_session('recipient@example.com')</pre>
       }).catch(e => log('warn', 'plan_update_persist_failed', { err: e.message }));
       applyKeyLimitEnforcement();
       res.writeHead(200); return res.end(J({ ok: true, key, plan }));
+    } catch(e) { res.writeHead(400); return res.end(J({ error: e.message })); }
+  }
+
+  // ── GET /v2/admin/keys/primary/:account_id — read an account's primary + members ──
+  // Read-only; path-param (mirrors /v2/admin/usage/:account_id) so no query parse.
+  const primaryGet = path.match(/^\/v2\/admin\/keys\/primary\/(.+)$/);
+  if (primaryGet && req.method === 'GET') {
+    const accountId = decodeURIComponent(primaryGet[1]);
+    const acct = accounts.get(accountId);
+    const members = [...(accountKeys.get(accountId) || [])].map((k) => {
+      const v = apiKeys.get(k) || {};
+      return { kid: v.kid || null, is_primary: !!v.is_primary, scope: v.scope || 'full', active: v.active !== false, label: v.label || '' };
+    });
+    const primaryKey = acct && acct.primary_api_key;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    return res.end(J({ ok: true, account_id: accountId, known: !!acct,
+      primary_kid: primaryKey ? ((apiKeys.get(primaryKey) || {}).kid || null) : null, keys: members }));
+  }
+
+  // ── POST /v2/admin/keys/primary — designate {key} as {account_id}'s primary ──
+  // Promotes the chosen key, demotes the previous primary within the account
+  // (keysTable.designatePrimary), then persists. Mismatched account_id => 400, so
+  // a key can never be moved into an account it does not belong to.
+  if (path === '/v2/admin/keys/primary' && req.method === 'POST') {
+    try {
+      const d = JSON.parse((await readBody(req, 1024)).toString());
+      const accountId = (d.account_id || '').toString();
+      const key = (d.key || '').toString();
+      if (!accountId || !key) { res.writeHead(400); return res.end(J({ error: 'account_id and key required' })); }
+      let result;
+      try { result = keysTable.designatePrimary(apiKeys, accounts, accountKeys, accountId, key); }
+      catch (ke) { res.writeHead(ke.code === 'key_not_found' ? 404 : 400); return res.end(J({ error: ke.code || 'invalid_request' })); }
+      _mutateUsersJson(ud => {
+        for (const entry of ud.api_keys) {
+          if ((entry.account_id || entry.key) === accountId) entry.is_primary = (entry.key === key);
+        }
+        ud.updated = new Date().toISOString();
+      }).then(() => log('info', 'primary_designated_via_admin', { account: accountId.slice(0, 12), persisted: true }))
+        .catch(we => log('warn', 'primary_persist_failed', { err: we.message }));
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(J({ ok: true, account_id: accountId, primary_key: key, previous_primary: result.previous }));
     } catch(e) { res.writeHead(400); return res.end(J({ error: e.message })); }
   }
 

--- a/relay/test/keys-table.test.js
+++ b/relay/test/keys-table.test.js
@@ -125,3 +125,40 @@ test('integration: migrate v1 file -> load -> rebuild produces consistent indexe
   assert.equal(kidIndex.size, 2);
   assert.equal(apiKeys.get('pgp_bob').account_id, 'pgp_bob');
 });
+
+// ── designatePrimary (stap 4) ────────────────────────────────────────────────
+function buildAccount() {
+  const apiKeys = new Map();
+  const set = (key, raw) => apiKeys.set(key, { plan: raw.plan || 'pro', label: raw.label || '', email: raw.email || '', active: raw.active !== false, ...kt.parseAccountFields({ ...raw, key }) });
+  set('pgp_primary', {});                                               // own account, seeded primary
+  set('pgp_second',  { account_id: 'pgp_primary', is_primary: false }); // a second key under that account
+  const accounts = new Map(), accountKeys = new Map(), kidIndex = new Map();
+  kt.rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex);
+  return { apiKeys, accounts, accountKeys };
+}
+
+test('designatePrimary: promotes the chosen key, demotes the old, repoints the account', () => {
+  const { apiKeys, accounts, accountKeys } = buildAccount();
+  assert.equal(accounts.get('pgp_primary').primary_api_key, 'pgp_primary');
+
+  const r = kt.designatePrimary(apiKeys, accounts, accountKeys, 'pgp_primary', 'pgp_second');
+  assert.deepEqual(r, { previous: 'pgp_primary', current: 'pgp_second' });
+  assert.equal(apiKeys.get('pgp_second').is_primary, true);            // promoted
+  assert.equal(apiKeys.get('pgp_primary').is_primary, false);          // demoted
+  assert.equal(accounts.get('pgp_primary').primary_api_key, 'pgp_second');
+});
+
+test('designatePrimary: refuses a key from another account (no cross-account move)', () => {
+  const { apiKeys, accounts, accountKeys } = buildAccount();
+  assert.throws(() => kt.designatePrimary(apiKeys, accounts, accountKeys, 'pgp_other', 'pgp_second'),
+    (e) => e.code === 'key_account_mismatch');
+});
+
+test('designatePrimary: rejects unknown and inactive keys', () => {
+  const { apiKeys, accounts, accountKeys } = buildAccount();
+  assert.throws(() => kt.designatePrimary(apiKeys, accounts, accountKeys, 'pgp_primary', 'pgp_nope'),
+    (e) => e.code === 'key_not_found');
+  apiKeys.get('pgp_second').active = false;
+  assert.throws(() => kt.designatePrimary(apiKeys, accounts, accountKeys, 'pgp_primary', 'pgp_second'),
+    (e) => e.code === 'key_inactive');
+});


### PR DESCRIPTION
## Stap 4, part 1 of 2 — the relay foundation (this PR)

Stap 4 = self-service key management (create/list/rotate/revoke). I'm landing it in **two reviewable pieces** because the self-service layer is auth-critical (a scoping bug = one account managing another's keys), and per your "stap 4/5 auth-rakend — per stuk reviewen". This PR is the **relay foundation**; it's additive and ADMIN_TOKEN-gated (no user-facing surface yet). The auth-critical admin layer is part 2 — designed below, built on your nod.

### What's here
- **`GET /v2/admin/keys`** now returns `kid, account_id, is_primary, scope, created` per key. **Additive** — `findUserByEmail`, `/keys/all`, the dashboard all read `key/plan/label/email/active` and are unchanged.
- **`GET /v2/admin/keys/primary/:account_id`** — read-only: the account's primary kid + member keys.
- **`POST /v2/admin/keys/primary {account_id, key}`** — designate the account's primary (promote chosen, demote old, persist) via the pure `keysTable.designatePrimary`.
- Both routes start with `/v2/admin` → inherit the existing ADMIN_TOKEN gate (`relay.js:3600`), **no new auth surface**. The create handler was already account-aware (stap 2).

### Tests / verification
- `relay/test/keys-table.test.js`: **15/15** (+3 for `designatePrimary`: promote/demote, cross-account refusal, unknown/inactive).
- `node --check relay/relay.js` clean. The new endpoints are ADMIN_TOKEN-gated, additive; behaviour-neutral for existing consumers.

### Part 2 (NOT in this PR) — admin self-service, the auth-critical layer
Planned `admin/server.js` endpoints under `authUser` (user session), each **scoped to the caller's own account, resolved from the session — never from client input**:
- `GET  /api/user/account/keys` — list MY account's keys (kids, not raw secrets)
- `POST /api/user/account/keys {label, scope}` — create a NON-primary key under MY account; raw key shown once
- `POST /api/user/account/keys/revoke {kid}` — revoke one of MY keys; refuse if it's not mine, and refuse revoking my **primary/last** key (lockout guard)
- `POST /api/user/account/keys/rotate {kid}` — create replacement + revoke old, within MY account

Security model (will be a pure, heavily-tested lib like stap 3's `account-keys.js`): resolve `account_id` from the session key via the now-account-aware list; `ownsKey()` / `scopeToAccount()` / `canRevoke()` with cross-account denial as the headline test.

### ⚠️ One architecture decision I want your call on before building part 2
A user's primary key is **fanned out across all 5 sector-relays** today (operator `/keys/all` creates the same key everywhere; `findUserByEmail` reads `health`). So for self-service **create/revoke**, should a new/revoked key:
- **(A, recommended)** fan out to **all sectors** (like `/keys/all`) so the key works on any sector — consistent with today's model; or
- **(B)** target a **single sector** (which? the account's "home"?) — simpler, but the key wouldn't work cross-sector and breaks the current replicated model.

I recommend **A**. Your call decides how part 2's create/revoke are built.

---
**Do not merge / do not deploy.** Relay change → deploys with the vangnet after your review, not agile-on-top. Part 2 lands as its own PR once you've okayed the foundation + the fan-out decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
