### PR TITLE
refresh(sovereignty): em-dashes out

### DIFF
--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -505,7 +505,7 @@
     <h3>DNS and CDN: Cloudflare (current, being replaced)</h3>
     <p>paramant.app currently uses Cloudflare for DNS hosting and static asset delivery. Cloudflare is a US company incorporated in Delaware, subject to US jurisdiction including the CLOUD Act and FISA 702.</p>
 
-    <p>The practical impact is bounded by architecture: all file content is encrypted client-side with ML-KEM-768 before any network transit. Cloudflare terminates TLS but receives only ciphertext — it cannot read file contents, encryption keys, or recipient identities. What is theoretically observable at the Cloudflare edge: source IP addresses, request timing, request volume, and HTTP headers (not body content).</p>
+    <p>The practical impact is bounded by architecture: all file content is encrypted client-side with ML-KEM-768 before any network transit. Cloudflare terminates TLS but receives only ciphertext, so it cannot read file contents, encryption keys, or recipient identities. What is theoretically observable at the Cloudflare edge: source IP addresses, request timing, request volume, and HTTP headers (not body content).</p>
 
     <p>For most threat models this is acceptable. For high-sensitivity use cases (legal, government, healthcare under strict NEN 7510 interpretation) where even metadata exposure is a concern, this is a gap we are closing.</p>
 
@@ -514,8 +514,8 @@
 
     <p>The migration is phased to avoid downtime:</p>
     <ul>
-      <li><strong>Phase 1 (Q2 early)</strong>: DNS-only migration from Cloudflare to Bunny DNS — nameserver change at registrar, zero downtime if TTLs managed correctly</li>
-      <li><strong>Phase 2 (Q2 mid)</strong>: Static asset CDN via Bunny Pull Zone — parallel paths during transition</li>
+      <li><strong>Phase 1 (Q2 early)</strong>: DNS-only migration from Cloudflare to Bunny DNS, with a nameserver change at the registrar and zero downtime if TTLs are managed correctly</li>
+      <li><strong>Phase 2 (Q2 mid)</strong>: Static asset CDN via Bunny Pull Zone, with parallel paths during transition</li>
       <li><strong>Phase 3 (Q2 late)</strong>: Full reverse proxy via Bunny with WAF, replacing Cloudflare DDoS protection</li>
     </ul>
 


### PR DESCRIPTION
## Page-refresh #3 — /sovereignty

`/sovereignty` was already in good shape brand-wise (lime eyebrow bar, a cobalt section, numbered section markers, and the title was already `Jurisdiction · Paramant`). So this is a **light pass**: the three remaining em-dashes (in the Cloudflare-edge and Bunny migration prose) become clean punctuation.

Content and facts unchanged. Only `sovereignty.html`; `nav.css` / `design-system.css` untouched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)