### PR TITLE
feat(home): state-aware hero + balanced, tighter, more visual panels

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,34 +38,36 @@
 .hero-badges li:hover { border-color: var(--navy); }
 .hero-badges li:hover a { color: var(--navy); }
 .home-split { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); max-width: 1040px; margin: var(--space-5) auto var(--space-6); padding: 0 var(--space-4); }
-.path { position: relative; display: flex; flex-direction: column; border: 1px solid var(--ink-hair); background: #fff; padding: var(--space-5); min-height: 220px; }
+.path { position: relative; display: flex; flex-direction: column; border: 1px solid var(--ink-hair); background: #fff; padding: var(--space-5); }
 .path-dev { background: var(--bone); }
-.path h2 { font-size: clamp(20px, 2.5vw, 27px); line-height: 1.12; letter-spacing: -0.015em; color: var(--navy); margin: 0 0 var(--space-3); max-width: 18ch; }
-.path > p { font-size: 15px; line-height: 1.55; color: var(--ink-dim); margin: 0 0 var(--space-4); max-width: 34ch; }
+.path h2 { font-size: clamp(20px, 2.5vw, 26px); line-height: 1.12; letter-spacing: -0.015em; color: var(--navy); margin: 0; max-width: 22ch; }
+.path > p { font-size: 15px; line-height: 1.55; color: var(--ink-dim); margin: var(--space-3) 0 0; max-width: 34ch; }
 .path-cta { margin-top: auto; }
 .path-cta-sub { display: inline-block; margin-top: var(--space-2); font-size: 13px; color: var(--ink-dim); text-decoration: underline; }
 .path-cta-sub:hover { color: var(--navy); }
 .path-breadth { margin: var(--space-2) 0 0; font-family: var(--mono); font-size: 11px; line-height: 1.4; letter-spacing: .02em; color: var(--ink-dim); }
-.path-pear { position: absolute; top: var(--space-4); right: var(--space-4); width: clamp(56px, 8vw, 84px); height: auto; opacity: .92; transform: scaleX(-1); user-select: none; -webkit-user-drag: none; }
-@media (max-width: 760px) { .home-split { grid-template-columns: 1fr; } .path { min-height: 0; } }
+@media (max-width: 760px) { .home-split { grid-template-columns: 1fr; } }
 
-/* ── Homepage panel animations — replace the corner mascot on both panels.
-   Pure CSS keyframes (no JS, CSP-safe), ~10s synchronised loops, deep-navy base
-   with lime (#B2FF3F) on the "it works" beats. prefers-reduced-motion shows a
-   static completed frame (the elements' base state). design-system.css and
-   nav.css are untouched — everything here is scoped to .path-anim / .cli. ── */
-.path-anim { position: absolute; top: var(--space-4); right: var(--space-4);
-  width: clamp(124px, 17vw, 164px); aspect-ratio: 4 / 3; border-radius: 10px; overflow: hidden;
-  background: #0a1626; box-shadow: 0 3px 14px rgba(11,58,106,.22), inset 0 0 0 1px rgba(178,255,63,.10);
+/* State-aware hero: the logged-out pitch is the default (and what scrapers
+   see); js/home-auth.js reveals the logged-in welcome + quick actions. */
+.home-state[hidden] { display: none; }
+.home-actions { display: flex; flex-wrap: wrap; gap: var(--space-3); justify-content: center; margin: var(--space-4) 0 0; }
+.home-act-ghost { background: transparent; color: var(--navy); border: 1px solid var(--ink-hair); }
+.home-act-ghost:hover { border-color: var(--navy); background: var(--bone); }
+.home-hi-name { color: var(--cobalt); }
+
+/* ── Homepage panel animations — now the centrepiece of each panel: a larger,
+   centred "screen" playing the loop, so the security is felt, not read. Pure
+   CSS keyframes (no JS, CSP-safe), ~10s loops, deep-navy base with lime
+   (#B2FF3F) on the "it works" beats. prefers-reduced-motion shows a static
+   completed frame. design-system.css and nav.css are untouched. ── */
+.path-anim { margin: var(--space-4) auto var(--space-5); width: clamp(210px, 82%, 300px);
+  aspect-ratio: 4 / 3; border-radius: 10px; overflow: hidden;
+  background: #0a1626; box-shadow: 0 4px 18px rgba(11,58,106,.22), inset 0 0 0 1px rgba(178,255,63,.10);
   user-select: none; --lime: #B2FF3F; --doc: #e7edf6; --ln: #56789f; --dim: #88a6cb; }
 .path-anim svg { display: block; width: 100%; height: 100%; }
 .path-anim text { font-family: var(--mono); font-weight: 600; letter-spacing: -.02em; }
-/* keep the panel text clear of the corner box (no grid/spacing change) */
-.path-human h2, .path-human > p, .path-dev h2, .path-dev > p { padding-right: clamp(0px, 19vw, 138px); }
-@media (max-width: 760px) {
-  .path-human h2, .path-human > p, .path-dev h2, .path-dev > p { padding-right: 0; }
-  .path-anim { position: static; order: -1; margin: 0 0 var(--space-3); width: clamp(160px, 50vw, 200px); }
-}
+@media (max-width: 760px) { .path-anim { width: clamp(200px, 70vw, 280px); } }
 
 /* LEFT — two pillars in one loop: (1) SIGN the document (ML-DSA-65 curve →
    "✓ signed"), then (2) SEND it — encrypt flicker → through the relay's RAM →
@@ -330,21 +332,31 @@
 <main id="main-content" role="main">
 
 <section class="home-hero">
-  <h1>Sign it. Send it. We never even had it.</h1>
-  <p class="lede">Post-quantum signatures and encrypted transfers, held in memory and gone after read. The server is blind by design, not by promise.</p>
-  <ul class="hero-badges" aria-label="At a glance">
-    <li><a href="https://github.com/Apolloccrypt/paramant-relay">Open source</a></li>
-    <li><a href="/pricing">Free</a></li>
-    <li><a href="/security">Fully auditable</a></li>
-    <li><a href="/sovereignty">EU-sovereign</a></li>
-    <li><a href="/crypto-agility">Post-quantum</a></li>
-  </ul>
+  <div class="home-state" data-home="out">
+    <h1>Sign it. Send it. We never even had it.</h1>
+    <p class="lede">Post-quantum signatures and encrypted transfers, held in memory and gone after read. The server is blind by design, not by promise.</p>
+    <ul class="hero-badges" aria-label="At a glance">
+      <li><a href="https://github.com/Apolloccrypt/paramant-relay">Open source</a></li>
+      <li><a href="/pricing">Free</a></li>
+      <li><a href="/security">Fully auditable</a></li>
+      <li><a href="/sovereignty">EU-sovereign</a></li>
+      <li><a href="/crypto-agility">Post-quantum</a></li>
+    </ul>
+  </div>
+  <div class="home-state" data-home="in" hidden>
+    <h1>Welcome back<span class="home-hi-name" data-home-name></span>.</h1>
+    <p class="lede">Your relay is ready. Pick up where you left off, or start something new.</p>
+    <div class="home-actions">
+      <a class="btn btn-lime" href="/sign">Sign a document</a>
+      <a class="btn home-act-ghost" href="/dashboard">Your dashboard</a>
+      <a class="btn home-act-ghost" href="/developer">Developer dashboard</a>
+    </div>
+  </div>
 </section>
 
 <section class="home-split" id="products" aria-label="Two ways to use Paramant">
   <div class="path path-human">
-    <h2>For people who sign things that matter.</h2>
-    <p>Sign documents and send files, in your browser. Nothing to install, nothing left behind.</p>
+    <h2>Sign and send, right in your browser.</h2>
     <div class="path-anim" role="img" aria-label="Phase one: a document is signed with a post-quantum ML-DSA-65 signature. Phase two: the same document is encrypted, sent through the relay's memory and delivered to the recipient, then burned after one read.">
       <svg viewBox="0 0 160 120" fill="none" xmlns="http://www.w3.org/2000/svg">
         <text class="l-phase l-phase1" x="80" y="13" fill="#7f9cc0" font-size="7.5" letter-spacing="1.4" text-anchor="middle">SIGN</text>
@@ -378,11 +390,12 @@
     </div>
     <div class="path-cta">
       <a class="btn btn-lime" href="/dashboard">Open your dashboard</a>
+      <a class="path-cta-sub" href="/pararules">or read the ParaRules</a>
+      <p class="path-breadth">Sign &#183; co-sign &#183; send &#183; burn-on-read</p>
     </div>
   </div>
   <div class="path path-dev">
-    <h2>For builders who don&rsquo;t trust servers either.</h2>
-    <p>Post-quantum encryption and signing as a pipe. Drop it into your stack, or self-host the whole thing.</p>
+    <h2>Drop post-quantum crypto into your stack.</h2>
     <div class="path-anim path-anim-cli" role="img" aria-label="Terminal cycling through Paramant command-line tools: s3-migrate moves an S3 object encrypted with ML-KEM-768 and burned on read; db-backup ships an encrypted off-site database dump; package-sign signs a release with ML-DSA-65. Ten encrypted CLI tools in total.">
       <div class="cli" aria-hidden="true">
         <div class="c-stack">
@@ -490,5 +503,6 @@
 </footer>
 <script src="/nav.js?v=12" defer></script>
 <script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/home-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/js/home-auth.js
+++ b/frontend/js/home-auth.js
@@ -1,0 +1,35 @@
+/* Homepage state swap.
+ *
+ * The homepage ships the logged-out pitch by default (so it works with JS off
+ * and is what link scrapers see). When a valid session is present, swap to the
+ * logged-in variant: "Welcome back" + quick actions, marketing badges gone.
+ *
+ * Uses the same probe the nav uses (GET /api/user/session/verify, credentials
+ * included). CSP-safe: external file, no inline script, no eval. Best-effort,
+ * tolerant: any failure leaves the logged-out pitch in place.
+ */
+(function () {
+  'use strict';
+  var out = document.querySelector('[data-home="out"]');
+  var inn = document.querySelector('[data-home="in"]');
+  if (!out || !inn) return;
+
+  fetch('/api/user/session/verify', { credentials: 'include', cache: 'no-store' })
+    .then(function (r) { return r.ok ? r.json() : null; })
+    .then(function (data) {
+      if (!data || !data.authenticated) return;
+
+      // Personalise with the email local-part if we have it (textContent, so
+      // no markup injection). Falls back to a plain "Welcome back." otherwise.
+      var nameEl = inn.querySelector('[data-home-name]');
+      if (nameEl && data.email) {
+        var at = String(data.email).indexOf('@');
+        var local = at > 0 ? String(data.email).slice(0, at) : String(data.email);
+        if (local) nameEl.textContent = ', ' + local;
+      }
+
+      out.hidden = true;
+      inn.hidden = false;
+    })
+    .catch(function () { /* stay on the logged-out pitch */ });
+})();


### PR DESCRIPTION
## Homepage overhaul (v1 — for your visual review, not merged/deployed)

Addresses the three points you raised. Iterative by design: first cut, meant to be tuned live.

### 1. Logged-in vs logged-out hero (the core)
- **Logged out** (default, and what scrapers see): the current pitch *"Sign it. Send it. We never even had it."* + the five trust badges, unchanged.
- **Logged in**: `js/home-auth.js` swaps the hero to **"Welcome back, `<name>`"** + three **direct actions** — Sign a document (`/sign`), Your dashboard (`/dashboard`), Developer dashboard (`/developer`) — and the marketing badges (Free / Open source …) drop away. No more selling someone what they already have.
- Detection uses the **same `/api/user/session/verify` probe the nav already uses**. Progressive enhancement: JS-off / scrapers / logged-out all keep the pitch.

### 2. Panel balance
The left ("people") panel was a lone button while the right ("builders") had a sublink + a breadth line. Left now has the **same structure** (sublink → `/pararules`, breadth line), so the two panels match in **height and weight**. `.path-cta { margin-top:auto }` keeps both CTAs bottom-aligned.

### 3. Tighter + more visual
- The two **existing animations are preserved** (the sign→send flow SVG on the left, the CLI loop on the right) — just moved from a **small top-right corner decoration** to a **larger, centred "screen"** that is the centrepiece of each panel.
- Panel **body copy trimmed** to a punchy heading + the animation + the CTA block, so the security is felt, not read.

### Boundaries kept
- Petrol/navy `#0B3A6A` + lime `#B2FF3F` only. **`nav.css` and `design-system.css` untouched.**
- Existing CSS keyframe animations preserved (container repositioned/resized only).
- **CSP-safe**: the auth swap is an external `/js/home-auth.js` (no inline script, no `on*`).
- Frontend-only. No relay/admin. Did not touch nginx cache config (CACHE-01 is session 1's lane).

### How to test live (after you deploy)
- **Logged out** (or incognito): the pitch + 5 badges + two panels with the centred animations.
- **Logged in**: hero becomes "Welcome back, …" + the three action buttons; badges gone. (Brief logged-out→logged-in swap on load is expected in v1; say the word if you want me to suppress the flash.)

Deploy is the surgical webroot rsync (`index.html` + new `js/home-auth.js`).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)