### PR TITLE
feat(login): neutral dual-path sign-in copy + prominent recovery link

### DIFF
--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -20,6 +20,7 @@
 .auth-or { display: flex; align-items: center; gap: 10px; margin: var(--space-3) 0; color: var(--ink-dim); font-family: var(--mono); font-size: 10px; letter-spacing: .1em; text-transform: uppercase; }
 .auth-or::before, .auth-or::after { content: ""; flex: 1; height: 1px; background: var(--ink-hair); }
 .auth-foot { text-align: center; margin-top: var(--space-4); }
+.auth-recovery { max-width: 380px; margin: var(--space-4) auto 0; }
 [hidden] { display: none !important; }
 .auth-sub { text-align: center; color: var(--ink-dim); font-size: 14px; margin: var(--space-2) 0 0; }
 .auth-hint { text-align: center; color: var(--ink-dim); font-size: 12px; margin: 8px 0 0; line-height: 1.5; }
@@ -213,9 +214,16 @@
   </div>
 </form>
 
+<div class="auth-recovery">
+  <a href="/auth/request-reset" class="btn btn-secondary" style="width:100%">Email me a sign-in link</a>
+  <p class="small" style="margin:8px 0 0;color:var(--ink-dim);text-align:center">
+    For a new account that still needs setup, or if you have lost your authenticator.
+    If an account exists for that email, we send a link; nothing is shown either way.
+  </p>
+</div>
+
 <p class="footer-text auth-foot">
   Lost your authenticator? <a href="/auth/backup">Use a backup code</a><br>
-  No backup codes? <a href="/auth/request-reset">Request a reset email</a><br>
   Don&rsquo;t have an account? <a href="/signup">Create one</a>
 </p>
 
@@ -252,13 +260,19 @@
       if (res.ok) {
         window.location = returnUrl;
       } else if (res.status === 401) {
-        errorDiv.textContent = 'Invalid email or code.';
+        // Neutral, dual-path copy. The server returns an identical
+        // 401 invalid_credentials for every failed sign-in (wrong code, inactive
+        // account, admin-required setup, or no such account), so this single
+        // branch with one fixed string is all the user ever sees. The "if this
+        // account needs setup" phrasing is true in every case and reveals
+        // nothing: there is no status, body, or wording that varies by account
+        // state, so it cannot be used as an account-enumeration oracle. (The
+        // server-side setup email is sent fire-and-forget for the setup case;
+        // the on-screen result does not depend on whether it was sent.)
+        errorDiv.textContent = 'We could not sign you in. If this account still needs setup, we have emailed a sign-in link to that address, so check your inbox. Otherwise, check your code and try again, or use "Email me a sign-in link" below.';
         errorDiv.classList.add('visible');
-        document.getElementById('totp').value = '';
-        document.getElementById('totp').focus();
-      } else if (res.status === 403) {
-        errorDiv.innerHTML = 'No authenticator linked to this account. <a href="/auth/request-reset">Request a setup link</a> or <a href="/signup">create an account</a>.';
-        errorDiv.classList.add('visible');
+        var totpEl = document.getElementById('totp');
+        if (totpEl) { totpEl.value = ''; totpEl.focus(); }
       } else if (res.status === 429) {
         errorDiv.textContent = 'Too many attempts. Try again in 15 minutes.';
         errorDiv.classList.add('visible');


### PR DESCRIPTION
Stacked on **`feat/auth-ux`** (base is that branch, not `main`) so the passkey-first login and this nudge stay consistent and only one branch lineage touches `login.html`.

## Problem

Accounts an admin flags `totp_required` (and TOTP-not-yet-configured accounts) trigger a **fire-and-forget setup email** on login, but the server deliberately answers `401 invalid_credentials` — identical to "no such account" — to avoid an account-enumeration oracle. The browser only said *"Invalid email or code."*, so the user got a link in their inbox with **no on-screen hint to look for it**. The `403` branch that once showed a helpful message is **dead code**: the server no longer returns `403`.

## Changes

- **Layer 1 — neutral dual-path copy.** The `401` message now reads: *"We could not sign you in. If this account still needs setup, we have emailed a sign-in link to that address, so check your inbox. Otherwise, check your code and try again, or use 'Email me a sign-in link' below."* Shown identically for every failed sign-in.
- **Layer 2 — prominent recovery button.** *"Email me a sign-in link"* wired to the existing, enumeration-safe `/auth/request-reset`. Always visible (so it reveals nothing), replacing the buried footer link.
- **Removed the dead `403` handler.**
- Layer 3 (interstitial screen) parked per review.

## Anti-enumeration verification (explicit, as requested)

The server returns a **byte-identical** response for all account states. Every failure path in `POST /api/user/login` (`admin/server.js`):

| Account state | Line | Response |
|---|---|---|
| Does not exist | `server.js:907` | `401 {"error":"invalid_credentials"}` |
| Exists, inactive, `totp_required` (setup email sent fire-and-forget) | `server.js:926` | `401 {"error":"invalid_credentials"}` |
| Exists, inactive, TOTP not configured | `server.js:930` | `401 {"error":"invalid_credentials"}` |
| Exists, active, wrong code | `server.js:934 / 936` | `401 {"error":"invalid_credentials"}` |

Client side: the **only** branch that renders for `401` is one fixed string — there is no branching on the response body, so the rendered text is identical in every case. No status, body, or wording varies by account state → no enumeration oracle. The setup email is dispatched server-side fire-and-forget; the on-screen result does not depend on whether it was sent.

> Honest footnote (pre-existing, unchanged by this PR): response *timing* differs slightly by account state (the argon2 verify path only runs for active accounts). That is a separate, pre-existing channel and is out of scope here; this PR keeps status + body + rendered copy identical.

## Safety

No new inline `<script>` / `on*` handlers (CSP `script-src 'self'` intact); no new css/js links (cache-bust guard unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)