### PR TITLE
chore(site): kill the remaining placeholder em-dashes

### DIFF
--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -536,28 +536,28 @@ FLAGS    1 byte    reserved for future features</pre>
         <tr>
           <td>ParaShare (webapp)</td>
           <td>ML-KEM-768 + ECDH P-256</td>
-          <td>—</td>
+          <td>n/a</td>
           <td>pre-v1 hybrid</td>
           <td>migrating to v1</td>
         </tr>
         <tr>
           <td>Send (browser-encrypted link)</td>
-          <td>—</td>
-          <td>—</td>
+          <td>n/a</td>
+          <td>n/a</td>
           <td>AES-256-GCM, key in URL fragment</td>
           <td>no identity-binding by design</td>
         </tr>
         <tr>
           <td>Chromium extension</td>
-          <td>—</td>
-          <td>—</td>
+          <td>n/a</td>
+          <td>n/a</td>
           <td>server-side path (relay encrypts)</td>
           <td>client-side crypto in progress</td>
         </tr>
         <tr>
           <td>Outlook add-in</td>
-          <td>—</td>
-          <td>—</td>
+          <td>n/a</td>
+          <td>n/a</td>
           <td>server-side path (relay encrypts)</td>
           <td>client-side crypto in progress</td>
         </tr>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -396,27 +396,27 @@ body { min-height:100vh; }
 
 <div class="stats">
   <div class="stat">
-    <div class="val" id="stat-total">—</div>
+    <div class="val" id="stat-total">n/a</div>
     <div class="lbl">Log entries</div>
   </div>
   <div class="stat">
-    <div class="val" id="stat-count">—</div>
+    <div class="val" id="stat-count">n/a</div>
     <div class="lbl">Registered relays</div>
   </div>
   <div class="stat">
-    <div class="val" id="stat-transfers">—</div>
+    <div class="val" id="stat-transfers">n/a</div>
     <div class="lbl">Transfer proofs</div>
   </div>
   <div class="stat">
-    <div class="val dim" id="stat-root">—</div>
+    <div class="val dim" id="stat-root">n/a</div>
     <div class="lbl">Merkle Root</div>
   </div>
   <div class="stat">
-    <div class="val green" id="stat-relay">—</div>
+    <div class="val green" id="stat-relay">n/a</div>
     <div class="lbl">Relay</div>
   </div>
   <div class="stat">
-    <div class="val dim" id="stat-last">—</div>
+    <div class="val dim" id="stat-last">n/a</div>
     <div class="lbl">Last Entry</div>
   </div>
 </div>
@@ -455,7 +455,7 @@ body { min-height:100vh; }
 
 <div class="pagination">
   <button id="prev-btn" onclick="changePage(-1)" disabled>&#8592; Prev</button>
-  <span id="page-info">—</span>
+  <span id="page-info">n/a</span>
   <button id="next-btn" onclick="changePage(1)" disabled>Next &#8594;</button>
 </div>
 
@@ -463,9 +463,9 @@ body { min-height:100vh; }
 
 <div id="pane-relays" style="display:none">
   <div class="stats" id="relay-stats">
-    <div class="stat"><div class="val" id="rstat-count">—</div><div class="lbl">Registered Relays</div></div>
-    <div class="stat"><div class="val green" id="rstat-sectors">—</div><div class="lbl">Sectors</div></div>
-    <div class="stat"><div class="val dim" id="rstat-last">—</div><div class="lbl">Last Registration</div></div>
+    <div class="stat"><div class="val" id="rstat-count">n/a</div><div class="lbl">Registered Relays</div></div>
+    <div class="stat"><div class="val green" id="rstat-sectors">n/a</div><div class="lbl">Sectors</div></div>
+    <div class="stat"><div class="val dim" id="rstat-last">n/a</div><div class="lbl">Last Registration</div></div>
   </div>
   <div class="relay-table-wrap">
     <div class="relay-table-head">
@@ -500,7 +500,7 @@ async function load() {
     document.getElementById('stat-transfers').textContent = transferCount;
     const root = d.root || '';
     document.getElementById('stat-root').textContent =
-      root && root !== '0'.repeat(64) ? root.slice(0,16)+'…' : '—';
+      root && root !== '0'.repeat(64) ? root.slice(0,16)+'…' : 'n/a';
 
     if (hRes && hRes.ok) {
       const h = await hRes.json();
@@ -517,7 +517,7 @@ async function load() {
       const ts = allEntries[0].ts;
       document.getElementById('stat-last').textContent = ts
         ? new Date(ts).toLocaleString('en-GB', {hour:'2-digit',minute:'2-digit',second:'2-digit',day:'2-digit',month:'short'})
-        : '—';
+        : 'n/a';
     }
 
     // Update notice: check if persistent (file-backed) by seeing if log survived restart
@@ -560,7 +560,7 @@ function render() {
     var ts  = e.ts;
     var time = ts
       ? new Date(ts).toLocaleString('en-GB', {hour:'2-digit',minute:'2-digit',second:'2-digit',day:'2-digit',month:'short'})
-      : '—';
+      : 'n/a';
     var leaf   = trunc(e.leaf_hash   || e.hash || '');
     var tree   = trunc(e.tree_hash   || e.merkle_root || '');
     var device = trunc(e.device_hash || e.pubkey_hash  || '');
@@ -580,17 +580,17 @@ function render() {
       + '</div>'
       + '<div class="entry-detail" id="d-'+gi+'">'
       + (e.type ? '<div class="drow"><span class="dkey">Type</span><span class="dval">'+esc(e.type)+'</span></div>' : '')
-      + '<div class="drow"><span class="dkey">Leaf hash</span><span class="dval">'+esc(e.leaf_hash||'—')+'</span></div>'
-      + '<div class="drow"><span class="dkey">Tree hash</span><span class="dval">'+esc(e.tree_hash||'—')+'</span></div>'
-      + '<div class="drow"><span class="dkey">Device hash</span><span class="dval">'+esc(e.device_hash||'—')+'</span></div>'
+      + '<div class="drow"><span class="dkey">Leaf hash</span><span class="dval">'+esc(e.leaf_hash||'n/a')+'</span></div>'
+      + '<div class="drow"><span class="dkey">Tree hash</span><span class="dval">'+esc(e.tree_hash||'n/a')+'</span></div>'
+      + '<div class="drow"><span class="dkey">Device hash</span><span class="dval">'+esc(e.device_hash||'n/a')+'</span></div>'
       + '<div class="drow"><span class="dkey">Index</span><span class="dval">'+esc(String(idx))+'</span></div>'
-      + '<div class="drow"><span class="dkey">Timestamp</span><span class="dval">'+(ts ? esc(new Date(ts).toISOString()) : '—')+'</span></div>'
+      + '<div class="drow"><span class="dkey">Timestamp</span><span class="dval">'+(ts ? esc(new Date(ts).toISOString()) : 'n/a')+'</span></div>'
       + proofHtml
       + '</div>';
   }).join('');
 }
 
-function trunc(h) { return h ? h.slice(0,20)+'…' : '—'; }
+function trunc(h) { return h ? h.slice(0,20)+'…' : 'n/a'; }
 
 function toggle(i) {
   var el = document.getElementById('d-'+i);
@@ -657,10 +657,10 @@ function verifyHash() {
     + '<pre>'
     + 'Matched field : ' + esc(field) + '\n'
     + 'Index         : ' + esc(String(match.index)) + '\n'
-    + 'Leaf hash     : ' + esc(match.leaf_hash||'—') + '\n'
-    + 'Tree hash     : ' + esc(match.tree_hash||'—') + '\n'
-    + 'Device hash   : ' + esc(match.device_hash||'—') + '\n'
-    + 'Timestamp     : ' + (match.ts ? esc(new Date(match.ts).toISOString()) : '—') + '\n'
+    + 'Leaf hash     : ' + esc(match.leaf_hash||'n/a') + '\n'
+    + 'Tree hash     : ' + esc(match.tree_hash||'n/a') + '\n'
+    + 'Device hash   : ' + esc(match.device_hash||'n/a') + '\n'
+    + 'Timestamp     : ' + (match.ts ? esc(new Date(match.ts).toISOString()) : 'n/a') + '\n'
     + (match.proof && match.proof.length ? 'Merkle proof  : ' + esc(match.proof.join(' → ')) : '')
     + '</pre>';
 }
@@ -688,11 +688,11 @@ async function loadRelays() {
 
     document.getElementById('rstat-count').textContent = relays.length || '0';
     var sectors = [...new Set(relays.map(function(r){return r.sector;}))];
-    document.getElementById('rstat-sectors').textContent = sectors.join(', ') || '—';
+    document.getElementById('rstat-sectors').textContent = sectors.join(', ') || 'n/a';
     var latest = relays.reduce(function(a,b){ return (b.last_seen > a) ? b.last_seen : a; }, '');
     document.getElementById('rstat-last').textContent = latest
       ? new Date(latest).toLocaleString('en-GB', {hour:'2-digit',minute:'2-digit',day:'2-digit',month:'short'})
-      : '—';
+      : 'n/a';
 
     if (relays.length === 0) {
       el.innerHTML = '<div class="empty-state"><div class="big">📡</div>'
@@ -705,14 +705,14 @@ async function loadRelays() {
     el.innerHTML = relays.map(function(relay) {
       var since = relay.verified_since
         ? new Date(relay.verified_since).toLocaleString('en-GB', {hour:'2-digit',minute:'2-digit',day:'2-digit',month:'short',year:'2-digit'})
-        : '—';
+        : 'n/a';
       var last = relay.last_seen
         ? new Date(relay.last_seen).toLocaleString('en-GB', {hour:'2-digit',minute:'2-digit',day:'2-digit',month:'short',year:'2-digit'})
-        : '—';
+        : 'n/a';
       var urlShort = esc(relay.url.replace(/^https?:\/\//, ''));
       return '<div class="relay-row">'
         + '<div class="url" title="' + esc(relay.url) + '">' + urlShort + '</div>'
-        + '<div class="cell green">' + esc(relay.sector || '—') + '</div>'
+        + '<div class="cell green">' + esc(relay.sector || 'n/a') + '</div>'
         + '<div class="cell">v' + esc(relay.version || '?') + '</div>'
         + '<div class="cell">' + esc(relay.edition || 'community') + '</div>'
         + '<div class="cell dim" title="CT log index ' + esc(String(relay.ct_index ?? '')) + '">' + since + '</div>'

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -423,7 +423,7 @@ curl -X POST https://health.paramant.app/v2/inbound \
   -H "Content-Type: application/json" \
   -d '{"hash":"sha256_of_payload","payload":"base64_5mb_blob","ttl_ms":3600000}'
 
-<span class="cm"># Retrieve (one-time — blob is burned after this)</span>
+<span class="cm"># Retrieve (one-time: blob is burned after this)</span>
 curl https://health.paramant.app/v2/outbound/abc123... \
   -H "X-Api-Key: pgp_your_key" -o received.bin</pre>
     </div>
@@ -470,10 +470,10 @@ gp = GhostPipe(
     sector  = "health",     <span class="cm"># routes to health.paramant.app</span>
 )
 
-<span class="cm"># Send — returns blob hash</span>
+<span class="cm"># Send: returns blob hash</span>
 hash_ = gp.send(open("scan.dcm", "rb").read(), ttl=3600)
 
-<span class="cm"># Receive — burn-on-read, returns plaintext bytes</span>
+<span class="cm"># Receive: burn-on-read, returns plaintext bytes</span>
 data = gp.receive(hash_)</pre>
     </div>
 
@@ -493,7 +493,7 @@ hash_, proof = gp.send(open("scan.dcm","rb").read(), ttl=3600)</pre></div>
     <h3><span class="sector-badge">legal</span>Legal &amp; Notary: eIDAS, KNB</h3>
     <p>Send signed deeds and court documents that are cryptographically gone after receipt. The CT log provides tamper-evident proof of delivery without storing content.</p>
     <div class="cb"><div class="cb-header"><div class="cb-dots"><span class="cb-dot"></span><span class="cb-dot"></span><span class="cb-dot"></span></div><span class="cb-lang">python</span></div>
-    <pre><span class="cm"># Signed deed — burn-on-read, CT log entry as proof of delivery</span>
+    <pre><span class="cm"># Signed deed: burn-on-read, CT log entry as proof of delivery</span>
 from paramant_sdk import GhostPipe
 gp = GhostPipe(api_key="pgp_xxx", device="notary-01", sector="legal")
 hash_, receipt = gp.send(open("deed.pdf","rb").read())
@@ -502,7 +502,7 @@ gp.verify_receipt(receipt)  <span class="cm"># ML-DSA-65 signed</span></pre></di
     <h3><span class="sector-badge">iot</span>Industrial IoT: IEC 62443</h3>
     <p>PLC and sensor data relay without VPN or direct OT internet exposure. Acts as a post-quantum data diode: OT side pushes outbound only, IT side receives. Fixed 5 MB padding defeats traffic analysis.</p>
     <div class="cb"><div class="cb-header"><div class="cb-dots"><span class="cb-dot"></span><span class="cb-dot"></span><span class="cb-dot"></span></div><span class="cb-lang">python</span></div>
-    <pre><span class="cm"># PLC telemetry — outbound only, no VPN, no inbound port</span>
+    <pre><span class="cm"># PLC telemetry: outbound only, no VPN, no inbound port</span>
 from paramant_sdk import GhostPipe
 gp = GhostPipe(api_key="pgp_xxx", device="plc-factory-01", sector="iot")
 while True:
@@ -524,9 +524,9 @@ hash_, receipt = gp.send(open("pacs008.xml","rb").read())
     <h2 id="endpoints">All endpoints</h2>
     <table>
       <tr><th>Method</th><th>Endpoint</th><th>Description</th><th>Auth</th></tr>
-      <tr><td><span class="method get">GET</span></td><td>/health</td><td>Node status, version, uptime, edition</td><td>—</td></tr>
+      <tr><td><span class="method get">GET</span></td><td>/health</td><td>Node status, version, uptime, edition</td><td>n/a</td></tr>
       <tr><td><span class="method post">POST</span></td><td>/v2/inbound</td><td>Upload encrypted blob from an authenticated client (RAM-only)</td><td>Key</td></tr>
-      <tr><td><span class="method post">POST</span></td><td>/v2/anon-inbound</td><td>Deprecated. Anonymous upload retained for sdk-js 3.x backward compatibility; removed in a future major release. New integrations must use <code>/v2/inbound</code>.</td><td>—</td></tr>
+      <tr><td><span class="method post">POST</span></td><td>/v2/anon-inbound</td><td>Deprecated. Anonymous upload retained for sdk-js 3.x backward compatibility; removed in a future major release. New integrations must use <code>/v2/inbound</code>.</td><td>n/a</td></tr>
       <tr><td><span class="method get">GET</span></td><td>/v2/outbound/:hash</td><td>Download + burn: one retrieval only</td><td>Key</td></tr>
       <tr><td><span class="method get">GET</span></td><td>/v2/status/:hash</td><td>Check blob availability without consuming</td><td>Key</td></tr>
       <tr><td><span class="method post">POST</span></td><td>/v2/ack</td><td>Confirm delivery, log latency to CT</td><td>Key</td></tr>
@@ -535,11 +535,11 @@ hash_, receipt = gp.send(open("pacs008.xml","rb").read())
       <tr><td><span class="method get">GET</span></td><td>/v2/stream</td><td>WebSocket push: blob_ready events</td><td>Ticket / Key</td></tr>
       <tr><td><span class="method post">POST</span></td><td>/v2/webhook</td><td>Register delivery webhook URL</td><td>Key</td></tr>
       <tr><td><span class="method post">POST</span></td><td>/v2/pubkey</td><td>Register ML-KEM + ECDH keypair</td><td>Key</td></tr>
-      <tr><td><span class="method get">GET</span></td><td>/v2/check-key</td><td>Verify key validity and plan</td><td>—</td></tr>
+      <tr><td><span class="method get">GET</span></td><td>/v2/check-key</td><td>Verify key validity and plan</td><td>n/a</td></tr>
       <tr><td><span class="method post">POST</span></td><td>/v2/did/register</td><td>Register W3C Decentralized Identity</td><td>Key</td></tr>
-      <tr><td><span class="method get">GET</span></td><td>/v2/did/:did</td><td>Resolve DID document</td><td>—</td></tr>
-      <tr><td><span class="method get">GET</span></td><td>/v2/ct/log</td><td>Certificate Transparency log (public)</td><td>—</td></tr>
-      <tr><td><span class="method get">GET</span></td><td>/v2/relays</td><td>Registered relay nodes and status</td><td>—</td></tr>
+      <tr><td><span class="method get">GET</span></td><td>/v2/did/:did</td><td>Resolve DID document</td><td>n/a</td></tr>
+      <tr><td><span class="method get">GET</span></td><td>/v2/ct/log</td><td>Certificate Transparency log (public)</td><td>n/a</td></tr>
+      <tr><td><span class="method get">GET</span></td><td>/v2/relays</td><td>Registered relay nodes and status</td><td>n/a</td></tr>
       <tr><td><span class="method get">GET</span></td><td>/v2/audit</td><td>Merkle audit chain: JSON + CSV export</td><td>Key</td></tr>
       <tr><td><span class="method get">GET</span></td><td>/v2/team/devices</td><td>List team devices</td><td>Key</td></tr>
       <tr><td><span class="method post">POST</span></td><td>/v2/team/add-device</td><td>Add device to team (Pro+)</td><td>Key</td></tr>
@@ -572,12 +572,12 @@ X-Api-Key: pgp_xxx
     <p>WebSocket endpoint for real-time <code>blob_ready</code> push notifications. Use a one-time ticket to avoid exposing the key in the URL.</p>
     <div class="cb">
       <div class="cb-header"><div class="cb-dots"><span class="cb-dot"></span><span class="cb-dot"></span><span class="cb-dot"></span></div><span class="cb-lang">javascript</span></div>
-      <pre><span class="cm">// Step 1 — get a one-time WebSocket ticket (30s TTL)</span>
+      <pre><span class="cm">// Step 1: get a one-time WebSocket ticket (30s TTL)</span>
 const { ticket } = await fetch('https://health.paramant.app/v2/ws-ticket', {
   method: 'POST', headers: { 'X-Api-Key': 'pgp_xxx' }
 }).then(r => r.json());
 
-<span class="cm">// Step 2 — connect with ticket (API key never appears in URL)</span>
+<span class="cm">// Step 2: connect with ticket (API key never appears in URL)</span>
 const ws = new WebSocket(`wss://health.paramant.app/v2/stream?ticket=${ticket}`);
 ws.onmessage = e => {
   const msg = JSON.parse(e.data);
@@ -645,7 +645,7 @@ curl http://localhost:3000/health
       <tr><td>relay-finance</td><td>127.0.0.1:3002</td><td>finance</td><td>finance.your-domain.com</td></tr>
       <tr><td>relay-legal</td><td>127.0.0.1:3003</td><td>legal</td><td>legal.your-domain.com</td></tr>
       <tr><td>relay-iot</td><td>127.0.0.1:3004</td><td>iot</td><td>iot.your-domain.com</td></tr>
-      <tr><td>admin</td><td>127.0.0.1:4200</td><td>—</td><td>your-domain.com/admin/</td></tr>
+      <tr><td>admin</td><td>127.0.0.1:4200</td><td>n/a</td><td>your-domain.com/admin/</td></tr>
     </table>
 
     <h3>Key .env variables</h3>
@@ -749,10 +749,10 @@ docker compose up -d --build
       <tr><td>paramant-admin</td><td>Manage users, keys, and relay config</td></tr>
       <tr><td>paramant-scan</td><td>Discover relay nodes on the network</td></tr>
     </table>
-    <pre><span class="cm"># Example — send a file and wait for ACK</span>
+    <pre><span class="cm"># Example: send a file and wait for ACK</span>
 paramant-send --key pgp_xxx --sector health --ack scan.dcm
 
-<span class="cm"># Example — stream mode (process persists, receives all blobs)</span>
+<span class="cm"># Example: stream mode (process persists, receives all blobs)</span>
 paramant-stream --key pgp_xxx --sector health --forward https://pacs.hospital/api</pre>
 
     <!-- ── ParamantOS CLI tools ───────────────────────────────────── -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="theme-color" content="#0B3A6A">
-<title>PARAMANT &mdash; Encrypted File Relay. Burn on Read.</title>
+<title>PARAMANT · Encrypted File Relay. Burn on Read.</title>
 <meta name="description" content="Post-quantum encrypted file relay. ML-KEM-768 + ML-DSA-65. Burn-on-read. EU/DE. Send files, sign documents, deploy your own.">
 <meta property="og:title" content="Paramant · Encrypted file relay">
 <meta property="og:description" content="Post-quantum encrypted file relay. Burn on read. EU/DE.">
@@ -27,7 +27,7 @@
 <link rel="stylesheet" href="/parapear.css?v=1">
 <link rel="stylesheet" href="/components-parasign.css?v=3">
 <style>
-/* Homepage — compact 50/50 launchpad. Existing design tokens + classes only;
+/* Homepage: compact 50/50 launchpad. Existing design tokens + classes only;
    design-system.css, nav.css and nav.js are untouched. */
 .home-hero { text-align: center; max-width: 64ch; margin: 0 auto; padding: var(--space-5) var(--space-4) var(--space-3); }
 .home-hero h1 { font-size: clamp(30px, 5.2vw, 50px); line-height: 1.05; letter-spacing: -0.025em; color: var(--navy); margin: 0 0 var(--space-3); }
@@ -56,7 +56,7 @@
 .home-act-ghost:hover { border-color: var(--navy); background: var(--bone); }
 .home-hi-name { color: var(--cobalt); }
 
-/* ── Homepage panel animations — now the centrepiece of each panel: a larger,
+/* ── Homepage panel animations: now the centrepiece of each panel: a larger,
    centred "screen" playing the loop, so the security is felt, not read. Pure
    CSS keyframes (no JS, CSP-safe), ~10s loops, deep-navy base with lime
    (#B2FF3F) on the "it works" beats. prefers-reduced-motion shows a static
@@ -69,8 +69,8 @@
 .path-anim text { font-family: var(--mono); font-weight: 600; letter-spacing: -.02em; }
 @media (max-width: 760px) { .path-anim { width: clamp(200px, 70vw, 280px); } }
 
-/* LEFT — two pillars in one loop: (1) SIGN the document (ML-DSA-65 curve →
-   "✓ signed"), then (2) SEND it — encrypt flicker → through the relay's RAM →
+/* LEFT: two pillars in one loop: (1) SIGN the document (ML-DSA-65 curve →
+   "✓ signed"), then (2) SEND it: encrypt flicker → through the relay's RAM →
    to the recipient → "✓ delivered · burn-on-read". ~10s. Base state
    (reduced-motion) = a signed document under the SIGN label. */
 .l-sig { stroke-dasharray: 66; stroke-dashoffset: 0; }
@@ -107,7 +107,7 @@
 @keyframes l-recv { 0%, 66% { opacity: .28; } 74% { opacity: 1; } 93% { opacity: 1; } 100% { opacity: .28; } }
 @keyframes l-delivered { 0%, 76% { opacity: 0; transform: translateY(2px); } 84% { opacity: 1; transform: translateY(0); } 93% { opacity: 1; } 100% { opacity: 0; } }
 
-/* RIGHT — a terminal cycling through three of the ten CLI tools, ~10s loop,
+/* RIGHT: a terminal cycling through three of the ten CLI tools, ~10s loop,
    one tool block at a time: type the command, show the ✓ result, hold, next.
    Base state (reduced-motion) = the first tool block, no typing, static caret. */
 .cli { position: relative; font-family: var(--mono); font-size: clamp(5.6px, 0.86vw, 7px); line-height: 1.6; color: #cfe0f2; padding: 9px 9px; height: 100%; box-sizing: border-box; letter-spacing: -.02em; }


### PR DESCRIPTION
Per "include the dashes": the last visible `—` placeholders are gone, so the site is em-dash free.

- **crypto-agility, docs**: `<td>—</td>` N/A table cells → `n/a`
- **ct-log**: stat-card + JS fallback `—` placeholders → `n/a` (verified nothing compares against `—`, display-only)
- **docs**: the nine shell/JS comment em-dashes in `<pre>` examples → `:`
- **index**: browser `<title>` `&mdash;` → `·`, plus CSS-comment dashes

Only the literal `<code>—</code>` in the changelog bug entry stays (it *describes* a `—` being shown). `nav.css` / `design-system.css` untouched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)