### PR TITLE
feat(vs): surface document signing + link /vs from the homepage

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -145,6 +145,9 @@
 /* ── ParaRules band: our policy, stated as the differentiator. Existing tokens
    only; light ground, hairline grid, lime eyebrow + a "signature" underline on
    the link. design-system.css / nav.css untouched. ── */
+.home-compare { text-align: center; max-width: 1040px; margin: calc(-1 * var(--space-2)) auto var(--space-6); padding: 0 var(--space-4); font-size: 14px; color: var(--ink-dim); }
+.home-compare a { color: var(--navy); border-bottom: 1px solid var(--lime); padding-bottom: 2px; text-decoration: none; }
+.home-compare a:hover { color: var(--cobalt); }
 .home-rules { max-width: 1040px; margin: 0 auto var(--space-7); padding: var(--space-6) var(--space-4) 0; border-top: 1px solid var(--ink-hair); }
 .rules-intro { text-align: center; max-width: 60ch; margin: 0 auto var(--space-5); }
 .rules-eyebrow { display: inline-flex; align-items: center; gap: 10px; margin: 0 0 var(--space-3); font-family: var(--mono); font-size: 11px; letter-spacing: .16em; text-transform: uppercase; color: var(--ink-dim); }
@@ -422,6 +425,8 @@
     </div>
   </div>
 </section>
+
+<p class="home-compare">Weighing the options? <a href="/vs">See how Paramant compares to Zivver, Tresorit, WeTransfer and SFTP &rarr;</a></p>
 
 <section class="home-rules" aria-labelledby="rules-h">
   <div class="rules-intro">

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -525,6 +525,11 @@
           <td class="cobalt-text">Paramant</td>
           <td>BUSL-1.1, Docker, Raspberry Pi capable</td>
         </tr>
+        <tr>
+          <td class="strong">Post-quantum document signing and co-signing</td>
+          <td class="cobalt-text">Paramant</td>
+          <td>ML-DSA-65 signatures in the browser, multi-party co-sign, public CT log</td>
+        </tr>
       </tbody>
     </table>
   </div>
@@ -538,7 +543,7 @@
       <div class="tag" style="color:rgba(248,250,252,.72)">architecture<br/>matters</div>
     </div>
 
-    <p style="color:var(--bone);max-width:720px">Paramant occupies a specific position. It is a post-quantum encrypted file relay with RAM-only storage, burn-on-read delivery, and public cryptographic transparency. It is not a cloud storage product, not an email plugin, and not a DLP platform.</p>
+    <p style="color:var(--bone);max-width:720px">Paramant occupies a specific position. It is a post-quantum encrypted file relay and document-signing service, with RAM-only storage, burn-on-read delivery, and public cryptographic transparency. It is not a cloud storage product, not an email plugin, and not a DLP platform.</p>
 
     <p style="color:var(--bone);max-width:720px;margin-top:16px">For organizations that need the combination of EU data sovereignty (without US ownership), post-quantum cryptography (today, not roadmap), zero-knowledge architecture (mathematically, not by policy), and the option to self-host, Paramant is presently the only option in this category.</p>
 


### PR DESCRIPTION
Closes the two open /vs items.

**Out of date → signing was missing.** /vs compared only file transfer and omitted Paramant's flagship **post-quantum document signing**. Added where it is a Paramant strength, **without asserting anything about competitors**:
- "When to choose what" table: a `post-quantum document signing and co-signing` → **Paramant** row (ML-DSA-65, multi-party co-sign, public CT log).
- Positioning prose: Paramant is now "a post-quantum encrypted file relay **and document-signing service**".

**Homepage mention** (you flagged /vs as important to surface): a small *"Weighing the options? See how Paramant compares to Zivver, Tresorit, WeTransfer and SFTP →"* line above the ParaRules band, linking `/vs`.

Competitor data left untouched (verified historical facts; I do not guess at competitor specifics). `nav.css` / `design-system.css` untouched.

Note: `/vs` row 387 still says "ParaSend" for the public-link send feature — possibly stale naming (vs "ParaShare"/"Send"), left as-is since I could not confirm the canonical name. Flag if you want it changed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)