### PR TITLE
feat(developer): make Configure and Run-in-browser actually work

### DIFF
--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -79,6 +79,23 @@ main.dev{max-width:1180px;margin:0 auto;padding:var(--space-5) var(--space-4) va
 .dev-btn[disabled]{opacity:.6}
 .dev-link{font-family:var(--mono);font-size:11px;color:#1D4ED8;text-decoration:none}
 .dev-link:hover{text-decoration:underline}
+/* enabled action buttons + the configure command-builder modal */
+.dev-btn-go{cursor:pointer;color:var(--navy);border-color:var(--ink-hair);background:#fff;transition:all .12s ease}
+.dev-btn-go:hover{border-color:#B2FF3F;background:rgba(178,255,63,.08);color:#0B3A6A}
+.dev-modal{position:fixed;inset:0;background:rgba(11,58,106,.45);display:flex;align-items:center;justify-content:center;padding:20px;z-index:1000}
+.dev-modal[hidden]{display:none}
+.dev-modal-card{background:#fff;border-radius:14px;max-width:560px;width:100%;padding:24px 26px;position:relative;box-shadow:0 20px 60px rgba(11,58,106,.25);max-height:88vh;overflow:auto}
+.dev-modal-x{position:absolute;top:12px;right:15px;border:none;background:none;font-size:22px;line-height:1;color:var(--ink-dim);cursor:pointer}
+.dev-modal-card h3{font-size:15px;font-weight:700;color:var(--navy);margin:0 0 4px;font-family:var(--mono)}
+.dev-modal-tag{font-size:13px;color:var(--ink-dim);margin:0 0 14px}
+.dev-modal-run{display:inline-block;font-family:var(--mono);font-size:12px;color:#0B3A6A;background:#B2FF3F;padding:8px 14px;border-radius:8px;text-decoration:none;margin:0 0 16px}
+.dev-step{margin-bottom:13px}
+.dev-step-h{display:flex;justify-content:space-between;align-items:center;font-family:var(--mono);font-size:11px;letter-spacing:.04em;color:var(--ink-dim);margin-bottom:5px}
+.dev-copy{border:1px solid var(--ink-hair);background:#fff;font-family:var(--mono);font-size:10px;padding:3px 9px;border-radius:6px;color:var(--navy);cursor:pointer}
+.dev-copy:hover{border-color:#B2FF3F}
+.dev-pre,.dev-run{font-family:var(--mono);font-size:11.5px;background:#0a1626;color:#cfe0f2;border:none;border-radius:8px;padding:11px 13px;width:100%;box-sizing:border-box;overflow-x:auto;white-space:pre-wrap;word-break:break-all;margin:0}
+.dev-run{resize:vertical;line-height:1.5}
+.dev-modal-src{font-family:var(--mono);font-size:11px;color:#1D4ED8;text-decoration:none}
 
 /* Section 4: Operations */
 .ops{display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-4);align-items:start}
@@ -176,13 +193,34 @@ main.dev{max-width:1180px;margin:0 auto;padding:var(--space-5) var(--space-4) va
   </section>
 
   <div class="wip">
-    <b>Operations dashboard · read-only.</b> Action capabilities (run, configure, new keys) arrive with self-service keys (account-schema steps 4&ndash;5).
+    <b>Operations dashboard.</b> Configure builds a ready-to-run command for any tool; transfer and signing tools run in your browser. Generating additional self-service API keys arrives with account-schema steps 4 and 5.
     Tools show live status from your activity; per-run stats appear once tool runs are logged to your audit trail.
     Source: <a href="https://github.com/Apolloccrypt/paramant-solutions" target="_blank" rel="noopener">github.com/Apolloccrypt/paramant-solutions</a>
   </div>
 </main>
 
+<div id="dev-modal" class="dev-modal" hidden role="dialog" aria-modal="true" aria-labelledby="dev-m-title">
+  <div class="dev-modal-card">
+    <button type="button" class="dev-modal-x" data-m="close" aria-label="Close">&times;</button>
+    <h3 id="dev-m-title" data-m="title">Configure</h3>
+    <p class="dev-modal-tag" data-m="tag"></p>
+    <a class="dev-modal-run" data-m="browser" hidden href="#">Run in your browser</a>
+    <div class="dev-step">
+      <div class="dev-step-h"><span>1 &middot; Install</span><button type="button" class="dev-copy" data-copy="install">copy</button></div>
+      <pre class="dev-pre" data-m="install"></pre>
+    </div>
+    <div class="dev-step">
+      <div class="dev-step-h"><span>2 &middot; Your API key (as an env var)</span><button type="button" class="dev-copy" data-copy="key">copy</button></div>
+      <pre class="dev-pre" data-m="key"></pre>
+    </div>
+    <div class="dev-step">
+      <div class="dev-step-h"><span>3 &middot; Run (edit the parameters)</span><button type="button" class="dev-copy" data-copy="run">copy</button></div>
+      <textarea class="dev-run" data-m="run" rows="2" spellcheck="false" aria-label="Run command"></textarea>
+    </div>
+    <a class="dev-modal-src" data-m="source" href="#" target="_blank" rel="noopener">View source &#8599;</a>
+  </div>
+</div>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/developer.js?v=1" defer></script>
+<script src="/js/developer.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/js/developer.js
+++ b/frontend/js/developer.js
@@ -26,6 +26,20 @@
 
   var STATE = { tools: [], status: {}, key: '', filter: '', feed: [] };
 
+  // Which tools can genuinely run in the browser: those whose input is a local
+  // file (transfer + sign). The rest need server-side data (an S3 object, your
+  // database, a Docker volume), so an in-browser run is impossible -- we say so
+  // honestly and point at Configure for the ready-to-run command.
+  function browserFlow(cat) {
+    if (cat === 'transfer') return { url: '/parashare', label: 'Send a file in your browser' };
+    if (cat === 'sign')     return { url: '/sign',      label: 'Sign a file in your browser' };
+    return null;
+  }
+  function serverReason(cat) {
+    var needs = { migrate: 'an S3 object or a Docker volume on your host', backup: 'your database', replicate: 'your database', sync: 'your local secrets', archive: 'your git repo', ship: 'your build output or logs' };
+    return 'Runs on your machine: it needs ' + (needs[cat] || 'access to your infrastructure') + '. Use Configure for the ready-to-run command.';
+  }
+
   /* ---------- render ---------- */
   function renderHeader(d) {
     var e = document.querySelector('[data-dv="email"]'); if (e) e.textContent = d.email || '—';
@@ -67,14 +81,18 @@
         : '<div class="tool-stats"><span>last <b>' + fmtAgo(st.last_run) + '</b></span>' +
             (st.success_rate != null ? '<span><b>' + st.success_rate + '%</b> ok/wk</span>' : '') +
             (st.avg_ms != null ? '<span>avg <b>' + fmtDur(st.avg_ms) + '</b></span>' : '') + '</div>';
+      var flow = browserFlow(t.category);
+      var runBtn = flow
+        ? '<button class="dev-btn dev-btn-go" data-run="' + esc(flow.url) + '" title="' + esc(flow.label) + '">Run in browser</button>'
+        : '<button class="dev-btn" disabled title="' + esc(serverReason(t.category)) + '">Run in browser</button>';
       return '<div class="dev-card tool">' +
         '<div class="tool-top"><div class="tool-icon">' + toolIcon(t.category) + '</div>' +
         '<div><div class="tool-name">' + esc(t.name) + '</div>' +
         '<span class="tool-status ' + (st.state === 'never_used' ? '' : st.state) + '"><span class="sd"></span>' + statusTxt + '</span></div></div>' +
         '<p class="tool-tag">' + esc(t.tagline) + '</p>' + statsHtml +
         '<div class="tool-actions">' +
-          '<button class="dev-btn" disabled title="Available with self-service keys (coming)">Run in browser</button>' +
-          '<button class="dev-btn" disabled title="Available with self-service keys (coming)">Configure</button>' +
+          runBtn +
+          '<button class="dev-btn dev-btn-go" data-config="' + esc(t.name) + '">Configure</button>' +
           '<a class="dev-link" href="' + esc(t.source) + '" target="_blank" rel="noopener">View source ↗</a>' +
         '</div></div>';
     }).join('');
@@ -157,6 +175,50 @@
 
   /* filter */
   var fi = $('#tl-filter'); if (fi) fi.addEventListener('input', function () { STATE.filter = fi.value; getJSON('/api/user/developer/snapshot').then(function (d) { renderTimeline(d.audit || []); }).catch(function () {}); });
+
+  /* ---------- tool actions: run-in-browser + the configure modal ---------- */
+  if (elTools) {
+    elTools.addEventListener('click', function (ev) {
+      var run = ev.target.closest && ev.target.closest('[data-run]');
+      if (run) { window.location.href = run.getAttribute('data-run'); return; }
+      var cfg = ev.target.closest && ev.target.closest('[data-config]');
+      if (cfg) { openConfig(cfg.getAttribute('data-config')); }
+    });
+  }
+  function openConfig(name) {
+    var t = null, i;
+    for (i = 0; i < STATE.tools.length; i++) { if (STATE.tools[i].name === name) { t = STATE.tools[i]; break; } }
+    var modal = document.getElementById('dev-modal');
+    if (!t || !modal) return;
+    var key = STATE.key || '';
+    var run = (t.usage || '').replace('{KEY}', key || 'pgp_YOUR_KEY');
+    modal.querySelector('[data-m="title"]').textContent = 'Configure ' + t.name;
+    modal.querySelector('[data-m="tag"]').textContent = t.tagline || '';
+    modal.querySelector('[data-m="install"]').textContent = t.install || '';
+    modal.querySelector('[data-m="key"]').textContent = 'export PARAMANT_API_KEY=' + (key || '<reveal it in the API keys panel>');
+    modal.querySelector('[data-m="run"]').value = run;
+    modal.querySelector('[data-m="source"]').setAttribute('href', t.source || '#');
+    var bf = browserFlow(t.category), rib = modal.querySelector('[data-m="browser"]');
+    if (rib) { if (bf) { rib.hidden = false; rib.setAttribute('href', bf.url); rib.textContent = '▶ ' + bf.label + ' →'; } else { rib.hidden = true; } }
+    modal.hidden = false;
+  }
+  (function wireModal() {
+    var modal = document.getElementById('dev-modal');
+    if (!modal) return;
+    function close() { modal.hidden = true; }
+    modal.addEventListener('click', function (ev) {
+      if (ev.target === modal || (ev.target.closest && ev.target.closest('[data-m="close"]'))) { close(); return; }
+      var c = ev.target.closest && ev.target.closest('[data-copy]');
+      if (!c) return;
+      var src = modal.querySelector('[data-m="' + c.getAttribute('data-copy') + '"]');
+      if (!src) return;
+      var text = (src.tagName === 'TEXTAREA' || src.tagName === 'INPUT') ? src.value : src.textContent;
+      if (navigator.clipboard && text) {
+        navigator.clipboard.writeText(text).then(function () { var o = c.textContent; c.textContent = 'copied'; setTimeout(function () { c.textContent = o; }, 1200); }).catch(function () {});
+      }
+    });
+    document.addEventListener('keydown', function (ev) { if (ev.key === 'Escape' && !modal.hidden) close(); });
+  })();
 
   /* ---------- boot ---------- */
   function boot() {


### PR DESCRIPTION
## /developer tool actions, implemented (frontend-only)

The **Run in browser** and **Configure** buttons were greyed out "until self-service keys (account-schema steps 4–5)". But they don't actually need that backend: the API key (`/api/user/account/key`), the tool metadata (`/api/user/developer/tools`) and the browser flows (`/parashare`, `/sign`) all already exist. So this wires real behaviour, no relay/admin change.

### Configure (all 11 tools)
Opens a **command-builder modal**:
1. **Install** command (copy)
2. **Your API key** as `export PARAMANT_API_KEY=…` (copy)
3. **Run** command with the key filled in and the **parameters editable** (copy)

Plus a "run in your browser" shortcut inside the modal for browser-capable tools, and a View-source link.

### Run in browser
Honest about what a browser can actually do:
- **transfer** (`dev-transfer`) → `/parashare`, **signing** (`package-sign`) → `/sign` — the real in-browser flows.
- The **nine server-side tools** (S3, database, Docker, …) can't run in a browser — they need data on your host. Instead of a dead button, they now say so (`Runs on your machine: it needs your database. Use Configure for the command.`) and Configure gives the exact command.

### Notes
- Footer updated; the **`+ New key`** button still needs the self-service-keys backend (account-schema steps 4 and 5) and stays disabled.
- **CSP-safe** (external `/js/developer.js` only, no inline). `nav.css` / `design-system.css` untouched. `developer.js?v=2`.
- `/developer` is gated, so blast radius is the allowlisted dev account(s). Frontend-only.

Live-test and tell me to retune (which tools map to which flow, the modal copy, etc.).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)