### PR TITLE
feat: account-setup UX — passkey-first numbered wizard (PR-1, frontend-only)

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -60,7 +60,7 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -143,7 +143,7 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -243,7 +243,7 @@
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -313,7 +313,7 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
   <div class="acct-grid2">
     <div class="acct-block">
       <h3>Authenticator app</h3>
-      <p>Connected. Algorithm: SHA-1, 30 seconds, 6 digits.</p>
+      <p>Connected. Algorithm: SHA-256, 30 seconds, 6 digits.</p>
       <button type="button" class="btn btn-secondary btn-small" id="reset-totp">Set up a new authenticator</button>
       <p class="small mt-2">Invalidates current TOTP. You will need to scan a new QR code.</p>
     </div>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -138,7 +138,7 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -221,7 +221,7 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -250,7 +250,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -333,7 +333,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -830,7 +830,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -107,7 +107,7 @@ section p+p{margin-top:14px}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -190,7 +190,7 @@ section p+p{margin-top:14px}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -331,7 +331,7 @@ section p+p{margin-top:14px}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Set up authenticator — Paramant</title>
+<title>Set up your account · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -166,32 +166,34 @@
 <main class="container-lg">
 
 <section class="section-lg">
-  <div class="eyebrow"><span class="bar"></span>account setup</div>
-  <h1>Scan the <em>QR code</em>.</h1>
+  <div class="eyebrow"><span class="bar"></span>step 3 of 5</div>
+  <h1>Choose how you <em>sign in</em>.</h1>
   <p class="lede">
-    One-time setup. Your authenticator app will generate 6-digit codes every 30 seconds.
+    Pick one. You can add the other later. This is the only real choice in setup.
   </p>
 </section>
 
-<!-- Start state (scanner-safe: no POST until user clicks) -->
+<!-- Step 3: pick a sign-in method. Passkey is recommended; the authenticator
+     route stays scanner-safe (no POST until the user clicks "instead"). -->
 <section id="state-loading" class="section">
-  <div class="marker">
-    <div class="num">&#8594;</div>
-    <h2>Ready to set up.</h2>
-    <div class="tag">starts<br>here</div>
-  </div>
-  <p class="lede" style="margin-top:16px">
-    Click the button below to generate your QR code and begin setup.
-  </p>
-  <div class="cta-row" style="margin-top:24px">
-    <button type="button" class="btn btn-primary" id="start-btn">Start setup</button>
+  <div class="card" style="border-left:3px solid #B2FF3F">
+    <div style="font-weight:600;color:var(--navy);margin-bottom:6px">Use a passkey &middot; Recommended</div>
+    <p style="margin:0 0 16px">
+      A passkey is like a key only your device has. You unlock it with your
+      fingerprint, face, or device PIN. Nothing to remember, nothing to type.
+      Best if you mostly use one phone or laptop.
+    </p>
+    <button type="button" class="btn btn-primary" id="passkey-register-btn">Set up a passkey</button>
+    <p id="passkey-status" class="small" aria-live="polite"></p>
   </div>
 
-  <div style="margin-top:28px">
-    <p class="small">Prefer a passkey? Use Face ID, Touch ID, Windows Hello, or a
-       security key &mdash; no authenticator app, and nothing to type at login.</p>
-    <button type="button" class="btn btn-secondary" id="passkey-register-btn">Set up a passkey instead</button>
-    <p id="passkey-status" class="small" aria-live="polite"></p>
+  <div class="card mt-3">
+    <div style="font-weight:600;color:var(--navy);margin-bottom:6px">Use an authenticator app</div>
+    <p style="margin:0 0 16px">
+      An app on your phone shows a fresh 6-digit code every 30 seconds. You type
+      that code to sign in. Good if you switch between many devices.
+    </p>
+    <button type="button" class="btn btn-secondary" id="start-btn">Use an authenticator app instead</button>
   </div>
 </section>
 
@@ -219,42 +221,25 @@
 
 <!-- Active setup -->
 <section id="state-active" class="section hidden">
-<div class="app-warning" role="alert">
-  <div class="app-warning__title">Google Authenticator, Microsoft Authenticator, and iCloud Keychain will NOT work.</div>
-  <p class="app-warning__body">Paramant uses SHA-256 TOTP. These apps only support SHA-1. If you scan this QR with them, every code you enter will fail at login &mdash; even when the code looks correct.</p>
-  <div class="app-warning__grid">
-    <div class="app-warning__no">Google Authenticator</div>
-    <div class="app-warning__yes">Authy</div>
-    <div class="app-warning__no">Microsoft Authenticator</div>
-    <div class="app-warning__yes">1Password</div>
-    <div class="app-warning__no">iCloud Keychain</div>
-    <div class="app-warning__yes">Aegis (Android)</div>
-    <div></div>
-    <div class="app-warning__yes">Raivo (iOS)</div>
-    <div></div>
-    <div class="app-warning__yes">Bitwarden &middot; Ente Auth &middot; 2FAS</div>
-  </div>
-  <a class="app-warning__link" href="/help/authenticator-apps">Why we use SHA-256 &rarr;</a>
-</div>
-
+  <div class="eyebrow"><span class="bar"></span>step 4 of 5</div>
   <div class="marker">
     <div class="num">01</div>
-    <h2>Scan with your authenticator.</h2>
-    <div class="tag">one-time<br>setup</div>
+    <h2>Add Paramant to your authenticator app.</h2>
+    <div class="tag">scan or<br>type the key</div>
   </div>
 
   <div class="setup-grid">
     <div class="qr-card">
       <div id="qr-code"></div>
       <p class="qr-caption">
-        Point your authenticator app at this code.
+        Open your authenticator app and scan this code.
       </p>
     </div>
 
     <div class="setup-info">
       <div class="info-row">
         <div class="info-label">Account</div>
-        <div class="info-value" id="setup-email">&mdash;</div>
+        <div class="info-value" id="setup-email">your account</div>
       </div>
 
       <div class="info-row">
@@ -263,17 +248,28 @@
       </div>
 
       <div class="info-row">
-        <div class="info-label">Manual entry</div>
+        <div class="info-label">Can't scan?</div>
         <div class="info-value">
-          <code class="secret-display" id="secret-display">&mdash;</code>
+          <code class="secret-display" id="secret-display">your key</code>
           <button type="button" class="btn btn-small btn-secondary" id="copy-secret">Copy</button>
         </div>
         <p class="small mt-2">
-          Use this if scanning fails. Enter it manually in your authenticator app.
+          Enter this key by hand in your authenticator app instead.
         </p>
       </div>
     </div>
   </div>
+
+  <details class="mt-4" style="border:1px solid var(--ink-hair,#E2E8F0);border-radius:6px;padding:14px 18px">
+    <summary style="cursor:pointer;font-weight:600;color:var(--navy)">Which apps work?</summary>
+    <p class="small mt-2" style="margin-bottom:0">
+      Paramant uses the stronger SHA-256 standard, so a few popular apps won't work. These do:
+      Raivo or 2FAS (iPhone), Aegis (Android), 1Password, Bitwarden, Authy, or Ente Auth.
+      Google Authenticator and Microsoft Authenticator do <strong>not</strong> work yet,
+      because they only support the older SHA-1 standard. If you have one of those, pick any app above instead.
+      <a href="/help/authenticator-apps">Why we use SHA-256</a>.
+    </p>
+  </details>
 </section>
 
 <!-- Verify -->
@@ -300,36 +296,39 @@
 
 <!-- Success + backup codes -->
 <section id="state-success" class="section hidden">
+  <div class="eyebrow"><span class="bar"></span>step 5 of 5</div>
   <div class="marker">
-    <div class="num">03</div>
-    <h2>Save your backup codes.</h2>
-    <div class="tag">one-time<br>display</div>
+    <div class="num">02</div>
+    <h2>Save your emergency codes.</h2>
+    <div class="tag">shown<br>once</div>
   </div>
 
   <div class="warning-box">
     <strong>Shown once. Save them now.</strong>
     <p>
-      Each code can be used exactly once to sign in without your authenticator. Save them in a password manager, print them, or store in a secure note.
+      These one-time codes get you back in if you ever lose your authenticator or your phone. We can't recover them for you, so keep them safe.
     </p>
   </div>
 
   <div id="backup-codes" class="backup-grid"></div>
 
   <div class="cta-row mt-3">
-    <button type="button" class="btn btn-secondary" id="copy-codes">Copy all</button>
-    <button type="button" class="btn btn-secondary" id="download-codes">Download .txt</button>
-    <button type="button" class="btn btn-secondary" id="print-codes">Print</button>
+    <button type="button" class="btn btn-primary" id="download-codes">Download my codes</button>
   </div>
+  <p class="small mt-2">
+    or <button type="button" id="copy-codes" style="background:none;border:none;color:#1D4ED8;font-weight:600;cursor:pointer;text-decoration:underline;padding:0;font:inherit">copy them</button>
+    &middot; <button type="button" id="print-codes" style="background:none;border:none;color:#1D4ED8;font-weight:600;cursor:pointer;text-decoration:underline;padding:0;font:inherit">print</button>
+  </p>
 
   <div class="form-checkbox mt-4">
     <input type="checkbox" id="saved-confirm">
     <label for="saved-confirm">
-      I have saved my backup codes in a safe place.
+      I have saved my codes somewhere safe.
     </label>
   </div>
 
   <button type="button" class="btn btn-primary mt-3" id="finish-btn" disabled>
-    Continue to dashboard
+    Finish setup
   </button>
 </section>
 
@@ -354,6 +353,27 @@
   </div>
 
   <button type="button" class="btn btn-primary mt-3" id="passkey-finish-btn">Continue to dashboard</button>
+</section>
+
+<!-- Welcome: a finish line, not another task. Shown after the TOTP route's
+     "Finish setup". (The passkey route's Continue still lands on /dashboard via
+     passkey.js; aligning it to this screen is a small follow-up: a passkey.js
+     edit + a site-wide passkey.js ?v= bump.) -->
+<section id="state-welcome" class="section hidden">
+  <div class="eyebrow"><span class="bar"></span>all set</div>
+  <h2>You're all set.</h2>
+  <p class="lede">What would you like to do first?</p>
+  <div class="grid2 mt-3">
+    <a href="/parashare" class="card" style="border-left:3px solid #B2FF3F;text-decoration:none;display:block">
+      <div style="font-weight:600;color:var(--navy);margin-bottom:6px">Send a file</div>
+      <p class="small" style="margin:0">Encrypt and send something, private end to end.</p>
+    </a>
+    <a href="/sign" class="card" style="text-decoration:none;display:block">
+      <div style="font-weight:600;color:var(--navy);margin-bottom:6px">Sign a document</div>
+      <p class="small" style="margin:0">Add your legally-binding signature to a PDF.</p>
+    </a>
+  </div>
+  <p class="small mt-3">You can always come back to this from your <a href="/dashboard">dashboard</a>.</p>
 </section>
 
 </main>
@@ -489,7 +509,8 @@
   });
 
   document.getElementById('finish-btn').addEventListener('click', function() {
-    window.location = '/dashboard';
+    show('state-welcome');
+    window.scrollTo(0, 0);
   });
 
   document.getElementById('start-btn').addEventListener('click', function() {

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -151,7 +151,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -234,7 +234,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -404,7 +404,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -82,7 +82,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -165,7 +165,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -370,7 +370,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -197,7 +197,7 @@ section h2{display:flex;align-items:baseline;gap:11px}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -280,7 +280,7 @@ section h2{display:flex;align-items:baseline;gap:11px}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -671,7 +671,7 @@ FLAGS    1 byte    reserved for future features</pre>
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -243,7 +243,7 @@ body { min-height:100vh; }
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -326,7 +326,7 @@ body { min-height:100vh; }
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -759,7 +759,7 @@ setInterval(load, 30000);
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -181,7 +181,7 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -264,7 +264,7 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -456,7 +456,7 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -195,7 +195,7 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -278,7 +278,7 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -609,7 +609,7 @@ paramant-receiver.py \
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -181,7 +181,7 @@ tr:last-child td{border-bottom:none}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -264,7 +264,7 @@ tr:last-child td{border-bottom:none}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -1055,7 +1055,7 @@ window.addEventListener('scroll', () => {
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -121,7 +121,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -204,7 +204,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -158,7 +158,7 @@ input:focus{border-color:var(--cobalt)}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -241,7 +241,7 @@ input:focus{border-color:var(--cobalt)}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -457,7 +457,7 @@ input:focus{border-color:var(--cobalt)}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -179,7 +179,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -262,7 +262,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -485,7 +485,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -207,7 +207,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -290,7 +290,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -619,7 +619,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -107,7 +107,7 @@ section p+p{margin-top:14px}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -190,7 +190,7 @@ section p+p{margin-top:14px}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -334,7 +334,7 @@ section p+p{margin-top:14px}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -166,7 +166,7 @@ section p+p{margin-top:14px}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -249,7 +249,7 @@ section p+p{margin-top:14px}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -520,7 +520,7 @@ section p+p{margin-top:14px}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -200,7 +200,7 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -283,7 +283,7 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -478,7 +478,7 @@
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -107,7 +107,7 @@ section p+p{margin-top:14px}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -190,7 +190,7 @@ section p+p{margin-top:14px}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -321,7 +321,7 @@ section p+p{margin-top:14px}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -138,7 +138,7 @@ footer a{color:var(--cobalt)}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -221,7 +221,7 @@ footer a{color:var(--cobalt)}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -368,7 +368,7 @@ Website: https://paramant.app</div>
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -107,7 +107,7 @@ section p+p{margin-top:14px}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -190,7 +190,7 @@ section p+p{margin-top:14px}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -322,7 +322,7 @@ section p+p{margin-top:14px}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -153,7 +153,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -236,7 +236,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -396,7 +396,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/ot-vs-data-diodes.html
+++ b/frontend/ot-vs-data-diodes.html
@@ -120,7 +120,7 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -203,7 +203,7 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -610,7 +610,7 @@
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -180,7 +180,7 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -263,7 +263,7 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -527,7 +527,7 @@ Level 1  Field devices  ──────────────────�
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/pararules.html
+++ b/frontend/pararules.html
@@ -148,7 +148,7 @@ footer a{color:var(--ink);text-decoration:none}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -231,7 +231,7 @@ footer a{color:var(--ink);text-decoration:none}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -366,7 +366,7 @@ footer a{color:var(--ink);text-decoration:none}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -290,7 +290,7 @@ select:focus{border-color:var(--cobalt)}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -373,7 +373,7 @@ select:focus{border-color:var(--cobalt)}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -1513,7 +1513,7 @@ function updateGlobeTransfer(userLat, userLng) {
         <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
         <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
         <a href="/docs#self-hosting">Deploy guide</a>
-        <a href="/setup">Setup wizard</a>
+        <a href="/setup">Relay setup wizard</a>
         <a href="/install.sh">install.sh</a>
         <a href="/install-pi.sh">install-pi.sh</a>
         <a href="/download">ParamantOS</a>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -100,7 +100,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -183,7 +183,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -303,7 +303,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -162,7 +162,7 @@ td{color:var(--cobalt)}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -245,7 +245,7 @@ td{color:var(--cobalt)}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -423,7 +423,7 @@ td{color:var(--cobalt)}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -147,7 +147,7 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -230,7 +230,7 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -476,7 +476,7 @@
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -147,7 +147,7 @@ footer a{color:var(--ink);text-decoration:none}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -230,7 +230,7 @@ footer a{color:var(--ink);text-decoration:none}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -388,7 +388,7 @@ footer a{color:var(--ink);text-decoration:none}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/quantum-urgency.html
+++ b/frontend/quantum-urgency.html
@@ -120,7 +120,7 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -203,7 +203,7 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -481,7 +481,7 @@
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -106,7 +106,7 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -189,7 +189,7 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -298,7 +298,7 @@
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -170,7 +170,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -253,7 +253,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -553,7 +553,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -183,7 +183,7 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -266,7 +266,7 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -593,7 +593,7 @@
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -4,16 +4,16 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Create account — Paramant</title>
-<meta name="description" content="Create a Paramant account. No password. Authenticator app required.">
+<title>Create account · Paramant</title>
+<meta name="description" content="Create a Paramant account. No password. Sign in with a passkey or an authenticator app.">
 <meta property="og:title" content="Create account · Paramant">
-<meta property="og:description" content="Create a Paramant account. No password. Authenticator app required.">
+<meta property="og:description" content="Create a Paramant account. No password. Sign in with a passkey or an authenticator app.">
 <meta property="og:url" content="https://paramant.app/signup">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Create account · Paramant">
-<meta name="twitter:description" content="Create a Paramant account. No password. Authenticator app required.">
+<meta name="twitter:description" content="Create a Paramant account. No password. Sign in with a passkey or an authenticator app.">
 <link rel="canonical" href="https://paramant.app/signup">
 <meta name="robots" content="index, follow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -270,98 +270,39 @@
 </div>
 
 <section class="section-lg">
-  <div class="eyebrow"><span class="bar"></span>create account</div>
-  <h1>Set up your <em>Paramant</em> account.</h1>
+  <div class="eyebrow"><span class="bar"></span>step 1 of 5</div>
+  <h1>Let's create your <em>account</em>.</h1>
   <p class="lede">
-    Three minutes. No password to create or remember.
+    We'll send a link to confirm it's you. No password to invent.
   </p>
 </section>
 
 <section class="section">
-  <div class="marker">
-    <div class="num">01</div>
-    <h2>What you get.</h2>
-    <div class="tag">three things<br>in one account</div>
-  </div>
-
-  <div class="grid2">
-    <div class="card">
-      <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px;color:var(--navy)">
-        Email + authenticator login
-      </div>
-      <p style="margin:0">
-        Sign in with your email address and a 6-digit code from your authenticator app. One hour session. Works on paramant.app and in the Gmail/Outlook extensions.
-      </p>
-    </div>
-
-    <div class="card">
-      <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px;color:var(--navy)">
-        API key for automation
-      </div>
-      <p style="margin:0">
-        Same account can be used from scripts, SDKs, and IoT devices. Your API key is visible in your account after setup. No TOTP required for headless use.
-      </p>
-    </div>
-
-    <div class="card">
-      <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px;color:var(--navy)">
-        10 backup codes
-      </div>
-      <p style="margin:0">
-        Single-use recovery codes in case you lose your authenticator app. Shown once during setup. Save them in a password manager or print them.
-      </p>
-    </div>
-
-    <div class="card">
-      <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px;color:var(--navy)">
-        No password
-      </div>
-      <p style="margin:0">
-        We do not store passwords. There is nothing to forget, reset, or phish. What we do not have, we cannot leak.
-      </p>
-    </div>
-  </div>
-</section>
-
-<section class="section">
-  <div class="marker">
-    <div class="num">02</div>
-    <h2>Create your account.</h2>
-    <div class="tag">one field<br>to start</div>
-  </div>
-
   <div id="already-signed-in" hidden style="margin:24px 0;padding:16px;background:rgba(178,255,63,0.1);border-left:3px solid #B2FF3F;">
-  <p style="margin:0;">
-    You are already signed in as <strong id="already-email"></strong>.
-    <a href="/account" style="color:#1D4ED8;font-weight:600;">Go to your account</a>
-    or <button type="button" id="already-signout" style="background:none;border:none;color:#991b1b;font-weight:600;cursor:pointer;text-decoration:underline;">sign out first</button>.
-  </p>
-</div>
+    <p style="margin:0;">
+      You are already signed in as <strong id="already-email"></strong>.
+      <a href="/account" style="color:#1D4ED8;font-weight:600;">Go to your account</a>
+      or <button type="button" id="already-signout" style="background:none;border:none;color:#991b1b;font-weight:600;cursor:pointer;text-decoration:underline;">sign out first</button>.
+    </p>
+  </div>
 
-<form id="signup-form" class="form-card" novalidate>
+  <form id="signup-form" class="form-card" novalidate>
     <label for="email">Email address</label>
     <input type="email" id="email" name="email" required autocomplete="email"
-           placeholder="you@example.com">
+           placeholder="you@work.com">
 
-    <label for="label" class="mt-3">Label (optional)</label>
+    <label for="label" class="mt-3">Label <span style="font-weight:400;color:var(--ink-dim,#64748b)">(optional)</span></label>
     <input type="text" id="label" name="label" autocomplete="organization"
-           placeholder="Acme Legal, Ward 3A, Home Lab, etc.">
-    <p class="small mt-2">
-      A short descriptor that appears in your account. Not shown to recipients.
+           placeholder="Acme Legal, Ward 3A, Home Lab">
+    <p class="small mt-2">A short name for this account. Only you see it.</p>
+
+    <p class="small mt-3">
+      By continuing you agree to our <a href="/dpa" target="_blank">Data Processing Agreement</a>
+      and <a href="/privacy" target="_blank">privacy policy</a>. We store as little as possible and never sell data.
     </p>
 
-    <div class="form-checkbox mt-3">
-      <input type="checkbox" id="dpa-accept" required>
-      <label for="dpa-accept">
-        I accept the
-        <a href="/dpa" target="_blank">Data Processing Agreement</a>
-        and
-        <a href="/privacy" target="_blank">privacy policy</a>.
-      </label>
-    </div>
-
     <button type="submit" class="btn btn-primary mt-3" id="submit-btn">
-      Send setup email
+      Continue
     </button>
 
     <div id="error" class="error"></div>
@@ -369,36 +310,23 @@
   </form>
 
   <p class="footer-text mt-4">
-    Already have an account? <a href="/auth/login">Sign in</a><br>
-    
+    Already have an account? <a href="/auth/login">Sign in</a>
   </p>
 </section>
 
-<section class="section">
-  <div class="marker">
-    <div class="num">03</div>
-    <h2>What happens next.</h2>
-    <div class="tag">four steps<br>three minutes</div>
-  </div>
-
-  <ol class="numbered-list">
-    <li>
-      <strong>We email you a setup link.</strong>
-      Valid for 14 days, one time use. Check your inbox within a minute.
-    </li>
-    <li>
-      <strong>Click the link, scan a QR code.</strong>
-      In your authenticator app: Raivo (iOS), Aegis (Android), 1Password, Bitwarden, Authy, Ente Auth, or 2FAS. <strong>Not</strong> Google or Microsoft Authenticator &mdash; those only support SHA-1.
-    </li>
-    <li>
-      <strong>Enter the first 6-digit code to confirm.</strong>
-      Your account becomes active.
-    </li>
-    <li>
-      <strong>Save your backup codes.</strong>
-      10 single-use codes for recovery. Shown once.
-    </li>
-  </ol>
+<section class="section" id="step2" hidden>
+  <div class="eyebrow"><span class="bar"></span>step 2 of 5</div>
+  <h2>Check your inbox.</h2>
+  <p class="lede">
+    We sent a confirmation link to <strong id="step2-email"></strong>. Open it to continue.
+    If you can, open it on this device so setup stays in one place.
+  </p>
+  <p class="small mt-3">
+    Didn't get it? Check spam, or
+    <button type="button" id="resend-btn" style="background:none;border:none;color:#1D4ED8;font-weight:600;cursor:pointer;text-decoration:underline;padding:0;font:inherit;">resend the link</button>.
+  </p>
+  <p class="small mt-2" id="resend-status" aria-live="polite"></p>
+  <p class="small mt-3" style="color:var(--ink-dim,#64748b)">The link works for 14 days.</p>
 </section>
 
 </main>
@@ -410,78 +338,68 @@
 (function() {
   const form = document.getElementById('signup-form');
   const errorDiv = document.getElementById('error');
-  const successDiv = document.getElementById('success');
   const submitBtn = document.getElementById('submit-btn');
+  const step2 = document.getElementById('step2');
+
+  // Shared signup call: invisible PoW, then POST. Throws {kind,...} on failure;
+  // callers own their own button/status so both the email form and the Step-2
+  // "resend" reuse it. dpa_accepted is true because continuing IS the agreement
+  // (the DPA is a line-with-link now, not a blocking checkbox).
+  async function doSignup(email, label, onProgress) {
+    let proof;
+    try { proof = await ParamantCaptcha.getCaptchaProof(onProgress || function(){}); }
+    catch (_) { throw { kind: 'captcha' }; }
+    const res = await fetch('/api/user/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, label, dpa_accepted: true, challenge_id: proof.challenge_id, nonce: proof.nonce }),
+    });
+    if (!res.ok) { const err = await res.json().catch(() => ({})); throw { kind: 'http', status: res.status, err }; }
+  }
+
+  function showError(e) {
+    if (e && e.kind === 'captcha') { errorDiv.textContent = 'Verification failed. Please try again.'; }
+    else if (e && e.kind === 'http') {
+      if (e.status === 403) errorDiv.textContent = 'Verification failed. Please refresh and try again.';
+      else if (e.status === 409) errorDiv.innerHTML = 'An account with this email already exists. <a href="/auth/login">Sign in</a>.';
+      else if (e.status === 422) errorDiv.textContent = 'This email domain is not accepted. Please use a real email address.';
+      else if (e.status === 429) errorDiv.textContent = 'Too many attempts. Please try again later.';
+      else errorDiv.textContent = (e.err && e.err.message) || 'Something went wrong. Please try again.';
+    } else { errorDiv.textContent = 'Network error. Please check your connection.'; }
+    errorDiv.classList.add('visible');
+  }
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     errorDiv.classList.remove('visible');
-    successDiv.classList.remove('visible');
-    submitBtn.disabled = true;
-    submitBtn.textContent = 'Sending...';
-
     const email = document.getElementById('email').value.trim();
     const label = document.getElementById('label').value.trim();
-    const dpa = document.getElementById('dpa-accept').checked;
-
-    if (!email || !dpa) {
-      errorDiv.textContent = 'Please fill in email and accept the DPA.';
-      errorDiv.classList.add('visible');
-      submitBtn.disabled = false;
-      submitBtn.textContent = 'Send setup email';
-      return;
-    }
-
+    if (!email) { errorDiv.textContent = 'Please enter your email address.'; errorDiv.classList.add('visible'); return; }
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Verifying…';
     try {
-      // Solve PoW challenge (invisible to user, ~1-2s)
-      let proof;
-      try {
-        submitBtn.textContent = 'Verifying…';
-        proof = await ParamantCaptcha.getCaptchaProof(n => {
-          submitBtn.textContent = 'Verifying… (' + (n / 1000).toFixed(0) + 'k)';
-        });
-      } catch (_) {
-        errorDiv.textContent = 'Verification failed. Please try again.';
-        errorDiv.classList.add('visible');
-        submitBtn.disabled = false;
-        submitBtn.textContent = 'Send setup email';
-        return;
-      }
-
-      const res = await fetch('/api/user/signup', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, label, dpa_accepted: true, challenge_id: proof.challenge_id, nonce: proof.nonce }),
-      });
-
-      if (res.ok) {
-        successDiv.innerHTML = '<strong>Check your inbox.</strong> We sent a verification link to ' +
-          email + '. Click it to activate your account. The link expires in 24 hours.';
-        successDiv.classList.add('visible');
-        form.style.display = 'none';
-      } else {
-        const err = await res.json().catch(() => ({}));
-        if (res.status === 403) {
-          errorDiv.textContent = 'Verification failed. Please refresh and try again.';
-        } else if (res.status === 409) {
-          errorDiv.innerHTML = 'An account with this email already exists. <a href="/auth/login">Sign in</a>.';
-        } else if (res.status === 422) {
-          errorDiv.textContent = 'This email domain is not accepted. Please use a real email address.';
-        } else if (res.status === 429) {
-          errorDiv.textContent = 'Too many attempts. Please try again later.';
-        } else {
-          errorDiv.textContent = err.message || 'Something went wrong. Please try again.';
-        }
-        errorDiv.classList.add('visible');
-        submitBtn.disabled = false;
-        submitBtn.textContent = 'Send setup email';
-      }
-    } catch (err) {
-      errorDiv.textContent = 'Network error. Please check your connection.';
-      errorDiv.classList.add('visible');
+      await doSignup(email, label, n => { submitBtn.textContent = 'Verifying… (' + (n / 1000).toFixed(0) + 'k)'; });
+      document.getElementById('step2-email').textContent = email;
+      form.style.display = 'none';
+      step2.hidden = false;
+      step2.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    } catch (e2) {
+      showError(e2);
       submitBtn.disabled = false;
-      submitBtn.textContent = 'Send setup email';
+      submitBtn.textContent = 'Continue';
     }
+  });
+
+  const resendBtn = document.getElementById('resend-btn');
+  if (resendBtn) resendBtn.addEventListener('click', async () => {
+    const status = document.getElementById('resend-status');
+    const email = document.getElementById('email').value.trim();
+    if (!email) return;
+    resendBtn.disabled = true;
+    status.style.color = ''; status.textContent = 'Sending…';
+    try { await doSignup(email, document.getElementById('label').value.trim()); status.textContent = 'Sent. Check your inbox again.'; }
+    catch (_) { status.style.color = 'var(--danger, #b91c1c)'; status.textContent = 'Could not resend. Try again in a moment.'; }
+    finally { resendBtn.disabled = false; }
   });
 })();
 </script>
@@ -516,7 +434,7 @@
   var map = {
     expired_token: {
       t: 'Your account is already active',
-      m: 'You\'ve already verified this email. <a href="/auth/login" style="background:#1D4ED8;color:#fff;padding:6px 14px;border-radius:4px;text-decoration:none;font-weight:600;display:inline-block;margin:6px 0">Sign in &rarr;</a> <br><span style="color:#78350F;font-size:13px">Need to finish authenticator setup? Look for the email <code>Complete your Paramant account setup</code> in your inbox. Use a SHA-256 app like Raivo (iOS), Aegis (Android), 1Password, Bitwarden, Authy, Ente Auth, or 2FAS &mdash; <strong>not</strong> Google or Microsoft Authenticator.</span>'
+      m: 'You\'ve already verified this email. <a href="/auth/login" style="background:#1D4ED8;color:#fff;padding:6px 14px;border-radius:4px;text-decoration:none;font-weight:600;display:inline-block;margin:6px 0">Sign in</a> <br><span style="color:#78350F;font-size:13px">Still finishing setup? Look for the email <code>Complete your Paramant account setup</code> in your inbox and open the link to continue.</span>'
     },
     invalid_token: {
       t: 'Verification link not recognised',

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -131,7 +131,7 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -214,7 +214,7 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -157,7 +157,7 @@ a:hover{opacity:.8}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -240,7 +240,7 @@ a:hover{opacity:.8}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -451,7 +451,7 @@ a:hover{opacity:.8}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -132,7 +132,7 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -215,7 +215,7 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -596,7 +596,7 @@
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -114,7 +114,7 @@ section p+p{margin-top:14px}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -197,7 +197,7 @@ section p+p{margin-top:14px}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -435,7 +435,7 @@ section p+p{margin-top:14px}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -170,7 +170,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -253,7 +253,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -351,7 +351,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -185,7 +185,7 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -268,7 +268,7 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -506,7 +506,7 @@ docker compose build   # build locally instead of pulling the published image</c
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -62,7 +62,7 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -145,7 +145,7 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -266,7 +266,7 @@
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -120,7 +120,7 @@
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -203,7 +203,7 @@
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -587,7 +587,7 @@
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -107,7 +107,7 @@ section p+p{margin-top:14px}
       <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
       <ul class="nav-dropdown-menu" role="menu">
         <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Setup wizard</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
         <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
@@ -190,7 +190,7 @@ section p+p{margin-top:14px}
     <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
     <div class="nav-mobile-group-items">
       <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Setup wizard</a>
+      <a href="/setup">Relay setup wizard</a>
       <a href="/install.sh">install.sh</a>
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
@@ -338,7 +338,7 @@ section p+p{margin-top:14px}
         <div class="footer-col-label">Self-host</div>
         <div class="footer-links">
           <a href="/docs#self-hosting">Deploy guide</a>
-          <a href="/setup">Setup wizard</a>
+          <a href="/setup">Relay setup wizard</a>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>


### PR DESCRIPTION
## Account-setup UX, PR-1 (frontend-only) — the copydeck-approved wizard

Makes the signup→first-use flow legible for a complete beginner. Built on the
auth-ux base already in main (#156). The functional signing-key change is **PR-2**
(separate, per your "extra zorg"). Copy = the deck you approved.

### Commits
1. `feat(signup)` — **Step 1/2**: marketing wall → "Step 1 of 5" one email field, DPA as a line-with-link (no blocking checkbox), "Step 2 of 5" check-inbox with resend. **Bug 1 fixed:** success said link "expires in 24 hours" but the real `setup_token` TTL is **14 days** (`EX: 14*86400`) → harmonised. Meta "Authenticator app required" → "passkey or an authenticator app". JS contract preserved (signup POST unchanged; `dpa_accepted:true` since continuing is the agreement).
2. `fix(account)` — **Bug 2:** TOTP card label `SHA-1` → `SHA-256` (it enforces SHA-256).
3. `ux(nav)` — **Bug 3:** the `/setup` nav link `Setup wizard` → `Relay setup wizard`, site-wide (43 files, 126 labels: dropdown + mobile drawer), so a beginner doesn't mistake the self-host relay wizard for account setup. Text-only; nav structure/CSS untouched.
4. `feat(setup)` — **Step 3-5 + welcome**, the heart:
   - **Step 3** "Choose how you sign in" leads with a **passkey (Recommended)** + plain-language explanation; authenticator app is the calm alternative. (Was authenticator-first, passkey as "instead".)
   - **Step 4** the **SHA-256 incompatibility moved from a red alert wall into a collapsed "Which apps work?" expander**, shown only on the authenticator route.
   - **Step 5** one prominent **"Download my codes"**; copy/print are quiet text actions. Friendlier "we can't recover them" copy.
   - **Welcome** finish-line "What would you like to do first? Send a file / Sign a document".

### Naming (throughout)
"Passkey" = signing in only; "signing key" = signing a document (PR-2 enforces the latter in the enrol screen). No "signing passkey".

### Verification
- **Every JS-contract id preserved** (signup form ids; setup state machine + `#start-btn`/`#passkey-register-btn`/`#qr-code`/`#verify-form`/`#backup-codes`/`#finish-btn`; new `#state-welcome`). State machine + `passkey.js` untouched.
- **cache-bust guard green**, no asset links changed; em-dashes out (incl. titles).
- **Screenshots, screen for screen** (rendered via headless chromium): `/tmp/setup-ux-shots/1-signup-step1.png … 6-setup-welcome.png`. I visually verified Step 3 (passkey-first, lime "Recommended") and Step 4 (the "Which apps work?" expander, no red wall) render correctly and on-brand. (Steps 4/5/welcome shots show the prior state above the target — a static-injection artifact; the real page hides it via `show()`.)

### Honest disclosures
- The **passkey route's "Continue" still lands on `/dashboard`** (wired in `passkey.js`); routing it to the new welcome screen needs a `passkey.js` edit + a site-wide `passkey.js ?v=` bump — a small **follow-up**, kept out of this PR to avoid that churn.
- **PR-2 (next, functional):** the `signing-enrol.js` inline-TOTP refactor with the agreed **two-entry** design (replay protection means one code can't gate both server calls), verified wiring + your on-device enrol test.

**Do not merge / do not deploy** — frontend-only; deploys via webroot rsync after your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
