### PR TITLE
feat(signing): inline TOTP enrol (two-entry), replacing the 3 window.prompt popups (PR-2)

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -358,6 +358,14 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
       <h3>Enrolled keys</h3>
       <p style="margin:0 0 12px" id="signing-empty" class="small">Checking your account...</p>
       <ul id="signing-list" style="margin:0;padding:0;list-style:none"></ul>
+      <div id="revoke-totp-wrap" hidden style="margin-top:10px;padding:12px 14px;border:1px solid var(--ink-hair,#E2E8F0);border-radius:6px">
+        <p class="small" style="margin:0 0 8px">Enter your 6-digit authenticator code to revoke this signing key.</p>
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+          <input type="text" id="revoke-totp" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code" placeholder="6-digit code" style="max-width:140px">
+          <button type="button" class="btn btn-small" id="revoke-totp-confirm">Confirm revoke</button>
+          <button type="button" class="btn btn-small btn-secondary" id="revoke-totp-cancel">Cancel</button>
+        </div>
+      </div>
     </div>
     <div class="acct-block">
       <h3>Browser vault</h3>
@@ -369,17 +377,27 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
   <div class="acct-block">
     <h3>Set up your signing key</h3>
     <p class="small">
-      Creates your ML-DSA-65 signing key in this browser, unlocked with Face ID /
-      Touch ID / a security key when you sign. The passphrase is your recovery floor &mdash;
-      we never see it and cannot reset it, so store it safely. Adding a signing key needs
-      your authenticator code.
+      A signing key is what makes your signature legally yours. It is created here, in this
+      browser, with ML-DSA-65 (post-quantum), and only you hold it. It is separate from how
+      you sign in. You confirm with Face ID, Touch ID, or a security key when you sign.
     </p>
     <div class="acct-field">
       <input type="text" id="signing-enrol-label" maxlength="40" placeholder="Label (optional, e.g. iPhone)" autocomplete="off">
-      <input type="password" id="signing-enrol-pass" placeholder="Recovery passphrase (min 12 characters)" autocomplete="new-password">
+      <input type="password" id="signing-enrol-pass" placeholder="Choose a passphrase (min 12 characters)" autocomplete="new-password">
+      <div id="signing-enrol-strength" class="small" aria-live="polite" style="margin:2px 0 0"></div>
       <input type="password" id="signing-enrol-pass2" placeholder="Confirm passphrase" autocomplete="new-password">
-      <div>
-        <button type="button" class="btn btn-primary btn-small" id="signing-enrol-btn">Set up signing</button>
+      <p class="small" style="margin:6px 0 0"><strong>Write this down.</strong> If you forget this passphrase and lose this browser, your signing key is gone for good. We can't reset it.</p>
+
+      <div id="signing-enrol-totp-wrap" hidden style="margin-top:12px;padding:12px 14px;border:1px solid var(--ink-hair,#E2E8F0);border-radius:6px">
+        <p id="signing-enrol-totp-prompt" class="small" style="margin:0 0 8px"></p>
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+          <input type="text" id="signing-enrol-totp" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code" placeholder="6-digit code" style="max-width:140px">
+          <button type="button" class="btn btn-primary btn-small" id="signing-enrol-totp-confirm">Confirm</button>
+        </div>
+      </div>
+
+      <div style="margin-top:10px">
+        <button type="button" class="btn btn-primary btn-small" id="signing-enrol-btn">Create my signing key</button>
       </div>
     </div>
     <p id="signing-enrol-status" class="small" aria-live="polite" style="margin-top:8px"></p>
@@ -714,10 +732,24 @@ async function loadEnrolledKeys() {
   }
 }
 
+function askRevokeTotp() {
+  return new Promise((resolve) => {
+    const wrap = document.getElementById('revoke-totp-wrap');
+    const input = document.getElementById('revoke-totp');
+    const ok = document.getElementById('revoke-totp-confirm');
+    const cancel = document.getElementById('revoke-totp-cancel');
+    if (!wrap || !input || !ok || !cancel) { resolve((window.prompt('Enter your 6-digit authenticator code to revoke this signing key.') || '').trim()); return; }
+    input.value = ''; wrap.hidden = false; input.focus();
+    const done = (v) => { ok.removeEventListener('click', onOk); cancel.removeEventListener('click', onCancel); input.removeEventListener('keydown', onKey); wrap.hidden = true; resolve(v); };
+    const onOk = () => { const t = (input.value || '').trim(); if (!/^\d{6}$/.test(t)) { input.focus(); return; } done(t); };
+    const onCancel = () => done('');
+    const onKey = (e) => { if (e.key === 'Enter') { e.preventDefault(); onOk(); } if (e.key === 'Escape') onCancel(); };
+    ok.addEventListener('click', onOk); cancel.addEventListener('click', onCancel); input.addEventListener('keydown', onKey);
+  });
+}
 async function revokeKey(pkHash) {
-  const totp = window.prompt('Revoke this signing key?\n\nEnter your 6-digit TOTP code to confirm.');
+  const totp = await askRevokeTotp();
   if (!totp) return;
-  if (!/^\d{6}$/.test(totp)) { alert('TOTP must be 6 digits.'); return; }
   try {
     const res = await fetch('/api/user/account/signing-key', {
       method: 'DELETE',
@@ -758,7 +790,7 @@ loadVaultStatus();
 document.addEventListener('signing-key-enrolled', () => { loadEnrolledKeys(); loadVaultStatus(); });
 </script>
 <script type="module" src="/js/passkey.js?v=3"></script>
-<script type="module" src="/js/signing-enrol.js?v=4"></script>
+<script type="module" src="/js/signing-enrol.js?v=5"></script>
 
 </body>
 </html>

--- a/frontend/js/signing-enrol.js
+++ b/frontend/js/signing-enrol.js
@@ -31,10 +31,41 @@ async function postJSON(url, body) {
   return { ok: r.ok, status: r.status, data };
 }
 
+// Inline TOTP entry (replaces window.prompt). The enrol makes TWO TOTP-gated
+// server calls (register-options, then bind-public-key) with the passkey
+// ceremony between them, and the relay replay-protects codes (relay.js
+// _usedTotpCodes + replayKey, 90s), so ONE code cannot gate both — the user
+// enters a fresh code each time, in this one inline field, no browser pop-ups.
+// Returns a Promise of the 6-digit string; a bad value re-prompts inline rather
+// than throwing.
 function askTotp(message) {
-  const t = (window.prompt(message) || '').trim();
-  if (!/^\d{6}$/.test(t)) throw new Error('A 6-digit authenticator code is required.');
-  return t;
+  return new Promise((resolve) => {
+    const wrap = document.getElementById('signing-enrol-totp-wrap');
+    const input = document.getElementById('signing-enrol-totp');
+    const confirmBtn = document.getElementById('signing-enrol-totp-confirm');
+    const promptEl = document.getElementById('signing-enrol-totp-prompt');
+    if (!wrap || !input || !confirmBtn || !promptEl) {
+      throw new Error('A 6-digit authenticator code is required.');   // rejects the promise
+    }
+    promptEl.textContent = message;
+    input.value = '';
+    wrap.hidden = false;
+    input.focus();
+    const finish = (val) => {
+      confirmBtn.removeEventListener('click', onConfirm);
+      input.removeEventListener('keydown', onKey);
+      wrap.hidden = true;
+      resolve(val);
+    };
+    const onConfirm = () => {
+      const t = (input.value || '').trim();
+      if (!/^\d{6}$/.test(t)) { promptEl.textContent = 'Enter the 6-digit code from your authenticator app.'; input.focus(); return; }
+      finish(t);
+    };
+    const onKey = (e) => { if (e.key === 'Enter') { e.preventDefault(); onConfirm(); } };
+    confirmBtn.addEventListener('click', onConfirm);
+    input.addEventListener('keydown', onKey);
+  });
 }
 
 // enrolSigningPasskey() stores the passphrase wrap FIRST, so an abort after that
@@ -58,6 +89,26 @@ function wireSigningEnrol() {
   const passEl = document.getElementById('signing-enrol-pass');
   const pass2El = document.getElementById('signing-enrol-pass2');
   const labelEl = document.getElementById('signing-enrol-label');
+
+  // Live passphrase strength hint (length + character variety). Cosmetic guide;
+  // the vault still enforces real strength server-side in vaultStore.
+  const strengthEl = document.getElementById('signing-enrol-strength');
+  if (passEl && strengthEl) {
+    passEl.addEventListener('input', () => {
+      const v = passEl.value || '';
+      if (!v) { strengthEl.textContent = ''; return; }
+      let label, color = 'var(--ink-dim, #6b7280)';
+      if (v.length < 12) { label = 'Too short (needs 12+ characters)'; color = 'var(--danger, #b91c1c)'; }
+      else {
+        const variety = (/[a-z]/.test(v) ? 1 : 0) + (/[A-Z]/.test(v) ? 1 : 0) + (/\d/.test(v) ? 1 : 0) + (/[^a-zA-Z0-9]/.test(v) ? 1 : 0);
+        if (v.length >= 20 && variety >= 3) label = 'Strong';
+        else if (v.length >= 16 || variety >= 3) label = 'Good';
+        else label = 'OK (longer is stronger)';
+      }
+      strengthEl.textContent = label;
+      strengthEl.style.color = color;
+    });
+  }
 
   const setStatus = (t, isErr) => {
     if (!status) return;
@@ -110,7 +161,7 @@ function wireSigningEnrol() {
             if (prfCapable) return { credentialId: prfCapable.credId, reused: true };
           }
 
-          const totp = askTotp('Set up your signing key — enter your current 6-digit authenticator code:');
+          const totp = await askTotp('Enter the 6-digit code from your authenticator app to start.');
           setStatus('Verifying code, then follow your device prompt…', false);
           const opt = await postJSON('/api/user/account/webauthn/register/options', { totp });
           if (opt.status === 403) throw new Error('That authenticator code was not accepted.');
@@ -157,7 +208,7 @@ function wireSigningEnrol() {
         //     recomputes pk_hash from pk_b64 server-side; the secret never
         //     leaves the browser.
         enrolPublicKey: async ({ pk_b64, label: keyLabel }) => {
-          const totp = askTotp('Finish enrolling your signing key — enter a fresh 6-digit code:');
+          const totp = await askTotp('Almost done. Your last code is used up, so enter a fresh 6-digit code to finish.');
           setStatus('Binding your public key to your account…', false);
           const r = await postJSON('/api/user/account/signing-key', { pk_b64, label: keyLabel, totp });
           if (!r.ok) throw new Error((r.data && r.data.error) || ('signing_key_enrol_failed_' + r.status));


### PR DESCRIPTION
## Account-setup UX, PR-2 (functional) — signing-key flow

Replaces the **three `window.prompt()` TOTP pop-ups** in the signing-key flow with inline fields, per item 4 of the approved copydeck. This is the **functional** half (`signing-enrol.js`); PR-1 (#189) shipped the frontend wizard. **ML-DSA-65 crypto is untouched.**

### The two-entry design (and why not one code)
Your instinct was "3 popups → one inline field". I found a functional constraint that makes a single code break enrolment, so the inline field is **used twice**:
- The enrol makes **two TOTP-gated server calls** — `register-options` (gets the passkey challenge) and `bind-public-key` — with the **passkey/biometric ceremony between them**.
- The relay **replay-protects TOTP codes** (`relay.js` `_usedTotpCodes` + `replayKey`, 90s), so the code that passes the first call is **rejected as a replay** on the second.
- So: one inline field, **two entries** — a fresh code each time, no pop-ups. The second prompt explains it ("your last code is used up, enter a fresh one").

### Changes
- **`signing-enrol.js`** `askTotp()`: `window.prompt` → a `Promise` that shows/awaits the inline `#signing-enrol-totp` field; both call sites `await` it. Bad input re-prompts inline instead of throwing.
- Live **passphrase strength** hint + a plain-language **"write this down, we can't reset it"** warning on the enrol card; button → **"Create my signing key"**; intro reworded ("a signing key is what makes your signature legally yours… separate from how you sign in").
- **`account.html` revoke** (the 3rd pop-up): `window.prompt` → inline `#revoke-totp` confirm field (with a `window.prompt` fallback only if the field is somehow absent).
- Naming kept throughout: **"signing key" / "document key", never "signing passkey"**.
- `signing-enrol.js` bumped **?v=4 → ?v=5** (edited an immutable-cached asset).

### Verification
- `signing-enrol.js` parses (`node --check`, ESM); **both** `account.html` inline `<script>` blocks parse; **cache-bust guard green** (single consistent `?v=`); **no active `window.prompt` TOTP** left.
- ⚠️ **Honest limit:** the full TOTP+passkey enrol **cannot be verified headlessly** (needs a real account + authenticator + a PRF-capable passkey). I verified wiring + syntax + the non-TOTP guards; **the end-to-end enrol is your on-device test.** The orchestration (`enrolSigningPasskey`, PRF, vault) and the relay are unchanged — only how the TOTP code is collected changed (prompt → inline field), so the enrolment contract is identical.

**Do not merge / do not deploy** — frontend-only; webroot rsync after your review + on-device enrol test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
