### PR TITLE
harden(admin-cli) least-privilege env + cross-device developer tool-config

### DIFF
--- a/admin/lib/cli-commands.js
+++ b/admin/lib/cli-commands.js
@@ -46,6 +46,7 @@ const COMMANDS = {
   'key list': {
     description: 'List active API keys (masked)',
     handler: 'paramant-key-list.sh',
+    needsAdminToken: true,
     args: [],
     class: 'read',
     totp: false,
@@ -53,6 +54,7 @@ const COMMANDS = {
   'key add': {
     description: 'Add new API key for a user',
     handler: 'paramant-key-add.sh',
+    needsAdminToken: true,
     args: [
       { name: 'email', type: 'email', required: true },
       { name: 'plan', type: 'enum', options: ['free', 'pro', 'enterprise'], default: 'free' },
@@ -63,6 +65,7 @@ const COMMANDS = {
   'key revoke': {
     description: 'Revoke an API key by hash-prefix',
     handler: 'paramant-key-revoke.sh',
+    needsAdminToken: true,
     args: [
       { name: 'key_prefix', type: 'string', minLength: 8, required: true },
     ],
@@ -86,6 +89,7 @@ const COMMANDS = {
   'audit recent': {
     description: 'Show recent audit-log entries',
     handler: 'paramant-audit-recent.sh',
+    needsAdminToken: true,
     args: [
       { name: 'limit', type: 'number', default: 50, min: 1, max: 500 },
     ],
@@ -111,6 +115,7 @@ const COMMANDS = {
   'backup create': {
     description: 'Create immediate backup',
     handler: 'paramant-backup.sh',
+    needsAdminToken: true,
     args: [],
     class: 'mutate',
     totp: true,
@@ -204,4 +209,24 @@ function maskArgs(values) {
   return out;
 }
 
-module.exports = { COMMANDS, SCRIPTS_DIR, validateArgs, buildArgv, maskArgs, SECRET_ARG_NAMES };
+// Least-privilege environment for a spawned handler. PATH/HOME + non-secret
+// operational vars only; the sensitive secrets (ADMIN_TOKEN, REDIS_*, RESEND_*,
+// PARAMANT_*) are NOT broadcast. ADMIN_TOKEN is added only for commands that
+// call the relay admin API (cmd.needsAdminToken). Pure + unit-tested.
+function buildChildEnv(cmd, processEnv, sectors, adminToken) {
+  processEnv = processEnv || {};
+  sectors = sectors || {};
+  const env = {
+    PATH: processEnv.PATH || '/usr/local/bin:/usr/bin:/bin',
+    HOME: processEnv.HOME || '/tmp',
+  };
+  for (const [k, v] of Object.entries(processEnv)) {
+    if (/^(PORT|BASE_PATH|NODE_ENV|RELAY_|SECTOR|NATS_|COMPOSE_|BACKUP_)/.test(k)) env[k] = v;
+  }
+  if (sectors.health) env.RELAY_URL = sectors.health;
+  env.RELAY_SECTORS = Object.entries(sectors).map(([n, u]) => `${n}=${u}`).join(',');
+  if (cmd && cmd.needsAdminToken && adminToken) env.ADMIN_TOKEN = adminToken;
+  return env;
+}
+
+module.exports = { COMMANDS, SCRIPTS_DIR, validateArgs, buildArgv, maskArgs, SECRET_ARG_NAMES, buildChildEnv };

--- a/admin/lib/developer-config.js
+++ b/admin/lib/developer-config.js
@@ -1,0 +1,57 @@
+'use strict';
+// Per-account storage for the /developer dashboard's saved tool commands
+// (cross-device counterpart of the browser localStorage cache). Pure helpers +
+// a Redis key; the endpoints in admin/server.js are gated by authUser +
+// developerGate and scope every read/write to the session's user_id.
+//
+// SECURITY MODEL
+//   - the stored value is the NON-SENSITIVE run command (bucket, recipient);
+//     never the API key -- the UI templates it as $PARAMANT_API_KEY. We refuse
+//     to persist anything that looks like a literal pgp_ key, as defence in
+//     depth (so even a buggy client cannot park a secret here).
+//   - only catalogue tool names are accepted; unknown keys are dropped.
+//   - per-command and per-account size caps bound storage abuse.
+//   - the config is data only -- it is NEVER executed server-side.
+
+const { DEVELOPER_TOOLS } = require('./developer-tools');
+
+const TOOL_NAMES = new Set(DEVELOPER_TOOLS.map((t) => t.name));
+const MAX_CMD = 2000;
+const MAX_TOTAL = 20000;
+const KEY = (uid) => `paramant:user:devcfg:${uid}`;
+
+// Validate a single save. Pure. -> { ok, tool, command } | { ok:false, error }.
+function validateConfig(tool, command) {
+  if (typeof tool !== 'string' || !TOOL_NAMES.has(tool)) return { ok: false, error: 'unknown_tool' };
+  if (typeof command !== 'string') return { ok: false, error: 'command_must_be_string' };
+  if (command.length > MAX_CMD) return { ok: false, error: 'command_too_long' };
+  // The run command must use $PARAMANT_API_KEY, never a literal key. Refuse to
+  // store anything that looks like one.
+  if (/\bpgp_[A-Za-z0-9_-]{6,}/.test(command)) return { ok: false, error: 'inline_key_not_allowed' };
+  return { ok: true, tool, command };
+}
+
+// Merge a validated entry into the existing JSON map, dropping unknown tools and
+// enforcing the total cap. Pure. -> { ok, map, json } | { ok:false, error }.
+function mergeConfig(existingJson, tool, command) {
+  let map = {};
+  if (existingJson) { try { map = JSON.parse(existingJson) || {}; } catch (e) { map = {}; } }
+  if (typeof map !== 'object' || Array.isArray(map)) map = {};
+  for (const k of Object.keys(map)) if (!TOOL_NAMES.has(k)) delete map[k];
+  map[tool] = command;
+  const json = JSON.stringify(map);
+  if (json.length > MAX_TOTAL) return { ok: false, error: 'config_too_large' };
+  return { ok: true, map, json };
+}
+
+// Remove one tool's entry. Pure. -> json string.
+function removeConfig(existingJson, tool) {
+  let map = {};
+  if (existingJson) { try { map = JSON.parse(existingJson) || {}; } catch (e) { map = {}; } }
+  if (typeof map !== 'object' || Array.isArray(map)) map = {};
+  delete map[tool];
+  for (const k of Object.keys(map)) if (!TOOL_NAMES.has(k)) delete map[k];
+  return JSON.stringify(map);
+}
+
+module.exports = { validateConfig, mergeConfig, removeConfig, KEY, TOOL_NAMES, MAX_CMD, MAX_TOTAL };

--- a/admin/server.js
+++ b/admin/server.js
@@ -2720,17 +2720,11 @@ async function verifyCliTotp(totp) {
 // Curated environment for handler scripts. We do NOT inherit the full process
 // env: only PATH/HOME plus paramant-relevant variables, and computed relay
 // locators. This bounds what `config show` can ever surface.
-function cliChildEnv() {
-  const env = { PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin', HOME: process.env.HOME || '/tmp' };
-  for (const [k, v] of Object.entries(process.env)) {
-    if (/^(PORT|BASE_PATH|NODE_ENV|RELAY_|SECTOR|ADMIN_|PARAMANT_|NATS_|REDIS_|RESEND_|COMPOSE_|BACKUP_)/.test(k)) {
-      env[k] = v;
-    }
-  }
-  env.RELAY_URL = SECTORS.health;
-  env.RELAY_SECTORS = Object.entries(SECTORS).map(([n, u]) => `${n}=${u}`).join(',');
-  env.ADMIN_TOKEN = ADMIN_TOKEN;
-  return env;
+function cliChildEnv(cmd) {
+  // Delegates to the pure, unit-tested builder (lib/cli-commands.buildChildEnv).
+  // Least-privilege: ADMIN_TOKEN is added only for cmd.needsAdminToken; the
+  // REDIS_/RESEND_/PARAMANT_ secrets are never broadcast to handler scripts.
+  return cliCommands.buildChildEnv(cmd, process.env, SECTORS, ADMIN_TOKEN);
 }
 
 // GET /api/admin/cli/commands -- whitelist metadata for completion/help.
@@ -2812,7 +2806,7 @@ api.post('/admin/cli/exec', authMiddleware, async (req, res) => {
   try {
     child = spawn(handlerPath, argv, {
       cwd: cliCommands.SCRIPTS_DIR,
-      env: cliChildEnv(),
+      env: cliChildEnv(cmd),
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (err) {

--- a/admin/server.js
+++ b/admin/server.js
@@ -619,6 +619,7 @@ function developerGate(req, res, next) {
 // admin/test/developer-snapshot.test.js.
 const { DEVELOPER_TOOLS } = require('./lib/developer-tools');
 const { buildSnapshot } = require('./lib/developer-snapshot');
+const developerConfig = require('./lib/developer-config');
 
 // Session cookie is SameSite=Lax (was Strict). Deliberate choice (ADR R018):
 // the invite/co-sign flow lands a recipient via a top-level navigation from an
@@ -1758,6 +1759,40 @@ api.get("/user/developer/check", authUser, (req, res) => {
 // testable from day one.
 api.get("/user/developer/tools", authUser, developerGate, (req, res) => {
   res.json({ status: "live", tools: DEVELOPER_TOOLS });
+});
+
+// ── Per-account saved tool config (cross-device). All three are gated by
+// authUser + developerGate and scoped to the session's user_id (no IDOR). Pure
+// validation lives in lib/developer-config (unit-tested). The config is data
+// only -- never executed; a literal key is refused (defence in depth).
+api.get("/user/developer/tool-config", authUser, developerGate, async (req, res) => {
+  try {
+    const raw = await redis().get(developerConfig.KEY(req.userSession.user_id));
+    let configs = {};
+    if (raw) { try { configs = JSON.parse(raw) || {}; } catch {} }
+    res.json({ configs });
+  } catch (e) { res.status(503).json({ error: "store_unavailable" }); }
+});
+api.post("/user/developer/tool-config", authUser, developerGate, async (req, res) => {
+  const { tool, command } = req.body || {};
+  const v = developerConfig.validateConfig(tool, command);
+  if (!v.ok) return res.status(400).json({ error: v.error });
+  try {
+    const raw = await redis().get(developerConfig.KEY(req.userSession.user_id));
+    const m = developerConfig.mergeConfig(raw, v.tool, v.command);
+    if (!m.ok) return res.status(400).json({ error: m.error });
+    await redis().set(developerConfig.KEY(req.userSession.user_id), m.json);
+    res.json({ ok: true });
+  } catch (e) { res.status(503).json({ error: "store_unavailable" }); }
+});
+api.delete("/user/developer/tool-config", authUser, developerGate, async (req, res) => {
+  const tool = (req.body && req.body.tool) || req.query.tool;
+  if (typeof tool !== "string" || !developerConfig.TOOL_NAMES.has(tool)) return res.status(400).json({ error: "unknown_tool" });
+  try {
+    const raw = await redis().get(developerConfig.KEY(req.userSession.user_id));
+    await redis().set(developerConfig.KEY(req.userSession.user_id), developerConfig.removeConfig(raw, tool));
+    res.json({ ok: true });
+  } catch (e) { res.status(503).json({ error: "store_unavailable" }); }
 });
 
 // GET /api/user/developer/snapshot — one call for the initial dashboard render:

--- a/admin/test/cli-childenv.test.js
+++ b/admin/test/cli-childenv.test.js
@@ -1,0 +1,66 @@
+'use strict';
+// Unit test for cli-commands.buildChildEnv: the least-privilege environment for
+// spawned web-CLI handlers. Proves the high-sensitivity secrets are NOT
+// broadcast to every command, and ADMIN_TOKEN reaches only the commands that
+// declare needsAdminToken.
+// Run: node admin/test/cli-childenv.test.js (no deps, non-zero exit on fail).
+
+const assert = require('assert');
+const { buildChildEnv, COMMANDS } = require('../lib/cli-commands');
+
+let passed = 0;
+const ok = (n) => { passed++; console.log('  ok -', n); };
+
+const PROC = {
+  PATH: '/usr/bin', HOME: '/root',
+  ADMIN_TOKEN: 'secret-admin', REDIS_URL: 'redis://x', REDIS_PASSWORD: 'p',
+  RESEND_API_KEY: 'resend', PARAMANT_API_KEY: 'pgp_secret', PARAMANT_SIGNING_KEY: 'sk',
+  RELAY_PORT: '3000', NATS_MONITOR_URL: 'http://nats', COMPOSE_CMD: 'docker compose',
+  BACKUP_DIR: '/b', SECTOR_X: 'y', PORT: '4200', NODE_ENV: 'production',
+};
+const SECTORS = { health: 'http://health', finance: 'http://finance' };
+const TOK = 'secret-admin';
+
+// 1. A read command carries NONE of the high-sensitivity secrets.
+const r = buildChildEnv(COMMANDS['status'], PROC, SECTORS, TOK);
+assert.strictEqual(r.ADMIN_TOKEN, undefined, 'read: no ADMIN_TOKEN');
+assert.strictEqual(r.REDIS_URL, undefined, 'no REDIS_URL');
+assert.strictEqual(r.REDIS_PASSWORD, undefined, 'no REDIS_PASSWORD');
+assert.strictEqual(r.RESEND_API_KEY, undefined, 'no RESEND_API_KEY');
+assert.strictEqual(r.PARAMANT_API_KEY, undefined, 'no PARAMANT_API_KEY');
+assert.strictEqual(r.PARAMANT_SIGNING_KEY, undefined, 'no PARAMANT_SIGNING_KEY');
+ok('read command env carries no secrets');
+
+// 2. Non-secret operational vars ARE present, plus the derived relay locators.
+assert.strictEqual(r.RELAY_PORT, '3000', 'RELAY_* kept');
+assert.strictEqual(r.NATS_MONITOR_URL, 'http://nats', 'NATS_* kept');
+assert.strictEqual(r.COMPOSE_CMD, 'docker compose', 'COMPOSE_* kept');
+assert.strictEqual(r.BACKUP_DIR, '/b', 'BACKUP_* kept');
+assert.strictEqual(r.RELAY_URL, 'http://health', 'RELAY_URL derived');
+assert.ok(r.RELAY_SECTORS.includes('finance=http://finance'), 'RELAY_SECTORS derived');
+ok('read command env carries operational vars');
+
+// 3. ADMIN_TOKEN reaches ONLY the commands that declare needsAdminToken.
+for (const name of ['key add', 'key list', 'key revoke', 'audit recent', 'backup create']) {
+  assert.ok(COMMANDS[name], 'command exists: ' + name);
+  const e = buildChildEnv(COMMANDS[name], PROC, SECTORS, TOK);
+  assert.strictEqual(e.ADMIN_TOKEN, TOK, name + ' gets ADMIN_TOKEN');
+  assert.strictEqual(e.REDIS_URL, undefined, name + ' still has no REDIS');
+}
+ok('ADMIN_TOKEN present only for needsAdminToken commands');
+
+// 4. Commands that must NEVER receive ADMIN_TOKEN (incl. config show, which
+//    surfaces env -> cannot leak a token it never holds).
+for (const name of ['status', 'health', 'logs', 'config show', 'relay list', 'nats status', 'restart']) {
+  assert.ok(COMMANDS[name], 'command exists: ' + name);
+  const e = buildChildEnv(COMMANDS[name], PROC, SECTORS, TOK);
+  assert.strictEqual(e.ADMIN_TOKEN, undefined, name + ' must NOT get ADMIN_TOKEN');
+}
+ok('no ADMIN_TOKEN for read/infra commands, incl. config show');
+
+// 5. Defensive: a missing/odd command never throws and never leaks.
+const e0 = buildChildEnv(undefined, PROC, SECTORS, TOK);
+assert.strictEqual(e0.ADMIN_TOKEN, undefined, 'undefined cmd: no token');
+ok('undefined command is safe');
+
+console.log('cli-childenv:', passed, 'groups passed');

--- a/admin/test/developer-config.test.js
+++ b/admin/test/developer-config.test.js
@@ -1,0 +1,46 @@
+'use strict';
+// Unit test for admin/lib/developer-config.js: validation + merge for the
+// per-account saved tool commands. Proves unknown tools, oversize, and literal
+// keys are rejected, and that the merged map drops unknown keys + caps size.
+// Run: node admin/test/developer-config.test.js (no deps, non-zero exit on fail).
+
+const assert = require('assert');
+const { validateConfig, mergeConfig, removeConfig, TOOL_NAMES, MAX_CMD } =
+  require('../lib/developer-config');
+
+let passed = 0;
+const ok = (n) => { passed++; console.log('  ok -', n); };
+
+const TOOL = [...TOOL_NAMES][0]; // a real catalogue tool name
+assert.ok(TOOL, 'catalogue is non-empty');
+
+// validateConfig
+assert.strictEqual(validateConfig('not-a-tool', 'x').ok, false, 'unknown tool rejected');
+assert.strictEqual(validateConfig(TOOL, 123).ok, false, 'non-string command rejected');
+assert.strictEqual(validateConfig(TOOL, 'a'.repeat(MAX_CMD + 1)).ok, false, 'oversize command rejected');
+assert.strictEqual(validateConfig(TOOL, 'paramant-x s3://b --to bob').ok, true, 'normal command accepted');
+ok('validateConfig basics');
+
+// a literal key must NEVER be storable
+assert.strictEqual(validateConfig(TOOL, 'PARAMANT_API_KEY=pgp_abc123def paramant-x').ok, false, 'literal pgp_ key refused');
+assert.strictEqual(validateConfig(TOOL, 'paramant-x --to bob # uses $PARAMANT_API_KEY').ok, true, 'env-var form accepted');
+ok('literal key is refused (defence in depth)');
+
+// mergeConfig: drops unknown keys, keeps known, enforces structure
+const m1 = mergeConfig(JSON.stringify({ 'bogus-tool': 'evil', [TOOL]: 'old' }), TOOL, 'new');
+assert.strictEqual(m1.ok, true, 'merge ok');
+assert.strictEqual(m1.map[TOOL], 'new', 'updates the entry');
+assert.strictEqual(m1.map['bogus-tool'], undefined, 'drops unknown tool keys');
+ok('mergeConfig drops unknown keys, updates entry');
+
+// mergeConfig: tolerant of garbage existing JSON
+assert.strictEqual(mergeConfig('not json', TOOL, 'x').ok, true, 'garbage existing JSON tolerated');
+assert.strictEqual(mergeConfig('[1,2,3]', TOOL, 'x').map[TOOL], 'x', 'array existing coerced to {}');
+ok('mergeConfig tolerant of bad existing state');
+
+// removeConfig
+const rj = removeConfig(JSON.stringify({ [TOOL]: 'x' }), TOOL);
+assert.strictEqual(JSON.parse(rj)[TOOL], undefined, 'removeConfig deletes the entry');
+ok('removeConfig');
+
+console.log('developer-config:', passed, 'groups passed');

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -225,6 +225,6 @@ main.dev{max-width:1180px;margin:0 auto;padding:var(--space-5) var(--space-4) va
   </div>
 </div>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/developer.js?v=3" defer></script>
+<script src="/js/developer.js?v=4" defer></script>
 </body>
 </html>

--- a/frontend/js/developer.js
+++ b/frontend/js/developer.js
@@ -24,7 +24,7 @@
   };
   function toolIcon(cat) { return '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="' + (ICONS[cat] || ICONS.transfer) + '"/></svg>'; }
 
-  var STATE = { tools: [], status: {}, key: '', filter: '', feed: [] };
+  var STATE = { tools: [], status: {}, key: '', filter: '', feed: [], cfg: {} };
 
   // Which tools can genuinely run in the browser: those whose input is a local
   // file (transfer + sign). The rest need server-side data (an S3 object, your
@@ -51,6 +51,15 @@
   function loadCfg(tool) { try { return localStorage.getItem(CFG_PREFIX + tool); } catch (e) { return null; } }
   function saveCfg(tool, val) { try { localStorage.setItem(CFG_PREFIX + tool, String(val).slice(0, 2000)); return true; } catch (e) { return false; } }
   function clearCfg(tool) { try { localStorage.removeItem(CFG_PREFIX + tool); } catch (e) {} }
+  // Cross-device sync via the gated, account-scoped server store. Best-effort:
+  // the localStorage cache above keeps Configure working if the server is
+  // unreachable. The server refuses to persist anything that looks like a key.
+  function saveCfgServer(tool, command) {
+    return fetch('/api/user/developer/tool-config', { method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ tool: tool, command: command }) }).catch(function () {});
+  }
+  function clearCfgServer(tool) {
+    return fetch('/api/user/developer/tool-config', { method: 'DELETE', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ tool: tool }) }).catch(function () {});
+  }
   function serverReason(cat) {
     var needs = { migrate: 'an S3 object or a Docker volume on your host', backup: 'your database', replicate: 'your database', sync: 'your local secrets', archive: 'your git repo', ship: 'your build output or logs' };
     return 'Runs on your machine: it needs ' + (needs[cat] || 'access to your infrastructure') + '. Use Configure for the ready-to-run command.';
@@ -210,7 +219,7 @@
     // The command relies on the PARAMANT_API_KEY env var (step 2), so the key is
     // never inlined -> nothing sensitive ever reaches localStorage.
     var def = (t.usage || '').replace(/^PARAMANT_API_KEY=\{KEY\}\s+/, '').replace('{KEY}', '$PARAMANT_API_KEY');
-    var saved = loadCfg(t.name);
+    var saved = (STATE.cfg && STATE.cfg[t.name] != null) ? STATE.cfg[t.name] : loadCfg(t.name);
     modal.querySelector('[data-m="title"]').textContent = 'Configure ' + t.name;
     modal.querySelector('[data-m="tag"]').textContent = t.tagline || '';
     modal.querySelector('[data-m="install"]').textContent = t.install || '';
@@ -234,7 +243,8 @@
       var save = ev.target.closest && ev.target.closest('[data-m="save"]');
       if (save) {
         var tool = modal.getAttribute('data-tool'), ta = modal.querySelector('[data-m="run"]');
-        if (tool && ta && saveCfg(tool, ta.value)) {
+        if (tool && ta) {
+          saveCfg(tool, ta.value); STATE.cfg[tool] = ta.value; saveCfgServer(tool, ta.value);
           var sn = modal.querySelector('[data-m="saved"]'); if (sn) sn.hidden = false;
           var os = save.textContent; save.textContent = 'saved'; setTimeout(function () { save.textContent = os; }, 1200);
         }
@@ -243,7 +253,7 @@
       var reset = ev.target.closest && ev.target.closest('[data-m="reset"]');
       if (reset) {
         var tool2 = modal.getAttribute('data-tool'), ta2 = modal.querySelector('[data-m="run"]');
-        if (tool2 && ta2) { clearCfg(tool2); ta2.value = ta2.getAttribute('data-default') || ''; var sn2 = modal.querySelector('[data-m="saved"]'); if (sn2) sn2.hidden = true; }
+        if (tool2 && ta2) { clearCfg(tool2); delete STATE.cfg[tool2]; clearCfgServer(tool2); ta2.value = ta2.getAttribute('data-default') || ''; var sn2 = modal.querySelector('[data-m="saved"]'); if (sn2) sn2.hidden = true; }
         return;
       }
       var c = ev.target.closest && ev.target.closest('[data-copy]');
@@ -264,9 +274,10 @@
     Promise.all([
       getJSON('/api/user/developer/snapshot'),
       getJSON('/api/user/developer/tools').catch(function () { return { tools: [] }; }),
-      getJSON('/api/user/account/key').then(function (k) { return k.api_key || ''; }).catch(function () { return ''; })
+      getJSON('/api/user/account/key').then(function (k) { return k.api_key || ''; }).catch(function () { return ''; }),
+      getJSON('/api/user/developer/tool-config').then(function (c) { return c.configs || {}; }).catch(function () { return {}; })
     ]).then(function (res) {
-      STATE.tools = res[1].tools || []; STATE.key = res[2];
+      STATE.tools = res[1].tools || []; STATE.key = res[2]; STATE.cfg = res[3] || {};
       applySnapshot(res[0]);
       connectSSE();
     }).catch(function () { heartbeat('down'); elTools.innerHTML = '<div class="dim mono" style="font-size:12px">Could not load dashboard data.</div>'; });


### PR DESCRIPTION
From the /developer security review (the `spawn()` finding).

## The gap
`cliChildEnv()` handed **every** whitelisted web-CLI command the full secret set — `ADMIN_TOKEN` + `REDIS_*` + `RESEND_*` + `PARAMANT_*` — including read-only ones (`status`, `config show`). A buggy/compromised handler ran with the admin token and DB/email creds in its env.

## The fix (least privilege)
Per-handler analysis of `scripts/cli/*.sh`: only **5** commands use `ADMIN_TOKEN` (key add/list/revoke, audit recent, backup create); **none** use `REDIS_/RESEND_/PARAMANT_`.

- `ADMIN_TOKEN` → only for commands that declare `needsAdminToken`.
- `REDIS_/RESEND_/PARAMANT_` → dropped from the broadcast entirely.
- Operational vars (`RELAY_/SECTOR/NATS_/COMPOSE_/BACKUP_`) + derived relay locators → unchanged.
- `config show` now **cannot** surface `ADMIN_TOKEN` — it is not in its environment.

The env builder is extracted to a **pure, unit-tested** function: `admin/test/cli-childenv.test.js` (5 groups, all green). No behaviour change for the commands that legitimately need the token.

## Deploy
Admin backend → needs an **admin container rebuild** (`docker compose up -d --build admin`) to take effect. The existing `deploy.sh admin` runs static-sanity → build → health → auth smoke before declaring success.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)