### PR TITLE
feat(signing): the sign-in passkey IS the signing key (one tap, no passphrase/TOTP)

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -1960,6 +1960,112 @@ api.post("/user/account/signing-key/tofu", authUser, async (req, res) => {
   }
 });
 
+// ── Passkey step-up for binding a signing key (ADR R018) — the "your sign-in
+// passkey IS your signing key" gate. A logged-in user proves possession of one
+// of THEIR OWN passkeys with a fresh assertion; that step-up replaces TOTP for
+// the signing-key bind, so a passkey-only account (no authenticator app) can
+// enrol a signing key, and nobody needs a separate signing passphrase. rpId/
+// origin are config constants (never request-derived). The SAME WebAuthn get()
+// the client runs for this assertion also carries the PRF eval that wraps the
+// ML-DSA key locally — one Face ID / Touch ID tap both authorises and unlocks.
+
+// POST /api/user/account/signing-key/step-up/options (authUser) — issue a
+// one-shot assertion challenge over THIS account's own passkeys.
+api.post("/user/account/signing-key/step-up/options", authUser, async (req, res) => {
+  const ip = req.headers["x-real-ip"] || req.socket?.remoteAddress || "unknown";
+  const L = webauthn.LIMITS.loginOptions;
+  if (!(await webauthn.rateHit(redis(), `su:ip:${ip}`, L.ip, L.windowSec)))
+    return res.status(429).json({ error: "rate_limited" });
+  const { user_id } = req.userSession;
+  if (!(await webauthn.rateHit(redis(), `su:acct:${webauthn.scopeHash(user_id)}`, L.account, L.windowSec)))
+    return res.status(429).json({ error: "rate_limited" });
+
+  // Challenge is bound to THIS account's own passkeys only. No passkey -> tell
+  // the client to add one first (the attested relay bind would reject anyway).
+  let allowCredentials = [];
+  try {
+    const r = await callRelay(`/v2/user/webauthn/credentials?user_id=${encodeURIComponent(user_id)}`, null, "GET");
+    if (r.status === 200) allowCredentials = ((await r.json()).credentials || []).map(c => ({ id: c.credId, transports: c.transports }));
+  } catch (e) { console.error("[signing-key/step-up/options]", e.message); return res.status(502).json({ error: "relay_unreachable" }); }
+  if (allowCredentials.length === 0) return res.status(409).json({ error: "no_passkey" });
+
+  let options;
+  try {
+    options = await generateAuthenticationOptions({
+      rpID: webauthn.RP_ID,
+      allowCredentials,
+      userVerification: "required",
+    });
+  } catch (e) { console.error("[signing-key/step-up/options]", e.message); return res.status(500).json({ error: "internal" }); }
+  const flowId = webauthn.newFlowId();
+  await webauthn.putAuthFlow(redis(), flowId, { challenge: options.challenge, user_id, step_up: "signing-key" });
+  res.json({ flowId, options });
+});
+
+// POST /api/user/account/signing-key/step-up/bind (authUser) — verify the fresh
+// assertion (mirrors login/verify) and, on success, forward the pubkey bind to
+// the relay's TOTP-free attested route. The asserted credential MUST belong to
+// the logged-in account; the flow is one-shot (consumed before any crypto).
+api.post("/user/account/signing-key/step-up/bind", authUser, async (req, res) => {
+  const ip = req.headers["x-real-ip"] || req.socket?.remoteAddress || "unknown";
+  const L = webauthn.LIMITS.loginVerify;
+  if (!(await webauthn.rateHit(redis(), `sub:ip:${ip}`, L.ip, L.windowSec)))
+    return res.status(429).json({ error: "rate_limited" });
+
+  const { user_id } = req.userSession;
+  const { flowId, response, pk_b64, label } = req.body || {};
+  if (!pk_b64 || typeof pk_b64 !== "string") return res.status(400).json({ error: "missing_pk_b64" });
+  const flow = await webauthn.takeAuthFlow(redis(), flowId);   // one-shot
+  if (!flow || !response || flow.step_up !== "signing-key") return res.status(401).json({ error: "step_up_required" });
+  // The step-up MUST belong to the same session that is binding the key.
+  if (flow.user_id !== user_id) return res.status(401).json({ error: "step_up_required" });
+
+  // Resolve the asserted credential and confirm it is THIS account's passkey.
+  let lookup;
+  try {
+    const r = await callRelay(`/v2/user/webauthn/lookup?cred_id=${encodeURIComponent(String(response.id || ""))}`, null, "GET");
+    if (r.status !== 200) return res.status(401).json({ error: "step_up_required" });
+    lookup = await r.json();
+  } catch (e) { return res.status(401).json({ error: "step_up_required" }); }
+  if (!lookup || !lookup.user_id || lookup.user_id !== user_id) return res.status(401).json({ error: "step_up_required" });
+
+  // Verify the assertion. expectedOrigin/expectedRPID are config constants.
+  let verification;
+  try {
+    verification = await verifyAuthenticationResponse({
+      response,
+      expectedChallenge: flow.challenge,
+      expectedOrigin: webauthn.EXPECTED_ORIGIN,
+      expectedRPID: webauthn.RP_ID,
+      credential: {
+        id: lookup.credId,
+        publicKey: new Uint8Array(Buffer.from(lookup.publicKey, "base64url")),
+        counter: lookup.counter | 0,
+      },
+      requireUserVerification: true,
+    });
+  } catch (e) { return res.status(401).json({ error: "step_up_required" }); }
+  if (!verification.verified) return res.status(401).json({ error: "step_up_required" });
+
+  // Cloned-authenticator guard (the same rule as login/verify).
+  const newCounter = verification.authenticationInfo.newCounter;
+  if (!webauthn.counterIsAcceptable(lookup.counter, newCounter)) {
+    try { logAuditEvent("webauthn_counter_regression", { user_id: String(user_id).slice(0, 12) + "…", stored: lookup.counter | 0, presented: newCounter | 0 }); } catch {}
+    return res.status(401).json({ error: "step_up_required" });
+  }
+  try { await callRelay("/v2/user/webauthn/counter", { user_id, cred_id: lookup.credId, counter: newCounter }); } catch {}
+
+  // Step-up proven -> forward the bind to the relay's TOTP-free attested route.
+  try {
+    const relayRes = await callRelay("/v2/user/signing-key/attested", { user_id, pk_b64, label }, "POST");
+    const body = await relayRes.json().catch(() => ({ error: "bad_relay_response" }));
+    return res.status(relayRes.status).json(body);
+  } catch (err) {
+    console.error("[signing-key/step-up/bind]", err.message);
+    return res.status(502).json({ error: "relay_unreachable" });
+  }
+});
+
 // GET /api/user/account/signing-key — list this user's enrolled keys
 api.get("/user/account/signing-key", authUser, async (req, res) => {
   const { user_id } = req.userSession;

--- a/admin/test/signing-key-stepup.test.js
+++ b/admin/test/signing-key-stepup.test.js
@@ -1,0 +1,57 @@
+'use strict';
+// Unit test for the passkey step-up flow-store the signing-key bind relies on
+// (admin POST /api/user/account/signing-key/step-up/{options,bind} — the
+// TOTP-equivalent gate for the "your sign-in passkey IS your signing key" path).
+// The bind route's replay safety + session binding rest on webauthn.putAuthFlow
+// / takeAuthFlow being one-shot and carrying the {user_id, step_up} the route
+// re-checks (flow.step_up === 'signing-key' && flow.user_id === session user).
+// Asserted here against an in-memory redis double.
+// Run: node admin/test/signing-key-stepup.test.js (no deps, non-zero exit on fail).
+
+const assert = require('assert');
+const wa = require('../lib/webauthn');
+
+function fakeRedis() {
+  const m = new Map();
+  return {
+    _m: m,
+    async set(k, v) { m.set(k, v); },          // EX ignored (no expiry in-test)
+    async get(k) { return m.has(k) ? m.get(k) : null; },
+    async del(k) { return m.delete(k) ? 1 : 0; },
+  };
+}
+
+let passed = 0;
+const ok = (n) => { passed++; console.log('  ok -', n); };
+
+async function main() {
+  const r = fakeRedis();
+  const flowId = wa.newFlowId();
+  assert.ok(/^[0-9a-f]{32}$/.test(flowId), 'flowId is 32-hex');
+
+  // The step-up challenge is bound to the account + marked as a signing-key step.
+  await wa.putAuthFlow(r, flowId, { challenge: 'chal-abc', user_id: 'pgp_u1', step_up: 'signing-key' });
+
+  // First take returns the record with its binding intact (the route checks
+  // flow.step_up === 'signing-key' && flow.user_id === the session user).
+  const got = await wa.takeAuthFlow(r, flowId);
+  assert.ok(got, 'flow resolves on first take');
+  assert.strictEqual(got.step_up, 'signing-key', 'step_up marker round-trips');
+  assert.strictEqual(got.user_id, 'pgp_u1', 'account binding round-trips');
+  assert.strictEqual(got.challenge, 'chal-abc', 'challenge round-trips');
+  ok('step-up flow: binding round-trips on first take');
+
+  // One-shot: a replay (second take of the same flowId) gets nothing — so a
+  // captured assertion challenge can never be re-bound.
+  assert.strictEqual(await wa.takeAuthFlow(r, flowId), null, 'second take -> null (one-shot consumed)');
+  ok('step-up flow: one-shot (replay refused)');
+
+  // Malformed flowId never resolves (input validation before any crypto).
+  assert.strictEqual(await wa.takeAuthFlow(r, 'not-a-flow-id'), null, 'malformed flowId -> null');
+  assert.strictEqual(await wa.takeAuthFlow(r, ''), null, 'empty flowId -> null');
+  ok('step-up flow: malformed flowId rejected');
+
+  console.log(`\n${passed} checks passed.`);
+}
+
+main().catch((e) => { console.error('FAIL:', (e && e.stack) || e); process.exit(1); });

--- a/docs/adrs/R018-parasign-invite-webauthn.md
+++ b/docs/adrs/R018-parasign-invite-webauthn.md
@@ -318,3 +318,47 @@ display string into a signed message; carry such fields outside the signature.
 No HSM, no SAM, no SAP/SAD implementation, no eIDAS conformance work. This ADR
 only guarantees the activation⇄key-use seam stays intact so a SAM can be added
 later. No new product features beyond the invite flow above.
+
+## Addendum 2026-06-02 — the sign-in passkey IS the signing key
+
+Field reality: a passkey-first account has no TOTP, but every signing-key bind
+(`/v2/user/signing-key`) and every fresh-passkey mint was TOTP-gated, so a
+passkey-only user could not enrol a signing key at all; and the enrol that did
+work demanded a separate passphrase + 2× TOTP and, when a registration-time
+`prfSupported` flag read false-negative, minted a *second* passkey — the "two
+passkeys / set up a signing passkey" loop. Decision: collapse the two
+credentials. The passkey you sign in with becomes the passkey you sign with.
+
+What changed:
+- **Passkey step-up = TOTP-equivalent bind.** New admin
+  `POST /api/user/account/signing-key/step-up/{options,bind}`: a logged-in user
+  proves possession of one of *their own* passkeys with a fresh assertion (the
+  admin verifies it exactly like login/verify — challenge one-shot, credential
+  resolved to this account, counter rule), which authorises a TOTP-free bind via
+  new relay `POST /v2/user/signing-key/attested` (internal-auth, gated on
+  `countActiveCredentials >= 1`, server-side pk_hash, cross-account-conflict
+  check — "as strict as the TOTP it replaces", mirroring `/tofu`). The original
+  TOTP route is untouched (still used by the /account TOTP path + back-compat).
+- **One tap does both.** The SAME `navigator.credentials.get()` carries the
+  server challenge (→ step-up assertion, sent to the server) and a `prf.eval`
+  (→ PRF output, kept in the browser to wrap the ML-DSA key). `ensureSigningKey()`
+  in `parasign-signer.js` is the single resolve-or-enrol entry point /sign,
+  /co-sign and /account all call; it reuses the sign-in passkey via
+  `allowCredentials` and never trusts a stored `prfSupported` flag, so it cannot
+  spawn a duplicate passkey or loop.
+- **PRF may be the sole wrap.** `vaultCreatePrfOnly()` creates a vault entry with
+  only a `webauthn-prf` wrap — no passphrase. This deliberately relaxes the
+  earlier "PRF is never the sole wrap / passphrase is the recovery floor"
+  invariant. Rationale: a *signing* key is not a login factor — losing it just
+  means enrolling a fresh one (the relay keeps a multi-key list, old signatures
+  stay verifiable by their stored pubkey), and the synced passkey (iCloud
+  Keychain / Google Password Manager) is the real recovery. Account login keeps
+  its own recovery (backup codes), unaffected. A passphrase wrap can still be
+  *added* via `vaultStore` as an optional break-glass.
+
+Seam intact (the whole point of R018): PRF still only **unlocks** a stored,
+randomly-generated ML-DSA-65 key (activation); key-use stays behind
+`ActivatedSigner.sign()`. The key is NOT derived from the PRF output — that
+fusion would be the forbidden one (a SAM/HSM could never be slotted in later).
+`signMessageBytes(...,3)` / the v3 sign-message are untouched, so already-signed
+envelopes stay `valid:true`.

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -370,34 +370,22 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
     <div class="acct-block">
       <h3>Browser vault</h3>
       <p style="margin:0 0 12px" id="vault-status" class="small">Checking this browser...</p>
-      <p class="small"><strong>Your passphrase encrypts your signing key in this browser. We never see it and we cannot reset it. If you forget it, this key is gone.</strong></p>
+      <p class="small"><strong>Your signing key is encrypted in this browser and unlocked only by your passkey (Face ID / Touch ID / security key). We never see it. Lose this device? Set up signing again on a new one — your account keeps every public key, so old signatures stay verifiable.</strong></p>
     </div>
   </div>
   <hr class="acct-divider">
   <div class="acct-block">
     <h3>Set up your signing key</h3>
     <p class="small">
-      A signing key is what makes your signature legally yours. It is created here, in this
-      browser, with ML-DSA-65 (post-quantum), and only you hold it. It is separate from how
-      you sign in. You confirm with Face ID, Touch ID, or a security key when you sign.
+      Your signing key is created here, in this browser, with ML-DSA-65 (post-quantum), and
+      only you hold it. You set it up — and unlock it every time you sign — with the SAME
+      passkey you sign in with (Face ID, Touch ID, or a security key). No passphrase, no extra
+      code: your sign-in passkey is your signing key.
     </p>
     <div class="acct-field">
       <input type="text" id="signing-enrol-label" maxlength="40" placeholder="Label (optional, e.g. iPhone)" autocomplete="off">
-      <input type="password" id="signing-enrol-pass" placeholder="Choose a passphrase (min 12 characters)" autocomplete="new-password">
-      <div id="signing-enrol-strength" class="small" aria-live="polite" style="margin:2px 0 0"></div>
-      <input type="password" id="signing-enrol-pass2" placeholder="Confirm passphrase" autocomplete="new-password">
-      <p class="small" style="margin:6px 0 0"><strong>Write this down.</strong> If you forget this passphrase and lose this browser, your signing key is gone for good. We can't reset it.</p>
-
-      <div id="signing-enrol-totp-wrap" hidden style="margin-top:12px;padding:12px 14px;border:1px solid var(--ink-hair,#E2E8F0);border-radius:6px">
-        <p id="signing-enrol-totp-prompt" class="small" style="margin:0 0 8px"></p>
-        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
-          <input type="text" id="signing-enrol-totp" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code" placeholder="6-digit code" style="max-width:140px">
-          <button type="button" class="btn btn-primary btn-small" id="signing-enrol-totp-confirm">Confirm</button>
-        </div>
-      </div>
-
       <div style="margin-top:10px">
-        <button type="button" class="btn btn-primary btn-small" id="signing-enrol-btn">Create my signing key</button>
+        <button type="button" class="btn btn-primary btn-small" id="signing-enrol-btn">Set up signing with my passkey</button>
       </div>
     </div>
     <p id="signing-enrol-status" class="small" aria-live="polite" style="margin-top:8px"></p>
@@ -790,7 +778,7 @@ loadVaultStatus();
 document.addEventListener('signing-key-enrolled', () => { loadEnrolledKeys(); loadVaultStatus(); });
 </script>
 <script type="module" src="/js/passkey.js?v=3"></script>
-<script type="module" src="/js/signing-enrol.js?v=5"></script>
+<script type="module" src="/js/signing-enrol.js?v=6"></script>
 
 </body>
 </html>

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -182,6 +182,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 </main>
 
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=1"></script>
-<script type="module" src="/co-sign.js?v=4"></script>
+<script type="module" src="/co-sign.js?v=5"></script>
 </body>
 </html>

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -18,7 +18,7 @@
 // the view receipt. The signing path itself is same-origin via the admin
 // (/api/user/sign/*), bound to the logged-in invitee session.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=3';
+import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey } from '/js/parasign-signer.js?v=4';
 
 const RELAY_PUBLIC = 'https://health.paramant.app';
 
@@ -180,21 +180,26 @@ async function prepareSigning() {
     return;
   }
 
-  // GATE 2 — has a passkey signing key (stuk 1). For a first-time invitee with no
-  // passkey, stuk 2 wires the inline TOFU enrol here; for now, point at /account.
+  // GATE 2 — a passkey signing key. We no longer dump a first-time recipient to
+  // /account: if this device has no signing key, doSign() sets one up inline with
+  // a single passkey tap (no passphrase, no TOTP) — the sign-in passkey becomes
+  // the signing key. Resolve now only to SHOW the fingerprint when one exists.
   try {
     __signKey = await resolvePasskeySigningKey();
   } catch (e) {
     if (e && e.code === 'no_signing_passkey') {
-      setStatus('warn', 'Signed in as ' + escapeHtml(__session.email || 'your account') + ', but signing isn\'t set up on this device yet. Set it up, then return to this link.');
-      showCta('<a class="btn btn-outline" href="/account">Set up your signing key</a>');
+      __signKey = null;   // doSign() will set it up with one tap before signing
     } else {
       setStatus('err', e.message || 'Could not check your signing key.');
+      return;
     }
-    return;
   }
 
-  setStatus('', 'Signed in as ' + escapeHtml(__session.email || 'your account') + '. You\'ll sign with your signing key (fingerprint ' + escapeHtml(__signKey.fingerprint) + ').');
+  if (__signKey) {
+    setStatus('', 'Signed in as ' + escapeHtml(__session.email || 'your account') + '. You\'ll sign with your signing key (fingerprint ' + escapeHtml(__signKey.fingerprint) + ').');
+  } else {
+    setStatus('', 'Signed in as ' + escapeHtml(__session.email || 'your account') + '. You\'ll sign with your sign-in passkey — set up with one tap when you sign (no passphrase, no code).');
+  }
   $('sign-confirm').onclick = doSign;
   refreshSignGate();   // stays disabled until the document has been reviewed (or blind-signing is acknowledged)
 }
@@ -286,9 +291,10 @@ function blindLinkHtml() {
 function refreshSignGate() {
   const btn = $('sign-confirm');
   const gate = $('review-gate');
-  // Login + passkey are handled by prepareSigning; until both exist the CTA there
-  // drives the flow and the sign button stays disabled.
-  if (!__session || !__signKey) { btn.disabled = true; gate.hidden = true; return; }
+  // Login is required; the signing key is NOT required up front — __signKey may be
+  // null for a first-time signer on this device, and doSign() sets it up with one
+  // passkey tap before signing. So gate only on the session here.
+  if (!__session) { btn.disabled = true; gate.hidden = true; return; }
 
   const reviewed = (__hashMatches === true) || __blindAck;
   btn.disabled = !reviewed;
@@ -322,6 +328,13 @@ async function doSign() {
   $('sign-cta').hidden = true;
 
   try {
+    // 0) Make sure this device has a passkey signing key — set one up inline with
+    //    a single passkey tap (no passphrase, no TOTP) if not. The sign-in passkey
+    //    becomes the signing key; no /account detour. Returns the existing key fast.
+    if (!__signKey) {
+      __signKey = await ensureSigningKey({ rpId: location.hostname, onStatus: (m) => setStatus('', m) });
+    }
+
     // 1) Per-document activation (authorize -> one-shot token). The admin checks
     //    the invited email == this party's email and the doc hash, then mints a
     //    300s one-shot activation. No token -> the client cannot proceed to unlock.
@@ -357,7 +370,10 @@ async function doSign() {
     showStep('step-done');
   } catch (e) {
     let msg = (e && e.message) ? e.message : String(e);
-    if (e && e.status === 401) msg = 'Your session expired. Sign in again as the invited recipient, then retry.';
+    if (e && e.code === 'no_passkey') msg = 'Add a passkey to your account first (Account → Passkey sign-in), then return to this link — your sign-in passkey becomes your signing key.';
+    else if (e && (e.code === 'no_prf' || e.code === 'vault_unavailable' || e.code === 'no_webauthn')) msg = e.message;
+    else if (e && e.name === 'NotAllowedError') msg = 'Passkey confirmation was cancelled or timed out. Tap Sign to try again.';
+    else if (e && e.status === 401) msg = 'Your session expired. Sign in again as the invited recipient, then retry.';
     else if (e && e.status === 403) msg = 'This invite is bound to a different email address. Sign in with the address the invite was sent to.';
     else if (e && e.status === 410) msg = 'This signing invite has expired (invites are valid for 7 days). Ask the sender for a new link.';
     else if (e && e.status === 409) msg = 'That signing authorization was already used or expired. Reload the page and try again.';

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -5,7 +5,7 @@
 // Tomorrow a RemoteSamSigner (SAP -> HSM-backed SAM) drops in behind the same
 // interface without touching callers. Self-hosted deps only (CSP 'self').
 import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
-import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultStore, vaultAddPrfWrap, vaultAvailable, vaultList } from '/vendor/vault.js?v=2';
+import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultStore, vaultAddPrfWrap, vaultCreatePrfOnly, vaultAvailable, vaultList } from '/vendor/vault.js?v=3';
 
 // Byte-identical to relay/envelope.js SIGN_DOMAIN_DOC (recipe v3). Keep in sync
 // across relay + SDK + core.
@@ -197,6 +197,147 @@ export async function enrolSigningPasskey({ label, passphrase, registerPasskey, 
     kp.secretKey.fill(0);   // zeroize the plaintext key once both wraps + enrol are done
   }
   return { pk_hash, pk_b64 };
+}
+
+// ── "Your sign-in passkey IS your signing key" — one-tap resolve-or-enrol ─────
+// The single entry point /sign and /co-sign call. If this device already has a
+// passkey-PRF signing key, return it. Otherwise enrol one WITHOUT a passphrase
+// and WITHOUT TOTP, reusing the very passkey the user signs in with:
+//   1. generate the ML-DSA-65 key in the browser;
+//   2. ask the admin for a step-up assertion challenge over THIS account's
+//      passkeys (POST .../step-up/options);
+//   3. run ONE navigator.credentials.get() with that challenge + a PRF eval —
+//      the platform offers the account's passkey (the sign-in passkey); the
+//      assertion proves possession AND yields the PRF output in a single tap;
+//   4. wrap the ML-DSA key with the PRF output locally (vaultCreatePrfOnly) —
+//      the PRF output never leaves the browser;
+//   5. send ONLY the assertion (no PRF) + the public key to the admin, which
+//      verifies the step-up and binds the pubkey via the relay attested route.
+// Reuses the sign-in passkey by allowCredentials, so it never mints a second
+// passkey and never depends on a registration-time prfSupported flag (the old
+// false-negative that spawned a duplicate passkey + the "set up a signing
+// passkey" loop). Respects the [[feedback_eidas_sam_seam]] seam: PRF only
+// UNLOCKS the stored ML-DSA key (activation) — key-use stays behind the signer.
+export async function ensureSigningKey({ rpId, label, onStatus } = {}) {
+  const say = (m) => { try { if (onStatus) onStatus(m); } catch { /* status is best-effort */ } };
+
+  // Fast path: a passkey signing key already exists on this device.
+  try {
+    return await resolvePasskeySigningKey();
+  } catch (e) {
+    if (!e || e.code !== 'no_signing_passkey') throw e;   // a real error, not "needs enrol"
+  }
+
+  if (!(await vaultAvailable())) {
+    const err = new Error('This browser cannot store signing keys (IndexedDB/WebCrypto unavailable).');
+    err.code = 'vault_unavailable';
+    throw err;
+  }
+  if (!(typeof PublicKeyCredential !== 'undefined' && navigator.credentials && navigator.credentials.get)) {
+    const err = new Error('This browser does not support passkeys, so it cannot set up signing.');
+    err.code = 'no_webauthn';
+    throw err;
+  }
+  rpId = rpId || location.hostname;
+
+  // 1) ML-DSA-65 keypair, generated + held only in the browser.
+  const seed = crypto.getRandomValues(new Uint8Array(32));
+  const kp = ml_dsa65.keygen(seed);
+  const pk_b64 = b64EncodeStd(kp.publicKey);
+  const pk_hash = toHex(sha3_256(kp.publicKey));
+  try {
+    // 2) Step-up challenge over THIS account's passkeys.
+    say('Setting up signing with your passkey…');
+    let opt;
+    try {
+      opt = await _postJSON('/api/user/account/signing-key/step-up/options', {});
+    } catch (e) {
+      if (e && e.status === 409 && e.data && e.data.error === 'no_passkey') {
+        const err = new Error('Add a passkey to your account first, then you can sign with it.');
+        err.code = 'no_passkey';
+        throw err;
+      }
+      throw e;
+    }
+    // opt: { flowId, options } — options.allowCredentials are the account's passkeys.
+
+    // 3) ONE WebAuthn get(): server challenge + per-wrap PRF eval salt. The
+    //    platform offers the account's sign-in passkey from allowCredentials.
+    const prfSalt = crypto.getRandomValues(new Uint8Array(16));
+    say('Confirm with Face ID / Touch ID / your security key…');
+    const cred = await navigator.credentials.get({
+      publicKey: {
+        challenge: b64urlToBytes(opt.options.challenge),
+        rpId,
+        allowCredentials: (opt.options.allowCredentials || []).map((c) => ({
+          type: 'public-key',
+          id: b64urlToBytes(c.id),
+          ...(c.transports ? { transports: c.transports } : {}),
+        })),
+        userVerification: 'required',
+        timeout: opt.options.timeout || 60000,
+        extensions: { prf: { eval: { first: prfSalt } } },
+      },
+    });
+    const prfFirst = cred.getClientExtensionResults()?.prf?.results?.first;
+    if (!prfFirst) {
+      const err = new Error('This passkey can’t produce a PRF result. Use a device/browser with passkey-PRF (iOS 18+, a recent Chrome/Edge, or a PRF-capable security key).');
+      err.code = 'no_prf';
+      throw err;
+    }
+    const prfOutput = new Uint8Array(prfFirst);
+
+    // 4) Wrap the ML-DSA key with the PRF output — PRF ONLY, no passphrase. The
+    //    PRF output stays in the browser; only the assertion goes to the server.
+    const credentialId = _b64urlFromBuffer(cred.rawId);
+    try {
+      await vaultCreatePrfOnly({ alg: 'ML-DSA-65', label: label || 'Signing key', pk_b64, pk_hash, secretKeyBytes: kp.secretKey, credentialId, prfSalt, prfOutput });
+    } finally {
+      prfOutput.fill(0);
+    }
+
+    // 5) Bind the PUBLIC key to the account: the admin verifies the step-up
+    //    assertion, then the relay records the pubkey (TOTP-free attested route).
+    say('Linking your signing key to your account…');
+    await _postJSON('/api/user/account/signing-key/step-up/bind', {
+      flowId: opt.flowId,
+      response: _serializeAssertion(cred),
+      pk_b64,
+      label: label || 'Signing key',
+    });
+  } finally {
+    kp.secretKey.fill(0);   // zeroize the plaintext key
+  }
+
+  // Closed loop: resolve the way /sign does, proving the key is usable now.
+  return await resolvePasskeySigningKey();
+}
+
+// Serialize a raw PublicKeyCredential assertion to the JSON shape
+// @simplewebauthn/server verifyAuthenticationResponse expects. The PRF result is
+// deliberately NOT included — it is key material and stays in the browser.
+function _serializeAssertion(cred) {
+  const r = cred.response;
+  const out = {
+    id: cred.id,
+    rawId: _b64urlFromBuffer(cred.rawId),
+    type: cred.type,
+    clientExtensionResults: {},
+    response: {
+      clientDataJSON:    _b64urlFromBuffer(r.clientDataJSON),
+      authenticatorData: _b64urlFromBuffer(r.authenticatorData),
+      signature:         _b64urlFromBuffer(r.signature),
+    },
+  };
+  if (r.userHandle) out.response.userHandle = _b64urlFromBuffer(r.userHandle);
+  return out;
+}
+
+function _b64urlFromBuffer(buf) {
+  const u8 = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  let s = '';
+  for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]);
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 // ── Same-origin admin calls for the per-document signing chain (R018) ────────

--- a/frontend/js/signing-enrol.js
+++ b/frontend/js/signing-enrol.js
@@ -1,114 +1,19 @@
 // Signing-key enrolment — wires the "Set up your signing key" action on
-// /account (ADR R018, the deferred "stuk 2"). This is the ONE place a signing
-// key is created; /sign points here. It runs the shared enrolSigningPasskey()
-// orchestration (parasign-signer.js) with the three ceremony callbacks
-// (registerPasskey / evalNewPrf / enrolPublicKey), then proves the result is
-// resolvable so /sign can find it. Self-hosted deps only (CSP script-src
-// 'self'); no-ops if the page lacks the enrol elements.
-import { enrolSigningPasskey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=3';
-import { startRegistration, browserSupportsWebAuthn } from '/vendor/simplewebauthn-browser/index.js';
-import { vaultList, vaultDelete } from '/vendor/vault.js?v=2';
-
-// base64url -> bytes (WebAuthn credential id / PRF salt). Same idiom as
-// parasign-signer.js so the credentialId we store round-trips at sign time.
-function b64urlToBytes(s) {
-  const t = (s || '').replace(/-/g, '+').replace(/_/g, '/');
-  const bin = atob(t + '='.repeat((4 - (t.length % 4)) % 4));
-  const u = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) u[i] = bin.charCodeAt(i);
-  return u;
-}
-
-async function postJSON(url, body) {
-  const r = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body || {}),
-    credentials: 'include',
-  });
-  let data = null;
-  try { data = await r.json(); } catch { /* non-JSON */ }
-  return { ok: r.ok, status: r.status, data };
-}
-
-// Inline TOTP entry (replaces window.prompt). The enrol makes TWO TOTP-gated
-// server calls (register-options, then bind-public-key) with the passkey
-// ceremony between them, and the relay replay-protects codes (relay.js
-// _usedTotpCodes + replayKey, 90s), so ONE code cannot gate both — the user
-// enters a fresh code each time, in this one inline field, no browser pop-ups.
-// Returns a Promise of the 6-digit string; a bad value re-prompts inline rather
-// than throwing.
-function askTotp(message) {
-  return new Promise((resolve) => {
-    const wrap = document.getElementById('signing-enrol-totp-wrap');
-    const input = document.getElementById('signing-enrol-totp');
-    const confirmBtn = document.getElementById('signing-enrol-totp-confirm');
-    const promptEl = document.getElementById('signing-enrol-totp-prompt');
-    if (!wrap || !input || !confirmBtn || !promptEl) {
-      throw new Error('A 6-digit authenticator code is required.');   // rejects the promise
-    }
-    promptEl.textContent = message;
-    input.value = '';
-    wrap.hidden = false;
-    input.focus();
-    const finish = (val) => {
-      confirmBtn.removeEventListener('click', onConfirm);
-      input.removeEventListener('keydown', onKey);
-      wrap.hidden = true;
-      resolve(val);
-    };
-    const onConfirm = () => {
-      const t = (input.value || '').trim();
-      if (!/^\d{6}$/.test(t)) { promptEl.textContent = 'Enter the 6-digit code from your authenticator app.'; input.focus(); return; }
-      finish(t);
-    };
-    const onKey = (e) => { if (e.key === 'Enter') { e.preventDefault(); onConfirm(); } };
-    confirmBtn.addEventListener('click', onConfirm);
-    input.addEventListener('keydown', onKey);
-  });
-}
-
-// enrolSigningPasskey() stores the passphrase wrap FIRST, so an abort after that
-// (cancelled Face ID, wrong code, no PRF) leaves a passphrase-only vault entry
-// that can never sign — v3 needs a webauthn-prf wrap. These are dead weight, so
-// sweep them after every attempt. A real signing key always ends up with BOTH
-// wraps, so this only ever removes orphans.
-async function cleanupOrphans() {
-  try {
-    for (const k of await vaultList()) {
-      const s = k.kekSources || [];
-      if (s.length === 1 && s[0] === 'passphrase') await vaultDelete(k.id);
-    }
-  } catch { /* best-effort hygiene */ }
-}
+// /account. v4: the signing key is set up with the SAME passkey you sign in
+// with (ADR R018). One Face ID / Touch ID / security-key tap generates the
+// ML-DSA-65 key in the browser, wraps it with that passkey's PRF (no
+// passphrase), and binds the public key to the account via a passkey step-up
+// (no TOTP). All of that ceremony lives in ensureSigningKey()
+// (parasign-signer.js) — the EXACT path /sign and /co-sign use — so this file
+// just wires the button + status and can never drift from the sign flow.
+// Self-hosted deps only (CSP script-src 'self'); no-ops if the button is absent.
+import { ensureSigningKey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=4';
 
 function wireSigningEnrol() {
   const btn = document.getElementById('signing-enrol-btn');
   if (!btn) return;                                  // not the account page
   const status = document.getElementById('signing-enrol-status');
-  const passEl = document.getElementById('signing-enrol-pass');
-  const pass2El = document.getElementById('signing-enrol-pass2');
   const labelEl = document.getElementById('signing-enrol-label');
-
-  // Live passphrase strength hint (length + character variety). Cosmetic guide;
-  // the vault still enforces real strength server-side in vaultStore.
-  const strengthEl = document.getElementById('signing-enrol-strength');
-  if (passEl && strengthEl) {
-    passEl.addEventListener('input', () => {
-      const v = passEl.value || '';
-      if (!v) { strengthEl.textContent = ''; return; }
-      let label, color = 'var(--ink-dim, #6b7280)';
-      if (v.length < 12) { label = 'Too short (needs 12+ characters)'; color = 'var(--danger, #b91c1c)'; }
-      else {
-        const variety = (/[a-z]/.test(v) ? 1 : 0) + (/[A-Z]/.test(v) ? 1 : 0) + (/\d/.test(v) ? 1 : 0) + (/[^a-zA-Z0-9]/.test(v) ? 1 : 0);
-        if (v.length >= 20 && variety >= 3) label = 'Strong';
-        else if (v.length >= 16 || variety >= 3) label = 'Good';
-        else label = 'OK (longer is stronger)';
-      }
-      strengthEl.textContent = label;
-      strengthEl.style.color = color;
-    });
-  }
 
   const setStatus = (t, isErr) => {
     if (!status) return;
@@ -117,121 +22,33 @@ function wireSigningEnrol() {
   };
 
   btn.addEventListener('click', async () => {
-    const passphrase = (passEl && passEl.value) || '';
-    const confirm = (pass2El && pass2El.value) || '';
     const label = ((labelEl && labelEl.value) || '').trim() || 'Signing key';
-
-    // Cheap client-side guards before any ceremony. The vault enforces real
-    // strength (assertStrongPassphrase) inside vaultStore; we mirror the
-    // length + match here for a clean message and to fail fast.
-    if (passphrase.length < 12) { setStatus('Passphrase must be at least 12 characters.', true); return; }
-    if (passphrase !== confirm) { setStatus('The two passphrases do not match.', true); return; }
-    if (!browserSupportsWebAuthn()) { setStatus('This browser does not support passkeys.', true); return; }
-
     btn.disabled = true;
-    setStatus('Setting up… follow the prompts on your device.', false);
-
     try {
-      // One signing-key enrolment (ADR R018): passphrase (recovery floor) ->
-      // passkey-PRF wrap -> bind the public key to the account. The private key
-      // (ML-DSA-65, post-quantum) is generated and wrapped entirely in the browser.
-      const { pk_hash } = await enrolSigningPasskey({
+      // Resolve-or-enrol with one passkey tap. If a key already exists on this
+      // device, ensureSigningKey() returns it without prompting.
+      const k = await ensureSigningKey({
+        rpId: location.hostname,
         label,
-        passphrase,
-
-        // (1) A PRF-CAPABLE passkey. Reuse an existing passkey ONLY if it
-        //     genuinely supports PRF — a non-PRF credential (e.g. one created
-        //     before PRF support) can never unlock the vault, and silently
-        //     reusing it is exactly what broke before. If there is no
-        //     PRF-capable passkey, register a FRESH one: the server enables
-        //     extensions.prf, and we strip excludeCredentials client-side so the
-        //     device will mint a PRF-capable passkey even when a pre-PRF passkey
-        //     already exists for this account (TOTP step-up still gates it).
-        registerPasskey: async ({ forceFresh } = {}) => {
-          // Fast path: reuse an existing PRF-capable passkey — UNLESS the caller
-          // forces a fresh one (the fallback when a reused credential turned out
-          // not to actually produce a PRF result, which is what caused the loop).
-          if (!forceFresh) {
-            let list = [];
-            try {
-              const cr = await fetch('/api/user/account/webauthn/credentials', { credentials: 'include' });
-              if (cr.ok) list = (await cr.json()).passkeys || [];
-            } catch { /* treat as no usable passkey */ }
-            const prfCapable = list.find(c => c.prfSupported && c.credId);
-            if (prfCapable) return { credentialId: prfCapable.credId, reused: true };
-          }
-
-          const totp = await askTotp('Enter the 6-digit code from your authenticator app to start.');
-          setStatus('Verifying code, then follow your device prompt…', false);
-          const opt = await postJSON('/api/user/account/webauthn/register/options', { totp });
-          if (opt.status === 403) throw new Error('That authenticator code was not accepted.');
-          if (!opt.ok) throw new Error((opt.data && opt.data.error) || ('register_options_failed_' + opt.status));
-          // Allow a new (PRF-capable) passkey even if a non-PRF one exists.
-          if (opt.data && opt.data.options) delete opt.data.options.excludeCredentials;
-          let attResp;
-          try {
-            attResp = await startRegistration({ optionsJSON: opt.data.options });
-          } catch (e) {
-            throw new Error(e && e.name === 'InvalidStateError'
-              ? 'Your device blocked creating a new passkey. Remove this site’s passkey in your device settings, then try again.'
-              : 'Passkey creation was cancelled.');
-          }
-          const ver = await postJSON('/api/user/account/webauthn/register/verify', { flowId: opt.data.flowId, response: attResp, label });
-          if (!ver.ok) throw new Error((ver.data && ver.data.error) || ('register_verify_failed_' + ver.status));
-          return { credentialId: attResp.id, reused: false };
-        },
-
-        // (2) Evaluate the passkey PRF with the per-wrap salt. This is the SAME
-        //     get()+prf.eval that LocalVaultSigner.activate() runs at sign time,
-        //     so a successful enrol guarantees a successful unlock later.
-        evalNewPrf: async ({ credentialId, prfSalt }) => {
-          setStatus('Confirm with Face ID / Touch ID / your security key…', false);
-          const assertion = await navigator.credentials.get({
-            publicKey: {
-              challenge: crypto.getRandomValues(new Uint8Array(32)),
-              rpId: location.hostname,
-              allowCredentials: [{ type: 'public-key', id: b64urlToBytes(credentialId) }],
-              userVerification: 'required',
-              extensions: { prf: { eval: { first: prfSalt } } },
-            },
-          });
-          const first = assertion.getClientExtensionResults()?.prf?.results?.first;
-          if (!first) {
-            const e = new Error('This passkey can’t produce a PRF result. Use a device/browser with passkey-PRF (iOS 18+ or a recent Chrome), or remove an old non-PRF passkey for this site and retry.');
-            e.code = 'no_prf';   // signals enrolSigningPasskey to retry with a FRESH passkey when this one was reused
-            throw e;
-          }
-          return new Uint8Array(first);
-        },
-
-        // (3) Bind the PUBLIC key to the account (TOTP-gated). The relay
-        //     recomputes pk_hash from pk_b64 server-side; the secret never
-        //     leaves the browser.
-        enrolPublicKey: async ({ pk_b64, label: keyLabel }) => {
-          const totp = await askTotp('Almost done. Your last code is used up, so enter a fresh 6-digit code to finish.');
-          setStatus('Binding your public key to your account…', false);
-          const r = await postJSON('/api/user/account/signing-key', { pk_b64, label: keyLabel, totp });
-          if (!r.ok) throw new Error((r.data && r.data.error) || ('signing_key_enrol_failed_' + r.status));
-        },
+        onStatus: (m) => setStatus(m, false),
       });
-
-      await cleanupOrphans();   // clear any passphrase-only leftovers from prior aborted attempts
-
-      // Close the loop: resolvePasskeySigningKey() is the EXACT call /sign makes.
-      // If it returns here, the vault now holds a webauthn-prf-wrapped key under
-      // id = pk_hash, and /sign will find it. Show the fingerprint as proof.
-      const k = await resolvePasskeySigningKey();
-      setStatus('Signing key ready — fingerprint ' + (k.fingerprint || pk_hash.slice(0, 16)) + '. You can now sign at /sign.', false);
-      if (passEl) passEl.value = '';
-      if (pass2El) pass2El.value = '';
+      setStatus('Signing key ready — fingerprint ' + (k.fingerprint || (k.pk_hash || '').slice(0, 16)) + '. You can now sign at /sign.', false);
       document.dispatchEvent(new CustomEvent('signing-key-enrolled'));
     } catch (e) {
-      await cleanupOrphans();   // don't leave a half-finished passphrase-only entry behind
-      setStatus((e && e.message) ? e.message : 'Could not set up your signing key.', true);
+      let msg = (e && e.message) ? e.message : 'Could not set up your signing key.';
+      if (e && e.code === 'no_passkey') msg = 'Add a passkey to your account first (the "Passkey sign-in" card above), then set up signing.';
+      else if (e && e.name === 'NotAllowedError') msg = 'Passkey confirmation was cancelled or timed out. Tap the button to try again.';
+      setStatus(msg, true);
     } finally {
       btn.disabled = false;
     }
   });
+
+  // If a signing key already exists in this browser, say so up front so the
+  // page doesn't read as "not set up".
+  resolvePasskeySigningKey()
+    .then((k) => setStatus('A signing key is already set up in this browser (fingerprint ' + k.fingerprint + '). Tap the button to re-create it.', false))
+    .catch(() => { /* none yet — leave the default prompt */ });
 }
 
 wireSigningEnrol();

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -11,7 +11,7 @@
 // sign path. Signing goes through the passkey-PRF activation chain (LocalVaultSigner
 // in parasign-signer.js); sha3_256 stays for document hashing only.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=3';
+import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey } from '/js/parasign-signer.js?v=4';
 
 // Read-only public relay host, used ONLY for the "view envelope status" link on
 // the done screen. The signing path itself is same-origin via the admin
@@ -444,9 +444,8 @@ async function showSigningIdentity() {
     if (e && e.code === 'no_signing_passkey') {
       const elsewhere = await serverHasSigningKey();
       el.innerHTML = (elsewhere
-        ? 'Your signing key was set up in another browser or on another device. Signing keys live in the browser where you create them, so set one up here too. '
-        : 'You haven\'t set up signing on this device yet — you need to before you can sign. ') +
-        '<a href="/account#signing-identity-section" class="btn btn-primary btn-small" style="margin-top:8px;display:inline-block">Set up your signing key →</a>';
+        ? 'You\'ll sign with your sign-in passkey. Signing keys live in the browser where you create them, so this device sets one up the first time you sign — one Face ID / Touch ID tap, no passphrase, no code.'
+        : 'You\'ll sign with your sign-in passkey — this device sets up your signing key with one tap the first time you sign. No passphrase, no separate code.');
     } else {
       el.textContent = (e && e.message) ? e.message : 'Could not check your signing key.';
     }
@@ -700,7 +699,7 @@ async function fillReviewKeyFingerprint() {
     const ksEl = $('ds-review-key-src'); if (ksEl) ksEl.textContent = 'Your signing key (' + k.fingerprint + ')';
   } catch (e) {
     const fpEl = $('ds-proof-fp');
-    if (fpEl) fpEl.textContent = (e && e.code === 'no_signing_passkey') ? '(set up your signing key first)' : '(unavailable)';
+    if (fpEl) fpEl.textContent = (e && e.code === 'no_signing_passkey') ? '(set up with one passkey tap when you sign)' : '(unavailable)';
   }
 }
 
@@ -1053,7 +1052,10 @@ async function doSign() {
     // its public half from vault metadata here (for the stamp fingerprint); the
     // secret is unlocked solely by the per-document PRF activation below.
     status('Locating your signing key...');
-    const signKey = await resolvePasskeySigningKey();   // { vaultId, pk_b64, fingerprint } — public only
+    // Resolve the account's passkey signing key, or set one up inline with a
+    // single passkey tap (no passphrase, no TOTP) if this device has none yet —
+    // the sign-in passkey becomes the signing key. No /account detour.
+    const signKey = await ensureSigningKey({ rpId: location.hostname, label: state.signer.name || 'Signing key', onStatus: status });
     const fingerprint = signKey.fingerprint;
     const dateStr = new Date().toISOString().slice(0, 19) + 'Z';
 
@@ -1141,7 +1143,9 @@ async function doSign() {
     $('ds-sign-status').className = 'ds-banner err';
     let msg = (e && e.message) ? e.message : String(e);
     if (e && e.status === 401) msg = 'Please sign in to sign documents. Open /auth/login, then return here.';
-    else if (e && e.code === 'no_signing_passkey') msg = 'Signing isn\'t set up on this device yet. Set it up at /account, then sign.';
+    else if (e && e.code === 'no_passkey') msg = 'Add a passkey to your account first (Account → Passkey sign-in), then sign — your sign-in passkey becomes your signing key.';
+    else if (e && (e.code === 'no_prf' || e.code === 'vault_unavailable' || e.code === 'no_webauthn')) msg = e.message;
+    else if (e && e.name === 'NotAllowedError') msg = 'Passkey confirmation was cancelled or timed out. Tap Sign now to try again.';
     $('ds-sign-status').textContent = msg;
     $('ds-sign-now').disabled = false;
   }

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -620,6 +620,6 @@
 <script src="/js/nav-auth.js?v=1" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=1"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
-<script type="module" src="/sign-flow.js?v=15"></script>
+<script type="module" src="/sign-flow.js?v=16"></script>
 </body>
 </html>

--- a/frontend/vendor/vault.js
+++ b/frontend/vendor/vault.js
@@ -293,6 +293,50 @@ export async function vaultAddPrfWrap({ pk_hash, secretKeyBytes, credentialId, p
   return { id: pk_hash, kekSources: entry.wraps.map(w => w.kekSource) };
 }
 
+// --- Create a NEW entry wrapped by a passkey PRF ONLY (no passphrase wrap).
+//     This is the "your sign-in passkey IS your signing key" path (ADR R018):
+//     the ML-DSA-65 key is generated in the browser and the ONLY thing that can
+//     unwrap it is the account's passkey PRF — there is no separate signing
+//     passphrase to choose, lose, or be phished for. Recovery is the synced
+//     passkey itself (iCloud Keychain / Google Password Manager) plus the
+//     ability to enrol a fresh key on a new device (the relay keeps a
+//     multi-key, GitHub-SSH-style list, so old signatures stay verifiable). A
+//     passphrase wrap can still be ADDED later via vaultStore as an optional
+//     break-glass; this path just no longer REQUIRES one up front. Note this
+//     deliberately relaxes the earlier "PRF is never the sole wrap" invariant —
+//     it is a documented product choice, not an oversight.
+export async function vaultCreatePrfOnly({ alg, label, pk_b64, pk_hash, secretKeyBytes, credentialId, prfSalt, prfOutput }) {
+  if (!alg || !pk_b64 || !pk_hash) throw new Error('vaultCreatePrfOnly: alg, pk_b64, pk_hash required');
+  if (!(secretKeyBytes instanceof Uint8Array) || secretKeyBytes.length === 0) throw new Error('vaultCreatePrfOnly: secretKeyBytes required');
+  if (!credentialId || !(prfOutput instanceof Uint8Array) || prfOutput.length < 16) throw new Error('vaultCreatePrfOnly: credentialId + prfOutput required');
+  if (!(prfSalt instanceof Uint8Array) || prfSalt.length < 16) throw new Error('vaultCreatePrfOnly: prfSalt (>=16 bytes, the WebAuthn PRF eval salt) required');
+
+  const iv  = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const kek = await _deriveKekFromPrf(prfOutput, prfSalt);
+  const ct  = new Uint8Array(await crypto.subtle.encrypt({ name: KEK_NAME, iv }, kek, secretKeyBytes));
+  const wrap = {
+    kekSource: 'webauthn-prf', credentialId, hkdf: 'HKDF-SHA256',
+    info: 'paramant/parasign/vault-kek/v1',
+    prfSalt: b64Encode(prfSalt), iv: b64Encode(iv), ciphertext: b64Encode(ct),
+  };
+
+  const db = await vaultOpen();
+  const store = _tx(db, 'readwrite');
+  const existing = await _toPromise(store.get(pk_hash));
+  const entry = existing ? { ...existing } : {
+    id: pk_hash, alg, label: label || null, pk_b64, pk_hash,
+    enrolled_at: new Date().toISOString(), wraps: [], last_used_at: null,
+  };
+  if (label) entry.label = label;
+  // Replace any existing prf wrap for THIS credential; keep other wraps (incl.
+  // an optional passphrase break-glass) intact.
+  entry.wraps = (entry.wraps || []).filter(w => !(w.kekSource === 'webauthn-prf' && w.credentialId === credentialId));
+  entry.wraps.push(wrap);
+  await _toPromise(store.put(entry));
+  db.close();
+  return { id: entry.id, alg: entry.alg, label: entry.label, pk_hash: entry.pk_hash, enrolled_at: entry.enrolled_at, kekSources: entry.wraps.map(w => w.kekSource) };
+}
+
 // Unlock via the webauthn-prf wrap. Returns raw secretKeyBytes. The caller must
 // zeroize them after signing (see parasign-signer.js dispose()).
 export async function vaultUnlockPrf(id, { prfOutput, credentialId } = {}) {

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -2488,6 +2488,61 @@ const server = http.createServer(async (req, res) => {
     }
   }
 
+  // POST /v2/user/signing-key/attested — enrol a signing pubkey gated by a
+  // PASSKEY STEP-UP the admin already verified, INSTEAD of TOTP. This is the
+  // "your sign-in passkey IS your signing key" path: a logged-in user who has a
+  // passkey proves possession with a fresh WebAuthn assertion (verified in the
+  // admin server, which owns rpId/origin — the relay never verifies assertions,
+  // see the storage block below), and that step-up authorises the bind. It lets
+  // a passkey-only account (no TOTP) enrol a signing key at all, which the
+  // TOTP-gated route above cannot. The relay does NOT blindly trust the caller:
+  //   GATE 1  internal-auth only (admin proxy);
+  //   GATE 2  the account MUST already have >=1 active passkey credential — with
+  //           no passkey there is nothing the admin could have stepped up, so a
+  //           TOTP-less, passkey-less account can never reach a TOTP-free bind;
+  //   + the cross-account-conflict check inside storeSigningPk still applies, and
+  //   the server recomputes pk_hash (a client-supplied hash is never trusted).
+  // Mirrors /tofu's "as strict as the TOTP gate it replaces" property.
+  if (req.method === "POST" && path === "/v2/user/signing-key/attested") {
+    if (!_internalOk()) return _internalReject();
+    try {
+      const { user_id, pk_b64, label } = JSON.parse((await readBody(req, 16384)).toString());
+      if (!user_id) { res.writeHead(400); return res.end(J({ error: "missing_user_id" })); }
+      if (!pk_b64 || typeof pk_b64 !== "string") { res.writeHead(400); return res.end(J({ error: "missing_pk_b64" })); }
+      // GATE 2 — the account must actually have a passkey (the factor the admin
+      // stepped up). No passkey -> no attested bind (fall back to the TOTP route).
+      const credCount = await userWebauthn.countActiveCredentials(redisClient, user_id);
+      if (!credCount) { res.writeHead(403); return res.end(J({ error: "no_passkey_enrolled" })); }
+      // Store (server-side pk_hash computation; cross-account-conflict check inside).
+      let result;
+      try {
+        result = await userSigning.storeSigningPk(redisClient, user_id, { pk_b64, label });
+      } catch (e) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        return res.end(J({ error: e.message }));   // e.g. 'pubkey already enrolled to a different account'
+      }
+      const ctEntry = ctAppendSigningPkEvent("signing_pk_enrolled_attested", user_id, result.entry.pk_hash_sha3);
+      log("info", "signing_pk_enrolled_attested", {
+        user_id: String(user_id).slice(0, 12) + "…",
+        pk_hash: result.entry.pk_hash_sha3.slice(0, 16) + "…",
+        reenrolled: result.reenrolled,
+        ct_index: ctEntry.index,
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(J({
+        ok: true,
+        pk_hash_sha3: result.entry.pk_hash_sha3,
+        label: result.entry.label,
+        enrolled_at: result.entry.enrolled_at,
+        reenrolled: result.reenrolled,
+        ct_index: ctEntry.index,
+      }));
+    } catch (err) {
+      console.error("[user/signing-key/attested]", err.message);
+      res.writeHead(500); return res.end(J({ error: "internal" }));
+    }
+  }
+
   // ── WebAuthn / passkey credential storage (ADR R018, PR-A) ───────────────────
   // Durable storage only. The WebAuthn ceremony (challenge issue + attestation/
   // assertion verification, rpId/origin checks) lives in the admin server and

--- a/relay/test/signing-key-attested.test.js
+++ b/relay/test/signing-key-attested.test.js
@@ -1,0 +1,88 @@
+'use strict';
+// Unit test for the invariants behind the TOTP-free, passkey-attested signing-
+// key bind (relay POST /v2/user/signing-key/attested — the "your sign-in passkey
+// IS your signing key" path). The route itself is thin HTTP glue; its SECURITY
+// rests on lib-level invariants, asserted here against the same in-memory redis
+// double the other relay tests use:
+//   1. GATE — countActiveCredentials(user) is the passkey gate: 0 for a fresh
+//      account (route -> 403 no_passkey_enrolled), >=1 once a passkey exists.
+//      This is what stops a TOTP-less, passkey-less account from ever reaching a
+//      TOTP-free bind.
+//   2. BIND — after the gate, storeSigningPk enrols the pubkey and it shows up
+//      active (the happy path the route returns), and re-binding is idempotent.
+//   3. CONFLICT — storeSigningPk still refuses a pubkey already bound to another
+//      account, so the attested path cannot graft a key onto someone else.
+// Run: node relay/test/signing-key-attested.test.js (no deps, non-zero exit on fail).
+
+const assert = require('assert');
+const wa = require('../lib/user-webauthn');
+const us = require('../lib/user-signing');
+
+function fakeRedis() {
+  const m = new Map();
+  return {
+    _m: m,
+    async get(k) { return m.has(k) ? m.get(k) : null; },
+    async set(k, v) { m.set(k, v); },
+    async del(k) { return m.delete(k) ? 1 : 0; },
+  };
+}
+
+const U1 = 'pgp_user_one';
+const U2 = 'pgp_user_two';
+// A valid ML-DSA-65 public key is exactly 1952 bytes (FIPS 204); storeSigningPk
+// validates the length, so the test keys must be exactly that size.
+const PK1 = Buffer.alloc(us.ML_DSA_65_PK_LEN, 7).toString('base64');
+const PK2 = Buffer.alloc(us.ML_DSA_65_PK_LEN, 9).toString('base64');
+const CRED = 'Y3JlZC1pZC1hdHRlc3RlZA';   // base64url-ish
+
+let passed = 0;
+const ok = (n) => { passed++; console.log('  ok -', n); };
+
+async function main() {
+  const r = fakeRedis();
+
+  // 1. GATE — a fresh account has no passkey, so the attested route would 403.
+  assert.strictEqual(await wa.countActiveCredentials(r, U1), 0, 'fresh account: 0 passkeys -> attested bind refused');
+  ok('gate: no passkey -> count 0 (route 403 no_passkey_enrolled)');
+
+  // After registering a passkey, the gate opens (count >= 1).
+  await wa.storeCredential(r, U1, { credId: CRED, publicKey: Buffer.from('cose').toString('base64url'), counter: 0, prfSupported: true });
+  assert.strictEqual(await wa.countActiveCredentials(r, U1), 1, 'with a passkey -> attested bind allowed');
+  ok('gate: passkey present -> count 1 (route proceeds)');
+
+  // 2. BIND — the happy path the route runs after the gate + step-up verify.
+  const res = await us.storeSigningPk(r, U1, { pk_b64: PK1, label: 'iPhone' });
+  assert.ok(res && res.entry && /^[0-9a-f]{64}$/.test(res.entry.pk_hash_sha3), 'server computes a 64-hex pk_hash');
+  assert.strictEqual(res.reenrolled, false, 'first bind is a fresh enroll');
+  const active = await us.getActiveSigningPks(r, U1);
+  assert.strictEqual(active.length, 1, 'the bound pubkey is active');
+  assert.strictEqual(active[0].pk_b64, PK1, 'the active key is the one we bound');
+  ok('bind: attested enroll stores the pubkey active');
+
+  // Idempotent re-bind (same pk, same user) — matches the route's reenrolled:true
+  // response when a device re-runs the one-tap setup.
+  const again = await us.storeSigningPk(r, U1, { pk_b64: PK1, label: 'iPhone' });
+  assert.strictEqual(again.reenrolled, true, 're-binding the same pubkey is idempotent');
+  assert.strictEqual((await us.getActiveSigningPks(r, U1)).length, 1, 'no duplicate entry on re-bind');
+  ok('bind: idempotent re-enroll');
+
+  // 3. CONFLICT — a pubkey already bound to U1 cannot be attested onto U2, so the
+  //    attested path can never graft someone else's key onto another account.
+  await wa.storeCredential(r, U2, { credId: 'b3RoZXItY3JlZA', publicKey: Buffer.from('cose2').toString('base64url'), counter: 0, prfSupported: true });
+  await assert.rejects(
+    () => us.storeSigningPk(r, U2, { pk_b64: PK1, label: 'theft' }),
+    /already enrolled to a different account/,
+    'cross-account pubkey conflict is refused',
+  );
+  ok('conflict: cross-account pubkey bind refused');
+
+  // A different pubkey for U2 is fine (independent accounts, independent keys).
+  await us.storeSigningPk(r, U2, { pk_b64: PK2, label: 'ok' });
+  assert.strictEqual((await us.getActiveSigningPks(r, U2)).length, 1, 'U2 binds its own distinct key');
+  ok('conflict: distinct key per account allowed');
+
+  console.log(`\n${passed} checks passed.`);
+}
+
+main().catch((e) => { console.error('FAIL:', (e && e.stack) || e); process.exit(1); });


### PR DESCRIPTION
## Wat & waarom

Mick: *"paramant signing passkey werkt nog steeds niet goed, zorg gewoon dat de login passkey ook de key is om te signen."*

De **login-passkey** en de **signing-key** waren twee aparte credentials. De grondoorzaken dat het "niet goed werkt":

1. **Passkey-first accounts hebben geen TOTP**, maar elke signing-key-bind (`/v2/user/signing-key`) én elke verse-passkey-mint was **TOTP-gated** → een passkey-only gebruiker kon *helemaal geen* signing-key aanmaken.
2. De enrol die wél werkte eiste een **passphrase + 2× TOTP**, en mintte een **tweede passkey** zodra de registratie-tijd `prfSupported`-vlag een false-negative gaf → de "set up a signing passkey"-loop (#131/#164).
3. Bij `no_signing_passkey` werd de gebruiker naar `/account` gestuurd i.p.v. inline te enrollen.

Deze PR klapt de twee credentials samen: **de passkey waarmee je inlogt is de passkey waarmee je tekent.**

## Hoe

- **relay** `POST /v2/user/signing-key/attested` — TOTP-vrije bind, gated op een passkey-step-up die de admin verifieerde + `countActiveCredentials >= 1`. Spiegelt het `/tofu`-vertrouwensmodel (de relay verifieert nooit assertions; de admin wel). De bestaande TOTP-route blijft ongemoeid.
- **admin** `POST /api/user/account/signing-key/step-up/{options,bind}` — verifieert een verse assertie van de gebruiker z'n **eigen** passkey (net als `login/verify`: one-shot challenge, credential gebonden aan dít account, counter-regel) en forwardt dan de attested bind. **Passkey-step-up = TOTP-equivalent.**
- **frontend** `ensureSigningKey()` — één resolve-or-enrol entry point voor `/sign`, `/co-sign` én `/account`. **Eén** `navigator.credentials.get()` draagt zowel de step-up-challenge (naar de server) als een `prf.eval` (blijft lokaal om de ML-DSA-key te wrappen). Hergebruikt de sign-in passkey via `allowCredentials`; vertrouwt **nooit** de opgeslagen `prfSupported`-vlag → geen tweede passkey, geen loop.
- **vault** `vaultCreatePrfOnly()` — PRF-only entry (geen passphrase).
- `/sign` + `/co-sign` dumpen first-time signers niet meer naar `/account` — ze enrollen inline met één tap en tekenen door.

## Twee bewust omgekeerde invarianten (graag jouw blik)

1. **Signing-key bind is niet langer verplicht TOTP-gated** — een passkey-step-up vervangt het. (Veiligheid: de bind eist een verse assertie van *jouw eigen* passkey; een gestolen sessie alleen kan niets binden. Even sterk als de TOTP die het vervangt.)
2. **"PRF is never the sole wrap" losgelaten** — een signing-key is geen login-factor: kwijt = nieuwe enrollen (relay houdt multi-key lijst, oude handtekeningen blijven verifieerbaar; gesyncte passkey is de recovery). Account-login houdt z'n eigen recovery (backup codes). Een passphrase-wrap kan optioneel als break-glass alsnog toegevoegd worden.

**Seam intact (eIDAS/R018):** PRF *ontsluit* alleen een random gegenereerde ML-DSA-65 key (activation); key-use blijft achter `ActivatedSigner.sign()`. De key wordt **niet** uit de PRF afgeleid → een SAM/HSM kan later nog tussen activation en key-use. De v3 sign-message is ongemoeid → al-getekende envelopes blijven `valid`. Detail in de R018-addendum.

## Geverifieerd

- `node --check` op alle 7 gewijzigde JS-bestanden ✅
- Nieuwe tests: `relay/test/signing-key-attested.test.js` (gate/bind/conflict-invarianten) + `admin/test/signing-key-stepup.test.js` (one-shot step-up flow) ✅
- **Volledige relay- én admin-testsuites groen** ✅
- De PRF-wrap die `vaultCreatePrfOnly` schrijft is byte-identiek aan het bestaande (werkende) `vaultAddPrfWrap` → het ongewijzigde `activate()`-pad ontsluit hem.

## Nog NIET gedaan — bewust

- **Niet gemerged, niet gedeployed.** De WebAuthn-PRF-ceremonie kan ik niet headless valideren; dit vraagt jouw **iPhone device-test** (de gebruikelijke werkwijze). 
- Deploy = backend rebuild (relay + admin) + frontend rsync. Geef expliciet GO als de device-test slaagt, dan zet ik de deploy-stappen klaar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)