### PR TITLE
fix(extensions): compose-knop in niet-Engelse Gmail + consistente sessie-checks

### DIFF
--- a/extensions/chromium/src/background/auth-client.js
+++ b/extensions/chromium/src/background/auth-client.js
@@ -88,6 +88,10 @@ export async function verifySession() {
   }
 
   if (s.auth_mode === 'apikey') {
+    // Must mirror getUploadCredentials' definition of "signed in": without the stored key,
+    // the popup would show "signed in" while every upload fails with not_authenticated. If a
+    // stale session is missing the key, clear it so the popup prompts a fresh sign-in.
+    if (!s.auth_apikey) { await clearAuth(); return { authenticated: false }; }
     return {
       authenticated: true, mode: 'apikey', plan: s.auth_plan || null, relay: s.auth_relay,
       expires_at: new Date(s.auth_until).toISOString(),

--- a/extensions/chromium/src/content/compose-inject.js
+++ b/extensions/chromium/src/content/compose-inject.js
@@ -49,11 +49,34 @@ export function initCompose(config) {
 }
 
 function waitForAttachButton(composeWin, config, attempts = 0) {
-  const btn = composeWin.querySelector(config.attachSelector);
+  const btn = locateAttach(composeWin, config);
   if (btn) return injectButton(composeWin, btn, config);
   if (attempts < (config.attachAttempts ?? 25)) {
     setTimeout(() => waitForAttachButton(composeWin, config, attempts + 1), config.attachDelay ?? 180);
+  } else {
+    console.debug('[Paramant] attach button not found in compose window — selector may need updating for this UI language');
   }
+}
+
+// The exact-label selector is fast but English-only. The label-regex fallback makes the
+// integration locale-independent: it matches the attach button's localized tooltip/aria-label
+// (e.g. NL "Bestanden bijvoegen", DE "Datei anhängen") while deliberately NOT matching the
+// Drive insert button, whose verb is "insert/invoegen/einfügen/insérer/insertar".
+function locateAttach(composeWin, config) {
+  if (config.attachSelector) {
+    const el = composeWin.querySelector(config.attachSelector);
+    if (el) return el;
+  }
+  if (config.attachMatch) {
+    const test = typeof config.attachMatch === 'function'
+      ? config.attachMatch
+      : (s) => config.attachMatch.test(s);
+    for (const el of composeWin.querySelectorAll('[data-tooltip], [aria-label]')) {
+      const label = `${el.getAttribute('data-tooltip') || ''} ${el.getAttribute('aria-label') || ''}`;
+      if (test(label)) return el;
+    }
+  }
+  return null;
 }
 
 function injectButton(composeWin, attachBtn, config) {
@@ -137,6 +160,7 @@ async function uploadOne(composeWin, file, config) {
     ui.succeed(t('success_inserted'));
   } catch (err) {
     if (transferId) send({ type: 'TRANSFER_ABORT', transferId }).catch(() => {});
+    if (String(err?.message || err || '') === 'not_authenticated') send({ type: 'OPEN_POPUP' }).catch(() => {});
     ui.fail(friendlyError(err));
   }
 }

--- a/extensions/chromium/src/content/gmail.js
+++ b/extensions/chromium/src/content/gmail.js
@@ -7,7 +7,15 @@ import { initCompose } from './compose-inject.js';
 initCompose({
   // Full compose dialog + inline reply.
   composeSelector: '.nH.Hd[role="dialog"], .dw.dw-sk-bUdYId',
+  // Fast path: the English exact label. Fallback below handles every other UI language.
   attachSelector:  '[data-tooltip="Attach files"], [aria-label="Attach files"]',
+  // Locale-independent match on the attach button's tooltip/aria-label. We match the "file"
+  // noun in the major Gmail UI languages and exclude the Drive "insert files" button (whose
+  // verb is insert/invoegen/einfügen/insérer/insertar) so we never grab the wrong control.
+  // This is what makes the button appear in e.g. Dutch ("Bestanden bijvoegen") Gmail.
+  attachMatch: (label) =>
+    /bestand|file|datei|fichier|archivo|allegat|arquivo|ficheiro|vedlegg|bilaga|liite|melléklet|załącz|příloh|вложение|附件|添付/i.test(label) &&
+    !/invoeg|insert|insér|inser|einfüg|drive/i.test(label),
   attachAttempts: 20,
   attachDelay: 150,
   findEditor(composeWin) {


### PR DESCRIPTION
## Twee veldbugs in de Gmail/Outlook compose-integratie

**1. Locale (bevestigd opgelost)** — de attach-knop-selector gebruikte alleen het Engelse label `"Attach files"`, dus in een niet-Engelse Gmail (NL "Bestanden bijvoegen") werd de Paramant-knop nooit geïnjecteerd. Nu een taal-onafhankelijke fallback die het "bestand"-zelfstandignaamwoord matcht en de Drive-"invoegen"-knop uitsluit. → knop verschijnt nu in NL Gmail.

**2. Sessie-consistentie** — `verifySession()` (achter `CHECK_SESSION`; stuurt de popup-status én het openen van de bestandskiezer) accepteerde een apikey-sessie die `getUploadCredentials()` afwees: het controleerde de opgeslagen sleutel niet. Een stale sessie met `auth_mode` maar zonder `auth_apikey` toonde "Signed in" terwijl elke upload faalde met `not_authenticated`. `verifySession` eist nu `auth_apikey` en wist een sleutelloze sessie zodat de popup opnieuw om inloggen vraagt. Een upload die alsnog `not_authenticated` raakt opent nu de popup.

## Status
- lint schoon, 16/16 vitest, productie-build groen.
- ⚠️ **Niet mergen tot bevestigd**: melder reproduceert nog `not_authenticated` na fix #2 — diagnose loopt (mogelijk stale/oude build geladen of re-login niet gepersisteerd). Fix #1 is wel bevestigd werkend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
