### PR TITLE
fix(parasign): PRF evalByCredential — fixes "can't produce a PRF result"

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -778,7 +778,7 @@ loadVaultStatus();
 document.addEventListener('signing-key-enrolled', () => { loadEnrolledKeys(); loadVaultStatus(); });
 </script>
 <script type="module" src="/js/passkey.js?v=3"></script>
-<script type="module" src="/js/signing-enrol.js?v=6"></script>
+<script type="module" src="/js/signing-enrol.js?v=7"></script>
 
 </body>
 </html>

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -182,6 +182,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 </main>
 
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=1"></script>
-<script type="module" src="/co-sign.js?v=5"></script>
+<script type="module" src="/co-sign.js?v=6"></script>
 </body>
 </html>

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -18,7 +18,7 @@
 // the view receipt. The signing path itself is same-origin via the admin
 // (/api/user/sign/*), bound to the logged-in invitee session.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey } from '/js/parasign-signer.js?v=4';
+import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey } from '/js/parasign-signer.js?v=5';
 
 const RELAY_PUBLIC = 'https://health.paramant.app';
 

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -81,13 +81,19 @@ export async function resolvePasskeySigningKey() {
 // was stored in the wrap at enrol (PRF output is deterministic per
 // (credential, salt), independent of the challenge).
 async function evalPrf({ rpId, credentialIdB64url, prfSaltB64url }) {
+  const saltBytes = b64urlToBytes(prfSaltB64url);
+  // WebAuthn-PRF with a non-empty allowCredentials REQUIRES evalByCredential
+  // (keyed by the base64url credential id) on Chromium + Gecko; a plain `eval`
+  // yields NO prf result there (and on WebKit once >1 passkey is offered). Send
+  // both: evalByCredential (used when the credential matches) + eval (fallback),
+  // same salt either way so the PRF output is identical to enrol time.
   const assertion = await navigator.credentials.get({
     publicKey: {
       challenge: crypto.getRandomValues(new Uint8Array(32)),
       rpId,
       allowCredentials: [{ type: 'public-key', id: b64urlToBytes(credentialIdB64url) }],
       userVerification: 'required',
-      extensions: { prf: { eval: { first: b64urlToBytes(prfSaltB64url) } } },
+      extensions: { prf: { eval: { first: saltBytes }, evalByCredential: { [credentialIdB64url]: { first: saltBytes } } } },
     },
   });
   const first = assertion.getClientExtensionResults()?.prf?.results?.first;
@@ -265,18 +271,30 @@ export async function ensureSigningKey({ rpId, label, onStatus } = {}) {
     //    platform offers the account's sign-in passkey from allowCredentials.
     const prfSalt = crypto.getRandomValues(new Uint8Array(16));
     say('Confirm with Face ID / Touch ID / your security key…');
+    const allowList = (opt.options.allowCredentials || []);
+    // WebAuthn-PRF with a non-empty allowCredentials needs evalByCredential
+    // (per-credential, keyed by the base64url id) on Chromium + Gecko — and on
+    // WebKit as soon as more than one passkey is offered — or NO prf result
+    // comes back (the "can't produce a PRF result" dead end). Same salt for
+    // every credential; whichever the user picks yields that credential's PRF,
+    // and we wrap with exactly that. eval stays as a single-credential fallback.
+    const prfExt = { eval: { first: prfSalt } };
+    if (allowList.length) {
+      prfExt.evalByCredential = {};
+      for (const c of allowList) prfExt.evalByCredential[c.id] = { first: prfSalt };
+    }
     const cred = await navigator.credentials.get({
       publicKey: {
         challenge: b64urlToBytes(opt.options.challenge),
         rpId,
-        allowCredentials: (opt.options.allowCredentials || []).map((c) => ({
+        allowCredentials: allowList.map((c) => ({
           type: 'public-key',
           id: b64urlToBytes(c.id),
           ...(c.transports ? { transports: c.transports } : {}),
         })),
         userVerification: 'required',
         timeout: opt.options.timeout || 60000,
-        extensions: { prf: { eval: { first: prfSalt } } },
+        extensions: { prf: prfExt },
       },
     });
     const prfFirst = cred.getClientExtensionResults()?.prf?.results?.first;

--- a/frontend/js/signing-enrol.js
+++ b/frontend/js/signing-enrol.js
@@ -7,7 +7,7 @@
 // (parasign-signer.js) — the EXACT path /sign and /co-sign use — so this file
 // just wires the button + status and can never drift from the sign flow.
 // Self-hosted deps only (CSP script-src 'self'); no-ops if the button is absent.
-import { ensureSigningKey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=4';
+import { ensureSigningKey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=5';
 
 function wireSigningEnrol() {
   const btn = document.getElementById('signing-enrol-btn');

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -11,7 +11,7 @@
 // sign path. Signing goes through the passkey-PRF activation chain (LocalVaultSigner
 // in parasign-signer.js); sha3_256 stays for document hashing only.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey } from '/js/parasign-signer.js?v=4';
+import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey } from '/js/parasign-signer.js?v=5';
 
 // Read-only public relay host, used ONLY for the "view envelope status" link on
 // the done screen. The signing path itself is same-origin via the admin

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -620,6 +620,6 @@
 <script src="/js/nav-auth.js?v=1" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=1"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
-<script type="module" src="/sign-flow.js?v=16"></script>
+<script type="module" src="/sign-flow.js?v=17"></script>
 </body>
 </html>


### PR DESCRIPTION
## Symptoom

Op de één-tap signing-key setup (`/account`, `/sign`, `/co-sign`): **"This passkey can't produce a PRF result."** — óók op een verse Firefox mobile, dus geen cache: een echte bug.

## Oorzaak

`navigator.credentials.get()` stuurde alleen `prf.eval` terwijl er een **niet-lege `allowCredentials`** werd meegegeven. Chromium en Gecko vereisen in dat geval **`prf.evalByCredential`** (gekeyed op het base64url credential-id) en geven voor een kale `eval` géén PRF-resultaat terug — en WebKit ook zodra er meer dan één passkey wordt aangeboden. `ensureSigningKey()` biedt juist **alle** passkeys van het account aan, dus dit raakt iedereen met >1 passkey (en op Chrome/Firefox zelfs met één).

## Fix

Beide `get()`-plekken sturen nu `evalByCredential` (zelfde salt per credential) náást `eval` als fallback:
- `ensureSigningKey()` — enrol, multi-credential (bouwt `evalByCredential` over alle aangeboden passkeys).
- `evalPrf()` — activate/sign, single-credential (ook gefixt, zodat tekenen op Chrome/Firefox niet stilletjes breekt).

Safari blijft werken (gebruikt `evalByCredential` voor de gekozen credential; zelfde salt → zelfde PRF-output als bij enrol).

**Frontend-only.** Cache-bust cascade: `parasign-signer ?v=5` in z'n 3 importers; `signing-enrol ?v=7`, `sign-flow ?v=17`, `co-sign ?v=6` in hun HTML.

## Geverifieerd

`node --check` op alle gewijzigde modules ✅. WebAuthn-PRF zelf is device-only — Micks iPhone/Firefox-test is de echte bevestiging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)