### PR TITLE
fix(parashare): preserve received filename so *.mp4 no longer saves as .txt

### DIFF
--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -644,22 +644,12 @@ async function receiveFile(msg, kyberSec, ecdhPrivRaw, opts = {}) {
   showStep('step-receiving');
   const tokens = msg.tokens.split(',');
   const totalChunks = parseInt(msg.total_chunks) || 1;
-  const fileName = msg.file_name || 'download';
+  let fileName = msg.file_name || 'download';
   const chunks = [];
   const burnedHashes = [];
   let fileWriter = null;  // File System Access API streaming writer
 
   try {
-    // Probeer File System Access API (Chrome/Edge) — true streaming, geen RAM limiet
-    if (window.showSaveFilePicker) {
-      try {
-        const handle = await window.showSaveFilePicker({ suggestedName: fileName, _startIn: 'downloads' });
-        fileWriter = await handle.createWritable();
-      } catch(e) {
-        // Gebruiker annuleerde of API niet beschikbaar — val terug op Blob
-        fileWriter = null;
-      }
-    }
     for (let i = 0; i < tokens.length; i++) {
       const pct = Math.round(10 + (i / tokens.length) * 75);
       $('recv-progress').style.width = pct + '%';
@@ -692,6 +682,19 @@ async function receiveFile(msg, kyberSec, ecdhPrivRaw, opts = {}) {
         }
         doff += 4 + metaLen;
       }
+
+      // Bestandsnaam is nu bekend (uit chunk 0). Open de save-picker met de juiste
+      // suggestedName. showSaveFilePicker vereist user-activation; lukt dat niet dan
+      // valt het terug op Blob-assembly onderaan, nu met de correcte bestandsnaam.
+      if (i === 0 && window.showSaveFilePicker) {
+        try {
+          const handle = await window.showSaveFilePicker({ suggestedName: fileName, _startIn: 'downloads' });
+          fileWriter = await handle.createWritable();
+        } catch(e) {
+          // Gebruiker annuleerde of geen user-activation — val terug op Blob
+          fileWriter = null;
+        }
+      }
       const decryptedChunk = plainPadded.slice(doff);
       if (fileWriter) {
         await fileWriter.write(decryptedChunk);
@@ -710,8 +713,9 @@ async function receiveFile(msg, kyberSec, ecdhPrivRaw, opts = {}) {
       fileWriter = null;
       totalSize = chunks.length; // niet beschikbaar, gebruik 0
     } else {
-      // Blob assembly: geef chunks direct aan Blob (efficienter dan concat)
-      const blob = new Blob(chunks);
+      // Blob assembly: geef chunks direct aan Blob (efficienter dan concat).
+      // Expliciet octet-stream zodat de browser geen .txt-extensie afleidt.
+      const blob = new Blob(chunks, { type: 'application/octet-stream' });
       totalSize = blob.size;
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');

--- a/tests/receive-filename.test.mjs
+++ b/tests/receive-filename.test.mjs
@@ -1,0 +1,85 @@
+// Regression test for the ParaShare receive-side filename + MIME bug.
+//
+// Mirrors the metadata wire format produced by frontend/parashare.html and the
+// header-parsing + download logic in frontend/ontvang.html (receiveFile()).
+//
+// Reported symptom: a sent *.mp4 saved as a *.txt file. Root cause was that
+// `fileName` was declared `const` and then reassigned from chunk-0 metadata.
+// The reassignment throws a TypeError that the surrounding `catch(_) {}`
+// swallowed, so the real filename was lost (stayed 'download') and the
+// typeless Blob let the browser infer a .txt extension.
+//
+// Run: node tests/receive-filename.test.mjs
+
+import assert from 'node:assert/strict';
+
+const META_MAGIC = new Uint8Array([0x50, 0x52, 0x53, 0x48]); // 'PRSH'
+
+function u32be(n) {
+  const b = new Uint8Array(4);
+  new DataView(b.buffer).setUint32(0, n, false); // big-endian, like parashare.html
+  return b;
+}
+function concat(...arrs) {
+  const len = arrs.reduce((a, x) => a + x.length, 0);
+  const out = new Uint8Array(len);
+  let o = 0;
+  for (const a of arrs) { out.set(a, o); o += a.length; }
+  return out;
+}
+
+// Sender (parashare.html ~line 1013): META_MAGIC | u32be(metaLen) | metaJSON | fileBytes
+function buildChunk0(fileName, fileBytes) {
+  const metaBytes = new TextEncoder().encode(JSON.stringify({ file_id: 'abc', file_name: fileName }));
+  return concat(META_MAGIC, u32be(metaBytes.length), metaBytes, fileBytes);
+}
+
+// Receiver — FIXED logic (current ontvang.html receiveFile)
+function receiveFixed(plainPadded, msgFileName) {
+  let fileName = msgFileName || 'download';
+  let doff = 0;
+  if (plainPadded[0] === META_MAGIC[0] && plainPadded[1] === META_MAGIC[1]) {
+    doff = 4;
+    const metaLen = new DataView(plainPadded.buffer).getUint32(doff, false);
+    try {
+      const metaObj = JSON.parse(new TextDecoder().decode(plainPadded.slice(doff + 4, doff + 4 + metaLen)));
+      if (metaObj.file_name) fileName = metaObj.file_name;
+    } catch (_) {}
+    doff += 4 + metaLen;
+  }
+  const fileData = plainPadded.slice(doff);
+  return { fileName, blob: new Blob([fileData], { type: 'application/octet-stream' }), fileData };
+}
+
+// Receiver — OLD buggy logic (const fileName + typeless Blob), kept to prove the test discriminates
+function receiveBuggy(plainPadded, msgFileName) {
+  const fileName = msgFileName || 'download'; // const -> reassignment below throws
+  let doff = 0;
+  if (plainPadded[0] === META_MAGIC[0] && plainPadded[1] === META_MAGIC[1]) {
+    doff = 4;
+    const metaLen = new DataView(plainPadded.buffer).getUint32(doff, false);
+    try {
+      const metaObj = JSON.parse(new TextDecoder().decode(plainPadded.slice(doff + 4, doff + 4 + metaLen)));
+      if (metaObj.file_name) fileName = metaObj.file_name; // TypeError, swallowed by catch
+    } catch (_) {}
+    doff += 4 + metaLen;
+  }
+  const fileData = plainPadded.slice(doff);
+  return { fileName, blob: new Blob([fileData]), fileData };
+}
+
+const fileBytes = new Uint8Array([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32]); // mp4 'ftypmp42'
+const payload = buildChunk0('holiday.mp4', fileBytes);
+
+// The receiver always starts with the placeholder 'download' (real name is only in the payload)
+const fixed = receiveFixed(payload, 'download');
+assert.equal(fixed.fileName, 'holiday.mp4', 'fixed: filename must be recovered from chunk-0 metadata');
+assert.equal(fixed.blob.type, 'application/octet-stream', 'fixed: blob must declare octet-stream');
+assert.deepEqual(new Uint8Array(await fixed.blob.arrayBuffer()), fileBytes, 'fixed: file bytes must be intact');
+
+const buggy = receiveBuggy(payload, 'download');
+assert.equal(buggy.fileName, 'download', 'buggy: const reassignment is swallowed -> name lost (reproduces .txt symptom)');
+assert.equal(buggy.blob.type, '', 'buggy: typeless blob');
+
+console.log('PASS: receiveFixed recovers "holiday.mp4" as application/octet-stream with intact bytes;');
+console.log('      old const-logic loses the name (reproduces the reported bug).');


### PR DESCRIPTION
## Symptom
A user sent a `*.mp4` via ParaShare. The receive-side download saved the file as a `*.txt` (the `.mp4` extension was gone). Reproducible for any file type, not just mp4.

## Root cause — `frontend/ontvang.html`, `receiveFile()`
The real filename travels only inside the encrypted payload (the relay never sees it, by design). The receiver starts with a `download` placeholder and recovers the real name from chunk-0 metadata:

```js
const fileName = msg.file_name || 'download';   // const
...
if (metaObj.file_name) fileName = metaObj.file_name;   // throws TypeError
```

`fileName` was `const`, so the reassignment throws `TypeError: Assignment to constant variable`. That throw sits inside a `catch(_) {}`, so it was **silently swallowed** and `fileName` stayed `download`. The fallback `new Blob(chunks)` had **no MIME type**, so the browser inferred a `.txt` extension on the extensionless name. Net result: `holiday.mp4` saved as `download.txt`.

## Fix
- `const fileName` → `let fileName` so the metadata name actually applies.
- Fallback Blob now declares `application/octet-stream` (no `.txt` inference).
- `showSaveFilePicker()` moved into the loop, after chunk-0 metadata is parsed, so the streaming save dialog also gets the real filename (it previously opened with the `download` placeholder *before* any chunk was fetched).

Diff is scoped to those changes only (17 insertions / 13 deletions in one function).

## Tests
- `tests/receive-filename.test.mjs` (new, zero-dep): builds a chunk-0 payload in the exact `PRSH | u32be(len) | meta | data` wire format, asserts the receive path recovers `holiday.mp4` as `application/octet-stream` with intact bytes, and asserts the old `const` logic reproduces the bug. `node tests/receive-filename.test.mjs` → PASS.
- Inline-script syntax gate on the served file → clean.
- `tests/static-sanity.sh` → PASS.

## Deploy status
Already hot-deployed to prod (`/home/paramant/app/ontvang.html`) per request, since the reporter was hitting it live. Pre-fix backup: `/home/paramant/backups/ontvang.html.20260605-123115.bak`. Served file verified to carry the fix (sha `25bf1aa7…`). Merging this PR just codifies what is live.

## Not addressed here (follow-ups)
- The reporter also saw a **first-attempt crash** before the successful (mis-named) second download. Not deterministically root-caused; likely transient (WASM crypto bridge not yet ready, per-chunk 60s fetch timeout, or RAM on the Blob path for a large file). Worth hardening separately if it recurs.
- Same typeless-`Blob` pattern exists in `get.html` and `parashare.html` (different flows, filename there already carries its extension, so lower impact). Can fold in if wanted.
