### PR TITLE
fix(deploy): point sector fallbacks at the container-internal :3000 listener

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -29,12 +29,16 @@ const BASE_PATH   = (process.env.BASE_PATH || '').replace(/\/$/, '');
 // every Object.keys(SECTORS) iteration in this file; add a sector here and
 // the rest follows. findUserByEmail() stays health-only on purpose: health
 // is the canonical admin-UI source and the lookup is hot-path.
+// Fallback ports are the container-internal listener, which is :3000 for
+// every sector (docker-compose.yml). The :3001-:3005 numbers exist only as
+// host-side port mappings and are unreachable on the compose network, so a
+// missing RELAY_* env would silently point the admin at a dead port.
 const SECTORS = {
   main:    process.env.RELAY_MAIN    || 'http://relay-main:3000',
-  health:  process.env.RELAY_HEALTH  || 'http://relay-health:3005',
-  legal:   process.env.RELAY_LEGAL   || 'http://relay-legal:3002',
-  finance: process.env.RELAY_FINANCE || 'http://relay-finance:3003',
-  iot:     process.env.RELAY_IOT     || 'http://relay-iot:3004',
+  health:  process.env.RELAY_HEALTH  || 'http://relay-health:3000',
+  legal:   process.env.RELAY_LEGAL   || 'http://relay-legal:3000',
+  finance: process.env.RELAY_FINANCE || 'http://relay-finance:3000',
+  iot:     process.env.RELAY_IOT     || 'http://relay-iot:3000',
 };
 
 if (!ADMIN_TOKEN) { console.error('[PARAMANT-ADMIN] ADMIN_TOKEN is not set — refusing to start'); process.exit(1); }

--- a/deploy/nginx-selfhost.conf
+++ b/deploy/nginx-selfhost.conf
@@ -18,10 +18,12 @@ limit_conn_zone $binary_remote_addr zone=conn:10m;
 # ── Sector routing — map Host header to upstream ──────────────────────────────
 # SNI routing fails when sectors share a domain; Host-header map works for both
 # single-domain (?sector=health) and subdomain (health.example.com) setups.
-upstream relay_health  { server relay-health:3005  max_fails=3 fail_timeout=10s; }
-upstream relay_legal   { server relay-legal:3002   max_fails=3 fail_timeout=10s; }
-upstream relay_finance { server relay-finance:3003 max_fails=3 fail_timeout=10s; }
-upstream relay_iot     { server relay-iot:3004     max_fails=3 fail_timeout=10s; }
+# Container-internal listener is :3000 for every sector (docker-compose.yml);
+# :3001-:3005 are host-side mappings that do not exist on the compose network.
+upstream relay_health  { server relay-health:3000  max_fails=3 fail_timeout=10s; }
+upstream relay_legal   { server relay-legal:3000   max_fails=3 fail_timeout=10s; }
+upstream relay_finance { server relay-finance:3000 max_fails=3 fail_timeout=10s; }
+upstream relay_iot     { server relay-iot:3000     max_fails=3 fail_timeout=10s; }
 
 map $http_host $relay_upstream {
     default        relay_health;

--- a/nginx-selfhost.conf
+++ b/nginx-selfhost.conf
@@ -4,10 +4,12 @@ limit_req_zone $binary_remote_addr zone=api:10m     rate=60r/m;
 limit_req_zone $binary_remote_addr zone=health:10m  rate=6r/m;
 limit_conn_zone $binary_remote_addr zone=conn:10m;
 
-upstream relay_health  { server relay-health:3005; }
-upstream relay_legal   { server relay-legal:3002; }
-upstream relay_finance { server relay-finance:3003; }
-upstream relay_iot     { server relay-iot:3004; }
+# Container-internal listener is :3000 for every sector (docker-compose.yml);
+# :3001-:3005 are host-side mappings that do not exist on the compose network.
+upstream relay_health  { server relay-health:3000; }
+upstream relay_legal   { server relay-legal:3000; }
+upstream relay_finance { server relay-finance:3000; }
+upstream relay_iot     { server relay-iot:3000; }
 
 # Route by HTTP Host header — works for both subdomain and localhost setups.
 # SNI-based routing (multiple server blocks) fails when all sectors share one


### PR DESCRIPTION
## Wat

Drie plekken wezen nog naar de oude per-sector poorten (`relay-health:3005`, `relay-legal:3002`, ...) terwijl elke relay-container op het compose-netwerk intern op **:3000** luistert (de :3001-:3005 nummers bestaan alleen als host-side mappings):

- `admin/server.js` — `SECTORS`-fallbacks (raakt alleen deployments zonder `RELAY_*` env; prod-compose zet die wel, dus daar gemaskeerd)
- `nginx-selfhost.conf` — upstreams
- `deploy/nginx-selfhost.conf` — upstreams

Lost known-issues **C3 + C4** op (paramant-solutions `docs/known-issues.md`).

## Bijvangst / besluitpunten (niet in deze PR)

1. **Twee diverged kopieën** van nginx-selfhost.conf (root 99 regels, `deploy/` 190 regels met hardening). Eén bron van waarheid kiezen is een opschoonbesluit.
2. **C5 sector-vocabulaire** (`SECTOR=relay` vs admin-key `main` vs `VALID_SECTORS={general,...}`): hernoemen raakt prod-metrics-labels, `X-Paramant-Sector` en DID-serviceEndpoints; bewust niet meegenomen.

## Test

- admin unit suite 14/14 groen
- `tests/static-sanity.sh` PASS
- geen overgebleven `relay-*:300[1-5]`-referenties (`grep`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)