### PR TITLE
fix(signup): close the TOCTOU window in signup-verify with a per-email lock

### DIFF
--- a/admin/lib/signup-lock.js
+++ b/admin/lib/signup-lock.js
@@ -1,0 +1,48 @@
+'use strict';
+// Serializes account creation in signup-verify per e-mail address.
+//
+// Two concurrent verify clicks -- two different pending tokens for the same
+// address, both issued while no account existed yet -- could both pass the
+// "does the account exist" re-check before either had created the account,
+// so one e-mail could end up with two keys (known-issues C1, TOCTOU).
+// A Redis NX lock on the e-mail hash closes the window: the loser waits and
+// re-runs the existence check, which then sees the winner's account.
+
+const crypto = require('crypto');
+
+const LOCK_TTL_S = 60;        // hard upper bound; normal hold time is <2s
+const RETRIES = 4;
+const RETRY_DELAY_MS = 700;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const lockKey = (email) =>
+  'paramant:signup:creating:' +
+  crypto.createHash('sha256').update(email.toLowerCase().trim()).digest('hex');
+
+// Returns { acquired, release }. release() only deletes the lock when the
+// stored value is still ours, so a lock that expired and was re-acquired by
+// another request is never deleted from under that request. The get+del pair
+// is not atomic, but with a 60s TTL against a <2s hold the value-match makes
+// a misdelete require a 58s stall between two specific commands.
+async function acquireSignupLock(redis, email, owner, opts = {}) {
+  const retries = opts.retries ?? RETRIES;
+  const delayMs = opts.delayMs ?? RETRY_DELAY_MS;
+  const key = lockKey(email);
+  for (let i = 0; i <= retries; i++) {
+    const ok = await redis.set(key, owner, { NX: true, EX: LOCK_TTL_S });
+    if (ok) {
+      return {
+        acquired: true,
+        release: async () => {
+          const cur = await redis.get(key).catch(() => null);
+          if (cur === owner) await redis.del(key).catch(() => {});
+        },
+      };
+    }
+    if (i < retries) await sleep(delayMs);
+  }
+  return { acquired: false, release: async () => {} };
+}
+
+module.exports = { acquireSignupLock, lockKey, LOCK_TTL_S };

--- a/admin/server.js
+++ b/admin/server.js
@@ -14,6 +14,7 @@ const cliRate = require('./lib/cli-ratelimit');
 const configStore = require('./lib/config-store');
 const webauthn = require('./lib/webauthn');
 const { sessionKeyFields, proxyApiKey, revealKey } = require('./lib/account-keys');
+const { acquireSignupLock } = require('./lib/signup-lock');
 const { generateAuthenticationOptions, verifyAuthenticationResponse, generateRegistrationOptions, verifyRegistrationResponse } = require('@simplewebauthn/server');
 
 const PORT        = parseInt(process.env.PORT || '4200', 10);
@@ -781,73 +782,97 @@ api.get("/user/signup/verify/:token", async (req, res) => {
   let pending;
   try { pending = JSON.parse(raw); } catch { return res.redirect('/signup?error=invalid_token'); }
 
-  // Consume immediately (one-shot)
-  await redis().del(`paramant:signup:pending:${token}`);
-
   const { email, label } = pending;
 
-  // Check again — race guard
-  const existing = await findUserByEmail(email);
-  if (existing) return res.redirect('/signup?error=account_exists');
-
-  // Create the account across every sector listed in SECTORS so the key works
-  // on every relay -- including main (relay.paramant.app, internal sector
-  // "relay") which the SDK and direct API consumers target. Before SECTORS
-  // gained the 'main' entry (added together with this comment), the fan-out
-  // silently skipped main even while claiming to write to "every sector",
-  // and main's users.json drifted weeks behind the others.
-  const keyVal = "pgp_" + crypto.randomBytes(32).toString("hex");
-  const createdAt = new Date().toISOString();
-  const createBody = {
-    key: keyVal,
-    email,
-    label: label || null,
-    plan: "community",
-    active: true,
-    created: createdAt,
-    created_at_ts: Date.now(),
-  };
-
-  // health is the source of truth for admin UI visibility. Must succeed.
-  const primaryRes = await relayFetch("health", "/v2/admin/keys", "POST", createBody, false, ADMIN_TOKEN);
-  if (primaryRes.status !== 200 && primaryRes.status !== 201) {
-    console.error("[signup/verify] key creation failed on health:", primaryRes.status, primaryRes.body);
-    return res.redirect('/signup?error=server_error');
+  // Race guard (known-issues C1, TOCTOU). Two different pending tokens for
+  // the same address can reach this point concurrently -- both were issued
+  // while no account existed yet -- and both used to pass the existence
+  // re-check before either had created the account. Serialize on the e-mail
+  // hash: exactly one request runs check + create, the loser waits and then
+  // sees the winner's account. The same lock also covers a double click on
+  // one link, because the token is re-read and consumed under the lock.
+  const lock = await acquireSignupLock(redis(), email, token);
+  if (!lock.acquired) {
+    // Creation for this address is still in flight after ~3s of waiting.
+    // The pending token was NOT consumed, so a retry of the same link works.
+    return res.redirect('/signup?error=busy');
   }
-
-  // Fan-out to the other sectors. Best-effort — if one is briefly unavailable, reload-users
-  // can pick it up later; we don't want to leak a half-created account by failing the whole
-  // signup here after health succeeded.
-  const otherSectors = Object.keys(SECTORS).filter(s => s !== "health");
-  await Promise.all(otherSectors.map(s =>
-    relayFetch(s, "/v2/admin/keys", "POST", createBody, false, ADMIN_TOKEN).catch(e => {
-      console.error(`[signup/verify] key propagation failed on ${s}:`, e && e.message || e);
-    })
-  ));
-
-  const setupToken = crypto.randomBytes(32).toString("hex");
-  await redis().set(
-    `paramant:user:setup_token:${setupToken}`,
-    JSON.stringify({ user_id: keyVal, email, label: label || null }),
-    { EX: 14 * 86400 }
-  );
-  await redis().set(
-    `paramant:user:meta:${keyVal}`,
-    JSON.stringify({ email, created_at: createdAt })
-  ).catch(() => {});
-
   try {
-    await sendSetupEmail(email, setupToken);
-  } catch (err) {
-    console.error("[signup/verify] setup email failed:", err.message);
-    // Account exists, don't undo — they can contact support
+
+    // Re-read under the lock: a parallel click on the same link may have
+    // consumed the token while we waited for the lock.
+    if (!(await redis().get(`paramant:signup:pending:${token}`))) {
+      const consumed = await redis().get(`paramant:signup:consumed:${token}`);
+      return res.redirect(consumed ? '/signup/verified' : '/signup?error=expired_token');
+    }
+    // Consume immediately (one-shot)
+    await redis().del(`paramant:signup:pending:${token}`);
+
+    const existing = await findUserByEmail(email);
+    if (existing) return res.redirect('/signup?error=account_exists');
+
+    // Create the account across every sector listed in SECTORS so the key works
+    // on every relay -- including main (relay.paramant.app, internal sector
+    // "relay") which the SDK and direct API consumers target. Before SECTORS
+    // gained the 'main' entry (added together with this comment), the fan-out
+    // silently skipped main even while claiming to write to "every sector",
+    // and main's users.json drifted weeks behind the others.
+    const keyVal = "pgp_" + crypto.randomBytes(32).toString("hex");
+    const createdAt = new Date().toISOString();
+    const createBody = {
+      key: keyVal,
+      email,
+      label: label || null,
+      plan: "community",
+      active: true,
+      created: createdAt,
+      created_at_ts: Date.now(),
+    };
+
+    // health is the source of truth for admin UI visibility. Must succeed.
+    const primaryRes = await relayFetch("health", "/v2/admin/keys", "POST", createBody, false, ADMIN_TOKEN);
+    if (primaryRes.status !== 200 && primaryRes.status !== 201) {
+      console.error("[signup/verify] key creation failed on health:", primaryRes.status, primaryRes.body);
+      return res.redirect('/signup?error=server_error');
+    }
+
+    // Fan-out to the other sectors. Best-effort — if one is briefly unavailable, reload-users
+    // can pick it up later; we don't want to leak a half-created account by failing the whole
+    // signup here after health succeeded.
+    const otherSectors = Object.keys(SECTORS).filter(s => s !== "health");
+    await Promise.all(otherSectors.map(s =>
+      relayFetch(s, "/v2/admin/keys", "POST", createBody, false, ADMIN_TOKEN).catch(e => {
+        console.error(`[signup/verify] key propagation failed on ${s}:`, e && e.message || e);
+      })
+    ));
+
+    const setupToken = crypto.randomBytes(32).toString("hex");
+    await redis().set(
+      `paramant:user:setup_token:${setupToken}`,
+      JSON.stringify({ user_id: keyVal, email, label: label || null }),
+      { EX: 14 * 86400 }
+    );
+    await redis().set(
+      `paramant:user:meta:${keyVal}`,
+      JSON.stringify({ email, created_at: createdAt })
+    ).catch(() => {});
+
+    try {
+      await sendSetupEmail(email, setupToken);
+    } catch (err) {
+      console.error("[signup/verify] setup email failed:", err.message);
+      // Account exists, don't undo — they can contact support
+    }
+
+    // Mark this token as consumed so later re-clicks (refresh/back/double-tap) route back to /signup/verified instead of error.
+    await redis().set(`paramant:signup:consumed:${token}`, keyVal, { EX: 30 * 86400 }).catch(() => {});
+
+    console.log(`[signup/verify] account created for ${email} (${keyVal.slice(0, 12)}...)`);
+    res.redirect('/signup/verified');
+
+  } finally {
+    await lock.release();
   }
-
-  // Mark this token as consumed so later re-clicks (refresh/back/double-tap) route back to /signup/verified instead of error.
-  await redis().set(`paramant:signup:consumed:${token}`, keyVal, { EX: 30 * 86400 }).catch(() => {});
-
-  console.log(`[signup/verify] account created for ${email} (${keyVal.slice(0, 12)}...)`);
-  res.redirect('/signup/verified');
 });
 
 // POST /api/user/setup/:token — retrieve TOTP QR data (idempotent)

--- a/admin/test/signup-lock.test.js
+++ b/admin/test/signup-lock.test.js
@@ -1,0 +1,75 @@
+'use strict';
+// signup-lock: serializes signup-verify account creation per e-mail (C1).
+// Run: node admin/test/signup-lock.test.js (no deps, non-zero exit on fail).
+
+const assert = require('assert');
+const { acquireSignupLock, lockKey, LOCK_TTL_S } = require('../lib/signup-lock');
+
+let passed = 0;
+const ok = (n) => { passed++; console.log('  ok -', n); };
+
+// Minimal in-memory stand-in for the node-redis v4 surface the lock uses.
+function fakeRedis() {
+  const store = new Map();
+  return {
+    async set(key, val, opts = {}) {
+      if (opts.NX && store.has(key)) return null;
+      store.set(key, String(val));
+      return 'OK';
+    },
+    async get(key) { return store.has(key) ? store.get(key) : null; },
+    async del(key) { return store.delete(key) ? 1 : 0; },
+    _store: store,
+  };
+}
+
+(async () => {
+  // lockKey: same address normalizes to the same key, different address differs
+  assert.strictEqual(lockKey('A@B.com '), lockKey('a@b.com'), 'case/space-insensitive');
+  assert.notStrictEqual(lockKey('a@b.com'), lockKey('c@d.com'), 'distinct per address');
+  assert.ok(lockKey('a@b.com').startsWith('paramant:signup:creating:'), 'namespaced');
+  assert.ok(!lockKey('a@b.com').includes('a@b.com'), 'address itself never in the key');
+  ok('lockKey');
+
+  // first caller acquires, NX blocks the second, release frees it
+  const r = fakeRedis();
+  const a = await acquireSignupLock(r, 'a@b.com', 'tok-A', { retries: 0 });
+  assert.strictEqual(a.acquired, true, 'first acquire wins');
+  const b = await acquireSignupLock(r, 'a@b.com', 'tok-B', { retries: 0 });
+  assert.strictEqual(b.acquired, false, 'second acquire blocked while held');
+  await a.release();
+  const c = await acquireSignupLock(r, 'a@b.com', 'tok-C', { retries: 0 });
+  assert.strictEqual(c.acquired, true, 'acquire succeeds after release');
+  await c.release();
+  ok('mutual exclusion + release');
+
+  // different e-mail addresses do not contend
+  const r2 = fakeRedis();
+  const x = await acquireSignupLock(r2, 'x@y.com', 'tok-X', { retries: 0 });
+  const y = await acquireSignupLock(r2, 'z@w.com', 'tok-Z', { retries: 0 });
+  assert.strictEqual(x.acquired && y.acquired, true, 'independent addresses');
+  ok('per-address scoping');
+
+  // the loser retries and gets the lock once the winner releases
+  const r3 = fakeRedis();
+  const w = await acquireSignupLock(r3, 'a@b.com', 'tok-W', { retries: 0 });
+  setTimeout(() => { w.release(); }, 30);
+  const l = await acquireSignupLock(r3, 'a@b.com', 'tok-L', { retries: 5, delayMs: 20 });
+  assert.strictEqual(l.acquired, true, 'retry wins after release');
+  ok('retry until released');
+
+  // release() of a stale handle never deletes someone else's lock
+  const r4 = fakeRedis();
+  const first = await acquireSignupLock(r4, 'a@b.com', 'tok-1', { retries: 0 });
+  // simulate TTL expiry + re-acquire by another request
+  r4._store.set(lockKey('a@b.com'), 'tok-2');
+  await first.release();
+  assert.strictEqual(await r4.get(lockKey('a@b.com')), 'tok-2', 'foreign lock survives stale release');
+  ok('stale release is a no-op');
+
+  // sanity: TTL bound exists so a crashed holder cannot deadlock signups
+  assert.ok(LOCK_TTL_S > 0 && LOCK_TTL_S <= 300, 'bounded TTL');
+  ok('bounded TTL');
+
+  console.log(`signup-lock: ${passed} checks passed`);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -447,6 +447,10 @@
     server_error: {
       t: 'Something went wrong on our side',
       m: 'Please try again in a few minutes, or email <a href="mailto:hello@paramant.app">hello@paramant.app</a> if it keeps failing.'
+    },
+    busy: {
+      t: 'Your account is still being created',
+      m: 'We received your verification a moment ago and are finishing it up. Wait a few seconds, then click the link in your email once more.'
     }
   };
   var e = map[err] || { t: 'Unknown error', m: 'Please try signing up again below.' };


### PR DESCRIPTION
## Probleem (known-issues C1, 🔴)

Twee gelijktijdige verify-clicks voor hetzelfde adres (twee pending tokens, beide uitgegeven toen er nog geen account bestond) passeerden allebei de `findUserByEmail`-recheck vóór een van beide het account had aangemaakt. Resultaat: één e-mail met twee `pgp_`-keys, verspreid over de sectoren.

## Fix

- **`admin/lib/signup-lock.js`** — Redis `SET NX EX`-lock op de SHA-256 van het e-mailadres (60s TTL als bovengrens, ~3s retry-venster, value-matched release zodat een stale handle nooit andermans lock vrijgeeft). Adres zelf komt nooit in de Redis-key.
- **Verify-route** — lock wordt verworven vóór het consumeren van de pending token; token wordt onder de lock opnieuw gelezen. Daarmee is ook de dubbel-klik op dezelfde link netjes: de verliezer ziet `/signup/verified` (consumed-marker) of `account_exists`. Lock-verlies na ~3s wachten → `error=busy` zonder de token te consumeren, dus de link blijft bruikbaar.
- **`frontend/signup.html`** — vriendelijke banner voor `error=busy`.

## Test

- Nieuw: `admin/test/signup-lock.test.js` (mutual exclusion, per-adres scoping, retry-after-release, stale-release no-op, bounded TTL)
- Admin suite 15/15 groen, `tests/static-sanity.sh` PASS, cache-bust guard OK
- `node --check admin/server.js` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)