### PR TITLE
fix(security.txt): geen Encryption-veld naar een niet-bestaande PGP-key

### DIFF
--- a/frontend/.well-known/security.txt
+++ b/frontend/.well-known/security.txt
@@ -10,8 +10,9 @@ Expires: 2027-04-19T23:59:59.000Z
 # Preferred languages for reports
 Preferred-Languages: en, nl
 
-# Encryption key for sensitive reports
-Encryption: https://paramant.app/.well-known/openpgp-key.asc
+# No PGP key is published right now. /.well-known/openpgp-key.asc explains
+# how to request the current key out-of-band; an Encryption: field will
+# return once a real key is in place (RFC 9116: only advertise what exists).
 
 # Canonical URL (RFC 9116 requires this)
 Canonical: https://paramant.app/.well-known/security.txt

--- a/frontend/security.txt
+++ b/frontend/security.txt
@@ -10,8 +10,9 @@ Expires: 2027-04-19T23:59:59.000Z
 # Preferred languages for reports
 Preferred-Languages: en, nl
 
-# Encryption key for sensitive reports
-Encryption: https://paramant.app/.well-known/openpgp-key.asc
+# No PGP key is published right now. /.well-known/openpgp-key.asc explains
+# how to request the current key out-of-band; an Encryption: field will
+# return once a real key is in place (RFC 9116: only advertise what exists).
 
 # Canonical URL (RFC 9116 requires this)
 Canonical: https://paramant.app/.well-known/security.txt


### PR DESCRIPTION
## Wat

`Encryption:` in security.txt wees naar `/.well-known/openpgp-key.asc` — dat bestand is een tekst-uitleg dat er géén key gepubliceerd is (open M-punt uit de productie-audit 2026-05-27). Een onderzoeker die wil encrypten loopt zo precies op het verkeerde moment dood.

- `Encryption:`-veld weg uit beide kopieën (root + `.well-known`), met comment wanneer het terugkomt
- `.asc`-explainer blijft staan (beschrijft de out-of-band route)

## Alternatief (jouw keuze)

Een échte PGP-key voor `privacy@paramant.app` genereren en publiceren is netter; dat vereist key-custody bij jou. Zodra die er is: key in `frontend/.well-known/openpgp-key.asc`, veld terugzetten, en deze PR is dan superseded.

Let op: live staat de oude versie nog (frontend-deploy is rsync, los van git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)