### PR TITLE
harden(trial): normalize e-mail for the trial rate-limit key (close gmail dot/plus farming, #5/#13)

### DIFF
--- a/relay/lib/email-normalize.js
+++ b/relay/lib/email-normalize.js
@@ -1,0 +1,31 @@
+'use strict';
+// Canonicalize an e-mail to the underlying mailbox for RATE-LIMIT keys only
+// (never for storage/sending — the address the user typed is kept verbatim).
+//
+// Closes the trial-farming bypass (#13) where a.b+1@gmail.com, a.b@gmail.com
+// and ab@gmail.com all deliver to one mailbox but counted as three distinct
+// rate-limit keys, letting one Gmail account mint unlimited trial keys.
+//
+// Rules:
+//  - lowercase + trim
+//  - drop a '+tag' suffix for EVERY provider (sub-addressing routes to the
+//    same mailbox, supported by Gmail, Outlook, Fastmail, Proton, ...)
+//  - strip dots in the local part ONLY for Gmail (its documented
+//    dot-insensitivity); googlemail.com is folded to gmail.com
+// Conservative by design: for unknown providers only the +tag is removed, so
+// we never collapse two genuinely different mailboxes.
+function normalizeEmailForRateLimit(email) {
+  const e = String(email || '').trim().toLowerCase();
+  const at = e.lastIndexOf('@');
+  if (at <= 0 || at === e.length - 1) return e;
+  let local = e.slice(0, at);
+  let domain = e.slice(at + 1);
+  const plus = local.indexOf('+');
+  if (plus !== -1) local = local.slice(0, plus);
+  if (domain === 'googlemail.com') domain = 'gmail.com';
+  if (domain === 'gmail.com') local = local.replace(/\./g, '');
+  if (!local) return e; // a bare "+tag@host" -> don't collapse to "@host"
+  return local + '@' + domain;
+}
+
+module.exports = { normalizeEmailForRateLimit };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -187,6 +187,11 @@ function escHtml(str) {
     .replace(/'/g, '&#x27;');
 }
 
+// Mailbox-canonical e-mail for rate-limit keys (closes #13 gmail dot/plus
+// farming). See relay/lib/email-normalize.js. Storage/sending always use the
+// raw address the user typed.
+const { normalizeEmailForRateLimit } = require('./lib/email-normalize');
+
 // ── NATS.io JetStream — push transport (vervangt polling) ────────────────────
 let natsClient = null;
 let natsJs = null;
@@ -2782,8 +2787,9 @@ const server = http.createServer(async (req, res) => {
         return res.end(J({ error: 'Too many requests' }));
       }
 
-      // Email rate limit: 1 per 7 days — generic 429 (no info disclosure about existing key)
-      const emailKey = rawEmail.toLowerCase();
+      // Email rate limit: 1 per 7 days — generic 429 (no info disclosure about existing key).
+      // Key on the normalized mailbox so gmail dot/plus aliases can't farm keys (#13).
+      const emailKey = normalizeEmailForRateLimit(rawEmail);
       if (trialRequests.has(emailKey) && now - trialRequests.get(emailKey) < 7 * DAY_MS) {
         res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': '604800' });
         return res.end(J({ error: 'Too many requests' }));

--- a/relay/test/email-normalize.test.js
+++ b/relay/test/email-normalize.test.js
@@ -1,0 +1,44 @@
+'use strict';
+// Unit tests for the trial rate-limit e-mail normalizer (#13).
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { normalizeEmailForRateLimit } = require('../lib/email-normalize');
+
+const N = normalizeEmailForRateLimit;
+
+test('gmail dots and plus-tags collapse to one mailbox', () => {
+  const canonical = 'jdoe@gmail.com';
+  assert.equal(N('jdoe@gmail.com'), canonical);
+  assert.equal(N('j.doe@gmail.com'), canonical);
+  assert.equal(N('j.d.o.e@gmail.com'), canonical);
+  assert.equal(N('jdoe+trial1@gmail.com'), canonical);
+  assert.equal(N('J.Doe+anything@Gmail.com'), canonical);
+  assert.equal(N('jdoe@googlemail.com'), canonical); // googlemail -> gmail
+});
+
+test('plus-tags are dropped for non-gmail providers too', () => {
+  assert.equal(N('alice+promo@outlook.com'), 'alice@outlook.com');
+  assert.equal(N('bob+x@fastmail.com'), 'bob@fastmail.com');
+});
+
+test('dots are preserved for non-gmail providers (distinct mailboxes)', () => {
+  assert.notEqual(N('a.b@outlook.com'), N('ab@outlook.com'));
+  assert.equal(N('a.b@outlook.com'), 'a.b@outlook.com');
+});
+
+test('distinct mailboxes stay distinct', () => {
+  assert.notEqual(N('alice@gmail.com'), N('bob@gmail.com'));
+  assert.notEqual(N('alice@gmail.com'), N('alice@outlook.com'));
+});
+
+test('case and whitespace normalized', () => {
+  assert.equal(N('  Alice@Example.COM '), 'alice@example.com');
+});
+
+test('malformed / edge inputs do not throw and never collapse to bare domain', () => {
+  assert.equal(N(''), '');
+  assert.equal(N('notanemail'), 'notanemail');
+  assert.equal(N(null), '');
+  assert.equal(N('+tag@gmail.com'), '+tag@gmail.com'); // empty local -> left as-is, not "@gmail.com"
+  assert.equal(N('a@'), 'a@');
+});


### PR DESCRIPTION
## 🟠 HIGH #5 + MEDIUM #13 — trial-key farming

`/v2/request-trial` cap't 1 key per e-mail per 7 dagen, maar keyt op `rawEmail.toLowerCase()`. Gmail dot- en plus-aliassen (`a.b@gmail.com`, `a+x@gmail.com`, `@googlemail.com`) raken **één** mailbox maar telden als **verschillende** keys → één Gmail-account kon ongelimiteerd trial-keys minten.

### Fix
De per-e-mail-limiet keyt nu op een **mailbox-canonieke** vorm:
- `+tag`-suffix valt weg voor élke provider (sub-addressing = zelfde mailbox)
- dots strippen + `googlemail`→`gmail` alleen voor Gmail (gedocumenteerde regel)
- conservatief voor onbekende providers (alleen `+tag` weg) — nooit twee echt-verschillende mailboxes samenvouwen

Opslag + de welcome/notify-mails gebruiken nog steeds het **getypte** adres.

### Test
- `relay/lib/email-normalize.js` + `relay/test/email-normalize.test.js` (6 cases)
- **Live geverifieerd:** `jdoe@gmail.com`→200, daarna `j.doe@` / `jdoe+x@` / `@googlemail.com`→429 (zelfde mailbox), `other@gmail.com`→200.
- Relay unit-suite 35/35 (incl. nieuw), static-sanity PASS.

### Companion-gaten (apart, bewust niet hier)
- De **per-IP-cap** is nog spoofbaar via `cf-connecting-ip` (#9/#11/#12, deployment-coupled — jouw aparte besluit).
- `admin/server.js` signup keyt z'n per-e-mail-limiet net zo en kan deze helper hergebruiken (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)