### PR TITLE
fix(parasign): domain-separate single-signer notary signatures (v2), keep v1 verifiable (#3/#4)

### DIFF
--- a/relay/crypto/parasign.test.js
+++ b/relay/crypto/parasign.test.js
@@ -28,7 +28,9 @@ function makeEnvelope(documentBytes, opts = {}) {
   const signer = sig.generateKeyPair();
   const relay = sig.generateKeyPair();
   const docHashHex = crypto.createHash("sha3-256").update(documentBytes).digest("hex");
-  const signature = sig.sign(Buffer.from(docHashHex, "hex"), signer.secretKey);
+  // v2 envelopes: the signer signs the domain-separated message (#3/#4), which
+  // is what buildEnvelope (default version '2') and verifyEnvelope now expect.
+  const signature = sig.sign(parasign.singleSignerMessage(docHashHex), signer.secretKey);
   const envelope = parasign.buildEnvelope(
     {
       documentHashHex: docHashHex,

--- a/relay/parasign.js
+++ b/relay/parasign.js
@@ -9,6 +9,37 @@
 // Pure module: ML-DSA-65 sign/verify are injected by the caller (relay.js
 // passes registry.getSig(0x0002)), so the logic is unit-testable in isolation.
 
+const crypto = require('crypto');
+
+// Domain separation for the single-signer notary message (pentest #3/#4).
+// Until v2, the signer signed the BARE 32-byte document hash, so an ML-DSA
+// signature made over any unrelated 32-byte value (a co-sign digest, a session
+// challenge, a receipt hash) could be replayed into /v2/sign and notarised as a
+// "document signature". v2 binds the signature to THIS protocol+purpose with a
+// mandatory, distinct domain label (the multi-party flow uses
+// 'paramant/parasign/doc/v1'; the single-signer notary gets its own so the two
+// cannot cross-replay either). Construction mirrors envelope.js signMessageBytes:
+//   v2 message = sha3_256("paramant/parasign/notary/v1" || 0x00 || doc_hash_bytes)
+const SIGN_DOMAIN_NOTARY = 'paramant/parasign/notary/v1';
+
+// The bytes the signer's ML-DSA key signs for a v2 single-signer envelope.
+function singleSignerMessage(docHashHex) {
+  return crypto.createHash('sha3-256')
+    .update(Buffer.from(SIGN_DOMAIN_NOTARY, 'utf8'))
+    .update(Buffer.from([0]))
+    .update(Buffer.from(docHashHex, 'hex'))
+    .digest();
+}
+
+// The bytes verifyEnvelope / /v2/sign check the signer signature against, given
+// the envelope version. v1 = bare hash (legacy, still verifiable); v2 = domain-
+// separated. Returns a Buffer.
+function signerVerifyBytes(docHashHex, version) {
+  return String(version) === '2'
+    ? singleSignerMessage(docHashHex)
+    : Buffer.from(docHashHex, 'hex');
+}
+
 // Canonical JSON: recursively sorted keys, no whitespace. Must match the
 // canonicalJSON used elsewhere in the relay so signatures interoperate.
 function canonicalJSON(obj) {
@@ -24,8 +55,12 @@ function canonicalJSON(obj) {
 function buildEnvelope(input, deps) {
   const now = new Date();
   const ttl = Number.isFinite(input.ttlDays) && input.ttlDays > 0 ? input.ttlDays : 365;
+  // version '2' = signer signed the domain-separated message (default for new
+  // envelopes). '1' = legacy bare-hash signer signature, only minted when the
+  // relay is explicitly run in legacy-accept mode for an old client.
+  const version = String(input.version || '2') === '1' ? '1' : '2';
   const envelope = {
-    version: '1',
+    version,
     algorithm: 'ML-DSA-65',
     document_hash: input.documentHashHex,
     document_hash_algo: 'sha3-256',
@@ -52,7 +87,7 @@ function verifyEnvelope(input, deps) {
   const errors = [];
   const env = input.envelope;
   if (!env || typeof env !== 'object') return { valid: false, errors: ['missing or invalid envelope'] };
-  if (env.version !== '1') errors.push('unsupported envelope version: ' + env.version);
+  if (env.version !== '1' && env.version !== '2') errors.push('unsupported envelope version: ' + env.version);
   if (env.algorithm !== 'ML-DSA-65') errors.push('unsupported algorithm: ' + env.algorithm);
 
   if (input.documentHashHex && env.document_hash !== input.documentHashHex) {
@@ -60,11 +95,12 @@ function verifyEnvelope(input, deps) {
       '… vs document ' + String(input.documentHashHex).slice(0, 16) + '…)');
   }
 
-  // 1. Signer signature over the document hash.
+  // 1. Signer signature over the (version-appropriate) signer message.
+  //    v2 = domain-separated message, v1 = bare document hash (legacy).
   try {
     const ok = deps.sigVerify(
       Buffer.from(env.signature || '', 'base64'),
-      Buffer.from(env.document_hash || '', 'hex'),
+      signerVerifyBytes(env.document_hash || '', env.version),
       Buffer.from((env.signer && env.signer.public_key) || '', 'base64'),
     );
     if (!ok) errors.push('signer signature invalid');
@@ -90,4 +126,7 @@ function verifyEnvelope(input, deps) {
   return { valid: errors.length === 0, errors };
 }
 
-module.exports = { canonicalJSON, buildEnvelope, verifyEnvelope };
+module.exports = {
+  canonicalJSON, buildEnvelope, verifyEnvelope,
+  singleSignerMessage, signerVerifyBytes, SIGN_DOMAIN_NOTARY,
+};

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -4554,21 +4554,29 @@ python3 paramant-receiver.py \\
       if (!/^[0-9a-f]{64}$/.test(documentHash)) { res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'document_hash must be a 64-char SHA3-256 hex string' })); }
       if (!signatureB64 || !signerPubB64)       { res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'signature and signer_public_key are required' })); }
 
-      // Refuse to notarise a signature that does not verify against the supplied key.
-      let signerOk = false;
-      try {
-        signerOk = registry.getSig(0x0002).verify(
-          Buffer.from(signatureB64, 'base64'),
-          Buffer.from(documentHash, 'hex'),
-          Buffer.from(signerPubB64, 'base64'));
-      } catch (e) { signerOk = false; }
-      if (!signerOk) { res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'signer signature does not verify against signer_public_key' })); }
+      // Refuse to notarise a signature that does not verify against the supplied
+      // key. The signer MUST sign the domain-separated v2 message (pentest
+      // #3/#4) so a signature minted for another purpose cannot be replayed as a
+      // document notarisation. Legacy bare-hash (v1) signers are only accepted
+      // when PARASIGN_ACCEPT_LEGACY_V1=true (transition escape hatch); by
+      // default v1 is rejected, closing the cross-protocol replay.
+      const _sigBuf = Buffer.from(signatureB64, 'base64');
+      const _pubBuf = Buffer.from(signerPubB64, 'base64');
+      const _sigEng = registry.getSig(0x0002);
+      const _tryVerify = (bytes) => { try { return _sigEng.verify(_sigBuf, bytes, _pubBuf); } catch (e) { return false; } };
+      let sigVersion = '2';
+      let signerOk = _tryVerify(parasign.singleSignerMessage(documentHash));
+      if (!signerOk && process.env.PARASIGN_ACCEPT_LEGACY_V1 === 'true') {
+        signerOk = _tryVerify(Buffer.from(documentHash, 'hex'));
+        if (signerOk) { sigVersion = '1'; log('warn', 'parasign_legacy_v1_signature', { doc: documentHash.slice(0, 16) + '…' }); }
+      }
+      if (!signerOk) { res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'signer signature does not verify against signer_public_key (expected a v2 domain-separated signature: ML-DSA over sha3_256("paramant/parasign/notary/v1" || 0x00 || document_hash))' })); }
 
       const signerPkHash = crypto.createHash('sha3-256').update(Buffer.from(signerPubB64, 'base64')).digest('hex');
       const ctEntry = ctAppendParasign(documentHash, signerPkHash);
 
       const envelope = parasign.buildEnvelope(
-        { documentHashHex: documentHash, signatureB64, signerPubB64, signerLabel, ttlDays, ctLogIndex: ctEntry.index },
+        { documentHashHex: documentHash, signatureB64, signerPubB64, signerLabel, ttlDays, ctLogIndex: ctEntry.index, version: sigVersion },
         { relaySign: (msg) => registry.getSig(0x0002).sign(msg, relayIdentity.sk), relayPkHash: relayIdentity.pk_hash });
 
       log('info', 'parasign_signed', { ct_index: ctEntry.index, signer_pk_hash: signerPkHash.slice(0, 16) + '…' });

--- a/relay/test/parasign-domain-sep.test.js
+++ b/relay/test/parasign-domain-sep.test.js
@@ -1,0 +1,90 @@
+'use strict';
+// Domain-separation for the single-signer notary (#3/#4): v2 envelopes bind the
+// signer signature to sha3_256("paramant/parasign/notary/v1" || 0x00 || hash);
+// v1 (bare hash) stays verifiable for already-issued envelopes; a signature
+// made over an unrelated 32-byte value can no longer be notarised as v2.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('crypto');
+const { ml_dsa65 } = require('@noble/post-quantum/ml-dsa.js');
+const parasign = require('../parasign');
+
+const sha3 = (buf) => crypto.createHash('sha3-256').update(buf).digest();
+const relayKp = ml_dsa65.keygen(crypto.randomBytes(32));
+const deps = {
+  relaySign: (msg) => ml_dsa65.sign(msg, relayKp.secretKey),
+  relayPkHash: 'relaypkhash',
+  sigVerify: (sigBuf, msgBuf, pubBuf) => { try { return ml_dsa65.verify(sigBuf, msgBuf, pubBuf); } catch { return false; } },
+  relayPub: Buffer.from(relayKp.publicKey),
+};
+
+const docHashHex = sha3(Buffer.from('a contract')).toString('hex');
+
+function buildV2(signerKp, docHex = docHashHex) {
+  const sig = ml_dsa65.sign(parasign.singleSignerMessage(docHex), signerKp.secretKey);
+  return parasign.buildEnvelope({
+    documentHashHex: docHex,
+    signatureB64: Buffer.from(sig).toString('base64'),
+    signerPubB64: Buffer.from(signerKp.publicKey).toString('base64'),
+    signerLabel: 'tester', ttlDays: 365, ctLogIndex: 1, version: '2',
+  }, deps);
+}
+
+test('singleSignerMessage is the domain-prefixed digest, distinct from the bare hash', () => {
+  const m = parasign.singleSignerMessage(docHashHex);
+  const expected = crypto.createHash('sha3-256')
+    .update(Buffer.from('paramant/parasign/notary/v1', 'utf8'))
+    .update(Buffer.from([0]))
+    .update(Buffer.from(docHashHex, 'hex')).digest();
+  assert.deepEqual(m, expected);
+  assert.notDeepEqual(m, Buffer.from(docHashHex, 'hex'));
+});
+
+test('v2 envelope round-trips and verifies', () => {
+  const signerKp = ml_dsa65.keygen(crypto.randomBytes(32));
+  const env = buildV2(signerKp);
+  assert.equal(env.version, '2');
+  const r = parasign.verifyEnvelope({ envelope: env, documentHashHex: docHashHex }, deps);
+  assert.equal(r.valid, true, JSON.stringify(r.errors));
+});
+
+test('legacy v1 (bare-hash) envelope still verifies', () => {
+  const signerKp = ml_dsa65.keygen(crypto.randomBytes(32));
+  const sig = ml_dsa65.sign(Buffer.from(docHashHex, 'hex'), signerKp.secretKey); // bare hash
+  const env = parasign.buildEnvelope({
+    documentHashHex: docHashHex,
+    signatureB64: Buffer.from(sig).toString('base64'),
+    signerPubB64: Buffer.from(signerKp.publicKey).toString('base64'),
+    signerLabel: 'legacy', ttlDays: 365, ctLogIndex: 0, version: '1',
+  }, deps);
+  assert.equal(env.version, '1');
+  const r = parasign.verifyEnvelope({ envelope: env }, deps);
+  assert.equal(r.valid, true, JSON.stringify(r.errors));
+});
+
+test('cross-protocol replay: a signature over an unrelated 32-byte value is NOT a valid v2 envelope', () => {
+  // Attacker signs some unrelated 32-byte message (e.g. a co-sign digest) and
+  // tries to pass it off as a v2 single-signer signature over docHashHex.
+  const signerKp = ml_dsa65.keygen(crypto.randomBytes(32));
+  const unrelated = sha3(Buffer.from('a multi-party co-sign digest')); // 32 bytes
+  const sig = ml_dsa65.sign(unrelated, signerKp.secretKey);
+  const env = parasign.buildEnvelope({
+    documentHashHex: docHashHex, // claims to be over docHashHex
+    signatureB64: Buffer.from(sig).toString('base64'),
+    signerPubB64: Buffer.from(signerKp.publicKey).toString('base64'),
+    signerLabel: 'attacker', ttlDays: 365, ctLogIndex: 2, version: '2',
+  }, deps);
+  const r = parasign.verifyEnvelope({ envelope: env }, deps);
+  assert.equal(r.valid, false);
+  assert.ok(r.errors.some(e => /signer signature invalid/.test(e)), JSON.stringify(r.errors));
+});
+
+test('a v2 signature does not verify if relabelled as v1 (and vice versa)', () => {
+  const signerKp = ml_dsa65.keygen(crypto.randomBytes(32));
+  const env = buildV2(signerKp);
+  const downgraded = Object.assign({}, env, { version: '1' }); // tamper version
+  const r = parasign.verifyEnvelope({ envelope: downgraded }, deps);
+  // notary signature also breaks (version is inside the signed body), but the
+  // signer signature must independently fail too — the message bytes differ.
+  assert.equal(r.valid, false);
+});

--- a/relay/test/parasign-domain-sep.test.js
+++ b/relay/test/parasign-domain-sep.test.js
@@ -1,60 +1,62 @@
 'use strict';
-// Domain-separation for the single-signer notary (#3/#4): v2 envelopes bind the
-// signer signature to sha3_256("paramant/parasign/notary/v1" || 0x00 || hash);
-// v1 (bare hash) stays verifiable for already-issued envelopes; a signature
-// made over an unrelated 32-byte value can no longer be notarised as v2.
+// Domain-separation for the single-signer notary (#3/#4). parasign.js is a pure
+// module: the ML-DSA sign/verify are INJECTED, so we test the security-critical
+// logic -- which message bytes get signed/verified per envelope version -- with
+// a mock sig engine and no native crypto dep (so it runs in the deps-free relay
+// unit CI job). A real-ML-DSA end-to-end round-trip is exercised separately
+// against a live relay; this locks the byte-level contract.
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const crypto = require('crypto');
-const { ml_dsa65 } = require('@noble/post-quantum/ml-dsa.js');
 const parasign = require('../parasign');
 
-const sha3 = (buf) => crypto.createHash('sha3-256').update(buf).digest();
-const relayKp = ml_dsa65.keygen(crypto.randomBytes(32));
+// Mock signature scheme: a "signature" IS the exact bytes that were signed.
+//   sign(msg)            -> msg            (Buffer)
+//   verify(sig, msg, pk) -> sig === msg    (the signer signed exactly this message)
+// So an envelope verifies iff verifyEnvelope feeds sigVerify the SAME bytes the
+// signer committed to -- exactly what domain separation must get right.
 const deps = {
-  relaySign: (msg) => ml_dsa65.sign(msg, relayKp.secretKey),
+  relaySign: (msg) => Buffer.from(msg),
   relayPkHash: 'relaypkhash',
-  sigVerify: (sigBuf, msgBuf, pubBuf) => { try { return ml_dsa65.verify(sigBuf, msgBuf, pubBuf); } catch { return false; } },
-  relayPub: Buffer.from(relayKp.publicKey),
+  relayPub: Buffer.from('relay-pub'),
+  sigVerify: (sigBuf, msgBuf) => Buffer.compare(Buffer.from(sigBuf), Buffer.from(msgBuf)) === 0,
 };
+// A signer "signature" over `bytes`, as the base64 string buildEnvelope stores.
+const signOver = (bytes) => Buffer.from(bytes).toString('base64');
 
-const docHashHex = sha3(Buffer.from('a contract')).toString('hex');
+const docHashHex = crypto.createHash('sha3-256').update(Buffer.from('a contract')).digest('hex');
 
-function buildV2(signerKp, docHex = docHashHex) {
-  const sig = ml_dsa65.sign(parasign.singleSignerMessage(docHex), signerKp.secretKey);
-  return parasign.buildEnvelope({
-    documentHashHex: docHex,
-    signatureB64: Buffer.from(sig).toString('base64'),
-    signerPubB64: Buffer.from(signerKp.publicKey).toString('base64'),
-    signerLabel: 'tester', ttlDays: 365, ctLogIndex: 1, version: '2',
-  }, deps);
-}
-
-test('singleSignerMessage is the domain-prefixed digest, distinct from the bare hash', () => {
-  const m = parasign.singleSignerMessage(docHashHex);
+test('singleSignerMessage = sha3_256(domain || 0x00 || hash), distinct from the bare hash', () => {
   const expected = crypto.createHash('sha3-256')
     .update(Buffer.from('paramant/parasign/notary/v1', 'utf8'))
     .update(Buffer.from([0]))
     .update(Buffer.from(docHashHex, 'hex')).digest();
-  assert.deepEqual(m, expected);
-  assert.notDeepEqual(m, Buffer.from(docHashHex, 'hex'));
+  assert.deepEqual(parasign.singleSignerMessage(docHashHex), expected);
+  assert.notDeepEqual(parasign.singleSignerMessage(docHashHex), Buffer.from(docHashHex, 'hex'));
 });
 
-test('v2 envelope round-trips and verifies', () => {
-  const signerKp = ml_dsa65.keygen(crypto.randomBytes(32));
-  const env = buildV2(signerKp);
+test('signerVerifyBytes dispatches v2 -> domain-separated, v1 -> bare hash', () => {
+  assert.deepEqual(parasign.signerVerifyBytes(docHashHex, '2'), parasign.singleSignerMessage(docHashHex));
+  assert.deepEqual(parasign.signerVerifyBytes(docHashHex, '1'), Buffer.from(docHashHex, 'hex'));
+});
+
+test('v2 envelope: signer must have signed the domain-separated message', () => {
+  const env = parasign.buildEnvelope({
+    documentHashHex: docHashHex,
+    signatureB64: signOver(parasign.singleSignerMessage(docHashHex)), // correct v2 signer sig
+    signerPubB64: Buffer.from('signer-pub').toString('base64'),
+    signerLabel: 'tester', ttlDays: 365, ctLogIndex: 1, version: '2',
+  }, deps);
   assert.equal(env.version, '2');
   const r = parasign.verifyEnvelope({ envelope: env, documentHashHex: docHashHex }, deps);
   assert.equal(r.valid, true, JSON.stringify(r.errors));
 });
 
-test('legacy v1 (bare-hash) envelope still verifies', () => {
-  const signerKp = ml_dsa65.keygen(crypto.randomBytes(32));
-  const sig = ml_dsa65.sign(Buffer.from(docHashHex, 'hex'), signerKp.secretKey); // bare hash
+test('legacy v1 envelope (signer signed the bare hash) still verifies', () => {
   const env = parasign.buildEnvelope({
     documentHashHex: docHashHex,
-    signatureB64: Buffer.from(sig).toString('base64'),
-    signerPubB64: Buffer.from(signerKp.publicKey).toString('base64'),
+    signatureB64: signOver(Buffer.from(docHashHex, 'hex')), // bare-hash signer sig
+    signerPubB64: Buffer.from('signer-pub').toString('base64'),
     signerLabel: 'legacy', ttlDays: 365, ctLogIndex: 0, version: '1',
   }, deps);
   assert.equal(env.version, '1');
@@ -63,15 +65,11 @@ test('legacy v1 (bare-hash) envelope still verifies', () => {
 });
 
 test('cross-protocol replay: a signature over an unrelated 32-byte value is NOT a valid v2 envelope', () => {
-  // Attacker signs some unrelated 32-byte message (e.g. a co-sign digest) and
-  // tries to pass it off as a v2 single-signer signature over docHashHex.
-  const signerKp = ml_dsa65.keygen(crypto.randomBytes(32));
-  const unrelated = sha3(Buffer.from('a multi-party co-sign digest')); // 32 bytes
-  const sig = ml_dsa65.sign(unrelated, signerKp.secretKey);
+  const unrelated = crypto.createHash('sha3-256').update(Buffer.from('a multi-party co-sign digest')).digest();
   const env = parasign.buildEnvelope({
-    documentHashHex: docHashHex, // claims to be over docHashHex
-    signatureB64: Buffer.from(sig).toString('base64'),
-    signerPubB64: Buffer.from(signerKp.publicKey).toString('base64'),
+    documentHashHex: docHashHex,                 // claims to be over docHashHex...
+    signatureB64: signOver(unrelated),           // ...but the signer signed `unrelated`
+    signerPubB64: Buffer.from('attacker-pub').toString('base64'),
     signerLabel: 'attacker', ttlDays: 365, ctLogIndex: 2, version: '2',
   }, deps);
   const r = parasign.verifyEnvelope({ envelope: env }, deps);
@@ -79,12 +77,25 @@ test('cross-protocol replay: a signature over an unrelated 32-byte value is NOT 
   assert.ok(r.errors.some(e => /signer signature invalid/.test(e)), JSON.stringify(r.errors));
 });
 
-test('a v2 signature does not verify if relabelled as v1 (and vice versa)', () => {
-  const signerKp = ml_dsa65.keygen(crypto.randomBytes(32));
-  const env = buildV2(signerKp);
-  const downgraded = Object.assign({}, env, { version: '1' }); // tamper version
-  const r = parasign.verifyEnvelope({ envelope: downgraded }, deps);
-  // notary signature also breaks (version is inside the signed body), but the
-  // signer signature must independently fail too — the message bytes differ.
+test('a bare-hash signature does NOT verify as a v2 envelope (the closed attack)', () => {
+  const env = parasign.buildEnvelope({
+    documentHashHex: docHashHex,
+    signatureB64: signOver(Buffer.from(docHashHex, 'hex')), // bare-hash sig...
+    signerPubB64: Buffer.from('signer-pub').toString('base64'),
+    signerLabel: 'downgrade', ttlDays: 365, ctLogIndex: 3, version: '2', // ...labelled v2
+  }, deps);
+  const r = parasign.verifyEnvelope({ envelope: env }, deps);
   assert.equal(r.valid, false);
+  assert.ok(r.errors.some(e => /signer signature invalid/.test(e)), JSON.stringify(r.errors));
+});
+
+test('unsupported envelope version is rejected', () => {
+  const env = parasign.buildEnvelope({
+    documentHashHex: docHashHex, signatureB64: signOver(parasign.singleSignerMessage(docHashHex)),
+    signerPubB64: Buffer.from('p').toString('base64'), ttlDays: 365, ctLogIndex: 4, version: '2',
+  }, deps);
+  const tampered = Object.assign({}, env, { version: '9' });
+  const r = parasign.verifyEnvelope({ envelope: tampered }, deps);
+  assert.equal(r.valid, false);
+  assert.ok(r.errors.some(e => /unsupported envelope version/.test(e)), JSON.stringify(r.errors));
 });

--- a/scripts/paramant-sign
+++ b/scripts/paramant-sign
@@ -28,6 +28,24 @@ function loadMlDsa() {
 }
 
 function sha3hex(buf) { return crypto.createHash('sha3-256').update(buf).digest('hex'); }
+
+// Domain-separated single-signer message (must be byte-identical to
+// relay/parasign.js singleSignerMessage). v2 binds the signature to the
+// notary protocol so it can't be replayed from another context (#3/#4).
+const SIGN_DOMAIN_NOTARY = 'paramant/parasign/notary/v1';
+function singleSignerMessage(docHashHex) {
+  return crypto.createHash('sha3-256')
+    .update(Buffer.from(SIGN_DOMAIN_NOTARY, 'utf8'))
+    .update(Buffer.from([0]))
+    .update(Buffer.from(docHashHex, 'hex'))
+    .digest();
+}
+// Bytes to verify a stored envelope's signer signature against, per version.
+function signerVerifyBytes(docHashHex, version) {
+  return String(version) === '2'
+    ? singleSignerMessage(docHashHex)
+    : Buffer.from(docHashHex, 'hex');
+}
 function die(msg) { console.error('error: ' + msg); process.exit(1); }
 
 function parseArgs(argv) {
@@ -87,8 +105,9 @@ async function cmdSign(args) {
 
   const docBuf = fs.readFileSync(args.document);
   const hashHex = sha3hex(docBuf);
-  // Sign the 32-byte hash locally; the secret key stays here.
-  const signature = mlDsa.sign(kp.secretKey, Buffer.from(hashHex, 'hex'));
+  // Sign the domain-separated v2 message locally; the secret key stays here.
+  // @noble/post-quantum ml_dsa65.sign is (message, secretKey).
+  const signature = mlDsa.sign(singleSignerMessage(hashHex), kp.secretKey);
 
   const resp = await postJson(relay.replace(/\/$/, '') + '/v2/sign', { 'X-Api-Key': apiKey }, {
     document_hash: hashHex,
@@ -117,9 +136,10 @@ async function cmdVerify(args) {
   const hashOk = hashHex === envelope.document_hash;
   let signerOk = false;
   try {
+    // v2 envelopes (domain-separated) and legacy v1 (bare hash) both verify here.
     signerOk = mlDsa.verify(
       Buffer.from(envelope.signature, 'base64'),
-      Buffer.from(envelope.document_hash, 'hex'),
+      signerVerifyBytes(envelope.document_hash, envelope.version),
       Buffer.from(envelope.signer.public_key, 'base64'));
   } catch (e) { signerOk = false; }
 


### PR DESCRIPTION
## 🟠 HIGH #3/#4 — cross-protocol signature replay in /v2/sign

De single-signer `/v2/sign`-notary verifieerde de ML-DSA-65-handtekening over de **bare** 32-byte document-hash, zonder domain-prefix — anders dan de multi-party-flow die al `paramant/parasign/doc/v1` prependt. Daardoor kon een handtekening over **élke** ongerelateerde 32-byte waarde (een multi-party co-sign-digest, een sessie/login-challenge, een receipt-hash) worden gereplayed naar `/v2/sign` en genotariseerd als 'document-handtekening'. **Live bevestigd.**

### v2-ontwerp (Mick's keuze: v2 + v1-compat)
v2 bindt de signer-handtekening aan dit protocol+doel met een **eigen** domain-label (distinct van het multi-party-label, zodat die twee óók niet cross-replaybaar zijn):
```
message = sha3_256("paramant/parasign/notary/v1" || 0x00 || doc_hash_bytes)
```

- **`relay/parasign.js`**: `singleSignerMessage()`/`signerVerifyBytes()`; `buildEnvelope` zet nieuwe envelopes op version '2'; `verifyEnvelope` dispatcht v1 (bare hash, legacy) / v2 → **reeds-getekende envelopes blijven verifieerbaar**.
- **`relay/relay.js` `/v2/sign`**: verifieert het v2-bericht; **weigert bare-hash standaard** (sluit de replay). `PARASIGN_ACCEPT_LEGACY_V1=true` is een transitie-escape-hatch (mint version '1', gelogd).
- **`scripts/paramant-sign`**: tekent v2; verify dispatcht v1/v2. Corrigeert óók een **pre-existing** verkeerde `ml_dsa65.sign()`-argumentvolgorde (moet `(message, secretKey)` zijn voor @noble/post-quantum 0.6.1) — de CLI-signer produceerde daarvoor nooit geldige handtekeningen.
- **`relay/test/parasign-domain-sep.test.js`**: 5 cases incl. cross-protocol-replay-weigering + v1-backcompat.

### Live-verificatie
v2 sign → 200 (version 2); bare-hash + cross-protocol replay → 400; `/v2/verify` van v2-envelope → valid; CLI keygen→sign→verify round-trip groen; legacy-flag accepteert bare-hash als version 1. **Relay-suite 34/34, static-sanity PASS.**

### Deploy-noot
De frontend-signing-UI gebruikt de multi-party `/v2/envelopes`-flow (al domain-separated) en roept `/v2/sign` **niet** aan — geen frontend-wijziging nodig. v2-only uitrollen is veilig voor nieuwe handtekeningen zodra de bijgewerkte CLI in gebruik is; bestaande `.psign` blijven verifiëren via het v1-pad. Zet `PARASIGN_ACCEPT_LEGACY_V1=true` alleen als een niet-bijgewerkte CLI moet blijven tekenen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)