### PR TITLE
harden(ssrf): block NAT64 / 6to4 IPv4-in-IPv6 embeddings; extract guard + test (#21)

### DIFF
--- a/relay/lib/ssrf-guard.js
+++ b/relay/lib/ssrf-guard.js
@@ -1,0 +1,47 @@
+'use strict';
+// URL-level SSRF guard (stage 1 of the relay's two-stage check; stage 2
+// re-resolves DNS and re-runs this on the resolved IP). Rejects https URLs that
+// point at loopback/link-local/RFC1918/ULA, numeric-encoding tricks, non-443
+// ports, internal metadata hosts, and IPv4-embedded IPv6 forms.
+function isSsrfSafeUrl(urlStr) {
+  try {
+    const u = new URL(urlStr);
+    if (u.protocol !== 'https:') return false;
+    const h = u.hostname.toLowerCase().replace(/^\[|\]$/g, ''); // strip IPv6 brackets
+    // Reject non-hostname forms: pure decimal (2130706433), hex (0x7f000001), short octal
+    if (/^\d+$/.test(h)) return false;                  // decimal IP
+    if (/^0x[0-9a-f]+$/i.test(h)) return false;          // hex IP
+    if (/^(0\d+\.){1,3}\d+$/.test(h)) return false;    // octal octets (0177.0.0.1)
+    if (/^\d+\.\d+$/.test(h)) return false;             // short-form (127.1)
+    // IPv4-mapped IPv6 ::ffff:x.x.x.x
+    if (/^::ffff:/i.test(h)) {
+      const v4part = h.replace(/^::ffff:/i, '');
+      return isSsrfSafeUrl('https://' + v4part + '/');
+    }
+    // Other IPv4-in-IPv6 embeddings (defence-in-depth, #21). The URL parser
+    // normalises e.g. [64:ff9b::127.0.0.1] to hex (64:ff9b::7f00:1), so detect
+    // the translation prefixes directly and also recheck any dotted IPv4 tail.
+    // These carry an IPv4 destination the relay must not be tricked into reaching.
+    if (/^64:ff9b:/i.test(h)) return false;   // NAT64 (64:ff9b::/96 + 64:ff9b:1::/48)
+    if (/^2002:/i.test(h)) return false;      // 6to4 (embeds IPv4 in the next 32 bits)
+    const v4tail = h.match(/:((?:\d{1,3}\.){3}\d{1,3})$/);
+    if (v4tail) return isSsrfSafeUrl('https://' + v4tail[1] + '/');
+    if (h === 'localhost' || h === '0.0.0.0' || h === '0') return false;
+    if (/^127\./.test(h)) return false;
+    if (/^::1$/.test(h)) return false;
+    if (/^169\.254\./.test(h)) return false;
+    if (/^fe80/i.test(h)) return false;
+    if (/^10\./.test(h)) return false;
+    if (/^192\.168\./.test(h)) return false;
+    if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return false;
+    if (/^f[cd]/i.test(h)) return false;                  // IPv6 ULA (fc00::/7)
+    if (h.endsWith('.local') || h.endsWith('.internal') || h.endsWith('.localhost')) return false;
+    if (h === 'metadata.google.internal' || h === 'metadata.aws.internal') return false;
+    // Restrict to standard HTTPS ports only.
+    const ALLOWED_PORTS = new Set(['', '443']);
+    if (!ALLOWED_PORTS.has(u.port)) return false;
+    return true;
+  } catch { return false; }
+}
+
+module.exports = { isSsrfSafeUrl };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1649,38 +1649,8 @@ setInterval(() => {
 // Blocks: RFC1918, loopback, link-local, IPv6 ULA, cloud metadata,
 //         and all alternate IP representations (decimal, hex, octal, short-form,
 //         IPv4-mapped IPv6) that bypass naive string-based checks.
-function isSsrfSafeUrl(urlStr) {
-  try {
-    const u = new URL(urlStr);
-    if (u.protocol !== 'https:') return false;
-    const h = u.hostname.toLowerCase().replace(/^\[|\]$/g, ''); // strip IPv6 brackets
-    // Reject non-hostname forms: pure decimal (2130706433), hex (0x7f000001), short octal
-    if (/^\d+$/.test(h)) return false;                  // decimal IP
-    if (/^0x[0-9a-f]+$/i.test(h)) return false;          // hex IP
-    if (/^(0\d+\.){1,3}\d+$/.test(h)) return false;    // octal octets (0177.0.0.1)
-    if (/^\d+\.\d+$/.test(h)) return false;             // short-form (127.1)
-    // IPv4-mapped IPv6 ::ffff:x.x.x.x
-    if (/^::ffff:/i.test(h)) {
-      const v4part = h.replace(/^::ffff:/i, '');
-      return isSsrfSafeUrl('https://' + v4part + '/');
-    }
-    if (h === 'localhost' || h === '0.0.0.0' || h === '0') return false;
-    if (/^127\./.test(h)) return false;
-    if (/^::1$/.test(h)) return false;
-    if (/^169\.254\./.test(h)) return false;
-    if (/^fe80/i.test(h)) return false;
-    if (/^10\./.test(h)) return false;
-    if (/^192\.168\./.test(h)) return false;
-    if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return false;
-    if (/^f[cd]/i.test(h)) return false;                  // IPv6 ULA (fc00::/7)
-    if (h.endsWith('.local') || h.endsWith('.internal') || h.endsWith('.localhost')) return false;
-    if (h === 'metadata.google.internal' || h === 'metadata.aws.internal') return false;
-    // Fix 11: restrict to standard HTTPS ports only
-    const ALLOWED_PORTS = new Set(['', '443']);
-    if (!ALLOWED_PORTS.has(u.port)) return false;
-    return true;
-  } catch { return false; }
-}
+// URL-level SSRF guard, extracted to relay/lib/ssrf-guard.js for unit coverage.
+const { isSsrfSafeUrl } = require('./lib/ssrf-guard');
 
 // ── Safe outbound HTTPS request ───────────────────────────────────────────────
 // Single helper used by every outbound request the relay makes (gossip,

--- a/relay/test/ssrf-guard.test.js
+++ b/relay/test/ssrf-guard.test.js
@@ -1,0 +1,46 @@
+'use strict';
+// URL-level SSRF guard, incl. the IPv4-in-IPv6 embeddings closed in #21.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { isSsrfSafeUrl } = require('../lib/ssrf-guard');
+
+const blocked = [
+  ['https://[64:ff9b::127.0.0.1]/', 'NAT64 -> loopback'],
+  ['https://[64:ff9b::a9fe:a9fe]/', 'NAT64 -> 169.254.169.254 (cloud metadata)'],
+  ['https://[64:ff9b:1::7f00:1]/', 'NAT64 local-use prefix'],
+  ['https://[2002:7f00:0001::]/', '6to4 -> 127.0.0.1'],
+  ['https://[64:ff9b::8.8.8.8]/', 'NAT64 to a public v4 is still not followed'],
+  ['https://[::ffff:127.0.0.1]/', 'IPv4-mapped loopback'],
+  ['https://[::1]/', 'IPv6 loopback'],
+  ['https://127.0.0.1/', 'IPv4 loopback'],
+  ['https://169.254.169.254/', 'link-local metadata'],
+  ['https://10.0.0.5/', 'RFC1918 10/8'],
+  ['https://192.168.1.1/', 'RFC1918 192.168/16'],
+  ['https://[fd00::1]/', 'IPv6 ULA'],
+  ['https://2130706433/', 'decimal-encoded 127.0.0.1'],
+  ['https://0x7f000001/', 'hex-encoded 127.0.0.1'],
+  ['https://metadata.google.internal/', 'GCP metadata host'],
+  ['https://example.com:8080/', 'non-443 port'],
+  ['http://example.com/', 'plain http'],
+];
+
+const allowed = [
+  ['https://example.com/', 'normal public host'],
+  ['https://relay.paramant.app/v2/sth', 'public host with path'],
+  ['https://[2606:4700::1111]/', 'real public IPv6 (Cloudflare)'],
+  ['https://1.1.1.1/', 'public IPv4'],
+];
+
+test('blocks loopback / RFC1918 / metadata / numeric / IPv4-in-IPv6 embeddings', () => {
+  for (const [u, desc] of blocked) assert.equal(isSsrfSafeUrl(u), false, 'should block: ' + desc + '  ' + u);
+});
+
+test('allows genuine public HTTPS endpoints', () => {
+  for (const [u, desc] of allowed) assert.equal(isSsrfSafeUrl(u), true, 'should allow: ' + desc + '  ' + u);
+});
+
+test('garbage input does not throw', () => {
+  for (const u of ['', 'not a url', 'ftp://x', null, undefined, '://', 'https://']) {
+    assert.equal(isSsrfSafeUrl(u), false);
+  }
+});


### PR DESCRIPTION
## ⚪ LOW #21 — SSRF allow-list accepts IPv4-in-IPv6 embeddings

`isSsrfSafeUrl` behandelde `::ffff:`-mapped adressen, maar niet **NAT64** (`64:ff9b::/96`, `64:ff9b:1::/48`) of **6to4** (`2002::/16`). Daardoor passeerde een webhook/relay-register-URL als `https://[64:ff9b::127.0.0.1]/` of de metadata-variant `https://[64:ff9b::a9fe:a9fe]/` (→169.254.169.254) de guard. Live bevestigd in de pentest.

### Fix
- NAT64 + 6to4 prefixes expliciet weigeren (de URL-parser normaliseert de bracket-literal naar hex, dus detectie op prefix); plus een dotted-IPv4-tail-hercheck. Dezelfde guard draait in **stage 2** (op het DNS-geresolvede IP), dus beide lagen zijn nu dicht.
- `isSsrfSafeUrl` geëxtraheerd naar `relay/lib/ssrf-guard.js` met `relay/test/ssrf-guard.test.js` (17 geblokkeerd + 4 toegestaan + garbage) → nu CI-dekking. Echt publiek IPv6 (bv. Cloudflare `2606:4700::`) blijft toegestaan.

### Verificatie
Relay start (200), live NAT64-webhook → **400**. SSRF-test 3/3, relay-suite groen, static-sanity PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)