### PR TITLE
harden(audit): make chain_valid a real tamper check — bind all fields + recompute (#19)

### DIFF
--- a/relay/lib/audit-chain.js
+++ b/relay/lib/audit-chain.js
@@ -1,0 +1,33 @@
+'use strict';
+// Tamper-evident audit chain helpers (extracted for unit coverage, #19).
+// chain_hash commits to EVERY field of an entry except chain_hash itself, using
+// a canonical (sorted-key) encoding so object key order never matters.
+const crypto = require('crypto');
+
+// Recursive canonical JSON (sorted keys, no whitespace) — identical contract to
+// the relay's canonicalJSON, kept local so this module is self-contained.
+function canonicalJSON(obj) {
+  if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
+  if (Array.isArray(obj)) return '[' + obj.map(canonicalJSON).join(',') + ']';
+  return '{' + Object.keys(obj).sort()
+    .map(k => JSON.stringify(k) + ':' + canonicalJSON(obj[k])).join(',') + '}';
+}
+
+function auditEntryHash(entry) {
+  const rest = Object.assign({}, entry);
+  delete rest.chain_hash; // exclude the field we are about to (re)compute
+  return crypto.createHash('sha3-256').update(canonicalJSON(rest)).digest('hex');
+}
+
+// Verify a Merkle audit chain: recompute each entry's chain_hash over ALL its
+// fields (tamper-evidence) AND verify the prev_hash linkage. Linkage is relative
+// so a trimmed chain (oldest entries dropped past MAX_AUDIT) still verifies.
+function verifyChain(entries) {
+  for (let i = 0; i < entries.length; i++) {
+    if (entries[i].chain_hash !== auditEntryHash(entries[i])) return false;
+    if (i > 0 && entries[i].prev_hash !== entries[i - 1].chain_hash) return false;
+  }
+  return true;
+}
+
+module.exports = { canonicalJSON, auditEntryHash, verifyChain };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1481,25 +1481,22 @@ function mnemonicToLookupHash(phrase) {
 }
 
 // ── Merkle audit chain ────────────────────────────────────────────────────────
-// Elke entry bevat hash van vorige entry — tamper-evident log
+// Tamper-evident log. chain_hash commits to EVERY field of the entry except
+// itself (canonical encoding, see relay/lib/audit-chain.js). The old preimage
+// covered only {ts,event,hash,bytes,prev_hash} so the richer fields (device,
+// views_left, sig, sig-validity) were unprotected, and verifyChain never
+// recomputed the hash at all — chain_valid was a false assurance (#19).
+const { auditEntryHash, verifyChain } = require('./lib/audit-chain');
+
 function auditAppend(key, event, data = {}) {
   if (!key) return;
   if (!auditChain.has(key)) auditChain.set(key, []);
   const chain    = auditChain.get(key);
   const prevHash = chain.length > 0 ? chain[chain.length - 1].chain_hash : '0'.repeat(64);
   const entry    = { ts: new Date().toISOString(), event, prev_hash: prevHash, ...data };
-  const entryStr = JSON.stringify({ ts: entry.ts, event, hash: data.hash||'', bytes: data.bytes||0, prev_hash: prevHash });
-  entry.chain_hash = crypto.createHash('sha3-256').update(entryStr).digest('hex');
+  entry.chain_hash = auditEntryHash(entry);
   chain.push(entry);
   if (chain.length > MAX_AUDIT) chain.shift();
-}
-
-function verifyChain(entries) {
-  // Verifieer integriteit van de audit chain
-  for (let i = 1; i < entries.length; i++) {
-    if (entries[i].prev_hash !== entries[i-1].chain_hash) return false;
-  }
-  return true;
 }
 
 // ── ML-DSA handtekening verificatie ──────────────────────────────────────────

--- a/relay/test/audit-chain.test.js
+++ b/relay/test/audit-chain.test.js
@@ -1,0 +1,69 @@
+'use strict';
+// Audit-chain tamper-evidence (#19): chain_hash binds every field and
+// verifyChain actually recomputes it.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { auditEntryHash, verifyChain } = require('../lib/audit-chain');
+
+// Build a chain the way auditAppend does (prev_hash links + chain_hash per entry).
+function build(events) {
+  const chain = [];
+  for (const ev of events) {
+    const prev_hash = chain.length ? chain[chain.length - 1].chain_hash : '0'.repeat(64);
+    const entry = { ts: ev.ts, event: ev.event, prev_hash, ...ev.data };
+    entry.chain_hash = auditEntryHash(entry);
+    chain.push(entry);
+  }
+  return chain;
+}
+
+const sample = () => build([
+  { ts: '2026-06-10T00:00:00.000Z', event: 'inbound',  data: { hash: 'a'.repeat(64), bytes: 10, device: 'dev1', views_left: 1 } },
+  { ts: '2026-06-10T00:00:01.000Z', event: 'outbound', data: { hash: 'a'.repeat(64), bytes: 10, device: 'dev1', views_left: 0, sig: 'deadbeef' } },
+  { ts: '2026-06-10T00:00:02.000Z', event: 'burned',   data: { hash: 'a'.repeat(64), bytes: 0 } },
+]);
+
+test('a well-formed chain verifies', () => {
+  assert.equal(verifyChain(sample()), true);
+});
+
+test('tampering a hash-covered field (event) is detected', () => {
+  const c = sample(); c[1].event = 'inbound';
+  assert.equal(verifyChain(c), false);
+});
+
+test('tampering a RICH field the old preimage ignored (device/views_left/sig) is now detected', () => {
+  for (const mut of [
+    (c) => { c[0].device = 'attacker'; },
+    (c) => { c[1].views_left = 99; },
+    (c) => { c[1].sig = 'forged'; },
+  ]) {
+    const c = sample(); mut(c);
+    assert.equal(verifyChain(c), false);
+  }
+});
+
+test('breaking the prev_hash linkage is detected', () => {
+  const c = sample(); c[2].prev_hash = '0'.repeat(64);
+  assert.equal(verifyChain(c), false);
+});
+
+test('re-stamping chain_hash after a tamper still fails (linkage breaks downstream)', () => {
+  const c = sample();
+  c[1].views_left = 99;
+  c[1].chain_hash = auditEntryHash(c[1]); // attacker recomputes this entry's hash
+  // entry[2].prev_hash still points at the OLD c[1].chain_hash -> linkage breaks
+  assert.equal(verifyChain(c), false);
+});
+
+test('object key order does not affect the hash (canonical)', () => {
+  const e1 = { ts: 't', event: 'x', prev_hash: '0'.repeat(64), a: 1, b: 2 };
+  const e2 = { b: 2, prev_hash: '0'.repeat(64), event: 'x', a: 1, ts: 't' };
+  assert.equal(auditEntryHash(e1), auditEntryHash(e2));
+});
+
+test('a trimmed chain (oldest entries dropped) still verifies on the relative linkage', () => {
+  const full = sample();
+  const trimmed = full.slice(1); // drop the genesis entry
+  assert.equal(verifyChain(trimmed), true);
+});


### PR DESCRIPTION
## ⚪ LOW #19 — audit `chain_valid` was a false assurance

`auditAppend` hashte alleen `{ts,event,hash,bytes,prev_hash}` terwijl elke entry óók `device`, `views_left`, `sig` en sig-validity opslaat; en `verifyChain` checkte **alleen de prev_hash-linkage**, herberekende `chain_hash` nooit. Dus elk van die rijkere velden kon worden aangepast terwijl `chain_valid` true bleef.

### Fix
- `chain_hash` commit nu op **elk** entry-veld behalve zichzelf, via canonieke (sorted-key) encoding — key-volgorde irrelevant.
- `verifyChain` herberekent elke `chain_hash` én checkt de linkage; linkage blijft relatief zodat een getrimde chain (voorbij `MAX_AUDIT`) blijft verifiëren.
- geëxtraheerd naar `relay/lib/audit-chain.js` + `relay/test/audit-chain.test.js` (7 cases: detecteert getamperde `device`/`views_left`/`sig`, re-stamp-dan-relink-falen, canonieke key-order-invariantie, getrimde chain).

De chain is **alleen in-memory** (vers herbouwd bij elke boot), dus geen persistente oude entries om te migreren.

### Verificatie
Live: `/v2/audit` geeft `chain_valid:true` na een echte upload. Relay-suite 36/36, static-sanity PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)