### PR TITLE
fix(parasign): Safari signing error — PRF evalByCredential fallback for WebKit

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -778,7 +778,7 @@ loadVaultStatus();
 document.addEventListener('signing-key-enrolled', () => { loadEnrolledKeys(); loadVaultStatus(); });
 </script>
 <script type="module" src="/js/passkey.js?v=3"></script>
-<script type="module" src="/js/signing-enrol.js?v=7"></script>
+<script type="module" src="/js/signing-enrol.js?v=8"></script>
 
 </body>
 </html>

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -182,6 +182,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 </main>
 
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=1"></script>
-<script type="module" src="/co-sign.js?v=6"></script>
+<script type="module" src="/co-sign.js?v=7"></script>
 </body>
 </html>

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -18,7 +18,7 @@
 // the view receipt. The signing path itself is same-origin via the admin
 // (/api/user/sign/*), bound to the logged-in invitee session.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey } from '/js/parasign-signer.js?v=5';
+import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey } from '/js/parasign-signer.js?v=6';
 
 const RELAY_PUBLIC = 'https://health.paramant.app';
 

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -77,6 +77,25 @@ export async function resolvePasskeySigningKey() {
   return { vaultId: k.id, pk_b64: k.pk_b64, fingerprint: (k.pk_hash || '').slice(0, 16) };
 }
 
+// One WebAuthn get() with PRF, portable across engines. Chromium + Gecko REQUIRE
+// prf.evalByCredential (keyed by the base64url credential id) whenever
+// allowCredentials is non-empty, or no PRF result comes back. WebKit (Safari)
+// is the mirror image: its PRF implementation only knows `eval` and throws
+// (NotSupportedError / SyntaxError / TypeError, before any UI is shown) as soon
+// as evalByCredential is present. So: try the full request first, and on such a
+// parse/support error retry ONCE with eval only — same salt, so the PRF output
+// is byte-identical either way. NotAllowedError (cancel/timeout) is never retried.
+async function getAssertionWithPrf(publicKey, prfExt) {
+  try {
+    return await navigator.credentials.get({ publicKey: { ...publicKey, extensions: { prf: prfExt } } });
+  } catch (e) {
+    const parseErr = e && (e.name === 'NotSupportedError' || e.name === 'SyntaxError' || e.name === 'TypeError');
+    if (!parseErr || !prfExt || !prfExt.evalByCredential) throw e;
+    const evalOnly = { eval: prfExt.eval || Object.values(prfExt.evalByCredential)[0] };
+    return await navigator.credentials.get({ publicKey: { ...publicKey, extensions: { prf: evalOnly } } });
+  }
+}
+
 // Reproduce the PRF output by running a WebAuthn get() with the SAME salt that
 // was stored in the wrap at enrol (PRF output is deterministic per
 // (credential, salt), independent of the challenge).
@@ -87,15 +106,12 @@ async function evalPrf({ rpId, credentialIdB64url, prfSaltB64url }) {
   // yields NO prf result there (and on WebKit once >1 passkey is offered). Send
   // both: evalByCredential (used when the credential matches) + eval (fallback),
   // same salt either way so the PRF output is identical to enrol time.
-  const assertion = await navigator.credentials.get({
-    publicKey: {
-      challenge: crypto.getRandomValues(new Uint8Array(32)),
-      rpId,
-      allowCredentials: [{ type: 'public-key', id: b64urlToBytes(credentialIdB64url) }],
-      userVerification: 'required',
-      extensions: { prf: { eval: { first: saltBytes }, evalByCredential: { [credentialIdB64url]: { first: saltBytes } } } },
-    },
-  });
+  const assertion = await getAssertionWithPrf({
+    challenge: crypto.getRandomValues(new Uint8Array(32)),
+    rpId,
+    allowCredentials: [{ type: 'public-key', id: b64urlToBytes(credentialIdB64url) }],
+    userVerification: 'required',
+  }, { eval: { first: saltBytes }, evalByCredential: { [credentialIdB64url]: { first: saltBytes } } });
   const first = assertion.getClientExtensionResults()?.prf?.results?.first;
   if (!first) throw new Error('passkey returned no PRF result (PRF unsupported on this authenticator)');
   return new Uint8Array(first);
@@ -283,20 +299,17 @@ export async function ensureSigningKey({ rpId, label, onStatus } = {}) {
       prfExt.evalByCredential = {};
       for (const c of allowList) prfExt.evalByCredential[c.id] = { first: prfSalt };
     }
-    const cred = await navigator.credentials.get({
-      publicKey: {
-        challenge: b64urlToBytes(opt.options.challenge),
-        rpId,
-        allowCredentials: allowList.map((c) => ({
-          type: 'public-key',
-          id: b64urlToBytes(c.id),
-          ...(c.transports ? { transports: c.transports } : {}),
-        })),
-        userVerification: 'required',
-        timeout: opt.options.timeout || 60000,
-        extensions: { prf: prfExt },
-      },
-    });
+    const cred = await getAssertionWithPrf({
+      challenge: b64urlToBytes(opt.options.challenge),
+      rpId,
+      allowCredentials: allowList.map((c) => ({
+        type: 'public-key',
+        id: b64urlToBytes(c.id),
+        ...(c.transports ? { transports: c.transports } : {}),
+      })),
+      userVerification: 'required',
+      timeout: opt.options.timeout || 60000,
+    }, prfExt);
     const prfFirst = cred.getClientExtensionResults()?.prf?.results?.first;
     if (!prfFirst) {
       const err = new Error('This passkey can’t produce a PRF result. Use a device/browser with passkey-PRF (iOS 18+, a recent Chrome/Edge, or a PRF-capable security key).');

--- a/frontend/js/signing-enrol.js
+++ b/frontend/js/signing-enrol.js
@@ -7,7 +7,7 @@
 // (parasign-signer.js) — the EXACT path /sign and /co-sign use — so this file
 // just wires the button + status and can never drift from the sign flow.
 // Self-hosted deps only (CSP script-src 'self'); no-ops if the button is absent.
-import { ensureSigningKey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=5';
+import { ensureSigningKey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=6';
 
 function wireSigningEnrol() {
   const btn = document.getElementById('signing-enrol-btn');

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -11,7 +11,7 @@
 // sign path. Signing goes through the passkey-PRF activation chain (LocalVaultSigner
 // in parasign-signer.js); sha3_256 stays for document hashing only.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey } from '/js/parasign-signer.js?v=5';
+import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey } from '/js/parasign-signer.js?v=6';
 
 // Read-only public relay host, used ONLY for the "view envelope status" link on
 // the done screen. The signing path itself is same-origin via the admin

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -620,6 +620,6 @@
 <script src="/js/nav-auth.js?v=1" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=1"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
-<script type="module" src="/sign-flow.js?v=17"></script>
+<script type="module" src="/sign-flow.js?v=18"></script>
 </body>
 </html>


### PR DESCRIPTION
**Probleem.** Tekenen/ondertekenen op paramant.app gaf in Safari een error bij de passkey-stap. Sinds ffa64f1 stuurt elke PRF-`get()` ook `prf.evalByCredential` mee zodra `allowCredentials` niet leeg is. Chromium/Gecko hebben dat nodig; WebKit (Safari, incl. iOS) implementeert PRF alleen met `eval` en gooit een fout zodra `evalByCredential` in de opties staat, nog vóór er UI verschijnt.

**Fix.** Nieuwe helper `getAssertionWithPrf()` in `parasign-signer.js`, gebruikt door beide PRF-call-sites (`evalPrf` en `ensureSigningKey`): eerst het volledige verzoek; bij `NotSupportedError`/`SyntaxError`/`TypeError` precies één retry met alleen `eval` (zelfde salt, dus byte-identieke PRF-output). `NotAllowedError` (annuleren/time-out) wordt nooit geretried. Gedrag getest met gestubde engines: Chromium-pad ongewijzigd, WebKit-pad valt terug, cancel propageert.

**Cache-busts.** parasign-signer ?v=6 · sign-flow ?v=18 (sign.html) · signing-enrol ?v=8 (account.html) · co-sign ?v=7 (co-sign.html).

**Testen na merge+deploy (on-device):** Safari op iPhone/Mac → /sign → document → Sign now → één Face ID/Touch ID-tap, geen error; daarna zelfde flow in Chrome ter controle (moet onveranderd zijn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)