### PR TITLE
fix(sign): align pdfjs-loader cache-bust to ?v=2 (cache-bust guard)

### DIFF
--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -618,7 +618,7 @@
 </footer>
 <script src="/nav.js?v=12" defer></script>
 <script src="/js/nav-auth.js?v=1" defer></script>
-<script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=1"></script>
+<script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script type="module" src="/sign-flow.js?v=18"></script>
 </body>


### PR DESCRIPTION
sign.html still pinned pdfjs-loader.js?v=1 after the .mjs->.js rename bumped
co-sign.html and get.html to ?v=2; the guard rightly flags one asset under two
cache keys, and /sign would keep loading the stale loader on warm caches.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
