### PR TITLE
feat(parasign): passphrase signing fallback for passkey providers without PRF (Proton Pass)

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -778,7 +778,7 @@ loadVaultStatus();
 document.addEventListener('signing-key-enrolled', () => { loadEnrolledKeys(); loadVaultStatus(); });
 </script>
 <script type="module" src="/js/passkey.js?v=3"></script>
-<script type="module" src="/js/signing-enrol.js?v=9"></script>
+<script type="module" src="/js/signing-enrol.js?v=10"></script>
 
 </body>
 </html>

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -152,6 +152,19 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <div class="banner" id="sign-status" hidden></div>
       <div id="sign-cta" style="margin-bottom:12px" hidden></div>
       <button class="btn" id="sign-confirm" type="button" disabled>Sign this document</button>
+      <!-- Passphrase fallback: shown only when the account's passkey provider can't
+           do WebAuthn-PRF (e.g. Proton Pass). The passkey still proves the account;
+           this passphrase protects the local signing key in place of the PRF. -->
+      <div class="banner" id="cs-pass-panel" hidden style="margin-top:12px">
+        <p id="cs-pass-prompt" style="margin-bottom:10px"></p>
+        <input type="password" id="cs-pass-input" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" placeholder="Signing passphrase" aria-label="Signing passphrase" style="width:100%;padding:10px;border:1px solid var(--ink-hair,#e2e8f0);border-radius:6px;margin-bottom:8px;font-size:14px">
+        <input type="password" id="cs-pass-input2" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" placeholder="Confirm passphrase" aria-label="Confirm signing passphrase" hidden style="width:100%;padding:10px;border:1px solid var(--ink-hair,#e2e8f0);border-radius:6px;margin-bottom:8px;font-size:14px">
+        <p id="cs-pass-err" hidden style="color:var(--danger,#b91c1c);font-size:13px;margin-bottom:8px"></p>
+        <div style="display:flex;gap:8px">
+          <button class="btn btn-outline" id="cs-pass-cancel" type="button">Cancel</button>
+          <button class="btn" id="cs-pass-confirm" type="button">Continue</button>
+        </div>
+      </div>
       <div class="review-gate" id="review-gate" hidden></div>
     </div>
   </div>
@@ -182,6 +195,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 </main>
 
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
-<script type="module" src="/co-sign.js?v=8"></script>
+<script type="module" src="/co-sign.js?v=9"></script>
 </body>
 </html>

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -18,13 +18,55 @@
 // the view receipt. The signing path itself is same-origin via the admin
 // (/api/user/sign/*), bound to the logged-in invitee session.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey } from '/js/parasign-signer.js?v=7';
+import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolSigningKeyWithPassphrase, assertStrongPassphrase } from '/js/parasign-signer.js?v=8';
 
 const RELAY_PUBLIC = 'https://health.paramant.app';
 
 // ---------- helpers ----------
 function $(id) { return document.getElementById(id); }
 function showStep(id) { document.querySelectorAll('.step').forEach((s) => s.classList.remove('active')); $(id).classList.add('active'); }
+
+// Passphrase prompt for the signing-key fallback (passkey providers without PRF).
+// Resolves with the entered passphrase, or null if the user cancels. mode 'set' =
+// create a new signing passphrase (two fields, strength-checked); 'unlock' = enter
+// an existing one (single field).
+function promptPassphrase(mode) {
+  return new Promise((resolve) => {
+    const panel = $('cs-pass-panel'), p1 = $('cs-pass-input'), p2 = $('cs-pass-input2');
+    const errEl = $('cs-pass-err'), promptEl = $('cs-pass-prompt');
+    const okBtn = $('cs-pass-confirm'), cancelBtn = $('cs-pass-cancel');
+    const setMode = mode === 'set';
+    promptEl.textContent = setMode
+      ? 'Your passkey provider can’t do the one-tap unlock signing uses, so set a signing passphrase. You enter it each time you sign on this browser. Keep it safe: it protects your signing key and cannot be reset.'
+      : 'Enter your signing passphrase to unlock your signing key.';
+    p1.value = ''; p2.value = '';
+    p1.placeholder = setMode ? 'New signing passphrase (min. 12 characters)' : 'Signing passphrase';
+    p2.hidden = !setMode;
+    errEl.hidden = true; errEl.textContent = '';
+    panel.hidden = false;
+    try { p1.focus(); } catch {}
+    const cleanup = () => {
+      okBtn.removeEventListener('click', onOk);
+      cancelBtn.removeEventListener('click', onCancel);
+      p1.removeEventListener('keydown', onKey); p2.removeEventListener('keydown', onKey);
+      panel.hidden = true; p1.value = ''; p2.value = '';
+    };
+    const fail = (m) => { errEl.textContent = m; errEl.hidden = false; };
+    const onOk = () => {
+      const v1 = p1.value, v2 = p2.value;
+      if (setMode) {
+        try { assertStrongPassphrase(v1); } catch (e) { return fail(e.message || 'Passphrase too weak.'); }
+        if (v1 !== v2) return fail('The two passphrases don’t match.');
+      } else if (!v1) { return fail('Enter your signing passphrase.'); }
+      cleanup(); resolve(v1);
+    };
+    const onCancel = () => { cleanup(); resolve(null); };
+    const onKey = (e) => { if (e.key === 'Enter') { e.preventDefault(); onOk(); } };
+    okBtn.addEventListener('click', onOk);
+    cancelBtn.addEventListener('click', onCancel);
+    p1.addEventListener('keydown', onKey); p2.addEventListener('keydown', onKey);
+  });
+}
 function showError(m) { $('error-msg').textContent = m; showStep('step-error'); }
 function toHex(u8) { let s = ''; for (let i = 0; i < u8.length; i++) s += u8[i].toString(16).padStart(2, '0'); return s; }
 function toB64(u8) { let s = ''; for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]); return btoa(s); }
@@ -61,7 +103,8 @@ let __envelope = null;
 let __partyIndex = -1;
 let __inviteToken = '';
 let __session = null;       // { email } when logged in as the invited recipient
-let __signKey = null;       // { vaultId, pk_b64, fingerprint } — PUBLIC metadata only
+let __signKey = null;       // { vaultId, pk_b64, fingerprint, hasPrf, hasPassphrase } — PUBLIC metadata only
+let __signPassphrase = null; // set when the signing key is passphrase-protected (provider without PRF)
 let __hashMatches = null;   // null = no file opened yet, true/false after a local hash check
 let __blindAck = false;     // user explicitly opted to sign without opening the document
 
@@ -332,7 +375,17 @@ async function doSign() {
     //    a single passkey tap (no passphrase, no TOTP) if not. The sign-in passkey
     //    becomes the signing key; no /account detour. Returns the existing key fast.
     if (!__signKey) {
-      __signKey = await ensureSigningKey({ rpId: location.hostname, onStatus: (m) => setStatus('', m) });
+      try {
+        __signKey = await ensureSigningKey({ rpId: location.hostname, onStatus: (m) => setStatus('', m) });
+      } catch (e) {
+        if (!e || e.code !== 'prf_unsupported') throw e;
+        // Passkey provider can't do PRF (e.g. Proton Pass): fall back to a
+        // passphrase-protected signing key, still bound to the account via the passkey.
+        __signPassphrase = await promptPassphrase('set');
+        if (__signPassphrase == null) { const c = new Error('cancelled'); c.code = 'cancelled'; throw c; }
+        setStatus('', 'Setting up your signing key…');
+        __signKey = await enrolSigningKeyWithPassphrase({ rpId: location.hostname, passphrase: __signPassphrase, onStatus: (m) => setStatus('', m) });
+      }
     }
 
     // 1) Per-document activation (authorize -> one-shot token). The admin checks
@@ -349,7 +402,13 @@ async function doSign() {
     // 2) Passkey-PRF unlock + sign of the v3 domain-prefixed message. The secret
     //    key lives ONLY inside the ActivatedSigner and is zeroized by dispose().
     setStatus('', 'Confirm to sign (Face ID / Touch ID / security key)...');
-    const signer = await new LocalVaultSigner().activate({ vaultId: __signKey.vaultId, rpId: location.hostname });
+    // PRF key: one tap. Passphrase key: unlock with the passphrase (reuse the one
+    // set on enrol, or ask for it on an already-enrolled passphrase key).
+    if (!__signKey.hasPrf && __signPassphrase == null) {
+      __signPassphrase = await promptPassphrase('unlock');
+      if (__signPassphrase == null) { const c = new Error('cancelled'); c.code = 'cancelled'; throw c; }
+    }
+    const signer = await new LocalVaultSigner().activate({ vaultId: __signKey.vaultId, rpId: location.hostname, passphrase: __signKey.hasPrf ? undefined : __signPassphrase });
     let sigB64;
     try {
       const message = buildDocSignMessage({ envelopeId: __envelope.id, docHash: __envelope.doc_hash, partyIndex: __partyIndex, emailHash: act.email_hash });
@@ -377,6 +436,9 @@ async function doSign() {
     else if (e && e.status === 403) msg = 'This invite is bound to a different email address. Sign in with the address the invite was sent to.';
     else if (e && e.status === 410) msg = 'This signing invite has expired (invites are valid for 7 days). Ask the sender for a new link.';
     else if (e && e.status === 409) msg = 'That signing authorization was already used or expired. Reload the page and try again.';
+    else if (e && e.code === 'cancelled') msg = 'Signing cancelled. Tap Sign when you’re ready.';
+    else if (e && /wrong passphrase/i.test(e.message || '')) msg = 'That signing passphrase didn’t match. Tap Sign and re-enter it.';
+    else if (e && (e.code === 'prf_unsupported' || e.code === 'need_passphrase')) msg = 'Your passkey can’t do one-tap signing here. Tap Sign to set or enter a signing passphrase instead.';
     else if (e && e.status) msg = 'Signing could not be completed right now (server error ' + e.status + '). Please try again in a moment.';
     else msg = 'Your passkey could not complete signing on this browser. Tap Sign to try again. If it keeps failing, try a different browser, or use the passkey on your phone.';
     setStatus('err', msg);

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -5,7 +5,10 @@
 // Tomorrow a RemoteSamSigner (SAP -> HSM-backed SAM) drops in behind the same
 // interface without touching callers. Self-hosted deps only (CSP 'self').
 import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
-import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultStore, vaultAddPrfWrap, vaultCreatePrfOnly, vaultAvailable, vaultList } from '/vendor/vault.js?v=3';
+import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultStore, vaultUnlock, vaultAddPrfWrap, vaultCreatePrfOnly, vaultAvailable, vaultList, assertStrongPassphrase } from '/vendor/vault.js?v=3';
+
+// Re-exported so the sign UIs can strength-check a new passphrase before enrol.
+export { assertStrongPassphrase };
 
 // Byte-identical to relay/envelope.js SIGN_DOMAIN_DOC (recipe v3). Keep in sync
 // across relay + SDK + core.
@@ -56,44 +59,44 @@ export function buildDocSignMessage({ envelopeId, docHash, partyIndex, emailHash
   ]));
 }
 
-// v3-only signing-key resolution — the SINGLE definition of "what a signing key
-// is", shared by /sign (self-sign) and /co-sign (recipient). The signing key is
-// the account's passkey-protected ML-DSA-65 key in the vault. We read its PUBLIC
-// half (pk_b64/pk_hash) from vault metadata WITHOUT unlocking; the secret is only
-// unlocked by the per-document passkey-PRF activation (LocalVaultSigner.activate,
-// the explicit step-2 action). No ephemeral/file/passphrase key source. If no
-// passkey signing key is enrolled, this throws with code 'no_signing_passkey' so
-// the caller can branch to the TOFU enrol sub-step (stuk 2 UI / enrolSigningPasskey).
+// v3 signing-key resolution — the SINGLE definition of "what a signing key is",
+// shared by /sign (self-sign) and /co-sign (recipient). The signing key is the
+// account's ML-DSA-65 key in the vault, unlocked either by the passkey's PRF
+// (one tap, preferred) or by a passphrase (the fallback for passkey providers
+// without PRF, e.g. some password managers). We read its PUBLIC half
+// (pk_b64/pk_hash) from vault metadata WITHOUT unlocking, plus which KEK sources
+// it has so the caller knows whether to do a one-tap PRF unlock or to ask for the
+// passphrase. If no signing key is enrolled, throws code 'no_signing_passkey'.
 export async function resolvePasskeySigningKey() {
   if (!(await vaultAvailable())) throw new Error('This browser cannot store signing keys (IndexedDB/WebCrypto unavailable).');
   const keys = await vaultList();
-  const usable = keys.filter((k) => (k.kekSources || []).includes('webauthn-prf'));
+  const usable = keys.filter((k) => (k.kekSources || []).some((s) => s === 'webauthn-prf' || s === 'passphrase'));
   if (usable.length === 0) {
-    const e = new Error('No passkey signing key on this device yet. Enrol a passkey for signing first.');
+    const e = new Error('No signing key on this device yet. Set one up when you sign.');
     e.code = 'no_signing_passkey';
     throw e;
   }
-  const k = usable[0];   // single signing identity for now
-  return { vaultId: k.id, pk_b64: k.pk_b64, fingerprint: (k.pk_hash || '').slice(0, 16) };
+  // Prefer a PRF-capable key (one tap) over a passphrase-only one.
+  const k = usable.find((x) => (x.kekSources || []).includes('webauthn-prf')) || usable[0];
+  const sources = k.kekSources || [];
+  return {
+    vaultId: k.id, pk_b64: k.pk_b64, fingerprint: (k.pk_hash || '').slice(0, 16),
+    kekSources: sources, hasPrf: sources.includes('webauthn-prf'), hasPassphrase: sources.includes('passphrase'),
+  };
 }
 
-// One WebAuthn get() with PRF, portable across ALL engines. The PRF extension
-// shape that actually works differs by engine, and there is no capability flag
-// to read up front:
+// One WebAuthn get() with PRF, portable across engines. The PRF extension shape
+// that works differs by engine and there is no capability flag to read up front:
 //   • Chromium needs prf.evalByCredential (keyed by the base64url credential id)
-//     when allowCredentials has more than one entry, or it returns NO prf result.
-//   • Firefox (Gecko) and Safari (WebKit) reject evalByCredential — Firefox
-//     surfaces it as an opaque, post-UI "AuthenticatorError" (a rejected get()),
-//     Safari as a synchronous NotSupportedError/SyntaxError/TypeError — and both
-//     understand a plain `eval`.
-// So we send the shape the RUNNING engine prefers FIRST (no wasted prompt in the
-// common case) and keep the other as a fallback. We advance to the next shape on
-// ANY failure that is not a genuine user cancel/timeout, AND when a get() resolves
-// but carries no prf result (a mis-detected engine). The salt is identical in
-// every shape, so the derived PRF output is byte-identical regardless of which
-// shape ultimately succeeds — unlock stays deterministic. NotAllowedError and
-// AbortError (cancel/timeout) are final: re-prompting a user who backed out is
-// pointless and hostile, so they are never retried.
+//     when allowCredentials has more than one entry, or it returns no prf result.
+//   • Firefox (Gecko) and Safari (WebKit) understand a plain `eval`; evalByCredential
+//     makes WebKit throw a synchronous NotSupportedError/SyntaxError/TypeError.
+// So we lead with the shape the RUNNING engine prefers (one prompt in the common
+// case). We retry the other shape ONLY on those synchronous parse errors, which
+// are thrown BEFORE any UI (free, no extra prompt). A cancel/timeout, or a post-UI
+// authenticator/provider failure (e.g. a passkey manager with no PRF extension
+// that engages then errors), is NOT retried — re-prompting is pointless; the
+// caller detects the failure and falls back to a passphrase-protected key.
 function _isChromiumEngine() {
   try {
     const brands = navigator.userAgentData && navigator.userAgentData.brands;
@@ -101,40 +104,20 @@ function _isChromiumEngine() {
   } catch { /* userAgentData unavailable — fall through to UA sniff */ }
   try { return /Chrom(e|ium)\//.test(navigator.userAgent || ''); } catch { return false; }
 }
-function _prfFirstOf(assertion) {
-  try { return assertion && assertion.getClientExtensionResults && assertion.getClientExtensionResults()?.prf?.results?.first; }
-  catch { return undefined; }
-}
 async function getAssertionWithPrf(publicKey, prfExt) {
   const hasByCred = !!(prfExt && prfExt.evalByCredential);
   const evalOnly = (prfExt && prfExt.eval)
     ? { eval: prfExt.eval }
     : (hasByCred ? { eval: Object.values(prfExt.evalByCredential)[0] } : prfExt);
-  // Order the attempts by the running engine's preferred PRF shape. With nothing
-  // to vary (no evalByCredential), there is a single attempt.
-  const order = !hasByCred ? [prfExt]
-    : (_isChromiumEngine() ? [prfExt, evalOnly] : [evalOnly, prfExt]);
-
-  let lastErr = null, lastResolved = null;
-  for (let i = 0; i < order.length; i++) {
-    const ext = order[i];
-    if (!ext) continue;
-    let assertion;
-    try {
-      assertion = await navigator.credentials.get({ publicKey: { ...publicKey, extensions: { prf: ext } } });
-    } catch (e) {
-      if (e && (e.name === 'NotAllowedError' || e.name === 'AbortError')) throw e;   // real cancel/timeout — final
-      lastErr = e;                                                                    // else: try the next shape
-      continue;
-    }
-    if (_prfFirstOf(assertion)) return assertion;   // got the PRF result — done (the common 1-prompt path)
-    lastResolved = assertion;                        // resolved without PRF — try the other shape if any
+  const primary   = (hasByCred && _isChromiumEngine()) ? prfExt : evalOnly;
+  const secondary = (primary === prfExt) ? evalOnly : prfExt;
+  try {
+    return await navigator.credentials.get({ publicKey: { ...publicKey, extensions: { prf: primary } } });
+  } catch (e) {
+    const parseErr = e && (e.name === 'NotSupportedError' || e.name === 'SyntaxError' || e.name === 'TypeError');
+    if (!parseErr || primary === secondary) throw e;   // cancel / post-UI failure: don't re-prompt
+    return await navigator.credentials.get({ publicKey: { ...publicKey, extensions: { prf: secondary } } });
   }
-  // Every shape either threw (non-cancel) or produced no PRF. Prefer a resolved
-  // assertion so the caller raises the clear "no PRF result" message; otherwise
-  // re-throw the last real error for the caller's error mapping.
-  if (lastResolved) return lastResolved;
-  throw lastErr;
 }
 
 // Reproduce the PRF output by running a WebAuthn get() with the SAME salt that
@@ -174,12 +157,23 @@ class ActivatedSigner {
 }
 
 export class LocalVaultSigner {
-  // ACTIVATION — the replaceable step. WebAuthn-PRF unlocks the vault key.
-  // Returns an ActivatedSigner; the caller signs exactly one document then
-  // calls dispose(). The PRF output (key-deriving material) is wiped here.
-  async activate({ vaultId, rpId }) {
+  // ACTIVATION — the replaceable step. Unlocks the vault's ML-DSA key for exactly
+  // one signature, then the caller disposes (zeroize). Two unlock sources:
+  //   • passphrase (when given): PBKDF2 -> AES-GCM unwrap, no WebAuthn.
+  //   • otherwise the passkey's PRF output (one tap).
+  // A passphrase-only key with no PRF wrap throws code 'need_passphrase' so the UI
+  // can ask for it and call again with { passphrase }.
+  async activate({ vaultId, rpId, passphrase } = {}) {
+    if (passphrase) {
+      const unlocked = await vaultUnlock(vaultId, passphrase);
+      return new ActivatedSigner(unlocked.secretKeyBytes, unlocked.pk_b64);
+    }
     const info = await vaultGetPrfWrapInfo(vaultId);
-    if (!info) throw new Error('no passkey-PRF wrap on this key — enrol a passkey first');
+    if (!info) {
+      const e = new Error('This signing key is protected by a passphrase on this browser.');
+      e.code = 'need_passphrase';
+      throw e;
+    }
     const prfOutput = await evalPrf({ rpId, credentialIdB64url: info.credentialId, prfSaltB64url: info.prfSalt });
     let unlocked;
     try {
@@ -341,21 +335,34 @@ export async function ensureSigningKey({ rpId, label, onStatus } = {}) {
       prfExt.evalByCredential = {};
       for (const c of allowList) prfExt.evalByCredential[c.id] = { first: prfSalt };
     }
-    const cred = await getAssertionWithPrf({
-      challenge: b64urlToBytes(opt.options.challenge),
-      rpId,
-      allowCredentials: allowList.map((c) => ({
-        type: 'public-key',
-        id: b64urlToBytes(c.id),
-        ...(c.transports ? { transports: c.transports } : {}),
-      })),
-      userVerification: 'required',
-      timeout: opt.options.timeout || 60000,
-    }, prfExt);
+    let cred;
+    try {
+      cred = await getAssertionWithPrf({
+        challenge: b64urlToBytes(opt.options.challenge),
+        rpId,
+        allowCredentials: allowList.map((c) => ({
+          type: 'public-key',
+          id: b64urlToBytes(c.id),
+          ...(c.transports ? { transports: c.transports } : {}),
+        })),
+        userVerification: 'required',
+        timeout: opt.options.timeout || 60000,
+      }, prfExt);
+    } catch (e) {
+      if (e && (e.name === 'NotAllowedError' || e.name === 'AbortError')) throw e;   // user cancelled / timed out
+      // The authenticator/provider engaged but could not complete a PRF assertion
+      // (e.g. a passkey manager like Proton Pass that implements passkeys but not
+      // the PRF extension). Signal the caller to fall back to a passphrase key.
+      const err = new Error('Your passkey provider can’t do the PRF unlock that one-tap signing needs.');
+      err.code = 'prf_unsupported'; err.cause = e;
+      throw err;
+    }
     const prfFirst = cred.getClientExtensionResults()?.prf?.results?.first;
     if (!prfFirst) {
-      const err = new Error('This passkey can’t produce a PRF result. Use a device/browser with passkey-PRF (iOS 18+, a recent Chrome/Edge, or a PRF-capable security key).');
-      err.code = 'no_prf';
+      // The assertion succeeded but produced no PRF result — same outcome: this
+      // passkey can't be a one-tap signing key. The caller falls back to a passphrase.
+      const err = new Error('This passkey doesn’t support the PRF extension that one-tap signing needs.');
+      err.code = 'prf_unsupported';
       throw err;
     }
     const prfOutput = new Uint8Array(prfFirst);
@@ -383,6 +390,79 @@ export async function ensureSigningKey({ rpId, label, onStatus } = {}) {
   }
 
   // Closed loop: resolve the way /sign does, proving the key is usable now.
+  return await resolvePasskeySigningKey();
+}
+
+// ── Passphrase-protected signing key — the fallback when the account's passkey
+// provider cannot do WebAuthn-PRF (e.g. a password manager such as Proton Pass
+// that implements passkeys but not the PRF extension). The passkey is STILL used
+// to prove account possession (a NORMAL step-up assertion, no PRF — exactly what
+// login does, so a non-PRF provider handles it); the local ML-DSA key is wrapped
+// with a user passphrase (PBKDF2 -> AES-256-GCM via vaultStore) instead of a PRF
+// KEK. Same account binding and same server route as the one-tap path; only the
+// local key-wrap differs. Signing later unlocks via LocalVaultSigner.activate
+// ({ passphrase }). Recovery floor is the passphrase, so it is enforced strong.
+export async function enrolSigningKeyWithPassphrase({ rpId, label, passphrase, onStatus } = {}) {
+  const say = (m) => { try { if (onStatus) onStatus(m); } catch { /* status is best-effort */ } };
+  assertStrongPassphrase(passphrase);   // fail closed on weak input (vaultStore re-checks)
+  if (!(await vaultAvailable())) {
+    const err = new Error('This browser cannot store signing keys (IndexedDB/WebCrypto unavailable).');
+    err.code = 'vault_unavailable';
+    throw err;
+  }
+  rpId = rpId || location.hostname;
+
+  // 1) ML-DSA-65 keypair, generated + held only in the browser.
+  const seed = crypto.getRandomValues(new Uint8Array(32));
+  const kp = ml_dsa65.keygen(seed);
+  const pk_b64 = b64EncodeStd(kp.publicKey);
+  const pk_hash = toHex(sha3_256(kp.publicKey));
+  try {
+    // 2) Wrap the ML-DSA key with the passphrase locally (no PRF, no WebAuthn).
+    await vaultStore({ alg: 'ML-DSA-65', label: label || 'Signing key', pk_b64, pk_hash, secretKeyBytes: kp.secretKey, passphrase });
+
+    // 3) Prove account possession with a NORMAL passkey step-up (no PRF — this is
+    //    what login does, so a provider without PRF still handles it).
+    say('Confirm with your passkey to link this signing key…');
+    let opt;
+    try {
+      opt = await _postJSON('/api/user/account/signing-key/step-up/options', {});
+    } catch (e) {
+      if (e && e.status === 409 && e.data && e.data.error === 'no_passkey') {
+        const err = new Error('Add a passkey to your account first, then you can sign with it.');
+        err.code = 'no_passkey';
+        throw err;
+      }
+      throw e;
+    }
+    const allowList = (opt.options.allowCredentials || []);
+    const cred = await navigator.credentials.get({
+      publicKey: {
+        challenge: b64urlToBytes(opt.options.challenge),
+        rpId,
+        allowCredentials: allowList.map((c) => ({
+          type: 'public-key',
+          id: b64urlToBytes(c.id),
+          ...(c.transports ? { transports: c.transports } : {}),
+        })),
+        userVerification: 'required',
+        timeout: opt.options.timeout || 60000,
+      },
+    });
+
+    // 4) Bind the PUBLIC key to the account — same admin route as the one-tap path.
+    say('Linking your signing key to your account…');
+    await _postJSON('/api/user/account/signing-key/step-up/bind', {
+      flowId: opt.flowId,
+      response: _serializeAssertion(cred),
+      pk_b64,
+      label: label || 'Signing key',
+    });
+  } finally {
+    kp.secretKey.fill(0);   // zeroize the plaintext key
+  }
+
+  // Resolve the way /sign does, proving the key is usable now.
   return await resolvePasskeySigningKey();
 }
 

--- a/frontend/js/signing-enrol.js
+++ b/frontend/js/signing-enrol.js
@@ -7,7 +7,7 @@
 // (parasign-signer.js) — the EXACT path /sign and /co-sign use — so this file
 // just wires the button + status and can never drift from the sign flow.
 // Self-hosted deps only (CSP script-src 'self'); no-ops if the button is absent.
-import { ensureSigningKey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=7';
+import { ensureSigningKey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=8';
 
 function wireSigningEnrol() {
   const btn = document.getElementById('signing-enrol-btn');
@@ -37,6 +37,7 @@ function wireSigningEnrol() {
     } catch (e) {
       let msg;
       if (e && e.code === 'no_passkey') msg = 'Add a passkey to your account first (the "Passkey sign-in" card above), then set up signing.';
+      else if (e && e.code === 'prf_unsupported') msg = 'Your passkey provider (for example Proton Pass) can’t do the one-tap unlock signing uses. Set up your signing key the first time you sign at /sign — you’ll choose a signing passphrase there — or use a PRF-capable security key.';
       else if (e && (e.code === 'no_prf' || e.code === 'vault_unavailable' || e.code === 'no_webauthn')) msg = e.message;
       else if (e && e.name === 'NotAllowedError') msg = 'Passkey confirmation was cancelled or timed out. Tap the button to try again.';
       else if (e && e.status) msg = 'Could not set up your signing key right now (server error ' + e.status + '). Please try again in a moment.';

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -11,7 +11,7 @@
 // sign path. Signing goes through the passkey-PRF activation chain (LocalVaultSigner
 // in parasign-signer.js); sha3_256 stays for document hashing only.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey } from '/js/parasign-signer.js?v=7';
+import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolSigningKeyWithPassphrase, assertStrongPassphrase } from '/js/parasign-signer.js?v=8';
 
 // Read-only public relay host, used ONLY for the "view envelope status" link on
 // the done screen. The signing path itself is same-origin via the admin
@@ -53,6 +53,50 @@ const state = {
 const $ = id => document.getElementById(id);
 function show(id) { $(id).hidden = false; }
 function hide(id) { $(id).hidden = true; }
+
+// Passphrase prompt for the signing-key fallback (passkey providers without PRF).
+// Reveals the in-step panel and resolves with the entered passphrase, or null if
+// the user cancels. mode 'set' = create a new signing passphrase (two fields,
+// strength-checked); mode 'unlock' = enter an existing one (single field).
+function promptPassphrase(mode) {
+  return new Promise((resolve) => {
+    const panel = $('ds-pass-panel'), p1 = $('ds-pass-input'), p2 = $('ds-pass-input2');
+    const errEl = $('ds-pass-err'), promptEl = $('ds-pass-prompt');
+    const okBtn = $('ds-pass-confirm'), cancelBtn = $('ds-pass-cancel');
+    const setMode = mode === 'set';
+    promptEl.textContent = setMode
+      ? 'Your passkey provider can’t do the one-tap unlock signing uses, so set a signing passphrase. You enter it each time you sign on this browser. Keep it safe: it protects your signing key and cannot be reset.'
+      : 'Enter your signing passphrase to unlock your signing key.';
+    p1.value = ''; p2.value = '';
+    p1.placeholder = setMode ? 'New signing passphrase (min. 12 characters)' : 'Signing passphrase';
+    p2.hidden = !setMode;
+    errEl.hidden = true; errEl.textContent = '';
+    panel.hidden = false;
+    try { p1.focus(); } catch {}
+    const cleanup = () => {
+      okBtn.removeEventListener('click', onOk);
+      cancelBtn.removeEventListener('click', onCancel);
+      p1.removeEventListener('keydown', onKey); p2.removeEventListener('keydown', onKey);
+      panel.hidden = true; p1.value = ''; p2.value = '';
+    };
+    const fail = (m) => { errEl.textContent = m; errEl.hidden = false; };
+    const onOk = () => {
+      const v1 = p1.value, v2 = p2.value;
+      if (setMode) {
+        try { assertStrongPassphrase(v1); } catch (e) { return fail(e.message || 'Passphrase too weak.'); }
+        if (v1 !== v2) return fail('The two passphrases don’t match.');
+      } else if (!v1) {
+        return fail('Enter your signing passphrase.');
+      }
+      cleanup(); resolve(v1);
+    };
+    const onCancel = () => { cleanup(); resolve(null); };
+    const onKey = (e) => { if (e.key === 'Enter') { e.preventDefault(); onOk(); } };
+    okBtn.addEventListener('click', onOk);
+    cancelBtn.addEventListener('click', onCancel);
+    p1.addEventListener('keydown', onKey); p2.addEventListener('keydown', onKey);
+  });
+}
 function setActive(stepId) {
   document.querySelectorAll('.ds-step').forEach(s => s.hidden = (s.id !== stepId));
   document.querySelectorAll('.ds-stepper li').forEach(li => {
@@ -1052,10 +1096,20 @@ async function doSign() {
     // its public half from vault metadata here (for the stamp fingerprint); the
     // secret is unlocked solely by the per-document PRF activation below.
     status('Locating your signing key...');
-    // Resolve the account's passkey signing key, or set one up inline with a
-    // single passkey tap (no passphrase, no TOTP) if this device has none yet —
-    // the sign-in passkey becomes the signing key. No /account detour.
-    const signKey = await ensureSigningKey({ rpId: location.hostname, label: state.signer.name || 'Signing key', onStatus: status });
+    // Resolve the account's signing key, or set one up inline. Happy path is one
+    // passkey tap (PRF). If the passkey provider can't do PRF (e.g. Proton Pass),
+    // ensureSigningKey throws prf_unsupported and we fall back to a passphrase-
+    // protected signing key — still bound to the account via the same passkey.
+    let signKey, signPassphrase = null;
+    try {
+      signKey = await ensureSigningKey({ rpId: location.hostname, label: state.signer.name || 'Signing key', onStatus: status });
+    } catch (e) {
+      if (!e || e.code !== 'prf_unsupported') throw e;
+      signPassphrase = await promptPassphrase('set');
+      if (signPassphrase == null) { const c = new Error('cancelled'); c.code = 'cancelled'; throw c; }
+      status('Setting up your signing key…');
+      signKey = await enrolSigningKeyWithPassphrase({ rpId: location.hostname, label: state.signer.name || 'Signing key', passphrase: signPassphrase, onStatus: status });
+    }
     const fingerprint = signKey.fingerprint;
     const dateStr = new Date().toISOString().slice(0, 19) + 'Z';
 
@@ -1097,7 +1151,13 @@ async function doSign() {
     const act = await requestSignActivation({ envelopeId: env.id, partyIndex: 0, docHash: docHashForEnvelope, inviteToken: myLink.invite_token });
 
     status('Confirm to sign (Face ID / Touch ID / security key)...');
-    const signer = await new LocalVaultSigner().activate({ vaultId: signKey.vaultId, rpId: location.hostname });
+    // PRF key: one tap. Passphrase key: unlock with the passphrase — reuse the one
+    // just set during enrol, or ask for it on an already-enrolled passphrase key.
+    if (!signKey.hasPrf && signPassphrase == null) {
+      signPassphrase = await promptPassphrase('unlock');
+      if (signPassphrase == null) { const c = new Error('cancelled'); c.code = 'cancelled'; throw c; }
+    }
+    const signer = await new LocalVaultSigner().activate({ vaultId: signKey.vaultId, rpId: location.hostname, passphrase: signKey.hasPrf ? undefined : signPassphrase });
     let sigB64;
     try {
       const message = buildDocSignMessage({ envelopeId: env.id, docHash: docHashForEnvelope, partyIndex: 0, emailHash: act.email_hash });
@@ -1150,6 +1210,9 @@ async function doSign() {
     else if (e && e.code === 'no_passkey') msg = 'Add a passkey to your account first (Account → Passkey sign-in), then sign — your sign-in passkey becomes your signing key.';
     else if (e && (e.code === 'no_prf' || e.code === 'vault_unavailable' || e.code === 'no_webauthn')) msg = e.message;
     else if (e && e.name === 'NotAllowedError') msg = 'Passkey confirmation was cancelled or timed out. Tap Sign now to try again.';
+    else if (e && e.code === 'cancelled') msg = 'Signing cancelled. Tap Sign now when you’re ready.';
+    else if (e && /wrong passphrase/i.test(e.message || '')) msg = 'That signing passphrase didn’t match. Tap Sign now and re-enter it.';
+    else if (e && (e.code === 'prf_unsupported' || e.code === 'need_passphrase')) msg = 'Your passkey can’t do one-tap signing here. Tap Sign now to set or enter a signing passphrase instead.';
     else if (e && (e.status === 403 || e.status === 409 || e.status === 410)) msg = 'That signing authorization was already used or has expired. Tap Sign now to start a fresh one.';
     else if (e && e.status) msg = 'Signing could not be completed right now (server error ' + e.status + '). Please try again in a moment.';
     else msg = 'Your passkey could not complete signing on this browser. Tap Sign now to try again. If it keeps failing, try a different browser, or use the passkey on your phone.';

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -509,6 +509,20 @@
       <button class="btn btn-primary" id="ds-sign-now" type="button">Sign this document</button>
     </div>
     <div class="ds-banner" id="ds-sign-status" hidden role="status" aria-live="polite"></div>
+
+    <!-- Passphrase fallback: shown only when the account's passkey provider can't
+         do WebAuthn-PRF (e.g. Proton Pass). The passkey still proves the account;
+         this passphrase protects the local signing key in place of the PRF. -->
+    <div class="ds-banner" id="ds-pass-panel" hidden>
+      <p id="ds-pass-prompt" style="margin-bottom:10px"></p>
+      <input class="ds-input" type="password" id="ds-pass-input" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" style="margin-bottom:8px" aria-label="Signing passphrase">
+      <input class="ds-input" type="password" id="ds-pass-input2" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" hidden style="margin-bottom:8px" aria-label="Confirm signing passphrase">
+      <p id="ds-pass-err" class="ds-hint" hidden style="color:var(--danger,#b91c1c);margin-bottom:8px"></p>
+      <div class="ds-actions">
+        <button class="btn btn-tertiary" id="ds-pass-cancel" type="button">Cancel</button>
+        <button class="btn btn-primary" id="ds-pass-confirm" type="button">Continue</button>
+      </div>
+    </div>
   </section>
 
   <!-- Done -->
@@ -620,6 +634,6 @@
 <script src="/js/nav-auth.js?v=1" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
-<script type="module" src="/sign-flow.js?v=19"></script>
+<script type="module" src="/sign-flow.js?v=20"></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem
Signing unlocks the account's ML-DSA-65 key with the passkey's **WebAuthn-PRF** output. Passkey managers that implement passkeys but **not the PRF extension (e.g. Proton Pass)** dead-ended: login works (no PRF) but signing rejected with an opaque `AuthenticatorError`. A provider without PRF cannot be made to produce one.

## Fix (frontend only)
Adds a **passphrase-protected signing key** fallback. The passkey still proves account possession (a normal step-up assertion, **no PRF** — which any provider can do); the local ML-DSA key is wrapped with a strong passphrase (PBKDF2 → AES-256-GCM) instead of the PRF KEK.

- `getAssertionWithPrf`: lead with the engine's preferred PRF shape; retry the other only on synchronous parse errors (no double prompt on a post-UI provider failure).
- `ensureSigningKey`: PRF failure → code `prf_unsupported` so the caller falls back.
- `enrolSigningKeyWithPassphrase()` (new) + `LocalVaultSigner.activate({passphrase})` + `resolvePasskeySigningKey` now returns `hasPrf`/`hasPassphrase`.
- `/sign` + `/co-sign`: in-step passphrase panel (set/unlock); account enrol surfaces a clear message.

## Proof (real browser)
Driven in real Chromium with a **no-PRF WebAuthn virtual authenticator**: `prf_unsupported` detection → passphrase enrol → activate → a **valid ML-DSA-65 signature (verify=true)**; wrong passphrase rejected. Already deployed to prod (backup `/home/paramant/backups/pre-passphrase-fallback-20260617-125607`).

Cache-bust: parasign-signer `?v=8` (3 importers), sign-flow `?v=20`, co-sign `?v=9`, signing-enrol `?v=10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
