### PR TITLE
refactor(parasign): shared passphrase prompt + account parity + signing E2E in CI

### DIFF
--- a/.github/workflows/sign-e2e.yml
+++ b/.github/workflows/sign-e2e.yml
@@ -1,0 +1,35 @@
+name: sign-e2e
+
+# Functional test of the ParaSign signing subsystem in real Chromium with a
+# WebAuthn virtual authenticator (tests/sign-full.test.mjs). Self-contained: it
+# serves frontend/ and stubs /api, so no backend/Redis is needed. Path-gated so it
+# only runs when the signing frontend (or the test) changes.
+on:
+  push:
+    paths:
+      - 'frontend/**'
+      - 'tests/sign-full.test.mjs'
+      - '.github/workflows/sign-e2e.yml'
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - 'tests/sign-full.test.mjs'
+      - '.github/workflows/sign-e2e.yml'
+
+jobs:
+  sign-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install deps (browsers installed separately)
+        run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Run signing functional suite
+        run: node tests/sign-full.test.mjs

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -389,6 +389,19 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
       </div>
     </div>
     <p id="signing-enrol-status" class="small" aria-live="polite" style="margin-top:8px"></p>
+    <!-- Passphrase fallback: shown only when the account's passkey provider can't
+         do WebAuthn-PRF (e.g. Proton Pass). The passkey still proves the account;
+         this passphrase protects the local signing key in place of the PRF. -->
+    <div id="en-pass-panel" class="acct-field" hidden style="margin-top:12px">
+      <p id="en-pass-prompt" class="small" style="margin-bottom:8px"></p>
+      <input type="password" id="en-pass-input" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" placeholder="Signing passphrase" aria-label="Signing passphrase">
+      <input type="password" id="en-pass-input2" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" placeholder="Confirm passphrase" aria-label="Confirm signing passphrase" hidden style="margin-top:8px">
+      <p id="en-pass-err" class="small" hidden style="color:var(--danger,#b91c1c);margin-top:8px"></p>
+      <div style="margin-top:10px;display:flex;gap:8px">
+        <button type="button" class="btn btn-small" id="en-pass-cancel">Cancel</button>
+        <button type="button" class="btn btn-primary btn-small" id="en-pass-confirm">Continue</button>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -778,7 +791,7 @@ loadVaultStatus();
 document.addEventListener('signing-key-enrolled', () => { loadEnrolledKeys(); loadVaultStatus(); });
 </script>
 <script type="module" src="/js/passkey.js?v=3"></script>
-<script type="module" src="/js/signing-enrol.js?v=11"></script>
+<script type="module" src="/js/signing-enrol.js?v=12"></script>
 
 </body>
 </html>

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -195,6 +195,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 </main>
 
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
-<script type="module" src="/co-sign.js?v=10"></script>
+<script type="module" src="/co-sign.js?v=11"></script>
 </body>
 </html>

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -18,7 +18,8 @@
 // the view receipt. The signing path itself is same-origin via the admin
 // (/api/user/sign/*), bound to the logged-in invitee session.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolSigningKeyWithPassphrase, assertStrongPassphrase } from '/js/parasign-signer.js?v=9';
+import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolSigningKeyWithPassphrase } from '/js/parasign-signer.js?v=10';
+import { promptPassphrase } from '/js/passphrase-prompt.js?v=1';
 
 const RELAY_PUBLIC = 'https://health.paramant.app';
 
@@ -26,47 +27,6 @@ const RELAY_PUBLIC = 'https://health.paramant.app';
 function $(id) { return document.getElementById(id); }
 function showStep(id) { document.querySelectorAll('.step').forEach((s) => s.classList.remove('active')); $(id).classList.add('active'); }
 
-// Passphrase prompt for the signing-key fallback (passkey providers without PRF).
-// Resolves with the entered passphrase, or null if the user cancels. mode 'set' =
-// create a new signing passphrase (two fields, strength-checked); 'unlock' = enter
-// an existing one (single field).
-function promptPassphrase(mode) {
-  return new Promise((resolve) => {
-    const panel = $('cs-pass-panel'), p1 = $('cs-pass-input'), p2 = $('cs-pass-input2');
-    const errEl = $('cs-pass-err'), promptEl = $('cs-pass-prompt');
-    const okBtn = $('cs-pass-confirm'), cancelBtn = $('cs-pass-cancel');
-    const setMode = mode === 'set';
-    promptEl.textContent = setMode
-      ? 'Your passkey provider can’t do the one-tap unlock signing uses, so set a signing passphrase. You enter it each time you sign on this browser. Keep it safe: it protects your signing key and cannot be reset.'
-      : 'Enter your signing passphrase to unlock your signing key.';
-    p1.value = ''; p2.value = '';
-    p1.placeholder = setMode ? 'New signing passphrase (min. 12 characters)' : 'Signing passphrase';
-    p2.hidden = !setMode;
-    errEl.hidden = true; errEl.textContent = '';
-    panel.hidden = false;
-    try { p1.focus(); } catch {}
-    const cleanup = () => {
-      okBtn.removeEventListener('click', onOk);
-      cancelBtn.removeEventListener('click', onCancel);
-      p1.removeEventListener('keydown', onKey); p2.removeEventListener('keydown', onKey);
-      panel.hidden = true; p1.value = ''; p2.value = '';
-    };
-    const fail = (m) => { errEl.textContent = m; errEl.hidden = false; };
-    const onOk = () => {
-      const v1 = p1.value, v2 = p2.value;
-      if (setMode) {
-        try { assertStrongPassphrase(v1); } catch (e) { return fail(e.message || 'Passphrase too weak.'); }
-        if (v1 !== v2) return fail('The two passphrases don’t match.');
-      } else if (!v1) { return fail('Enter your signing passphrase.'); }
-      cleanup(); resolve(v1);
-    };
-    const onCancel = () => { cleanup(); resolve(null); };
-    const onKey = (e) => { if (e.key === 'Enter') { e.preventDefault(); onOk(); } };
-    okBtn.addEventListener('click', onOk);
-    cancelBtn.addEventListener('click', onCancel);
-    p1.addEventListener('keydown', onKey); p2.addEventListener('keydown', onKey);
-  });
-}
 function showError(m) { $('error-msg').textContent = m; showStep('step-error'); }
 function toHex(u8) { let s = ''; for (let i = 0; i < u8.length; i++) s += u8[i].toString(16).padStart(2, '0'); return s; }
 function toB64(u8) { let s = ''; for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]); return btoa(s); }
@@ -381,7 +341,7 @@ async function doSign() {
         if (!e || e.code !== 'prf_unsupported') throw e;
         // Passkey provider can't do PRF (e.g. Proton Pass): fall back to a
         // passphrase-protected signing key, still bound to the account via the passkey.
-        __signPassphrase = await promptPassphrase('set');
+        __signPassphrase = await promptPassphrase('cs-pass', 'set');
         if (__signPassphrase == null) { const c = new Error('cancelled'); c.code = 'cancelled'; throw c; }
         setStatus('', 'Setting up your signing key…');
         __signKey = await enrolSigningKeyWithPassphrase({ rpId: location.hostname, passphrase: __signPassphrase, onStatus: (m) => setStatus('', m) });
@@ -405,7 +365,7 @@ async function doSign() {
     // PRF key: one tap. Passphrase key: unlock with the passphrase (reuse the one
     // set on enrol, or ask for it on an already-enrolled passphrase key).
     if (!__signKey.hasPrf && __signPassphrase == null) {
-      __signPassphrase = await promptPassphrase('unlock');
+      __signPassphrase = await promptPassphrase('cs-pass', 'unlock');
       if (__signPassphrase == null) { const c = new Error('cancelled'); c.code = 'cancelled'; throw c; }
     }
     const signer = await new LocalVaultSigner().activate({ vaultId: __signKey.vaultId, rpId: location.hostname, passphrase: __signKey.hasPrf ? undefined : __signPassphrase });

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -7,9 +7,6 @@
 import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
 import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultStore, vaultUnlock, vaultAddPrfWrap, vaultCreatePrfOnly, vaultAvailable, vaultList, assertStrongPassphrase } from '/vendor/vault.js?v=3';
 
-// Re-exported so the sign UIs can strength-check a new passphrase before enrol.
-export { assertStrongPassphrase };
-
 // Byte-identical to relay/envelope.js SIGN_DOMAIN_DOC (recipe v3). Keep in sync
 // across relay + SDK + core.
 export const SIGN_DOMAIN_DOC = 'paramant/parasign/doc/v1';

--- a/frontend/js/passphrase-prompt.js
+++ b/frontend/js/passphrase-prompt.js
@@ -1,0 +1,52 @@
+// Shared in-page passphrase prompt for the ParaSign signing-key fallback.
+// Used when the account's passkey provider can't do WebAuthn-PRF (e.g. Proton
+// Pass): the passkey still proves the account, and this passphrase protects the
+// local ML-DSA signing key in place of the PRF KEK. Self-hosted (CSP script-src
+// 'self'); the only dependency is the vault's strength check.
+//
+// The page supplies a panel whose elements follow a
+//   `${prefix}-{panel,prompt,input,input2,err,confirm,cancel}`
+// id convention. promptPassphrase resolves with the entered passphrase, or null
+// if the user cancels. mode 'set' = create a new passphrase (two fields, strength
+// checked); 'unlock' = enter an existing one (single field).
+import { assertStrongPassphrase } from '/vendor/vault.js?v=3';
+
+export function promptPassphrase(prefix, mode) {
+  const $ = (s) => document.getElementById(prefix + '-' + s);
+  return new Promise((resolve) => {
+    const panel = $('panel'), p1 = $('input'), p2 = $('input2');
+    const errEl = $('err'), promptEl = $('prompt'), okBtn = $('confirm'), cancelBtn = $('cancel');
+    const setMode = mode === 'set';
+    promptEl.textContent = setMode
+      ? 'Your passkey provider can’t do the one-tap unlock signing uses, so set a signing passphrase. You enter it each time you sign on this browser. Keep it safe: it protects your signing key and cannot be reset.'
+      : 'Enter your signing passphrase to unlock your signing key.';
+    p1.value = ''; if (p2) p2.value = '';
+    p1.placeholder = setMode ? 'New signing passphrase (min. 12 characters)' : 'Signing passphrase';
+    if (p2) p2.hidden = !setMode;
+    errEl.hidden = true; errEl.textContent = '';
+    panel.hidden = false;
+    try { p1.focus(); } catch { /* focus is best-effort */ }
+    const cleanup = () => {
+      okBtn.removeEventListener('click', onOk);
+      cancelBtn.removeEventListener('click', onCancel);
+      p1.removeEventListener('keydown', onKey); if (p2) p2.removeEventListener('keydown', onKey);
+      panel.hidden = true; p1.value = ''; if (p2) p2.value = '';
+    };
+    const fail = (m) => { errEl.textContent = m; errEl.hidden = false; };
+    const onOk = () => {
+      const v1 = p1.value, v2 = p2 ? p2.value : '';
+      if (setMode) {
+        try { assertStrongPassphrase(v1); } catch (e) { return fail(e.message || 'Passphrase too weak.'); }
+        if (v1 !== v2) return fail('The two passphrases don’t match.');
+      } else if (!v1) {
+        return fail('Enter your signing passphrase.');
+      }
+      cleanup(); resolve(v1);
+    };
+    const onCancel = () => { cleanup(); resolve(null); };
+    const onKey = (e) => { if (e.key === 'Enter') { e.preventDefault(); onOk(); } };
+    okBtn.addEventListener('click', onOk);
+    cancelBtn.addEventListener('click', onCancel);
+    p1.addEventListener('keydown', onKey); if (p2) p2.addEventListener('keydown', onKey);
+  });
+}

--- a/frontend/js/signing-enrol.js
+++ b/frontend/js/signing-enrol.js
@@ -7,7 +7,8 @@
 // (parasign-signer.js) — the EXACT path /sign and /co-sign use — so this file
 // just wires the button + status and can never drift from the sign flow.
 // Self-hosted deps only (CSP script-src 'self'); no-ops if the button is absent.
-import { ensureSigningKey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=9';
+import { ensureSigningKey, resolvePasskeySigningKey, enrolSigningKeyWithPassphrase } from '/js/parasign-signer.js?v=10';
+import { promptPassphrase } from '/js/passphrase-prompt.js?v=1';
 
 function wireSigningEnrol() {
   const btn = document.getElementById('signing-enrol-btn');
@@ -25,20 +26,26 @@ function wireSigningEnrol() {
     const label = ((labelEl && labelEl.value) || '').trim() || 'Signing key';
     btn.disabled = true;
     try {
-      // Resolve-or-enrol with one passkey tap. If a key already exists on this
-      // device, ensureSigningKey() returns it without prompting.
-      const k = await ensureSigningKey({
-        rpId: location.hostname,
-        label,
-        onStatus: (m) => setStatus(m, false),
-      });
+      let k;
+      try {
+        // One passkey tap (PRF). Returns an existing key fast if present.
+        k = await ensureSigningKey({ rpId: location.hostname, label, onStatus: (m) => setStatus(m, false) });
+      } catch (e) {
+        if (!e || e.code !== 'prf_unsupported') throw e;
+        // Passkey provider can't do PRF (e.g. Proton Pass): set a signing passphrase
+        // here, same as /sign. The passkey still proves the account (step-up, no PRF).
+        const passphrase = await promptPassphrase('en-pass', 'set');
+        if (passphrase == null) { setStatus('Set-up cancelled. Tap the button when you’re ready.', false); return; }
+        setStatus('Setting up your signing key…', false);
+        k = await enrolSigningKeyWithPassphrase({ rpId: location.hostname, label, passphrase, onStatus: (m) => setStatus(m, false) });
+      }
       setStatus('Signing key ready — fingerprint ' + (k.fingerprint || (k.pk_hash || '').slice(0, 16)) + '. You can now sign at /sign.', false);
       document.dispatchEvent(new CustomEvent('signing-key-enrolled'));
     } catch (e) {
       let msg;
       if (e && e.code === 'no_passkey') msg = 'Add a passkey to your account first (the "Passkey sign-in" card above), then set up signing.';
-      else if (e && e.code === 'prf_unsupported') msg = 'Your passkey provider (for example Proton Pass) can’t do the one-tap unlock signing uses. Set up your signing key the first time you sign at /sign — you’ll choose a signing passphrase there — or use a PRF-capable security key.';
       else if (e && (e.code === 'vault_unavailable' || e.code === 'no_webauthn')) msg = e.message;
+      else if (e && /wrong passphrase/i.test(e.message || '')) msg = 'That signing passphrase didn’t match. Tap the button and re-enter it.';
       else if (e && e.name === 'NotAllowedError') msg = 'Passkey confirmation was cancelled or timed out. Tap the button to try again.';
       else if (e && e.status) msg = 'Could not set up your signing key right now (server error ' + e.status + '). Please try again in a moment.';
       else msg = 'Your passkey could not complete setup on this browser. Tap the button to try again. If it keeps failing, try a different browser, or use the passkey on your phone.';

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -11,7 +11,8 @@
 // sign path. Signing goes through the passkey-PRF activation chain (LocalVaultSigner
 // in parasign-signer.js); sha3_256 stays for document hashing only.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolSigningKeyWithPassphrase, assertStrongPassphrase } from '/js/parasign-signer.js?v=9';
+import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolSigningKeyWithPassphrase } from '/js/parasign-signer.js?v=10';
+import { promptPassphrase } from '/js/passphrase-prompt.js?v=1';
 
 // Read-only public relay host, used ONLY for the "view envelope status" link on
 // the done screen. The signing path itself is same-origin via the admin
@@ -54,49 +55,6 @@ const $ = id => document.getElementById(id);
 function show(id) { $(id).hidden = false; }
 function hide(id) { $(id).hidden = true; }
 
-// Passphrase prompt for the signing-key fallback (passkey providers without PRF).
-// Reveals the in-step panel and resolves with the entered passphrase, or null if
-// the user cancels. mode 'set' = create a new signing passphrase (two fields,
-// strength-checked); mode 'unlock' = enter an existing one (single field).
-function promptPassphrase(mode) {
-  return new Promise((resolve) => {
-    const panel = $('ds-pass-panel'), p1 = $('ds-pass-input'), p2 = $('ds-pass-input2');
-    const errEl = $('ds-pass-err'), promptEl = $('ds-pass-prompt');
-    const okBtn = $('ds-pass-confirm'), cancelBtn = $('ds-pass-cancel');
-    const setMode = mode === 'set';
-    promptEl.textContent = setMode
-      ? 'Your passkey provider can’t do the one-tap unlock signing uses, so set a signing passphrase. You enter it each time you sign on this browser. Keep it safe: it protects your signing key and cannot be reset.'
-      : 'Enter your signing passphrase to unlock your signing key.';
-    p1.value = ''; p2.value = '';
-    p1.placeholder = setMode ? 'New signing passphrase (min. 12 characters)' : 'Signing passphrase';
-    p2.hidden = !setMode;
-    errEl.hidden = true; errEl.textContent = '';
-    panel.hidden = false;
-    try { p1.focus(); } catch {}
-    const cleanup = () => {
-      okBtn.removeEventListener('click', onOk);
-      cancelBtn.removeEventListener('click', onCancel);
-      p1.removeEventListener('keydown', onKey); p2.removeEventListener('keydown', onKey);
-      panel.hidden = true; p1.value = ''; p2.value = '';
-    };
-    const fail = (m) => { errEl.textContent = m; errEl.hidden = false; };
-    const onOk = () => {
-      const v1 = p1.value, v2 = p2.value;
-      if (setMode) {
-        try { assertStrongPassphrase(v1); } catch (e) { return fail(e.message || 'Passphrase too weak.'); }
-        if (v1 !== v2) return fail('The two passphrases don’t match.');
-      } else if (!v1) {
-        return fail('Enter your signing passphrase.');
-      }
-      cleanup(); resolve(v1);
-    };
-    const onCancel = () => { cleanup(); resolve(null); };
-    const onKey = (e) => { if (e.key === 'Enter') { e.preventDefault(); onOk(); } };
-    okBtn.addEventListener('click', onOk);
-    cancelBtn.addEventListener('click', onCancel);
-    p1.addEventListener('keydown', onKey); p2.addEventListener('keydown', onKey);
-  });
-}
 function setActive(stepId) {
   document.querySelectorAll('.ds-step').forEach(s => s.hidden = (s.id !== stepId));
   document.querySelectorAll('.ds-stepper li').forEach(li => {
@@ -1105,7 +1063,7 @@ async function doSign() {
       signKey = await ensureSigningKey({ rpId: location.hostname, label: state.signer.name || 'Signing key', onStatus: status });
     } catch (e) {
       if (!e || e.code !== 'prf_unsupported') throw e;
-      signPassphrase = await promptPassphrase('set');
+      signPassphrase = await promptPassphrase('ds-pass', 'set');
       if (signPassphrase == null) { const c = new Error('cancelled'); c.code = 'cancelled'; throw c; }
       status('Setting up your signing key…');
       signKey = await enrolSigningKeyWithPassphrase({ rpId: location.hostname, label: state.signer.name || 'Signing key', passphrase: signPassphrase, onStatus: status });
@@ -1154,7 +1112,7 @@ async function doSign() {
     // PRF key: one tap. Passphrase key: unlock with the passphrase — reuse the one
     // just set during enrol, or ask for it on an already-enrolled passphrase key.
     if (!signKey.hasPrf && signPassphrase == null) {
-      signPassphrase = await promptPassphrase('unlock');
+      signPassphrase = await promptPassphrase('ds-pass', 'unlock');
       if (signPassphrase == null) { const c = new Error('cancelled'); c.code = 'cancelled'; throw c; }
     }
     const signer = await new LocalVaultSigner().activate({ vaultId: signKey.vaultId, rpId: location.hostname, passphrase: signKey.hasPrf ? undefined : signPassphrase });

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -634,6 +634,6 @@
 <script src="/js/nav-auth.js?v=1" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
-<script type="module" src="/sign-flow.js?v=21"></script>
+<script type="module" src="/sign-flow.js?v=22"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "paramant",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paramant",
-      "version": "1.0.0",
+      "version": "3.0.0",
       "dependencies": {
         "redis": "^4.7.1"
       },
       "devDependencies": {
         "javascript-obfuscator": "^5.4.1",
+        "playwright": "^1.61.0",
         "terser": "^5.31.0"
       }
     },
@@ -722,6 +723,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1227,6 +1243,38 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "javascript-obfuscator": "^5.4.1",
+    "playwright": "^1.61.0",
     "terser": "^5.31.0"
   },
   "dependencies": {

--- a/tests/sign-full.test.mjs
+++ b/tests/sign-full.test.mjs
@@ -1,0 +1,207 @@
+// Full functional test of the ParaSign signing subsystem, in real Chromium.
+//
+// Exercises the actual frontend modules (parasign-signer.js + vault.js +
+// paramant-pqc.js + passphrase-prompt.js) with real WebCrypto, real IndexedDB,
+// and a real WebAuthn virtual authenticator (CDP). Self-contained: it serves
+// frontend/ over http and stubs the same-origin /api/* calls, so it needs no
+// backend, Redis, or network.
+//
+//   Phase 1  pure + vault round-trips (passphrase + PRF + dual-wrap)
+//   Phase 2  WebAuthn flows: enrol-with-passphrase, ensureSigningKey branching
+//   Phase 3  shared promptPassphrase against the real ds-/cs-/en- panels
+//
+// The one path a virtual authenticator can't simulate is live WebAuthn-PRF
+// *derivation* (needs PRF-capable hardware); everything our code does with a PRF
+// output is covered via the vault layer.
+//
+// CI: `npx playwright install --with-deps chromium` then `node tests/sign-full.test.mjs`.
+// Local: PLAYWRIGHT_CHROMIUM_PATH=<chrome binary> node tests/sign-full.test.mjs
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = { '.js':'text/javascript','.mjs':'text/javascript','.css':'text/css','.html':'text/html','.svg':'image/svg+xml','.json':'application/json','.wasm':'application/wasm','.png':'image/png' };
+
+const server = http.createServer((req, res) => {
+  const p = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+  if (p === '/__proof') { res.writeHead(200, {'content-type':'text/html'}); return res.end('<!doctype html><meta charset=utf8><title>t</title>'); }
+  const file = path.join(ROOT, p);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+  fs.readFile(file, (e, b) => { if (e) { res.writeHead(404); return res.end(); } res.writeHead(200, {'content-type': MIME[path.extname(file)] || 'application/octet-stream'}); res.end(b); });
+});
+await new Promise(r => server.listen(0, '127.0.0.1', r));
+const ORIGIN = `http://localhost:${server.address().port}`;
+
+let CRED_ID = null, noPasskeyMode = false;
+const CHAL = 'A'.repeat(43);
+
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+const ctx = await browser.newContext({ baseURL: ORIGIN });
+const page = await ctx.newPage();
+const cdp = await ctx.newCDPSession(page);
+await cdp.send('WebAuthn.enable');
+await cdp.send('WebAuthn.addVirtualAuthenticator', { options: { protocol: 'ctap2', transport: 'internal', hasResidentKey: true, hasUserVerification: true, isUserVerified: true, automaticPresenceSimulation: true } });
+
+await page.route('**/api/**', (route) => {
+  const u = new URL(route.request().url());
+  const j = (o, s = 200) => route.fulfill({ status: s, contentType: 'application/json', body: JSON.stringify(o) });
+  if (u.pathname.endsWith('/signing-key/step-up/options')) {
+    if (noPasskeyMode) return j({ error: 'no_passkey' }, 409);
+    return j({ flowId: 'f', options: { challenge: CHAL, allowCredentials: CRED_ID ? [{ id: CRED_ID, transports: ['internal'] }] : [], userVerification: 'required', timeout: 20000, rpId: 'localhost' } });
+  }
+  if (u.pathname.endsWith('/signing-key/step-up/bind')) return j({ ok: true });
+  return j({ ok: true });
+});
+
+await page.goto(`${ORIGIN}/__proof`);
+CRED_ID = await page.evaluate(async () => {
+  const c = await navigator.credentials.create({ publicKey: { rp: { id: 'localhost', name: 't' }, user: { id: new Uint8Array([1,2,3,4]), name: 'u', displayName: 'u' }, challenge: new Uint8Array(32), pubKeyCredParams: [{ type: 'public-key', alg: -7 }], authenticatorSelection: { userVerification: 'required', residentKey: 'preferred' }, timeout: 20000 } });
+  const u = new Uint8Array(c.rawId); let s = ''; for (const x of u) s += String.fromCharCode(x); return btoa(s).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
+});
+
+const phase1 = await page.evaluate(async () => {
+  const m = await import('/js/parasign-signer.js?v=10');
+  const pqc = await import('/vendor/paramant-pqc.js');
+  const vault = await import('/vendor/vault.js?v=3');
+  const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
+  const eqU8 = (a,b) => a.length===b.length && a.every((x,i)=>x===b[i]);
+  const hex = (u8) => Array.from(u8).map(b=>b.toString(16).padStart(2,'0')).join('');
+  const b64 = (u8) => { let s=''; for (let i=0;i<u8.length;i++) s+=String.fromCharCode(u8[i]); return btoa(s); };
+  const rnd = (n) => crypto.getRandomValues(new Uint8Array(n));
+  const delDB = () => new Promise(r => { const q = indexedDB.deleteDatabase('paramant'); q.onsuccess=q.onerror=q.onblocked=()=>r(); });
+  const mk = () => { const s=rnd(32),k=pqc.ml_dsa65.keygen(s); return { k, pk:b64(k.publicKey), ph:hex(pqc.sha3_256(k.publicKey)), sk:k.secretKey.slice() }; };
+  const PASS = 'correct-horse-battery-staple-42';
+  const base = { envelopeId:'env_test_000000000001', docHash:'a'.repeat(64), partyIndex:0, emailHash:'b'.repeat(64) };
+  try {
+    const h0 = hex(m.buildDocSignMessage(base));
+    ok('A1 buildDocSignMessage deterministic', h0===hex(m.buildDocSignMessage(base)));
+    ok('A2 binds envelopeId', h0!==hex(m.buildDocSignMessage({...base,envelopeId:'env_test_000000000002'})));
+    ok('A3 binds docHash', h0!==hex(m.buildDocSignMessage({...base,docHash:'c'.repeat(64)})));
+    ok('A4 binds partyIndex', h0!==hex(m.buildDocSignMessage({...base,partyIndex:1})));
+    ok('A5 binds emailHash', h0!==hex(m.buildDocSignMessage({...base,emailHash:'d'.repeat(64)})));
+    const rej = (p) => { try { vault.assertStrongPassphrase(p); return false; } catch { return true; } };
+    const acc = (p) => { try { vault.assertStrongPassphrase(p); return true; } catch { return false; } };
+    ok('B1 reject empty', rej(''));
+    ok('B2 reject short', rej('short1'));
+    ok('B3 reject all-same-char', rej('aaaaaaaaaaaaaaaa'));
+    ok('B4 reject common-word', rej('mypasswordhere12'));
+    ok('B5 reject 12 lc-only', rej('abcdefghijkl'));
+    ok('B6 accept long passphrase', acc(PASS));
+    ok('B7 accept 16 mixed-classes', acc('Tr0ub4dour&3xtra'));
+    await delDB(); const C = mk();
+    await vault.vaultStore({ alg:'ML-DSA-65', label:'C', pk_b64:C.pk, pk_hash:C.ph, secretKeyBytes:C.k.secretKey, passphrase:PASS });
+    const uC = await vault.vaultUnlock(C.ph, PASS);
+    ok('C1 passphrase unlock returns the key', eqU8(uC.secretKeyBytes, C.sk));
+    const msg = m.buildDocSignMessage(base);
+    ok('C2 unlocked key signs + verifies', pqc.ml_dsa65.verify(C.k.publicKey, msg, pqc.ml_dsa65.sign(uC.secretKeyBytes, msg)));
+    let w=false; try { await vault.vaultUnlock(C.ph,'wrong-pass-wrong-1'); } catch(e){ w=/wrong passphrase/.test(e.message); } ok('C3 wrong passphrase rejected', w);
+    let n=false; try { await vault.vaultUnlock('deadbeefdeadbeef','x'); } catch(e){ n=/no such key/.test(e.message); } ok('C4 unknown id rejected', n);
+    await delDB(); const D = mk(); const salt=rnd(16),out=rnd(32),cid='dGVzdGNyZWQ';
+    await vault.vaultCreatePrfOnly({ alg:'ML-DSA-65', label:'D', pk_b64:D.pk, pk_hash:D.ph, secretKeyBytes:D.k.secretKey, credentialId:cid, prfSalt:salt, prfOutput:out.slice() });
+    const info = await vault.vaultGetPrfWrapInfo(D.ph);
+    ok('D1 getPrfWrapInfo returns credentialId+salt', info && info.credentialId===cid && !!info.prfSalt);
+    const uD = await vault.vaultUnlockPrf(D.ph, { prfOutput:out.slice(), credentialId:cid });
+    ok('D2 PRF unlock returns the key', eqU8(uD.secretKeyBytes, D.sk));
+    ok('D3 PRF-unlocked key signs + verifies', pqc.ml_dsa65.verify(D.k.publicKey, msg, pqc.ml_dsa65.sign(uD.secretKeyBytes, msg)));
+    let wp=false; try { await vault.vaultUnlockPrf(D.ph,{ prfOutput:rnd(32), credentialId:cid }); } catch(e){ wp=true; } ok('D4 wrong PRF output rejected', wp);
+    await delDB(); const E = mk(); const sE=rnd(16),oE=rnd(32);
+    await vault.vaultStore({ alg:'ML-DSA-65', label:'E', pk_b64:E.pk, pk_hash:E.ph, secretKeyBytes:E.k.secretKey, passphrase:PASS });
+    await vault.vaultAddPrfWrap({ pk_hash:E.ph, secretKeyBytes:E.sk.slice(), credentialId:'ZHVhbA', prfSalt:sE, prfOutput:oE.slice() });
+    const le = (await vault.vaultList()).find(k=>k.pk_hash===E.ph);
+    ok('E1 both kekSources present', le && le.kekSources.includes('passphrase') && le.kekSources.includes('webauthn-prf'));
+    const ep = await vault.vaultUnlock(E.ph, PASS), epr = await vault.vaultUnlockPrf(E.ph,{ prfOutput:oE.slice(), credentialId:'ZHVhbA' });
+    ok('E2 passphrase + PRF unlock the SAME key', eqU8(ep.secretKeyBytes,E.sk) && eqU8(epr.secretKeyBytes,E.sk));
+    await delDB(); let f1=false; try { await m.resolvePasskeySigningKey(); } catch(e){ f1=e.code==='no_signing_passkey'; } ok('F1 empty vault -> no_signing_passkey', f1);
+    await delDB(); const Fa=mk(); await vault.vaultStore({ alg:'ML-DSA-65', label:'pp', pk_b64:Fa.pk, pk_hash:Fa.ph, secretKeyBytes:Fa.k.secretKey, passphrase:PASS });
+    let rf = await m.resolvePasskeySigningKey(); ok('F2 passphrase-only -> hasPassphrase', rf.hasPassphrase===true && rf.hasPrf===false);
+    await delDB(); const Fb=mk(); await vault.vaultCreatePrfOnly({ alg:'ML-DSA-65', label:'prf', pk_b64:Fb.pk, pk_hash:Fb.ph, secretKeyBytes:Fb.k.secretKey, credentialId:'Yg', prfSalt:rnd(16), prfOutput:rnd(32) });
+    let rf2 = await m.resolvePasskeySigningKey(); ok('F3 PRF-only -> hasPrf', rf2.hasPrf===true && rf2.hasPassphrase===false);
+    const Fc=mk(); await vault.vaultStore({ alg:'ML-DSA-65', label:'pp2', pk_b64:Fc.pk, pk_hash:Fc.ph, secretKeyBytes:Fc.k.secretKey, passphrase:PASS });
+    let rf3 = await m.resolvePasskeySigningKey(); ok('F4 both present -> prefers PRF key', rf3.hasPrf===true && rf3.fingerprint===Fb.ph.slice(0,16));
+    await delDB(); const H=mk(); await vault.vaultStore({ alg:'ML-DSA-65', label:'h', pk_b64:H.pk, pk_hash:H.ph, secretKeyBytes:H.k.secretKey, passphrase:PASS });
+    let np=false; try { await new m.LocalVaultSigner().activate({ vaultId:H.ph, rpId:'localhost' }); } catch(e){ np=e.code==='need_passphrase'; } ok('H1 passphrase key w/o passphrase -> need_passphrase', np);
+    const sg = await new m.LocalVaultSigner().activate({ vaultId:H.ph, rpId:'localhost', passphrase:PASS });
+    ok('H2 activate(passphrase) signs + verifies', pqc.ml_dsa65.verify(H.k.publicKey, msg, await sg.sign(msg)));
+    ok('H3 signer.publicKey matches enrolled pk', sg.publicKey===H.pk);
+    sg.dispose(); let dp=false; try { await sg.sign(msg); } catch(e){ dp=/disposed/.test(e.message); } ok('H4 sign after dispose throws', dp);
+  } catch(e){ ok('PHASE1 FATAL', false, e.message); }
+  return T;
+});
+
+const phase2a = await page.evaluate(async () => {
+  const m = await import('/js/parasign-signer.js?v=10');
+  const pqc = await import('/vendor/paramant-pqc.js');
+  const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
+  const delDB = () => new Promise(r => { const q = indexedDB.deleteDatabase('paramant'); q.onsuccess=q.onerror=q.onblocked=()=>r(); });
+  const base = { envelopeId:'env_test_000000000001', docHash:'a'.repeat(64), partyIndex:0, emailHash:'' };
+  try {
+    await delDB(); let i1=false; try { await m.ensureSigningKey({ rpId:'localhost' }); } catch(e){ i1=e.code==='prf_unsupported'; } ok('I1 no-PRF authenticator -> prf_unsupported', i1);
+    const PASS = 'correct-horse-battery-staple-42';
+    const key = await m.enrolSigningKeyWithPassphrase({ rpId:'localhost', label:'g', passphrase:PASS });
+    ok('G1a enrol returns passphrase key', key.hasPassphrase===true && key.hasPrf===false && (key.pk_b64||'').length>1000);
+    const signer = await new m.LocalVaultSigner().activate({ vaultId:key.vaultId, rpId:'localhost', passphrase:PASS });
+    const msg = m.buildDocSignMessage(base); const sig = await signer.sign(msg); const pub = Uint8Array.from(atob(key.pk_b64), c=>c.charCodeAt(0)); signer.dispose();
+    ok('G1b enrolled key signs + verifies (ML-DSA-65)', pqc.ml_dsa65.verify(pub, msg, sig));
+    let g2=false; try { await m.enrolSigningKeyWithPassphrase({ rpId:'localhost', passphrase:'weak' }); } catch(e){ g2=/too weak/.test(e.message); } ok('G2 weak passphrase rejected', g2);
+    const fp = await m.ensureSigningKey({ rpId:'localhost' }); ok('I2 fast-path returns existing key', fp && fp.hasPassphrase===true && fp.vaultId===key.vaultId);
+  } catch(e){ ok('PHASE2a FATAL', false, e.message); }
+  return T;
+});
+
+noPasskeyMode = true;
+const phase2b = await page.evaluate(async () => {
+  const m = await import('/js/parasign-signer.js?v=10');
+  const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
+  const delDB = () => new Promise(r => { const q = indexedDB.deleteDatabase('paramant'); q.onsuccess=q.onerror=q.onblocked=()=>r(); });
+  await delDB();
+  let c=''; try { await m.ensureSigningKey({ rpId:'localhost' }); } catch(e){ c=e.code; } ok('I3 server 409 no_passkey -> code no_passkey', c==='no_passkey', c);
+  return T;
+});
+noPasskeyMode = false;
+
+// Phase 3: the shared promptPassphrase against each real panel (ds-/cs-/en-).
+const PANELS = [{ page: 'sign.html', prefix: 'ds-pass' }, { page: 'co-sign.html', prefix: 'cs-pass' }, { page: 'account.html', prefix: 'en-pass' }];
+const phase3 = [];
+for (const { page: pg, prefix } of PANELS) {
+  await page.goto(`${ORIGIN}/${pg}`, { waitUntil: 'domcontentloaded' });
+  const r = await page.evaluate(async (prefix) => {
+    const out = {};
+    const { promptPassphrase } = await import('/js/passphrase-prompt.js?v=1');
+    const $ = (s) => document.getElementById(s);
+    out.panelExists = !!$(prefix + '-panel') && !!$(prefix + '-input') && !!$(prefix + '-confirm');
+    const tick = () => new Promise(r => setTimeout(r, 15));
+    // unlock: enter a value, confirm -> resolves with it
+    const p1 = promptPassphrase(prefix, 'unlock'); await tick();
+    $(prefix + '-input').value = 'enter-me'; $(prefix + '-confirm').click();
+    out.unlock = (await p1) === 'enter-me';
+    // set: matching strong values -> resolves; panel hidden again
+    const p2 = promptPassphrase(prefix, 'set'); await tick();
+    $(prefix + '-input').value = 'correct-horse-battery-staple-42'; $(prefix + '-input2').value = 'correct-horse-battery-staple-42'; $(prefix + '-confirm').click();
+    out.set = (await p2) === 'correct-horse-battery-staple-42';
+    out.hiddenAfter = $(prefix + '-panel').hidden === true;
+    // set mismatch -> error shown, promise still pending; cancel to clean up
+    const p3 = promptPassphrase(prefix, 'set'); await tick();
+    $(prefix + '-input').value = 'correct-horse-battery-staple-42'; $(prefix + '-input2').value = 'different-but-also-strong-99'; $(prefix + '-confirm').click(); await tick();
+    out.mismatchErr = $(prefix + '-err').hidden === false;
+    $(prefix + '-cancel').click(); out.cancelNull = (await p3) === null;
+    return out;
+  }, prefix);
+  phase3.push({ name: `P3 ${prefix} panel (${pg}): exists=${r.panelExists} unlock=${r.unlock} set=${r.set} hidden=${r.hiddenAfter} mismatchErr=${r.mismatchErr} cancel=${r.cancelNull}`,
+    pass: r.panelExists && r.unlock && r.set && r.hiddenAfter && r.mismatchErr && r.cancelNull, detail: '' });
+}
+
+await browser.close();
+await new Promise(r => server.close(r));
+
+const all = [...phase1, ...phase2a, ...phase2b, ...phase3];
+let passed = 0;
+console.log('\n================ ParaSign signing — FULL functional test ================');
+for (const t of all) { console.log(`  ${t.pass ? 'PASS' : 'FAIL'}  ${t.name}${t.detail ? '   (' + t.detail + ')' : ''}`); if (t.pass) passed++; }
+console.log(`\n  ${passed}/${all.length} passed`);
+console.log('  (live WebAuthn-PRF derivation needs PRF-capable hardware; vault layer covers our PRF code)');
+console.log('==========================================================================');
+process.exit(passed === all.length ? 0 : 1);


### PR DESCRIPTION
Post-audit improvements (the 3 recommended follow-ups). No behaviour change to the proven sign flows.

- **DRY**: identical inline `promptPassphrase()` in sign-flow.js + co-sign.js extracted to `frontend/js/passphrase-prompt.js` (parameterised by id-prefix), used by /sign (`ds-pass`), /co-sign (`cs-pass`) and /account (`en-pass`). Drops the `assertStrongPassphrase` re-export from parasign-signer.js.
- **Account parity**: `/account` "Set up signing" now does the passphrase fallback itself (`en-pass` panel + `enrolSigningKeyWithPassphrase`) when the provider can't do PRF, instead of only pointing to /sign.
- **CI coverage**: `tests/sign-full.test.mjs` — self-contained functional suite (real Chromium + WebAuthn virtual authenticator + real WebCrypto/IndexedDB) covering every signing path + the shared prompt on all three panels. New path-gated `sign-e2e` workflow runs it; `playwright` added as devDependency. **39/39 pass** locally.

Cache-bust: parasign-signer `?v=10`, passphrase-prompt `?v=1`, sign-flow `?v=22`, co-sign `?v=11`, signing-enrol `?v=12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
