### PR TITLE
fix(parasign): land Safari/WebKit signing fixes to main + cache-bust the v3 chain

### DIFF
--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -195,6 +195,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 </main>
 
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
-<script type="module" src="/co-sign.js?v=11"></script>
+<script type="module" src="/co-sign.js?v=12"></script>
 </body>
 </html>

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -18,7 +18,7 @@
 // the view receipt. The signing path itself is same-origin via the admin
 // (/api/user/sign/*), bound to the logged-in invitee session.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolSigningKeyWithPassphrase } from '/js/parasign-signer.js?v=10';
+import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolSigningKeyWithPassphrase } from '/js/parasign-signer.js?v=11';
 import { promptPassphrase } from '/js/passphrase-prompt.js?v=1';
 
 const RELAY_PUBLIC = 'https://health.paramant.app';

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -11,7 +11,7 @@
 // sign path. Signing goes through the passkey-PRF activation chain (LocalVaultSigner
 // in parasign-signer.js); sha3_256 stays for document hashing only.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolSigningKeyWithPassphrase } from '/js/parasign-signer.js?v=10';
+import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolSigningKeyWithPassphrase } from '/js/parasign-signer.js?v=11';
 import { promptPassphrase } from '/js/passphrase-prompt.js?v=1';
 
 // Read-only public relay host, used ONLY for the "view envelope status" link on

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -634,6 +634,6 @@
 <script src="/js/nav-auth.js?v=1" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
-<script type="module" src="/sign-flow.js?v=22"></script>
+<script type="module" src="/sign-flow.js?v=23"></script>
 </body>
 </html>


### PR DESCRIPTION
## Waarom
Signen mislukte structureel op iPhone/Safari. Root cause: de WebKit/Safari/Firefox PRF-sign-fixketen (`getAssertionWithPrf`, engine-adaptieve PRF-shape, passphrase-fallback, gedeelde passphrase-prompt, signing-E2E in CI) leeft alléén op deze branch en is **naar prod gedeployed maar nooit naar main gemerged**. Main heeft enkel de simpele `evalByCredential`-aanpak (`ffa64f1`) die op WebKit juist een synchrone `NotSupportedError` gooit → geen PRF → sign faalt.

`git log -S getAssertionWithPrf -- frontend/js/parasign-signer.js` op main = leeg: de fix is nooit in main geweest. Dit is de regressie.

## Extra: immutable-cache-bust
De fix stond wel in de webroot, maar onder dezelfde `?v=` queries terwijl `/js/parasign-signer.js` `immutable, max-age=31536000` serveert. Clients die `?v=10` vóór de fix cachten, hielden de Safari-brekende signer een jaar vast. Daarom: `parasign-signer.js?v=10→11` (sign-flow.js + co-sign.js imports), `sign-flow.js?v=22→23` (sign.html), `co-sign.js?v=11→12` (co-sign.html). De cache-bust is al live gedeployed in de webroot; deze PR brengt main op één lijn met prod.

## Inhoud
Volledige parasign-signing-keten (signer + sign-flow + co-sign + sign/co-sign.html + account.html + passphrase-prompt.js + signing-enrol.js + pdfjs .mjs→.js), `sign-e2e.yml` CI + `tests/sign-full.test.mjs`, plus de cache-bust commit. Bevat ook de privacy.html doc-wijziging die op deze branch is gemaakt.

Na merge: main = source-of-truth voor signing; een toekomstige main-deploy breekt Safari niet meer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)