### PR TITLE
docs: @noble extended-only / dormant in core-mode

### DIFF
--- a/docs/adrs/R006-crypto-mode-opt-in.md
+++ b/docs/adrs/R006-crypto-mode-opt-in.md
@@ -59,6 +59,15 @@ trail consolidated with the M5b ML-KEM-768 migration).
 - The wire-format spec (docs/wire-format-v1.md) still documents all 18 algorithm
   IDs as recognized values. /v2/capabilities is the runtime source of truth for
   what is actually accepted.
+- Dependency surface: the two core impls (mlkem768.js, mldsa65.js) route to
+  @paramant/core; only the 16 extended impls require @noble/post-quantum. In the
+  core default @noble runs no crypto on the hot path (dormant), so the core
+  audit surface is @paramant/core, not @noble. @noble cannot move to a
+  devDependency, however: bootstrap.js requires all extended impls eagerly (so a
+  broken impl fails at startup, not first use), which loads @noble into the
+  process even in core mode. Pruning it from runtime deps would mean lazy
+  require()s in the extended impls (deferred to extended mode), a separate change
+  with its own startup-failure tradeoff.
 
 ## Alternatives considered
 

--- a/relay/crypto/bootstrap.js
+++ b/relay/crypto/bootstrap.js
@@ -10,6 +10,16 @@
 //                variants. Crypto-agility for experimental clients
 //                using the raw HTTP API.
 //
+// Backing libraries differ by tier. The two core impls (mlkem768.js, mldsa65.js)
+// route to @paramant/core (the Rust PQ-crypto core, NAPI binding). The 16
+// extended impls are the only code that requires @noble/post-quantum. So in the
+// production default (CRYPTO_MODE=core) @noble runs no crypto: it is dormant on
+// the hot path, and the core audit surface is @paramant/core, not @noble. The
+// extended impl files are still required eagerly (see below), so @noble is
+// loaded into the process even in core mode; it cannot move to a devDependency
+// without breaking that eager require. See ADR R006 for the dependency-surface
+// rationale.
+//
 // To enable extended mode: set CRYPTO_MODE=extended in .env. See ADR R006.
 
 const { registerKEM, registerSig } = require('./registry');


### PR DESCRIPTION
Documenteert dat @noble/post-quantum alleen de EXTENDED-algoritmen bedient en in CRYPTO_MODE=core dormant is. Review-only.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>