### PR TITLE
feat(pricing): make the community-free promise explicit

### DIFF
--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -285,9 +285,16 @@
       <h2>Pricing</h2>
       <span style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)">Three tiers</span>
     </div>
-    <p style="font-size:var(--text-md);color:var(--ink);line-height:1.75;margin-bottom:var(--space-6)">
+    <p style="font-size:var(--text-md);color:var(--ink);line-height:1.75;margin-bottom:var(--space-5)">
       Send files for free with a Paramant account. Scale when you need audit trails, team access, or a dedicated relay.
     </p>
+    <div style="text-align:left;max-width:760px;margin:0 auto var(--space-6);padding:var(--space-4) var(--space-5);border:1px solid var(--ink-hair);border-left:3px solid var(--lime);background:var(--bone)">
+      <p style="font-size:var(--text-base);color:var(--ink);line-height:1.7;margin:0">
+        <strong>Free for everyday and community use, forever.</strong> Heavy users and businesses pay for the higher
+        limits (longer links, more reads, more devices, a dedicated relay), not to unlock features. The community
+        tier stays free.
+      </p>
+    </div>
     <a href="/dashboard" class="btn btn-secondary">Open your dashboard &rarr;</a>
   </div>
 </section>


### PR DESCRIPTION
Adds a callout under the pricing header making the model explicit per request:

> Free for everyday and community use, forever. Heavy users and businesses pay for the higher limits (longer links, more reads, more devices, a dedicated relay), not to unlock features. The community tier stays free.

Copy-only, frontend-only. A "buy me a coffee" support link will follow once the URL is provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)