### PR TITLE
feat(home): label hero badge "Free for community"

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -340,7 +340,7 @@
     <p class="lede">Post-quantum signatures and encrypted transfers, held in memory and gone after read. The server is blind by design, not by promise.</p>
     <ul class="hero-badges" aria-label="At a glance">
       <li><a href="https://github.com/Apolloccrypt/paramant-relay">Open source</a></li>
-      <li><a href="/pricing">Free</a></li>
+      <li><a href="/pricing">Free for community</a></li>
       <li><a href="/security">Fully auditable</a></li>
       <li><a href="/sovereignty">EU-sovereign</a></li>
       <li><a href="/crypto-agility">Post-quantum</a></li>


### PR DESCRIPTION
Surfaces the free-for-community promise on the homepage hero (links to /pricing). Copy-only, frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)