### PR TITLE
fix(relay): critical — DID-auth privilege bypass (inv_ DID forges pro session)

### DIFF
--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1862,12 +1862,19 @@ const server = http.createServer(async (req, res) => {
     if (didAuthEntry) log('info', 'did_auth_mode', { did: didHeader.slice(0,30) });
   }
   const dsaSig  = req.headers['x-dsa-signature'] || '';
-  const keyData = apiKeys.get(apiKey) || (didAuthEntry ? { plan: 'pro', active: true, label: didAuthEntry.device_id } : null);
-  // account_id is what Phase 3 counters key on. For now it is 1:1 with apiKey
-  // (or with the DID device for DID-auth), which means existing single-device
-  // users see no change. Once multi-device sharing of an account_id lands, the
-  // counter math automatically aggregates across devices.
-  if (keyData && !keyData.account_id) keyData.account_id = apiKey || (didAuthEntry && didAuthEntry.device_id) || null;
+  // DID-auth NEVER mints its own principal. A DID only authenticates as the API
+  // key it was REGISTERED under: inherit that key's real plan/active. Keyless DIDs
+  // (e.g. 'inv_' receiver-session DIDs, registered without an API key) therefore
+  // grant NO authenticated principal here — they keep working only through the
+  // per-endpoint INVITE_RE pubkey-exchange bypass, never as a general auth subject.
+  // (Previously any valid DID-auth forged {plan:'pro',active:true}, which let an
+  // anonymous attacker self-register an inv_ DID and ride it into a pro session.)
+  const didOwner = (didAuthEntry && didAuthEntry.key) ? apiKeys.get(didAuthEntry.key) : null;
+  const keyData = apiKeys.get(apiKey)
+    || ((didOwner && didOwner.active) ? { ...didOwner, label: didAuthEntry.device_id } : null);
+  // account_id is what Phase 3 counters key on: the owning API key (1:1 today),
+  // or for DID-auth the key the DID was registered under — never the device id.
+  if (keyData && !keyData.account_id) keyData.account_id = apiKey || (didAuthEntry && didAuthEntry.key) || null;
   const clientIp = getClientIp(req);
 
   // Community Edition limit: block keys that exceed the 5-key cap


### PR DESCRIPTION
## Critical

`authByDid()` returns the DID registry entry; any successful DID-auth set `keyData = {plan:'pro',active:true}`. Because `inv_` receiver-session DIDs register **without** an API key (relay.js:4106), an unauthenticated attacker could self-register an `inv_` DID with their own key, sign the request URL, and ride DID-auth into a forged active pro-tier principal that passes the X-Api-Key gate on every non-admin relay endpoint.

Found by the paramant audit swarm, 3/3 adversarially confirmed, and re-verified by hand against relay.js:1865 + 4106 and the `INVITE_RE` receiver-session path.

## Fix
DID-auth now authenticates only as the API key the DID was **registered under** (`apiKeys.get(didAuthEntry.key)`), inheriting that key's real plan/active; keyless/inactive owners grant no principal. Legitimate `inv_` receiver sessions are unaffected (they use the per-endpoint `INVITE_RE` pubkey bypass, not `keyData`). Also closes the `plan:'pro'` tier upgrade and the account_id mis-attribution.

Backend change → needs a relay rebuild/redeploy (held for Mick's go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)