### PR TITLE
fix(relay): crypto defense-in-depth (TOTP AAD, fail-closed pk index, receipt leaf binding)

### DIFF
--- a/relay/lib/encryption.js
+++ b/relay/lib/encryption.js
@@ -13,28 +13,46 @@ function getMasterKey() {
   return key;
 }
 
-function encryptSecret(plaintext) {
+// `aad` (optional) binds the ciphertext to a context (e.g. the userId), so a
+// Redis-write attacker can't lift one user's encrypted blob into another user's
+// key and have it decrypt — the GCM tag covers the AAD. Callers pass a stable
+// per-record string. Backward compatible: blobs written before AAD existed have
+// none, so decryptSecret retries without AAD when an AAD-bound decrypt fails (the
+// next write upgrades them).
+function encryptSecret(plaintext, aad) {
   const key    = getMasterKey();
   const nonce  = crypto.randomBytes(NONCE_LEN);
   const cipher = crypto.createCipheriv(ALGO, key, nonce);
+  if (aad) cipher.setAAD(Buffer.from(String(aad), 'utf8'));
   const enc    = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
   const tag    = cipher.getAuthTag();
   key.fill(0);
   return `${nonce.toString('base64')}:${enc.toString('base64')}:${tag.toString('base64')}`;
 }
 
-function decryptSecret(serialized) {
-  const parts = (serialized || '').split(':');
-  if (parts.length !== 3) throw new Error('Invalid encrypted format');
+function _decrypt(parts, aad) {
   const nonce = Buffer.from(parts[0], 'base64');
   const ct    = Buffer.from(parts[1], 'base64');
   const tag   = Buffer.from(parts[2], 'base64');
   const key   = getMasterKey();
   const dec   = crypto.createDecipheriv(ALGO, key, nonce);
+  if (aad) dec.setAAD(Buffer.from(String(aad), 'utf8'));
   dec.setAuthTag(tag);
   const plain = Buffer.concat([dec.update(ct), dec.final()]);
   key.fill(0);
   return plain.toString('utf8');
+}
+
+function decryptSecret(serialized, aad) {
+  const parts = (serialized || '').split(':');
+  if (parts.length !== 3) throw new Error('Invalid encrypted format');
+  try {
+    return _decrypt(parts, aad);
+  } catch (e) {
+    // Legacy blob written without AAD: retry unbound (only when we tried AAD).
+    if (aad) return _decrypt(parts, null);
+    throw e;
+  }
 }
 
 module.exports = { encryptSecret, decryptSecret };

--- a/relay/lib/user-signing.js
+++ b/relay/lib/user-signing.js
@@ -63,7 +63,9 @@ async function storeSigningPk(redisClient, userId, { pk_b64, label }) {
       }
     } catch (e) {
       if (e.message === 'pubkey already enrolled to a different account') throw e;
-      // malformed index entry — overwrite below
+      // Fail closed: an index entry exists but is unreadable. Overwriting it would
+      // be fail-open (could silently re-map a pubkey across accounts on corruption).
+      throw new Error('pubkey index unreadable; refusing to overwrite');
     }
   }
 

--- a/relay/lib/user-totp.js
+++ b/relay/lib/user-totp.js
@@ -71,15 +71,20 @@ async function consumeBackupCode(redisClient, userId, providedCode) {
   return { valid: false };
 }
 
+// AAD binds the TOTP secret blob to this user, so a Redis-write attacker can't
+// transplant one user's secret into another's key (decrypt is backward-compatible
+// with pre-AAD blobs; see encryption.js).
+function _totpAad(userId) { return `totp:${userId}`; }
+
 async function storeUserTotpSecret(redisClient, userId, base32Secret) {
-  const encrypted = encryptSecret(base32Secret);
+  const encrypted = encryptSecret(base32Secret, _totpAad(userId));
   await redisClient.set(`paramant:user:totp:${userId}`, encrypted);
 }
 
 async function getUserTotpSecret(redisClient, userId) {
   const encrypted = await redisClient.get(`paramant:user:totp:${userId}`);
   if (!encrypted) return null;
-  return decryptSecret(encrypted);
+  return decryptSecret(encrypted, _totpAad(userId));
 }
 
 async function deleteUserTotp(redisClient, userId) {

--- a/relay/lib/user-webauthn.js
+++ b/relay/lib/user-webauthn.js
@@ -94,7 +94,8 @@ async function storeCredential(redisClient, userId, cred) {
       if (idx.userId && idx.userId !== userId) throw new Error('credential already registered to a different account');
     } catch (e) {
       if (e.message === 'credential already registered to a different account') throw e;
-      // malformed index — overwrite below
+      // Fail closed: index exists but is unreadable; refuse rather than overwrite.
+      throw new Error('credential index unreadable; refusing to overwrite');
     }
   }
 

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -4875,6 +4875,16 @@ python3 paramant-receiver.py \\
         res.writeHead(200, { 'Content-Type': 'application/json' });
         return res.end(J({ valid: false, reason: 'inclusion_proof_missing_leaf_hash' }));
       }
+      // Bind the proof's leaf to the asserted blob_hash: recompute the leaf the
+      // same way the relay produced it. Without this the proof only proves "some
+      // leaf is in the tree", not that it is the leaf for THIS blob_hash. (The
+      // signature already covers both, so this is defense-in-depth against a
+      // relay self-inconsistency.)
+      const expectedLeaf = blobLeafHash(receiptObj.blob_hash, receiptObj.sector, receiptObj.ts);
+      if (proof.leaf_hash !== expectedLeaf) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        return res.end(J({ valid: false, reason: 'leaf_hash_mismatch' }));
+      }
       let computedRoot = proof.leaf_hash;
       for (const step of (proof.audit_path || [])) {
         if (step.position === 'right') {


### PR DESCRIPTION
Three relay crypto-hardening fixes from the audit (all defense-in-depth, not HTTP-reachable):
- **TOTP secret AAD**: bind the AES-GCM TOTP blob to its userId so a Redis-write attacker can't transplant it across accounts. Backward-compatible decrypt (retries unbound for legacy blobs).
- **Fail-closed pk/credential reverse-index**: an unreadable index was overwritten (fail-open); now refuses.
- **verify-receipt leaf binding**: recompute the leaf from blob_hash/sector/ts and reject mismatch.

Flagged (not changed, would break existing artifacts): legacy /v2/sign + verifyEnvelope bare-hash domain separation. Backend → needs redeploy (held for go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)