### PR TITLE
fix(infra): backup perms, dead Fly proxy removal, CI pin, client-IP normalization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,10 +51,16 @@ jobs:
       # byte-compatibility against the binding. Interim until publish.
       - name: Install liboqs build deps
         run: sudo apt-get update && sudo apt-get install -y cmake ninja-build clang libclang-dev
-      - name: Build @paramant/core (sibling checkout)
+      # Pin paramant-core to a fixed commit so the crypto byte-compat gate runs
+      # against a known revision, not a moving HEAD. Bump this SHA deliberately
+      # (and review the diff) when adopting a new paramant-core.
+      - name: Build @paramant/core (sibling checkout, pinned)
+        env:
+          PARAMANT_CORE_SHA: 45a3d3521adda7924692d58be5db60d5b094371f
         run: |
-          git clone --depth 1 https://github.com/Apolloccrypt/paramant-core.git "${GITHUB_WORKSPACE}/../paramant-core"
+          git clone --no-checkout https://github.com/Apolloccrypt/paramant-core.git "${GITHUB_WORKSPACE}/../paramant-core"
           cd "${GITHUB_WORKSPACE}/../paramant-core"
+          git checkout "${PARAMANT_CORE_SHA}"
           rustup show
           cargo build -p paramant-core-node --release
           cp target/release/libparamant_core_node.so crates/paramant-core-node/index.node

--- a/deploy/nginx-paramant-live.conf
+++ b/deploy/nginx-paramant-live.conf
@@ -87,6 +87,7 @@ server {
         proxy_pass http://127.0.0.1:4200/admin/api/captcha/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP "";
         client_max_body_size 4k;
     }
 
@@ -120,6 +121,7 @@ server {
         proxy_pass http://127.0.0.1:4200/admin/api/user/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP "";
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header Cookie $http_cookie;
         proxy_pass_header Set-Cookie;
@@ -128,11 +130,14 @@ server {
         location = /api/check-key {
         proxy_pass http://127.0.0.1:3001/v2/check-key;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP "";
     }
     location = /api/request-key {
         proxy_pass http://127.0.0.1:4200/admin/api/request-key;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP "";
         proxy_set_header X-Forwarded-For $remote_addr;
         client_max_body_size 16k;
     }
@@ -144,6 +149,7 @@ server {
         proxy_pass http://127.0.0.1:3000/v2/sign-dpa;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP "";
         proxy_set_header X-Forwarded-For '';
         client_max_body_size 16k;
     }
@@ -173,24 +179,24 @@ location = /users.json { deny all; return 404; }    location ~ /.env { deny all;
     }
     error_page 404 /404.html;
     location = /404.html { internal; }
-    # DICOM info page (must come before /dicom/ proxy block to avoid nginx
-    # auto-redirect /dicom → http://127.0.0.1:8080/dicom/ using internal address)
+    # DICOM info page
     location = /dicom { try_files /dicom.html =404; }
-
-    # DICOM Gateway
-    location /dicom/ {
-        proxy_pass http://127.0.0.1:8090/;
-        proxy_set_header Host $host;
-        client_max_body_size 50M;
-    }
-
+    # NOTE: the /dicom/ gateway proxy was removed (sec/infra-hardening). Its only
+    # upstream was the dead :8090 → paramant-ghost-pipe.fly.dev server block,
+    # which has been removed below; the info page above stays.
 
     # Admin panel API proxy (same-origin, geen CORS issues)
+    # Normalize the client-IP headers on every relay proxy: hand the relay the
+    # real first hop ($remote_addr) and clear any client-supplied CF-Connecting-IP
+    # so a spoofed CF-Connecting-IP / X-Real-IP cannot defeat the relay's per-IP
+    # rate limits (getClientIp trusts those headers).
     location /rp/health/ {
         client_max_body_size 30M;
         proxy_pass http://127.0.0.1:3001/;
         proxy_http_version 1.1;
         proxy_set_header Host health.paramant.app;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP "";
         proxy_set_header X-Api-Key $http_x_api_key;
         proxy_set_header X-Admin-Token $http_x_admin_token;
     }
@@ -198,6 +204,8 @@ location = /users.json { deny all; return 404; }    location ~ /.env { deny all;
         proxy_pass http://127.0.0.1:3003/;
         proxy_http_version 1.1;
         proxy_set_header Host legal.paramant.app;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP "";
         proxy_set_header X-Api-Key $http_x_api_key;
         proxy_set_header X-Admin-Token $http_x_admin_token;
     }
@@ -205,6 +213,8 @@ location = /users.json { deny all; return 404; }    location ~ /.env { deny all;
         proxy_pass http://127.0.0.1:3002/;
         proxy_http_version 1.1;
         proxy_set_header Host finance.paramant.app;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP "";
         proxy_set_header X-Api-Key $http_x_api_key;
         proxy_set_header X-Admin-Token $http_x_admin_token;
     }
@@ -212,18 +222,16 @@ location = /users.json { deny all; return 404; }    location ~ /.env { deny all;
         proxy_pass http://127.0.0.1:3004/;
         proxy_http_version 1.1;
         proxy_set_header Host iot.paramant.app;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP "";
         proxy_set_header X-Api-Key $http_x_api_key;
         proxy_set_header X-Admin-Token $http_x_admin_token;
     }
-    location /rp/fly/ {
-        resolver 8.8.8.8 valid=300s ipv6=off;
-        set $fly_host paramant-ghost-pipe.fly.dev;
-        proxy_pass https://$fly_host/;
-        proxy_ssl_server_name on;
-        proxy_set_header Host $fly_host;
-        proxy_set_header X-Api-Key $http_x_api_key;
-        proxy_set_header X-Admin-Token $http_x_admin_token;
-    }
+    # NOTE: the dead /rp/fly/ proxy block was removed (sec/infra-hardening). It
+    # forwarded X-Admin-Token + X-Api-Key to paramant-ghost-pipe.fly.dev over
+    # TLS with no proxy_ssl_verify, and had zero live callers (already removed
+    # from CSP connect-src). If a Fly route is ever revived, enable
+    # proxy_ssl_verify on + a trusted CA bundle and never forward the admin token.
 
 
 }
@@ -253,6 +261,7 @@ location = /users.json { deny all; return 404; }    location ~ /.env { deny all;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP "";
         proxy_set_header X-Forwarded-For '';
         proxy_read_timeout 3600s;
     }
@@ -263,9 +272,9 @@ server {
     root /home/paramant/app-legal;
     index index.html;
     access_log off;
-    location /v2/ { proxy_pass http://127.0.0.1:3002; proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection 'upgrade'; proxy_read_timeout 3600s; }
-    location /health { proxy_pass http://127.0.0.1:3002; }
-    location /admin/ { proxy_pass http://127.0.0.1:3002; }
+    location /v2/ { proxy_pass http://127.0.0.1:3002; proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection 'upgrade'; proxy_set_header X-Real-IP $remote_addr; proxy_set_header CF-Connecting-IP ""; proxy_read_timeout 3600s; }
+    location /health { proxy_pass http://127.0.0.1:3002; proxy_set_header X-Real-IP $remote_addr; proxy_set_header CF-Connecting-IP ""; }
+    location /admin/ { proxy_pass http://127.0.0.1:3002; proxy_set_header X-Real-IP $remote_addr; proxy_set_header CF-Connecting-IP ""; }
 
     location = /outlook/taskpane {
         alias /home/paramant/app/outlook/taskpane.html;
@@ -304,7 +313,7 @@ server {
         default_type application/xml;
     }
 location = /users.json { deny all; return 404; }    location ~ /.env { deny all; return 404; }    location ~ /.git { deny all; return 404; }
-    location / { proxy_pass http://127.0.0.1:3003; proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection 'upgrade'; proxy_read_timeout 3600s; }
+    location / { proxy_pass http://127.0.0.1:3003; proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection 'upgrade'; proxy_set_header X-Real-IP $remote_addr; proxy_set_header CF-Connecting-IP ""; proxy_read_timeout 3600s; }
 }
 
 server {
@@ -326,7 +335,7 @@ server {
         default_type application/xml;
     }
 location = /users.json { deny all; return 404; }    location ~ /.env { deny all; return 404; }    location ~ /.git { deny all; return 404; }
-    location / { proxy_pass http://127.0.0.1:3004; proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection 'upgrade'; proxy_read_timeout 3600s; }
+    location / { proxy_pass http://127.0.0.1:3004; proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection 'upgrade'; proxy_set_header X-Real-IP $remote_addr; proxy_set_header CF-Connecting-IP ""; proxy_read_timeout 3600s; }
 }
 
 server {
@@ -348,30 +357,8 @@ server {
         default_type application/xml;
     }
 location = /users.json { deny all; return 404; }    location ~ /.env { deny all; return 404; }    location ~ /.git { deny all; return 404; }
-    location / { proxy_pass http://127.0.0.1:3005; proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection 'upgrade'; proxy_read_timeout 3600s; }
+    location / { proxy_pass http://127.0.0.1:3005; proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection 'upgrade'; proxy_set_header X-Real-IP $remote_addr; proxy_set_header CF-Connecting-IP ""; proxy_read_timeout 3600s; }
 }
-server {
-    listen 127.0.0.1:8090;
-
-    location = /outlook/taskpane {
-        alias /home/paramant/app/outlook/taskpane.html;
-        default_type text/html;
-        add_header Access-Control-Allow-Origin "https://outlook.office.com" always;
-        add_header Access-Control-Allow-Origin "https://outlook.office365.com" always;
-    }
-    location = /outlook/commands {
-        alias /home/paramant/app/outlook/commands.html;
-        default_type text/html;
-    }
-    location = /outlook/manifest.xml {
-        alias /home/paramant/app/outlook/manifest.xml;
-        default_type application/xml;
-    }
-location = /users.json { deny all; return 404; }    location ~ /.env { deny all; return 404; }    location ~ /.git { deny all; return 404; }
-    location / {
-        resolver 8.8.8.8 valid=300s ipv6=off;
-        set $fly_host paramant-ghost-pipe.fly.dev;
-        proxy_pass https://$fly_host;
-        proxy_set_header Host $fly_host;
-    }
-}
+# NOTE: the :8090 server block was removed (sec/infra-hardening). It blindly
+# proxied to paramant-ghost-pipe.fly.dev (the dead DICOM/Fly upstream) and had
+# no live callers once the /dicom/ and /rp/fly/ blocks above were removed.

--- a/deploy/nginx/snippets/paramant-security-headers.conf
+++ b/deploy/nginx/snippets/paramant-security-headers.conf
@@ -16,4 +16,9 @@ add_header Referrer-Policy "no-referrer" always;
 # camera=(self) required for the QR scanner
 add_header Permissions-Policy "geolocation=(), microphone=(), camera=(self)" always;
 # CSP: libs are vendored locally (no esm.sh / cdnjs); ghost-pipe.fly.dev & ipapi.co removed.
-add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://relay.paramant.app wss://relay.paramant.app https://health.paramant.app wss://health.paramant.app https://legal.paramant.app wss://legal.paramant.app https://finance.paramant.app wss://finance.paramant.app https://iot.paramant.app wss://iot.paramant.app; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:" always;
+# NOTE: script-src still carries 'unsafe-inline' because the app depends on inline
+# scripts/handlers (~14 HTML files, ~64 onclick). Removing it requires externalizing
+# all inline JS to /js/*.js (or nonce/hash) first — a separate, larger effort. Left
+# in place deliberately; the additions below (frame-ancestors/base-uri/form-action)
+# tighten clickjacking, <base> hijack and form-target without touching script-src.
+add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://relay.paramant.app wss://relay.paramant.app https://health.paramant.app wss://health.paramant.app https://legal.paramant.app wss://legal.paramant.app https://finance.paramant.app wss://finance.paramant.app https://iot.paramant.app wss://iot.paramant.app; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;

--- a/deploy/preflight.sh
+++ b/deploy/preflight.sh
@@ -37,8 +37,21 @@ if ! command -v docker &>/dev/null; then
     echo -e "${RED}✗  Docker not found${NC}"; echo ""
     read -p "   Install Docker now? [y/N]: " install_docker
     if [[ "$install_docker" =~ ^[Yy]$ ]]; then
-        echo "   Installing Docker..."; curl -fsSL https://get.docker.com | sh; sudo usermod -aG docker $USER
-        echo -e "${GREEN}✓  Docker installed — you may need to log out and back in${NC}"
+        # Download the vendor install script to a temp file first, then execute
+        # it (after the operator confirmation above) instead of piping the
+        # network stream straight into a shell. This makes the fetched script
+        # inspectable and avoids partial-download execution. (Ideally pin a
+        # SHA256 here too, but get.docker.com publishes no stable checksum.)
+        echo "   Installing Docker..."
+        DOCKER_INSTALL_SH=$(mktemp /tmp/get-docker.XXXXXX.sh)
+        if curl -fsSL https://get.docker.com -o "$DOCKER_INSTALL_SH"; then
+            sh "$DOCKER_INSTALL_SH"; rm -f "$DOCKER_INSTALL_SH"
+            sudo usermod -aG docker $USER
+            echo -e "${GREEN}✓  Docker installed — you may need to log out and back in${NC}"
+        else
+            rm -f "$DOCKER_INSTALL_SH"
+            echo -e "${RED}   Failed to download the Docker install script. Install from https://docs.docker.com/get-docker/${NC}"; exit 1
+        fi
     else
         echo -e "${RED}   Docker is required. Install from https://docs.docker.com/get-docker/${NC}"; exit 1
     fi

--- a/scripts/paramant-backup.sh
+++ b/scripts/paramant-backup.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # paramant-backup — backup relay keys and CT log
 
+# Secrets hardening: backups contain keys.json (relay signing keys) and
+# users.json. Restrict everything this script creates to root only so a local
+# non-root account can never read the crown jewels (source files are 0600).
+umask 077
+
 BACKUP_BASE="/var/lib/paramant-backup"
 GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'
 CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
@@ -10,7 +15,9 @@ echo "────────────────────────�
 
 TIMESTAMP=$(date '+%Y%m%d-%H%M%S')
 DEST="${BACKUP_BASE}/${TIMESTAMP}"
-mkdir -p "$DEST"
+mkdir -p "$BACKUP_BASE" "$DEST"
+chmod 700 "$BACKUP_BASE" "$DEST"
+chown root:paramant "$BACKUP_BASE" "$DEST" 2>/dev/null || true
 
 EXPORTED=0
 
@@ -18,11 +25,14 @@ for dir in /var/lib/paramant-relay /var/lib/paramant-relay-*; do
   [[ -d "$dir" ]] || continue
   name=$(basename "$dir")
   mkdir -p "${DEST}/${name}"
+  chmod 700 "${DEST}/${name}"
 
   for f in users.json ct-log ct_log keys.json; do
     SRC="${dir}/${f}"
     if [[ -f "$SRC" ]]; then
       cp "$SRC" "${DEST}/${name}/"
+      chmod 600 "${DEST}/${name}/${f}"
+      chown root:paramant "${DEST}/${name}/${f}" 2>/dev/null || true
       SIZE=$(du -sh "$SRC" | cut -f1)
       echo -e "  ${GREEN}✓${RESET}  ${name}/${f}  (${SIZE})"
       EXPORTED=$((EXPORTED+1))

--- a/scripts/paramant-cron.sh
+++ b/scripts/paramant-cron.sh
@@ -77,15 +77,22 @@ After=network.target
 Type=oneshot
 User=root
 ExecStart=/bin/bash -c '\
+  umask 077; \
   TS=$(date +%%Y%%m%%d-%%H%%M%%S); \
   DEST=/var/lib/paramant-backup/${TS}; \
-  mkdir -p "$DEST"; \
+  mkdir -p /var/lib/paramant-backup "$DEST"; \
+  chmod 700 /var/lib/paramant-backup "$DEST"; \
+  chown root:paramant /var/lib/paramant-backup "$DEST" 2>/dev/null || true; \
   for d in /var/lib/paramant-relay /var/lib/paramant-relay-*; do \
     [ -d "$d" ] || continue; \
     name=$(basename "$d"); \
     mkdir -p "$DEST/$name"; \
+    chmod 700 "$DEST/$name"; \
     cp "$d"/users.json "$DEST/$name/" 2>/dev/null || true; \
     cp "$d"/ct-log     "$DEST/$name/" 2>/dev/null || true; \
+    cp "$d"/keys.json  "$DEST/$name/" 2>/dev/null || true; \
+    chmod 600 "$DEST/$name"/* 2>/dev/null || true; \
+    chown root:paramant "$DEST/$name"/* 2>/dev/null || true; \
   done; \
   echo "Backup complete: $DEST"; \
   find /var/lib/paramant-backup -maxdepth 1 -type d -mtime +30 -exec rm -rf {} + 2>/dev/null || true'

--- a/scripts/paramant-setup.sh
+++ b/scripts/paramant-setup.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Secrets hardening: the license file holds PLK_KEY and ADMIN_TOKEN. Default
+# every file this script creates to owner-only, then widen explicitly where the
+# relay (running as user `paramant`) genuinely needs group-read.
+umask 077
+
 SETUP_DONE_FILE="/etc/paramant/.setup-done"
 LICENSE_FILE="/etc/paramant/license"
+
+# Apply correct owner/perms to the license file in one place. The relay service
+# runs as `paramant` and reads this file, so it needs group-read: root:paramant
+# + 0640 (NOT a bare 640, whose group bit is inert when the group is root).
+secure_license_file() {
+  chown root:paramant "$LICENSE_FILE" 2>/dev/null || true
+  chmod 640 "$LICENSE_FILE"
+}
 
 # ── Colour helpers ─────────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
@@ -126,12 +139,13 @@ else
 fi
 
 mkdir -p /etc/paramant
+chown root:paramant /etc/paramant 2>/dev/null || true
 chmod 750 /etc/paramant
 
 if [[ -n "$PLK_KEY" ]]; then
   if [[ "$PLK_KEY" == plk_* ]]; then
     printf 'PLK_KEY=%s\nADMIN_TOKEN=%s\n' "$PLK_KEY" "$ADMIN_TOKEN" > "$LICENSE_FILE"
-    chmod 640 "$LICENSE_FILE"
+    secure_license_file
     sudo paramant-relay-ctl restart paramant-relay 2>/dev/null || true
     sleep 2
     EDITION=$(curl -sf http://localhost:3000/health 2>/dev/null | jq -r '.edition // "unknown"' 2>/dev/null || echo "unknown")
@@ -141,7 +155,7 @@ if [[ -n "$PLK_KEY" ]]; then
     if [[ -n "$ADMIN_TOKEN" ]]; then
       printf 'ADMIN_TOKEN=%s\n' "$ADMIN_TOKEN" > "$LICENSE_FILE"
       [[ -n "$CURRENT_KEY" ]] && printf 'PLK_KEY=%s\n' "$CURRENT_KEY" >> "$LICENSE_FILE"
-      chmod 640 "$LICENSE_FILE"
+      secure_license_file
     fi
   fi
 else
@@ -152,7 +166,7 @@ else
     else
       printf 'ADMIN_TOKEN=%s\n' "$ADMIN_TOKEN" > "$LICENSE_FILE"
     fi
-    chmod 640 "$LICENSE_FILE"
+    secure_license_file
   fi
   info "No license key — running Community Edition (max 5 keys)."
 fi


### PR DESCRIPTION
Infra/secrets hardening from the 2026-06-21 audit dossier. Scope is limited to `scripts/`, `deploy/`, and `.github/` (relay/admin/frontend untouched — owned by other branches).

## Changes

1. **Backup script world-readable secrets** (`scripts/paramant-backup.sh` + the inline backup ExecStart in `scripts/paramant-cron.sh`): added `umask 077`; `chmod 700` on the backup base/run dirs; `chmod 600` + `chown root:paramant` on copied `keys.json` / `users.json` / `ct-log`. Previously these landed 0644, downgrading the source's 0600 and exposing relay signing keys and user records to any local non-root account. The cron unit now also backs up `keys.json` to match the interactive script.

2. **Dead Fly proxy blocks** (`deploy/nginx-paramant-live.conf`): removed the `/rp/fly/` location and the `:8090` Fly server block. They forwarded `X-Admin-Token` + `X-Api-Key` to `paramant-ghost-pipe.fly.dev` over TLS with no `proxy_ssl_verify`, had zero live callers, and were already removed from the CSP `connect-src`. Also removed the now-orphaned `/dicom/` gateway proxy whose only upstream was that `:8090` block; the `/dicom` info page (static HTML) stays. Replaced each with an explanatory comment.

3. **CSP hardening** (`deploy/nginx/snippets/paramant-security-headers.conf`): appended `frame-ancestors 'none'; base-uri 'self'; form-action 'self'`. Left `script-src 'unsafe-inline'` in place (the app still depends on ~64 inline handlers across ~14 HTML files) with a comment noting that externalizing inline JS is a separate, larger effort.

4. **CI clones unpinned paramant-core HEAD** (`.github/workflows/test.yml`): pinned the crypto byte-compat gate's clone to a fixed commit SHA (`45a3d3521adda7924692d58be5db60d5b094371f`, current origin/main of paramant-core) via `git clone --no-checkout` + `git checkout $SHA`, with a comment that it should be bumped deliberately.

5. **preflight curl|bash** (`deploy/preflight.sh`): the `curl get.docker.com | sh` now downloads to a temp file and executes after the existing operator confirmation, with failed-download handling. Comment notes SHA-pinning is not possible (vendor publishes no stable checksum).

6. **Setup/license file perms** (`scripts/paramant-setup.sh`): added `umask 077`; replaced the three bare `chmod 640` calls with a `secure_license_file` helper that does explicit `chown root:paramant && chmod 640`. Kept 640 (not 600) because the relay runs as user `paramant` and genuinely reads the license via group; the original 640-without-chown left the group bit inert. `/etc/paramant` is now `chown root:paramant`.

7. **IP-spoof rate-limit bypass — nginx side** (`deploy/nginx-paramant-live.conf`): every relay/admin `proxy_pass` now sets `X-Real-IP $remote_addr` and clears `CF-Connecting-IP ""`, so a spoofed client `CF-Connecting-IP`/`X-Real-IP` can no longer defeat the relay's per-IP rate limits. Applied consistently across all sector vhosts (health/legal/finance/iot/main relay) and the `/rp/*` admin + `/api/*` proxy blocks. (Relay-side `TRUST_PROXY` gating is handled separately.)

## Validation
- `bash -n` passes on all four edited shell scripts.
- nginx config eyeballed: braces balanced (98/98), 6 server blocks (was 7), no remaining live `:8090`/`fly`/dicom-proxy references (comments only). `nginx -t` not run (nginx not installed in this env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)