### PR TITLE
fix(infra): backup perms, drop admin-token Fly proxy, CSP headers, CI pin, safe preflight

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,10 +51,16 @@ jobs:
       # byte-compatibility against the binding. Interim until publish.
       - name: Install liboqs build deps
         run: sudo apt-get update && sudo apt-get install -y cmake ninja-build clang libclang-dev
-      - name: Build @paramant/core (sibling checkout)
+      # Pin paramant-core to a fixed commit so the crypto byte-compat gate runs
+      # against a known revision, not a moving HEAD. Bump this SHA deliberately
+      # (and review the diff) when adopting a new paramant-core.
+      - name: Build @paramant/core (sibling checkout, pinned)
+        env:
+          PARAMANT_CORE_SHA: 45a3d3521adda7924692d58be5db60d5b094371f
         run: |
-          git clone --depth 1 https://github.com/Apolloccrypt/paramant-core.git "${GITHUB_WORKSPACE}/../paramant-core"
+          git clone --no-checkout https://github.com/Apolloccrypt/paramant-core.git "${GITHUB_WORKSPACE}/../paramant-core"
           cd "${GITHUB_WORKSPACE}/../paramant-core"
+          git checkout "${PARAMANT_CORE_SHA}"
           rustup show
           cargo build -p paramant-core-node --release
           cp target/release/libparamant_core_node.so crates/paramant-core-node/index.node

--- a/deploy/nginx-paramant-live.conf
+++ b/deploy/nginx-paramant-live.conf
@@ -215,15 +215,13 @@ location = /users.json { deny all; return 404; }    location ~ /.env { deny all;
         proxy_set_header X-Api-Key $http_x_api_key;
         proxy_set_header X-Admin-Token $http_x_admin_token;
     }
-    location /rp/fly/ {
-        resolver 8.8.8.8 valid=300s ipv6=off;
-        set $fly_host paramant-ghost-pipe.fly.dev;
-        proxy_pass https://$fly_host/;
-        proxy_ssl_server_name on;
-        proxy_set_header Host $fly_host;
-        proxy_set_header X-Api-Key $http_x_api_key;
-        proxy_set_header X-Admin-Token $http_x_admin_token;
-    }
+    # Removed (sec/infra-hardening): the /rp/fly/ block forwarded X-Admin-Token +
+    # X-Api-Key to paramant-ghost-pipe.fly.dev over an UNVERIFIED TLS connection
+    # (no proxy_ssl_verify) resolving via public DNS — an on-path/DNS-poison
+    # attacker could harvest the admin token. It had no live callers (already gone
+    # from CSP connect-src). The :8090 Fly server block and /dicom/ gateway are
+    # left in place pending an operator decision (the /dicom/ upstream still
+    # responds, so "dead" is not confirmed — see audit dossier).
 
 
 }

--- a/deploy/nginx/snippets/paramant-security-headers.conf
+++ b/deploy/nginx/snippets/paramant-security-headers.conf
@@ -16,4 +16,9 @@ add_header Referrer-Policy "no-referrer" always;
 # camera=(self) required for the QR scanner
 add_header Permissions-Policy "geolocation=(), microphone=(), camera=(self)" always;
 # CSP: libs are vendored locally (no esm.sh / cdnjs); ghost-pipe.fly.dev & ipapi.co removed.
-add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://relay.paramant.app wss://relay.paramant.app https://health.paramant.app wss://health.paramant.app https://legal.paramant.app wss://legal.paramant.app https://finance.paramant.app wss://finance.paramant.app https://iot.paramant.app wss://iot.paramant.app; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:" always;
+# NOTE: script-src still carries 'unsafe-inline' because the app depends on inline
+# scripts/handlers (~14 HTML files, ~64 onclick). Removing it requires externalizing
+# all inline JS to /js/*.js (or nonce/hash) first — a separate, larger effort. Left
+# in place deliberately; the additions below (frame-ancestors/base-uri/form-action)
+# tighten clickjacking, <base> hijack and form-target without touching script-src.
+add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://relay.paramant.app wss://relay.paramant.app https://health.paramant.app wss://health.paramant.app https://legal.paramant.app wss://legal.paramant.app https://finance.paramant.app wss://finance.paramant.app https://iot.paramant.app wss://iot.paramant.app; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;

--- a/deploy/preflight.sh
+++ b/deploy/preflight.sh
@@ -37,8 +37,21 @@ if ! command -v docker &>/dev/null; then
     echo -e "${RED}✗  Docker not found${NC}"; echo ""
     read -p "   Install Docker now? [y/N]: " install_docker
     if [[ "$install_docker" =~ ^[Yy]$ ]]; then
-        echo "   Installing Docker..."; curl -fsSL https://get.docker.com | sh; sudo usermod -aG docker $USER
-        echo -e "${GREEN}✓  Docker installed — you may need to log out and back in${NC}"
+        # Download the vendor install script to a temp file first, then execute
+        # it (after the operator confirmation above) instead of piping the
+        # network stream straight into a shell. This makes the fetched script
+        # inspectable and avoids partial-download execution. (Ideally pin a
+        # SHA256 here too, but get.docker.com publishes no stable checksum.)
+        echo "   Installing Docker..."
+        DOCKER_INSTALL_SH=$(mktemp /tmp/get-docker.XXXXXX.sh)
+        if curl -fsSL https://get.docker.com -o "$DOCKER_INSTALL_SH"; then
+            sh "$DOCKER_INSTALL_SH"; rm -f "$DOCKER_INSTALL_SH"
+            sudo usermod -aG docker $USER
+            echo -e "${GREEN}✓  Docker installed — you may need to log out and back in${NC}"
+        else
+            rm -f "$DOCKER_INSTALL_SH"
+            echo -e "${RED}   Failed to download the Docker install script. Install from https://docs.docker.com/get-docker/${NC}"; exit 1
+        fi
     else
         echo -e "${RED}   Docker is required. Install from https://docs.docker.com/get-docker/${NC}"; exit 1
     fi

--- a/scripts/paramant-backup.sh
+++ b/scripts/paramant-backup.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # paramant-backup — backup relay keys and CT log
 
+# Secrets hardening: backups contain keys.json (relay signing keys) and
+# users.json. Restrict everything this script creates to root only so a local
+# non-root account can never read the crown jewels (source files are 0600).
+umask 077
+
 BACKUP_BASE="/var/lib/paramant-backup"
 GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'
 CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
@@ -10,7 +15,9 @@ echo "────────────────────────�
 
 TIMESTAMP=$(date '+%Y%m%d-%H%M%S')
 DEST="${BACKUP_BASE}/${TIMESTAMP}"
-mkdir -p "$DEST"
+mkdir -p "$BACKUP_BASE" "$DEST"
+chmod 700 "$BACKUP_BASE" "$DEST"
+chown root:paramant "$BACKUP_BASE" "$DEST" 2>/dev/null || true
 
 EXPORTED=0
 
@@ -18,11 +25,14 @@ for dir in /var/lib/paramant-relay /var/lib/paramant-relay-*; do
   [[ -d "$dir" ]] || continue
   name=$(basename "$dir")
   mkdir -p "${DEST}/${name}"
+  chmod 700 "${DEST}/${name}"
 
   for f in users.json ct-log ct_log keys.json; do
     SRC="${dir}/${f}"
     if [[ -f "$SRC" ]]; then
       cp "$SRC" "${DEST}/${name}/"
+      chmod 600 "${DEST}/${name}/${f}"
+      chown root:paramant "${DEST}/${name}/${f}" 2>/dev/null || true
       SIZE=$(du -sh "$SRC" | cut -f1)
       echo -e "  ${GREEN}✓${RESET}  ${name}/${f}  (${SIZE})"
       EXPORTED=$((EXPORTED+1))

--- a/scripts/paramant-cron.sh
+++ b/scripts/paramant-cron.sh
@@ -77,15 +77,22 @@ After=network.target
 Type=oneshot
 User=root
 ExecStart=/bin/bash -c '\
+  umask 077; \
   TS=$(date +%%Y%%m%%d-%%H%%M%%S); \
   DEST=/var/lib/paramant-backup/${TS}; \
-  mkdir -p "$DEST"; \
+  mkdir -p /var/lib/paramant-backup "$DEST"; \
+  chmod 700 /var/lib/paramant-backup "$DEST"; \
+  chown root:paramant /var/lib/paramant-backup "$DEST" 2>/dev/null || true; \
   for d in /var/lib/paramant-relay /var/lib/paramant-relay-*; do \
     [ -d "$d" ] || continue; \
     name=$(basename "$d"); \
     mkdir -p "$DEST/$name"; \
+    chmod 700 "$DEST/$name"; \
     cp "$d"/users.json "$DEST/$name/" 2>/dev/null || true; \
     cp "$d"/ct-log     "$DEST/$name/" 2>/dev/null || true; \
+    cp "$d"/keys.json  "$DEST/$name/" 2>/dev/null || true; \
+    chmod 600 "$DEST/$name"/* 2>/dev/null || true; \
+    chown root:paramant "$DEST/$name"/* 2>/dev/null || true; \
   done; \
   echo "Backup complete: $DEST"; \
   find /var/lib/paramant-backup -maxdepth 1 -type d -mtime +30 -exec rm -rf {} + 2>/dev/null || true'

--- a/scripts/paramant-setup.sh
+++ b/scripts/paramant-setup.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Secrets hardening: the license file holds PLK_KEY and ADMIN_TOKEN. Default
+# every file this script creates to owner-only, then widen explicitly where the
+# relay (running as user `paramant`) genuinely needs group-read.
+umask 077
+
 SETUP_DONE_FILE="/etc/paramant/.setup-done"
 LICENSE_FILE="/etc/paramant/license"
+
+# Apply correct owner/perms to the license file in one place. The relay service
+# runs as `paramant` and reads this file, so it needs group-read: root:paramant
+# + 0640 (NOT a bare 640, whose group bit is inert when the group is root).
+secure_license_file() {
+  chown root:paramant "$LICENSE_FILE" 2>/dev/null || true
+  chmod 640 "$LICENSE_FILE"
+}
 
 # ── Colour helpers ─────────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
@@ -126,12 +139,13 @@ else
 fi
 
 mkdir -p /etc/paramant
+chown root:paramant /etc/paramant 2>/dev/null || true
 chmod 750 /etc/paramant
 
 if [[ -n "$PLK_KEY" ]]; then
   if [[ "$PLK_KEY" == plk_* ]]; then
     printf 'PLK_KEY=%s\nADMIN_TOKEN=%s\n' "$PLK_KEY" "$ADMIN_TOKEN" > "$LICENSE_FILE"
-    chmod 640 "$LICENSE_FILE"
+    secure_license_file
     sudo paramant-relay-ctl restart paramant-relay 2>/dev/null || true
     sleep 2
     EDITION=$(curl -sf http://localhost:3000/health 2>/dev/null | jq -r '.edition // "unknown"' 2>/dev/null || echo "unknown")
@@ -141,7 +155,7 @@ if [[ -n "$PLK_KEY" ]]; then
     if [[ -n "$ADMIN_TOKEN" ]]; then
       printf 'ADMIN_TOKEN=%s\n' "$ADMIN_TOKEN" > "$LICENSE_FILE"
       [[ -n "$CURRENT_KEY" ]] && printf 'PLK_KEY=%s\n' "$CURRENT_KEY" >> "$LICENSE_FILE"
-      chmod 640 "$LICENSE_FILE"
+      secure_license_file
     fi
   fi
 else
@@ -152,7 +166,7 @@ else
     else
       printf 'ADMIN_TOKEN=%s\n' "$ADMIN_TOKEN" > "$LICENSE_FILE"
     fi
-    chmod 640 "$LICENSE_FILE"
+    secure_license_file
   fi
   info "No license key — running Community Edition (max 5 keys)."
 fi


### PR DESCRIPTION
Safe subset of the infra audit findings. Backup file perms (no more world-readable keys.json/users.json), removed the /rp/fly/ block that forwarded the admin token over unverified TLS, CSP frame-ancestors/base-uri/form-action, paramant-core CI SHA pin, download-then-exec preflight.

**Held for operator decision** (supersedes the auto-generated PR #234): nginx client-IP normalization (a Caddy edge fronts nginx, so blind `X-Real-IP $remote_addr` would collapse all client IPs into one rate-limit bucket — needs `set_real_ip_from` the edge) and the /dicom/+:8090 removal (the live /dicom/ still responds, so 'dead' is unconfirmed). Closing #234 in favor of this.

Infra/config → takes effect only on deploy (held for go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)