### PR TITLE
fix(frontend): XSS/encoding sweep, secret zeroization, a11y + SSE single-poll

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -247,9 +247,9 @@
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -266,6 +266,6 @@
     </div>
   </div>
 </footer>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -455,7 +455,7 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
 </main>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script>
 (function() {
   function show(id) {
@@ -487,9 +487,17 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
       (data.sessions || []).forEach(function(s) {
         const el = document.createElement('div');
         el.className = 'info-row';
-        el.innerHTML =
-          '<div class="info-label">' + s.ip_masked + (s.current ? ' (this session)' : '') + '</div>' +
-          '<div class="info-value">' + s.user_agent_short + ' &middot; last seen ' + new Date(s.last_seen).toLocaleString() + '</div>';
+        // user_agent_short (and ip_masked) are attacker-controllable at login,
+        // so build the nodes with textContent rather than innerHTML to avoid
+        // self/stored DOM XSS.
+        const labelEl = document.createElement('div');
+        labelEl.className = 'info-label';
+        labelEl.textContent = (s.ip_masked || '') + (s.current ? ' (this session)' : '');
+        const valueEl = document.createElement('div');
+        valueEl.className = 'info-value';
+        valueEl.textContent = (s.user_agent_short || '') + ' · last seen ' + new Date(s.last_seen).toLocaleString();
+        el.appendChild(labelEl);
+        el.appendChild(valueEl);
         sessionsList.appendChild(el);
       });
 
@@ -669,7 +677,7 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
 </script>
 
 <script type="module">
-import { vaultAvailable, vaultList } from '/vendor/vault.js?v=4';
+import { vaultAvailable, vaultList } from '/vendor/vault.js?v=5';
 
 const escHtml = s => String(s == null ? '' : s)
   .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
@@ -779,7 +787,7 @@ loadVaultStatus();
 document.addEventListener('signing-key-enrolled', () => { loadEnrolledKeys(); loadVaultStatus(); });
 </script>
 <script type="module" src="/js/passkey.js?v=3"></script>
-<script type="module" src="/js/signing-enrol.js?v=13"></script>
+<script type="module" src="/js/signing-enrol.js?v=14"></script>
 
 </body>
 </html>

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -834,9 +834,9 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -855,6 +855,6 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -335,9 +335,9 @@ section p+p{margin-top:14px}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -355,6 +355,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -207,7 +207,7 @@
 </main>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script>
 (function() {
   const form = document.getElementById('backup-form');

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -235,7 +235,7 @@
 </main>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script>
 (function() {
   const form = document.getElementById('login-form');

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -187,7 +187,7 @@
 
 <script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script>
 (function() {
   const form = document.getElementById('reset-form');

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -209,7 +209,7 @@
 </main>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script>
 (function() {
   const token = window.location.pathname.split('/').pop();

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -379,7 +379,7 @@
 </main>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script>
 (function() {
   const token = window.location.pathname.split('/').pop();

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -408,9 +408,9 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -439,5 +439,5 @@ async function demoKeygen(){
 }
 </script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body></html>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -374,9 +374,9 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -395,6 +395,6 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -195,6 +195,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 </main>
 
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
-<script type="module" src="/co-sign.js?v=12"></script>
+<script type="module" src="/co-sign.js?v=13"></script>
 </body>
 </html>

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -18,7 +18,7 @@
 // the view receipt. The signing path itself is same-origin via the admin
 // (/api/user/sign/*), bound to the logged-in invitee session.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolEphemeralSigningKeyWithTotp } from '/js/parasign-signer.js?v=11';
+import { LocalVaultSigner, buildDocSignMessage, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolEphemeralSigningKeyWithTotp } from '/js/parasign-signer.js?v=12';
 import { promptTotp } from '/js/totp-prompt.js?v=1';
 
 const RELAY_PUBLIC = 'https://health.paramant.app';
@@ -128,11 +128,16 @@ function renderEnvelope() {
     const row = document.createElement('div');
     row.className = 'party-row' + (p.index === __partyIndex ? ' me' : '');
     const label = escapeHtml(p.label || ('Party ' + (p.index + 1)));
-    const status = p.status === 'signed' ? 'SIGNED' : p.status === 'viewed' ? 'VIEWED' : 'PENDING';
+    // Allowlist the status to a known enum before putting it in the class attr
+    // (and the visible label) so a hostile relay value can't break out of the
+    // attribute. Unknown -> 'pending'.
+    const statusClass = (p.status === 'signed' || p.status === 'viewed') ? p.status : 'pending';
+    const statusText = statusClass === 'signed' ? 'SIGNED' : statusClass === 'viewed' ? 'VIEWED' : 'PENDING';
+    const idx = Number(p.index);
     row.innerHTML =
-      '<div class="party-idx">#' + p.index + '</div>' +
+      '<div class="party-idx">#' + (Number.isFinite(idx) ? idx : '') + '</div>' +
       '<div class="party-label">' + label + (p.index === __partyIndex ? ' (you)' : '') + '</div>' +
-      '<div class="party-status ' + (p.status || 'pending') + '">' + status + '</div>';
+      '<div class="party-status ' + statusClass + '">' + statusText + '</div>';
     list.appendChild(row);
   }
 

--- a/frontend/compliance/iec62443.html
+++ b/frontend/compliance/iec62443.html
@@ -637,9 +637,9 @@ Level 1  Field devices     ─────────────────�
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -657,6 +657,6 @@ Level 1  Field devices     ─────────────────�
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/compliance/nen7510.html
+++ b/frontend/compliance/nen7510.html
@@ -516,9 +516,9 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -536,6 +536,6 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/compliance/nis2.html
+++ b/frontend/compliance/nis2.html
@@ -516,9 +516,9 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -536,6 +536,6 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -675,9 +675,9 @@ FLAGS    1 byte    reserved for future features</pre>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -695,6 +695,6 @@ FLAGS    1 byte    reserved for future features</pre>
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -763,9 +763,9 @@ setInterval(load, 30000);
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -783,6 +783,6 @@ setInterval(load, 30000);
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -460,9 +460,9 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -481,7 +481,7 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script src="/js/dashboard.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -225,6 +225,6 @@ main.dev{max-width:1180px;margin:0 auto;padding:var(--space-5) var(--space-4) va
   </div>
 </div>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/developer.js?v=4" defer></script>
+<script src="/js/developer.js?v=5" defer></script>
 </body>
 </html>

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -571,7 +571,7 @@ paramant-receiver.py \
     </div>
     <div class="cta-links">
       <a href="mailto:privacy@paramant.app?subject=DICOM+access+request" class="btn-p">Request access &rarr;</a>
-      <a href="https://health.paramant.app" class="btn-s" target="_blank">Live relay &rarr;</a>
+      <a href="https://health.paramant.app" class="btn-s" target="_blank" rel="noopener">Live relay &rarr;</a>
     </div>
   </div>
 
@@ -613,9 +613,9 @@ paramant-receiver.py \
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -634,6 +634,6 @@ paramant-receiver.py \
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -757,7 +757,7 @@ paramant-stream --key pgp_xxx --sector health --forward https://pacs.hospital/ap
 
     <!-- ── ParamantOS CLI tools ───────────────────────────────────── -->
     <h2 id="paramant-os-tools">ParamantOS: 39 operator tools</h2>
-    <p><a href="https://github.com/Apolloccrypt/ParamantOS" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">ParamantOS</a> is a hardened Linux distribution (NixOS + Mint editions) for relay operators. All 39 tools are pre-installed.</p>
+    <p><a href="https://github.com/Apolloccrypt/ParamantOS" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)" rel="noopener">ParamantOS</a> is a hardened Linux distribution (NixOS + Mint editions) for relay operators. All 39 tools are pre-installed.</p>
     <table>
       <tr><th>Category</th><th>Command</th><th>What it does</th></tr>
       <tr><td rowspan="5" style="color:var(--ink-dim);font-size:11px;vertical-align:top;padding-top:12px">Setup &amp; diagnostics</td><td>paramant-setup</td><td>First-boot wizard: password, relay URL, API key</td></tr>
@@ -800,7 +800,7 @@ paramant-stream --key pgp_xxx --sector health --forward https://pacs.hospital/ap
       <tr><td>paramant-data-ctl</td><td>Privileged relay data-dir management</td></tr>
       <tr><td>paramant-cron</td><td>Manage systemd timers for relay maintenance</td></tr>
     </table>
-    <p>Download ParamantOS: <a href="https://github.com/Apolloccrypt/ParamantOS/releases" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">NixOS edition (v2.4.5)</a> · <a href="https://github.com/Apolloccrypt/ParamantOS/releases/tag/v1.0-mint" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">Mint edition (v1.0-β)</a></p>
+    <p>Download ParamantOS: <a href="https://github.com/Apolloccrypt/ParamantOS/releases" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)" rel="noopener">NixOS edition (v2.4.5)</a> · <a href="https://github.com/Apolloccrypt/ParamantOS/releases/tag/v1.0-mint" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)" rel="noopener">Mint edition (v1.0-β)</a></p>
 
     <!-- ── Crypto stack ─────────────────────────────────────────── -->
     <h2 id="crypto">Crypto stack</h2>
@@ -908,7 +908,7 @@ python3 scripts/paramant-admin.py sync</pre>
       <tr><td>Apr 2026</td><td>R. Zwarts (independent)</td><td>6 total (3H · 3M)</td><td>All resolved: 0db3ef0</td></tr>
       <tr><td>Apr 2026</td><td>Ryan Williams · Smart Cyber Solutions</td><td>4C · 5H · 6M · 5L</td><td>All resolved: 0db3ef0</td></tr>
     </table>
-    <p>All findings are publicly documented in <a href="https://github.com/Apolloccrypt/paramant-relay/blob/main/SECURITY.md" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">SECURITY.md</a>. To report a vulnerability: <a href="mailto:privacy@paramant.app" style="color:var(--cobalt)">privacy@paramant.app</a>.</p>
+    <p>All findings are publicly documented in <a href="https://github.com/Apolloccrypt/paramant-relay/blob/main/SECURITY.md" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)" rel="noopener">SECURITY.md</a>. To report a vulnerability: <a href="mailto:privacy@paramant.app" style="color:var(--cobalt)">privacy@paramant.app</a>.</p>
 
     <!-- ── Compliance ───────────────────────────────────────────── -->
     <h2 id="compliance-nis2">Compliance: NIS2 / DORA</h2>
@@ -996,7 +996,7 @@ python3 scripts/paramant-admin.py sync</pre>
 
     <div class="faq-item">
       <div class="faq-q">Is the source code auditable?</div>
-      <div class="faq-a">Yes. The full relay source is at <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" style="color:var(--cobalt)">github.com/Apolloccrypt/paramant-relay</a> under BUSL-1.1. Three independent security audits were conducted in April 2026: all findings are publicly documented in SECURITY.md. The relay binary checksum is verified on startup and logged to the CT log.</div>
+      <div class="faq-a">Yes. The full relay source is at <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" style="color:var(--cobalt)" rel="noopener">github.com/Apolloccrypt/paramant-relay</a> under BUSL-1.1. Three independent security audits were conducted in April 2026: all findings are publicly documented in SECURITY.md. The relay binary checksum is verified on startup and logged to the CT log.</div>
     </div>
 
     <div class="faq-item">
@@ -1022,7 +1022,7 @@ window.addEventListener('scroll', () => {
 }, { passive: true });
 </script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <footer>
   <div class="container-lg">
     <div class="footer-grid">
@@ -1059,9 +1059,9 @@ window.addEventListener('scroll', () => {
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -461,9 +461,9 @@ input:focus{border-color:var(--cobalt)}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -537,6 +537,6 @@ input:focus{border-color:var(--cobalt)}
 }());
 </script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -36,18 +36,6 @@ main{max-width:520px;margin:0 auto;padding:80px 24px}
 main:has(#step-preview.active){max-width:880px}
 #preview-canvas-list canvas{width:100%;height:auto;display:block;border:1px solid var(--ink-hair);margin-bottom:12px;background:#fff}
 .page-wrap{position:relative;margin-bottom:12px}
-.page-wrap.placing{cursor:crosshair}
-.stamp-marker{position:absolute;border:2px solid var(--cobalt);background:rgba(11,58,106,0.06);pointer-events:none;font-family:var(--mono);font-size:9px;color:var(--navy);padding:4px;box-sizing:border-box;line-height:1.25;overflow:hidden}
-.stamp-marker .sm-name{font-weight:700;font-size:10px}
-.stamp-marker .sm-meta{color:var(--ink-dim);font-size:8px}
-.stamp-marker .sm-pqtag{position:absolute;right:3px;bottom:2px;font-size:7px;letter-spacing:.08em;color:var(--cobalt)}
-.sign-toolbar{background:var(--bone-2);border:1px solid var(--ink-hair);padding:14px 16px;margin-bottom:12px;font-size:12px;color:var(--ink-dim)}
-.sign-toolbar .st-hint{font-family:var(--mono);font-size:11px;margin-bottom:6px}
-.sign-form{display:grid;gap:10px;margin-top:10px}
-.sign-form label{font-family:var(--mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-dim)}
-.sign-form input,.sign-form select{width:100%;padding:9px 10px;border:1px solid var(--ink-hair);background:var(--bone);color:var(--ink);font-family:var(--mono);font-size:12px}
-.disclaimer{background:#fff4d6;border:1px solid #d4a017;padding:10px 14px;font-size:12px;color:#5a3f00;margin-bottom:14px;line-height:1.5}
-.disclaimer strong{display:block;font-size:11px;letter-spacing:.06em;text-transform:uppercase;margin-bottom:4px;color:#7a5300}
 .btn-row{display:flex;gap:10px;flex-wrap:wrap}
 .btn-row .btn{flex:1;margin:0}
 h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
@@ -373,35 +361,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
     </div>
   </div>
 
-  <div class="sign-toolbar" id="sign-toolbar" hidden>
-    <div class="st-hint" id="sign-hint">Click on the page where you want to place your signature.</div>
-    <div class="sign-form" id="sign-form" hidden>
-      <div>
-        <label for="signer-name">Signer name</label>
-        <input type="text" id="signer-name" maxlength="80" autocomplete="name" placeholder="e.g. Mick Beer">
-      </div>
-      <div>
-        <label for="signer-key-src">Signing key</label>
-        <select id="signer-key-src">
-          <option value="ephemeral">Generate one-time key for this signature</option>
-        </select>
-      </div>
-      <div class="btn-row">
-        <button class="btn" id="sign-confirm" type="button">Sign and download</button>
-        <button class="btn btn-outline" id="sign-move" type="button">Move stamp</button>
-        <button class="btn btn-outline" id="sign-cancel" type="button">Cancel</button>
-      </div>
-    </div>
-  </div>
-
   <div id="preview-canvas-list" style="margin:16px 0"></div>
-
-  <div class="disclaimer" id="sign-disclaimer" hidden>
-    <strong>Post-quantum, zero-knowledge. Not eIDAS-qualified.</strong>
-    The signature uses ML-DSA-65 (FIPS 204) and is produced locally in your browser.
-    The relay never sees the document. This is a cryptographic attestation, not a
-    qualified electronic signature under eIDAS or a notarised legal instrument.
-  </div>
 
   <div style="margin-bottom:24px">
     <span class="tag green">Decrypted locally</span>
@@ -410,25 +370,10 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   </div>
 
   <div class="btn-row" id="preview-actions">
-    <button class="btn" id="preview-sign" type="button">Sign this document</button>
+    <a class="btn" href="/sign">Sign this document</a>
     <button class="btn btn-outline" id="preview-download" type="button">Download original PDF</button>
   </div>
   <a href="/dashboard" class="btn btn-outline" style="margin-top:12px">Open your dashboard</a>
-
-  <div class="card" id="sign-result" hidden style="margin-top:24px">
-    <div class="card-head"><div class="dot"></div><div class="card-head-title">Signed</div></div>
-    <div class="card-body">
-      <div class="file-name" id="sign-result-name"></div>
-      <div class="file-size" id="sign-result-meta"></div>
-      <div class="btn-row" style="margin-top:14px">
-        <button class="btn" id="sign-download-pdf" type="button">Download signed PDF</button>
-        <button class="btn btn-outline" id="sign-download-psign" type="button">Download .psign envelope</button>
-      </div>
-      <p class="sub" style="margin-top:12px;font-size:11px">
-        Recipients can verify the envelope at <a href="/verify">/verify</a>.
-      </p>
-    </div>
-  </div>
 </div>
 
 <!-- Burned / already used -->
@@ -489,9 +434,9 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -509,10 +454,8 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
-<script type="module" src="/vendor/parasign-bridge.js?v=2"></script>
-<script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script>
 const RELAY = 'https://health.paramant.app';
 
@@ -568,18 +511,10 @@ async function waitForPdfjs() {
   });
 }
 
-// Cache the decrypted PDF bytes + filename so the sign-mode can re-use them
-// without going back to the relay (which has burned its copy by now).
-let __pdfBytes = null;
-let __pdfFilename = '';
-
 async function renderPdfPreview(bytes, name) {
-  __pdfBytes = bytes;
-  __pdfFilename = name;
-
   const pdfjs = await waitForPdfjs();
   // PDF.js mutates the input buffer. Pass a copy so the original stays intact
-  // for the download-original and sign-stamp paths.
+  // for the download-original path.
   const copy = new Uint8Array(bytes);
   const pdf = await pdfjs.getDocument({ data: copy, disableAutoFetch: true, disableStream: true }).promise;
 
@@ -612,9 +547,6 @@ async function renderPdfPreview(bytes, name) {
 
   const dlBtn = document.getElementById('preview-download');
   dlBtn.onclick = () => downloadBytes(bytes, name, 'application/pdf');
-
-  const signBtn = document.getElementById('preview-sign');
-  if (signBtn) signBtn.onclick = enterSignMode;
 }
 
 function downloadBytes(bytes, name, mime) {
@@ -626,244 +558,6 @@ function downloadBytes(bytes, name, mime) {
   document.body.appendChild(a);
   a.click();
   setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 2000);
-}
-
-// ====================================================================
-// Sign-mode (Model 1: recipient signs the document they just received).
-// Zero-knowledge: relay never sees the document or the new signature.
-// ML-DSA-65 + SHA3-256 produced locally via /vendor/paramant-pqc.js.
-// ====================================================================
-
-const STAMP_PDF_W = 200;
-const STAMP_PDF_H = 70;
-
-let __stampState = null;     // { pageIndex, x, y, w, h } in PDF points
-let __signerKey  = null;     // { secretKey, publicKey } Uint8Arrays
-
-function toHex(u8) {
-  let s = '';
-  for (let i = 0; i < u8.length; i++) s += u8[i].toString(16).padStart(2, '0');
-  return s;
-}
-
-function toB64(u8) {
-  let s = '';
-  for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]);
-  return btoa(s);
-}
-
-async function waitForParasign() {
-  if (window.__parasign) return window.__parasign;
-  return new Promise((resolve, reject) => {
-    const t = setTimeout(() => reject(new Error('Signing library failed to load')), 10000);
-    window.addEventListener('parasign:ready', () => { clearTimeout(t); resolve(window.__parasign); }, { once: true });
-  });
-}
-
-async function waitForPdfLib() {
-  if (window.PDFLib) return window.PDFLib;
-  // pdf-lib is loaded with `defer` so it should be present after DOMContentLoaded.
-  return new Promise((resolve, reject) => {
-    const start = Date.now();
-    const tick = () => {
-      if (window.PDFLib) return resolve(window.PDFLib);
-      if (Date.now() - start > 10000) return reject(new Error('pdf-lib failed to load'));
-      setTimeout(tick, 50);
-    };
-    tick();
-  });
-}
-
-async function enterSignMode() {
-  document.getElementById('sign-toolbar').hidden = false;
-  document.getElementById('sign-disclaimer').hidden = false;
-  document.getElementById('sign-form').hidden = true;
-  document.getElementById('sign-hint').textContent = 'Click on the page where you want to place your signature.';
-  document.querySelectorAll('.page-wrap').forEach(wrap => {
-    wrap.classList.add('placing');
-    wrap.addEventListener('click', onPlaceClick);
-  });
-  document.getElementById('preview-actions').style.display = 'none';
-
-  // This quick-sign on a received file uses a one-time ephemeral key. Persistent
-  // signing keys are unlocked by your passkey at /sign (vault keys are no longer
-  // passphrase-unlockable, R018 v4), so they aren't offered as a source here.
-
-  document.getElementById('sign-cancel').onclick = exitSignMode;
-  document.getElementById('sign-move').onclick = () => {
-    clearStampMarker();
-    document.getElementById('sign-form').hidden = true;
-    document.getElementById('sign-hint').textContent = 'Click again to reposition the signature.';
-    document.querySelectorAll('.page-wrap').forEach(wrap => {
-      wrap.classList.add('placing');
-      wrap.addEventListener('click', onPlaceClick);
-    });
-  };
-  document.getElementById('sign-confirm').onclick = confirmSign;
-}
-
-function exitSignMode() {
-  document.getElementById('sign-toolbar').hidden = true;
-  document.getElementById('sign-disclaimer').hidden = true;
-  document.getElementById('preview-actions').style.display = '';
-  clearStampMarker();
-  document.querySelectorAll('.page-wrap').forEach(wrap => {
-    wrap.classList.remove('placing');
-    wrap.removeEventListener('click', onPlaceClick);
-  });
-  __stampState = null;
-}
-
-function clearStampMarker() {
-  document.querySelectorAll('.stamp-marker').forEach(el => el.remove());
-}
-
-function onPlaceClick(e) {
-  const wrap = e.currentTarget;
-  const canvas = wrap.querySelector('canvas');
-  const rect = canvas.getBoundingClientRect();
-  const ratio = wrap._pdfPage.width / rect.width;   // pdf-points per displayed pixel
-  const pxX = e.clientX - rect.left;
-  const pxY = e.clientY - rect.top;
-  const stampPxW = STAMP_PDF_W / ratio;
-  const stampPxH = STAMP_PDF_H / ratio;
-  const left = Math.max(0, Math.min(rect.width  - stampPxW, pxX - stampPxW / 2));
-  const top  = Math.max(0, Math.min(rect.height - stampPxH, pxY - stampPxH / 2));
-  const pdfX = left * ratio;
-  const pdfYTop = top * ratio;
-  // pdf-lib uses bottom-left origin in PDF points.
-  const pdfYBottom = wrap._pdfPage.height - pdfYTop - STAMP_PDF_H;
-  __stampState = {
-    pageIndex: wrap._pdfPage.index,
-    x: pdfX, y: pdfYBottom, w: STAMP_PDF_W, h: STAMP_PDF_H
-  };
-  clearStampMarker();
-  renderStampMarker(wrap, left, top, stampPxW, stampPxH);
-  // Stop placing-mode until the user clicks Move.
-  document.querySelectorAll('.page-wrap').forEach(w => {
-    w.classList.remove('placing');
-    w.removeEventListener('click', onPlaceClick);
-  });
-  document.getElementById('sign-form').hidden = false;
-  document.getElementById('sign-hint').textContent = 'Signature position selected on page ' + (wrap._pdfPage.index + 1) + '. Fill in your name and confirm.';
-}
-
-function renderStampMarker(wrap, left, top, w, h) {
-  const m = document.createElement('div');
-  m.className = 'stamp-marker';
-  m.style.left = left + 'px';
-  m.style.top  = top  + 'px';
-  m.style.width  = w + 'px';
-  m.style.height = h + 'px';
-  const name = (document.getElementById('signer-name').value || 'Signer').slice(0, 40);
-  m.innerHTML =
-    '<div class="sm-name">Signed by ' + escapeHtml(name) + '</div>' +
-    '<div class="sm-meta">' + new Date().toISOString().slice(0, 10) + '</div>' +
-    '<div class="sm-meta">PQ key: pending</div>' +
-    '<div class="sm-pqtag">PARAMANT - PQ</div>';
-  wrap.appendChild(m);
-}
-
-function escapeHtml(s) {
-  return s.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
-}
-
-async function ensureSignerKey() {
-  const sel = document.getElementById('signer-key-src').value;
-  const p = await waitForParasign();
-  if (sel === 'ephemeral') {
-    const seed = crypto.getRandomValues(new Uint8Array(32));
-    const kp = p.ml_dsa65.keygen(seed);
-    __signerKey = { secretKey: kp.secretKey, publicKey: kp.publicKey };
-    return __signerKey;
-  }
-  throw new Error('Unsupported key source');
-}
-
-async function buildStampedPdf(origBytes, stamp, signerName, dateStr, fingerprint8) {
-  const PDFLib = await waitForPdfLib();
-  const pdfDoc = await PDFLib.PDFDocument.load(origBytes);
-  const page = pdfDoc.getPages()[stamp.pageIndex];
-  const font = await pdfDoc.embedFont(PDFLib.StandardFonts.Helvetica);
-  const fontBold = await pdfDoc.embedFont(PDFLib.StandardFonts.HelveticaBold);
-  const navy = PDFLib.rgb(0.043, 0.227, 0.416);
-  const dim  = PDFLib.rgb(0.3, 0.3, 0.3);
-
-  page.drawRectangle({
-    x: stamp.x, y: stamp.y, width: stamp.w, height: stamp.h,
-    borderColor: navy, borderWidth: 1.2,
-    color: navy, opacity: 0.04
-  });
-  const padding = 6;
-  let yCursor = stamp.y + stamp.h - padding - 8;
-  page.drawText('Signed by ' + signerName, { x: stamp.x + padding, y: yCursor, size: 9, font: fontBold, color: navy });
-  yCursor -= 12;
-  page.drawText(dateStr, { x: stamp.x + padding, y: yCursor, size: 7, font, color: dim });
-  yCursor -= 10;
-  page.drawText('PQ key: ' + fingerprint8, { x: stamp.x + padding, y: yCursor, size: 7, font, color: dim });
-  page.drawText('PARAMANT - PQ', { x: stamp.x + stamp.w - 66, y: stamp.y + 4, size: 6, font: fontBold, color: navy });
-
-  return await pdfDoc.save();
-}
-
-async function confirmSign() {
-  if (!__stampState) return;
-  const name = (document.getElementById('signer-name').value || '').trim();
-  if (!name) { document.getElementById('sign-hint').textContent = 'Please enter your name.'; return; }
-
-  document.getElementById('sign-hint').textContent = 'Signing in browser (ML-DSA-65)...';
-  document.getElementById('sign-confirm').disabled = true;
-
-  try {
-    const p = await waitForParasign();
-    const key = await ensureSignerKey();
-    const fingerprint = toHex(p.sha3_256(key.publicKey)).slice(0, 16);
-    const dateStr = new Date().toISOString().slice(0, 19) + 'Z';
-
-    const stampedPdfBytes = await buildStampedPdf(__pdfBytes, __stampState, name, dateStr, fingerprint);
-    const origHash = p.sha3_256(__pdfBytes);
-    const stampedHash = p.sha3_256(stampedPdfBytes);
-
-    const coords = { pageIndex: __stampState.pageIndex, x: __stampState.x, y: __stampState.y, w: __stampState.w, h: __stampState.h, name, date: dateStr };
-    const coordsBytes = new TextEncoder().encode(JSON.stringify(coords));
-
-    const msg = new Uint8Array(origHash.length + stampedHash.length + coordsBytes.length);
-    msg.set(origHash, 0);
-    msg.set(stampedHash, origHash.length);
-    msg.set(coordsBytes, origHash.length + stampedHash.length);
-
-    const signature = p.ml_dsa65.sign(key.secretKey, msg);
-
-    const envelope = {
-      version: 'parasign-visual-1',
-      algorithm: 'ML-DSA-65',
-      hash_algorithm: 'SHA3-256',
-      original_filename: __pdfFilename,
-      stamped_filename: 'signed-' + __pdfFilename,
-      original_hash: toHex(origHash),
-      stamped_hash: toHex(stampedHash),
-      coords,
-      signer_public_key: toB64(key.publicKey),
-      signer_pk_fingerprint: fingerprint,
-      signature: toB64(signature),
-      signed_at: dateStr,
-      disclaimer: 'Post-quantum, zero-knowledge. Not eIDAS-qualified.'
-    };
-
-    const stampedName = 'signed-' + __pdfFilename;
-    const psignName = stampedName.replace(/\.pdf$/i, '') + '.psign';
-
-    document.getElementById('sign-result').hidden = false;
-    document.getElementById('sign-result-name').textContent = stampedName;
-    document.getElementById('sign-result-meta').textContent = formatSize(stampedPdfBytes.length) + ' - ML-DSA-65 - fingerprint ' + fingerprint;
-    document.getElementById('sign-download-pdf').onclick = () => downloadBytes(stampedPdfBytes, stampedName, 'application/pdf');
-    document.getElementById('sign-download-psign').onclick = () => downloadBytes(new TextEncoder().encode(JSON.stringify(envelope, null, 2)), psignName, 'application/json');
-
-    document.getElementById('sign-hint').textContent = 'Signed. Download the stamped PDF and the .psign envelope below.';
-  } catch (e) {
-    document.getElementById('sign-hint').textContent = 'Signing failed: ' + (e.message || e);
-    document.getElementById('sign-confirm').disabled = false;
-  }
 }
 
 function goReceive() {

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -623,9 +623,9 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -644,6 +644,6 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -338,9 +338,9 @@ section p+p{margin-top:14px}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -358,6 +358,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -426,9 +426,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -447,6 +447,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -360,9 +360,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -381,6 +381,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -461,9 +461,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -482,6 +482,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -433,9 +433,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -454,6 +454,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -467,9 +467,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -488,6 +488,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -386,9 +386,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -407,6 +407,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -448,9 +448,9 @@ print(resp.json()["url"])</div>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -469,6 +469,6 @@ print(resp.json()["url"])</div>
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -419,9 +419,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -440,6 +440,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -455,9 +455,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -476,6 +476,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -421,9 +421,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -442,6 +442,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -524,9 +524,9 @@ section p+p{margin-top:14px}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -544,6 +544,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -487,9 +487,9 @@
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -507,7 +507,7 @@
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script src="/js/home-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/js/developer.js
+++ b/frontend/js/developer.js
@@ -44,6 +44,18 @@
     return typeof u === 'string' && u.charAt(0) === '/' && u.indexOf('//') === -1 &&
            u.indexOf(':') === -1 && /^[A-Za-z0-9/_.?=&#-]+$/.test(u);
   }
+  // A tool's "source" URL comes from the server-rendered tools list. Only treat
+  // it as a link if it's an http(s) URL (or a same-origin root-relative path);
+  // anything else (javascript:, data:, ...) becomes '#' so it can't execute.
+  function safeSourceUrl(u) {
+    var s = String(u == null ? '' : u).trim();
+    if (/^\/(?!\/)/.test(s)) { return s; }
+    try {
+      var url = new URL(s, location.origin);
+      if (url.protocol === 'http:' || url.protocol === 'https:') { return url.href; }
+    } catch (e) { /* not parseable */ }
+    return '#';
+  }
   // Per-user (per-browser) tool config: remembers your edited command per tool.
   // localStorage only -- no server, no new attack surface. Holds non-sensitive
   // params (bucket, recipient); never the key (the command uses $PARAMANT_API_KEY).
@@ -118,7 +130,7 @@
         '<div class="tool-actions">' +
           runBtn +
           '<button class="dev-btn dev-btn-go" data-config="' + esc(t.name) + '">Configure</button>' +
-          '<a class="dev-link" href="' + esc(t.source) + '" target="_blank" rel="noopener">View source ↗</a>' +
+          '<a class="dev-link" href="' + esc(safeSourceUrl(t.source)) + '" target="_blank" rel="noopener">View source ↗</a>' +
         '</div></div>';
     }).join('');
   }
@@ -175,28 +187,33 @@
 
   function refreshSnapshot() { return getJSON('/api/user/developer/snapshot').then(applySnapshot); }
 
-  /* SSE with polling fallback */
-  var lastPing = 0, pollTimer = null, es = null;
-  function startPolling() {
-    if (pollTimer) return;
-    heartbeat('poll');
-    pollTimer = setInterval(function () { refreshSnapshot().then(function () { heartbeat('poll'); }).catch(function () { heartbeat('down'); }); }, 5000);
-  }
-  function stopPolling() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
+  /* SSE with polling fallback.
+   * ONE shared 5s snapshot poll runs for the whole page: it keeps the quota
+   * fresh even while SSE is up, and IS the fallback when SSE drops. We never
+   * spin up a second poll loop, so the dashboard polls /snapshot at most once
+   * per interval (previously startPolling()'s timer + the quota timer both ran,
+   * double-polling during the fallback). The heartbeat is gated on SSE health:
+   * if SSE has pinged within the window we show 'up', otherwise 'poll'. */
+  var lastPing = 0, es = null;
+  var SSE_STALE_MS = 8000;
+  function sseHealthy() { return !!es && (Date.now() - lastPing) <= SSE_STALE_MS; }
   function connectSSE() {
-    if (!window.EventSource) { startPolling(); return; }
-    try { es = new EventSource('/api/user/developer/stream'); } catch (e) { startPolling(); return; }
-    es.addEventListener('hello', function () { lastPing = Date.now(); heartbeat('up'); stopPolling(); });
+    if (!window.EventSource) { heartbeat('poll'); return; }
+    try { es = new EventSource('/api/user/developer/stream'); } catch (e) { es = null; heartbeat('poll'); return; }
+    es.addEventListener('hello', function () { lastPing = Date.now(); heartbeat('up'); });
     es.addEventListener('ping', function () { lastPing = Date.now(); heartbeat('up'); });
     es.addEventListener('audit', function (m) {
       try { var ev = JSON.parse(m.data); pushFeed(ev, true); STATE.status = STATE.status || {}; renderTimeline([ev].concat(STATE.feed.slice(1))); } catch (e) {}
     });
-    es.onerror = function () { heartbeat('poll'); startPolling(); };
+    es.onerror = function () { heartbeat('poll'); };
   }
-  // quota stays fresh even over SSE: light snapshot poll every 5s
-  setInterval(function () { refreshSnapshot().catch(function () {}); }, 5000);
-  // watchdog: if no ping for 8s, mark polling
-  setInterval(function () { if (es && Date.now() - lastPing > 8000) { heartbeat('poll'); startPolling(); } }, 4000);
+  // Single shared timer: refresh the snapshot every 5s and set the heartbeat
+  // from SSE health (so the live audit stream stays primary, polling backstops).
+  setInterval(function () {
+    refreshSnapshot()
+      .then(function () { heartbeat(sseHealthy() ? 'up' : 'poll'); })
+      .catch(function () { heartbeat('down'); });
+  }, 5000);
 
   /* filter */
   var fi = $('#tl-filter'); if (fi) fi.addEventListener('input', function () { STATE.filter = fi.value; getJSON('/api/user/developer/snapshot').then(function (d) { renderTimeline(d.audit || []); }).catch(function () {}); });
@@ -229,7 +246,7 @@
     runEl.setAttribute('data-default', def);
     modal.setAttribute('data-tool', t.name);
     var savedNote = modal.querySelector('[data-m="saved"]'); if (savedNote) savedNote.hidden = (saved == null);
-    modal.querySelector('[data-m="source"]').setAttribute('href', t.source || '#');
+    modal.querySelector('[data-m="source"]').setAttribute('href', safeSourceUrl(t.source));
     var bf = browserFlow(t.category), rib = modal.querySelector('[data-m="browser"]');
     if (rib) { if (bf) { rib.hidden = false; rib.setAttribute('href', bf.url); rib.textContent = '▶ ' + bf.label + ' →'; } else { rib.hidden = true; } }
     modal.hidden = false;

--- a/frontend/js/nav-auth.js
+++ b/frontend/js/nav-auth.js
@@ -10,10 +10,13 @@
 
   function renderLoggedIn(email) {
     var shortEmail = email.length > 24 ? email.slice(0, 18) + '...' : email;
+    // Never interpolate the email into innerHTML (stored/self DOM XSS): the
+    // signup regex permits HTML metacharacters. Build static markup, then set
+    // the email via textContent (mirrors home-auth.js / dashboard.js).
     container.innerHTML =
       '<div class="nav-user">' +
         '<button type="button" class="nav-user-trigger" aria-expanded="false">' +
-          '<span class="nav-user-email">' + shortEmail + '</span>' +
+          '<span class="nav-user-email"></span>' +
           '<span class="nav-user-chevron">\u25be</span>' +
         '</button>' +
         '<div class="nav-user-menu" hidden>' +
@@ -28,6 +31,8 @@
     var trigger = container.querySelector('.nav-user-trigger');
     var menu    = container.querySelector('.nav-user-menu');
     var signout = container.querySelector('#nav-signout');
+    var emailEl = container.querySelector('.nav-user-email');
+    if (emailEl) emailEl.textContent = shortEmail;
 
     trigger.addEventListener('click', function(e) {
       e.stopPropagation();

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -5,7 +5,7 @@
 // Tomorrow a RemoteSamSigner (SAP -> HSM-backed SAM) drops in behind the same
 // interface without touching callers. Self-hosted deps only (CSP 'self').
 import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
-import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultAddPrfWrap, vaultCreatePrfOnly, vaultAvailable, vaultList } from '/vendor/vault.js?v=4';
+import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultAddPrfWrap, vaultCreatePrfOnly, vaultAvailable, vaultList } from '/vendor/vault.js?v=5';
 
 // Byte-identical to relay/envelope.js SIGN_DOMAIN_DOC (recipe v3). Keep in sync
 // across relay + SDK + core.
@@ -223,6 +223,7 @@ export async function ensureSigningKey({ rpId, label, onStatus } = {}) {
   // 1) ML-DSA-65 keypair, generated + held only in the browser.
   const seed = crypto.getRandomValues(new Uint8Array(32));
   const kp = ml_dsa65.keygen(seed);
+  seed.fill(0);   // the keypair is derived; the seed is key material, zeroize it
   const pk_b64 = b64EncodeStd(kp.publicKey);
   const pk_hash = toHex(sha3_256(kp.publicKey));
   try {
@@ -340,6 +341,7 @@ export async function enrolEphemeralSigningKeyWithTotp({ label, totp, onStatus }
   // secret transfers to the returned ActivatedSigner, which zeroizes on dispose().
   const seed = crypto.getRandomValues(new Uint8Array(32));
   const kp = ml_dsa65.keygen(seed);
+  seed.fill(0);   // the keypair is derived; the seed is key material, zeroize it
   const pk_b64 = b64EncodeStd(kp.publicKey);
   const pk_hash = toHex(sha3_256(kp.publicKey));
 

--- a/frontend/js/signing-enrol.js
+++ b/frontend/js/signing-enrol.js
@@ -7,7 +7,7 @@
 // (parasign-signer.js) — the EXACT path /sign and /co-sign use — so this file
 // just wires the button + status and can never drift from the sign flow.
 // Self-hosted deps only (CSP script-src 'self'); no-ops if the button is absent.
-import { ensureSigningKey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=11';
+import { ensureSigningKey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=12';
 
 function wireSigningEnrol() {
   const btn = document.getElementById('signing-enrol-btn');

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -325,9 +325,9 @@ section p+p{margin-top:14px}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -345,6 +345,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -372,9 +372,9 @@ Website: https://paramant.app</div>
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -393,6 +393,6 @@ Website: https://paramant.app</div>
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -326,9 +326,9 @@ section p+p{margin-top:14px}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -346,6 +346,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -400,9 +400,9 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -786,6 +786,6 @@ window.addEventListener('mlkem-ready', () => {
 });
 </script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/ot-vs-data-diodes.html
+++ b/frontend/ot-vs-data-diodes.html
@@ -576,7 +576,7 @@
 </section>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 
 <footer>
   <div class="container-lg">
@@ -614,9 +614,9 @@
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -531,9 +531,9 @@ Level 1  Field devices  ──────────────────�
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -551,6 +551,6 @@ Level 1  Field devices  ──────────────────�
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/pararules.html
+++ b/frontend/pararules.html
@@ -370,9 +370,9 @@ footer a{color:var(--ink);text-decoration:none}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -391,6 +391,6 @@ footer a{color:var(--ink);text-decoration:none}
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -1487,7 +1487,7 @@ function updateGlobeTransfer(userLat, userLng) {
 }
 </script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <footer style="border-top:1px solid var(--ink-hair);padding:var(--space-12) var(--space-8);position:relative;z-index:10">
   <div class="footer-grid">
     <div>
@@ -1509,9 +1509,9 @@ function updateGlobeTransfer(userLat, userLng) {
     <div>
       <div class="footer-col-label">Self-host</div>
       <div class="footer-links">
-        <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-        <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
-        <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
+        <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
+        <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
         <a href="/docs#self-hosting">Deploy guide</a>
         <a href="/setup">Relay setup wizard</a>
         <a href="/install.sh">install.sh</a>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -291,9 +291,9 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -311,6 +311,6 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -427,9 +427,9 @@ td{color:var(--cobalt)}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -448,6 +448,6 @@ td{color:var(--cobalt)}
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -487,9 +487,9 @@
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -508,7 +508,7 @@
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script>
 (function() {
   async function initUpgrade() {

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -402,9 +402,9 @@ footer a{color:var(--ink);text-decoration:none}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -423,6 +423,6 @@ footer a{color:var(--ink);text-decoration:none}
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/quantum-urgency.html
+++ b/frontend/quantum-urgency.html
@@ -447,7 +447,7 @@
 </section>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 
 <footer>
   <div class="container-lg">
@@ -485,9 +485,9 @@
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -302,9 +302,9 @@
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -324,6 +324,6 @@
 
 <script src="/nav.js?v=12"></script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -514,7 +514,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <tr><td>CVEs mitigated</td><td>CVE-2023-51767, CVE-2025-26465, CVE-2025-26466, CVE-2025-32728</td></tr>
     </tbody>
   </table>
-  <p style="margin-top:12px"><a href="https://github.com/Apolloccrypt/ParamantOS" target="_blank">ParamantOS on GitHub &rarr;</a></p>
+  <p style="margin-top:12px"><a href="https://github.com/Apolloccrypt/ParamantOS" target="_blank" rel="noopener">ParamantOS on GitHub &rarr;</a></p>
 
   <h2 id="customer-transparency">Customer transparency</h2>
   <p>Security is also about knowing what the vendor can and cannot do. The <a href="/trust">Trust &amp; Transparency page</a> documents, in plain terms, how license-check works, what Paramant can see of your relay (and what it never can), how to verify your deployment, and which remote actions are possible versus structurally impossible. Each claim there is tagged as live today or planned, with links to the public protocol specifications.</p>
@@ -557,9 +557,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -578,6 +578,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -243,9 +243,9 @@
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -263,6 +263,6 @@
   </div>
 </footer>
 
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -106,6 +106,6 @@
     </div>
   </main>
 
-  <script src="/setup.js?v=1"></script>
+  <script src="/setup.js?v=2"></script>
 </body>
 </html>

--- a/frontend/setup.js
+++ b/frontend/setup.js
@@ -127,7 +127,25 @@ function dnsPreflight() {
     .catch(function () { out.textContent = ''; });
 }
 
-function esc(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;'); }
+// Full HTML-entity encoder (escapes & < > " ') so esc() is safe in both text
+// and attribute contexts.
+function esc(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+    return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c];
+  });
+}
+// Only allow http(s) absolute URLs or a same-origin root-relative path as an
+// href; anything else (javascript:, data:, protocol-relative, ...) falls back
+// to '#' so a hostile value can never become a live link.
+function safeHref(u) {
+  var s = String(u == null ? '' : u).trim();
+  if (/^\/(?!\/)/.test(s)) { return s; }           // root-relative, not protocol-relative
+  try {
+    var url = new URL(s, location.origin);
+    if (url.protocol === 'http:' || url.protocol === 'https:') { return url.href; }
+  } catch (e) { /* not a parseable URL */ }
+  return '#';
+}
 
 function renderReview() {
   var c = state.config;
@@ -191,9 +209,11 @@ function renderDone(res) {
       (b.env_backed_up ? ' (previous one backed up to <code>.env.pre-setup</code>)' : '') +
       '. Restart the relay (<code>docker compose up -d</code>) to apply compliance and TLS settings.</p>';
   }
+  var healthHref = safeHref(b.health_url || '/all-systems-go');
+  var dashHref = safeHref(b.dashboard_url || '/dashboard');
   html += '<div class="actions" style="margin-top:16px">' +
-    '<a class="btn" href="' + esc(b.health_url || '/all-systems-go') + '">Check all systems</a> ' +
-    '<a class="btn" href="' + esc((b.dashboard_url || '/dashboard')) + '?welcome=1">Go to dashboard</a>' +
+    '<a class="btn" href="' + esc(healthHref) + '">Check all systems</a> ' +
+    '<a class="btn" href="' + esc(dashHref) + (dashHref === '#' ? '' : '?welcome=1') + '">Go to dashboard</a>' +
     '</div>';
   body.innerHTML = html;
   var copyBtn = $('#copy-key');

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -11,7 +11,7 @@
 // sign path. Signing goes through the passkey-PRF activation chain (LocalVaultSigner
 // in parasign-signer.js); sha3_256 stays for document hashing only.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolEphemeralSigningKeyWithTotp } from '/js/parasign-signer.js?v=11';
+import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolEphemeralSigningKeyWithTotp } from '/js/parasign-signer.js?v=12';
 import { promptTotp } from '/js/totp-prompt.js?v=1';
 
 // Read-only public relay host, used ONLY for the "view envelope status" link on
@@ -55,8 +55,20 @@ const $ = id => document.getElementById(id);
 function show(id) { $(id).hidden = false; }
 function hide(id) { $(id).hidden = true; }
 
+let __firstStepRender = true;
 function setActive(stepId) {
   document.querySelectorAll('.ds-step').forEach(s => s.hidden = (s.id !== stepId));
+  // Move focus to the new step's heading so keyboard + screen-reader users land
+  // on the freshly revealed content (skip the very first render at page load).
+  if (!__firstStepRender) {
+    const stepEl = document.getElementById(stepId);
+    const heading = stepEl && stepEl.querySelector('h2');
+    if (heading) {
+      if (!heading.hasAttribute('tabindex')) heading.setAttribute('tabindex', '-1');
+      try { heading.focus({ preventScroll: false }); } catch (e) { heading.focus(); }
+    }
+  }
+  __firstStepRender = false;
   document.querySelectorAll('.ds-stepper li').forEach(li => {
     const k = li.dataset.step;
     const order = ['doc', 'place', 'recipients', 'identity', 'sign'];
@@ -215,6 +227,14 @@ function initStepDoc() {
   const dz = $('ds-dropzone');
   const inp = $('ds-doc-input');
   dz.addEventListener('click', () => inp.click());
+  // Keyboard activation: the dropzone is role="button" tabindex="0", so Enter
+  // and Space must open the file picker the same way a click does.
+  dz.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+      e.preventDefault();
+      inp.click();
+    }
+  });
   dz.addEventListener('dragover', e => { e.preventDefault(); dz.classList.add('drag'); });
   dz.addEventListener('dragleave', () => dz.classList.remove('drag'));
   dz.addEventListener('drop', e => {
@@ -400,9 +420,22 @@ async function initStepIdentity() {
   });
   $('ds-signer-name').dispatchEvent(new Event('input'));
 
-  // Signature style tabs
-  document.querySelectorAll('.ds-sig-tabs .ds-tab').forEach(tab => {
+  // Signature style tabs: click to select, plus full keyboard tablist support
+  // (Left/Right/Home/End move and select per the WAI-ARIA tabs pattern).
+  const tabs = Array.from(document.querySelectorAll('.ds-sig-tabs .ds-tab'));
+  tabs.forEach((tab, i) => {
     tab.addEventListener('click', () => selectSigStyle(tab.dataset.sig));
+    tab.addEventListener('keydown', e => {
+      let next = -1;
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (i + 1) % tabs.length;
+      else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (i - 1 + tabs.length) % tabs.length;
+      else if (e.key === 'Home') next = 0;
+      else if (e.key === 'End') next = tabs.length - 1;
+      if (next < 0) return;
+      e.preventDefault();
+      selectSigStyle(tabs[next].dataset.sig);
+      tabs[next].focus();
+    });
   });
   initDrawCanvas();
   initImageUpload();
@@ -471,6 +504,8 @@ function selectSigStyle(style) {
     const active = t.dataset.sig === style;
     t.classList.toggle('active', active);
     t.setAttribute('aria-selected', active ? 'true' : 'false');
+    // Roving tabindex: only the selected tab is in the tab order.
+    t.setAttribute('tabindex', active ? '0' : '-1');
   });
   for (const k of ['typed', 'drawn', 'image']) {
     $('ds-sig-panel-' + k).hidden = (k !== style);
@@ -1047,6 +1082,8 @@ async function doSign() {
   $('ds-sign-now').disabled = true;
   $('ds-sign-status').hidden = false;
   $('ds-sign-status').className = 'ds-banner';
+  // Progress updates are non-urgent: announce them politely.
+  $('ds-sign-status').setAttribute('aria-live', 'polite');
   const status = (t) => { $('ds-sign-status').textContent = t; };
 
   let ephemeralSigner = null;   // hoisted so the catch can zeroize an unconsumed TOTP secret
@@ -1160,6 +1197,8 @@ async function doSign() {
     // Zeroize any unconsumed ephemeral secret (error before it was handed to the signer).
     if (ephemeralSigner) { try { ephemeralSigner.dispose(); } catch { /* best-effort */ } ephemeralSigner = null; }
     $('ds-sign-status').className = 'ds-banner err';
+    // A failed signing attempt is urgent and actionable: announce it assertively.
+    $('ds-sign-status').setAttribute('aria-live', 'assertive');
     // Map to an actionable message. A passkey/provider error (e.g. Firefox's
     // opaque "AuthenticatorError" from a PRF assertion) has no e.status/e.code,
     // so it lands in the final else with a recovery path — never the raw engine
@@ -1261,6 +1300,27 @@ function showDone() {
 
   // Render the signed result so the user can see their stamp before downloading.
   renderSignedPreview().catch(() => {});
+
+  // Best-effort: the signature is done and the result (stamped bytes + envelope)
+  // is what the page now uses. The raw source document bytes and any drawn/
+  // uploaded signature-image bytes are no longer needed, so clear them from
+  // memory rather than leaving them resident until the next GC.
+  clearSensitiveDocState();
+}
+
+// Zero/null the in-memory document + signature-image bytes once they are no
+// longer needed (success path). Best-effort: never throws.
+function clearSensitiveDocState() {
+  try {
+    if (state.doc && state.doc.bytes instanceof Uint8Array) { state.doc.bytes.fill(0); }
+    if (state.doc) { state.doc.bytes = null; }
+    if (state.signer && state.signer.sigImageBytes instanceof Uint8Array) { state.signer.sigImageBytes.fill(0); }
+    if (state.signer) {
+      state.signer.sigImageBytes = null;
+      state.signer.sigImageDataUrl = null;
+      state.signer.docImageDataUrl = null;
+    }
+  } catch (e) { /* best-effort */ }
 }
 
 // Invite-to-sign done screen: there is no signed document (the requester didn't
@@ -1440,10 +1500,11 @@ function buildRecipientRow(idx, data) {
   const row = document.createElement('div');
   row.className = 'ds-recipient-row';
   row.dataset.idx = String(idx);
+  const n = idx + 1;
   row.innerHTML =
-    `<input class="ds-input" type="text" data-field="label" maxlength="80" placeholder="Recipient name (required)" value="${escapeHtml(data.label || '')}">` +
-    `<input class="ds-input" type="email" data-field="email" maxlength="200" placeholder="Email (optional, for your reference only)" value="${escapeHtml(data.email || '')}">` +
-    `<button class="ds-rm" type="button" data-action="remove">Remove</button>`;
+    `<input class="ds-input" type="text" data-field="label" maxlength="80" placeholder="Recipient name (required)" aria-label="Recipient ${n} name (required)" value="${escapeHtml(data.label || '')}">` +
+    `<input class="ds-input" type="email" data-field="email" maxlength="200" placeholder="Email (optional, for your reference only)" aria-label="Recipient ${n} email (optional, for your reference only)" value="${escapeHtml(data.email || '')}">` +
+    `<button class="ds-rm" type="button" data-action="remove" aria-label="Remove recipient ${n}">Remove</button>`;
   row.querySelector('[data-action="remove"]').addEventListener('click', () => removeRecipientRow(idx));
   return row;
 }

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -418,23 +418,23 @@
     </div>
 
     <div class="ds-field">
-      <label class="ds-label">Signature style</label>
-      <div class="ds-sig-tabs" role="tablist">
-        <button class="ds-tab active" data-sig="typed" type="button" role="tab" aria-selected="true">Typed name</button>
-        <button class="ds-tab" data-sig="drawn" type="button" role="tab" aria-selected="false">Draw signature</button>
-        <button class="ds-tab" data-sig="image" type="button" role="tab" aria-selected="false">Upload image</button>
+      <label class="ds-label" id="ds-sig-style-label">Signature style</label>
+      <div class="ds-sig-tabs" role="tablist" aria-labelledby="ds-sig-style-label">
+        <button class="ds-tab active" id="ds-tab-typed" data-sig="typed" type="button" role="tab" aria-selected="true" aria-controls="ds-sig-panel-typed" tabindex="0">Typed name</button>
+        <button class="ds-tab" id="ds-tab-drawn" data-sig="drawn" type="button" role="tab" aria-selected="false" aria-controls="ds-sig-panel-drawn" tabindex="-1">Draw signature</button>
+        <button class="ds-tab" id="ds-tab-image" data-sig="image" type="button" role="tab" aria-selected="false" aria-controls="ds-sig-panel-image" tabindex="-1">Upload image</button>
       </div>
-      <div class="ds-sig-panel" id="ds-sig-panel-typed">
+      <div class="ds-sig-panel" id="ds-sig-panel-typed" role="tabpanel" aria-labelledby="ds-tab-typed" tabindex="0">
         <p class="ds-hint">Your name will appear as text inside the stamp. Choose 'Draw' if you want a handwritten signature.</p>
       </div>
-      <div class="ds-sig-panel" id="ds-sig-panel-drawn" hidden>
+      <div class="ds-sig-panel" id="ds-sig-panel-drawn" role="tabpanel" aria-labelledby="ds-tab-drawn" tabindex="0" hidden>
         <p class="ds-hint">Draw with mouse or finger. Use a steady stroke - the result is rendered as PNG and embedded in the PDF.</p>
-        <canvas id="ds-sig-canvas" width="500" height="160"></canvas>
+        <canvas id="ds-sig-canvas" width="500" height="160" role="img" aria-label="Signature drawing area - draw your signature with mouse or finger"></canvas>
         <div class="ds-actions" style="margin-top:8px">
           <button class="btn btn-tertiary" id="ds-sig-clear" type="button">Clear</button>
         </div>
       </div>
-      <div class="ds-sig-panel" id="ds-sig-panel-image" hidden>
+      <div class="ds-sig-panel" id="ds-sig-panel-image" role="tabpanel" aria-labelledby="ds-tab-image" tabindex="0" hidden>
         <p class="ds-hint">Upload a PNG or JPG of your signature. A transparent PNG works best.</p>
         <label class="ds-dropzone" id="ds-sig-image-drop" style="padding:20px;text-align:center;display:block">
           <input type="file" id="ds-sig-image-input" accept="image/png,image/jpeg" hidden>
@@ -611,9 +611,9 @@
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -631,9 +631,9 @@
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
-<script type="module" src="/sign-flow.js?v=23"></script>
+<script type="module" src="/sign-flow.js?v=24"></script>
 </body>
 </html>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -297,8 +297,8 @@
     <p class="small mt-2">A short name for this account. Only you see it.</p>
 
     <p class="small mt-3">
-      By continuing you agree to our <a href="/dpa" target="_blank">Data Processing Agreement</a>
-      and <a href="/privacy" target="_blank">privacy policy</a>. We store as little as possible and never sell data.
+      By continuing you agree to our <a href="/dpa" target="_blank" rel="noopener">Data Processing Agreement</a>
+      and <a href="/privacy" target="_blank" rel="noopener">privacy policy</a>. We store as little as possible and never sell data.
     </p>
 
     <button type="submit" class="btn btn-primary mt-3" id="submit-btn">
@@ -333,7 +333,7 @@
 
 <script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script>
 (function() {
   const form = document.getElementById('signup-form');

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/nav.css?v=13">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
   <style>
     body { background: #F8FAFC; }
     .vwrap { max-width: 620px; margin: 48px auto; padding: 0 20px; }

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -455,9 +455,9 @@ a:hover{opacity:.8}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -475,6 +475,6 @@ a:hover{opacity:.8}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -562,7 +562,7 @@
 </section>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 
 <footer>
   <div class="container-lg">
@@ -600,9 +600,9 @@
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -439,9 +439,9 @@ section p+p{margin-top:14px}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -459,6 +459,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -355,9 +355,9 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -518,6 +518,6 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
 }());
 </script>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -510,9 +510,9 @@ docker compose build   # build locally instead of pulling the published image</c
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -531,6 +531,6 @@ docker compose build   # build locally instead of pulling the published image</c
 </footer>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/vendor/parasign-bridge.js
+++ b/frontend/vendor/parasign-bridge.js
@@ -4,7 +4,7 @@
 // Non-module callers wait for the 'parasign:ready' CustomEvent (or check
 // window.__parasign).
 import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
-import { vaultAvailable, vaultList } from '/vendor/vault.js?v=4';
+import { vaultAvailable, vaultList } from '/vendor/vault.js?v=5';
 
 window.__parasign = { ml_dsa65, sha3_256, vaultAvailable, vaultList };
 window.dispatchEvent(new CustomEvent('parasign:ready'));

--- a/frontend/vendor/vault.js
+++ b/frontend/vendor/vault.js
@@ -202,7 +202,7 @@ export async function vaultUnlockPrf(id, { prfOutput, credentialId } = {}) {
   let plain;
   try {
     plain = new Uint8Array(await crypto.subtle.decrypt({ name: KEK_NAME, iv: b64Decode(wrap.iv) }, kek, b64Decode(wrap.ciphertext)));
-  } catch (e) { db.close(); throw new Error('prf unwrap failed'); }
+  } catch (e) { db.close(); throw new Error('prf unwrap failed', { cause: e }); }
   try { const rw = _tx(db, 'readwrite'); const fresh = await _toPromise(rw.get(id)); if (fresh) { fresh.last_used_at = new Date().toISOString(); await _toPromise(rw.put(fresh)); } } catch {}
   db.close();
   return { secretKeyBytes: plain, pk_b64: entry.pk_b64, pk_hash: entry.pk_hash, label: entry.label };

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -270,9 +270,9 @@
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -290,7 +290,7 @@
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 <script type="module" src="/parasign-verify.js?v=2"></script>
 </body>
 </html>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -558,7 +558,7 @@
 </section>
 
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 
 <footer>
   <div class="container-lg">
@@ -596,9 +596,9 @@
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -342,9 +342,9 @@ section p+p{margin-top:14px}
           <a href="/install.sh">install.sh</a>
           <a href="/install-pi.sh">install-pi.sh</a>
           <a href="/download">ParamantOS</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank">GitHub</a>
-          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank">Docker Hub</a>
-          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank">Releases</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://hub.docker.com/r/mtty001/relay" target="_blank" rel="noopener">Docker Hub</a>
+          <a href="https://github.com/Apolloccrypt/paramant-relay/releases" target="_blank" rel="noopener">Releases</a>
         </div>
       </div>
       <div>
@@ -362,6 +362,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=12" defer></script>
-<script src="/js/nav-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=2" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Frontend-only security/quality sweep from the 2026-06-21 audit dossier. Scope is strictly `frontend/`.

## Security (XSS / encoding)
- **nav-auth.js** — user email rendered via `.textContent`, not interpolated into `innerHTML` (self/stored DOM XSS; signup regex permits HTML metacharacters).
- **account.html** — session rows (`user_agent_short`, `ip_masked`) built with `textContent` instead of `innerHTML`.
- **setup.js** — `esc()` is now a full HTML-entity encoder (`& < > " '`); added `safeHref()` that only allows http(s) or same-origin root-relative paths before a value becomes an `href`.
- **co-sign.js** — party `status` allowlisted to a known enum before it goes in the `class` attribute; party index coerced to a number.
- **developer.js** — tool `source` URL validated as http(s)/same-origin before being rendered as a link (both the card and the modal).
- **\*.html** — `rel="noopener"` added to every `target="_blank"` anchor via a careful multiline-aware codemod (171 tags across 55 files; no double-adds, verified 0 remaining).

## Secret hygiene
- **parasign-signer.js** — `seed.fill(0)` after `ml_dsa65.keygen(seed)` at both keygen sites.
- **sign-flow.js** — zero/null the source document bytes and any signature-image bytes on the success path (`showDone`).
- **vault.js** — preserve `err.cause` on PRF-unwrap failure so a GCM tamper stays distinguishable.
- **get.html** — **removed the legacy quick-sign path entirely.** It produced `parasign-visual-1` envelopes over a raw, non-domain-separated, ambiguously concatenated message that no verifier (including Paramant's own `/verify`) accepts, and it left the ephemeral signing secret + seed un-zeroized. Replaced the in-page "Sign this document" with a link to the real `/sign` flow (which produces domain-separated, verifiable envelopes); removed the now-dead UI, handlers, CSS, and the two signing-only `<script>` deps.

## Accessibility (sign flow)
- Dropzone keyboard activation (Enter/Space).
- Signature-style tablist: arrow/Home/End navigation, roving tabindex, full tab/tabpanel ARIA wiring.
- Wizard steps move focus to the new step heading.
- Sign error banner announced assertively (progress updates stay polite).
- Recipient inputs get real accessible names; draw canvas gets an accessible name.

## Performance
- **developer.js** — collapsed the SSE-fallback double-poll into a single shared 5s snapshot timer gated on SSE health.

## Cache-bust
Bumped every changed JS in all referencing HTML/JS: nav-auth 1→2, setup 1→2, co-sign 12→13, developer 4→5, sign-flow 23→24, parasign-signer 11→12, vault 4→5, signing-enrol 13→14. `scripts/check-cache-bust.sh` passes; all changed JS pass `node --check` / `--input-type=module --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)