### PR TITLE
fix(frontend): mobile comparison tables scroll horizontally

### DIFF
--- a/frontend/design-system.css
+++ b/frontend/design-system.css
@@ -1788,8 +1788,17 @@ pre code { background: none; padding: 0; }
 /* Responsive */
 @media (max-width: 768px) {
   .two-col { grid-template-columns: 1fr; }
+  /* Wide comparison tables: scroll horizontally instead of being clipped by
+     html{overflow-x:clip}. display:block turns the table into its own scroll
+     box; nowrap keeps content wider than the viewport so it actually scrolls. */
   .compare-table,
-  .ownership-table { font-size: 12px; }
+  .ownership-table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    white-space: nowrap;
+    font-size: 12px;
+  }
   .compare-table th,
   .ownership-table th,
   .compare-table td,


### PR DESCRIPTION
Reported from mobile: the "Feature comparison" table (vs.html, Paramant/Zivver/Tresorit) is cut off and does not scroll horizontally on iOS.

**Cause:** `html{overflow-x:clip}` clips page-level horizontal overflow, and the wide `.compare-table`/`.ownership-table` have no scroll container, so extra columns are clipped instead of scrollable.

**Fix:** at `<=768px` the table becomes its own horizontal scroll box (`display:block; overflow-x:auto; -webkit-overflow-scrolling:touch; white-space:nowrap`). Columns stay aligned (single table), full table reachable by swiping. Desktop unchanged.

CSS-only, affects every `.compare-table`/`.ownership-table` site-wide. Not yet deployed (rsync on GO). Needs a real-device check on iOS Safari.