### PR TITLE
docs(privacy): correct Resend US sub-processor mislabel on sovereignty page

### DIFF
--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -504,14 +504,18 @@
       <div class="tag">honest about<br/>the gaps</div>
     </div>
 
-    <p>Paramant's application infrastructure is fully EU-based and EU-owned:</p>
+    <p>Paramant's core application infrastructure is EU-based and EU-owned:</p>
     <ul>
       <li><strong>Application servers</strong>: Hetzner (Nuremberg, Germany &amp; Helsinki, Finland)</li>
-      <li><strong>Email delivery</strong>: Resend (EU data processing agreement)</li>
       <li><strong>SIEM/logging</strong>: Wazuh on dedicated EU infrastructure</li>
     </ul>
 
-    <p>Two dependencies at the DNS and CDN layer currently sit outside this boundary:</p>
+    <p>Three dependencies currently sit outside this boundary, at the email, DNS, and CDN layers:</p>
+
+    <h3>Transactional email: Resend (US, under SCC / Data Privacy Framework)</h3>
+    <p>Outbound transactional email (account verification, signing invites, billing notices) is sent through <strong>Resend</strong>. Resend is operated by Plus Five Five, Inc., a US company based in San Francisco; its data processing addendum states that its primary processing takes place in the United States, governed by Standard Contractual Clauses and the EU-US Data Privacy Framework rather than EU data residency. It is therefore subject to US jurisdiction, including the CLOUD Act.</p>
+
+    <p>The practical impact is bounded: Resend receives only the recipient email address and the message we send (a verification link, an invite, or a billing notice). It never receives file contents, encryption keys, account passwords, or relay metadata. It is never used for marketing. This dependency is the same as disclosed in the <a href="/privacy">privacy policy</a>; an EU-resident email provider is on the roadmap.</p>
 
     <h3>DNS and CDN: Cloudflare (current, being replaced)</h3>
     <p>paramant.app currently uses Cloudflare for DNS hosting and static asset delivery. Cloudflare is a US company incorporated in Delaware, subject to US jurisdiction including the CLOUD Act and FISA 702.</p>


### PR DESCRIPTION
**Beehive audit, `privacy-docs` theme.** Two findings confirmed genuinely-open against `origin/main`. One gets a surgical doc fix; one is intentionally skipped with rationale (the auditor's own verdict was no-change-required).

## Finding 1 (MEDIUM) — Fixed: Resend mislabeled "EU" on the sovereignty page

**Cited anchor:** `frontend/sovereignty.html:510`

The line read:
> `<li><strong>Email delivery</strong>: Resend (EU data processing agreement)</li>`

listed under the claim *"Paramant's application infrastructure is **fully EU-based and EU-owned**"*. This is inaccurate. Resend is operated by **Plus Five Five, Inc.**, a US company in San Francisco. Per [Resend's own DPA](https://resend.com/legal/dpa), *"the Company's primary processing operations take place in the United States"*, governed by **Standard Contractual Clauses** and the **EU-US Data Privacy Framework**, not EU data residency. It is subject to US jurisdiction including the CLOUD Act. The `(EU data processing agreement)` label was the cited inaccuracy. PR #145 touches this file (Hetzner city genericization) but left this exact line as unchanged context, so the residual mislabel remained.

`frontend/privacy.html` on `origin/main` already discloses Resend correctly in a Subprocessors section without the false EU claim, and `frontend/dpa.html:346` already states *"Resend Inc. operates in the United States; the transfer is covered by Standard Contractual Clauses"*. So sovereignty.html was the lone outlier.

**Fix (7 insertions / 3 deletions, HTML only):**
- Removed Resend from the "fully EU" list; softened the intro to "core application infrastructure is EU-based and EU-owned".
- Disclosed Resend as a US dependency using the **same honest pattern this page already applies to Cloudflare**: named legal entity, US jurisdiction, CLOUD Act, SCC/DPF basis, plus the bounded-impact mitigation (Resend only ever receives the recipient address and the transactional message we send: a verification link, invite, or billing notice; never file contents, encryption keys, passwords, or relay metadata; never marketing).
- Now consistent with `dpa.html` and `privacy.html`.

This also aligns with the page's own stated principle (the section callout): *"Claiming full EU sovereignty while running ... on a US company is a contradiction ... transparency about current limitations is more useful than aspirational claims."*

## Finding 2 (LOW) — Skipped (intentional, auditor-blessed): admin operator IP in Redis audit log

**Anchor:** `admin/server.js` (~19 sites) -> `admin/lib/audit.js`

`admin_ip = req.headers['x-real-ip']` is persisted into Redis audit events for privileged admin actions (key revoke, plan change, account delete, etc.). Verified these routes sit behind `authMiddleware`, so the recorded IP is the **authenticated admin operator's own IP**, not an end-user's. This is a deliberate **operator audit trail** for accountability and incident response.

The finding's own verdict: *"Auditor's own verdict is no-change-required for end-user privacy (operator audit trail), so open-but-acceptable; flagged only for completeness."* `coveredByPr` is empty and severity is LOW.

**Decision:** left in place. Stripping the operator IP would weaken the security audit trail (the opposite of an improvement) without any end-user privacy benefit. Changing ~19 call sites for a control the auditor explicitly judged acceptable would be an unrequested behavioral regression. Documented here and in the commit message for traceability.

## Verification
- Doc/HTML-only change; **no `.js` modified** (so `node --check` not applicable).
- `grep` confirms `Resend (EU data processing agreement)` and `fully EU-based and EU-owned` strings are **gone**.
- HTML tag balance preserved: `section` 8/8, `ul` 9/9, `li` 61/61, `h3` 9/9, `div` 63/63 all match; no stray/unclosed tags.
- No em-dashes in the new copy (house style).
- Branch based on `origin/main` (9ac316c); single commit.

**Do not deploy / merge — hold for review (public-facing claims).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)