### PR TITLE
sec(admin-frontend-xss): escape CT-feed innerHTML + block CLI option injection

### DIFF
--- a/admin/lib/cli-commands.js
+++ b/admin/lib/cli-commands.js
@@ -182,6 +182,14 @@ function validateArgs(cmd, rawArgs) {
         if (/[\x00-\x1f\x7f`$;&|<>(){}\\]/.test(v)) {
           return { ok: false, error: `Arg ${spec.name} contains disallowed characters` };
         }
+        // Reject a leading '-' so a value can never be read by a handler script
+        // as an option flag instead of a positional argument (option/argument
+        // injection). A '--' terminator in buildArgv is NOT usable here because
+        // the handlers consume argv as their own $1/$2 positionals (see note on
+        // buildArgv), so this upstream rejection is the guard.
+        if (v[0] === '-') {
+          return { ok: false, error: `Arg ${spec.name} must not start with '-'` };
+        }
         break;
       default:
         return { ok: false, error: `Unknown arg type for ${spec.name}` };
@@ -192,6 +200,12 @@ function validateArgs(cmd, rawArgs) {
 }
 
 // Build the positional argv array for spawn(), in schema declared order.
+// NOTE: handlers in scripts/cli read these as their OWN positional params
+// ($1, $2, ...), so we must NOT prepend a '--' option terminator here -- that
+// would land as $1 and shift every real value by one, breaking the handlers.
+// Option/flag injection is instead blocked upstream in validateArgs(), which
+// rejects any string value beginning with '-'; non-string args are enum/number
+// /email and can never be a bare flag.
 function buildArgv(cmd, values) {
   return cmd.args
     .filter(spec => values[spec.name] !== undefined)

--- a/admin/test/cli-argvalidate.test.js
+++ b/admin/test/cli-argvalidate.test.js
@@ -1,0 +1,55 @@
+'use strict';
+// Unit test for cli-commands.validateArgs / buildArgv: proves a string arg can
+// never smuggle a leading '-' that a handler script would read as an option
+// flag instead of a positional value (option/argument injection). Also pins
+// the existing control-char / shell-metachar rejection and the positional
+// buildArgv contract (no '--' terminator, which would shift handler args).
+// Run: node admin/test/cli-argvalidate.test.js (no deps, non-zero exit on fail).
+
+const assert = require('assert');
+const { validateArgs, buildArgv, COMMANDS } = require('../lib/cli-commands');
+
+let passed = 0;
+const ok = (n) => { passed++; console.log('  ok -', n); };
+
+const REVOKE = COMMANDS['key revoke']; // sole string-typed arg: key_prefix (minLength 8)
+
+// 1. A normal hash-prefix is accepted and passed through unchanged.
+const good = validateArgs(REVOKE, { key_prefix: 'a1b2c3d4e5' });
+assert.ok(good.ok, 'valid key_prefix accepted: ' + good.error);
+assert.strictEqual(good.values.key_prefix, 'a1b2c3d4e5');
+ok('valid string arg accepted');
+
+// 2. A leading '-' value is REJECTED (option-injection guard). Each sample is
+//    >= minLength (8) so it must fail specifically on the leading-dash rule,
+//    not on length. (A short leading-dash value is still rejected, by length.)
+for (const bad of ['--helpme1', '-rf------', '--output=/etc']) {
+  const r = validateArgs(REVOKE, { key_prefix: bad });
+  assert.strictEqual(r.ok, false, 'leading-dash rejected: ' + bad);
+  assert.ok(/start with '-'/.test(r.error), 'clear error for ' + bad + ': ' + r.error);
+}
+ok('leading-dash string values rejected');
+
+// 3. A dash NOT in the leading position is still allowed (it cannot be a flag),
+//    so legitimate prefixes are not over-rejected.
+const mid = validateArgs(REVOKE, { key_prefix: 'a1b2-c3d4' });
+assert.ok(mid.ok, 'non-leading dash allowed: ' + mid.error);
+ok('non-leading dash allowed');
+
+// 4. The pre-existing control-char / shell-metachar rejection still holds.
+//    Samples use explicit escapes (\t, \x00) so the source stays byte-clean.
+for (const bad of ['abc;rm-rf1', 'a$bcdefgh', 'abc\tdefgh', 'abc\x00defg', 'abc`id`xx', 'pipe|cat1']) {
+  const r = validateArgs(REVOKE, { key_prefix: bad });
+  assert.strictEqual(r.ok, false, 'metachar/control rejected: ' + JSON.stringify(bad));
+}
+ok('control-char and shell-metachar values still rejected');
+
+// 5. buildArgv keeps the strict positional contract: it emits ONLY the values
+//    in declared order, with no leading '--' terminator (which would land as
+//    $1 in the handler and shift every real positional).
+const argv = buildArgv(REVOKE, good.values);
+assert.deepStrictEqual(argv, ['a1b2c3d4e5'], 'argv is bare positional, no -- prefix');
+assert.notStrictEqual(argv[0], '--', 'no -- option terminator injected');
+ok('buildArgv emits bare positional argv');
+
+console.log('cli-argvalidate:', passed, 'groups passed');

--- a/frontend/ct-stats.js
+++ b/frontend/ct-stats.js
@@ -2,6 +2,15 @@
 (function() {
   var RELAY = 'https://health.paramant.app';
 
+  // Full HTML-entity encoder (escapes & < > " ') so esc() is safe in both text
+  // and attribute contexts. The /ct/feed JSON is relay-controlled, not strictly
+  // trusted, so anything interpolated into innerHTML below is run through this.
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+      return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c];
+    });
+  }
+
   function set(id, val) {
     var el = document.getElementById(id);
     if (el) el.textContent = val;
@@ -41,10 +50,15 @@
           var rows = last3.map(function(e) {
             var ts = new Date(e.t);
             var time = ts.toISOString().slice(11, 19);
-            var hash = e.h ? e.h.slice(0, 12) + '...' : '--';
-            return '<div><span style="color:var(--quiet)">#' + e.i + '</span>'
-              + ' &nbsp;&middot;&nbsp; ' + hash
-              + ' &nbsp;&middot;&nbsp; <span style="color:var(--quiet)">' + time + ' UTC</span></div>';
+            // index is an integer log position; coerce and drop anything else.
+            var idx = Number(e.i);
+            var idxStr = Number.isFinite(idx) ? String(Math.trunc(idx)) : '?';
+            // hash is a hex digest; keep only the hex prefix, else show nothing.
+            var hex = /^[0-9a-fA-F]+$/.test(e.h) ? e.h.slice(0, 12) : '';
+            var hash = hex ? hex + '...' : '--';
+            return '<div><span style="color:var(--quiet)">#' + esc(idxStr) + '</span>'
+              + ' &nbsp;&middot;&nbsp; ' + esc(hash)
+              + ' &nbsp;&middot;&nbsp; <span style="color:var(--quiet)">' + esc(time) + ' UTC</span></div>';
           });
           feedEl.innerHTML = rows.join('');
         }


### PR DESCRIPTION
Fixes two confirmed-open findings from the beehive audit, theme **admin-frontend-xss**. Minimal, surgical, follows existing codebase patterns. No deploy.

## Findings fixed

### 1. Unescaped CT-log entry fields rendered into innerHTML (low)
`frontend/ct-stats.js` — the `/ct/feed` widget built `feedEl.innerHTML` with the relay-controlled entry index (`e.i`) and hash (`e.h`) interpolated **raw** (no escape, no coercion, no validation).

**Fix** (defense at the sink, three layers):
- `e.i` is `Number`-coerced + `Math.trunc`'d; non-numeric falls back to `'?'`.
- `e.h` is hex-validated (`/^[0-9a-fA-F]+$/`); non-hex falls back to `'--'`.
- every interpolated value passes through a local `esc()` entity-encoder — the same `esc()` already used in `dashboard.js` / `setup.js` / `developer.js`.

A hostile entry (`i: "<img src=x onerror=alert(1)>"`, `h: "</span><script>…"`) now renders to an inert `<div><span>#?</span> -- <span>… UTC</span></div>` (verified by simulation).

### 2. CLI string args allowed leading-dash values — option/argument injection (info)
`admin/lib/cli-commands.js` — `validateArgs()` string-case rejected control/shell metacharacters but **not a leading `-`**, so a value (the sole string arg, `key_prefix`, authenticated-admin only) could be read by a `scripts/cli` handler as an **option flag** instead of a positional argument.

**Fix:** `validateArgs` now rejects any string value beginning with `-`, with a clear error.

**Why not a `--` terminator in `buildArgv`:** the audit offered "add `--` before positionals **or** reject leading `-`". A `--` prepend is **not usable here** — the handler scripts consume `argv` as their **own** `$1`/`$2` positionals (e.g. `PREFIX="${1:?…}"`), so a leading `--` would land as `$1` and shift every real value, breaking `logs`/`key revoke`/`restart`/etc. (demonstrated with bash). The upstream leading-dash rejection is the correct guard; an inline note on `buildArgv` documents this so the contract isn't "fixed" into a break later.

## Tests
Added `admin/test/cli-argvalidate.test.js` (no-deps `assert`, runs under the existing `node --test test/*.test.js` admin CI job). Covers: leading-dash rejection (≥minLength samples to isolate the rule), non-leading dash allowance, the pre-existing metachar/control-char rejection, and the bare-positional `buildArgv` contract.

## Verification
- `node --check` on all edited/new files — pass.
- Full admin suite as CI runs it (`node --test test/*.test.js`) — **15/15 pass, 0 fail**.
- Re-grep confirms the raw `e.i`/`e.h` innerHTML sink and the missing leading-dash guard are gone; only guarded forms remain.
- Hostile-payload simulation of the CT render yields inert HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)