### PR TITLE
harden: supply-chain pins (Docker lockfiles, CI action SHAs, installer)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     name: shell — bash -n
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Bash syntax check on all .sh files
         run: |
           set -e
@@ -33,7 +33,7 @@ jobs:
     name: frontend — cache-bust guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: All local css/js links must carry a single ?v= cache-bust
         run: scripts/check-cache-bust.sh
 
@@ -41,8 +41,8 @@ jobs:
     name: relay - crypto suite (@paramant/core)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
       # @paramant/core is the Rust NAPI binding in the sibling paramant-core
@@ -75,8 +75,8 @@ jobs:
     name: relay - unit suite (no native deps)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
       # Pure-JS units: account-split schema (keys-table), static-serve, envelope
@@ -90,8 +90,8 @@ jobs:
     name: admin - unit suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
       - name: Admin unit suite

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -7,8 +7,11 @@ LABEL org.opencontainers.image.title="paramant-admin" \
       org.opencontainers.image.licenses="BUSL-1.1"
 
 WORKDIR /app
-COPY package.json .
-RUN npm install --production --quiet && npm cache clean --force
+# Copy the lockfile too and use `npm ci` so the build installs the exact
+# versions in package-lock.json instead of re-resolving the ^ ranges on every
+# rebuild (reproducible, supply-chain-pinned image).
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --quiet && npm cache clean --force
 COPY server.js .
 COPY lib/ lib/
 COPY public/ public/

--- a/install.sh
+++ b/install.sh
@@ -116,9 +116,13 @@ ok "Disk: ${AVAIL_DISK_GB}GB available"
 if swapon --show 2>/dev/null | grep -q .; then
   warn "Swap is active. Disabling (relay uses RAM-only storage)..."
   swapoff -a
-  # Persist across reboots
-  sed -i '/\sswap\s/d' /etc/fstab 2>/dev/null || true
-  ok "Swap disabled"
+  # Persist across reboots. Back up /etc/fstab before editing so the operator can
+  # restore swap if this host should not have had it removed.
+  if [[ -f /etc/fstab ]]; then
+    cp -a /etc/fstab "/etc/fstab.paramant-bak.$(date -u +%Y%m%dT%H%M%SZ)" 2>/dev/null || true
+    sed -i '/\sswap\s/d' /etc/fstab 2>/dev/null || true
+  fi
+  ok "Swap disabled (fstab backed up to /etc/fstab.paramant-bak.*)"
 else
   ok "Swap already disabled"
 fi
@@ -245,10 +249,18 @@ if [[ -d "$INSTALL_DIR/.git" ]]; then
   git -C "$INSTALL_DIR" pull --ff-only -q
   ok "Updated to latest"
 else
-  info "Cloning ${REPO}..."
-  git clone --depth 1 --branch "${VERSION}" "$REPO" "$INSTALL_DIR" -q 2>/dev/null \
-    || git clone --depth 1 "$REPO" "$INSTALL_DIR" -q
-  ok "Cloned to ${INSTALL_DIR}"
+  info "Cloning ${REPO} at ${VERSION}..."
+  # Pin to the release tag. Do NOT silently fall back to an unpinned default-
+  # branch clone if the tag is missing/unreachable: that would install whatever
+  # HEAD happens to be (supply-chain integrity gap). Fail loudly so the operator
+  # can pick a known-good VERSION instead of getting a surprise revision.
+  if ! git clone --depth 1 --branch "${VERSION}" "$REPO" "$INSTALL_DIR" -q; then
+    err "Could not clone ${REPO} at tag ${VERSION}."
+    err "Refusing to fall back to an unpinned clone. Check your network, or set"
+    err "VERSION to a tag that exists (see ${REPO}/tags) and re-run."
+    exit 1
+  fi
+  ok "Cloned ${VERSION} to ${INSTALL_DIR}"
 fi
 
 cd "$INSTALL_DIR"

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -6,7 +6,7 @@
 # Compiles the paramant-core-node napi binding for musl, so it loads inside the
 # node:22-alpine runtime (a glibc build would not). Pinned to a paramant-core
 # commit for reproducibility; bump PARAMANT_CORE_COMMIT when upgrading.
-FROM rust:1.95-alpine AS paramant-core-binding
+FROM rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS paramant-core-binding
 
 RUN apk add --no-cache musl-dev gcc g++ make cmake ninja clang clang-dev llvm-dev perl nasm git bash
 ENV LIBCLANG_PATH=/usr/lib
@@ -29,11 +29,14 @@ FROM node:22-alpine3.21@sha256:af8023ec879993821f6d5b21382ed915622a1b0f1cc03dbeb
 RUN apk add --no-cache python3 make g++
 
 WORKDIR /app
-COPY package.json ./
+COPY package.json package-lock.json ./
 # Strip the @paramant/core dev file-link (resolvable only in a sibling checkout);
 # the binding is installed from the paramant-core-binding stage in the runtime.
-RUN node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));if(p.dependencies)delete p.dependencies['@paramant/core'];fs.writeFileSync('package.json',JSON.stringify(p,null,2))" \
- && npm install --omit=dev && npm cache clean --force
+# Strip it from BOTH package.json and package-lock.json so the two stay in sync
+# and `npm ci` (which fails on any drift) accepts the lockfile. Every other
+# dependency then installs at its exact lockfile-pinned version (no ^ re-resolve).
+RUN node -e "const fs=require('fs');for(const f of ['package.json','package-lock.json']){const j=JSON.parse(fs.readFileSync(f));if(j.dependencies)delete j.dependencies['@paramant/core'];if(j.packages){if(j.packages['']&&j.packages[''].dependencies)delete j.packages[''].dependencies['@paramant/core'];delete j.packages['node_modules/@paramant/core'];delete j.packages['../../paramant-core/crates/paramant-core-node'];}fs.writeFileSync(f,JSON.stringify(j,null,2));}" \
+ && npm ci --omit=dev && npm cache clean --force
 
 # ── Stage 2: runtime ─────────────────────────────────────────────────────────
 # Lean image: no build tools, no npm, no compilers — only the relay and its deps.


### PR DESCRIPTION
Beehive **supply-chain** audit theme. Five findings, all confirmed GENUINELY OPEN against `origin/main`, fixed here with minimal, pattern-matching changes (no unrelated refactor). 4 files changed.

## Findings & fixes

### [MEDIUM] Docker builds ignored the lockfile
`relay/Dockerfile`, `admin/Dockerfile` — both images copied only `package.json` and ran `npm install`, so floating `^` ranges re-resolved on every rebuild and the committed `package-lock.json` (which already exists in the repo) was never used at build time.
**Fix:** both now `COPY package.json package-lock.json ./` and run `npm ci` (exact pinned install). The relay strips its `@paramant/core` dev `file:` link from **both** `package.json` and `package-lock.json` before `npm ci` so the two stay in sync (`npm ci` fails on any drift); the napi binding still comes from the `paramant-core-binding` stage exactly as before. admin switched `npm install --production` → `npm ci --omit=dev`.

### [MEDIUM] GitHub Actions pinned to floating major tags
`.github/workflows/test.yml` — 5× `actions/checkout@v4` and 3× `actions/setup-node@v4` (lines 18,36,44,45,78,79,93,94).
**Fix:** all 8 pinned to the full commit SHA with the version in a trailing comment:
- `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
- `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`

Dependabot is already configured for `github-actions`, so it will keep bumping the SHA + comment together.

### [MEDIUM] install.sh silent unpinned clone fallback
`install.sh` — the pinned `git clone --branch "$VERSION"` fell back, on **any** failure, to `git clone --depth 1 "$REPO"` (default-branch HEAD), silently abandoning the version pin and installing whatever HEAD happened to be.
**Fix:** the pinned clone is now authoritative; on failure the installer errors out and tells the operator to pick a known-good `VERSION` rather than dropping the pin. Also: back up `/etc/fstab` (timestamped) before the swap-disabling `sed` edit, so swap removal is recoverable.

### [LOW] rust builder base image not digest-pinned
`relay/Dockerfile:9` — `FROM rust:1.95-alpine` was the only base image without a digest (node bases and redis are digest-pinned).
**Fix:** `FROM rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2`. Digest verified three ways: Docker Hub registry `docker-content-digest` HEAD, `skopeo inspect`, and a digest-only `docker pull rust@sha256:…` (exit 0). Dependabot's docker updater keeps it current.

### [LOW] install.sh prints the freshly generated TOTP secret — intentionally left as-is
The operator must see the secret once to enrol their authenticator app; it is locally generated and auditor-accepted (scrollback exposure only). Removing it would break the documented enrolment UX. **No change** — noted for completeness.

## Verification
- `bash -n install.sh` → OK (the repo's own CI shell-syntax gate).
- `test.yml` parses as valid YAML; re-grep shows 0 floating action tags, 8 SHA-pinned.
- **Real Docker builds** (not just dry-run):
  - admin full build → `npm ci --omit=dev` → *added 98 packages* (exit 0).
  - relay `--target build` stage → strip → `npm ci --omit=dev` → *added 29 packages* with argon2 native compile (exit 0).
- `npm ci --dry-run` after the strip confirms `package.json` ↔ `package-lock.json` stay in sync for both relay and admin.
- Re-grep confirms gone: `npm install` in either Dockerfile, floating `actions/*@vN` tag, unpinned `rust:…-alpine` base, unpinned `git clone "$REPO"` fallback.
- No `.js` files changed (these are Dockerfile / YAML / shell only), so `node --check` is N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)