### PR TITLE
fix(relay): mask secret API keys in GET /v2/admin/keys bulk list

### DIFF
--- a/admin/lib/telemetry.js
+++ b/admin/lib/telemetry.js
@@ -30,7 +30,9 @@ async function getRecentAuditEvents(limit = 20) {
 
 async function getUsersWithTotp(relayFetch, ADMIN_TOKEN) {
   let r;
-  try { r = await relayFetch('health', '/v2/admin/keys', 'GET', null, false, ADMIN_TOKEN); }
+  // reveal=1: k.key is used as the raw Redis id (totp_active/totp/meta) and
+  // surfaced as key_id for per-user actions, so this needs the full value.
+  try { r = await relayFetch('health', '/v2/admin/keys?reveal=1', 'GET', null, false, ADMIN_TOKEN); }
   catch (e) { console.error('[telemetry] relay unavailable:', e.message); return []; }
   const keys = r.body?.keys || [];
   const users = await Promise.all(keys.map(async k => {

--- a/admin/server.js
+++ b/admin/server.js
@@ -516,10 +516,13 @@ async function callRelay(endpoint, body, method = "POST") {
   return res;
 }
 
-// Find API key entry by email (queries health relay)
+// Find API key entry by email (queries health relay).
+// reveal=1: the returned entry's full .key becomes the session user_id (Redis
+// id + relay operation token), so this server-to-server lookup needs the raw
+// value, not the masked default.
 async function findUserByEmail(email) {
   const lower = email.toLowerCase();
-  const r = await relayFetch("health", "/v2/admin/keys", "GET", null, false, ADMIN_TOKEN);
+  const r = await relayFetch("health", "/v2/admin/keys?reveal=1", "GET", null, false, ADMIN_TOKEN);
   if (r.status !== 200) return null;
   const keys = r.body?.keys || [];
   return keys.find(k => k.email && k.email.toLowerCase() === lower && k.active !== false) || null;
@@ -529,9 +532,10 @@ async function findUserByEmail(email) {
 // usernameless/discoverable passkey login to resolve the email for the session
 // record after identity has been proven by the credential. Same source/cost as
 // findUserByEmail (one /v2/admin/keys read). Returns null if not found.
+// reveal=1: matches on the raw .key (userId is a full pgp_ value).
 async function findUserById(userId) {
   if (!userId) return null;
-  const r = await relayFetch("health", "/v2/admin/keys", "GET", null, false, ADMIN_TOKEN);
+  const r = await relayFetch("health", "/v2/admin/keys?reveal=1", "GET", null, false, ADMIN_TOKEN);
   if (r.status !== 200) return null;
   const keys = r.body?.keys || [];
   return keys.find(k => k.key === userId && k.active !== false) || null;
@@ -2447,7 +2451,7 @@ api.post("/user/billing/checkout/:token/confirm", authUser, async (req, res) => 
   if (session.status !== 'pending') return res.status(409).json({ error: 'already_processed' });
 
   // Get current plan for audit log
-  const keysRes = await relayFetch("health", "/v2/admin/keys", "GET", null, false, ADMIN_TOKEN);
+  const keysRes = await relayFetch("health", "/v2/admin/keys?reveal=1", "GET", null, false, ADMIN_TOKEN);
   const currentKey = (keysRes.body?.keys || []).find(k => k.key === session.user_id);
   const fromPlan = currentKey?.plan || 'community';
 
@@ -2505,7 +2509,7 @@ api.get("/user/billing/status", authUser, async (req, res) => {
   const billingRaw = await redis().get(`paramant:user:billing:${user_id}`);
   const billing = billingRaw ? JSON.parse(billingRaw) : null;
   const cancelAt = await redis().get(`paramant:user:plan_cancel_at:${user_id}`);
-  const keysRes = await relayFetch("health", "/v2/admin/keys", "GET", null, false, ADMIN_TOKEN);
+  const keysRes = await relayFetch("health", "/v2/admin/keys?reveal=1", "GET", null, false, ADMIN_TOKEN);
   const currentKey = (keysRes.body?.keys || []).find(k => k.key === user_id);
   res.json({
     current_plan: currentKey?.plan || 'community',
@@ -2730,7 +2734,7 @@ api.post('/admin/force-totp', authMiddleware, async (req, res) => {
 // ── Admin helpers ─────────────────────────────────────────────────────────────
 async function getAdminKeyMeta(key_id) {
   const [keysRes, metaRaw] = await Promise.all([
-    relayFetch('health', '/v2/admin/keys', 'GET', null, false, ADMIN_TOKEN),
+    relayFetch('health', '/v2/admin/keys?reveal=1', 'GET', null, false, ADMIN_TOKEN),
     redis().get(`paramant:user:meta:${key_id}`).catch(() => null),
   ]);
   const k = (keysRes.body?.keys || []).find(k => k.key === key_id) || {};
@@ -2887,7 +2891,7 @@ api.get('/admin/user-details/:key', authMiddleware, async (req, res) => {
   if (!key?.startsWith('pgp_')) return res.status(400).json({ error: 'invalid_key' });
   try {
     const [keysRes, metaRaw, billingRaw, auditEvents] = await Promise.all([
-      relayFetch('health', '/v2/admin/keys', 'GET', null, false, ADMIN_TOKEN),
+      relayFetch('health', '/v2/admin/keys?reveal=1', 'GET', null, false, ADMIN_TOKEN),
       redis().get(`paramant:user:meta:${key}`).catch(() => null),
       redis().get(`paramant:user:billing:${key}`).catch(() => null),
       getAuditEvents(key, { limit: 20 }),

--- a/relay/lib/keys-table.js
+++ b/relay/lib/keys-table.js
@@ -21,6 +21,18 @@ function computeKid(key) {
   return 'k_' + crypto.createHash('sha256').update(String(key)).digest('hex').slice(0, 12);
 }
 
+// Mask a secret API key for list/observation output so the full pgp_ value is
+// never returned in bulk. Keeps a short prefix + last 4 so an operator can tell
+// rows apart, without leaking enough to use the key. The full value is only
+// returned by the explicit ?reveal=1 list opt-in or the single-key reveal route
+// (both ADMIN_TOKEN-gated, for server-to-server callers). Short strings (<=12)
+// are returned unchanged — they are not full keys.
+function maskApiKey(key) {
+  const s = String(key || '');
+  if (s.length <= 12) return s;
+  return s.slice(0, 8) + '…' + s.slice(-4);
+}
+
 // Parse the additive account fields off a raw users.json key record, with
 // backward-compatible defaults. A record with no explicit account_id is its own
 // account (account_id = key), is its own primary, full scope, and — being a
@@ -165,4 +177,4 @@ function designatePrimary(apiKeys, accounts, accountKeys, accountId, key) {
   return { previous, current: key };
 }
 
-module.exports = { VALID_SCOPES, computeKid, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2, computeOverLimit, designatePrimary };
+module.exports = { VALID_SCOPES, computeKid, maskApiKey, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2, computeOverLimit, designatePrimary };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1795,6 +1795,10 @@ function safeEqual(a, b) {
   } catch { return false; }
 }
 
+// Mask a secret API key for list/observation output. Canonical implementation
+// lives in lib/keys-table.js (unit-tested); aliased here for the admin handlers.
+const maskKey = keysTable.maskApiKey;
+
 function authByDid(didStr, signature, payload) {
   const entry = didRegistry.get(didStr);
   if (!entry) return null;
@@ -4334,13 +4338,40 @@ session = client.create_session('recipient@example.com')</pre>
     // Account fields (kid/account_id/is_primary/scope/created) are ADDITIVE —
     // existing consumers read key/plan/label/email/active; stap-4 self-service
     // and the account-aware admin view use the account grouping.
+    //
+    // Blast-radius hygiene: the bulk list MASKS the secret key by default so a
+    // full pgp_ value is never returned for every account at once. Server-to-
+    // server callers that genuinely need the raw key (revoke/plan-change/reset)
+    // opt in with ?reveal=1; per-row reveal is also available at
+    // GET /v2/admin/keys/reveal/:account_id. key_masked is always present so
+    // browser-facing list views can render rows without ever holding a secret.
+    const reveal = query.reveal === '1' || query.reveal === 'true';
     const keys = [...apiKeys.entries()].map(([k, v]) => ({
-      key: k, plan: v.plan, label: v.label, email: v.email || null, active: v.active, over_limit: v.over_limit || false,
+      key: reveal ? k : maskKey(k), key_masked: maskKey(k), plan: v.plan, label: v.label, email: v.email || null, active: v.active, over_limit: v.over_limit || false,
       kid: v.kid || null, account_id: v.account_id || k, is_primary: !!v.is_primary, scope: v.scope || 'full', created: v.created || null
     }));
     const licenseInfo = { edition: EDITION, active_keys: keys.length, key_limit: LICENSE_MAX_KEYS === Infinity ? null : LICENSE_MAX_KEYS, ...(LICENSE_PAYLOAD ? { license_expires: LICENSE_PAYLOAD.expires_at } : {}) };
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    return res.end(J({ ok: true, count: keys.length, keys, license: licenseInfo }));
+    return res.end(J({ ok: true, count: keys.length, masked: !reveal, keys, license: licenseInfo }));
+  }
+
+  // ── GET /v2/admin/keys/reveal/:account_id — reveal ONE full secret key ──────
+  // Single-key counterpart to the masked list: returns the full pgp_ value for
+  // exactly one account/key so an operator never has to pull the whole table in
+  // the clear. Path-param (mirrors /v2/admin/usage/:account_id) so no query
+  // parse. ADMIN_TOKEN-gated by the admin-path guard above. Matches by
+  // account_id, then by the raw key, then by kid.
+  const revealGet = path.match(/^\/v2\/admin\/keys\/reveal\/(.+)$/);
+  if (revealGet && req.method === 'GET') {
+    const id = decodeURIComponent(revealGet[1]);
+    const entry = [...apiKeys.entries()].find(([k, v]) => (v.account_id || k) === id || k === id || v.kid === id);
+    if (!entry) { res.writeHead(404, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'key_not_found' })); }
+    const [k, v] = entry;
+    log('info', 'admin_key_revealed', { account: String(v.account_id || k).slice(0, 12), kid: v.kid || null });
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    return res.end(J({ ok: true, key: k, key_masked: maskKey(k), kid: v.kid || null,
+      account_id: v.account_id || k, plan: v.plan, label: v.label, email: v.email || null,
+      active: v.active, is_primary: !!v.is_primary, scope: v.scope || 'full', created: v.created || null }));
   }
 
   // ── GET /v2/admin/usage[/:account_id] — Phase 4 read-only observation ────

--- a/relay/test/keys-mask.test.js
+++ b/relay/test/keys-mask.test.js
@@ -1,0 +1,45 @@
+'use strict';
+// Unit tests for maskApiKey — the helper that keeps GET /v2/admin/keys from
+// returning full pgp_ secrets in its bulk list (blast-radius hygiene). Pure:
+// imports the helper only, never starts the relay server.
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { maskApiKey } = require('../lib/keys-table');
+
+const FULL = 'pgp_' + 'a'.repeat(60) + 'beef'; // 4 + 64 = 68 chars
+
+test('masks a full pgp_ key to prefix + … + last4', () => {
+  const m = maskApiKey(FULL);
+  assert.equal(m, 'pgp_aaaa…beef');
+});
+
+test('mask never contains the full secret', () => {
+  const m = maskApiKey(FULL);
+  assert.ok(!m.includes(FULL));
+  assert.ok(m.length < FULL.length);
+});
+
+test('mask reveals at most 8-char prefix + 4-char suffix', () => {
+  const m = maskApiKey(FULL);
+  // The visible characters must be a strict subset: 8 from the front, 4 from
+  // the back. An attacker who sees the mask learns <= 12 of the 64 hex chars.
+  assert.ok(FULL.startsWith(m.slice(0, 8)));
+  assert.ok(FULL.endsWith(m.slice(-4)));
+});
+
+test('two distinct keys with shared prefix stay distinguishable by suffix', () => {
+  const a = 'pgp_' + '0'.repeat(60) + 'aaaa';
+  const b = 'pgp_' + '0'.repeat(60) + 'bbbb';
+  assert.notEqual(maskApiKey(a), maskApiKey(b));
+});
+
+test('short / non-key strings pass through unchanged', () => {
+  assert.equal(maskApiKey('short'), 'short');
+  assert.equal(maskApiKey('pgp_12345678'), 'pgp_12345678'); // exactly 12, not masked
+});
+
+test('null / undefined / empty are safe', () => {
+  assert.equal(maskApiKey(null), '');
+  assert.equal(maskApiKey(undefined), '');
+  assert.equal(maskApiKey(''), '');
+});


### PR DESCRIPTION
## Theme: relay-admin (beehive audit)

One confirmed GENUINELY-OPEN finding against `origin/main`.

### Finding (LOW · ADMIN_TOKEN-gated · hygiene / blast-radius)
**GET /v2/admin/keys returns full `pgp_` API key values in the response body.**

`relay/relay.js` mapped `apiKeys.entries()` to `{ key: k, ... }`, returning the
**full secret key for every account** in a single list response. Any consumer of
the bulk list (admin backend, telemetry, any future caller) received every key in
the clear. ADMIN_TOKEN-gated, so blast-radius/hygiene rather than direct exposure,
but still confirmed open: no masked list variant and no separate reveal-one
endpoint existed.

### How it is fixed
- **Masked by default.** The bulk list now returns `key: maskKey(k)`
  (`pgp_xxxx…last4`) plus an always-present `key_masked`, and a top-level
  `masked: true|false` flag. New canonical helper `maskApiKey()` lives in
  `relay/lib/keys-table.js` (the existing pure key-helper module), reusing the
  codebase's `slice`-based masking convention.
- **Full key only on explicit opt-in:**
  - `GET /v2/admin/keys?reveal=1` for server-to-server callers that genuinely
    need raw keys (matching / Redis ids / operation tokens).
  - `GET /v2/admin/keys/reveal/:account_id` reveals exactly **one** full key
    (mirrors the `/v2/admin/usage/:account_id` path-param style), logging
    `admin_key_revealed`, so an operator never pulls the whole table in the clear.
  - Both remain behind the existing ADMIN_TOKEN admin-path guard.
- **Admin app callers partitioned** (`admin/server.js`, `admin/lib/telemetry.js`):
  - Need raw key → now pass `?reveal=1`: `findUserByEmail`, `findUserById`,
    billing checkout/status plan lookups, `getAdminKeyMeta`, user-details,
    `getUsersWithTotp` (uses `k.key` as the Redis id + `key_id` for actions).
  - Display/aggregation only → keep the masked default: `/keys/all` and
    `/sectors/:sector/keys` browser-facing list proxies, `getPlanDistribution`,
    `countSignupsToday`. **Bonus:** the browser-facing key listings no longer
    carry secrets either.

No behavioural change for callers that opt into `reveal=1` (relay returns the full
key exactly as before), so the admin UI's user management, revoke, plan-change and
TOTP flows are preserved.

### Verification
- `node --check` on all 5 edited/new files: **pass**.
- New unit test `relay/test/keys-mask.test.js` (6 cases: prefix+last4 shape, no
  full-secret leak, ≤12 visible chars, distinguishability, pass-through, null
  safety) + existing `keys-table.test.js` (15) + `keys-cap.test.js` (9): **all
  pass** via `node --test`.
- Tests requiring `node_modules`/`relay.js` (ws/redis/@noble) are not runnable in
  the audit env (deps not installed); covered by `node --check` + grep.
- Re-grep confirms the unconditional `key: k` in the bulk map is gone; the only
  remaining full-key sink is the explicit single-key reveal endpoint.

> Not deployed, not merged. Isolated worktree off `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)