### PR TITLE
sec(relay-auth): bind DID-auth against replay + bind open-mode envelope signatures to the signer key

### DIFF
--- a/relay/envelope.js
+++ b/relay/envelope.js
@@ -105,7 +105,14 @@ function safeTokenEqual(stored, provided) {
 //     as any other signed message (pentest H3). The label is byte-identical
 //     across relay + SDK + core; the NUL terminator delimits it from the id.
 //       sha3_256("paramant/parasign/doc/v1" || 0x00 || id || doc || pi || email_hash)
-function signMessageBytes(envelopeId, docHashHex, partyIndex, partyEmailHashHex, recipeVersion) {
+//   recipeVersion 4 (open-mode signer binding): like v3 but the SIGNER's public
+//     key is APPENDED, so the signature commits to "key K signed slot i of doc D".
+//     Open envelopes have no email/invite-token gate, so without this any caller
+//     who knew the envelope id could fill any party slot with a substituted key.
+//     Binding the pubkey turns each open-slot signature into a genuine, non-
+//     forgeable commitment to the exact key that produced it.
+//       sha3_256("paramant/parasign/doc/v1" || 0x00 || id || doc || pi || email_hash || signer_pub)
+function signMessageBytes(envelopeId, docHashHex, partyIndex, partyEmailHashHex, recipeVersion, signerPubB64) {
   const v = Number(recipeVersion) || 1;
   const h = crypto.createHash('sha3-256');
   if (v >= 3) {
@@ -118,6 +125,12 @@ function signMessageBytes(envelopeId, docHashHex, partyIndex, partyEmailHashHex,
     // Decoded email-hash bytes: 32 bytes when present, 0 bytes when the party
     // has no email -- deterministic either way.
     h.update(Buffer.from(partyEmailHashHex || '', 'hex'));
+  }
+  if (v >= 4) {
+    // Signer public-key bytes bind the signature to the exact key. base64 in,
+    // raw bytes mixed in (deterministic; empty -> 0 bytes, but sign() rejects
+    // an empty signer key before reaching here).
+    h.update(Buffer.from(signerPubB64 || '', 'base64'));
   }
   return h.digest();
 }
@@ -389,8 +402,18 @@ class EnvelopeStore {
     // party_index (and, for v2, the party's email hash) - so the recipient
     // signs over their hash, not the document. This binds the signature to
     // this envelope slot. The recipe is chosen by the stored recipe_version.
-    const recipeVersion = parseInt(h.recipe_version, 10) || 1;
-    const msg = signMessageBytes(id, h.doc_hash, pi, emailHash, recipeVersion);
+    //
+    // Open-mode slots have NO email/invite-token gate, so a bare id+party_index
+    // message would let any caller who knew the id fill any slot with a
+    // substituted key. For open mode we therefore upgrade to recipe v4, which
+    // APPENDS the signer's public key: the signature now commits to the exact
+    // key that produced it. (email/v2 and PRF/v3 keep their stored recipe — the
+    // email_hash / internal-proxy path already binds the signer there.) A v4
+    // message mixes the pubkey bytes, so reject an empty signer key up front.
+    const storedRecipe = parseInt(h.recipe_version, 10) || 1;
+    const effectiveRecipe = (mode === 'open') ? 4 : storedRecipe;
+    if (effectiveRecipe >= 4 && !signerPubB64) return { ok: false, code: 'bad_signature' };
+    const msg = signMessageBytes(id, h.doc_hash, pi, emailHash, effectiveRecipe, signerPubB64);
     let verified = false;
     try {
       verified = !!this.sigVerify(Buffer.from(signatureB64, 'base64'), msg, Buffer.from(signerPubB64, 'base64'));

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1795,22 +1795,76 @@ function safeEqual(a, b) {
   } catch { return false; }
 }
 
-function authByDid(didStr, signature, payload) {
+// ── DID-auth replay protection ────────────────────────────────────────────────
+// The previous DID-auth signed ONLY req.url, so any captured (X-DID,
+// X-DID-Signature) pair replayed forever against the same URL. We now bind a
+// freshness window (X-DID-TS, ±DID_AUTH_SKEW_MS) and a one-time nonce
+// (X-DID-Nonce) into the signed message, and reject any (did|nonce) we have
+// already accepted. The nonce cache self-evicts after the freshness window
+// (mirrors the _usedTotpCodes sweep) and is hard-capped to bound memory under a
+// nonce flood (evict-oldest, like the relay registry).
+const DID_AUTH_SKEW_MS  = 300_000;        // ±5 min, matches the /v2/relays/register window
+const MAX_DID_NONCES     = 50_000;        // hard cap on the in-flight nonce cache
+const _usedDidNonces = new Map();         // `${did}|${nonce}` → expiry ms
+setInterval(() => { const now = Date.now(); for (const [k, exp] of _usedDidNonces) if (now > exp) _usedDidNonces.delete(k); }, 30_000);
+
+// Canonical bytes a DID client must sign. Binding the method + url + timestamp +
+// nonce makes each signature single-use and non-transferable across requests.
+// Byte-identical recipe MUST be reproduced by the SDK:
+//   `${method}\n${url}\n${ts}\n${nonce}`
+function didAuthMessage(method, url, ts, nonce) {
+  return Buffer.from(`${String(method || '').toUpperCase()}\n${url}\n${ts}\n${nonce}`, 'utf8');
+}
+
+// authByDid: verify a DID-auth credential with replay protection. `ctx` carries
+// the request method and the freshness headers (ts, nonce). A missing/stale ts,
+// missing/oversized nonce, or a previously-seen (did|nonce) yields NO principal
+// (fail-closed) — the legacy bare-url signature is no longer accepted.
+function authByDid(didStr, signature, ctx) {
   const entry = didRegistry.get(didStr);
   if (!entry) return null;
   const vm = entry.doc.verificationMethod?.[0];
   if (!vm || !vm.publicKeyHex) return null;
+
+  const { method = 'GET', url = '', ts = '', nonce = '' } = (ctx && typeof ctx === 'object') ? ctx : { url: ctx };
+  // Freshness: timestamp must be a finite ms-epoch within the skew window.
+  const tsNum = Number(ts);
+  if (!ts || !Number.isFinite(tsNum) || Math.abs(Date.now() - tsNum) > DID_AUTH_SKEW_MS) {
+    log('warn', 'did_auth_stale_or_missing_ts', { did: didStr.slice(0,30) });
+    return null;
+  }
+  // Nonce: required, hex, bounded length (128 hex = 64 random bytes is plenty).
+  if (!nonce || !/^[0-9a-fA-F]{16,128}$/.test(nonce)) {
+    log('warn', 'did_auth_bad_nonce', { did: didStr.slice(0,30) });
+    return null;
+  }
+  const nonceKey = `${didStr}|${nonce.toLowerCase()}`;
+  if (_usedDidNonces.has(nonceKey)) {
+    log('warn', 'did_auth_replay_blocked', { did: didStr.slice(0,30) });
+    return null;
+  }
+
   try {
     const rawKey = Buffer.from(vm.publicKeyHex, 'hex');
     // Wrap raw uncompressed P-256 point in DER-SPKI if not already encoded (0x30 = SEQUENCE tag)
     const spkiKey = rawKey[0] === 0x30 ? rawKey : Buffer.concat([P256_SPKI_PREFIX, rawKey]);
     const valid = crypto.verify(
       'SHA256',
-      Buffer.from(payload),
+      didAuthMessage(method, url, ts, nonce),
       { key: spkiKey, format: 'der', type: 'spki' },
       Buffer.from(signature, 'hex')
     );
-    if (valid) return entry;
+    if (valid) {
+      // Burn the nonce only after a valid signature, so an attacker cannot pre-
+      // poison the cache with arbitrary nonces. Expires one skew-window out;
+      // evict the oldest entry first if the cache is at capacity (flood guard).
+      if (_usedDidNonces.size >= MAX_DID_NONCES) {
+        const oldest = _usedDidNonces.keys().next().value;
+        if (oldest !== undefined) _usedDidNonces.delete(oldest);
+      }
+      _usedDidNonces.set(nonceKey, Date.now() + DID_AUTH_SKEW_MS);
+      return entry;
+    }
   } catch(e) {
     log('warn', 'did_auth_verify_error', { err: e.message, did: didStr.slice(0,30) });
   }
@@ -1831,7 +1885,7 @@ function setHeaders(res, req) {
   res.setHeader('Access-Control-Allow-Origin',  allowOrigin);
   res.setHeader('Vary',                         'Origin');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Api-Key, X-Dsa-Signature, Authorization, X-DID, X-DID-Signature');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Api-Key, X-Dsa-Signature, Authorization, X-DID, X-DID-Signature, X-DID-TS, X-DID-Nonce');
   res.setHeader('Cache-Control',                'no-store, no-cache, must-revalidate');
   res.setHeader('X-Content-Type-Options',       'nosniff');
   res.setHeader('Content-Security-Policy',      "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; img-src 'self' data:; frame-ancestors 'none'");
@@ -1879,9 +1933,13 @@ const server = http.createServer(async (req, res) => {
   }
   const didHeader = req.headers['x-did'] || '';
   const didSig    = req.headers['x-did-signature'] || '';
+  // Freshness factors that make a DID-auth credential single-use (replay guard):
+  // the client signs `${method}\n${url}\n${ts}\n${nonce}` and sends ts/nonce here.
+  const didTs     = req.headers['x-did-ts']    || '';
+  const didNonce  = req.headers['x-did-nonce'] || '';
   let didAuthEntry = null;
   if (!apiKey && didHeader && didSig) {
-    didAuthEntry = authByDid(didHeader, didSig, req.url);
+    didAuthEntry = authByDid(didHeader, didSig, { method: req.method, url: req.url, ts: didTs, nonce: didNonce });
     if (didAuthEntry) log('info', 'did_auth_mode', { did: didHeader.slice(0,30) });
   }
   const dsaSig  = req.headers['x-dsa-signature'] || '';
@@ -4750,9 +4808,14 @@ python3 paramant-receiver.py \\
     if (!store) { res.writeHead(503, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'Envelope store unavailable' })); }
     const id = path.slice('/v2/envelopes/'.length).split('/')[0];
     if (!/^[A-Za-z0-9_-]{20,64}$/.test(id)) { res.writeHead(404, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'not found' })); }
-    const recipeFor = (v) => v >= 2
-      ? 'sha3_256(envelope.id || doc_hash || party_index_as_decimal || party_email_hash_bytes)'
-      : 'sha3_256(envelope.id || doc_hash || party_index_as_decimal)';
+    // Recipe the co-signer must reproduce. Open-mode slots are signer-bound
+    // (recipe v4): the signer's public key is appended so the signature commits
+    // to the exact key. Email/PRF slots stay email/document-hash bound (v2/v3).
+    const recipeFor = (v, mode) => (mode || 'open') === 'open'
+      ? 'sha3_256("paramant/parasign/doc/v1" || 0x00 || envelope.id || doc_hash || party_index_as_decimal || party_email_hash_bytes || signer_public_key_bytes)'
+      : (v >= 2
+        ? 'sha3_256(envelope.id || doc_hash || party_index_as_decimal || party_email_hash_bytes)'
+        : 'sha3_256(envelope.id || doc_hash || party_index_as_decimal)');
     try {
       // ?p=<i>&t=<invite_token> -> party-scoped view. For email-bound envelopes
       // the token must match (getForParty returns null otherwise); for open
@@ -4764,12 +4827,12 @@ python3 paramant-receiver.py \\
         const view = await store.getForParty(id, pi, token);
         if (!view) { res.writeHead(404, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'not found' })); }
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        return res.end(J({ ok: true, envelope: view, sign_message_recipe: recipeFor(view.recipe_version) }));
+        return res.end(J({ ok: true, envelope: view, sign_message_recipe: recipeFor(view.recipe_version, view.binding_mode) }));
       }
       const env = await store.getRedacted(id);
       if (!env) { res.writeHead(404, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'not found' })); }
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      return res.end(J({ ok: true, envelope: env, sign_message_recipe: recipeFor(env.recipe_version) }));
+      return res.end(J({ ok: true, envelope: env, sign_message_recipe: recipeFor(env.recipe_version, env.binding_mode) }));
     } catch (e) {
       res.writeHead(500, { 'Content-Type': 'application/json' });
       return res.end(J({ error: 'internal' }));

--- a/relay/test/envelope-binding.test.js
+++ b/relay/test/envelope-binding.test.js
@@ -63,6 +63,15 @@ async function main() {
   assert.ok(signMessageBytes(ID, DOC, 2, '', 2).equals(signMessageBytes(ID, DOC, 2)), 'v2 empty-email == v1');
   ok('signMessageBytes v2 email commitment');
 
+  // 3b. signMessageBytes v4 commits to the SIGNER pubkey (open-mode binding).
+  const PUB_A = 'cHViQQ==', PUB_B = 'cHViQg==';
+  const v4a = signMessageBytes(ID, DOC, 0, '', 4, PUB_A);
+  const v4b = signMessageBytes(ID, DOC, 0, '', 4, PUB_B);
+  assert.ok(!v4a.equals(v4b), 'v4 changes with a different signer pubkey');
+  assert.ok(!v4a.equals(signMessageBytes(ID, DOC, 0, '', 3, PUB_A)), 'v4 differs from v3 (pubkey appended)');
+  assert.ok(!v4a.equals(signMessageBytes(ID, DOC, 0)), 'v4 differs from the unbound v1 recipe');
+  ok('signMessageBytes v4 signer-pubkey commitment');
+
   // 4. sign(): email-bound slot rejects a public (non-internal) caller
   {
     const store = new EnvelopeStore(fakeRedis(emailHashOf(EMAIL_HASH)), { sigVerify: () => true });
@@ -96,9 +105,11 @@ async function main() {
     ok('sign() accepts matching internal caller with v2 message');
   }
 
-  // 7. sign(): legacy/open envelope (no binding_mode) still works via public path
-  //    and verifies the v1 message - the existing co-sign flow is unchanged.
+  // 7. sign(): open envelope (no binding_mode) works via the public path but is
+  //    now SIGNER-BOUND (recipe v4): the verified message appends the signer's
+  //    public key, so the signature commits to the exact key that produced it.
   {
+    const SIGNER_PUB = 'cHViMQ==';   // base64('pub1')
     const hash = {
       id: ID, doc_hash: DOC, status: 'sent',   // no binding_mode, no recipe_version
       party_count: '1', signed_count: '0', p0_email_hash: '', p0_status: 'pending',
@@ -107,10 +118,15 @@ async function main() {
     const store = new EnvelopeStore(fakeRedis(hash), {
       sigVerify: (_sig, msg) => { seenMsg = msg; return true; },
     });
-    const r = await store.sign(ID, 0, 'cHVi', 'c2ln');   // public, no opts
+    const r = await store.sign(ID, 0, SIGNER_PUB, 'c2ln');   // public, no opts
     assert.strictEqual(r.ok, true, 'open envelope accepts public caller');
-    assert.ok(seenMsg && seenMsg.equals(signMessageBytes(ID, DOC, 0)), 'open envelope verifies v1 message');
-    ok('sign() legacy/open envelope unchanged (v1, public)');
+    // The verified message is the v4 recipe bound to THIS signer pubkey...
+    assert.ok(seenMsg && seenMsg.equals(signMessageBytes(ID, DOC, 0, '', 4, SIGNER_PUB)),
+      'open envelope verifies the signer-bound v4 message');
+    // ...and is provably NOT the old (signer-agnostic) v1 message.
+    assert.ok(!seenMsg.equals(signMessageBytes(ID, DOC, 0)),
+      'open-mode message is no longer the unbound v1 recipe');
+    ok('sign() open envelope is signer-bound (v4, public)');
   }
 
   // 8. getForParty: email mode is token-gated and never leaks the invite token
@@ -165,6 +181,53 @@ async function main() {
     const view = await vstore.getForParty(ID, 0, TOKEN);
     assert.ok(view.sign_expires_at && Date.parse(view.sign_expires_at) > Date.now(), 'sign_expires_at set + in the future for a fresh email invite');
     ok('sign() enforces the 7-day signing-invite window (email mode; open unaffected)');
+  }
+
+  // 10. sign(): open-mode signer-substitution is rejected. A real ML-DSA verify
+  //     only passes when the signature matches the message AND the submitted
+  //     pubkey. We model that: the verifier accepts iff the message equals the
+  //     v4 recipe for the *submitted* pubkey. An attacker who signs the legacy
+  //     (signer-agnostic) message, or presents a signature minted for a
+  //     different key, no longer validates against any other key/slot.
+  {
+    const hash = {
+      id: ID, doc_hash: DOC, status: 'sent',   // open envelope
+      party_count: '1', signed_count: '0', p0_email_hash: '', p0_status: 'pending',
+    };
+    // Honest verifier: bind sig<->(message, pubkey). Here a "signature" is just
+    // the v4 message the signer committed to; it verifies only if it equals the
+    // v4 message recomputed for the pubkey actually submitted to sign().
+    const honest = (committedMsgB64) => (sigBuf, msg, pubBuf) => {
+      const submittedPub = pubBuf.toString('base64');
+      const expected = signMessageBytes(ID, DOC, 0, '', 4, submittedPub);
+      return Buffer.from(committedMsgB64, 'base64').equals(msg) && msg.equals(expected);
+    };
+
+    const PUB_A = 'cHViQQ==';   // base64('pubA')
+    const PUB_B = 'cHViQg==';   // base64('pubB')
+
+    // (a) Honest signer A: commits to v4 message for PUB_A, submits PUB_A -> ok.
+    const msgA = signMessageBytes(ID, DOC, 0, '', 4, PUB_A).toString('base64');
+    const okStore = new EnvelopeStore(fakeRedis(hash), { sigVerify: honest(msgA) });
+    assert.strictEqual((await okStore.sign(ID, 0, PUB_A, msgA)).ok, true, 'honest signer with matching v4 commitment accepted');
+
+    // (b) Attacker captured A's signature (committed to PUB_A) but submits PUB_B
+    //     to claim the slot as a different identity -> rejected (message for
+    //     PUB_B differs, so the captured commitment no longer verifies).
+    const subStore = new EnvelopeStore(fakeRedis(hash), { sigVerify: honest(msgA) });
+    assert.strictEqual((await subStore.sign(ID, 0, PUB_B, msgA)).code, 'bad_signature', 'key-substituted signature rejected');
+
+    // (c) Legacy attack: sign the OLD signer-agnostic v1 message -> rejected,
+    //     because open mode now verifies the signer-bound v4 message only.
+    const legacyMsg = signMessageBytes(ID, DOC, 0).toString('base64');
+    const legacyStore = new EnvelopeStore(fakeRedis(hash), { sigVerify: honest(legacyMsg) });
+    assert.strictEqual((await legacyStore.sign(ID, 0, PUB_A, legacyMsg)).code, 'bad_signature', 'legacy signer-agnostic signature rejected');
+
+    // (d) Empty signer key is rejected before verify (v4 mixes the pubkey).
+    const emptyStore = new EnvelopeStore(fakeRedis(hash), { sigVerify: () => true });
+    assert.strictEqual((await emptyStore.sign(ID, 0, '', 'c2ln')).code, 'bad_signature', 'empty signer key rejected');
+
+    ok('sign() open-mode signer binding blocks key substitution + legacy replay');
   }
 }
 

--- a/tests/static-sanity.sh
+++ b/tests/static-sanity.sh
@@ -126,6 +126,50 @@ if [ -f "$ROOT/admin/server.js" ]; then
   fi
 fi
 
+# ── 7. DID-auth credential is replay-protected ───────────────────────────────
+# The DID-auth signature MUST bind a freshness window + one-time nonce, not just
+# req.url (which replayed forever). Guard against a regression to the bare form.
+echo ""
+echo "7. DID-auth replay protection present..."
+RELAY="$ROOT/relay/relay.js"
+if [ -f "$RELAY" ]; then
+  did7_fail=0
+  # 7a. The replay nonce cache + freshness window + bound message must exist.
+  for needle in "_usedDidNonces" "DID_AUTH_SKEW_MS" "didAuthMessage(" "x-did-nonce" "x-did-ts"; do
+    if ! grep -q "$needle" "$RELAY"; then
+      printf "   FAIL  relay.js  — DID-auth replay guard missing: %s\n" "$needle"
+      did7_fail=1
+    fi
+  done
+  # 7b. authByDid must NOT verify the bare url/payload (the old, replayable form:
+  #     crypto.verify('SHA256', Buffer.from(payload), ...) on a multi-line call).
+  if grep -A2 -P "crypto\.verify\(\s*$" "$RELAY" 2>/dev/null | grep -q "Buffer.from(payload)"; then
+    printf "   FAIL  relay.js  — DID-auth still verifies bare Buffer.from(payload) (replayable)\n"
+    did7_fail=1
+  fi
+  if [ "$did7_fail" -eq 0 ]; then
+    printf "   OK  relay.js  (DID-auth binds ts+nonce, no bare-url replay)\n"
+  else
+    FAIL=$((FAIL + did7_fail))
+  fi
+fi
+
+# ── 8. Open-mode envelope signatures are signer-bound ────────────────────────
+# Open party slots have no email/invite-token gate, so the signature MUST commit
+# to the signer pubkey (recipe v4) — otherwise any caller who knows the envelope
+# id can fill any slot with a substituted key.
+echo ""
+echo "8. Open-mode envelope signer binding present..."
+ENV="$ROOT/relay/envelope.js"
+if [ -f "$ENV" ]; then
+  if grep -q "effectiveRecipe" "$ENV" && grep -q "v >= 4" "$ENV"; then
+    printf "   OK  envelope.js  (open-mode sign() binds signer pubkey via recipe v4)\n"
+  else
+    printf "   FAIL  envelope.js  — open-mode signature is not signer-bound (recipe v4 missing)\n"
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "════════ RESULT ════════"


### PR DESCRIPTION
Closes two **genuinely-open** `relay-auth` findings from the beehive audit, verified against `origin/main`. No deploy, no merge — review only.

## [HIGH] DID-auth credential is replayable
`relay/relay.js` — `authByDid` (+ header resolution)

**Issue.** On `origin/main`, `authByDid` verified `crypto.verify('SHA256', req.url, ...)` with **no** nonce / timestamp / method / replay-cache. Any captured `(X-DID, X-DID-Signature)` pair replayed indefinitely against the same URL and authenticated as the key the DID was registered under (inheriting its plan/active). PR #204 only *scoped* the DID to its registering key; it added **no freshness**, so the replay core was untouched.

**Fix.**
- The DID client now signs a freshness-bound message: `` `${method}\n${url}\n${ts}\n${nonce}` `` (`didAuthMessage`).
- `authByDid` rejects (grants **no** principal — fail-closed) when:
  - `X-DID-TS` is missing or outside ±5 min (`DID_AUTH_SKEW_MS`, matching the existing `/v2/relays/register` window),
  - `X-DID-Nonce` is missing or not 16–128 hex chars,
  - the `(did|nonce)` pair was already accepted (one-time nonce).
- The nonce is burned **only after** a valid signature (an attacker can't pre-poison the cache). The cache self-evicts after the skew window (mirrors the existing `_usedTotpCodes` sweep) and is hard-capped at `MAX_DID_NONCES = 50_000` with evict-oldest (mirrors the relay-registry cap).
- CORS `Access-Control-Allow-Headers` extended with `X-DID-TS, X-DID-Nonce`.

**Client contract change.** The legacy bare-`req.url` signature no longer authenticates. SDK/device clients must send `X-DID-TS` + `X-DID-Nonce` and sign the new message. This is intentional: leaving the old form accepted would keep the indefinite replay open.

## [LOW] Open-mode multiparty envelopes accept any key for any party slot
`relay/envelope.js` — `sign()` / `signMessageBytes`

**Issue.** On `origin/main`, open-mode `sign()` verified `sha3_256(id || doc_hash || party_index)` — the signed message **never bound the signer pubkey**. Open slots have no email/invite-token gate, so any caller who knew the envelope `id` could fill any party slot with a substituted key. (PR #208 domain-separated the unrelated single-signer `/v2/sign` notary, not this multiparty open-mode binding.)

**Fix.**
- New **recipe v4** in `signMessageBytes` **appends the signer's public key** to the message: `sha3_256("paramant/parasign/doc/v1" || 0x00 || id || doc || pi || email_hash || signer_pub)`.
- Open-mode `sign()` now verifies the v4 (signer-bound) message, so each open-slot signature is a non-forgeable commitment to the exact key that produced it. An empty signer key is rejected up front.
- **Email/v2 and PRF/v3 flows are byte-identical and untouched** — the live frontend (`sign-flow.js` / `co-sign.js`, recipe v3 via `buildDocSignMessage`) and the email/admin-proxy path already bind the signer, so they keep their stored recipe.
- `GET /v2/envelopes/:id` advertises the signer-bound recipe string for open mode.

## Verification (node --check + grep + test runner)
- `node --check` clean on `relay/relay.js`, `relay/envelope.js`, and the test.
- `relay/test/envelope-binding.test.js` extended **9 → 11 checks**: v4 pubkey commitment; open-mode signer-substitution rejected; legacy (signer-agnostic) signature rejected; empty-key rejected. **All 7 `relay/test/*.test.js` suites pass.**
- Standalone **real P-256 ECDSA** harness proved for the DID path: fresh credential authenticates; exact replay, URL-swap, method-swap, stale-ts, and legacy bare-url (no ts/nonce) are all rejected.
- `tests/static-sanity.sh` gains check **#7** (DID freshness present; no bare-`Buffer.from(payload)` verify) and **#8** (open-mode signer binding present). Full static-sanity suite: **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)