### PR TITLE
fix(audit-followups): install.sh clobber + peer-STH disk reclaim + dead nginx route

### DIFF
--- a/deploy/nginx-paramant-public.conf
+++ b/deploy/nginx-paramant-public.conf
@@ -143,15 +143,6 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
     ssl_prefer_server_ciphers off;
-    location = /v2/request-trial {
-        limit_req zone=relay_trial burst=2 nodelay;
-        limit_req_status 429;
-        proxy_pass http://127.0.0.1:3000;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_read_timeout 30s;
-    }
     location = /v2/sign-dpa {
         limit_req zone=relay_trial burst=2 nodelay;
         limit_req_status 429;

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ dim()  { echo -e "${D}$*${E}"; }
 
 INSTALL_DIR="${PARAMANT_DIR:-/opt/paramant}"
 REPO="https://github.com/Apolloccrypt/paramant-relay"
-VERSION="v3.0.0"
+RELAY_VERSION="${PARAMANT_VERSION:-v3.0.0}"
 MIN_RAM_MB=512
 MIN_DISK_GB=4
 INSTALL_T0=$(date +%s)   # for the "download to dashboard" timer
@@ -47,7 +47,7 @@ ${C}${BOLD}  ██╔═══╝ ██╔══██║██╔══██
 ${C}${BOLD}  ██║     ██║  ██║██║  ██║██║  ██║██║ ╚═╝ ██║██║  ██║██║ ╚███║   ██║   ${E}
 ${C}${BOLD}  ╚═╝     ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚══╝   ╚═╝   ${E}
 
-  ${D}Post-Quantum Relay Installer ${VERSION}${E}
+  ${D}Post-Quantum Relay Installer ${RELAY_VERSION}${E}
   ${D}ML-KEM-768 · Burn-on-read · Community Edition${E}
 
   ${Y}License: BUSL-1.1 — free for up to 5 API keys.${E}
@@ -249,18 +249,18 @@ if [[ -d "$INSTALL_DIR/.git" ]]; then
   git -C "$INSTALL_DIR" pull --ff-only -q
   ok "Updated to latest"
 else
-  info "Cloning ${REPO} at ${VERSION}..."
+  info "Cloning ${REPO} at ${RELAY_VERSION}..."
   # Pin to the release tag. Do NOT silently fall back to an unpinned default-
   # branch clone if the tag is missing/unreachable: that would install whatever
   # HEAD happens to be (supply-chain integrity gap). Fail loudly so the operator
-  # can pick a known-good VERSION instead of getting a surprise revision.
-  if ! git clone --depth 1 --branch "${VERSION}" "$REPO" "$INSTALL_DIR" -q; then
-    err "Could not clone ${REPO} at tag ${VERSION}."
+  # can pick a known-good PARAMANT_VERSION instead of getting a surprise revision.
+  if ! git clone --depth 1 --branch "${RELAY_VERSION}" "$REPO" "$INSTALL_DIR" -q; then
+    err "Could not clone ${REPO} at tag ${RELAY_VERSION}."
     err "Refusing to fall back to an unpinned clone. Check your network, or set"
-    err "VERSION to a tag that exists (see ${REPO}/tags) and re-run."
+    err "PARAMANT_VERSION to a tag that exists (see ${REPO}/tags) and re-run."
     exit 1
   fi
-  ok "Cloned ${VERSION} to ${INSTALL_DIR}"
+  ok "Cloned ${RELAY_VERSION} to ${INSTALL_DIR}"
 fi
 
 cd "$INSTALL_DIR"

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -769,6 +769,9 @@ function _evictPeerSthsIfNeeded() {
     if (peerSths.size <= PEER_STH_MAX_PEERS) break;
     peerSths.delete(pkHash);
     _peerSthStreamClose(pkHash);
+    // Reclaim the evicted peer's on-disk .jsonl so the file set is actually
+    // bounded (not just the fd table); a later re-ingest re-creates it fresh.
+    try { fs.unlinkSync(path.join(PEER_STH_DIR, pkHash.replace(/[^a-f0-9]/g, '').slice(0, 64) + '.jsonl')); } catch {}
     log('info', 'peer_sth_evicted', { id: pkHash.slice(0, 16), peers: peerSths.size });
   }
 }


### PR DESCRIPTION
Post-deploy regression+bug hunt on the deployed audit PRs (#240-247) found 3 confirmed issues; this fixes all three. Not deployed.

**HIGH - #245 regression: install.sh fresh-install broke.** Sourcing /etc/os-release clobbered the script VERSION (os-release exports its own VERSION=), so the pinned clone used the OS string and exited 1. Renamed to RELAY_VERSION (overridable via PARAMANT_VERSION). Still needs a v3.0.0 git tag to exist for the pinned clone to succeed (the relay self-reports 3.0.0 but no tag exists; latest is v2.4.5). The deployed /home/paramant/app/install.sh still has the old working fallback, so live installs were not affected.

**LOW - #243: peer-STH .jsonl never reclaimed.** _evictPeerSthsIfNeeded closed the fd but left the file on disk; the eviction comment claimed the .jsonl set was bounded but it was not. Now fs.unlinkSync on eviction.

**LOW - #241: dead nginx route.** Removed the leftover 'location = /v2/request-trial' block; the relay_trial limit_req zone stays (used by /v2/sign-dpa).

Verified: node --check relay.js, bash -n install.sh, nginx brace-balanced.