### PR TITLE
fix(parasign): solid white seal body so the stamp is always legible

### DIFF
--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -930,8 +930,9 @@ async function buildStampedImage(origBytes, stamp, signerName, dateStr, fingerpr
 
 function drawStampOnCanvas(ctx, stamp, signerName, dateStr, fingerprint8, sigImg) {
   const { x, y, w, h } = stamp;
-  // Outer fill + border
-  ctx.fillStyle = 'rgba(11, 58, 106, 0.03)';
+  // Solid WHITE body so the seal is always legible on any document (dark text on
+  // white), instead of a near-transparent fill that let busy/dark images bleed through.
+  ctx.fillStyle = '#ffffff';
   ctx.fillRect(x, y, w, h);
   ctx.strokeStyle = '#0b3a6a';
   ctx.lineWidth = Math.max(1, w / 200);
@@ -1010,8 +1011,9 @@ async function buildStampedPdf(origBytes, stamp, signerName, dateStr, fingerprin
   const dim   = PDFLib.rgb(0.30, 0.30, 0.30);
   const white = PDFLib.rgb(1, 1, 1);
 
-  // Outer border + faint fill
-  page.drawRectangle({ x: stamp.x, y: stamp.y, width: stamp.w, height: stamp.h, borderColor: navy, borderWidth: 1.2, color: navy, opacity: 0.03 });
+  // Outer border + SOLID WHITE body (always legible: dark text on white, not a
+  // near-transparent fill that lets the document bleed through).
+  page.drawRectangle({ x: stamp.x, y: stamp.y, width: stamp.w, height: stamp.h, borderColor: navy, borderWidth: 1.2, color: white, opacity: 1 });
 
   // Branded top band: cobalt bar with logo + PQ badge
   const bandH = 16;

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -50,7 +50,7 @@
 .ds-info-card dd{font-family:var(--mono);font-size:12px;color:var(--ink);word-break:break-all;margin:0}
 .ds-page-wrap{position:relative;margin-bottom:14px;cursor:crosshair}
 .ds-page-wrap canvas{width:100%;height:auto;display:block;border:1px solid var(--ink-hair);background:#fff}
-.ds-stamp-marker{position:absolute;border:1px solid var(--cobalt);background:rgba(11,58,106,.03);pointer-events:none;box-sizing:border-box;overflow:hidden;display:flex;flex-direction:column;font-family:Inter,sans-serif;color:var(--navy)}
+.ds-stamp-marker{position:absolute;border:1px solid var(--cobalt);background:#fff;pointer-events:none;box-sizing:border-box;overflow:hidden;display:flex;flex-direction:column;font-family:Inter,sans-serif;color:var(--navy)}
 .ds-sm-band{background:var(--cobalt);color:#fff;display:flex;justify-content:space-between;align-items:center;padding:2px 5px;line-height:1;flex:0 0 auto}
 .ds-sm-logo{font-family:var(--mono);font-weight:700;letter-spacing:.04em;font-size:8px}
 .ds-sm-logo span{color:var(--lime)}
@@ -95,7 +95,7 @@
 .ds-review-pane.has-pdf{padding:0;background:#fff;align-items:flex-start;max-height:380px;overflow-y:auto}
 .ds-review-pane canvas{width:100%;height:auto;display:block}
 .ds-review-pane img{max-width:100%;max-height:120px}
-.ds-review-pane .ds-mockup-stamp{position:absolute;border:1px solid var(--cobalt);background:rgba(11,58,106,.03);pointer-events:none;box-sizing:border-box;overflow:hidden;display:flex;flex-direction:column;font-family:Inter,sans-serif;color:var(--navy)}
+.ds-review-pane .ds-mockup-stamp{position:absolute;border:1px solid var(--cobalt);background:#fff;pointer-events:none;box-sizing:border-box;overflow:hidden;display:flex;flex-direction:column;font-family:Inter,sans-serif;color:var(--navy)}
 .ds-review-pane .ds-pane-meta{font-family:var(--mono);font-size:11px;color:var(--ink-dim);line-height:1.6;word-break:break-all;text-align:left;padding:6px}
 .ds-typed-preview{font-family:'Brush Script MT', cursive, sans-serif;font-size:32px;color:var(--navy);font-weight:400}
 .ds-review-cap{font-size:11px;color:var(--ink-dim);margin:0 0 8px;line-height:1.5}


### PR DESCRIPTION
The visual seal filled its body with `rgba(11,58,106,.03)` (97% transparent), so on busy or dark documents the dark metadata text (signer name, date, ML-DSA fingerprint) and the signature bled into the background and became unreadable — see the reported screenshots of a logo image being signed.

Fix: solid **white** seal body with dark text, across all three render paths so preview == output:
- image canvas — `drawStampOnCanvas`
- PDF — `buildStampedPdf` (rectangle `color: white, opacity: 1`)
- on-screen mockup — `.ds-stamp-marker` / `.ds-mockup-stamp`

Header band stays navy + white; signature + footer metadata now read cleanly on any document. Deployed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)