### PR TITLE
feat(vault): client-side file encryption to .prmnt (passphrase MVP)

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -6,7 +6,7 @@
 <title>Your Paramant — Dashboard</title>
 <meta name="description" content="Sign in to your Paramant dashboard.">
 <meta name="theme-color" content="#0B1622">
-<link rel="icon" type="image/svg+xml" href="/assets/paramant-icon.svg">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://relay.paramant.app">
 <link rel="stylesheet" href="/design-system.css?v=19">
 <link rel="stylesheet" href="/nav.css?v=13">
@@ -359,6 +359,7 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
       <a class="dh-tool" href="/get"><h3>Receive a file</h3><p>Open a secure link someone sent you. Decryption happens locally.</p></a>
       <a class="dh-tool" href="/parashare"><h3>ParaShare</h3><p>Verified, signed delivery with receipts. Multi-recipient. Sector audit log.</p></a>
       <a class="dh-tool" href="/verify"><h3>Verify a signature</h3><p>Check a .psign envelope against its document. Local hash, relay-side math.</p></a>
+      <a class="dh-tool" href="/vault"><h3>Lock a file</h3><p>Encrypt any file into a <code>.prmnt</code> with a passphrase. Opens only with the passphrase. Fully on your device.</p></a>
     </section>
 
     <div class="dh-tools-head"><h2>Operations</h2></div>

--- a/frontend/vault.html
+++ b/frontend/vault.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}[hidden]{display:none !important}</style>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Lock a file · Paramant</title>
+<meta name="description" content="Encrypt a file into a .prmnt container with a passphrase. Everything happens on your device; the file and key never leave your browser.">
+<meta property="og:title" content="Lock a file · Paramant">
+<meta property="og:description" content="Encrypt a file with a passphrase, right in your browser. The file never leaves your device.">
+<meta property="og:url" content="https://paramant.app/vault">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<link rel="canonical" href="https://paramant.app/vault">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="theme-color" content="#0B3A6A">
+<link rel="stylesheet" href="/design-system.css?v=19">
+<style>
+.vt-bar{display:flex;align-items:center;justify-content:space-between;padding:14px 24px;border-bottom:1px solid var(--ink-hair)}
+.vt-brand{font-family:var(--mono);font-size:13px;font-weight:700;letter-spacing:.04em;color:var(--navy);text-decoration:none}
+.vt-brand span{color:var(--cobalt)}
+.vt-back{font-family:var(--mono);font-size:12px;color:var(--ink-dim);text-decoration:none}
+.vt-back:hover{color:var(--cobalt)}
+.vt-wrap{max-width:640px;margin:40px auto;padding:0 20px}
+.vt-kicker{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:8px}
+.vt-title{font-size:30px;font-weight:700;letter-spacing:-.02em;margin:0 0 10px;color:var(--navy)}
+.vt-lede{font-size:14px;color:var(--ink-dim);line-height:1.7;margin:0 0 26px}
+.vt-tabs{display:flex;gap:8px;margin-bottom:22px}
+.vt-tab{flex:1;padding:14px;border:1px solid var(--ink-hair);background:var(--bone);color:var(--ink-dim);font-family:var(--mono);font-size:13px;font-weight:600;letter-spacing:.02em;cursor:pointer;border-radius:12px;text-align:center;transition:all .14s}
+.vt-tab.on{border-color:var(--cobalt);color:var(--navy);background:rgba(11,58,106,.05)}
+.vt-card{background:#fff;border:1px solid var(--ink-hair);border-radius:16px;padding:24px}
+.vt-drop{border:2px dashed var(--ink-hair);background:var(--bone);border-radius:14px;padding:36px 20px;text-align:center;cursor:pointer;transition:all .14s;outline:none}
+.vt-drop:hover,.vt-drop:focus-visible,.vt-drop.drag{border-color:var(--cobalt);background:rgba(11,58,106,.04)}
+.vt-drop .big{font-size:16px;font-weight:600;color:var(--navy);margin:0 0 4px}
+.vt-drop .small{font-size:12px;color:var(--ink-dim);margin:0}
+.vt-info{margin-top:12px;font-family:var(--mono);font-size:12px;color:var(--navy);background:var(--bone-2,rgba(11,58,106,.04));border:1px solid var(--ink-hair);border-radius:10px;padding:10px 12px;word-break:break-all}
+.vt-field{margin-top:16px}
+.vt-label{display:block;font-family:var(--mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:6px}
+.vt-input{width:100%;box-sizing:border-box;padding:12px 14px;border:1px solid var(--ink-hair);border-radius:10px;background:var(--bone);color:var(--ink);font-family:var(--mono);font-size:14px}
+.vt-input:focus{outline:none;border-color:var(--cobalt)}
+.vt-run{width:100%;margin-top:20px;min-height:48px;font-size:15px}
+.vt-status{margin-top:16px;padding:12px 14px;border-radius:10px;font-size:13px;line-height:1.5;border:1px solid var(--ink-hair);background:var(--bone)}
+.vt-status.ok{border-color:var(--lime);background:rgba(178,255,63,.14);color:var(--navy)}
+.vt-status.err{border-color:rgba(200,30,30,.5);background:rgba(255,80,80,.06);color:rgba(170,20,20,1)}
+.vt-note{margin-top:22px;font-size:12px;color:var(--ink-dim);line-height:1.6;text-align:center}
+.vt-warn{margin:20px 0;padding:14px 16px;border:1px solid #d4a017;background:#fff4d6;border-radius:10px;color:#5a3f00;font-size:13px}
+</style>
+</head>
+<body>
+<header class="vt-bar">
+  <a class="vt-brand" href="/dashboard">Para<span>MANT</span></a>
+  <a class="vt-back" href="/dashboard">← Dashboard</a>
+</header>
+
+<main class="vt-wrap">
+  <div class="vt-kicker">Paramant Vault</div>
+  <h1 class="vt-title">Lock a file</h1>
+  <p class="vt-lede">Pick a file and a passphrase. Paramant turns it into a locked <code>.prmnt</code> file that only your passphrase can open. Everything happens on this device — the file and the passphrase never leave your browser.</p>
+
+  <div id="vt-unsupported" class="vt-warn" hidden>Your browser does not support the encryption this page needs. Try a recent Chrome, Edge, Safari or Firefox.</div>
+
+  <div class="vt-tabs" role="tablist">
+    <button class="vt-tab on" data-mode="lock" role="tab" aria-selected="true">Lock a file</button>
+    <button class="vt-tab" data-mode="open" role="tab" aria-selected="false">Open a .prmnt</button>
+  </div>
+
+  <!-- Lock -->
+  <section id="panel-lock" class="vt-card" role="tabpanel">
+    <div id="lock-drop" class="vt-drop" tabindex="0" role="button" aria-label="Choose a file to lock">
+      <p class="big">Drop a file here</p>
+      <p class="small">or click to choose · any file type</p>
+    </div>
+    <input id="lock-input" type="file" hidden>
+    <div id="lock-info" class="vt-info" hidden></div>
+    <div class="vt-field">
+      <label class="vt-label" for="lock-pw">Passphrase</label>
+      <input id="lock-pw" class="vt-input" type="password" autocomplete="new-password" placeholder="At least 6 characters">
+    </div>
+    <div class="vt-field">
+      <label class="vt-label" for="lock-pw2">Repeat passphrase</label>
+      <input id="lock-pw2" class="vt-input" type="password" autocomplete="new-password" placeholder="Type it again">
+    </div>
+    <button id="lock-run" class="btn btn-primary vt-run" type="button" disabled>Lock file</button>
+    <div id="lock-status" class="vt-status" hidden></div>
+  </section>
+
+  <!-- Open -->
+  <section id="panel-open" class="vt-card" role="tabpanel" hidden>
+    <div id="open-drop" class="vt-drop" tabindex="0" role="button" aria-label="Choose a .prmnt file to open">
+      <p class="big">Drop a .prmnt file here</p>
+      <p class="small">or click to choose</p>
+    </div>
+    <input id="open-input" type="file" accept=".prmnt" hidden>
+    <div id="open-info" class="vt-info" hidden></div>
+    <div class="vt-field">
+      <label class="vt-label" for="open-pw">Passphrase</label>
+      <input id="open-pw" class="vt-input" type="password" autocomplete="current-password" placeholder="The passphrase it was locked with">
+    </div>
+    <button id="open-run" class="btn btn-primary vt-run" type="button" disabled>Open file</button>
+    <div id="open-status" class="vt-status" hidden></div>
+  </section>
+
+  <p class="vt-note">Locked with AES-256-GCM (quantum-resistant), key from your passphrase via PBKDF2. Lose the passphrase and the file cannot be recovered — that is the point.</p>
+</main>
+
+<script src="/vault.js?v=1" defer></script>
+</body>
+</html>

--- a/frontend/vault.js
+++ b/frontend/vault.js
@@ -46,6 +46,7 @@
 
   function unpackPlain(buf) {
     const metaLen = new DataView(buf.buffer, buf.byteOffset, 4).getUint32(0, true);
+    if (metaLen > buf.length - 4) throw new Error('Damaged .prmnt file.');   // bounds before slice/parse
     const meta = JSON.parse(td.decode(buf.subarray(4, 4 + metaLen)));
     return { meta, bytes: buf.subarray(4 + metaLen) };
   }
@@ -74,6 +75,9 @@
     for (let i = 0; i < 5; i++) if (buf[i] !== MAGIC[i]) throw new Error('That is not a .prmnt file.');
     if (buf[5] !== VERSION) throw new Error('This .prmnt was made with a newer version.');
     const iter = new DataView(buf.buffer, buf.byteOffset + 7, 4).getUint32(0, true);
+    // iter is unauthenticated header data; clamp so a crafted/corrupt file can't drive
+    // PBKDF2 to billions of rounds and freeze the tab (DoS) before the passphrase check.
+    if (iter < 1000 || iter > 1000000) throw new Error('That is not a .prmnt file.');
     const salt = buf.subarray(11, 27), nonce = buf.subarray(27, 39), ct = buf.subarray(39);
     const key = await deriveKey(passphrase, salt, iter);
     let plain;

--- a/frontend/vault.js
+++ b/frontend/vault.js
@@ -1,0 +1,194 @@
+// Paramant Vault — client-side file encryption to a .prmnt container.
+//
+// MVP = passphrase mode: PBKDF2-SHA256 -> AES-256-GCM, all in the browser via
+// WebCrypto. Nothing is uploaded; the server never sees the file or the key
+// (server-blind by design). AES-256 is quantum-resistant, so this is already
+// post-quantum-safe for confidentiality. The .prmnt header is versioned so the
+// public-key / passkey (ML-KEM) key-slots can be added later without breaking it.
+//
+// .prmnt container (binary):
+//   MAGIC "PRMNT" (5) | VERSION (1) | KDF id (1) | ITER u32-LE (4)
+//   | SALT (16) | NONCE (12) | CIPHERTEXT (AES-256-GCM)
+// Plaintext inside the ciphertext: [metaLen u32-LE (4)][meta JSON][file bytes],
+// so the original filename/type is encrypted too (not leaked in the container).
+
+(function () {
+  'use strict';
+
+  const MAGIC = new Uint8Array([0x50, 0x52, 0x4d, 0x4e, 0x54]); // "PRMNT"
+  const VERSION = 1;
+  const KDF_PBKDF2 = 1;
+  const ITER = 210000;
+  const HDR_LEN = 5 + 1 + 1 + 4 + 16 + 12; // 39
+
+  const te = new TextEncoder();
+  const td = new TextDecoder();
+  const $ = (id) => document.getElementById(id);
+
+  function rand(n) { const b = new Uint8Array(n); crypto.getRandomValues(b); return b; }
+
+  async function deriveKey(passphrase, salt, iter) {
+    const base = await crypto.subtle.importKey('raw', te.encode(passphrase), 'PBKDF2', false, ['deriveKey']);
+    return crypto.subtle.deriveKey(
+      { name: 'PBKDF2', salt, iterations: iter, hash: 'SHA-256' },
+      base, { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']
+    );
+  }
+
+  function packPlain(meta, bytes) {
+    const metaBuf = te.encode(JSON.stringify(meta));
+    const out = new Uint8Array(4 + metaBuf.length + bytes.length);
+    new DataView(out.buffer).setUint32(0, metaBuf.length, true);
+    out.set(metaBuf, 4);
+    out.set(bytes, 4 + metaBuf.length);
+    return out;
+  }
+
+  function unpackPlain(buf) {
+    const metaLen = new DataView(buf.buffer, buf.byteOffset, 4).getUint32(0, true);
+    const meta = JSON.parse(td.decode(buf.subarray(4, 4 + metaLen)));
+    return { meta, bytes: buf.subarray(4 + metaLen) };
+  }
+
+  async function encryptFile(file, passphrase) {
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const salt = rand(16), nonce = rand(12);
+    const key = await deriveKey(passphrase, salt, ITER);
+    const meta = { name: file.name, type: file.type || 'application/octet-stream', size: bytes.length };
+    const plain = packPlain(meta, bytes);
+    const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv: nonce }, key, plain));
+    const out = new Uint8Array(HDR_LEN + ct.length);
+    out.set(MAGIC, 0);
+    out[5] = VERSION;
+    out[6] = KDF_PBKDF2;
+    new DataView(out.buffer).setUint32(7, ITER, true);
+    out.set(salt, 11);
+    out.set(nonce, 27);
+    out.set(ct, HDR_LEN);
+    return out;
+  }
+
+  async function decryptFile(file, passphrase) {
+    const buf = new Uint8Array(await file.arrayBuffer());
+    if (buf.length < HDR_LEN) throw new Error('That is not a .prmnt file.');
+    for (let i = 0; i < 5; i++) if (buf[i] !== MAGIC[i]) throw new Error('That is not a .prmnt file.');
+    if (buf[5] !== VERSION) throw new Error('This .prmnt was made with a newer version.');
+    const iter = new DataView(buf.buffer, buf.byteOffset + 7, 4).getUint32(0, true);
+    const salt = buf.subarray(11, 27), nonce = buf.subarray(27, 39), ct = buf.subarray(39);
+    const key = await deriveKey(passphrase, salt, iter);
+    let plain;
+    try {
+      plain = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv: nonce }, key, ct));
+    } catch (e) {
+      throw new Error('Wrong passphrase, or the file is damaged.');
+    }
+    return unpackPlain(plain);
+  }
+
+  function downloadBytes(bytes, name, type) {
+    const blob = new Blob([bytes], { type: type || 'application/octet-stream' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = name;
+    document.body.appendChild(a); a.click();
+    setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 1500);
+  }
+
+  // ── UI ─────────────────────────────────────────────────────────────────────
+  const state = { mode: 'lock', file: null };
+
+  function setStatus(el, msg, kind) {
+    el.textContent = msg || '';
+    el.className = 'vt-status' + (kind ? ' ' + kind : '');
+    el.hidden = !msg;
+  }
+
+  function fmtSize(n) {
+    if (n < 1024) return n + ' B';
+    if (n < 1048576) return (n / 1024).toFixed(1) + ' KB';
+    return (n / 1048576).toFixed(1) + ' MB';
+  }
+
+  function wirePanel(cfg) {
+    const drop = $(cfg.drop), input = $(cfg.input), info = $(cfg.info);
+    const run = $(cfg.run), status = $(cfg.status);
+    let file = null;
+
+    function pick(f) {
+      file = f;
+      if (f) {
+        info.hidden = false;
+        info.textContent = f.name + ' · ' + fmtSize(f.size);
+      } else {
+        info.hidden = true;
+      }
+      validate();
+    }
+
+    function validate() {
+      const pw = cfg.pw ? $(cfg.pw).value : '';
+      const pw2 = cfg.pw2 ? $(cfg.pw2).value : null;
+      let ok = !!file && pw.length >= 6;
+      if (pw2 !== null) ok = ok && pw === pw2;
+      run.disabled = !ok;
+    }
+
+    drop.addEventListener('click', () => input.click());
+    drop.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); input.click(); } });
+    drop.addEventListener('dragover', (e) => { e.preventDefault(); drop.classList.add('drag'); });
+    drop.addEventListener('dragleave', () => drop.classList.remove('drag'));
+    drop.addEventListener('drop', (e) => {
+      e.preventDefault(); drop.classList.remove('drag');
+      if (e.dataTransfer.files && e.dataTransfer.files[0]) pick(e.dataTransfer.files[0]);
+    });
+    input.addEventListener('change', () => { if (input.files[0]) pick(input.files[0]); });
+    if (cfg.pw) $(cfg.pw).addEventListener('input', validate);
+    if (cfg.pw2) $(cfg.pw2).addEventListener('input', validate);
+
+    run.addEventListener('click', async () => {
+      if (!file) return;
+      run.disabled = true;
+      const orig = run.textContent;
+      run.textContent = cfg.busy;
+      setStatus(status, '', '');
+      try {
+        const pw = $(cfg.pw).value;
+        if (cfg.mode === 'lock') {
+          const out = await encryptFile(file, pw);
+          downloadBytes(out, file.name + '.prmnt', 'application/octet-stream');
+          setStatus(status, 'Locked. Your .prmnt file is downloading. Keep your passphrase safe — without it the file cannot be opened.', 'ok');
+        } else {
+          const { meta, bytes } = await decryptFile(file, pw);
+          downloadBytes(bytes, meta.name || 'unlocked', meta.type);
+          setStatus(status, 'Opened. Your original file (' + (meta.name || 'file') + ') is downloading.', 'ok');
+        }
+      } catch (e) {
+        setStatus(status, e.message || 'Something went wrong.', 'err');
+      }
+      run.textContent = orig;
+      run.disabled = false;
+    });
+  }
+
+  function switchMode(mode) {
+    state.mode = mode;
+    document.querySelectorAll('.vt-tab').forEach((t) => {
+      const on = t.dataset.mode === mode;
+      t.classList.toggle('on', on);
+      t.setAttribute('aria-selected', on ? 'true' : 'false');
+    });
+    $('panel-lock').hidden = mode !== 'lock';
+    $('panel-open').hidden = mode !== 'open';
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    if (!window.crypto || !crypto.subtle) {
+      const w = $('vt-unsupported'); if (w) w.hidden = false;
+      return;
+    }
+    document.querySelectorAll('.vt-tab').forEach((t) => t.addEventListener('click', () => switchMode(t.dataset.mode)));
+    wirePanel({ mode: 'lock', drop: 'lock-drop', input: 'lock-input', info: 'lock-info', pw: 'lock-pw', pw2: 'lock-pw2', run: 'lock-run', status: 'lock-status', busy: 'Locking…' });
+    wirePanel({ mode: 'open', drop: 'open-drop', input: 'open-input', info: 'open-info', pw: 'open-pw', run: 'open-run', status: 'open-status', busy: 'Opening…' });
+    switchMode('lock');
+  });
+})();


### PR DESCRIPTION
New **/vault** page + a "Lock a file" card in the dashboard tools. This starts the `.prmnt` file-encryption direction.

## What it does
- **Lock**: pick a file + passphrase → a `.prmnt` container (PBKDF2-SHA256 → AES-256-GCM, all in the browser via WebCrypto). The server never sees the file or the key.
- **Open**: drop a `.prmnt` + passphrase → original file back (filename/type are encrypted inside the container, not leaked).
- Grandma-simple UI, Paramant style, fully offline.

## Crypto
- AES-256-GCM (quantum-resistant for confidentiality), key from passphrase via PBKDF2 (210k iters).
- `.prmnt` header is versioned (`MAGIC | VERSION | KDF | ITER | SALT | NONCE | CT`) so the ML-KEM **passkey / recovery key-slots** can be added next without breaking the format.
- Verified with a headless encrypt→decrypt round-trip (bytes identical; wrong passphrase fails cleanly).

Also fixes the dashboard 404 favicon reference. Deployed live at /vault.

Next: passkey (Windows Hello) key-slot + printed recovery key, per the desktop spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)