### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md notes)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+PARAMANT is a post-quantum encrypted file relay. The components relevant to local
+development are the **relay** (`relay/`, Node.js HTTP server), the **admin panel**
+(`admin/`, Express), and the static **frontend** (`frontend/`). Standard
+build/run commands live in `README.md`, `CONTRIBUTING.md`, `package.json` scripts,
+and `scripts/dev-local.sh` — prefer those. The notes below are the non-obvious
+caveats discovered while setting the environment up.
+
+### Running the dev stack
+- `bash scripts/dev-local.sh` boots the full local stack on a single origin:
+  relay-health on `:3001`, admin on `:4200`, and a single-origin dev proxy on
+  `http://localhost:8080`. It prints a passkey setup URL and tails to
+  `/tmp/paramant-dev-relay.log` and `/tmp/paramant-dev-admin.log`. Ctrl-C stops all
+  three. This is the dev path; `docker compose up` (the README path) is
+  production-like and Docker is **not** installed in this environment.
+- Redis is required and is installed as a system service. If `redis-cli ping`
+  does not return `PONG`, start it with `sudo service redis-server start`.
+
+### The `@paramant/core` native binding (critical gotcha)
+- `relay/package.json` declares `@paramant/core` as a file link to a **sibling
+  repo that is not in this monorepo**: `file:../../paramant-core/crates/paramant-core-node`.
+  The relay loads its ML-KEM-768 / ML-DSA-65 crypto from this binding at startup
+  (`relay/crypto/bootstrap.js` requires the impls eagerly), so **the relay crashes
+  on boot if the binding is missing** — there is no pure-JS fallback in the current
+  code despite README mentions of `@noble`.
+- The binding is prebuilt in the VM at `/paramant-core` (cloned sibling) with the
+  compiled artifact at `/paramant-core/crates/paramant-core-node/index.node`, which
+  the file link resolves to. This persists in the VM image; `npm install` in
+  `relay/` just symlinks it.
+- To rebuild it from scratch: clone `https://github.com/Apolloccrypt/paramant-core`
+  at the commit pinned by `PARAMANT_CORE_COMMIT` in `relay/Dockerfile`, run
+  `cargo build --release -p paramant-core-node` (needs `cmake`, `nasm`, `ninja`,
+  clang; toolchain auto-fetched via `rust-toolchain.toml`), then copy
+  `target/release/libparamant_core_node.so` to
+  `crates/paramant-core-node/index.node`.
+
+### Testing
+- Lint / static checks: `bash tests/static-sanity.sh` (also wired as the
+  `.git/hooks/pre-commit` hook).
+- Unit tests: `node --test tests/receive-filename.test.mjs tests/sign-full.test.mjs`.
+  `sign-full.test.mjs` drives a real browser; Playwright browsers are **not**
+  downloaded here, so run it with the system Chrome:
+  `PLAYWRIGHT_CHROMIUM_PATH=/usr/bin/google-chrome node tests/sign-full.test.mjs`.
+- `tests/auth-smoke.sh` asserts production semantics (e.g. `/request-key` → 410,
+  captcha shape, signup route). Several of its checks fail against the local
+  dev stack — that is expected, not a regression.
+
+### Other caveats
+- The relay logs `EACCES ... mkdir '/data'` warnings when run by `dev-local.sh`
+  (no writable `/data`). Harmless in dev: the relay identity is regenerated each
+  restart and nothing is persisted. Set `RELAY_IDENTITY_FILE` / `USERS_FILE` /
+  `CT_FILE` to writable paths if you need persistence.
+- Account email validation rejects dotless domains, so `dev-local.sh`'s
+  `dev@localhost` account auto-create returns a harmless `400`. When creating keys
+  via `POST /v2/admin/keys` (header `X-Admin-Token`), use a dotted email
+  (e.g. `alice@example.com`).
+- The relay stores opaque blobs keyed by a client-supplied SHA-256 hash; it does
+  not verify the hash. End-to-end smoke test of the core flow:
+  `POST /v2/inbound` then `GET /v2/outbound/<hash>` (burns after one read).
+- Browser apps (`frontend/parashare.html`, etc.) hardcode the production relay
+  hosts (`health.paramant.app`, …) and discover relays via `/v2/check-key`; they
+  do **not** target the local relay without code edits. Exercise the relay API
+  directly for end-to-end testing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the development environment for the PARAMANT relay so the app, lint, and tests run in Cursor Cloud, and documents the non-obvious setup caveats in `AGENTS.md` under `## Cursor Cloud specific instructions`.

No application code is changed — this PR only adds `AGENTS.md`. The dependency-refresh logic is captured separately in the VM update script.

## Walkthrough (logged-in, against the local dev stack)

Logged in with a real account (`alice@paramant.dev`, TOTP) and exercised the core products end-to-end on `scripts/dev-local.sh` (relay-health :3001, admin :4200, proxy :8080):

Login + user dashboard:
[01_login_and_dashboard.mp4](https://cursor.com/agents/bc-68941f8e-4938-4dd6-8b62-b91675c78451/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F01_login_and_dashboard.mp4)

ParaSign — sign a document (in-browser ML-DSA-65 signature, recorded on relay + CT log, `.psign` download):
[02_parasign_sign_document.mp4](https://cursor.com/agents/bc-68941f8e-4938-4dd6-8b62-b91675c78451/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F02_parasign_sign_document.mp4)

ParaShare — send an encrypted file end-to-end with explicit proof of receipt (ML-KEM-768 + AES-256-GCM, matching fingerprint, receiver "File received" + burn-on-read, and the decrypted file opened showing its unique marker). The in-browser apps hardcode the production relay hosts, so for this local demo only I temporarily pointed `parashare.html`/`ontvang.html` at the local relay; that override was reverted and is NOT part of this PR:
[03_parashare_send_and_receive_proof.mp4](https://cursor.com/agents/bc-68941f8e-4938-4dd6-8b62-b91675c78451/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F03_parashare_send_and_receive_proof.mp4)

Backend core relay flow proven directly via the API (send → ML-DSA-65 signed receipt → receive → burn):
[relay_hello_world.log](https://cursor.com/agents/bc-68941f8e-4938-4dd6-8b62-b91675c78451/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frelay_hello_world.log)

## Environment setup performed (persisted in the VM image)

- Installed Redis (`redis-server`) and Python `cryptography`.
- Built the external `@paramant/core` NAPI binding (the relay's ML-KEM/ML-DSA crypto). It is a `file:` link to a sibling repo not in this monorepo; without it the relay crashes at boot. Cloned `Apolloccrypt/paramant-core` at the `relay/Dockerfile`-pinned commit, `cargo build --release -p paramant-core-node`, and placed the artifact at `/paramant-core/crates/paramant-core-node/index.node`.
- Installed Node deps for `relay/`, `admin/`, and root.

## Update script (registered separately)

```
( cd admin && npm install )
if [ -f /paramant-core/crates/paramant-core-node/index.node ]; then ( cd relay && npm install ); else echo "skip relay deps: @paramant/core binding missing at /paramant-core"; fi
PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install
pip install --user --quiet cryptography
```

## Verification

- Ran the full dev stack via `scripts/dev-local.sh` (relay-health :3001, admin :4200, proxy :8080).
- End-to-end logged-in flows: TOTP login + dashboard, ParaSign document signing, and ParaShare encrypted file send/receive with proof of receipt (see videos).
- ✅ `bash tests/static-sanity.sh`
- ✅ `node --test tests/receive-filename.test.mjs` + `PLAYWRIGHT_CHROMIUM_PATH=/usr/bin/google-chrome node tests/sign-full.test.mjs` (26/26)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68941f8e-4938-4dd6-8b62-b91675c78451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68941f8e-4938-4dd6-8b62-b91675c78451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

