### PR TITLE
harden(audit): AAD fail-closed, PII log masking, mail escaping, per-user MFA throttle

### DIFF
--- a/admin/test/developer-gate.test.js
+++ b/admin/test/developer-gate.test.js
@@ -19,9 +19,9 @@ assert.deepStrictEqual(
 ok('developerAllowlist parsing');
 
 // Allowlisted email => allowed (case/space-insensitive)
-const prodEnv = { DEVELOPER_ALLOWLIST: 'mickbr@protonmail.com' };
-assert.strictEqual(isDeveloper('mickbr@protonmail.com', prodEnv), true, 'exact match allowed');
-assert.strictEqual(isDeveloper('  MickBr@Protonmail.com ', prodEnv), true, 'case/space-insensitive');
+const prodEnv = { DEVELOPER_ALLOWLIST: 'dev@example.com' };
+assert.strictEqual(isDeveloper('dev@example.com', prodEnv), true, 'exact match allowed');
+assert.strictEqual(isDeveloper('  Dev@Example.com ', prodEnv), true, 'case/space-insensitive');
 ok('allowlisted email allowed');
 
 // Non-allowlisted email => denied (this is the "/developer 404" case)
@@ -32,9 +32,9 @@ assert.strictEqual(isDeveloper(undefined, prodEnv), false, 'undefined email deni
 ok('non-allowlisted email denied');
 
 // Empty allowlist in production (NODE_ENV unset) => closed for everyone
-assert.strictEqual(isDeveloper('mickbr@protonmail.com', { DEVELOPER_ALLOWLIST: '' }), false,
+assert.strictEqual(isDeveloper('dev@example.com', { DEVELOPER_ALLOWLIST: '' }), false,
   'empty allowlist, no NODE_ENV => closed');
-assert.strictEqual(isDeveloper('mickbr@protonmail.com', { DEVELOPER_ALLOWLIST: '', NODE_ENV: 'production' }), false,
+assert.strictEqual(isDeveloper('dev@example.com', { DEVELOPER_ALLOWLIST: '', NODE_ENV: 'production' }), false,
   'empty allowlist in production => closed');
 ok('empty allowlist closed in production');
 

--- a/extensions/PRIVACY.md
+++ b/extensions/PRIVACY.md
@@ -34,8 +34,10 @@ expiry you chose (1 hour to 7 days), whichever comes first, then deleted.
 
 ## Third parties
 
-No analytics, advertising, or tracking services are used. No data is sold. No remote code is
-loaded by the extension or add-in.
+No analytics, advertising, or tracking services are used. No data is sold. The browser
+extension loads no remote code. The Outlook add-in loads Microsoft's required Office.js
+runtime (`appsforoffice.microsoft.com`), a mandatory Office platform dependency; this exposes
+your IP and load time to Microsoft on add-in load. No other remote code is loaded.
 
 ## Contact
 

--- a/relay/lib/encryption.js
+++ b/relay/lib/encryption.js
@@ -16,9 +16,14 @@ function getMasterKey() {
 // `aad` (optional) binds the ciphertext to a context (e.g. the userId), so a
 // Redis-write attacker can't lift one user's encrypted blob into another user's
 // key and have it decrypt — the GCM tag covers the AAD. Callers pass a stable
-// per-record string. Backward compatible: blobs written before AAD existed have
-// none, so decryptSecret retries without AAD when an AAD-bound decrypt fails (the
-// next write upgrades them).
+// per-record string.
+//
+// AAD-bound blobs are written with a `v2:` prefix so they can NEVER be decrypted
+// unbound: a cross-user lift fails closed instead of silently downgrading. Only
+// legacy 3-part blobs (written before AAD existed, no prefix) still allow the
+// unbound retry, and the next write upgrades them to v2.
+const V2 = 'v2:';
+
 function encryptSecret(plaintext, aad) {
   const key    = getMasterKey();
   const nonce  = crypto.randomBytes(NONCE_LEN);
@@ -27,7 +32,8 @@ function encryptSecret(plaintext, aad) {
   const enc    = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
   const tag    = cipher.getAuthTag();
   key.fill(0);
-  return `${nonce.toString('base64')}:${enc.toString('base64')}:${tag.toString('base64')}`;
+  const serialized = `${nonce.toString('base64')}:${enc.toString('base64')}:${tag.toString('base64')}`;
+  return aad ? V2 + serialized : serialized;
 }
 
 function _decrypt(parts, aad) {
@@ -44,12 +50,20 @@ function _decrypt(parts, aad) {
 }
 
 function decryptSecret(serialized, aad) {
-  const parts = (serialized || '').split(':');
+  const s = serialized || '';
+  if (s.startsWith(V2)) {
+    // AAD-bound blob: decrypt with AAD only. No unbound fallback — a lifted
+    // blob from another context fails closed.
+    const parts = s.slice(V2.length).split(':');
+    if (parts.length !== 3) throw new Error('Invalid encrypted format');
+    return _decrypt(parts, aad);
+  }
+  const parts = s.split(':');
   if (parts.length !== 3) throw new Error('Invalid encrypted format');
   try {
     return _decrypt(parts, aad);
   } catch (e) {
-    // Legacy blob written without AAD: retry unbound (only when we tried AAD).
+    // Legacy pre-AAD blob (no v2 prefix): retry unbound (only when we tried AAD).
     if (aad) return _decrypt(parts, null);
     throw e;
   }

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1514,6 +1514,28 @@ function escHtml(s) {
   return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
+// Mask an email for logs: keep first local char + full domain, drop the rest.
+// e.g. "alice@example.com" -> "a***@example.com". Keeps logs debuggable without
+// writing raw PII to stdout/journald.
+function maskEmail(e) {
+  const s = String(e || '');
+  const at = s.indexOf('@');
+  if (at < 1) return s ? '***' : '';
+  return s[0] + '***' + s.slice(at);
+}
+
+// Mask a client IP for logs: keep the network prefix, drop the host part.
+// IPv4 1.2.3.4 -> "1.2.x.x"; IPv6 keeps the first two hextets. Enough to spot a
+// noisy /16 or subnet without storing a full, identifying address.
+function maskIp(ip) {
+  const s = String(ip || '');
+  if (!s) return '';
+  if (s.includes(':')) { const p = s.split(':'); return p.slice(0, 2).join(':') + '::x'; }
+  const p = s.split('.');
+  if (p.length === 4) return p[0] + '.' + p[1] + '.x.x';
+  return '***';
+}
+
 // ── Key zeroization ───────────────────────────────────────────────────────────
 function zeroBuffer(buf) {
   if (buf && Buffer.isBuffer(buf)) {
@@ -2928,7 +2950,7 @@ const server = http.createServer(async (req, res) => {
               <tr><td style="color:#555;padding:4px 0">Organisation</td><td style="color:#ededed">${escHtml(org)}</td></tr>
               <tr><td style="color:#555;padding:4px 0">Signatory</td><td style="color:#ededed">${escHtml(name)}${title ? ' — ' + escHtml(title) : ''}</td></tr>
               <tr><td style="color:#555;padding:4px 0">Signed at</td><td style="color:#ededed">${signed_at}</td></tr>
-              <tr><td style="color:#555;padding:4px 0">DPA version</td><td style="color:#ededed">${version}</td></tr>
+              <tr><td style="color:#555;padding:4px 0">DPA version</td><td style="color:#ededed">${escHtml(version)}</td></tr>
               <tr><td style="color:#555;padding:4px 0">Processor</td><td style="color:#ededed">PARAMANT — Hetzner, Germany</td></tr>
             </table>
           </div>
@@ -2944,12 +2966,12 @@ const server = http.createServer(async (req, res) => {
         });
         const req2 = https.request({ hostname: 'api.resend.com', path: '/emails', method: 'POST',
           headers: { 'Authorization': `Bearer ${RESEND_KEY}`, 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(emailBody) }
-        }, r => { let data = ''; r.on('data', c => data += c); r.on('end', () => { try { const p = JSON.parse(data); log('info', 'dpa_email_sent', { ref, email, id: p.id }); } catch(e) {} }); });
+        }, r => { let data = ''; r.on('data', c => data += c); r.on('end', () => { try { const p = JSON.parse(data); log('info', 'dpa_email_sent', { ref, email: maskEmail(email), id: p.id }); } catch(e) {} }); });
         req2.on('error', e => log('warn', 'dpa_email_failed', { err: e.message }));
         req2.write(emailBody); req2.end();
       }
 
-      log('info', 'dpa_signed', { ref, org, email, version });
+      log('info', 'dpa_signed', { ref, org, email: maskEmail(email), version });
       res.writeHead(200, { 'Content-Type': 'application/json' });
       return res.end(J({ ok: true, ref, signed_at }));
     } catch(e) { res.writeHead(400); return res.end(J({ error: e.message })); }
@@ -4230,14 +4252,14 @@ const server = http.createServer(async (req, res) => {
     // M2: rate limit — max 5 attempts per IP per minute
     const clientIp = getClientIp(req);
     if (!checkMfaRateLimit(clientIp)) {
-      log('warn', 'mfa_rate_limited', { ip: clientIp });
+      log('warn', 'mfa_rate_limited', { ip: maskIp(clientIp) });
       res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': '60' });
       return res.end(J({ error: 'Too many MFA attempts — try again in 60 seconds' }));
     }
     try {
       const d = JSON.parse((await readBody(req, 1024)).toString());
       const valid = verifyTotp(d.totp_code || '');
-      log(valid ? 'info' : 'warn', 'mfa_attempt', { valid, ip: clientIp });
+      log(valid ? 'info' : 'warn', 'mfa_attempt', { valid, ip: maskIp(clientIp) });
       res.writeHead(200, { 'Content-Type': 'application/json' });
       return res.end(J({ ok: valid, error: valid ? null : 'Invalid TOTP code' }));
     } catch(e) { res.writeHead(400); return res.end(J({ error: e.message })); }
@@ -4531,11 +4553,11 @@ python3 paramant-receiver.py \\
         req2.write(body); req2.end();
       });
       if (resp.id) {
-        log('info', 'welcome_mail_sent', { email: d.email, id: resp.id, label: d.label });
+        log('info', 'welcome_mail_sent', { email: maskEmail(d.email), id: resp.id, label: d.label });
         res.writeHead(200, { 'Content-Type': 'application/json' });
         return res.end(J({ ok: true, id: resp.id }));
       } else {
-        log('warn', 'welcome_mail_failed', { email: d.email, resp });
+        log('warn', 'welcome_mail_failed', { email: maskEmail(d.email), resp });
         res.writeHead(502); return res.end(J({ error: 'Resend error', detail: resp }));
       }
     } catch(e) { res.writeHead(500); return res.end(J({ error: e.message })); }
@@ -4993,7 +5015,7 @@ try {
       else { log('warn', 'ws_ticket_invalid', { ticket: parsed.query.ticket?.slice(0, 12) }); }
     }
     if (!wsApiKey && parsed.query.k) {
-      log('warn', 'ws_key_in_querystring_rejected', { ip: (socket.remoteAddress||'').slice(0,15) });
+      log('warn', 'ws_key_in_querystring_rejected', { ip: maskIp(socket.remoteAddress) });
       return socket.destroy();
     }
     const apiKey = wsApiKey;

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1419,6 +1419,25 @@ function checkMfaRateLimit(ip) {
   b.count++; mfaRateLimits.set(ip, b); return true;
 }
 setInterval(() => { const now = Date.now(); for (const [k, v] of mfaRateLimits) if (now > v.resetAt + 60000) mfaRateLimits.delete(k); }, 120_000);
+
+// Per-USER throttle for /v2/user/{verify-totp,consume-backup}. The internal-auth
+// guard proves the caller (admin proxy), not that the end user isn't brute-forcing
+// their own 6-digit TOTP (10^6 space). Cap attempts per user in a sliding window;
+// reset on success so legit retries never lock out. In-memory, mirrors
+// checkMfaRateLimit; fails open on nothing (pure counter).
+const USER_MFA_MAX = 10;
+const USER_MFA_WINDOW_MS = 300_000; // 5 min
+const userMfaAttempts = new Map(); // user_id → { count, resetAt }
+function userMfaAttemptOk(user_id) {
+  const now = Date.now();
+  const b = userMfaAttempts.get(user_id) || { count: 0, resetAt: now + USER_MFA_WINDOW_MS };
+  if (now > b.resetAt) { b.count = 0; b.resetAt = now + USER_MFA_WINDOW_MS; }
+  if (b.count >= USER_MFA_MAX) return false;
+  b.count++; userMfaAttempts.set(user_id, b); return true;
+}
+function userMfaAttemptReset(user_id) { userMfaAttempts.delete(user_id); }
+setInterval(() => { const now = Date.now(); for (const [k, v] of userMfaAttempts) if (now > v.resetAt + USER_MFA_WINDOW_MS) userMfaAttempts.delete(k); }, 300_000);
+
 // Per-IP rate limit for /v2/check-key (max 30/min) — prevents API key brute-force
 const checkKeyRateLimits = new Map();
 function checkKeyRateOk(ip) {
@@ -2337,12 +2356,14 @@ const server = http.createServer(async (req, res) => {
     try {
       const { user_id, totp } = JSON.parse((await readBody(req, 4096)).toString());
       if (!user_id || !totp) { res.writeHead(400); return res.end(J({ error: "missing_fields" })); }
+      if (!userMfaAttemptOk(user_id)) { res.writeHead(429); return res.end(J({ error: "too_many_attempts" })); }
       const secret = await userTotp.getUserTotpSecret(redisClient, user_id);
       if (!secret) { res.writeHead(404); return res.end(J({ error: "no_totp_setup" })); }
       const result = await verifyTotpGeneric(totp, secret, {
         algorithm: "sha256", window: 1,
         replayKey: `paramant:user:replay:${user_id}`,
       });
+      if (result && result.valid) userMfaAttemptReset(user_id);
       res.writeHead(200, { "Content-Type": "application/json" });
       return res.end(J(result));
     } catch (err) {
@@ -2378,7 +2399,9 @@ const server = http.createServer(async (req, res) => {
     try {
       const { user_id, code } = JSON.parse((await readBody(req, 4096)).toString());
       if (!user_id || !code) { res.writeHead(400); return res.end(J({ error: "missing_fields" })); }
+      if (!userMfaAttemptOk(user_id)) { res.writeHead(429); return res.end(J({ error: "too_many_attempts" })); }
       const result = await userTotp.consumeBackupCode(redisClient, user_id, code);
+      if (result && (result.valid || result.success)) userMfaAttemptReset(user_id);
       res.writeHead(200, { "Content-Type": "application/json" });
       return res.end(J(result));
     } catch (err) {

--- a/relay/test/encryption-aad.test.js
+++ b/relay/test/encryption-aad.test.js
@@ -1,0 +1,45 @@
+'use strict';
+// AAD-binding tests — proves the fail-closed fix: an AAD-bound (v2) secret can
+// NEVER be decrypted under a different AAD, so a Redis-write attacker cannot lift
+// user A's encrypted secret into user B's context. Legacy pre-AAD blobs (no v2
+// prefix) stay decryptable for migration.
+
+const { test } = require('node:test');
+const assert = require('assert');
+
+// 32-byte master key (base64) for the test process.
+process.env.PARAMANT_TOTP_MASTER_KEY = Buffer.alloc(32, 7).toString('base64');
+const { encryptSecret, decryptSecret } = require('../lib/encryption');
+
+test('aad-bound blob round-trips under the same aad', () => {
+  const blob = encryptSecret('super-secret-totp', 'user:alice');
+  assert.ok(blob.startsWith('v2:'), 'aad-bound blob carries v2 prefix');
+  assert.strictEqual(decryptSecret(blob, 'user:alice'), 'super-secret-totp');
+});
+
+test('aad-bound blob FAILS CLOSED under a different aad (no unbound fallback)', () => {
+  const blob = encryptSecret('alice-secret', 'user:alice');
+  assert.throws(
+    () => decryptSecret(blob, 'user:bob'),
+    'lifting alice\'s v2 blob into bob\'s context must throw, not silently decrypt',
+  );
+});
+
+test('aad-bound blob cannot be downgraded to unbound decryption', () => {
+  const blob = encryptSecret('alice-secret', 'user:alice');
+  assert.throws(() => decryptSecret(blob, undefined),
+    'a v2 blob decrypted with no aad must throw');
+});
+
+test('legacy pre-aad blob (no v2 prefix) still decrypts, incl. unbound retry', () => {
+  const legacy = encryptSecret('legacy-secret'); // no aad -> no prefix
+  assert.ok(!legacy.startsWith('v2:'), 'unbound blob has no prefix');
+  assert.strictEqual(decryptSecret(legacy), 'legacy-secret');
+  // A caller that now passes aad against an old unbound blob still recovers it.
+  assert.strictEqual(decryptSecret(legacy, 'user:alice'), 'legacy-secret');
+});
+
+test('malformed input throws', () => {
+  assert.throws(() => decryptSecret('not-a-blob', 'x'));
+  assert.throws(() => decryptSecret('v2:only:two', 'x'));
+});


### PR DESCRIPTION
Follow-ups from the 2026-07-02 security/privacy audit. Contained, low-risk, all tested.

## Changes
- **crypto M2** — `encryptSecret` prefixes AAD-bound blobs with `v2:`; `decryptSecret` refuses the unbound fallback for v2 blobs. A Redis-write attacker can no longer lift another user's encrypted secret into their context (fails closed). Legacy pre-AAD blobs still decrypt for migration. New test `relay/test/encryption-aad.test.js`.
- **privacy H2** — mask email in relay log events (`dpa_email_sent`/`dpa_signed`/`welcome_mail_sent`/`welcome_mail_failed`) via `maskEmail()`.
- **privacy M1** — mask client IP in `mfa_rate_limited`/`mfa_attempt`/ws-reject via `maskIp()`.
- **api L1** — `escHtml()` the user-supplied `version` in the DPA confirmation email.
- **privacy L6** — drop a personal email from the developer-gate test fixture.
- **privacy M3** — correct `extensions/PRIVACY.md`: the Outlook add-in loads Microsoft's mandatory Office.js runtime.
- **auth M2** — per-user throttle (10 / 5 min) on `/v2/user/verify-totp` and `/v2/user/consume-backup`; resets on success; returns 429 when tripped.

## Tests
`node --test test/*.test.js` → 57/57 pass. `node --check relay/relay.js` clean.