### PR TITLE
harden(quota+privacy): enforce monthly tier caps on active use; mask admin logs

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -361,7 +361,7 @@ api.post('/admin/resend-setup', async (req, res) => {
     const expiresAt = Date.now() + 14 * 86400 * 1000;
     const setupUrl = `${SITE_URL}/auth/setup/${setupToken}`;
     try { await logAuditEvent(user_id, 'admin_setup_resent', { email, admin_ip: req.headers['x-real-ip'] || 'unknown' }); } catch {}
-    console.log(`[admin/resend-setup] sent to ${email}`);
+    console.log(`[admin/resend-setup] sent to ${maskEmail(email)}`);
     res.json({ success: true, email, expires_at: expiresAt, setup_url: setupUrl });
   } catch (err) {
     console.error('[admin/resend-setup]', err.message);
@@ -888,7 +888,7 @@ api.get("/user/signup/verify/:token", async (req, res) => {
     // Mark this token as consumed so later re-clicks (refresh/back/double-tap) route back to /signup/verified instead of error.
     await redis().set(`paramant:signup:consumed:${token}`, keyVal, { EX: 30 * 86400 }).catch(() => {});
 
-    console.log(`[signup/verify] account created for ${email} (${keyVal.slice(0, 12)}...)`);
+    console.log(`[signup/verify] account created for ${maskEmail(email)} (${keyVal.slice(0, 12)}...)`);
     res.redirect('/signup/verified');
 
   } finally {
@@ -1680,7 +1680,7 @@ api.post("/user/auth/request-totp-reset", async (req, res) => {
 
   try {
     await sendResetConfirmEmail(norm, confirmToken, maskedIp, new Date(requestedAt).toISOString());
-    console.log(`[totp-reset-req] confirmation email sent to ${norm}`);
+    console.log(`[totp-reset-req] confirmation email sent to ${maskEmail(norm)}`);
   } catch (err) {
     console.error("[totp-reset-req] email failed:", err.message);
   }
@@ -1730,7 +1730,7 @@ api.post("/user/auth/reset-confirm", async (req, res) => {
     return res.status(500).json({ error: "email_failed" });
   }
 
-  console.log(`[reset-confirm] TOTP reset completed for ${email}`);
+  console.log(`[reset-confirm] TOTP reset completed for ${maskEmail(email)}`);
   res.json({ success: true, message: "Setup email sent. Check your inbox." });
 });
 
@@ -1957,6 +1957,16 @@ function maskIp(ip) {
     return `${p[0]}.${p[1]}.${p[2]}.0`;
   }
   return ip.split(":").slice(0, 2).join(":") + "::0";
+}
+
+// Mask an email for stdout/journald logs: keep first local char + full domain.
+// e.g. "alice@example.com" -> "a***@example.com". Audit-chain records keep the
+// full email on purpose (admin traceability); this is only for process logs.
+function maskEmail(e) {
+  const s = String(e || "");
+  const at = s.indexOf("@");
+  if (at < 1) return s ? "***" : "";
+  return s[0] + "***" + s.slice(at);
 }
 
 // GET /api/user/account/key

--- a/relay/lib/quota.js
+++ b/relay/lib/quota.js
@@ -80,6 +80,62 @@ async function recordSign(redisClient, accountId, log) {
   }
 }
 
+// ── Phase 4 enforcement ──────────────────────────────────────────────────────
+// Decline NEW active use once the monthly tier cap is reached, WITHOUT touching
+// access to existing data (download/view paths never call these). Fail-open:
+// missing account, unlimited plan, or any Redis trouble => allowed:true, so a
+// paying user is never locked out by infra and existing access always works.
+//
+// gateTransfer also counts (it replaces recordTransfer on the upload path) so a
+// declined transfer is never counted and can't be bypassed by retrying — the
+// dedup `seen` key is only claimed once we've decided to count.
+async function gateTransfer(redisClient, accountId, chunkHash, limit, log) {
+  if (!accountId || !redisClient || !redisClient.isReady || !Number.isFinite(limit)) {
+    const r = await recordTransfer(redisClient, accountId, chunkHash, log);
+    return { allowed: true, counted: r.counted, deduped: r.deduped, over_limit: false, error: r.error };
+  }
+  try {
+    if (chunkHash) {
+      const sk = seenKey(accountId, chunkHash);
+      // Continuing an already-counted (multi-chunk) upload is always allowed.
+      if (await redisClient.exists(sk)) return { allowed: true, counted: false, deduped: true, over_limit: false, error: null };
+      const cur = parseInt((await redisClient.get(transfersKey(accountId))) || '0', 10);
+      if (cur >= limit) return { allowed: false, counted: false, deduped: false, over_limit: true, error: null };
+      // Under cap: claim the seen key, then count.
+      const setRes = await redisClient.set(sk, '1', { NX: true, EX: SEEN_TTL_SECONDS });
+      if (setRes !== 'OK') return { allowed: true, counted: false, deduped: true, over_limit: false, error: null };
+    } else {
+      const cur = parseInt((await redisClient.get(transfersKey(accountId))) || '0', 10);
+      if (cur >= limit) return { allowed: false, counted: false, deduped: false, over_limit: true, error: null };
+    }
+    const tk = transfersKey(accountId);
+    const n  = await redisClient.incr(tk);
+    if (n === 1) await redisClient.expire(tk, MONTH_TTL_SECONDS);
+    return { allowed: true, counted: true, deduped: false, over_limit: false, error: null };
+  } catch (e) {
+    if (log) log('warn', 'quota_gate_transfer_failed', { account: String(accountId).slice(0, 12), err: e.message });
+    return { allowed: true, counted: false, deduped: false, over_limit: false, error: e.message }; // fail open
+  }
+}
+
+async function gateSign(redisClient, accountId, limit, log) {
+  if (!accountId || !redisClient || !redisClient.isReady || !Number.isFinite(limit)) {
+    const r = await recordSign(redisClient, accountId, log);
+    return { allowed: true, counted: r.counted, over_limit: false, error: r.error };
+  }
+  try {
+    const cur = parseInt((await redisClient.get(signsKey(accountId))) || '0', 10);
+    if (cur >= limit) return { allowed: false, counted: false, over_limit: true, error: null };
+    const sk = signsKey(accountId);
+    const n  = await redisClient.incr(sk);
+    if (n === 1) await redisClient.expire(sk, MONTH_TTL_SECONDS);
+    return { allowed: true, counted: true, over_limit: false, error: null };
+  } catch (e) {
+    if (log) log('warn', 'quota_gate_sign_failed', { account: String(accountId).slice(0, 12), err: e.message });
+    return { allowed: true, counted: false, over_limit: false, error: e.message }; // fail open
+  }
+}
+
 // Read the current month's counts. Used by the Phase 4 admin/usage endpoint.
 async function readUsage(redisClient, accountId, ym) {
   if (!accountId || !redisClient || !redisClient.isReady) {
@@ -107,6 +163,8 @@ module.exports = {
   firstChunkHash,
   recordTransfer,
   recordSign,
+  gateTransfer,
+  gateSign,
   readUsage,
   // exported for tests / admin tooling
   transfersKey,

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -3922,6 +3922,23 @@ const server = http.createServer(async (req, res) => {
         if (!argon2Lib) { res.writeHead(501); return res.end(J({ error: 'Argon2id not available on this relay' })); }
         pw_hash = await argon2Lib.hash(password, { type: argon2Lib.argon2id, memoryCost: 19456, timeCost: 2, parallelism: 1 });
       }
+      // Phase 4 quota enforcement: decline a NEW transfer once the monthly tier
+      // cap is reached. Access to existing blobs (download/view) is never gated.
+      // A continuing multi-chunk upload (dedup hit) and Redis outages both pass
+      // (fail-open) — this only declines fresh active use over the cap.
+      if (keyData && keyData.account_id) {
+        const _dedupKey = (meta && meta.file_id)
+          ? crypto.createHash('sha3-256').update(String(meta.file_id)).digest('hex')
+          : quota.firstChunkHash(blob);
+        const _tLimit = tiers.tierLimitNum(keyData.plan || 'community', 'transfers_month');
+        const _tGate  = await quota.gateTransfer(redisClient, keyData.account_id, _dedupKey, _tLimit, log);
+        if (!_tGate.allowed) {
+          log('info', 'quota_transfer_declined', { account: String(keyData.account_id).slice(0, 12), plan: keyData.plan || 'community', limit: _tLimit });
+          res.writeHead(402, { 'Content-Type': 'application/json' });
+          return res.end(J({ error: 'monthly_transfer_quota_reached', dimension: 'transfers_month', plan: keyData.plan || 'community', limit: _tLimit }));
+        }
+      }
+
       // Append transfer to CT log before storing — so proof is available at outbound time
       const ctEntry = ctAppendTransfer(hash, SECTOR);
       blobStore.set(hash, { blob, ts: Date.now(), ttl, size: blob.length,
@@ -3947,22 +3964,7 @@ const server = http.createServer(async (req, res) => {
       auditAppend(apiKey, 'inbound', { hash: hash.slice(0,16)+'...', bytes: blob.length, device: deviceId, sig: sigResult.valid ? 'ML-DSA-OK' : 'unsigned' });
       log('info', 'blob_stored', { hash: hash.slice(0,16), size: blob.length, sig: sigResult.valid });
 
-      // Phase 3 quota counter: tally one transfer per account_id per month.
-      // ParaShare sends chunks of the same file with a shared meta.file_id, so
-      // we dedup on file_id (preferred) or on the encrypted-blob hash (single-
-      // blob SDK path). A 111-chunk upload counts as one transfer; a brand-new
-      // upload tomorrow with the same file_id counts as a new transfer (24 h
-      // dedup window).
-      //
-      // COUNT ONLY -- no gate, no 402. If Redis is unavailable the counter is
-      // skipped silently; the upload completes either way.
-      if (keyData && keyData.account_id) {
-        const dedupKey = (meta && meta.file_id)
-          ? crypto.createHash('sha3-256').update(String(meta.file_id)).digest('hex')
-          : quota.firstChunkHash(blob);
-        quota.recordTransfer(redisClient, keyData.account_id, dedupKey, log)
-          .catch(() => { /* never throws but be defensive */ });
-      }
+      // (Transfer already counted by the quota gate above, before storage.)
 
       if (deviceId) {
         pushWebhooks(apiKey, deviceId, 'blob_ready', { hash, size: blob.length, ttl_ms: ttl, sig_valid: sigResult.valid });
@@ -4703,6 +4705,19 @@ python3 paramant-receiver.py \\
       }
       if (!signerOk) { res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'signer signature does not verify against signer_public_key (expected a v2 domain-separated signature: ML-DSA over sha3_256("paramant/parasign/notary/v1" || 0x00 || document_hash))' })); }
 
+      // Phase 4 quota enforcement: decline a NEW counter-signature once the
+      // monthly tier cap is reached. Verifying/reading existing envelopes is not
+      // gated. Redis outages pass (fail-open).
+      if (keyData && keyData.account_id) {
+        const _sLimit = tiers.tierLimitNum(keyData.plan || 'community', 'signs_month');
+        const _sGate  = await quota.gateSign(redisClient, keyData.account_id, _sLimit, log);
+        if (!_sGate.allowed) {
+          log('info', 'quota_sign_declined', { account: String(keyData.account_id).slice(0, 12), plan: keyData.plan || 'community', limit: _sLimit });
+          res.writeHead(402, { 'Content-Type': 'application/json' });
+          return res.end(J({ error: 'monthly_sign_quota_reached', dimension: 'signs_month', plan: keyData.plan || 'community', limit: _sLimit }));
+        }
+      }
+
       const signerPkHash = crypto.createHash('sha3-256').update(Buffer.from(signerPubB64, 'base64')).digest('hex');
       const ctEntry = ctAppendParasign(documentHash, signerPkHash);
 
@@ -4712,12 +4727,7 @@ python3 paramant-receiver.py \\
 
       log('info', 'parasign_signed', { ct_index: ctEntry.index, signer_pk_hash: signerPkHash.slice(0, 16) + '…' });
 
-      // Phase 3 quota counter: tally one sign per account_id per month.
-      // No dedup -- every counter-signature is a billable event.
-      // COUNT ONLY -- no gate, no 402. Redis failure does not block the response.
-      if (keyData && keyData.account_id) {
-        quota.recordSign(redisClient, keyData.account_id, log).catch(() => {});
-      }
+      // (Sign already counted by the quota gate above, before the envelope was built.)
 
       res.writeHead(200, { 'Content-Type': 'application/json' });
       return res.end(J({ ok: true, envelope }));

--- a/relay/test/quota-gate.test.js
+++ b/relay/test/quota-gate.test.js
@@ -1,0 +1,85 @@
+'use strict';
+// Quota enforcement tests — proves the Phase 4 gate: NEW active use is declined
+// over the monthly cap, dedup'd multi-chunk uploads and Redis outages pass
+// (fail-open), and a declined transfer is never counted (no retry-bypass).
+
+const { test } = require('node:test');
+const assert = require('assert');
+const quota = require('../lib/quota');
+
+// Minimal in-memory Redis stub covering the ops gateTransfer/gateSign use.
+function fakeRedis() {
+  const store = new Map();
+  return {
+    isReady: true,
+    async get(k) { return store.has(k) ? store.get(k) : null; },
+    async exists(k) { return store.has(k) ? 1 : 0; },
+    async incr(k) { const n = (parseInt(store.get(k) || '0', 10)) + 1; store.set(k, String(n)); return n; },
+    async expire() { return 1; },
+    async set(k, v, opts) {
+      if (opts && opts.NX && store.has(k)) return null;
+      store.set(k, v); return 'OK';
+    },
+    _store: store,
+  };
+}
+
+test('transfer under cap is allowed and counted', async () => {
+  const r = fakeRedis();
+  const g = await quota.gateTransfer(r, 'acct1', 'hashA', 10, null);
+  assert.strictEqual(g.allowed, true);
+  assert.strictEqual(g.counted, true);
+});
+
+test('transfer AT cap is declined and NOT counted', async () => {
+  const r = fakeRedis();
+  r._store.set(quota.transfersKey('acct1'), '10'); // already at community cap
+  const g = await quota.gateTransfer(r, 'acct1', 'newHash', 10, null);
+  assert.strictEqual(g.allowed, false);
+  assert.strictEqual(g.over_limit, true);
+  // count unchanged
+  assert.strictEqual(await r.get(quota.transfersKey('acct1')), '10');
+});
+
+test('declined transfer cannot be bypassed by retrying the same chunk', async () => {
+  const r = fakeRedis();
+  r._store.set(quota.transfersKey('acct1'), '10');
+  const g1 = await quota.gateTransfer(r, 'acct1', 'chunkX', 10, null);
+  const g2 = await quota.gateTransfer(r, 'acct1', 'chunkX', 10, null);
+  assert.strictEqual(g1.allowed, false);
+  assert.strictEqual(g2.allowed, false, 'retry of a declined chunk stays declined');
+  // seen key was never claimed on decline
+  assert.strictEqual(await r.exists(quota.seenKey('acct1', 'chunkX')), 0);
+});
+
+test('continuing a multi-chunk (dedup) upload is allowed even at cap', async () => {
+  const r = fakeRedis();
+  // simulate the file already counted this month: seen key set, count at cap
+  r._store.set(quota.seenKey('acct1', 'fileHash'), '1');
+  r._store.set(quota.transfersKey('acct1'), '10');
+  const g = await quota.gateTransfer(r, 'acct1', 'fileHash', 10, null);
+  assert.strictEqual(g.allowed, true);
+  assert.strictEqual(g.deduped, true);
+});
+
+test('unlimited plan (Infinity) always allowed, still counted', async () => {
+  const r = fakeRedis();
+  r._store.set(quota.transfersKey('ent'), '99999');
+  const g = await quota.gateTransfer(r, 'ent', 'h', Infinity, null);
+  assert.strictEqual(g.allowed, true);
+});
+
+test('Redis not ready => fail open (allowed)', async () => {
+  const g = await quota.gateTransfer({ isReady: false }, 'acct1', 'h', 10, null);
+  assert.strictEqual(g.allowed, true);
+});
+
+test('sign under cap allowed; at cap declined and not counted', async () => {
+  const r = fakeRedis();
+  const ok = await quota.gateSign(r, 'acct1', 2, null);
+  assert.strictEqual(ok.allowed, true);
+  r._store.set(quota.signsKey('acct1'), '2');
+  const no = await quota.gateSign(r, 'acct1', 2, null);
+  assert.strictEqual(no.allowed, false);
+  assert.strictEqual(await r.get(quota.signsKey('acct1')), '2');
+});


### PR DESCRIPTION
Follow-up from the 2026-07-02 audit. Depends on #266 (merged).

## Quota enforcement (API M1)
Decline NEW active use once the monthly tier cap is reached, **without touching access to existing data** (download/view/verify are never gated).
- `lib/quota.js`: `gateTransfer` / `gateSign` — check-then-count, return 402 over cap. Fail-open on missing account / unlimited plan (enterprise) / any Redis trouble, so paying users are never locked out by infra. A declined transfer is never counted and can't be bypassed by retry (the dedup `seen` key is only claimed once we decide to count).
- `relay.js`: gate `/v2/inbound` before storage and the parasign `/sign` path before the envelope is built. Continuing a dedup'd multi-chunk upload is always allowed.
- Old COUNT-ONLY blocks removed (the gate counts now).

## Privacy H2 (admin logs)
`maskEmail()` on the resend / account-created / totp-reset stdout logs. Audit-chain records keep the full email on purpose (admin traceability).

## Tests
`relay node --test test/*.test.js` 64/64 (incl. new `quota-gate.test.js` 7/7). Admin suite green. `node --check` clean on relay.js / quota.js / admin/server.js.