### PR TITLE
harden(privacy M2): bound audit PII retention; mask IPs in persistent records

### DIFF
--- a/admin/lib/audit.js
+++ b/admin/lib/audit.js
@@ -3,20 +3,42 @@ const { redis } = require('./redis');
 
 const AUDIT_KEY = uid => `paramant:user:audit:${uid}`;
 const MAX_ENTRIES = 1000;
+// Retention window: audit entries carry PII (the account email). The rank-trim
+// alone (1000/user) keeps low-activity accounts' entries forever, so also drop
+// anything older than this window. Configurable; default 400 days (covers a
+// full year plus a dispute tail).
+const RETENTION_MS = parseInt(process.env.AUDIT_RETENTION_DAYS || '400', 10) * 86400 * 1000;
+
+// Mask an operator IP before it is persisted in an audit entry: keep the network
+// prefix, drop the host part. Full operator IPs are not needed for traceability.
+function _maskIp(ip) {
+  const s = String(ip || '');
+  if (!s || s === 'unknown') return s;
+  if (s.includes('.')) { const p = s.split('.'); return `${p[0]}.${p[1]}.x.x`; }
+  if (s.includes(':')) return s.split(':').slice(0, 2).join(':') + '::x';
+  return '***';
+}
 
 async function logAuditEvent(user_id, event_type, metadata = {}) {
   const ts = Date.now();
-  const entry = JSON.stringify({ user_id, event_type, metadata, ts });
+  // Mask any operator IP in the metadata before it is written.
+  const meta = { ...metadata };
+  if (meta.admin_ip) meta.admin_ip = _maskIp(meta.admin_ip);
+  if (meta.ip) meta.ip = _maskIp(meta.ip);
+  const entry = JSON.stringify({ user_id, event_type, metadata: meta, ts });
   const userKey = AUDIT_KEY(user_id);
   const r = redis();
   await Promise.all([
     r.zAdd(userKey, { score: ts, value: entry }),
     r.zAdd('paramant:audit:global', { score: ts, value: entry }),
   ]);
-  // Trim per-user to 1000, global to 10000
+  // Bound retention by BOTH count (rank) and age (score).
+  const cutoff = ts - RETENTION_MS;
   await Promise.all([
     r.zRemRangeByRank(userKey, 0, -1001),
     r.zRemRangeByRank('paramant:audit:global', 0, -10001),
+    r.zRemRangeByScore(userKey, 0, cutoff),
+    r.zRemRangeByScore('paramant:audit:global', 0, cutoff),
   ]);
 }
 

--- a/admin/test/audit-retention.test.js
+++ b/admin/test/audit-retention.test.js
@@ -1,0 +1,57 @@
+'use strict';
+// Proves the M2 privacy fix in lib/audit.js:
+//  - operator IP in metadata is masked before it is stored
+//  - the account email is preserved (admin traceability)
+//  - retention is bounded by age (zRemRangeByScore with a cutoff), not just count
+
+const Module = require('module');
+const assert = require('assert');
+
+const calls = { added: [], remByScore: [], remByRank: [] };
+const fakeClient = {
+  async zAdd(key, { value }) { calls.added.push({ key, value }); },
+  async zRemRangeByRank(key, a, b) { calls.remByRank.push({ key, a, b }); },
+  async zRemRangeByScore(key, min, max) { calls.remByScore.push({ key, min, max }); },
+};
+
+const origLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request === './redis' || request.endsWith('/lib/redis')) {
+    return { redis: () => fakeClient };
+  }
+  return origLoad.apply(this, arguments);
+};
+
+const { logAuditEvent } = require('../lib/audit');
+
+function ok(name) { console.log('  ok - ' + name); }
+
+(async () => {
+  const before = Date.now();
+  await logAuditEvent('user-1', 'admin_welcome_sent', {
+    email: 'alice@example.com',
+    admin_ip: '203.0.113.7',
+  });
+
+  // The per-user store received an entry.
+  const userEntry = calls.added.find(a => a.key === 'paramant:user:audit:user-1');
+  assert(userEntry, 'per-user audit entry written');
+  const stored = JSON.parse(userEntry.value);
+
+  assert.strictEqual(stored.metadata.admin_ip, '203.0.x.x', 'operator IP is masked');
+  assert.strictEqual(stored.metadata.email, 'alice@example.com', 'account email preserved');
+  ok('operator IP masked, account email preserved');
+
+  // Retention trims by age as well as rank.
+  assert(calls.remByRank.length >= 1, 'rank trim still applied');
+  const scoreTrim = calls.remByScore.find(c => c.key === 'paramant:user:audit:user-1');
+  assert(scoreTrim, 'age-based trim applied to the user key');
+  assert.strictEqual(scoreTrim.min, 0, 'age trim starts at 0');
+  const windowMs = 400 * 86400 * 1000;
+  assert(scoreTrim.max <= before - windowMs + 5000 && scoreTrim.max >= before - windowMs - 5000,
+    'age trim cutoff is ~now minus the retention window');
+  ok('retention bounded by age (zRemRangeByScore cutoff ~= now - 400d)');
+
+  console.log('\nall audit-retention checks passed.');
+  Module._load = origLoad;
+})().catch(e => { console.error(e); process.exit(1); });

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -2989,7 +2989,10 @@ const server = http.createServer(async (req, res) => {
 
       // Persist DPA signature record (append-only)
       const DPA_FILE = process.env.DPA_FILE || '/etc/paramant/dpa-signatures.jsonl';
-      const record = JSON.stringify({ ref, name, title, org, kvk, email, version, signed_at, ip: getClientIp(req) });
+      // Keep the signing party's identity (name/org/email) for the legal Art. 28
+      // record, but store only a masked IP: the full address is not needed for
+      // the agreement and is unnecessary PII in a permanent append-only file.
+      const record = JSON.stringify({ ref, name, title, org, kvk, email, version, signed_at, ip: maskIp(getClientIp(req)) });
       fs.promises.appendFile(DPA_FILE, record + '\n').catch(e => log('warn', 'dpa_persist_failed', { err: e.message }));
 
       // Send countersigned DPA email


### PR DESCRIPTION
Audit finding **M2** (unbounded PII retention).

- **admin/lib/audit.js** — entries hold the account email; the rank-trim (1000/user) alone keeps low-activity accounts' PII indefinitely. Add an **age-based trim** (`zRemRangeByScore`, default **400 days**, `AUDIT_RETENTION_DAYS`-configurable) and **mask the operator IP** (`admin_ip`/`ip`) before storing. Email is kept for admin traceability. New `audit-retention.test.js` asserts masking + age cutoff.
- **relay.js** — the DPA Art. 28 record (permanent, append-only) stored the full client IP. Keep the party identity (name/org/email) for the legal record, store only a **masked IP**.

Tests: relay 64/64; admin suite green incl. the new test.