### PR TITLE
harden(signing): fresh step-up token on /attested (Auth M1) + pin signerPub to enrolled key (Crypto M1)

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -1627,6 +1627,9 @@ api.post("/user/sign/submit", authUser, async (req, res) => {
   try {
     const r = await callRelay(`/v2/envelopes/${encodeURIComponent(act.envelope_id)}/sign`, {
       party_index: act.party_index, signer_public_key, signature, verified_email_hash: act.email_hash,
+      // Crypto M1: the account this activation was issued to, so the relay can
+      // pin the submitted key to that account's enrolled signing keys.
+      account_id: act.account_id,
     }, "POST");
     const body = await r.json().catch(() => ({}));
     if (r.status !== 200) return res.status(r.status).json({ error: body.error || "sign_failed" });
@@ -2136,9 +2139,18 @@ api.post("/user/account/signing-key/step-up/bind", authUser, async (req, res) =>
   }
   try { await callRelay("/v2/user/webauthn/counter", { user_id, cred_id: lookup.credId, counter: newCounter }); } catch {}
 
-  // Step-up proven -> forward the bind to the relay's TOTP-free attested route.
+  // Step-up proven -> mint a one-shot proof token the relay consumes, then
+  // forward the bind. The token (256-bit, bound to this user, EX 120s in the
+  // SHARED Redis) lets the relay enforce the step-up itself (Auth M1) instead of
+  // trusting "a passkey exists"; a code path that skips this ceremony has no
+  // valid token and is rejected by the relay.
+  const stepUpToken = crypto.randomBytes(32).toString("hex");
   try {
-    const relayRes = await callRelay("/v2/user/signing-key/attested", { user_id, pk_b64, label }, "POST");
+    await redis().set(`paramant:signing:stepup:${stepUpToken}`,
+      JSON.stringify({ user_id, ts: Date.now() }), { EX: 120 });
+  } catch (e) { return res.status(502).json({ error: "step_up_store_unavailable" }); }
+  try {
+    const relayRes = await callRelay("/v2/user/signing-key/attested", { user_id, pk_b64, label, step_up_token: stepUpToken }, "POST");
     const body = await relayRes.json().catch(() => ({ error: "bad_relay_response" }));
     return res.status(relayRes.status).json(body);
   } catch (err) {

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -2685,9 +2685,27 @@ const server = http.createServer(async (req, res) => {
   if (req.method === "POST" && path === "/v2/user/signing-key/attested") {
     if (!_internalOk()) return _internalReject();
     try {
-      const { user_id, pk_b64, label } = JSON.parse((await readBody(req, 16384)).toString());
+      const { user_id, pk_b64, label, step_up_token } = JSON.parse((await readBody(req, 16384)).toString());
       if (!user_id) { res.writeHead(400); return res.end(J({ error: "missing_user_id" })); }
       if (!pk_b64 || typeof pk_b64 !== "string") { res.writeHead(400); return res.end(J({ error: "missing_pk_b64" })); }
+      // GATE 1 (Auth M1) — a FRESH, one-shot step-up proof. The admin mints this
+      // only after a live WebAuthn assertion and binds it to this user in Redis;
+      // the relay consumes it atomically (getDel) and checks the binding. Without
+      // it, "a passkey exists" (the old gate 2) — or any second admin code path
+      // that skips the step-up ceremony — could enroll an attacker's signing key
+      // on a hijacked session. The relay now enforces the step-up independently.
+      if (typeof step_up_token !== "string" || !/^[a-f0-9]{64}$/.test(step_up_token)) {
+        res.writeHead(403); return res.end(J({ error: "step_up_required" }));
+      }
+      if (!redisClient || !redisClient.isReady) { res.writeHead(503); return res.end(J({ error: "step_up_store_unavailable" })); }
+      const _suKey = `paramant:signing:stepup:${step_up_token}`;
+      const _suRaw = redisClient.getDel
+        ? await redisClient.getDel(_suKey)
+        : await (async () => { const v = await redisClient.get(_suKey); if (v !== null) await redisClient.del(_suKey); return v; })();
+      let _su = null; try { _su = _suRaw ? JSON.parse(_suRaw) : null; } catch { _su = null; }
+      // Freshness is enforced by the Redis EX on the token; a returned value means
+      // still-valid. Bind the token to this exact account.
+      if (!_su || _su.user_id !== user_id) { res.writeHead(403); return res.end(J({ error: "step_up_invalid" })); }
       // GATE 2 — the account must actually have a passkey (the factor the admin
       // stepped up). No passkey -> no attested bind (fall back to the TOTP route).
       const credCount = await userWebauthn.countActiveCredentials(redisClient, user_id);
@@ -4929,9 +4947,28 @@ const server = http.createServer(async (req, res) => {
       const pi = parseInt(d.party_index, 10);
       const signerPub = (d.signer_public_key || '').toString();
       const sig = (d.signature || '').toString();
+      const accountId = (d.account_id || '').toString();
       if (!Number.isInteger(pi) || pi < 0 || !signerPub || !sig) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         return res.end(J({ error: 'party_index, signer_public_key, signature required' }));
+      }
+      // Crypto M1: when the trusted admin proxy names the signer's account_id,
+      // pin the submitted key to that account's ENROLLED active signing keys.
+      // The email-binding check proves *which mailbox*; this proves the signature
+      // was made by a key the account actually enrolled — so a leaked internal
+      // token can't fill an email-bound slot with an attacker-substituted key.
+      // Fail-closed (Redis is already a hard dependency of the envelope store).
+      if (accountId) {
+        try {
+          const active = await userSigning.getActiveSigningPks(redisClient, accountId);
+          const subj = Buffer.from(signerPub, 'base64');
+          const enrolled = active.some(e => {
+            try { return Buffer.from(e.pk_b64, 'base64').equals(subj); } catch { return false; }
+          });
+          if (!enrolled) { res.writeHead(403, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'signer_not_enrolled' })); }
+        } catch (e) {
+          res.writeHead(403, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'signer_not_enrolled' }));
+        }
       }
       // Email-bound envelopes (R018): the store accepts the signature only when
       // a trusted internal caller (the admin proxy, which verified the signer's


### PR DESCRIPTION
Two coordinated relay+admin fixes from the audit. The **relay** does the enforcement so a second/future admin code path can't silently bypass it. **Frontend unchanged** (proofs stay server-side).

## Auth M1 — /attested required only "a passkey exists"
A hijacked session (passkey on file) could enroll an attacker's signing key. Now:
- **admin** `step-up/bind`: after the live WebAuthn assertion, mint a one-shot 256-bit token bound to the user (`EX 120s`, shared Redis) and pass `step_up_token`.
- **relay** `/v2/user/signing-key/attested`: consume it atomically (`getDel`) and check the user binding before enrolling. No token -> `step_up_required`; wrong/expired -> `step_up_invalid`.

## Crypto M1 — email-bound slot accepted any key matching the email
- **admin** `/user/sign/submit`: forward the activation's `account_id`.
- **relay** envelope sign: pin the submitted `signer_public_key` to that account's **enrolled active** signing keys (byte-compare vs `getActiveSigningPks`) -> `signer_not_enrolled` otherwise. Fail-closed.

## Tests
relay 64/64; admin suite green. The live signing flow is smoke-tested after deploy (needs Redis + a real session).