### PR TITLE
fix(admin): survive node-redis v5/v6 scanIterator batch semantics

### DIFF
--- a/admin/lib/redis.js
+++ b/admin/lib/redis.js
@@ -1,5 +1,7 @@
 'use strict';
-const { createClient } = require('redis');
+// `redis` is required lazily inside initRedis() so this module can be imported
+// (e.g. for scanKeys in the unit tests) without the npm package installed —
+// the admin test job runs `node --test` without `npm ci`.
 
 let client = null;
 
@@ -8,6 +10,7 @@ async function initRedis() {
     console.error('[admin/redis] FATAL: REDIS_URL not set');
     process.exit(1);
   }
+  const { createClient } = require('redis');
   client = createClient({
     url: process.env.REDIS_URL,
     socket: {
@@ -32,4 +35,14 @@ function redis() {
   return client;
 }
 
-module.exports = { initRedis, redis };
+// node-redis v5+ laat scanIterator BATCHES (arrays) van keys yielden waar v4
+// losse strings gaf. scanKeys vlakt beide vormen af naar één key per iteratie,
+// zodat call-sites versie-agnostisch blijven.
+async function* scanKeys(c, opts) {
+  for await (const batch of c.scanIterator(opts)) {
+    if (Array.isArray(batch)) { for (const key of batch) yield key; }
+    else yield batch;
+  }
+}
+
+module.exports = { initRedis, redis, scanKeys };

--- a/admin/lib/telemetry.js
+++ b/admin/lib/telemetry.js
@@ -1,9 +1,9 @@
 'use strict';
-const { redis } = require('./redis');
+const { redis, scanKeys } = require('./redis');
 
 async function countActiveSessions() {
   let count = 0;
-  for await (const _ of redis().scanIterator({ MATCH: 'paramant:user:session:*', COUNT: 200 })) count++;
+  for await (const _ of scanKeys(redis(), { MATCH: 'paramant:user:session:*', COUNT: 200 })) count++;
   return count;
 }
 
@@ -17,7 +17,7 @@ async function getRecentAuditEvents(limit = 20) {
   }
   // Fallback: SCAN (first run before any events written to global ZSET)
   const events = [];
-  for await (const key of redis().scanIterator({ MATCH: 'paramant:user:audit:*', COUNT: 100 })) {
+  for await (const key of scanKeys(redis(), { MATCH: 'paramant:user:audit:*', COUNT: 100 })) {
     const userId = key.split(':').pop();
     const entries = await redis().zRange(key, 0, -1, { REV: true }).catch(() => []);
     for (const entry of entries.slice(0, limit)) {

--- a/admin/server.js
+++ b/admin/server.js
@@ -5,7 +5,7 @@ const pow = require('./lib/pow-captcha');
 const http    = require('http');
 const crypto  = require('crypto');
 const path    = require('path');
-const { initRedis, redis } = require('./lib/redis');
+const { initRedis, redis, scanKeys } = require('./lib/redis');
 const { logAuditEvent, getAuditEvents } = require('./lib/audit');
 const { spawn } = require('child_process');
 const cliCommands = require('./lib/cli-commands');
@@ -347,7 +347,7 @@ api.post('/admin/resend-setup', async (req, res) => {
       redis().del(`paramant:user:backup_codes:${user_id}`),
       redis().del(`paramant:user:backup_codes_plaintext:${user_id}`),
     ]);
-    for await (const k of redis().scanIterator({ MATCH: 'paramant:user:setup_token:*', COUNT: 100 })) {
+    for await (const k of scanKeys(redis(), { MATCH: 'paramant:user:setup_token:*', COUNT: 100 })) {
       const raw = await redis().get(k);
       if (raw) { try { const d = JSON.parse(raw); if (d.user_id === user_id) await redis().del(k); } catch {} }
     }
@@ -1714,7 +1714,7 @@ api.post("/user/auth/reset-confirm", async (req, res) => {
     redis().del(`paramant:user:backup_codes:${user_id}`),
     redis().del(`paramant:user:backup_codes_plaintext:${user_id}`),
   ]);
-  for await (const k of redis().scanIterator({ MATCH: "paramant:user:setup_token:*", COUNT: 100 })) {
+  for await (const k of scanKeys(redis(), { MATCH: "paramant:user:setup_token:*", COUNT: 100 })) {
     const r = await redis().get(k);
     if (r) { try { const d = JSON.parse(r); if (d.user_id === user_id) await redis().del(k); } catch {} }
   }
@@ -1920,7 +1920,7 @@ api.get("/user/account", authUser, async (req, res) => {
     const backupCount = await redis().sCard(`paramant:user:backup_codes:${user_id}`).catch(() => 0);
 
     const sessions = [];
-    for await (const key of redis().scanIterator({ MATCH: "paramant:user:session:*", COUNT: 100 })) {
+    for await (const key of scanKeys(redis(), { MATCH: "paramant:user:session:*", COUNT: 100 })) {
       const raw = await redis().get(key);
       if (!raw) continue;
       // One corrupt session blob (this user's OR any other user's, since the
@@ -2218,7 +2218,7 @@ api.post("/user/account/totp/reset", authUser, async (req, res) => {
   }
 
   // Invalidate all sessions for this user
-  for await (const key of redis().scanIterator({ MATCH: "paramant:user:session:*", COUNT: 100 })) {
+  for await (const key of scanKeys(redis(), { MATCH: "paramant:user:session:*", COUNT: 100 })) {
     const raw = await redis().get(key);
     if (raw) { const s = JSON.parse(raw); if (s.user_id === user_id) await redis().del(key); }
   }
@@ -2231,7 +2231,7 @@ api.post("/user/account/totp/reset", authUser, async (req, res) => {
 api.post("/user/account/sessions/revoke-others", authUser, async (req, res) => {
   const { user_id } = req.userSession;
   let revoked = 0;
-  for await (const key of redis().scanIterator({ MATCH: "paramant:user:session:*", COUNT: 100 })) {
+  for await (const key of scanKeys(redis(), { MATCH: "paramant:user:session:*", COUNT: 100 })) {
     const raw = await redis().get(key);
     if (!raw) continue;
     const s = JSON.parse(raw);
@@ -2255,7 +2255,7 @@ api.delete("/user/account", authUser, async (req, res) => {
 
   await callRelay("/v2/user/delete-totp", { user_id });
 
-  for await (const key of redis().scanIterator({ MATCH: "paramant:user:session:*", COUNT: 100 })) {
+  for await (const key of scanKeys(redis(), { MATCH: "paramant:user:session:*", COUNT: 100 })) {
     const raw = await redis().get(key);
     if (raw) { const s = JSON.parse(raw); if (s.user_id === user_id) await redis().del(key); }
   }
@@ -2676,7 +2676,7 @@ api.get("/admin/audit", authMiddleware, async (req, res) => {
     const eventFilter = req.query.event || null;
     const sinceMs = req.query.since ? new Date(req.query.since).getTime() : 0;
     const events = [];
-    for await (const key of redis().scanIterator({ MATCH: "paramant:user:audit:*", COUNT: 100 })) {
+    for await (const key of scanKeys(redis(), { MATCH: "paramant:user:audit:*", COUNT: 100 })) {
       const userId = key.split(":").pop();
       if (userFilter && !userId.includes(userFilter)) continue;
       const entries = await redis().zRange(key, 0, -1).catch(() => []);
@@ -2761,7 +2761,7 @@ api.post('/admin/force-totp', authMiddleware, async (req, res) => {
     if (required) {
       const totpActive = await redis().get(`paramant:user:totp_active:${key}`).catch(() => null);
       if (totpActive !== 'true') {
-        for await (const rkey of redis().scanIterator({ MATCH: `paramant:user:session:*`, COUNT: 100 })) {
+        for await (const rkey of scanKeys(redis(), { MATCH: `paramant:user:session:*`, COUNT: 100 })) {
           const raw = await redis().get(rkey).catch(() => null);
           if (raw) { try { const ss = JSON.parse(raw); if (ss.user_id === key) { await redis().del(rkey); sessions_revoked++; } } catch {} }
         }
@@ -2881,7 +2881,7 @@ api.post('/admin/revoke-sessions', authMiddleware, async (req, res) => {
   if (!key?.startsWith('pgp_')) return res.status(400).json({ error: 'invalid_key' });
   try {
     let count = 0;
-    for await (const rkey of redis().scanIterator({ MATCH: 'paramant:user:session:*', COUNT: 100 })) {
+    for await (const rkey of scanKeys(redis(), { MATCH: 'paramant:user:session:*', COUNT: 100 })) {
       const raw = await redis().get(rkey).catch(() => null);
       if (raw) { try { const s = JSON.parse(raw); if (s.user_id === key) { await redis().del(rkey); count++; } } catch {} }
     }
@@ -2917,7 +2917,7 @@ api.post('/admin/delete-account', authMiddleware, async (req, res) => {
     const meta = await getAdminKeyMeta(key);
     await eachSector(Object.keys(SECTORS), async s => relayFetch(s, '/v2/admin/keys/revoke', 'POST', { key }, false, ADMIN_TOKEN).catch(() => {}));
     await callRelay('/v2/user/delete-totp', { user_id: key }).catch(() => {});
-    for await (const rkey of redis().scanIterator({ MATCH: `paramant:user:session:*`, COUNT: 100 })) {
+    for await (const rkey of scanKeys(redis(), { MATCH: `paramant:user:session:*`, COUNT: 100 })) {
       const raw = await redis().get(rkey).catch(() => null);
       if (raw) { try { const s = JSON.parse(raw); if (s.user_id === key) await redis().del(rkey); } catch {} }
     }
@@ -2950,7 +2950,7 @@ api.get('/admin/user-details/:key', authMiddleware, async (req, res) => {
     let meta = {}; try { if (metaRaw) meta = JSON.parse(metaRaw); } catch {}
     let billing = null; try { if (billingRaw) billing = JSON.parse(billingRaw); } catch {}
     let sessionCount = 0;
-    for await (const rkey of redis().scanIterator({ MATCH: 'paramant:user:session:*', COUNT: 100 })) {
+    for await (const rkey of scanKeys(redis(), { MATCH: 'paramant:user:session:*', COUNT: 100 })) {
       const raw = await redis().get(rkey).catch(() => null);
       if (raw) { try { const s = JSON.parse(raw); if (s.user_id === key) sessionCount++; } catch {} }
     }

--- a/admin/test/redis-scan-keys.test.js
+++ b/admin/test/redis-scan-keys.test.js
@@ -1,0 +1,32 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { scanKeys } = require('../lib/redis');
+
+function fakeClient(yields) {
+  return { scanIterator: async function* () { for (const y of yields) yield y; } };
+}
+
+async function collect(gen) { const out = []; for await (const k of gen) out.push(k); return out; }
+
+test('scanKeys vlakt v5/v6-batches (arrays) af naar losse keys', async () => {
+  const c = fakeClient([['a:1', 'a:2'], ['a:3'], []]);
+  assert.deepEqual(await collect(scanKeys(c, {})), ['a:1', 'a:2', 'a:3']);
+});
+
+test('scanKeys laat v4-stijl losse strings ongemoeid', async () => {
+  const c = fakeClient(['a:1', 'a:2']);
+  assert.deepEqual(await collect(scanKeys(c, {})), ['a:1', 'a:2']);
+});
+
+test('scanKeys op lege scan levert niets', async () => {
+  assert.deepEqual(await collect(scanKeys(fakeClient([]), {})), []);
+});
+
+test('elke afgevlakte key is een string met werkende .split (de crash-site)', async () => {
+  const c = fakeClient([['paramant:user:audit:pgp_x'], 'paramant:user:audit:pgp_y']);
+  for (const k of await collect(scanKeys(c, {}))) {
+    assert.equal(typeof k, 'string');
+    assert.ok(k.split(':').pop().startsWith('pgp_'));
+  }
+});


### PR DESCRIPTION
## Wat
De dependabot-bump redis 4.7.1→6.0.1 (#254) lag slapend tot de admin-container op 13-07 herbouwd werd. In node-redis v5+ levert `scanIterator` **batches (arrays)** van keys per iteratie i.p.v. losse strings; alle 13 v4-stijl call-sites in `admin/server.js` + `admin/lib/telemetry.js` braken daardoor.

## Impact (prod, nu)
- `/admin/audit` → 500 (`key.split is not a function`)
- `/user/account` → 503 (`get(array)`), raakte echte gebruikers
- **Stil kapot** (`.catch` slikte de TypeError): admin revoke-sessions, key-revoke sessie-cleanup, force-TOTP-revocatie deden 0 sessies — precies het pad dat je bij compromittering nodig hebt. Actieve-sessieteller telde batches.

## Fix
`scanKeys()` in `admin/lib/redis.js` vlakt beide vormen af (v4-string én v5/v6-array); alle call-sites erop omgezet. Regressietests dekken v4-, v5/v6- en lege-scan-vorm.

## Test
21/21 admin-tests groen, incl. 4 nieuwe in `admin/test/redis-scan-keys.test.js`. Cherry-picked schoon op origin/main; geen ongedekte scanIterator-sites over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)