### PR TITLE
fix(verify-chain): repareer de hele transparantieketen — D1 receipt + D2 CT-index + D3 v3 verify

### DIFF
--- a/frontend/parasign-verify.js
+++ b/frontend/parasign-verify.js
@@ -72,7 +72,10 @@ async function verify() {
 // Returns an HTML fragment (already-escaped) or '' if no attribution found.
 async function lookupSignerHtml(envelope) {
   try {
-    const pkB64 = envelope && envelope.signer && envelope.signer.public_key;
+    // v1/v2 nest the key under signer.public_key; v3 (parasign-doc-3) carries it
+    // flat as signer_public_key.
+    const pkB64 = (envelope && envelope.signer && envelope.signer.public_key)
+      || (envelope && envelope.signer_public_key);
     if (!pkB64) return '';
     const pkBytes = fromB64(pkB64);
     const pkHash = toHex(sha3_256(pkBytes));

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -1420,6 +1420,7 @@ async function doSign() {
         signature_style: state.signer.sigStyle,
         signature_image_hash: state.signer.sigImageBytes ? toHex(sha3_256(state.signer.sigImageBytes)) : null,
         signer_public_key: signKey.pk_b64, signer_pk_fingerprint: fingerprint,
+        party_email_hash: act.email_hash || '',
         signature: sigB64, signed_at: dateStr, multiparty: mp,
         disclaimer: 'Post-quantum, zero-knowledge. Not eIDAS-qualified.',
       };
@@ -1430,6 +1431,7 @@ async function doSign() {
         original_filename: state.doc.name, document_hash: docHashForEnvelope,
         signer_name: state.signer.name,
         signer_public_key: signKey.pk_b64, signer_pk_fingerprint: fingerprint,
+        party_email_hash: act.email_hash || '',
         signature: sigB64, signed_at: dateStr, multiparty: mp,
         disclaimer: 'Post-quantum, zero-knowledge. Not eIDAS-qualified.',
       };

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -660,6 +660,6 @@
 <script src="/js/nav-auth.js?v=2" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
-<script type="module" src="/sign-flow.js?v=24"></script>
+<script type="module" src="/sign-flow.js?v=25"></script>
 </body>
 </html>

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -291,6 +291,6 @@
 </footer>
 <script src="/nav.js?v=12" defer></script>
 <script src="/js/nav-auth.js?v=2" defer></script>
-<script type="module" src="/parasign-verify.js?v=2"></script>
+<script type="module" src="/parasign-verify.js?v=3"></script>
 </body>
 </html>

--- a/relay/crypto/parasign.test.js
+++ b/relay/crypto/parasign.test.js
@@ -19,7 +19,8 @@ function relayDeps(relaySk, relayPk) {
 function verifyDeps(relayPk) {
   return {
     sigVerify: (s, m, p) => { try { return sig.verify(s, m, p); } catch { return false; } },
-    relayPub: Buffer.from(relayPk),
+    // v3 doc-sign envelopes have no notary signature, so relayPk is optional.
+    relayPub: relayPk ? Buffer.from(relayPk) : Buffer.alloc(0),
   };
 }
 
@@ -99,4 +100,70 @@ test("expired envelope fails", () => {
   const r = parasign.verifyEnvelope({ documentHashHex: docHashHex, envelope }, verifyDeps(relayPk));
   assert.strictEqual(r.valid, false);
   assert.ok(r.errors.some((e) => e.includes("expired")), JSON.stringify(r.errors));
+});
+
+// ── v3 doc-sign envelopes (parasign-doc-3) — the .psign the /sign page emits ──
+const { signMessageBytes } = require("../envelope");
+
+// Build a v3 .psign the way the browser client does: the signer signs the
+// doc-sign message (recipe 3) over the STAMPED hash for pdf/image documents.
+function makeV3Envelope(opts = {}) {
+  const signer = sig.generateKeyPair();
+  const envelopeId = opts.envelopeId || "env_" + crypto.randomBytes(6).toString("hex");
+  const partyIndex = opts.partyIndex != null ? opts.partyIndex : 0;
+  const stampedHash = crypto.createHash("sha3-256").update(Buffer.from(opts.doc || "stamped-pdf")).digest("hex");
+  const emailHash = opts.emailHash != null ? opts.emailHash
+    : crypto.createHash("sha3-256").update(Buffer.from("alice@example.com")).digest("hex");
+  const msg = signMessageBytes(envelopeId, stampedHash, partyIndex, emailHash, 3);
+  const signature = sig.sign(msg, signer.secretKey);
+  const envelope = {
+    version: "parasign-doc-3", recipe_version: 3, sign_domain: "paramant/parasign/doc/v1",
+    algorithm: "ML-DSA-65", hash_algorithm: "SHA3-256",
+    original_hash: crypto.createHash("sha3-256").update(Buffer.from("orig")).digest("hex"),
+    stamped_hash: stampedHash,
+    signer_public_key: Buffer.from(signer.publicKey).toString("base64"),
+    signature: Buffer.from(signature).toString("base64"),
+    party_email_hash: emailHash,
+    multiparty: { envelope_id: envelopeId, party_index: partyIndex },
+  };
+  return { envelope, stampedHash, signerPk: signer.publicKey };
+}
+
+test("v3: valid doc-sign envelope verifies offline (was always INVALID before D3)", () => {
+  const { envelope, stampedHash } = makeV3Envelope();
+  const r = parasign.verifyEnvelope({ documentHashHex: stampedHash, envelope }, verifyDeps());
+  assert.strictEqual(r.valid, true, JSON.stringify(r.errors));
+});
+
+test("v3: tampered signature fails", () => {
+  const { envelope } = makeV3Envelope();
+  const b = Buffer.from(envelope.signature, "base64"); b[0] ^= 0xff;
+  envelope.signature = b.toString("base64");
+  const r = parasign.verifyEnvelope({ envelope }, verifyDeps());
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.errors.some((e) => e.includes("signer signature invalid")), JSON.stringify(r.errors));
+});
+
+test("v3: a different email_hash breaks verification (email is bound into the message)", () => {
+  const { envelope } = makeV3Envelope();
+  envelope.party_email_hash = crypto.createHash("sha3-256").update(Buffer.from("mallory@example.com")).digest("hex");
+  const r = parasign.verifyEnvelope({ envelope }, verifyDeps());
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.errors.some((e) => e.includes("signer signature invalid")), JSON.stringify(r.errors));
+});
+
+test("v3: missing party_email_hash is reported (cannot verify offline)", () => {
+  const { envelope } = makeV3Envelope();
+  delete envelope.party_email_hash;
+  const r = parasign.verifyEnvelope({ envelope }, verifyDeps());
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.errors.some((e) => e.includes("party_email_hash")), JSON.stringify(r.errors));
+});
+
+test("v3: document-hash binding rejects a mismatched stamped hash", () => {
+  const { envelope } = makeV3Envelope();
+  const wrong = crypto.createHash("sha3-256").update(Buffer.from("nope")).digest("hex");
+  const r = parasign.verifyEnvelope({ documentHashHex: wrong, envelope }, verifyDeps());
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.errors.some((e) => e.includes("document_hash mismatch")), JSON.stringify(r.errors));
 });

--- a/relay/lib/ct-hash.js
+++ b/relay/lib/ct-hash.js
@@ -1,0 +1,64 @@
+'use strict';
+// Pure CT-log hash primitives, extracted from relay.js so the transparency
+// keten is unit-testable in isolation (the receipt/inclusion-proof roundtrip
+// has no server dependencies). Domain separators: 0x00 pubkey leaf, 0x01 inner
+// node, 0x02 blob/transfer leaf. SHA3-256 throughout.
+const crypto = require('crypto');
+
+function ctNodeHash(left, right) {
+  return crypto.createHash('sha3-256')
+    .update(Buffer.from([0x01]))
+    .update(Buffer.from(left, 'hex'))
+    .update(Buffer.from(right, 'hex'))
+    .digest('hex');
+}
+
+function ctTreeHash(entries) {
+  if (entries.length === 0) return '0'.repeat(64);
+  let hashes = entries.map(e => e.leaf_hash);
+  while (hashes.length > 1) {
+    const next = [];
+    for (let i = 0; i < hashes.length; i += 2) {
+      next.push(i + 1 < hashes.length ? ctNodeHash(hashes[i], hashes[i + 1]) : hashes[i]);
+    }
+    hashes = next;
+  }
+  return hashes[0];
+}
+
+// Merkle audit path for `idx`. Each step is { hash, position:'left'|'right' }.
+function ctInclusionProof(entries, idx) {
+  if (entries.length <= 1) return [];
+  let hashes = entries.map(e => e.leaf_hash);
+  const path = [];
+  let i = idx;
+  while (hashes.length > 1) {
+    const sibling = i % 2 === 0 ? i + 1 : i - 1;
+    if (sibling < hashes.length) {
+      path.push({ hash: hashes[sibling], position: i % 2 === 0 ? 'right' : 'left' });
+    }
+    const next = [];
+    for (let j = 0; j < hashes.length; j += 2) {
+      next.push(j + 1 < hashes.length ? ctNodeHash(hashes[j], hashes[j + 1]) : hashes[j]);
+    }
+    hashes = next;
+    i = Math.floor(i / 2);
+  }
+  return path;
+}
+
+// Leaf hash for blob/transfer entries — domain separator 0x02. Commits to the
+// transfer hash + sector + timestamp without exposing payload content. `ts` is
+// REQUIRED: it is part of the committed leaf, so the receipt must carry it back
+// for /v2/verify-receipt to recompute the same leaf.
+function blobLeafHash(blobHash, sector, ts) {
+  if (ts === undefined || ts === null) throw new TypeError('blobLeafHash: ts is required');
+  const data = Buffer.concat([
+    Buffer.from(blobHash, 'hex'),
+    crypto.createHash('sha3-256').update(sector || 'relay').digest(),
+    Buffer.from(String(ts), 'utf8'),
+  ]);
+  return crypto.createHash('sha3-256').update(Buffer.from([0x02])).update(data).digest('hex');
+}
+
+module.exports = { ctNodeHash, ctTreeHash, ctInclusionProof, blobLeafHash };

--- a/relay/lib/ct-window.js
+++ b/relay/lib/ct-window.js
@@ -1,0 +1,80 @@
+'use strict';
+// Bounded, monotonically-indexed CT-log window (D2).
+//
+// The CT log keeps at most `max` recent entries in memory and rebuilds its
+// Merkle tree over that window on every append. The old code used
+// `index = ctLog.length` and `ctLog.shift()`, so once the window was full the
+// index froze at `max` (duplicate indices, frozen STH tree_size) and the
+// positional lookup `ctLog[idx]` returned the wrong entry after the first shift.
+//
+// CtWindow separates the two numbers that were conflated:
+//   - logical index  : monotonic, never reused, = base + position. Public
+//                       ct_log_index that clients (parasign notary) hold.
+//   - window position : 0..windowLength-1, where the Merkle tree/proof live.
+// An entry whose logical index has aged out of the window returns null on
+// lookup (honestly "pruned") instead of a wrong or duplicate-indexed entry.
+class CtWindow {
+  constructor(max) {
+    this.max = max;
+    this.entries = [];   // the retained window, oldest first
+    this.base = 0;       // logical index of entries[0]
+  }
+
+  // Total number of entries ever appended (monotonic). This is what the STH
+  // tree_size and the /ct feed size report as "how far the log has advanced".
+  get size() { return this.base + this.entries.length; }
+
+  // Number of leaves currently in the window (== the Merkle tree leaf count).
+  get windowLength() { return this.entries.length; }
+
+  // The logical index the next append() will receive.
+  nextIndex() { return this.base + this.entries.length; }
+
+  // Window position for a logical index, or -1 if it is outside the window.
+  position(logicalIndex) {
+    const p = logicalIndex - this.base;
+    return (p >= 0 && p < this.entries.length) ? p : -1;
+  }
+
+  // Retrieve an entry by its logical index, or null if pruned/absent.
+  get(logicalIndex) {
+    const p = this.position(logicalIndex);
+    return p === -1 ? null : this.entries[p];
+  }
+
+  last() { return this.entries.length ? this.entries[this.entries.length - 1] : null; }
+
+  // Append a pre-built entry. Its .index MUST already equal nextIndex() (the
+  // caller sets it before building leaf/tree/proof). Enforces the cap, advancing
+  // base so logical indices stay monotonic.
+  append(entry) {
+    if (entry.index !== this.nextIndex()) {
+      throw new Error(`CtWindow.append: entry.index ${entry.index} != nextIndex ${this.nextIndex()}`);
+    }
+    this.entries.push(entry);
+    if (this.entries.length > this.max) { this.entries.shift(); this.base++; }
+    return entry;
+  }
+
+  // Up to `count` entries starting at a logical index (for /v2/ct/log paging).
+  // Clamps to the retained window; entries below base are pruned.
+  sliceByIndex(fromLogical, count) {
+    const start = Math.max(0, fromLogical - this.base);
+    return this.entries.slice(start, start + count);
+  }
+
+  // The most recent `n` entries (for the /ct feed).
+  recent(n) { return this.entries.slice(-n); }
+
+  // Rehydrate from a persisted list (oldest first). Each entry carries its own
+  // monotonic .index; base is taken from the first retained entry. Trims to the
+  // cap, keeping the newest.
+  load(list) {
+    const arr = Array.isArray(list) ? list.filter(e => e && typeof e === 'object' && !Array.isArray(e)) : [];
+    const trimmed = arr.length > this.max ? arr.slice(arr.length - this.max) : arr;
+    this.entries = trimmed;
+    this.base = trimmed.length && Number.isInteger(trimmed[0].index) ? trimmed[0].index : 0;
+  }
+}
+
+module.exports = { CtWindow };

--- a/relay/parasign.js
+++ b/relay/parasign.js
@@ -10,6 +10,11 @@
 // passes registry.getSig(0x0002)), so the logic is unit-testable in isolation.
 
 const crypto = require('crypto');
+// v3 .psign envelopes bind the signer signature to the multiparty doc-sign
+// message; signMessageBytes is the single source of that construction (shared
+// with the relay's own party-sign path). envelope.js is pure (crypto only), no
+// require cycle.
+const { signMessageBytes } = require('./envelope');
 
 // Domain separation for the single-signer notary message (pentest #3/#4).
 // Until v2, the signer signed the BARE 32-byte document hash, so an ML-DSA
@@ -83,10 +88,67 @@ function buildEnvelope(input, deps) {
 // Verify a .psign envelope. Collects every failure rather than short-circuiting.
 //   input: { documentHashHex (optional -- binds envelope to a document), envelope }
 //   deps:  { sigVerify(sigBuf, msgBuf, pubBuf)->bool, relayPub: Buffer }
+// Verify a v3 doc-sign .psign envelope (`version: 'parasign-doc-3'`). Unlike
+// v1/v2 the relay is not the notary here: the authoritative record is the
+// CT-logged multiparty envelope, and this .psign is a self-contained receipt.
+// The signer signature is over the doc-sign message (envelope.js signMessageBytes
+// recipe 3): domain || 0x00 || envelope_id || signed_hash || party_index ||
+// party_email_hash. There is no envelope_signature. For pdf/image the signed
+// hash is stamped_hash; for other documents it is document_hash. To verify
+// offline the .psign must carry party_email_hash (the hash mixed into the
+// signed message); without it the signature cannot be reconstructed.
+function verifyDocEnvelopeV3(input, deps) {
+  const errors = [];
+  const env = input.envelope;
+  if (env.algorithm && env.algorithm !== 'ML-DSA-65') errors.push('unsupported algorithm: ' + env.algorithm);
+  const mp = env.multiparty || {};
+  if (!mp.envelope_id) errors.push('missing multiparty.envelope_id');
+
+  // pdf/image sign the stamped document; other documents sign document_hash.
+  const signedHash = env.stamped_hash || env.document_hash;
+  if (!signedHash) errors.push('missing signed document hash (stamped_hash or document_hash)');
+  if (input.documentHashHex && signedHash && signedHash !== input.documentHashHex) {
+    errors.push('document_hash mismatch (envelope ' + String(signedHash).slice(0, 16) +
+      '… vs document ' + String(input.documentHashHex).slice(0, 16) + '…)');
+  }
+
+  const signerPk = env.signer_public_key;
+  if (!signerPk) errors.push('missing signer_public_key');
+  if (env.party_email_hash == null) {
+    errors.push('missing party_email_hash (cannot reconstruct the signed message offline)');
+  }
+
+  if (errors.length === 0) {
+    try {
+      const msg = signMessageBytes(
+        String(mp.envelope_id),
+        signedHash,
+        mp.party_index != null ? mp.party_index : 0,
+        env.party_email_hash || '',
+        3,
+      );
+      const ok = deps.sigVerify(
+        Buffer.from(env.signature || '', 'base64'),
+        msg,
+        Buffer.from(signerPk, 'base64'),
+      );
+      if (!ok) errors.push('signer signature invalid');
+    } catch (e) { errors.push('signer signature verify error: ' + e.message); }
+  }
+
+  if (env.expires_at && new Date(env.expires_at) < new Date()) {
+    errors.push('envelope expired at ' + env.expires_at);
+  }
+  return { valid: errors.length === 0, errors };
+}
+
 function verifyEnvelope(input, deps) {
   const errors = [];
   const env = input.envelope;
   if (!env || typeof env !== 'object') return { valid: false, errors: ['missing or invalid envelope'] };
+  if (env.version === 'parasign-doc-3' || String(env.recipe_version) === '3') {
+    return verifyDocEnvelopeV3(input, deps);
+  }
   if (env.version !== '1' && env.version !== '2') errors.push('unsupported envelope version: ' + env.version);
   if (env.algorithm !== 'ML-DSA-65') errors.push('unsupported algorithm: ' + env.algorithm);
 
@@ -127,6 +189,6 @@ function verifyEnvelope(input, deps) {
 }
 
 module.exports = {
-  canonicalJSON, buildEnvelope, verifyEnvelope,
+  canonicalJSON, buildEnvelope, verifyEnvelope, verifyDocEnvelopeV3,
   singleSignerMessage, signerVerifyBytes, SIGN_DOMAIN_NOTARY,
 };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -497,60 +497,8 @@ function ctLeafHash(deviceIdHash, pubKeyHex, ts) {
   return crypto.createHash('sha3-256').update(Buffer.from([0x00])).update(data).digest('hex');
 }
 
-function ctNodeHash(left, right) {
-  return crypto.createHash('sha3-256')
-    .update(Buffer.from([0x01]))
-    .update(Buffer.from(left, 'hex'))
-    .update(Buffer.from(right, 'hex'))
-    .digest('hex');
-}
-
-function ctTreeHash(entries) {
-  if (entries.length === 0) return '0'.repeat(64);
-  let hashes = entries.map(e => e.leaf_hash);
-  while (hashes.length > 1) {
-    const next = [];
-    for (let i = 0; i < hashes.length; i += 2) {
-      next.push(i + 1 < hashes.length ? ctNodeHash(hashes[i], hashes[i+1]) : hashes[i]);
-    }
-    hashes = next;
-  }
-  return hashes[0];
-}
-
-// Returns the Merkle audit path for `idx` in the given entries array.
-// Each element is { hash, position: 'left'|'right' } so verifiers know how to combine.
-// Verification: start with leaf_hash, for each step combine with sibling per position.
-function ctInclusionProof(entries, idx) {
-  if (entries.length <= 1) return [];
-  let hashes = entries.map(e => e.leaf_hash);
-  const path = [];
-  let i = idx;
-  while (hashes.length > 1) {
-    const sibling = i % 2 === 0 ? i + 1 : i - 1;
-    if (sibling < hashes.length) {
-      path.push({ hash: hashes[sibling], position: i % 2 === 0 ? 'right' : 'left' });
-    }
-    const next = [];
-    for (let j = 0; j < hashes.length; j += 2) {
-      next.push(j + 1 < hashes.length ? ctNodeHash(hashes[j], hashes[j+1]) : hashes[j]);
-    }
-    hashes = next;
-    i = Math.floor(i / 2);
-  }
-  return path;
-}
-
-// Leaf hash for blob/transfer entries — domain separator 0x02 (0x00=pubkey, 0x01=inner node)
-// Commits to transfer hash + sector without exposing payload content.
-function blobLeafHash(blobHash, sector, ts) {
-  const data = Buffer.concat([
-    Buffer.from(blobHash, 'hex'),                                        // 32 bytes — transfer hash
-    crypto.createHash('sha3-256').update(sector || 'relay').digest(),    // 32 bytes — sector identity
-    Buffer.from(ts, 'utf8')                                              // ISO timestamp
-  ]);
-  return crypto.createHash('sha3-256').update(Buffer.from([0x02])).update(data).digest('hex');
-}
+// CT-log hash primitives live in ./lib/ct-hash (pure, unit-tested there).
+const { ctNodeHash, ctTreeHash, ctInclusionProof, blobLeafHash } = require('./lib/ct-hash');
 
 // Coarsen an ISO timestamp to the top of its hour for PUBLIC projections only.
 // The full-precision ts stays in the stored entry (and is committed in the leaf
@@ -3764,7 +3712,8 @@ const server = http.createServer(async (req, res) => {
         blob, ts: now, ttl, size: blob.length,
         apiKey: null, max_views: 1, views_remaining: 1, sector: SECTOR,
         ct_entry: { index: ctEntry.index, leaf_hash: ctEntry.leaf_hash, tree_hash: ctEntry.tree_hash,
-                    tree_size: ctEntry.index + 1, audit_path: ctEntry.proof, sth: ctEntry.sth || null },
+                    tree_size: ctEntry.index + 1, audit_path: ctEntry.proof, sth: ctEntry.sth || null,
+                    ts: ctEntry.ts },
       });
       setTimeout(() => { const e = blobStore.get(hash); if (e) { zeroBuffer(e.blob); blobStore.delete(hash); } }, ttl);
       ipTimes.push(now);
@@ -4005,6 +3954,7 @@ const server = http.createServer(async (req, res) => {
           tree_size: ctEntry.index + 1,
           audit_path: ctEntry.proof,
           sth:       ctEntry.sth || null,
+          ts:        ctEntry.ts,
         }
       });
       setTimeout(() => {
@@ -4132,6 +4082,7 @@ const server = http.createServer(async (req, res) => {
       };
       const receiptPayload = {
         blob_hash:              outm[1],
+        ts:                     ctData.ts,
         retrieved_at:           Date.now(),
         sector:                 entry.sector || SECTOR,
         relay_id:               RELAY_SELF_URL || (SECTOR + '.paramant.app'),

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -285,8 +285,12 @@ function createDidDocument(did, deviceId, ecdhPubHex, dsaPubHex) {
 }
 
 // ── Certificate Transparency Log ─────────────────────────────────────────────
-const ctLog = [];
 const CT_MAX = 10000;
+// Bounded, monotonically-indexed window (see lib/ct-window). Past CT_MAX the
+// logical index keeps advancing (no duplicates / frozen STH) and lookups for a
+// pruned index return null instead of the wrong entry.
+const { CtWindow } = require('./lib/ct-window');
+const ctWindow = new CtWindow(CT_MAX);
 const CT_FILE     = process.env.CT_FILE     || null; // opt-in only — auto-derive disabled to preserve RAM-only default
 const CT_MAX_SIZE = parseInt(process.env.CT_MAX_SIZE || String(100 * 1024 * 1024)); // 100 MB default
 
@@ -344,19 +348,21 @@ function _flushCtOnExit() {
 if (CT_FILE) {
   try {
     const lines = fs.readFileSync(CT_FILE, 'utf8').split('\n').filter(l => l.trim());
+    const loaded = [];
     for (const line of lines) {
       try {
         const parsed = JSON.parse(line);
         if (Array.isArray(parsed)) {
           for (const entry of parsed) {
-            if (entry && typeof entry === 'object' && !Array.isArray(entry)) ctLog.push(entry);
+            if (entry && typeof entry === 'object' && !Array.isArray(entry)) loaded.push(entry);
           }
         } else {
-          ctLog.push(parsed);
+          loaded.push(parsed);
         }
       } catch {}
     }
-    if (ctLog.length) log('info', 'ct_log_loaded', { entries: ctLog.length, file: CT_FILE });
+    ctWindow.load(loaded);
+    if (ctWindow.windowLength) log('info', 'ct_log_loaded', { entries: ctWindow.windowLength, file: CT_FILE });
   } catch (e) {
     if (e.code !== 'ENOENT') log('warn', 'ct_log_load_failed', { err: e.message });
   }
@@ -461,7 +467,7 @@ const relayRegistry = new Map();
 const MAX_RELAY_REGISTRY = parseInt(process.env.MAX_RELAY_REGISTRY || '10000');
 
 function relayRegistryFromCTLog() {
-  for (const entry of ctLog) {
+  for (const entry of ctWindow.entries) {
     if (entry.type !== 'relay_reg') continue;
     const key = entry.relay_pk_hash;
     if (!key) continue;
@@ -522,16 +528,15 @@ function ctAppend(deviceId, pubKeyHex, apiKey) {
   const ts = new Date().toISOString();
   const deviceIdHash = crypto.createHash('sha3-256').update(deviceId + apiKey.slice(0,8)).digest('hex');
   const leaf_hash = ctLeafHash(deviceIdHash, pubKeyHex, ts);
-  const index = ctLog.length;
-  const allEntries = [...ctLog, { leaf_hash }];
+  const index = ctWindow.nextIndex();
+  const allEntries = [...ctWindow.entries, { leaf_hash }];
   const tree_hash = ctTreeHash(allEntries);
-  const proof = ctInclusionProof(allEntries, index); // real audit path, not a slice
+  const proof = ctInclusionProof(allEntries, allEntries.length - 1); // real audit path at the new leaf position
   const entry = { index, leaf_hash, tree_hash, device_hash: deviceIdHash, ts, proof };
-  ctLog.push(entry);
-  if (ctLog.length > CT_MAX) ctLog.shift();
+  ctWindow.append(entry);
   // Fix 8: async write via stream queue instead of appendFileSync
   ctWrite(entry);
-  produceSth(entry.index + 1, entry.tree_hash);
+  produceSth(allEntries.length, entry.tree_hash);
   return entry;
 }
 
@@ -543,10 +548,10 @@ function ctAppendRelayReg(relayUrl, sector, version, edition, pkHash) {
   const urlSectorHash = crypto.createHash('sha3-256').update(relayUrl + '|' + sector).digest('hex');
   // ctLeafHash(deviceIdHash, pubKeyHex, ts) — reuse with urlSectorHash as identity, pkHash as key
   const leaf_hash = ctLeafHash(urlSectorHash, pkHash, ts);
-  const index = ctLog.length;
-  const allEntries = [...ctLog, { leaf_hash }];
+  const index = ctWindow.nextIndex();
+  const allEntries = [...ctWindow.entries, { leaf_hash }];
   const tree_hash = ctTreeHash(allEntries);
-  const proof = ctInclusionProof(allEntries, index);
+  const proof = ctInclusionProof(allEntries, allEntries.length - 1);
   const entry = {
     index, type: 'relay_reg', leaf_hash, tree_hash,
     device_hash: pkHash,          // reused field — relay public key hash
@@ -555,11 +560,10 @@ function ctAppendRelayReg(relayUrl, sector, version, edition, pkHash) {
     relay_pk_hash: pkHash,
     ts, proof
   };
-  ctLog.push(entry);
-  if (ctLog.length > CT_MAX) ctLog.shift();
+  ctWindow.append(entry);
   // Fix 8: async write via stream queue
   ctWrite(entry);
-  produceSth(entry.index + 1, entry.tree_hash);
+  produceSth(allEntries.length, entry.tree_hash);
   return entry;
 }
 
@@ -570,18 +574,17 @@ function ctAppendRelayReg(relayUrl, sector, version, edition, pkHash) {
 function ctAppendTransfer(blobHash, sector) {
   const ts = new Date().toISOString();
   const leaf_hash = blobLeafHash(blobHash, sector, ts);
-  const index = ctLog.length;
-  const allEntries = [...ctLog, { leaf_hash }];
+  const index = ctWindow.nextIndex();
+  const allEntries = [...ctWindow.entries, { leaf_hash }];
   const tree_hash = ctTreeHash(allEntries);
-  const proof = ctInclusionProof(allEntries, index);
+  const proof = ctInclusionProof(allEntries, allEntries.length - 1);
   const entry = {
     index, type: 'transfer', leaf_hash, tree_hash,
     blob_hash: blobHash, sector, ts, proof
   };
-  ctLog.push(entry);
-  if (ctLog.length > CT_MAX) ctLog.shift();
+  ctWindow.append(entry);
   ctWrite(entry);
-  const sth = produceSth(entry.index + 1, entry.tree_hash);
+  const sth = produceSth(allEntries.length, entry.tree_hash);
   return { ...entry, sth };
 }
 
@@ -592,18 +595,17 @@ function ctAppendTransfer(blobHash, sector) {
 function ctAppendParasign(documentHashHex, signerPkHash) {
   const ts = new Date().toISOString();
   const leaf_hash = ctLeafHash(signerPkHash, documentHashHex, ts);
-  const index = ctLog.length;
-  const allEntries = [...ctLog, { leaf_hash }];
+  const index = ctWindow.nextIndex();
+  const allEntries = [...ctWindow.entries, { leaf_hash }];
   const tree_hash = ctTreeHash(allEntries);
-  const proof = ctInclusionProof(allEntries, index);
+  const proof = ctInclusionProof(allEntries, allEntries.length - 1);
   const entry = {
     index, type: 'parasign', leaf_hash, tree_hash,
     document_hash: documentHashHex, signer_pk_hash: signerPkHash, ts, proof
   };
-  ctLog.push(entry);
-  if (ctLog.length > CT_MAX) ctLog.shift();
+  ctWindow.append(entry);
   ctWrite(entry);
-  produceSth(entry.index + 1, entry.tree_hash);
+  produceSth(allEntries.length, entry.tree_hash);
   return entry;
 }
 
@@ -616,18 +618,17 @@ function ctAppendEnvelope(eventType, envelopeId, payload) {
     .update(eventType).update('|').update(envelopeId).update('|')
     .update(JSON.stringify(payload || {})).digest('hex');
   const leaf_hash = ctLeafHash(envelopeId, valueHash, ts);
-  const index = ctLog.length;
-  const allEntries = [...ctLog, { leaf_hash }];
+  const index = ctWindow.nextIndex();
+  const allEntries = [...ctWindow.entries, { leaf_hash }];
   const tree_hash = ctTreeHash(allEntries);
-  const proof = ctInclusionProof(allEntries, index);
+  const proof = ctInclusionProof(allEntries, allEntries.length - 1);
   const entry = {
     index, type: 'envelope_' + eventType, leaf_hash, tree_hash,
     envelope_id: envelopeId, payload: payload || {}, ts, proof
   };
-  ctLog.push(entry);
-  if (ctLog.length > CT_MAX) ctLog.shift();
+  ctWindow.append(entry);
   ctWrite(entry);
-  produceSth(entry.index + 1, entry.tree_hash);
+  produceSth(allEntries.length, entry.tree_hash);
   return entry;
 }
 
@@ -642,18 +643,17 @@ function ctAppendSigningPkEvent(eventType, userId, signerPkHash) {
   const ts = new Date().toISOString();
   const userIdHash = crypto.createHash('sha3-256').update(String(userId)).digest('hex');
   const leaf_hash = ctLeafHash(userIdHash, signerPkHash, ts);
-  const index = ctLog.length;
-  const allEntries = [...ctLog, { leaf_hash }];
+  const index = ctWindow.nextIndex();
+  const allEntries = [...ctWindow.entries, { leaf_hash }];
   const tree_hash = ctTreeHash(allEntries);
-  const proof = ctInclusionProof(allEntries, index);
+  const proof = ctInclusionProof(allEntries, allEntries.length - 1);
   const entry = {
     index, type: eventType, leaf_hash, tree_hash,
     user_id_hash: userIdHash, signer_pk_hash: signerPkHash, ts, proof
   };
-  ctLog.push(entry);
-  if (ctLog.length > CT_MAX) ctLog.shift();
+  ctWindow.append(entry);
   ctWrite(entry);
-  produceSth(entry.index + 1, entry.tree_hash);
+  produceSth(allEntries.length, entry.tree_hash);
   return entry;
 }
 
@@ -820,11 +820,13 @@ function _subproof(m, nodes, b) {
   return [_merkleRootOf(nodes.slice(0, k))].concat(_subproof(m - k, nodes.slice(k), false));
 }
 
-// 0 ≤ fromSize ≤ toSize ≤ ctLog.length
+// Consistency proof over the retained window. fromSize/toSize are leaf counts
+// within the in-memory tree (0 ≤ from ≤ to ≤ windowLength); entries pruned past
+// the CT_MAX window cannot participate.
 function ctConsistencyProof(fromSize, toSize) {
-  if (fromSize < 0 || toSize < fromSize || toSize > ctLog.length) return null;
+  if (fromSize < 0 || toSize < fromSize || toSize > ctWindow.windowLength) return null;
   if (fromSize === 0 || fromSize === toSize) return [];
-  const leaves = ctLog.slice(0, toSize).map(e => e.leaf_hash);
+  const leaves = ctWindow.entries.slice(0, toSize).map(e => e.leaf_hash);
   return _subproof(fromSize, leaves, fromSize === leaves.length);
 }
 
@@ -873,7 +875,7 @@ function renderPrometheus() {
     L.push(`# TYPE paramant_${k} counter`);
     L.push(`paramant_${k}{sector="${SECTOR}",v="${VERSION}"} ${v}`);
   }
-  for(const [k,v] of [['blobs_in_flight',blobStore.size],['pubkeys',pubkeys.size],['edition',EDITION==='licensed'?1:0],['did_registry',didRegistry.size],['ct_log',ctLog.length],['uptime_s',Math.floor(process.uptime())],['heap_bytes',process.memoryUsage().heapUsed]]){
+  for(const [k,v] of [['blobs_in_flight',blobStore.size],['pubkeys',pubkeys.size],['edition',EDITION==='licensed'?1:0],['did_registry',didRegistry.size],['ct_log',ctWindow.size],['uptime_s',Math.floor(process.uptime())],['heap_bytes',process.memoryUsage().heapUsed]]){
     L.push(`# TYPE paramant_${k} gauge`);
     L.push(`paramant_${k}{sector="${SECTOR}"} ${v}`);
   }
@@ -3021,14 +3023,14 @@ const server = http.createServer(async (req, res) => {
 
   // ── GET /ct/feed — public JSON feed for CT log UI (no auth, no keys) ─────────
   if (path === '/ct/feed' && req.method === 'GET') {
-    const last50 = ctLog.slice(-50);
-    const root   = ctLog.length ? ctLog[ctLog.length - 1].tree_hash : '0'.repeat(64);
+    const last50 = ctWindow.recent(50);
+    const root   = ctWindow.last() ? ctWindow.last().tree_hash : '0'.repeat(64);
     res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' });
     return res.end(J({
       relay_id: relayIdentity ? relayIdentity.pk_hash : null,
       sector:   SECTOR,
       version:  VERSION,
-      tree_size: ctLog.length,
+      tree_size: ctWindow.size,
       root,
       entries: last50.map(e => ({
         i:    e.index,
@@ -3052,15 +3054,15 @@ const server = http.createServer(async (req, res) => {
     // across sector relays. The transparency guarantee does NOT depend on it:
     // tamper-evidence comes from leaf_hash + tree_hash + the Merkle proof
     // (/v2/ct/proof) + the signed tree head, none of which reveal identity.
-    const entries = ctLog.slice(from, from + limit).map(e => ({ index: e.index, type: e.type, leaf_hash: e.leaf_hash, tree_hash: e.tree_hash, ts: ctCoarseTs(e.ts) }));
+    const entries = ctWindow.sliceByIndex(from, limit).map(e => ({ index: e.index, type: e.type, leaf_hash: e.leaf_hash, tree_hash: e.tree_hash, ts: ctCoarseTs(e.ts) }));
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    return res.end(J({ ok: true, size: ctLog.length, root: ctLog.length ? ctLog[ctLog.length-1].tree_hash : '0'.repeat(64), entries }));
+    return res.end(J({ ok: true, size: ctWindow.size, root: ctWindow.last() ? ctWindow.last().tree_hash : '0'.repeat(64), entries }));
   }
   const ctpm0 = path.match(/^\/v2\/ct\/proof\/(\d+)$/);
   const ctpq0 = (!ctpm0 && path === '/v2/ct/proof') ? query.index : null;
   if (ctpm0 || (ctpq0 !== null && ctpq0 !== undefined)) {
     const idx = parseInt(ctpm0 ? ctpm0[1] : ctpq0);
-    const entry = ctLog[idx];
+    const entry = ctWindow.get(idx);
     if (!entry) { res.writeHead(404); return res.end(J({ error: 'Index not found' })); }
     res.writeHead(200, { 'Content-Type': 'application/json' });
     return res.end(J({ ok: true, index: idx, leaf_hash: entry.leaf_hash, tree_hash: entry.tree_hash, proof: entry.proof, ts: ctCoarseTs(entry.ts) }));
@@ -3280,14 +3282,14 @@ const server = http.createServer(async (req, res) => {
   // ── GET /v2/sth/consistency — RFC 6962 consistency proof ──────────────────────
   if (path === '/v2/sth/consistency' && req.method === 'GET') {
     const fromSize = parseInt(query.from);
-    const toSize   = query.to !== undefined ? parseInt(query.to) : ctLog.length;
+    const toSize   = query.to !== undefined ? parseInt(query.to) : ctWindow.windowLength;
     if (isNaN(fromSize) || isNaN(toSize)) {
       res.writeHead(400, { 'Content-Type': 'application/json' });
       return res.end(J({ error: 'Query params required: from=<integer> (and optionally to=<integer>)' }));
     }
-    if (fromSize < 0 || toSize < fromSize || toSize > ctLog.length) {
+    if (fromSize < 0 || toSize < fromSize || toSize > ctWindow.windowLength) {
       res.writeHead(400, { 'Content-Type': 'application/json' });
-      return res.end(J({ error: `Invalid range: 0 ≤ from (${fromSize}) ≤ to (${toSize}) ≤ log size (${ctLog.length})` }));
+      return res.end(J({ error: `Invalid range: 0 ≤ from (${fromSize}) ≤ to (${toSize}) ≤ window size (${ctWindow.windowLength})` }));
     }
     const proof = ctConsistencyProof(fromSize, toSize);
     if (proof === null) { res.writeHead(500); return res.end(J({ error: 'Could not compute proof' })); }
@@ -4086,7 +4088,7 @@ const server = http.createServer(async (req, res) => {
         retrieved_at:           Date.now(),
         sector:                 entry.sector || SECTOR,
         relay_id:               RELAY_SELF_URL || (SECTOR + '.paramant.app'),
-        tree_size_at_retrieval: ctLog.length,
+        tree_size_at_retrieval: ctWindow.size,
         inclusion_proof:        inclusionProof,
         burn_confirmed:         burned,
       };
@@ -5273,9 +5275,9 @@ loadPeerSths();
 // Generate a startup STH if the CT log has entries but no STH was persisted.
 // Covers the case where the STH file was missing or the relay restarted after
 // new CT entries were written without a corresponding STH flush.
-if (ctLog.length > 0 && sthLog.length === 0) {
-  const last = ctLog[ctLog.length - 1];
-  produceSth(ctLog.length, last.tree_hash);
+if (ctWindow.windowLength > 0 && sthLog.length === 0) {
+  const last = ctWindow.last();
+  produceSth(ctWindow.windowLength, last.tree_hash);
 }
 // Periodic STH gossip — re-broadcast latest STH every 10 min to catch newly registered peers
 setInterval(() => {

--- a/relay/test/ct-receipt.test.js
+++ b/relay/test/ct-receipt.test.js
@@ -1,0 +1,54 @@
+'use strict';
+// Regression test for the delivery-receipt roundtrip (D1): the leaf recomputed
+// at /v2/verify-receipt time must equal the leaf the relay committed at upload.
+// Before the fix the receipt dropped `ts`, so blobLeafHash(...,undefined) threw
+// and every verify returned 400. Run: node relay/test/ct-receipt.test.js
+const assert = require('assert');
+const crypto = require('crypto');
+const { blobLeafHash, ctNodeHash, ctInclusionProof, ctTreeHash } = require('../lib/ct-hash');
+
+let passed = 0;
+const ok = n => { passed++; console.log('  ok -', n); };
+
+// Recompute a Merkle root from a leaf + audit path exactly as /v2/verify-receipt does.
+function rootFromProof(leaf, auditPath) {
+  let root = leaf;
+  for (const step of auditPath) {
+    root = step.position === 'right' ? ctNodeHash(root, step.hash) : ctNodeHash(step.hash, root);
+  }
+  return root;
+}
+
+// ── ts is mandatory: the pre-fix bug was passing undefined ──────────────────
+assert.throws(() => blobLeafHash('aa'.repeat(32), 'health', undefined), /ts is required/);
+ok('blobLeafHash rejects a missing ts (the pre-fix 400 cause)');
+
+// ── append/verify agree when ts is carried through ─────────────────────────
+const blobHash = crypto.randomBytes(32).toString('hex');
+const sector = 'health';
+const ts = '2026-07-16T05:00:00.000Z';
+const appendLeaf = blobLeafHash(blobHash, sector, ts);
+
+// Simulate the receipt the outbound handler now emits (with ts) and the verify
+// recompute from receipt.blob_hash + receipt.sector + receipt.ts.
+const receipt = { blob_hash: blobHash, sector, ts };
+const verifyLeaf = blobLeafHash(receipt.blob_hash, receipt.sector, receipt.ts);
+assert.strictEqual(verifyLeaf, appendLeaf, 'verify leaf must equal append leaf');
+ok('receipt roundtrip: recomputed leaf equals the committed leaf');
+
+// ── a wrong ts must NOT verify (leaf binds the timestamp) ──────────────────
+assert.notStrictEqual(blobLeafHash(blobHash, sector, '2026-07-16T06:00:00.000Z'), appendLeaf);
+ok('a different ts yields a different leaf (timestamp is bound)');
+
+// ── inclusion proof + root recompute holds for a small tree ────────────────
+const entries = [];
+for (let i = 0; i < 5; i++) {
+  entries.push({ leaf_hash: blobLeafHash(crypto.randomBytes(32).toString('hex'), sector, ts) });
+}
+const idx = 3;
+const proof = ctInclusionProof(entries, idx);
+assert.strictEqual(rootFromProof(entries[idx].leaf_hash, proof), ctTreeHash(entries),
+  'proof-recomputed root must equal the tree root');
+ok('inclusion proof for a mid-tree leaf recomputes the tree root');
+
+console.log(`\n${passed} passed`);

--- a/relay/test/ct-window.test.js
+++ b/relay/test/ct-window.test.js
@@ -1,0 +1,134 @@
+'use strict';
+// Regression test for the CT-log windowing (D2): monotonic indices past the cap,
+// bounds-safe lookups, and window position mapping. Before the fix the index
+// froze at CT_MAX (duplicates) and ctLog[idx] returned the wrong entry after the
+// first shift. Run: node relay/test/ct-window.test.js
+const assert = require('assert');
+const crypto = require('crypto');
+const { CtWindow } = require('../lib/ct-window');
+const { ctTreeHash, ctInclusionProof, ctNodeHash } = require('../lib/ct-hash');
+
+let passed = 0;
+const ok = n => { passed++; console.log('  ok -', n); };
+
+// Append n entries the way relay.js does: index = nextIndex() before build.
+function fill(w, n) {
+  for (let i = 0; i < n; i++) {
+    const index = w.nextIndex();
+    w.append({ index, leaf_hash: 'leaf' + index, type: 't' });
+  }
+}
+
+// ── below the cap: index == position, everything retained ──────────────────
+{
+  const w = new CtWindow(100);
+  fill(w, 10);
+  assert.strictEqual(w.size, 10);
+  assert.strictEqual(w.windowLength, 10);
+  assert.strictEqual(w.nextIndex(), 10);
+  assert.strictEqual(w.get(0).leaf_hash, 'leaf0');
+  assert.strictEqual(w.get(9).leaf_hash, 'leaf9');
+  assert.strictEqual(w.position(3), 3);
+  ok('below the cap: indices and positions coincide, all retained');
+}
+
+// ── past the cap: indices stay monotonic, no duplicates, oldest pruned ──────
+{
+  const w = new CtWindow(4);
+  fill(w, 10);                       // indices 0..9, window holds the last 4
+  assert.strictEqual(w.size, 10, 'monotonic total keeps advancing');
+  assert.strictEqual(w.windowLength, 4);
+  assert.strictEqual(w.nextIndex(), 10, 'next index is 10, NOT frozen at max');
+  // The retained window is indices 6,7,8,9 — each distinct.
+  const idxs = w.entries.map(e => e.index);
+  assert.deepStrictEqual(idxs, [6, 7, 8, 9]);
+  assert.strictEqual(new Set(idxs).size, 4, 'no duplicate indices');
+  ok('past the cap: index advances monotonically, oldest 4 pruned');
+}
+
+// ── lookups after pruning: correct entry or null, never the wrong one ───────
+{
+  const w = new CtWindow(4);
+  fill(w, 10);
+  assert.strictEqual(w.get(9).leaf_hash, 'leaf9', 'newest retained by its real index');
+  assert.strictEqual(w.get(6).leaf_hash, 'leaf6', 'oldest retained by its real index');
+  assert.strictEqual(w.get(5), null, 'pruned index returns null, not a wrong entry');
+  assert.strictEqual(w.get(0), null, 'long-gone index returns null');
+  assert.strictEqual(w.get(10), null, 'not-yet-appended index returns null');
+  assert.strictEqual(w.position(7), 1, 'logical 7 sits at window position 1');
+  assert.strictEqual(w.position(5), -1);
+  ok('lookups after pruning resolve the right entry or null');
+}
+
+// ── the exact old-bug scenario: the wrong entry at the old positional index ─
+{
+  const w = new CtWindow(4);
+  fill(w, 10);
+  // The buggy code did ctLog[idx]; at idx=0 that would now be entry index 6.
+  // get(0) must NOT return the entry currently sitting at array position 0.
+  assert.notStrictEqual(w.get(0), w.entries[0]);
+  assert.strictEqual(w.get(0), null);
+  assert.strictEqual(w.entries[0].index, 6);
+  ok('positional lookup bug is gone: get(0) != entries[0] after pruning');
+}
+
+// ── append enforces the monotonic contract ─────────────────────────────────
+{
+  const w = new CtWindow(4);
+  assert.throws(() => w.append({ index: 5, leaf_hash: 'x' }), /nextIndex/);
+  ok('append rejects a non-monotonic index');
+}
+
+// ── sliceByIndex + recent clamp to the window ───────────────────────────────
+{
+  const w = new CtWindow(4);
+  fill(w, 10);
+  assert.deepStrictEqual(w.sliceByIndex(7, 2).map(e => e.index), [7, 8]);
+  assert.deepStrictEqual(w.sliceByIndex(0, 100).map(e => e.index), [6, 7, 8, 9], 'pruned start clamps to base');
+  assert.deepStrictEqual(w.recent(2).map(e => e.index), [8, 9]);
+  ok('sliceByIndex and recent clamp to the retained window');
+}
+
+// ── load rehydrates base from the persisted entries and trims to the cap ────
+{
+  const w = new CtWindow(3);
+  w.load([{ index: 6, leaf_hash: 'a' }, { index: 7, leaf_hash: 'b' }, { index: 8, leaf_hash: 'c' }, { index: 9, leaf_hash: 'd' }]);
+  assert.strictEqual(w.windowLength, 3, 'trimmed to cap keeping newest');
+  assert.strictEqual(w.base, 7, 'base taken from the first retained entry');
+  assert.strictEqual(w.get(9).leaf_hash, 'd');
+  assert.strictEqual(w.get(6), null, 'the trimmed-away entry is gone');
+  assert.strictEqual(w.nextIndex(), 10, 'append continues monotonically after load');
+  ok('load rehydrates base and continues monotonically');
+}
+
+// ── integration: an entry's inclusion proof still validates past the cap ─────
+// Replicates the relay's ctAppend* body (index=nextIndex, proof at the new leaf
+// position, tree over the window) and checks the fresh entry's proof recomputes
+// its own tree root — the guarantee that broke when the index froze at the cap.
+{
+  const w = new CtWindow(8);
+  function rootFromProof(leaf, path) {
+    let r = leaf;
+    for (const step of path) r = step.position === 'right' ? ctNodeHash(r, step.hash) : ctNodeHash(step.hash, r);
+    return r;
+  }
+  let last = null;
+  for (let i = 0; i < 25; i++) {                       // well past the cap of 8
+    const index = w.nextIndex();
+    const leaf_hash = crypto.createHash('sha3-256').update('leaf' + index).digest('hex');
+    const allEntries = [...w.entries, { leaf_hash }];
+    const tree_hash = ctTreeHash(allEntries);
+    const proof = ctInclusionProof(allEntries, allEntries.length - 1);
+    const entry = { index, leaf_hash, tree_hash, proof };
+    w.append(entry);
+    last = entry;
+  }
+  assert.strictEqual(rootFromProof(last.leaf_hash, last.proof), last.tree_hash,
+    'fresh entry proof must recompute its tree root past the cap');
+  assert.strictEqual(last.index, 24, 'index kept advancing (24), not frozen at 8');
+  assert.strictEqual(w.get(24).leaf_hash, last.leaf_hash);
+  assert.strictEqual(w.get(10), null, 'a pruned index is gone, not misresolved');
+  ok('integration: inclusion proof validates for a fresh entry past the cap');
+}
+
+console.log(`\n${passed} passed`);


### PR DESCRIPTION
De drie defecten uit de gap-analyse die paramants kernbelofte (bewijsbare, offline-verifieerbare ondertekening) onderuithaalden. Alle drie op deze branch, met tests.

## D1 — /v2/verify-receipt gaf altijd 400
Het receipt droeg de CT-entry `ts` niet mee → `blobLeafHash(...,undefined)` TypeError → 400. `ts` nu door beide `ct_entry`-sites + `receiptPayload`; vier pure CT-hashhelpers naar `relay/lib/ct-hash.js`. Test: `relay/test/ct-receipt.test.js`.

## D2 — CT-log-index ontspoorde bij de cap van 10.000
`index = ctLog.length` + `ctLog.shift()` → na de cap dubbele indices, bevroren STH tree_size, en `ctLog[idx]` gaf de verkeerde entry. Nieuwe `relay/lib/ct-window.js` (CtWindow): monotone logische index + base-offset, bounds-safe lookup (pruned index → null/404), cap-beheer. De zes `ctAppend*`-functies + feed/log/proof/consistency/startup lezen er nu doorheen. STH tree_size = echte tree-leaf-count. Windowed-log-semantiek onveranderd (incremental Merkle-tree blijft future work). Test: `relay/test/ct-window.test.js` incl. integratie-lus voorbij de cap.

## D3 — /verify wees elke v3 .psign af als INVALID
`verifyEnvelope` kende alleen v1/v2. Nu dispatcht het `parasign-doc-3` naar `verifyDocEnvelopeV3`: reconstrueert het getekende bericht via `signMessageBytes` (recipe 3) en verifieert de signer-signature tegen `signer_public_key` — **offline, geen Redis** (de gekozen aanpak). Signed hash = `stamped_hash` (pdf/image) of `document_hash`. Frontend bakt `party_email_hash` in de v3 .psign; `lookupSignerHtml` leest `signer_public_key` als fallback. Cache-bust gebumpt.

## Test
- `relay/test/ct-window.test.js` (8) · `relay/test/ct-receipt.test.js` (4) · 5 v3-cases in `relay/crypto/parasign.test.js`.
- 66/66 relay-unit, 11/11 crypto, cache-bust + csp-inline + sign-e2e groen.

## Let op
Frontend `sign-flow.js` wordt parallel bewerkt op `feat/parasign-pdf-quality`; de `party_email_hash`-toevoeging kan een triviale merge-conflict geven (beide willen het veld) — forward-fix bij merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)