### PR TITLE
build(relay): re-pin rust to 1.95-alpine (1.97 breaks liboqs build)

### DIFF
--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -14,7 +14,7 @@
 # live relay images; revert until paramant-core's oqs crate supports the newer
 # liboqs. NOTE: CI's crypto suite does not build via this musl Dockerfile, so it
 # stayed green through the bump — this base must be verified by an actual image build.
-FROM rust:1.97-alpine@sha256:ec9c91e77119ce498cd1e87d96d77e0f75b2cee21655a29bc2bf75a51a2b20a4 AS paramant-core-binding
+FROM rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS paramant-core-binding
 
 RUN apk add --no-cache musl-dev gcc g++ make cmake ninja clang clang-dev llvm-dev perl nasm git bash
 ENV LIBCLANG_PATH=/usr/lib


### PR DESCRIPTION
Reverts the rust 1.95 to 1.97-alpine bump (#280). The relay Dockerfile is deliberately pinned to 1.95-alpine; newer Alpine breaks the liboqs/oqs compile, and CI does not build via this musl Dockerfile so it passed green. Fixes the prod build failure on deploy.