### PR TITLE
style: plain punctuation in deploy comments; fix stale post-deploy checks

### DIFF
--- a/deploy/preflight.sh
+++ b/deploy/preflight.sh
@@ -22,9 +22,9 @@ check_port() {
                 if [ -f .env ]; then sed -i '/^HTTP_PORT=/d' .env; sed -i '/^HTTPS_PORT=/d' .env; fi
                 echo "HTTP_PORT=${alt_http}" >> .env; echo "HTTPS_PORT=${alt_https}" >> .env
                 export HTTP_PORT=${alt_http}; export HTTPS_PORT=${alt_https}
-                echo -e "${GREEN}✓  Will use ports ${alt_http}/${alt_https} — saved to .env${NC}" ;;
+                echo -e "${GREEN}✓  Will use ports ${alt_http}/${alt_https} - saved to .env${NC}" ;;
             2) echo -e "${YELLOW}   Stop ${proc} and re-run this script${NC}"; exit 1 ;;
-            3) echo -e "${YELLOW}   Skipping — startup may fail${NC}"; ISSUES=$((ISSUES + 1)) ;;
+            3) echo -e "${YELLOW}   Skipping - startup may fail${NC}"; ISSUES=$((ISSUES + 1)) ;;
         esac
     else
         echo -e "${GREEN}✓  Port ${port} free${NC}"
@@ -47,7 +47,7 @@ if ! command -v docker &>/dev/null; then
         if curl -fsSL https://get.docker.com -o "$DOCKER_INSTALL_SH"; then
             sh "$DOCKER_INSTALL_SH"; rm -f "$DOCKER_INSTALL_SH"
             sudo usermod -aG docker $USER
-            echo -e "${GREEN}✓  Docker installed — you may need to log out and back in${NC}"
+            echo -e "${GREEN}✓  Docker installed - you may need to log out and back in${NC}"
         else
             rm -f "$DOCKER_INSTALL_SH"
             echo -e "${RED}   Failed to download the Docker install script. Install from https://docs.docker.com/get-docker/${NC}"; exit 1
@@ -68,7 +68,7 @@ echo "Checking swap..."
 DISK_SWAP=$(swapon --show=TYPE,NAME --noheadings 2>/dev/null | grep -v zram | grep -v "^$" || true)
 ZRAM_SWAP=$(swapon --show=TYPE,NAME --noheadings 2>/dev/null | grep zram || true)
 if [ -n "$DISK_SWAP" ]; then
-    echo -e "${RED}✗  Disk swap is active — security risk for RAM-only storage${NC}"; echo "   $DISK_SWAP"; echo ""
+    echo -e "${RED}✗  Disk swap is active - security risk for RAM-only storage${NC}"; echo "   $DISK_SWAP"; echo ""
     read -p "   Disable disk swap now? [Y/n]: " disable_swap
     if [[ ! "$disable_swap" =~ ^[Nn]$ ]]; then
         if sudo swapoff -a 2>/dev/null && sudo sed -i '/swap/d' /etc/fstab 2>/dev/null; then
@@ -100,7 +100,7 @@ else
         chmod 600 .env 2>/dev/null || true
         unset TOKEN
         echo ""; echo -e "${GREEN}✓  ADMIN_TOKEN generated and saved to .env (chmod 600)${NC}"
-        # Do NOT echo the token to stdout — it would land in CI logs, shell
+        # Do NOT echo the token to stdout - it would land in CI logs, shell
         # scrollback and screen-shares. Tell the operator how to read it instead.
         echo -e "${YELLOW}   Read it when you need it:${NC}  grep '^ADMIN_TOKEN=' .env"; echo ""
     fi

--- a/scripts/post-deploy-verify.sh
+++ b/scripts/post-deploy-verify.sh
@@ -103,9 +103,9 @@ note "== frontend pages =="
 check "/setup reachable" "200" "$(http_code "$SITE/setup")" no
 check "/docs reachable"  "200" "$(http_code "$SITE/docs")" no
 DASH=$($CURL -L "$SITE/dashboard" 2>/dev/null)
-contains "/dashboard renders cards" "$DASH" "cards-grid" no
-HOME=$($CURL -L "$SITE/" 2>/dev/null)
-contains "homepage advertises PQC" "$HOME" "ML-KEM" no
+contains "/dashboard renders cards" "$DASH" "dh-acct-grid" no
+HOMEPG=$($CURL -L "$SITE/" 2>/dev/null)
+contains "homepage advertises PQC" "$HOMEPG" "ML-KEM" no
 
 note ""
 note "== admin pages =="


### PR DESCRIPTION
Follow-up on #206. preflight.sh: em-dashes to plain hyphens (style guard). post-deploy-verify.sh: dashboard class is dh-acct-grid; homepage PQC check used $HOME which the shell overrides (renamed to HOMEPG). No runtime code touched.