### PR TITLE
Fix dead module scripts on account, ontvang and parashare

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -469,7 +469,7 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
 <script src="/js/nav-auth.js?v=4" defer></script>
 <script src="/js/account.inline1.js?v=1"></script>
 
-<script src="/js/account.inline2.js?v=1"></script>
+<script type="module" src="/js/account.inline2.js?v=2"></script>
 <script type="module" src="/js/passkey.js?v=3"></script>
 <script type="module" src="/js/signing-enrol.js?v=14"></script>
 

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -387,7 +387,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 </footer>
 
 <script type="module" src="/noble-mlkem-loader.js?v=4"></script>
-<script src="/js/ontvang.inline1.js?v=1"></script>
+<script type="module" src="/js/ontvang.inline1.js?v=2"></script>
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/ontvang.page.js?v=1" defer></script>
 <script src="/nav.js?v=14" defer></script>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -662,7 +662,7 @@ select:focus{border-color:var(--cobalt)}
 </div>
 
 <script src="./vendor/qrcode.min.js?v=1"></script>
-<script src="/js/parashare.inline1.js?v=1"></script>
+<script type="module" src="/js/parashare.inline1.js?v=2"></script>
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/quota-upgrade.js?v=2" defer></script>
 <script src="/js/parashare.page.js?v=2" defer></script>

--- a/tests/frontend-module-scripts.test.mjs
+++ b/tests/frontend-module-scripts.test.mjs
@@ -1,0 +1,88 @@
+// A script that uses `import` or `export` at top level MUST be loaded with
+// type="module". Without it the browser rejects the whole file as a SyntaxError
+// and NOT ONE LINE runs. There is no error in the UI, no failed request in the
+// network tab, just a feature that silently does nothing.
+//
+// That is exactly what shipped: account.html, ontvang.html and parashare.html
+// each loaded a module as a classic script. Consequences on production
+// (measured 2026-07-25): the account page kept saying "Checking your
+// account..." forever, and window._cryptoBridge was never set, so
+// ontvang.page.js threw 'WASM crypto bridge not ready' and parashare.page.js
+// refused to encrypt. Receiving and sending a file, the core product, was dead.
+//
+// This gate reads every frontend page, resolves every local script it loads and
+// fails on any module loaded as a classic script. Node builtins only, no
+// browser, so it runs in the "Root integration suites" CI job.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FRONTEND = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+
+function htmlFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return entry.name === 'node_modules' ? [] : htmlFiles(full);
+    return entry.isFile() && entry.name.endsWith('.html') ? [full] : [];
+  });
+}
+
+// Top-level import/export only: an `import(` expression is legal in a classic
+// script, and the word inside a string or comment must not trip the gate.
+const MODULE_SYNTAX = /^\s*(?:import\s+[^(]|import\s*\{|import\s+['"]|export\s+(?:default|const|let|var|function|class|\{))/m;
+
+function isModuleSource(file) {
+  let src;
+  try { src = fs.readFileSync(file, 'utf8'); } catch { return false; }
+  const stripped = src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((line) => !/^\s*\/\//.test(line))
+    .join('\n');
+  return MODULE_SYNTAX.test(stripped);
+}
+
+// Resolve the src attribute of a page-local script to a file on disk. Absolute
+// paths are document-root relative, relative ones sit next to the page.
+function resolveSrc(pageFile, src) {
+  if (/^(https?:)?\/\//.test(src)) return null;      // third party, not ours
+  const clean = src.split('?')[0].split('#')[0];
+  const file = clean.startsWith('/')
+    ? path.join(FRONTEND, clean)
+    : path.join(path.dirname(pageFile), clean);
+  return file.startsWith(FRONTEND) && fs.existsSync(file) ? file : null;
+}
+
+const SCRIPT_TAG = /<script\b([^>]*)>/gi;
+
+test('every module script is loaded with type="module"', () => {
+  const offenders = [];
+  for (const page of htmlFiles(FRONTEND)) {
+    const html = fs.readFileSync(page, 'utf8');
+    for (const [, attrs] of html.matchAll(SCRIPT_TAG)) {
+      const srcMatch = attrs.match(/\bsrc\s*=\s*["']([^"']+)["']/i);
+      if (!srcMatch) continue;
+      const isModule = /\btype\s*=\s*["']module["']/i.test(attrs);
+      if (isModule) continue;
+      const file = resolveSrc(page, srcMatch[1]);
+      if (file && isModuleSource(file)) {
+        offenders.push(`${path.relative(FRONTEND, page)} loads ${srcMatch[1]} (a module) as a classic script`);
+      }
+    }
+  }
+  assert.deepEqual(offenders, [], `\n  ${offenders.join('\n  ')}\n`);
+});
+
+// The inverse mistake is cheap to catch here too: a page that declares
+// type="module" for a file with no module syntax is harmless but usually means
+// the file was meant to export something and does not.
+test('the pages that need the WASM crypto bridge load its shim as a module', () => {
+  for (const [page, shim] of [['ontvang.html', 'ontvang.inline1.js'], ['parashare.html', 'parashare.inline1.js']]) {
+    const html = fs.readFileSync(path.join(FRONTEND, page), 'utf8');
+    const tag = [...html.matchAll(SCRIPT_TAG)].map(([, a]) => a).find((a) => a.includes(shim));
+    assert.ok(tag, `${page} no longer loads ${shim}; window._cryptoBridge would be unset`);
+    assert.match(tag, /\btype\s*=\s*["']module["']/i, `${page} must load ${shim} as a module`);
+  }
+});


### PR DESCRIPTION
Three pages loaded an ES module as a classic script. The browser rejects the whole file as a SyntaxError and runs none of it, with no visible error and no failed request.

Measured on production 2026-07-25:

- `/ontvang` and `/parashare`: `window._cryptoBridge` never set, so `ontvang.page.js` threw 'WASM crypto bridge not ready' and `parashare.page.js` refused to encrypt. Receiving and sending a file was dead.
- `/account`: "Checking your account..." and "Checking this browser..." stayed forever.

Fix: `type="module"` on the three tags, cache version bumped to v2.

Gate: `tests/frontend-module-scripts.test.mjs` resolves every local script on every frontend page and fails on any module loaded as a classic script. It also asserts that the two pages needing the crypto bridge still load their shim as a module. Node builtins only, runs in the existing "Root integration suites" job. Verified red before the fix (3 offenders), green after.
