### PR TITLE
Split a missing Mollie key from an unknown payment in the billing webhook

### DIFF
--- a/relay/lib/billing.js
+++ b/relay/lib/billing.js
@@ -81,4 +81,30 @@ async function processPayment(payment, deps) {
   return { result: 'ignored', level: 'info', account: accountId, product, reason: `status_${status}` };
 }
 
-module.exports = { processPayment };
+// A failed re-fetch of the payment is not one thing, and the answer decides
+// what Mollie does next. Mollie retries a webhook for about a day, so:
+//   - no API key, a rejected key, a 5xx or a timeout -> a retry can still land
+//     once the config or Mollie is fixed. Ask for one (503).
+//   - 404 / 410 / 422 -> this payment id will never resolve. A retry cannot
+//     help, so accept the event and stop the hammering (200).
+// Answering 503 for everything did both wrong: it kept Mollie retrying a
+// webhook that could never succeed, and it hid a missing MOLLIE_API_KEY behind
+// the same body as an id that simply does not exist. The wire body stays
+// 'fetch_failed' for every retryable case so a public prober learns nothing
+// about our config; the distinction lives in the log, at the right level.
+function classifyFetchError(err) {
+  const msg = (err && err.message) || '';
+  const status = err && err.status;
+  if (msg.startsWith('mollie_key_missing')) {
+    return { retry: true, level: 'error', reason: 'mollie_key_missing' };
+  }
+  if (status === 401 || status === 403) {
+    return { retry: true, level: 'error', reason: `mollie_key_rejected:${status}` };
+  }
+  if (status === 404 || status === 410 || status === 422) {
+    return { retry: false, level: 'warn', reason: `mollie_permanent:${status}` };
+  }
+  return { retry: true, level: 'warn', reason: status ? `mollie_${status}` : (msg || 'fetch_error') };
+}
+
+module.exports = { processPayment, classifyFetchError };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -5142,7 +5142,14 @@ const server = http.createServer(async (req, res) => {
     let payment;
     try { payment = await mollie.getPayment(mode, paymentId); }
     catch (e) {
-      log('warn', 'billing_webhook_fetch_failed', { payment_id: paymentId, err: e.message, status: e.status });
+      const f = billing.classifyFetchError(e);
+      log(f.level, 'billing_webhook_fetch_failed', {
+        payment_id: paymentId, err: e.message, status: e.status, reason: f.reason, retry: f.retry });
+      if (!f.retry) {
+        // Permanent: acknowledge so Mollie stops retrying an event we can never
+        // resolve. Nothing was granted; the warn log above is the trail.
+        res.writeHead(200, { 'Content-Type': 'application/json' }); return res.end(J({ ok: true, ignored: 'unknown_payment' }));
+      }
       res.writeHead(503, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'fetch_failed' }));
     }
     const _rok = () => !!(redisClient && redisClient.isReady);
@@ -6355,6 +6362,15 @@ server.listen(PORT, process.env.HOST || '0.0.0.0', () => {
   log('info', 'relay_started', { port: PORT, version: VERSION, sector: SECTOR, mode: RELAY_MODE,
       dsa: !!mlDsa, protocol: 'ghost-pipe-v2',
       relay_identity: relayIdentity ? relayIdentity.pk_hash.slice(0,16)+'…' : 'none' });
+  // Say it once, loudly, at boot: without a key for the active billing mode
+  // every checkout and every webhook fails, and the only earlier symptom was a
+  // 503 on a public endpoint that nobody watches. Never log the key itself.
+  {
+    const _bm = mollie.billingMode();
+    const _bk = mollie.apiKeyFor(_bm);
+    log(_bk ? 'info' : 'error', 'billing_config', {
+      mode: _bm, key_present: !!_bk, key_prefix: _bk ? _bk.slice(0, 5) : null });
+  }
   // Register to the relay registry after a short delay to let the server fully bind
   if (relayIdentity && RELAY_SELF_URL) setTimeout(registerSelf, 500);
 });

--- a/relay/test/billing.test.js
+++ b/relay/test/billing.test.js
@@ -146,6 +146,39 @@ async function main() {
     ok('re-processing without a marker asks for the same grant (setter is idempotent)');
   }
 
+  // ── classification of a failed re-fetch decides Mollie's retry behaviour ────
+  {
+    const keyMissing = billing.classifyFetchError(new Error('mollie_key_missing:live'));
+    assert.strictEqual(keyMissing.retry, true, 'a missing key must still be retried once it is set');
+    assert.strictEqual(keyMissing.level, 'error', 'a missing key is an alert, not a warning');
+    assert.strictEqual(keyMissing.reason, 'mollie_key_missing');
+    ok('missing MOLLIE_API_KEY -> retryable, logged at error level');
+  }
+  {
+    const rejected = billing.classifyFetchError(Object.assign(new Error('mollie_get_failed'), { status: 401 }));
+    assert.strictEqual(rejected.retry, true);
+    assert.strictEqual(rejected.level, 'error', 'a rejected key must be as loud as a missing one');
+    ok('rejected Mollie key (401) -> retryable, error level');
+  }
+  {
+    for (const status of [404, 410, 422]) {
+      const permanent = billing.classifyFetchError(Object.assign(new Error('mollie_get_failed'), { status }));
+      assert.strictEqual(permanent.retry, false, `${status} can never resolve, so do not ask Mollie to retry`);
+      assert.strictEqual(permanent.level, 'warn');
+      assert.strictEqual(permanent.reason, `mollie_permanent:${status}`);
+    }
+    ok('unknown payment id (404/410/422) -> not retryable, acknowledged');
+  }
+  {
+    const transient = billing.classifyFetchError(Object.assign(new Error('mollie_get_failed'), { status: 502 }));
+    assert.strictEqual(transient.retry, true, 'a Mollie outage must be retried');
+    assert.strictEqual(transient.level, 'warn');
+    const timeout = billing.classifyFetchError(new Error('mollie_timeout'));
+    assert.strictEqual(timeout.retry, true, 'a timeout must be retried');
+    assert.strictEqual(timeout.reason, 'mollie_timeout');
+    ok('Mollie 5xx and timeout -> retryable, warn level');
+  }
+
   console.log(`\nPASS billing: ${passed} checks`);
 }
 


### PR DESCRIPTION
The webhook answered `503 fetch_failed` for every failed re-fetch of a payment. That collapsed two very different states into one answer:

- Mollie returned 404 because the payment id does not exist (harmless, e.g. a probe with a made-up `tr_` id).
- `MOLLIE_API_KEY` is not set on the box, so every real payment silently goes nowhere.

From outside, and from the response body, these are the same. It also asked Mollie to retry for ~24h on errors that can never resolve.

**Changes**

- `classifyFetchError` in `relay/lib/billing.js`: missing or rejected key stays retryable but logs at `error` level; 404/410/422 get a `200` so the retry loop stops; 5xx and timeouts keep the `503`.
- The wire body for every retryable case stays `fetch_failed`, so a public prober still learns nothing about our configuration. The distinction lives in the log.
- Boot logs `billing_config` with the active mode and whether a key is present (prefix only, never the key), at `error` level when missing. A relay billing into the void used to look healthy.

**Tests**: 4 new cases in `relay/test/billing.test.js` (19 checks total, was 15). Verified red before the change (`classifyFetchError is not a function`), green after.
