### PR TITLE
Point the ParaSend crypto bridge import at the document root

### DIFF
--- a/.github/workflows/product-heartbeat.yml
+++ b/.github/workflows/product-heartbeat.yml
@@ -1,0 +1,69 @@
+name: product-heartbeat
+
+# Does the site still DO anything, in a real browser (tests/product-heartbeat.test.mjs).
+#
+# Runs twice, on purpose:
+#   build   on every frontend change, against the checkout. Catches a break
+#           before it is merged.
+#   live    hourly and on demand, against https://paramant.app. Catches a break
+#           that only exists on production: a half-finished deploy, an nginx
+#           rule, a file in the docroot that no longer matches the commit.
+#
+# The July 2026 breaks (relative import 404, module loaded as classic script,
+# CSP-blocked signup) were all invisible to the Node suites and loud in a
+# browser console. This is the gate that sees them.
+on:
+  push:
+    paths:
+      - 'frontend/**'
+      - 'tests/product-heartbeat.test.mjs'
+      - '.github/workflows/product-heartbeat.yml'
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - 'tests/product-heartbeat.test.mjs'
+      - '.github/workflows/product-heartbeat.yml'
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: heartbeat — this checkout
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install deps (browsers installed separately)
+        run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Heartbeat against frontend/
+        run: node --test tests/product-heartbeat.test.mjs
+
+  live:
+    name: heartbeat — production
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install deps (browsers installed separately)
+        run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Heartbeat against paramant.app
+        run: node --test tests/product-heartbeat.test.mjs
+        env:
+          PARAMANT_BASE_URL: https://paramant.app

--- a/frontend/js/parashare.inline1.js
+++ b/frontend/js/parashare.inline1.js
@@ -1,4 +1,4 @@
 
-import { initCrypto, encryptBlob as _eb } from './crypto-bridge.js?v=4';
+import { initCrypto, encryptBlob as _eb } from '/crypto-bridge.js?v=4';
 window._cryptoBridge = { encryptBlob: _eb };
 initCrypto().catch(e => console.error('WASM init failed:', e));

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -695,7 +695,7 @@ select:focus{border-color:var(--cobalt)}
 </div>
 
 <script src="./vendor/qrcode.min.js?v=1"></script>
-<script type="module" src="/js/parashare.inline1.js?v=2"></script>
+<script type="module" src="/js/parashare.inline1.js?v=3"></script>
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/quota-upgrade.js?v=2" defer></script>
 <script src="/js/parashare.page.js?v=2" defer></script>

--- a/scripts/check-prod-drift.sh
+++ b/scripts/check-prod-drift.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Docroot drift guard. The production docroot is /home/paramant/app, NOT the
+# repo, and deploys are file copies. So the docroot can differ from the commit
+# it is supposed to be running, in both directions:
+#
+#   behind  a fix was merged but never copied out (July 2026: editor, v3-verify,
+#           email, signup and claim all ran older code than main)
+#   ahead   a file was hand-edited on the server and exists nowhere in git
+#
+# Both are silent. This script compares, by checksum, what is on the server with
+# what is in a given commit, and reports every difference. It changes nothing.
+#
+# Run from the NUC, where the prod key lives:
+#   scripts/check-prod-drift.sh [ref]        (default: origin/main)
+#
+# Exit 0 = docroot matches the ref, 1 = drift, 2 = cannot check.
+#
+# Files the docroot legitimately holds and the repo does not (dist/, the
+# investor brief, paramant-mark.svg) are listed in IGNORE below. They are the
+# reason a deploy must never use --delete.
+set -euo pipefail
+
+REF="${1:-origin/main}"
+KEY="${PARAMANT_PROD_KEY:-$HOME/.ssh/paramant_prod_claude}"
+HOST="${PARAMANT_PROD_HOST:-root@116.203.86.81}"
+DOCROOT="${PARAMANT_DOCROOT:-/home/paramant/app}"
+WORKTREE="$(mktemp -d /tmp/paramant-drift.XXXXXX)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Present on the server by design, absent from the repo.
+IGNORE=(--exclude 'dist/***' --exclude 'paramant-mark.svg' --exclude 'developer.js' --exclude 'docs/paramant-investor-brief.html')
+
+cleanup() { git -C "$ROOT" worktree remove --force "$WORKTREE" >/dev/null 2>&1 || rm -rf "$WORKTREE"; }
+trap cleanup EXIT
+
+[ -r "$KEY" ] || { echo "prod key not readable: $KEY (run this on the NUC)" >&2; exit 2; }
+
+git -C "$ROOT" fetch -q origin
+rmdir "$WORKTREE"
+git -C "$ROOT" worktree add -q --detach "$WORKTREE" "$REF"
+COMMIT="$(git -C "$WORKTREE" rev-parse --short HEAD)"
+
+# -c compares content, not timestamps: a deploy that copied the bytes but not
+# the mtime is not drift. -i lists what WOULD change, -n changes nothing.
+drift="$(rsync -rinc --no-times "${IGNORE[@]}" \
+  -e "ssh -i $KEY -o BatchMode=yes" \
+  "$WORKTREE/frontend/" "$HOST:$DOCROOT/" 2>/dev/null | grep -v '^$' || true)"
+
+if [ -z "$drift" ]; then
+  echo "prod drift guard: OK — $DOCROOT matches $REF ($COMMIT)"
+  exit 0
+fi
+
+echo "prod drift guard: DRIFT — $DOCROOT differs from $REF ($COMMIT)"
+echo
+echo "$drift"
+echo
+echo "Lines starting with <f are files the server would receive: prod is behind"
+echo "the ref, or was edited by hand. Investigate before deploying."
+exit 1

--- a/tests/frontend-module-scripts.test.mjs
+++ b/tests/frontend-module-scripts.test.mjs
@@ -75,6 +75,45 @@ test('every module script is loaded with type="module"', () => {
   assert.deepEqual(offenders, [], `\n  ${offenders.join('\n  ')}\n`);
 });
 
+// Loading the module correctly is only half of it: its own imports must resolve
+// as the browser resolves them. A relative specifier is resolved against the
+// importing file, not against the page. When the inline block of parashare.html
+// was extracted to js/parashare.inline1.js during the CSP hardening (042b4c5,
+// 2026-07-02), its `./crypto-bridge.js` moved with it and started pointing at
+// /js/crypto-bridge.js, which does not exist. The import 404s, the module never
+// runs, window._cryptoBridge stays unset and parashare.page.js aborts with
+// "WASM crypto module not loaded". Sending a file, the core product, was dead
+// with no build error and nothing red in CI. ontvang.inline1.js survived only
+// because it imports the same file as /crypto-bridge.js, document-root absolute.
+const STATIC_IMPORT = /(?:^|\n)\s*(?:import\s[^'"]*?from\s*|import\s*)['"]([^'"]+)['"]/g;
+
+function jsFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return entry.name === 'node_modules' ? [] : jsFiles(full);
+    return entry.isFile() && entry.name.endsWith('.js') ? [full] : [];
+  });
+}
+
+test('every import inside a frontend module resolves to a file that exists', () => {
+  const offenders = [];
+  for (const file of jsFiles(FRONTEND)) {
+    if (!isModuleSource(file)) continue;
+    const src = fs.readFileSync(file, 'utf8');
+    for (const [, spec] of src.matchAll(STATIC_IMPORT)) {
+      if (/^(https?:)?\/\//.test(spec)) continue;               // third party
+      const clean = spec.split('?')[0].split('#')[0];
+      const target = clean.startsWith('/')
+        ? path.join(FRONTEND, clean)                             // document root
+        : path.resolve(path.dirname(file), clean);               // next to the importer
+      if (!fs.existsSync(target)) {
+        offenders.push(`${path.relative(FRONTEND, file)} imports '${spec}' -> ${path.relative(FRONTEND, target)} does not exist`);
+      }
+    }
+  }
+  assert.deepEqual(offenders, [], `\n  ${offenders.join('\n  ')}\n`);
+});
+
 // The inverse mistake is cheap to catch here too: a page that declares
 // type="module" for a file with no module syntax is harmless but usually means
 // the file was meant to export something and does not.

--- a/tests/product-heartbeat.test.mjs
+++ b/tests/product-heartbeat.test.mjs
@@ -1,0 +1,139 @@
+// Product heartbeat: does the site still DO anything, in a real browser.
+//
+// Three breaks shipped silently in July 2026 and none of them was caught by a
+// test, because all three failed in the browser and nowhere else:
+//
+//   042b4c5 (07-02)  CSP extraction moved inline code into js/. A relative
+//                    import moved with it and 404'd. Sending a file was dead
+//                    for three weeks.
+//   before 7da4e39   Three pages loaded a module as a classic script. The
+//                    browser rejected the file as a SyntaxError and ran none
+//                    of it. Sending, receiving and the account page were dead.
+//   PR 278 (07)      Signup died on a CSP-blocked inline script.
+//
+// Every one of them is invisible to a Node test suite and loud in a browser
+// console. So this suite opens each page in Chromium and fails on:
+//
+//   1. any uncaught page error (SyntaxError, ReferenceError, ...)
+//   2. any console error, including CSP refusals
+//   3. any failed request for one of our own static assets (a 404 on a script,
+//      stylesheet, module import or wasm blob)
+//   4. a per-page heartbeat: the one global that proves the page's core
+//      machinery actually initialised
+//
+// Rules 1-3 need no maintenance and cover features nobody wrote a check for.
+// Rule 4 is where a product owner states what "alive" means for a page.
+//
+// Local  : node tests/product-heartbeat.test.mjs          (serves frontend/)
+// Prod   : PARAMANT_BASE_URL=https://paramant.app node tests/product-heartbeat.test.mjs
+// CI     : npx playwright install --with-deps chromium, then as local.
+import { chromium } from 'playwright';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = { '.js':'text/javascript','.mjs':'text/javascript','.css':'text/css','.html':'text/html','.svg':'image/svg+xml','.json':'application/json','.wasm':'application/wasm','.png':'image/png','.webp':'image/webp','.woff2':'font/woff2','.ico':'image/x-icon' };
+
+// A page is alive when its core machinery left something behind on window.
+// Keep this list short and mean it: every entry is a promise to the user.
+const PAGES = [
+  {
+    url: '/parashare.html',
+    what: 'ParaSend, sending a file',
+    // parashare.page.js:304 refuses to encrypt without this. It was undefined
+    // on production from 2026-07-02 until 2026-07-26.
+    heartbeat: () => typeof window._cryptoBridge?.encryptBlob === 'function',
+    because: 'window._cryptoBridge.encryptBlob is missing, so the send aborts with "WASM crypto module not loaded"',
+  },
+  {
+    url: '/ontvang.html',
+    what: 'ParaSend, receiving a file',
+    heartbeat: () => typeof window._cryptoBridge?.decryptBlob === 'function',
+    because: 'window._cryptoBridge.decryptBlob is missing, so ontvang.page.js throws "WASM crypto bridge not ready"',
+  },
+  { url: '/index.html',   what: 'homepage' },
+  { url: '/pricing.html', what: 'pricing, the paid funnel' },
+  { url: '/signup.html',  what: 'signup' },
+  { url: '/sign.html',    what: 'ParaSign' },
+  { url: '/verify.html',  what: 'signature verification' },
+  { url: '/paraid.html',  what: 'ParaID' },
+];
+
+// Only our own static assets. A 401 on /api/* without a session is correct
+// behaviour, not a break, and third party hosts are not ours to police.
+const OUR_ASSET = /\.(js|mjs|css|wasm|woff2?|svg|png|webp|ico)(\?|$)/i;
+
+const BASE = process.env.PARAMANT_BASE_URL?.replace(/\/$/, '');
+let server = null;
+let origin = BASE;
+
+if (!BASE) {
+  server = http.createServer((req, res) => {
+    const p = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+    const file = path.join(ROOT, p);
+    if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+    fs.readFile(file, (e, b) => {
+      if (e) { res.writeHead(404); return res.end(); }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      res.end(b);
+    });
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  origin = `http://127.0.0.1:${server.address().port}`;
+}
+
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+
+test.after(async () => {
+  await browser.close();
+  server?.close();
+});
+
+for (const page of PAGES) {
+  test(`${page.url} — ${page.what}`, async () => {
+    const ctx = await browser.newContext();
+    const tab = await ctx.newPage();
+    const problems = [];
+
+    tab.on('pageerror', (e) => problems.push(`uncaught ${e.message}`));
+    // "Failed to load resource" carries no url, so it is useless on its own and
+    // duplicates what the response handler below reports with a path. Every
+    // other console error is kept, CSP refusals included.
+    tab.on('console', (m) => {
+      if (m.type() !== 'error') return;
+      if (/^Failed to load resource/.test(m.text())) return;
+      problems.push(`console: ${m.text()}`);
+    });
+    tab.on('requestfailed', (r) => {
+      if (OUR_ASSET.test(r.url()) && new URL(r.url()).origin === new URL(origin).origin) {
+        problems.push(`request failed ${r.url()} (${r.failure()?.errorText})`);
+      }
+    });
+    tab.on('response', (r) => {
+      if (r.status() >= 400 && OUR_ASSET.test(r.url()) && new URL(r.url()).origin === new URL(origin).origin) {
+        problems.push(`HTTP ${r.status()} on our own asset ${new URL(r.url()).pathname}`);
+      }
+    });
+
+    const resp = await tab.goto(origin + page.url, { waitUntil: 'networkidle', timeout: 45000 });
+    assert.ok(resp?.ok(), `${page.url} did not load: HTTP ${resp?.status()}`);
+    await tab.waitForTimeout(1200);   // let deferred modules and wasm settle
+
+    if (page.heartbeat) {
+      const alive = await tab.evaluate(page.heartbeat);
+      assert.ok(alive, `${page.what} is dead: ${page.because}`);
+    }
+
+    // A console error the page recovers from is still a break waiting to be
+    // reported by a user, so it fails here too. Drop the noise, not the signal.
+    const real = problems.filter((p) => !/favicon|\/api\/|401|403|Failed to load resource: the server responded with a status of 40[13]/.test(p));
+    assert.deepEqual(real, [], `\n  ${page.url}\n  ${real.join('\n  ')}\n`);
+
+    await ctx.close();
+  });
+}


### PR DESCRIPTION
Sending a file on /parashare has been dead on production. The page loads, the flow runs, and the send aborts with "WASM crypto module not loaded".

## Cause

`frontend/js/parashare.inline1.js` imports `./crypto-bridge.js`. A relative specifier resolves against the importing file, so the browser requests `/js/crypto-bridge.js`. That file does not exist. The bridge lives at `/crypto-bridge.js`.

The import 404s, so the module never executes, `window._cryptoBridge` stays unset, and `parashare.page.js:304` refuses to encrypt.

The path broke on 2026-07-02 in 042b4c5, when the inline block was extracted out of `parashare.html` for the CSP hardening: the relative specifier moved into `js/` and kept pointing next to itself. Until 2026-07-25 the file was still loaded as a classic script, so it died on the top level import anyway. Fixing the script type (7da4e39) left this older break exposed.

`ontvang.inline1.js` imports the same module as `/crypto-bridge.js`, document-root absolute, and was never affected. That is why receiving kept working while sending did not.

## Measured

Live paramant.app, before:

```
GET /js/crypto-bridge.js?v=4   404
/parashare.html   window._cryptoBridge  undefined
/ontvang.html     window._cryptoBridge  object, encryptBlob function
```

Served locally, after: `window._cryptoBridge.encryptBlob` is a function and `initCrypto()` resolves.

## Guard

`tests/frontend-module-scripts.test.mjs` gains a test that resolves every static import in every frontend module the way the browser does and fails when the target is not on disk. Red before this change on exactly this import, green after. `check-cache-bust.sh` and `check-csp-inline.sh` stay green.