### PR TITLE
Run the product gates on every pull request, and make a red heartbeat visible

### DIFF
--- a/.github/workflows/csp-inline-check.yml
+++ b/.github/workflows/csp-inline-check.yml
@@ -1,9 +1,10 @@
 name: CSP inline-script check
 
+# Not path-gated: this is a required status check, and a skipped check never
+# reports, so the pull request would wait on it forever. The scan takes seconds.
 on:
   pull_request:
-    paths:
-      - 'frontend/**'
+    branches: [main]
   push:
     branches: [main]
 

--- a/.github/workflows/product-heartbeat.yml
+++ b/.github/workflows/product-heartbeat.yml
@@ -12,17 +12,17 @@ name: product-heartbeat
 # The July 2026 breaks (relative import 404, module loaded as classic script,
 # CSP-blocked signup) were all invisible to the Node suites and loud in a
 # browser console. This is the gate that sees them.
+#
+# Deliberately NOT path-gated. A required status check that is skipped never
+# reports, and a pull request then waits forever on a check that will not run.
+# A gate that only guards the changes it expects is not a gate: the ParaSend
+# break came from a CSP commit, and the signup break from an nginx rule. One
+# minute of CI per push buys a gate that is always there.
 on:
   push:
-    paths:
-      - 'frontend/**'
-      - 'tests/product-heartbeat.test.mjs'
-      - '.github/workflows/product-heartbeat.yml'
+    branches: [main]
   pull_request:
-    paths:
-      - 'frontend/**'
-      - 'tests/product-heartbeat.test.mjs'
-      - '.github/workflows/product-heartbeat.yml'
+    branches: [main]
   schedule:
     - cron: '17 * * * *'
   workflow_dispatch:
@@ -52,6 +52,9 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
@@ -64,6 +67,56 @@ jobs:
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
       - name: Heartbeat against paramant.app
-        run: node --test tests/product-heartbeat.test.mjs
+        id: beat
+        # shell: bash sets pipefail. Without it the pipe into tee would hand the
+        # step tee's exit code and every failure would be reported as green.
+        shell: bash
+        run: node --test tests/product-heartbeat.test.mjs 2>&1 | tee /tmp/heartbeat.log
         env:
           PARAMANT_BASE_URL: https://paramant.app
+
+      # An hourly job that turns red in a tab nobody opens is not an alarm. A
+      # red run opens an issue with the failing output; a green run closes it
+      # again, so the issue list tracks the site instead of collecting noise.
+      - name: Open an issue when production is down
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const log = fs.readFileSync('/tmp/heartbeat.log', 'utf8').split('\n')
+              .filter(l => /^(✖|not ok|  AssertionError|ℹ fail)/.test(l)).slice(0, 40).join('\n');
+            const title = 'Production heartbeat is failing';
+            const open = await github.rest.issues.listForRepo({
+              ...context.repo, state: 'open', labels: 'heartbeat',
+            });
+            const body = [
+              `The hourly heartbeat against https://paramant.app failed.`,
+              ``,
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              ``,
+              '```',
+              log || 'see the run log',
+              '```',
+            ].join('\n');
+            if (open.data.length) {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: open.data[0].number, body });
+            } else {
+              await github.rest.issues.create({ ...context.repo, title, body, labels: ['heartbeat'] });
+            }
+
+      - name: Close the issue when production is healthy again
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const open = await github.rest.issues.listForRepo({
+              ...context.repo, state: 'open', labels: 'heartbeat',
+            });
+            for (const issue of open.data) {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number,
+                body: `Heartbeat green again as of run ${context.runId}. Closing.`,
+              });
+              await github.rest.issues.update({ ...context.repo, issue_number: issue.number, state: 'closed' });
+            }

--- a/.github/workflows/sign-e2e.yml
+++ b/.github/workflows/sign-e2e.yml
@@ -29,3 +29,12 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: Run signing functional suite
         run: node tests/sign-full.test.mjs
+
+      # Every other root suite that drives a browser. They import playwright, so
+      # the no-install unit job could never run them, and they were on no other
+      # workflow either: cosign appearance and delivery, the developer and user
+      # dashboards, the navigation shell, multi-verify and invite delivery had
+      # no CI at all. Selected by import, so a new browser suite is picked up
+      # here the day it is written. product-heartbeat has its own workflow.
+      - name: Browser suites
+        run: node --test $(grep -l "from 'playwright'" tests/*.mjs | grep -vE 'sign-full|product-heartbeat')

--- a/.github/workflows/sign-e2e.yml
+++ b/.github/workflows/sign-e2e.yml
@@ -2,19 +2,15 @@ name: sign-e2e
 
 # Functional test of the ParaSign signing subsystem in real Chromium with a
 # WebAuthn virtual authenticator (tests/sign-full.test.mjs). Self-contained: it
-# serves frontend/ and stubs /api, so no backend/Redis is needed. Path-gated so it
-# only runs when the signing frontend (or the test) changes.
+# serves frontend/ and stubs /api, so no backend/Redis is needed.
+#
+# No longer path-gated: this is a required status check, and a skipped check
+# never reports, so the pull request would wait on it forever.
 on:
   push:
-    paths:
-      - 'frontend/**'
-      - 'tests/sign-full.test.mjs'
-      - '.github/workflows/sign-e2e.yml'
+    branches: [main]
   pull_request:
-    paths:
-      - 'frontend/**'
-      - 'tests/sign-full.test.mjs'
-      - '.github/workflows/sign-e2e.yml'
+    branches: [main]
 
 jobs:
   sign-e2e:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,16 @@ jobs:
         working-directory: relay
         run: node --test $(find crypto -name '*.test.js')
 
+      # inbound-hash-verify spawns a real relay.js, so it needs the installed
+      # dependencies and belongs here, not in the no-install unit job. It sat in
+      # that job from 2026-07-20 and failed every single run with "relay did not
+      # become healthy in time", which is what a missing `redis` module looks
+      # like through a spawn with stdio ignored. Thirty red runs in a row on
+      # main, and a suite nobody trusts is a suite nobody reads.
+      - name: Relay integration suite (needs deps)
+        working-directory: relay
+        run: node --test test/inbound-hash-verify.test.js
+
   relay-unit-tests:
     name: relay - unit suite (no native deps)
     runs-on: ubuntu-latest
@@ -82,17 +92,20 @@ jobs:
       # Pure-JS units: account-split schema (keys-table), static-serve, envelope
       # binding, webauthn helpers. No @paramant/core build and no Redis, so the
       # relay/test suite that previously had zero CI coverage now gates here.
+      # inbound-hash-verify is excluded: it spawns a real relay.js and needs the
+      # installed dependencies, so it runs in the crypto job above.
       - name: Relay unit suite
         working-directory: relay
-        run: node --test test/*.test.js
+        run: node --test $(ls test/*.test.js | grep -v inbound-hash-verify)
 
       # Root integration suites (tests/*.mjs): dependency-injected, node builtins
       # only (no @paramant/core, no Redis, no npm install). Excludes the Playwright
-      # browser e2e (sign-full, vault-filename), which run in the sign-e2e workflow.
+      # browser e2e (sign-full, vault-filename, product-heartbeat), which run in
+      # the sign-e2e and product-heartbeat workflows.
       # Gates the ParaSign open-API conformance suite + key-issuance + pdf-ops that
       # previously ran in no workflow at all.
       - name: Root integration suites (no browser)
-        run: node --test $(ls tests/*.mjs | grep -vE 'sign-full|vault-filename')
+        run: node --test $(ls tests/*.mjs | grep -vE 'sign-full|vault-filename|product-heartbeat')
 
   admin-unit-tests:
     name: admin - unit suite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,13 +99,17 @@ jobs:
         run: node --test $(ls test/*.test.js | grep -v inbound-hash-verify)
 
       # Root integration suites (tests/*.mjs): dependency-injected, node builtins
-      # only (no @paramant/core, no Redis, no npm install). Excludes the Playwright
-      # browser e2e (sign-full, vault-filename, product-heartbeat), which run in
-      # the sign-e2e and product-heartbeat workflows.
+      # only (no @paramant/core, no Redis, no npm install). The browser suites are
+      # excluded by what they import, not by a hand-kept list of names: this job
+      # installs nothing, so a file importing playwright can only fail here. That
+      # list had drifted, and six suites (cosign x2, developer dashboard,
+      # navigation shell, multi-verify, invite delivery, user dashboard) were
+      # failing on every run because they were never on it. They now run in the
+      # sign-e2e workflow, which installs Chromium.
       # Gates the ParaSign open-API conformance suite + key-issuance + pdf-ops that
       # previously ran in no workflow at all.
       - name: Root integration suites (no browser)
-        run: node --test $(ls tests/*.mjs | grep -vE 'sign-full|vault-filename|product-heartbeat')
+        run: node --test $(grep -L "from 'playwright'" tests/*.mjs)
 
   admin-unit-tests:
     name: admin - unit suite


### PR DESCRIPTION
Follow-up to #299, which fixed the ParaSend break and added the heartbeat. This makes the gates enforceable.

## Why

Three gates were path-gated to `frontend/**`: the heartbeat, the CSP inline check and sign-e2e. A required status check that never runs also never reports, so a pull request would wait on it forever. Branch protection over these gates was impossible while they stayed path-gated.

Path-gating also assumes the break arrives through the path it guards. The July breaks did not: ParaSend died in a CSP hardening commit, signup in an nginx rule.

Cost: about two minutes of CI per push, for gates that are always there.

## Alarm

The hourly production heartbeat now opens an issue labelled `heartbeat` when it fails, comments on the existing one while it is still failing, and closes it when production is healthy again.

The live step runs under `shell: bash` for pipefail. Without it the pipe into `tee` would hand the step tee's exit code and every failure would be reported as green.

## After merging

`main` can then require: the six `tests` jobs, `csp-inline`, `sign-e2e` and `heartbeat — this checkout`. Not `heartbeat — production`, which is skipped on push by design.