### PR TITLE
Add a transfer canary: a real file through the real relay, hourly

### DIFF
--- a/.github/workflows/product-heartbeat.yml
+++ b/.github/workflows/product-heartbeat.yml
@@ -75,6 +75,18 @@ jobs:
         env:
           PARAMANT_BASE_URL: https://paramant.app
 
+      # The heartbeat proves the pages initialise; the canary proves the product
+      # works: a real blob through the real relay, back byte for byte, then gone.
+      # It covers what a browser cannot see, the relay process, nginx, the rate
+      # limits, the CT append. always() so a dead page never hides a dead relay.
+      - name: Transfer canary against the live relay
+        if: always()
+        shell: bash
+        run: node --test tests/transfer-canary.test.mjs 2>&1 | tee -a /tmp/heartbeat.log
+        env:
+          PARAMANT_RELAY_URL: https://relay.paramant.app
+          PARAMANT_API_KEY: ${{ secrets.PARAMANT_CANARY_KEY }}
+
       # An hourly job that turns red in a tab nobody opens is not an alarm. A
       # red run opens an issue with the failing output; a green run closes it
       # again, so the issue list tracks the site instead of collecting noise.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,10 @@ jobs:
       # Gates the ParaSign open-API conformance suite + key-issuance + pdf-ops that
       # previously ran in no workflow at all.
       - name: Root integration suites (no browser)
-        run: node --test $(grep -L "from 'playwright'" tests/*.mjs)
+        # transfer-canary is excluded too: it talks to the live relay, so it
+        # measures production, not this commit. It runs hourly in the
+        # product-heartbeat workflow.
+        run: node --test $(grep -L "from 'playwright'" tests/*.mjs | grep -v transfer-canary)
 
   admin-unit-tests:
     name: admin - unit suite

--- a/tests/transfer-canary.test.mjs
+++ b/tests/transfer-canary.test.mjs
@@ -1,0 +1,94 @@
+// Transfer canary: does the relay still move a file, end to end, right now.
+//
+// The heartbeat proves the pages initialise. This proves the product works:
+// upload a blob, get it back byte for byte, and confirm it burned. It talks to
+// the live relay over plain HTTP, so it also covers everything the browser
+// suite cannot see: the relay process, nginx, rate limits, TLS, the CT log
+// append, and disk.
+//
+// No secret required. The anonymous route is the free tier every visitor gets,
+// so the canary measures what an unauthenticated user actually experiences. Set
+// PARAMANT_API_KEY to also exercise the keyed route a paying customer uses.
+//
+//   node --test tests/transfer-canary.test.mjs
+//   PARAMANT_RELAY_URL=https://relay.paramant.app node --test tests/transfer-canary.test.mjs
+//
+// It leaves nothing behind: burn-on-read destroys the blob, and the assertion
+// that it is gone is itself part of the promise being tested.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+
+const RELAY = (process.env.PARAMANT_RELAY_URL || 'https://relay.paramant.app').replace(/\/$/, '');
+const API_KEY = process.env.PARAMANT_API_KEY || '';
+const TTL_MS = 600000;
+
+const sha256hex = (buf) => crypto.createHash('sha256').update(buf).digest('hex');
+
+// A distinct payload per run, so two canaries can never collide on one hash and
+// burn each other's blob.
+function payload(label) {
+  return Buffer.from(`paramant transfer canary ${label} ${crypto.randomUUID()}`);
+}
+
+async function upload(route, body, headers = {}) {
+  const r = await fetch(`${RELAY}${route}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(30000),
+  });
+  const text = await r.text();
+  let json = null;
+  try { json = JSON.parse(text); } catch { /* keep the raw body in the message */ }
+  return { status: r.status, json, text };
+}
+
+test('anonymous transfer: upload, download, burn', async () => {
+  const blob = payload('anon');
+  const hash = sha256hex(blob);
+
+  const up = await upload('/v2/anon-inbound', { hash, payload: blob.toString('base64'), ttl_ms: TTL_MS });
+  assert.equal(up.status, 200, `upload rejected: HTTP ${up.status} ${up.text.slice(0, 200)}`);
+  assert.equal(up.json?.ok, true, 'relay did not accept the upload');
+  assert.equal(up.json?.hash, hash, 'relay stored the blob under a different hash');
+  assert.ok(up.json?.download_token, 'no download token, so the recipient has no way to fetch it');
+
+  const dl = await fetch(`${RELAY}/v2/dl/${up.json.download_token}/get`, { signal: AbortSignal.timeout(30000) });
+  assert.equal(dl.status, 200, `download failed: HTTP ${dl.status}`);
+  const got = Buffer.from(await dl.arrayBuffer());
+  assert.equal(sha256hex(got), hash, 'the bytes that came back are not the bytes that went in');
+
+  // Burn-on-read is a promise on the front page, not an implementation detail.
+  const again = await fetch(`${RELAY}/v2/dl/${up.json.download_token}/get`, { signal: AbortSignal.timeout(30000) });
+  assert.equal(again.status, 410, `the blob survived its read: HTTP ${again.status}, burn-on-read is broken`);
+});
+
+test('a corrupted hash is refused before the blob is stored', async () => {
+  const blob = payload('mismatch');
+  const up = await upload('/v2/anon-inbound', {
+    hash: 'f'.repeat(64),
+    payload: blob.toString('base64'),
+    ttl_ms: TTL_MS,
+  });
+  assert.equal(up.status, 400, `a payload that does not match its hash was accepted: HTTP ${up.status}`);
+  assert.equal(up.json?.error, 'hash_mismatch');
+});
+
+test('keyed transfer: upload, download, burn', { skip: API_KEY ? false : 'PARAMANT_API_KEY not set' }, async () => {
+  const blob = payload('keyed');
+  const hash = sha256hex(blob);
+
+  const up = await upload('/v2/inbound', { hash, payload: blob.toString('base64'), ttl_ms: TTL_MS }, { 'X-Api-Key': API_KEY });
+  assert.equal(up.status, 200, `keyed upload rejected: HTTP ${up.status} ${up.text.slice(0, 200)}`);
+  assert.equal(up.json?.ok, true, 'relay did not accept the keyed upload');
+
+  const dl = await fetch(`${RELAY}/v2/outbound/${hash}`, {
+    headers: { 'X-Api-Key': API_KEY },
+    signal: AbortSignal.timeout(30000),
+  });
+  assert.equal(dl.status, 200, `keyed download failed: HTTP ${dl.status}`);
+  const got = Buffer.from(await dl.arrayBuffer());
+  assert.equal(sha256hex(got), hash, 'the bytes that came back are not the bytes that went in');
+  assert.equal(dl.headers.get('x-paramant-burned'), 'true', 'the relay did not report the blob as burned');
+});


### PR DESCRIPTION
Third and last step of the borging work started in #299 and #300.

The heartbeat proves the pages initialise. It cannot prove the product works: a page can come up perfectly while the relay behind it refuses every upload.

## What it does

`tests/transfer-canary.test.mjs` against the live relay:

1. upload a blob, assert the relay accepts it and returns a download token
2. fetch it back, assert the bytes are byte-for-byte identical
3. fetch again, assert 410, because burn-on-read is a promise on the front page
4. upload a payload that does not match its hash, assert `hash_mismatch` before anything is stored

That covers what no browser test can see: the relay process, nginx, the rate limits, TLS, the CT append.

## No secret needed

It uses the anonymous route, the free tier every visitor gets, so it measures what an unauthenticated user actually experiences. Setting a `PARAMANT_CANARY_KEY` secret adds the keyed route a paying customer uses. Without it that one test is explicitly skipped, not silently absent.

## Where it runs

In the hourly production job next to the heartbeat, under `always()`, so a dead page cannot hide a dead relay. It feeds the same issue alarm. Excluded from the per-commit suites, which test the commit and not production.

Verified against relay.paramant.app: upload accepted, download byte-identical, 410 on the second read.