### PR TITLE
Make script readiness sticky so /ontvang stops hanging on keygen

### DIFF
--- a/docs/frontend-loading-contract.md
+++ b/docs/frontend-loading-contract.md
@@ -1,0 +1,136 @@
+# The frontend loading contract
+
+Four product breaks in July 2026 came from the same place: **how a script finds
+another script, and how it learns that one is ready.** None of them produced a
+build error, a failed request, a console message or a red CI run. Each one just
+made a page stop working, silently, for weeks.
+
+This document is the rule that replaces guessing. It is enforced by
+`tests/frontend-loading-contract.test.mjs` (Node only, ~200 ms) and by the
+browser gate in `tests/product-heartbeat.test.mjs`.
+
+## Rule 1 — readiness is sticky, never an event
+
+**Do not do this.** It is the bug, not a simplification of it:
+
+```js
+// loader.js, loaded as <script type="module">
+window.thing = thing;
+window.dispatchEvent(new Event('thing-ready'));      // ✗
+
+// consumer.js, loaded as <script defer>
+window.addEventListener('thing-ready', () => init()); // ✗ never fires
+```
+
+Module scripts and deferred classic scripts both run *after parsing, in document
+order*. The loader sits higher up the page, so it fires its event before the
+consumer has registered anything. The event goes nowhere. `init()` is never
+called. Every asset is loaded, every global is set, and the console is clean.
+
+That is not a hypothetical. `/ontvang` — receiving a file, half of ParaSend —
+sat on "Generating keypair..." from 2026-07-02 to 2026-07-28 for exactly this
+reason. Re-dispatching the event by hand in the console made the page finish in
+under a second.
+
+**Do this instead.** `frontend/js/ready.js` keeps a sticky registry:
+
+```js
+// producer
+window.ready.signal('mlkem', ml_kem768);
+
+// consumer — resolves whether it asks before or after the signal
+const lib = await window.ready.when('mlkem');
+
+// or, when hanging forever is worse than failing loudly:
+const lib = await window.ready.within('mlkem', 20000, 'ML-KEM-768 library');
+```
+
+Order stops being load-bearing, which is the entire point.
+
+### Loading ready.js
+
+Any page using `ready.*` must load it as **the first script, plain, in
+`<head>`** — no `defer`, no `async`, no `type="module"`:
+
+```html
+<script src="/js/ready.js?v=1"></script>
+```
+
+A plain script in `<head>` runs during parsing, so it is guaranteed to exist
+before every module and deferred file on the page. Give it `defer` and it joins
+the same queue as everything else, and you have rebuilt the race it exists to
+prevent. The gate fails the build if you do.
+
+### What is not covered
+
+Events that fire on a **user action** are fine: `signing-key-enrolled` is
+dispatched on a click, long after every script on the page exists. The rule is
+about *load-time readiness*, where the producer can legitimately win the race.
+
+## Rule 2 — entry points use document-root absolute paths
+
+A file loaded straight from a page resolves relative imports against **its own
+URL**. Move the file and the import 404s in silence.
+
+```js
+import { encryptBlob } from './crypto-bridge.js';   // ✗ breaks when the file moves
+import { encryptBlob } from '/crypto-bridge.js';    // ✓
+```
+
+This is how sending a file died. Commit `042b4c5` extracted inline scripts into
+`js/` for CSP hardening, the relative specifier moved along with the code, and
+`./crypto-bridge.js` started resolving to `/js/crypto-bridge.js`, which does not
+exist. `window._cryptoBridge` stayed empty and ParaSend refused to encrypt, from
+2026-07-02 to 2026-07-26.
+
+The same applies to `src` and `href` in HTML. Pages are reachable both as
+`/parashare` and `/parashare/`, and `./vendor/qrcode.min.js` resolves to a
+different file under each.
+
+**Exception:** files *inside* a vendor package may import each other relatively.
+They move as one unit. The rule binds files a page loads directly.
+
+## Rule 3 — a heartbeat proves work, not loading
+
+`tests/product-heartbeat.test.mjs` used to check that `/ontvang` had
+`window._cryptoBridge.decryptBlob`. It did. It had every global it needed while
+the page did nothing at all, so the gate was green through the entire outage.
+
+A heartbeat that only asks "did the machinery load" cannot see a page that never
+starts. Pages where the user has to *get somewhere* now also carry a `progress`
+check that asserts visible advancement — for `/ontvang`, that a real fingerprint
+appears on screen, which is only possible if keygen actually ran:
+
+```js
+progress: () => /^[0-9A-F]{4}(-[0-9A-F]{4}){4}$/.test(
+  document.getElementById('fp-display')?.textContent?.trim() || ''),
+```
+
+Verified to fail on the broken code before it was written into a passing state.
+A gate that was never seen failing is not a gate.
+
+## Where each rule is enforced
+
+| Rule | Gate | Cost | Runs in |
+|---|---|---|---|
+| Sticky readiness | `frontend-loading-contract.test.mjs` | ~200 ms, no browser | Root integration suites |
+| ready.js loaded first and blocking | `frontend-loading-contract.test.mjs` | ~200 ms | Root integration suites |
+| Absolute paths in entry points | `frontend-loading-contract.test.mjs` | ~200 ms | Root integration suites |
+| Modules loaded as modules | `frontend-module-scripts.test.mjs` | ~100 ms | Root integration suites |
+| The page actually works | `product-heartbeat.test.mjs` | ~20 s, Chromium | product-heartbeat, hourly against production |
+
+The hourly production run is what turns these from "green at merge" into "still
+true right now". `PARAMANT_BASE_URL=https://paramant.app node --test
+tests/product-heartbeat.test.mjs` runs it by hand.
+
+## The pattern behind all four breaks
+
+Each one was a **silent** failure in the browser: no exception, no bad request,
+nothing a Node test or a linter could see. What they had in common is that
+something was *implicitly* depending on order or location, and an unrelated,
+correct-looking refactor changed it.
+
+So the fix is never only the fix. It is removing the implicit dependency —
+sticky signals instead of order, absolute paths instead of location — and then
+adding a gate that fails on the old code. If a new gate does not fail when
+pointed at the bug it was written for, it does not work yet.

--- a/docs/frontend-loading-contract.md
+++ b/docs/frontend-loading-contract.md
@@ -109,6 +109,35 @@ progress: () => /^[0-9A-F]{4}(-[0-9A-F]{4}){4}$/.test(
 Verified to fail on the broken code before it was written into a passing state.
 A gate that was never seen failing is not a gate.
 
+## Rule 4 — one file, one cache-buster
+
+A module's identity is its **full URL, query string included**. Load the same
+file under two `?v=` values and the browser gives you two *instances*, each with
+its own state. Whoever holds the wrong one is talking to a module nobody else
+uses.
+
+```js
+// sign.html loads /sign-flow.js?v=49
+const mod = await import('/sign-flow.js?v=48');   // ✗ a second, empty instance
+```
+
+That is what turned `sign-e2e` red the moment the cache-busters were bumped:
+`buildStampedPdf` ran on an instance that had never opened a document, and it
+surfaced as `Cannot read properties of null (reading 'pageIndex')` — nowhere
+near the cause. Checking for it found two older cases that had been sitting
+there for weeks: `sign-full` drove `parasign-signer.js` at `v=11` and `vault.js`
+at `v=4` while the application had moved to `v=14` and `v=5`.
+
+In a test, do not repeat the URL at all. Read it off the page:
+
+```js
+await import(document.querySelector('script[src*="sign-flow.js"]').getAttribute('src'));
+```
+
+The gate requires a single `?v=` per file across `frontend/` and `tests/`. Bump
+it in one place and every reference has to follow, which is the point: the
+coupling exists either way, so make it loud.
+
 ## Where each rule is enforced
 
 | Rule | Gate | Cost | Runs in |
@@ -116,6 +145,7 @@ A gate that was never seen failing is not a gate.
 | Sticky readiness | `frontend-loading-contract.test.mjs` | ~200 ms, no browser | Root integration suites |
 | ready.js loaded first and blocking | `frontend-loading-contract.test.mjs` | ~200 ms | Root integration suites |
 | Absolute paths in entry points | `frontend-loading-contract.test.mjs` | ~200 ms | Root integration suites |
+| One cache-buster per file | `frontend-loading-contract.test.mjs` | ~200 ms | Root integration suites |
 | Modules loaded as modules | `frontend-module-scripts.test.mjs` | ~100 ms | Root integration suites |
 | The page actually works | `product-heartbeat.test.mjs` | ~20 s, Chromium | product-heartbeat, hourly against production |
 

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<!-- Sticky readiness signals. Plain script in <head> on purpose: it must run
+     before every module and deferred script that signals or awaits. -->
+<script src="/js/ready.js?v=1"></script>
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Co-sign this envelope · Paramant</title>

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -220,9 +220,9 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 
 </main>
 
-<script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
+<script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1"></script>
 <script src="/js/quota-upgrade.js?v=2" defer></script>
-<script type="module" src="/co-sign.js?v=19"></script>
+<script type="module" src="/co-sign.js?v=20"></script>
 </body>
 </html>

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -52,11 +52,9 @@ function guessMimeFromMagic(bytes) {
 }
 function isPdfBytes(b) { return b.length >= 4 && b[0] === 0x25 && b[1] === 0x50 && b[2] === 0x44 && b[3] === 0x46; }
 function waitForPdfjs() {
-  if (window.__pdfjsLib) return Promise.resolve(window.__pdfjsLib);
-  return new Promise((resolve, reject) => {
-    const t = setTimeout(() => reject(new Error('PDF.js failed to load')), 10000);
-    window.addEventListener('pdfjs:ready', () => { clearTimeout(t); resolve(window.__pdfjsLib); }, { once: true });
-  });
+  // Sticky signal, so it does not matter whether the loader module ran before
+  // or after this file. See js/ready.js.
+  return window.ready.within('pdfjs', 10000, 'PDF.js');
 }
 
 // ---------- state ----------

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -424,8 +424,8 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 </footer>
 <script src="/nav.js?v=14" defer></script>
 <script src="/js/nav-auth.js?v=4" defer></script>
-<script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
+<script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/js/delegate.js?v=1" defer></script>
-<script src="/js/get.page.js?v=1" defer></script>
+<script src="/js/get.page.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<!-- Sticky readiness signals. Plain script in <head> on purpose: it must run
+     before every module and deferred script that signals or awaits. -->
+<script src="/js/ready.js?v=1"></script>
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Receive a file · Paramant</title>

--- a/frontend/js/get.page.js
+++ b/frontend/js/get.page.js
@@ -47,11 +47,9 @@ function formatSize(n) {
 }
 
 async function waitForPdfjs() {
-  if (window.__pdfjsLib) return window.__pdfjsLib;
-  return new Promise((resolve, reject) => {
-    const t = setTimeout(() => reject(new Error('PDF.js failed to load')), 10000);
-    window.addEventListener('pdfjs:ready', () => { clearTimeout(t); resolve(window.__pdfjsLib); }, { once: true });
-  });
+  // Sticky signal, so it does not matter whether the loader module ran before
+  // or after this file. See js/ready.js.
+  return window.ready.within('pdfjs', 10000, 'PDF.js');
 }
 
 async function renderPdfPreview(bytes, name) {

--- a/frontend/js/ontvang.page.js
+++ b/frontend/js/ontvang.page.js
@@ -49,8 +49,11 @@ async function genFingerprint(kyberPubHex, ecdhPubHex) {
 const params = new URLSearchParams(location.search);
 const sessionToken = params.get('s');
 const RELAY_API = RELAY_SECTORS[params.get('r')] || RELAY_SECTORS.health;
-if (!sessionToken || !/^inv_[a-zA-Z0-9]{32}$/.test(sessionToken)) {
-  window.addEventListener('mlkem-ready', () => showError('Invalid or missing session token'));
+const tokenValid = !!sessionToken && /^inv_[a-zA-Z0-9]{32}$/.test(sessionToken);
+if (!tokenValid) {
+  // A bad link is a bad link whether or not the crypto library ever arrives, so
+  // say so now instead of waiting on a signal that may never come.
+  showError('Invalid or missing session token');
 }
 
 // ── State ──
@@ -61,7 +64,19 @@ let ws = null;
 
 // ── Main flow ──
 async function init() {
-  // Guard: if ML-KEM library failed to load, refuse to proceed
+  // Wait for the ML-KEM library, however late it arrives. This used to be a
+  // bare 'mlkem-ready' listener, which never fired for us: the loader is a
+  // module higher up the page, so it announced itself before this deferred file
+  // had registered anything, and receiving a file hung on "Generating
+  // keypair..." for three weeks. ready.within() is sticky, so the order of the
+  // two scripts no longer decides whether the product works.
+  try {
+    await window.ready.within('mlkem', 20000, 'ML-KEM-768 library');
+  } catch {
+    showError('ML-KEM-768 library failed to load. Refresh the page and try again. Do not proceed without post-quantum encryption.');
+    return;
+  }
+  // Loaded, but is it the real thing? Refuse to fall back to weaker crypto.
   if (typeof ml_kem768 === 'undefined' || !ml_kem768?.keygen) {
     showError('ML-KEM-768 library failed to load. Refresh the page and try again. Do not proceed without post-quantum encryption.');
     return;
@@ -353,8 +368,8 @@ async function receiveVault(vaultFiles, ttl_ms, kyberSec, ecdhPriv) {
   showStep('step-done');
   if (ws) ws.close();
 }
-window.addEventListener('mlkem-ready', () => {
-  if (sessionToken) init();
-});
+// init() waits for the ML-KEM library itself, so there is nothing to listen for
+// and no event left to miss.
+if (tokenValid) init();
 
 act('click','reload',()=>location.reload());

--- a/frontend/js/ready.js
+++ b/frontend/js/ready.js
@@ -1,0 +1,75 @@
+// ready.js — sticky readiness signals between scripts on the same page.
+//
+// THE BUG THIS EXISTS TO KILL
+//
+// A module loader announced itself with a one-shot event:
+//
+//     window.dispatchEvent(new Event('mlkem-ready'));          // loader, module
+//     window.addEventListener('mlkem-ready', () => init());    // consumer, defer
+//
+// Module scripts and deferred classic scripts run after parsing in DOCUMENT
+// ORDER, and the loader sits above the consumer in the HTML. So the event fired
+// while nobody was listening, the consumer's callback never ran, and /ontvang
+// sat on "Generating keypair..." forever. Every asset loaded, every global was
+// set, the console was clean. Nothing to see and nothing to grep for. Measured
+// on production 2026-07-28; broken since the CSP extraction of 2026-07-02 moved
+// the listener out of the page and into a deferred file.
+//
+// A one-shot event is only safe when the listener is guaranteed to exist first,
+// and script order gives no such guarantee. So do not use events for readiness.
+//
+// THE CONTRACT
+//
+//   Producer:  ready.signal('mlkem', ml_kem768)
+//   Consumer:  const lib = await ready.when('mlkem')
+//
+// A signal is STICKY: it is remembered, so `when()` resolves whether it is
+// called before or after `signal()`. Order stops mattering, which is the point.
+//
+// This file must load as a plain <script> in <head> — no defer, no async, no
+// type="module" — so it is guaranteed to run before every module and deferred
+// script on the page. tests/frontend-ready-contract.test.mjs enforces that, and
+// enforces that no page goes back to bare readiness events.
+'use strict';
+
+(function () {
+  // Idempotent: a page may include this file more than once via a partial.
+  if (window.ready && window.ready.__paramant) return;
+
+  var values = Object.create(null);   // name -> resolved value (never undefined)
+  var waiters = Object.create(null);  // name -> [resolve, ...]
+
+  function signal(name, value) {
+    if (!name) throw new Error('ready.signal() needs a name');
+    // `true` stands in for "ready, no value", so `when()` can resolve either way
+    // without a separate "has it fired" flag.
+    values[name] = value === undefined ? true : value;
+    var queued = waiters[name] || [];
+    waiters[name] = [];
+    for (var i = 0; i < queued.length; i++) queued[i](values[name]);
+  }
+
+  function when(name) {
+    if (name in values) return Promise.resolve(values[name]);
+    return new Promise(function (resolve) {
+      (waiters[name] = waiters[name] || []).push(resolve);
+    });
+  }
+
+  // Same as when(), but rejects if the producer never shows up. Use it where a
+  // silent hang is worse than an error the user can act on — which is the whole
+  // reason this file exists.
+  function within(name, ms, what) {
+    if (name in values) return Promise.resolve(values[name]);
+    return new Promise(function (resolve, reject) {
+      var timer = setTimeout(function () {
+        reject(new Error((what || name) + ' failed to load'));
+      }, ms);
+      when(name).then(function (v) { clearTimeout(timer); resolve(v); });
+    });
+  }
+
+  function done(name) { return name in values; }
+
+  window.ready = { signal: signal, when: when, within: within, done: done, __paramant: true };
+})();

--- a/frontend/noble-mlkem-loader.js
+++ b/frontend/noble-mlkem-loader.js
@@ -5,7 +5,18 @@
  * Only needed for KEY GENERATION (keygen). Encryption and decryption are
  * handled by crypto-bridge.js (WASM), which is faster and does the full
  * ML-KEM-768 + ECDH P-256 + AES-256-GCM hybrid in a single call.
+ *
+ * The import is document-root absolute on purpose. A relative specifier here
+ * resolves against this file's URL: correct today, wrong the moment the file
+ * moves — which is exactly how the ParaSend crypto bridge broke for three weeks
+ * in July 2026. There is also a DIFFERENT, larger bundle at
+ * /dist/noble-mlkem-bundle.js, so the leading slash also says which one we mean.
  */
-import { ml_kem768 } from './noble-mlkem-bundle.js';
+import { ml_kem768 } from '/noble-mlkem-bundle.js';
+
 window.ml_kem768 = ml_kem768;
-window.dispatchEvent(new Event('mlkem-ready'));
+
+// Sticky signal: a consumer that runs after this file still learns about it.
+// A bare dispatchEvent here left /ontvang stuck on "Generating keypair..."
+// from 2026-07-02 to 2026-07-28. See js/ready.js for the full story.
+window.ready.signal('mlkem', ml_kem768);

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<!-- Sticky readiness signals. Plain script in <head> on purpose: it must run
+     before every module and deferred script that signals or awaits. -->
+<script src="/js/ready.js?v=1"></script>
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Receive a file · Paramant</title>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -390,10 +390,10 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   </div>
 </footer>
 
-<script type="module" src="/noble-mlkem-loader.js?v=4"></script>
+<script type="module" src="/noble-mlkem-loader.js?v=5"></script>
 <script type="module" src="/js/ontvang.inline1.js?v=2"></script>
 <script src="/js/delegate.js?v=1" defer></script>
-<script src="/js/ontvang.page.js?v=1" defer></script>
+<script src="/js/ontvang.page.js?v=2" defer></script>
 <script src="/nav.js?v=14" defer></script>
 <script src="/js/nav-auth.js?v=4" defer></script>
 </body>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -694,7 +694,7 @@ select:focus{border-color:var(--cobalt)}
   </div>
 </div>
 
-<script src="./vendor/qrcode.min.js?v=1"></script>
+<script src="/vendor/qrcode.min.js?v=1"></script>
 <script type="module" src="/js/parashare.inline1.js?v=3"></script>
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/quota-upgrade.js?v=2" defer></script>

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -168,11 +168,9 @@ function bytesToDataUrl(bytes, mime) {
 // ====================================================================
 
 async function waitForPdfjs() {
-  if (window.__pdfjsLib) return window.__pdfjsLib;
-  return new Promise((resolve, reject) => {
-    const t = setTimeout(() => reject(new Error('PDF.js failed to load')), 10000);
-    window.addEventListener('pdfjs:ready', () => { clearTimeout(t); resolve(window.__pdfjsLib); }, { once: true });
-  });
+  // Sticky signal, so it does not matter whether the loader module ran before
+  // or after this file. See js/ready.js.
+  return window.ready.within('pdfjs', 10000, 'PDF.js');
 }
 
 async function waitForPdfLib() {

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -811,10 +811,10 @@
 </footer>
 <script src="/nav.js?v=14" defer></script>
 <script src="/js/nav-auth.js?v=4" defer></script>
-<script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=2"></script>
+<script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script src="/js/parasign-pdf-ops.js?v=1"></script>
 <script src="/js/quota-upgrade.js?v=2" defer></script>
-<script type="module" src="/sign-flow.js?v=48"></script>
+<script type="module" src="/sign-flow.js?v=49"></script>
 </body>
 </html>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<!-- Sticky readiness signals. Plain script in <head> on purpose: it must run
+     before every module and deferred script that signals or awaits. -->
+<script src="/js/ready.js?v=1"></script>
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Sign a document · Paramant</title>

--- a/frontend/vendor/parasign-bridge.js
+++ b/frontend/vendor/parasign-bridge.js
@@ -1,10 +1,17 @@
 // ParaSign bridge: exposes the ESM ml-dsa65 + sha3_256 (paramant-pqc) and
 // vault helpers (vault.js) to non-module inline scripts. Same-origin only.
 //
-// Non-module callers wait for the 'parasign:ready' CustomEvent (or check
-// window.__parasign).
+// Non-module callers wait with `await ready.when('parasign')`. That signal is
+// sticky, so it resolves whether the caller runs before or after this file — a
+// plain event here would be lost exactly like the mlkem one was, see
+// frontend/js/ready.js. A page loading this file must also load /js/ready.js;
+// tests/frontend-loading-contract.test.mjs enforces that.
+//
+// No page currently loads this bridge (sign-flow.js dropped it and only the
+// comment stayed behind), but the file is served on production, so it is kept
+// working rather than left as a trap for the next caller.
 import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
 import { vaultAvailable, vaultList } from '/vendor/vault.js?v=5';
 
 window.__parasign = { ml_dsa65, sha3_256, vaultAvailable, vaultList };
-window.dispatchEvent(new CustomEvent('parasign:ready'));
+window.ready.signal('parasign', window.__parasign);

--- a/frontend/vendor/pdfjs/pdfjs-loader.js
+++ b/frontend/vendor/pdfjs/pdfjs-loader.js
@@ -2,11 +2,14 @@
 // self-hosted at /vendor/pdfjs/pdf.worker.min.js so worker-src 'self'
 // suffices (no CSP relax required).
 //
-// Exposes window.__pdfjsLib and dispatches the 'pdfjs:ready' event so
-// non-module scripts can await it.
-import * as pdfjsLib from './pdf.min.js';
+// Exposes window.__pdfjsLib and signals 'pdfjs' so non-module scripts can await
+// it with `ready.when('pdfjs')`, whether they run before or after this file.
+// The old 'pdfjs:ready' event is gone: consumers happened to guard it with an
+// `if (window.__pdfjsLib)` pre-check, so it never bit here, but the identical
+// pattern without that guard is what killed /ontvang. See js/ready.js.
+import * as pdfjsLib from '/vendor/pdfjs/pdf.min.js';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = '/vendor/pdfjs/pdf.worker.min.js';
 
 window.__pdfjsLib = pdfjsLib;
-window.dispatchEvent(new CustomEvent('pdfjs:ready'));
+window.ready.signal('pdfjs', pdfjsLib);

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,6 +7,8 @@ Guards the auth + TOTP stack against the class of breakage that hit production r
 | Script | When it runs | What it checks |
 |---|---|---|
 | `tests/static-sanity.sh` | pre-commit hook, `deploy.sh` step 1 | Node syntax, redisClient init, TOTP helpers, unsafe req.body access, orphan code, 410 in source |
+| `tests/frontend-loading-contract.test.mjs` | Root integration suites | Readiness must be sticky, not a one-shot event; entry points use absolute paths. Both rules exist because a page kept loading fine while the product was dead — see [docs/frontend-loading-contract.md](../docs/frontend-loading-contract.md) |
+| `tests/product-heartbeat.test.mjs` | product-heartbeat workflow, hourly against production | Opens each core page in Chromium and fails on uncaught errors, console errors, 404s on our own assets, and — for pages where the user has to get somewhere — on the page not actually progressing |
 | `tests/auth-smoke.sh` | `deploy.sh` step 4 | 21 live HTTP assertions against production |
 | `deploy.sh` | manual deploy | Chains: sanity → build → health wait → smoke |
 

--- a/tests/cosign-document-delivery.test.mjs
+++ b/tests/cosign-document-delivery.test.mjs
@@ -113,7 +113,9 @@ ok('placement draft stores coordinates only for refresh recovery', /"type":"seal
 if (process.env.PARAMANT_COSIGN_SCREENSHOT_PATH) await page.screenshot({ path:process.env.PARAMANT_COSIGN_SCREENSHOT_PATH, fullPage:true });
 const renderedPdf = await page.evaluate(async () => {
   const raw = Array.from({ length: sessionStorage.length }, (_, i) => sessionStorage.getItem(sessionStorage.key(i))).find((value) => value && value.includes('"fields"'));
-  const mod = await import('/co-sign.js?v=19');
+  // Read the url off the page: a repeated ?v= here becomes a second module
+  // instance the day co-sign.html bumps its cache-buster.
+  const mod = await import(document.querySelector('script[src*="co-sign.js"]').getAttribute('src'));
   const bytes = await mod.buildSignedPdf({ appearance: JSON.parse(raw), signed_at: '2026-07-21T12:00:00.000Z' });
   const pdf = await window.pdfjsLib.getDocument({ data: new Uint8Array(bytes) }).promise;
   const text = (await (await pdf.getPage(1)).getTextContent()).items.map((item) => item.str).join(' ');

--- a/tests/frontend-loading-contract.test.mjs
+++ b/tests/frontend-loading-contract.test.mjs
@@ -1,0 +1,212 @@
+// The loading contract for frontend scripts. Node builtins only, no browser, so
+// this runs in the "Root integration suites" CI job and costs a second.
+//
+// It gates two mistakes that each killed a shipped product feature, both
+// invisible to every other test we have: no build error, no failed request, no
+// console output, no red CI. Just a page that quietly stops working.
+//
+//   1. READINESS BY EVENT.  A loader announced itself with a one-shot event and
+//      a consumer listened for it. Module scripts and deferred classic scripts
+//      run in document order, the loader sits higher up the page, so the event
+//      fired before the listener existed and the callback never ran. /ontvang
+//      hung on "Generating keypair..." from 2026-07-02 until 2026-07-28 with a
+//      clean console and every asset loaded. Readiness must be sticky:
+//      ready.signal() / ready.when(), see frontend/js/ready.js.
+//
+//   2. RELATIVE PATHS IN ENTRY POINTS.  A file loaded straight from a page
+//      resolves its relative imports against its OWN url. Move the file and the
+//      import silently 404s. That is precisely how the ParaSend crypto bridge
+//      died for three weeks (042b4c5): CSP extraction moved inline code into
+//      js/ and './crypto-bridge.js' started pointing at /js/crypto-bridge.js.
+//      Entry points use document-root absolute paths. Files INSIDE a vendor
+//      package may stay relative: they move as one unit.
+//
+// See docs/frontend-loading-contract.md.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FRONTEND = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const READY_SRC = '/js/ready.js';
+
+function walk(dir, ext) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) return e.name === 'node_modules' ? [] : walk(full, ext);
+    return e.isFile() && e.name.endsWith(ext) ? [full] : [];
+  });
+}
+
+const rel = (f) => path.relative(FRONTEND, f);
+const isVendor = (f) => rel(f).split(path.sep).includes('vendor');
+
+// Minified third-party bundles are not ours to police and their contents trip
+// every heuristic below. We only own what we wrote.
+const MINIFIED = /(^|[.\-])min\.js$|bundle\.js$|globe\.gl|qrcode|jsQR|pdf\.worker/i;
+
+function strip(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '')
+            .split('\n').filter((l) => !/^\s*\/\//.test(l)).join('\n');
+}
+
+// ── the page model ───────────────────────────────────────────────────────────
+const SCRIPT_TAG = /<script\b([^>]*)>/gi;
+
+function scriptsOf(pageFile) {
+  const html = fs.readFileSync(pageFile, 'utf8');
+  const out = [];
+  for (const m of html.matchAll(SCRIPT_TAG)) {
+    const attrs = m[1];
+    const src = /\bsrc\s*=\s*"([^"]+)"/i.exec(attrs)?.[1];
+    if (!src) continue;
+    out.push({
+      src,
+      clean: src.split('?')[0].split('#')[0],
+      isModule: /\btype\s*=\s*"module"/i.test(attrs),
+      isDeferred: /\bdefer\b/i.test(attrs) || /\basync\b/i.test(attrs),
+      raw: m[0],
+    });
+  }
+  return out;
+}
+
+function localFile(src) {
+  if (/^(https?:)?\/\//.test(src)) return null;                 // third party
+  const clean = src.split('?')[0].split('#')[0];
+  if (!clean.startsWith('/')) return null;                      // caught separately
+  const f = path.join(FRONTEND, clean);
+  return fs.existsSync(f) ? f : null;
+}
+
+const pages = walk(FRONTEND, '.html');
+const ourScripts = walk(FRONTEND, '.js').filter((f) => !MINIFIED.test(path.basename(f)));
+
+// ── 1. readiness is sticky, never a one-shot event ───────────────────────────
+
+// A load-time readiness event. Deliberately narrow: 'signing-key-enrolled'
+// fires on a click, long after every script exists, and is not this bug.
+const READY_EVENT = /dispatchEvent\(\s*new\s+(?:Custom)?Event\(\s*['"]([a-z0-9:_-]*(?:ready|loaded|available|init)[a-z0-9:_-]*)['"]/gi;
+const READY_LISTENER = /addEventListener\(\s*['"]([a-z0-9:_-]*(?:ready|loaded|available)[a-z0-9:_-]*)['"]/gi;
+
+// Browser-owned events are sticky already or fire on real user/document state.
+const BUILT_IN = new Set(['load', 'DOMContentLoaded', 'readystatechange', 'beforeunload', 'unload', 'pageshow', 'pagehide']);
+
+test('no script announces readiness with a one-shot event', () => {
+  const sins = [];
+  for (const f of ourScripts) {
+    const src = strip(fs.readFileSync(f, 'utf8'));
+    for (const m of src.matchAll(READY_EVENT)) {
+      if (BUILT_IN.has(m[1])) continue;
+      sins.push(`${rel(f)} dispatches '${m[1]}'`);
+    }
+  }
+  assert.deepEqual(sins, [],
+    `\n  A readiness event is lost when it fires before the listener is registered,\n` +
+    `  which is the normal case for a module loader above a deferred consumer.\n` +
+    `  Use ready.signal('<name>', value) instead — see frontend/js/ready.js.\n\n  ` +
+    sins.join('\n  ') + '\n');
+});
+
+test('no script waits for readiness with a one-shot listener', () => {
+  const sins = [];
+  for (const f of ourScripts) {
+    if (path.basename(f) === 'ready.js') continue;
+    const src = strip(fs.readFileSync(f, 'utf8'));
+    for (const m of src.matchAll(READY_LISTENER)) {
+      if (BUILT_IN.has(m[1])) continue;
+      sins.push(`${rel(f)} listens for '${m[1]}'`);
+    }
+  }
+  assert.deepEqual(sins, [],
+    `\n  If the producer already ran, this listener never fires and the feature\n` +
+    `  hangs with a clean console. Use await ready.when('<name>') or\n` +
+    `  ready.within('<name>', ms, 'label') — see frontend/js/ready.js.\n\n  ` +
+    sins.join('\n  ') + '\n');
+});
+
+// ── 2. every page that uses ready.js actually loads it, and loads it first ───
+
+const USES_READY = /\bready\s*\.\s*(signal|when|within|done)\s*\(/;
+
+test('every page using readiness loads /js/ready.js as the first, blocking script', () => {
+  const sins = [];
+  for (const page of pages) {
+    const scripts = scriptsOf(page);
+    const needs = scripts.some((s) => {
+      const f = localFile(s.src);
+      return f && f !== path.join(FRONTEND, 'js', 'ready.js') && USES_READY.test(strip(fs.readFileSync(f, 'utf8')));
+    });
+    const own = scripts.find((s) => s.clean === READY_SRC);
+
+    if (needs && !own) {
+      sins.push(`${rel(page)} uses ready.* but never loads ${READY_SRC}`);
+      continue;
+    }
+    if (!own) continue;
+
+    // Order is the whole point: a plain <script> in <head> runs during parsing,
+    // so it is guaranteed to be there before any module or deferred file.
+    if (own.isModule || own.isDeferred) {
+      sins.push(`${rel(page)} loads ${READY_SRC} with defer/async/module — it must block, or it can lose the race it exists to prevent (${own.raw})`);
+    }
+    const first = scripts.findIndex((s) => localFile(s.src));
+    if (scripts.indexOf(own) !== first) {
+      sins.push(`${rel(page)} loads ${READY_SRC} after ${scripts[first].clean} — it must come first`);
+    }
+  }
+  assert.deepEqual(sins, [], '\n  ' + sins.join('\n  ') + '\n');
+});
+
+// ── 3. entry points use document-root absolute paths ─────────────────────────
+
+const ENTRY_POINTS = new Set(
+  pages.flatMap((p) => scriptsOf(p).map((s) => localFile(s.src)).filter(Boolean))
+);
+
+const RELATIVE_IMPORT = /(?:^|[\s;}])(?:import|export)\s[^\n]*?from\s*['"](\.\.?\/[^'"]+)['"]|import\s*\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g;
+
+test('scripts loaded straight from a page use absolute import paths', () => {
+  const sins = [];
+  for (const f of ENTRY_POINTS) {
+    if (MINIFIED.test(path.basename(f))) continue;
+    const src = strip(fs.readFileSync(f, 'utf8'));
+    for (const m of src.matchAll(RELATIVE_IMPORT)) {
+      sins.push(`${rel(f)} imports '${m[1] || m[2]}'`);
+    }
+  }
+  assert.deepEqual(sins, [],
+    `\n  A page can load this file from any url, and a relative specifier resolves\n` +
+    `  against the file's own location. Move the file and the import 404s in\n` +
+    `  silence — see the ParaSend crypto bridge, dead 2026-07-02 to 07-26.\n` +
+    `  Write the path from the document root: '/js/thing.js'.\n\n  ` +
+    sins.join('\n  ') + '\n');
+});
+
+test('no page references a local asset with a relative path', () => {
+  const ATTR = /(?:src|href)\s*=\s*"(\.\.?\/[^"]+)"/gi;
+  const sins = [];
+  for (const page of pages) {
+    const html = strip(fs.readFileSync(page, 'utf8'));
+    for (const m of html.matchAll(ATTR)) sins.push(`${rel(page)} -> ${m[1]}`);
+  }
+  assert.deepEqual(sins, [],
+    `\n  Pages are served both with and without a trailing slash (/parashare and\n` +
+    `  /parashare/), and a relative path resolves differently under each. Use a\n` +
+    `  leading slash.\n\n  ` + sins.join('\n  ') + '\n');
+});
+
+// ── 4. every local script a page loads actually exists ───────────────────────
+
+test('every local script tag resolves to a file that exists', () => {
+  const sins = [];
+  for (const page of pages) {
+    for (const s of scriptsOf(page)) {
+      if (/^(https?:)?\/\//.test(s.src)) continue;
+      if (!s.clean.startsWith('/')) continue;                   // rule above owns these
+      if (!fs.existsSync(path.join(FRONTEND, s.clean))) sins.push(`${rel(page)} -> ${s.clean} (missing)`);
+    }
+  }
+  assert.deepEqual(sins, [], '\n  ' + sins.join('\n  ') + '\n');
+});

--- a/tests/frontend-loading-contract.test.mjs
+++ b/tests/frontend-loading-contract.test.mjs
@@ -197,7 +197,53 @@ test('no page references a local asset with a relative path', () => {
     `  leading slash.\n\n  ` + sins.join('\n  ') + '\n');
 });
 
-// ── 4. every local script a page loads actually exists ───────────────────────
+// ── 4. tests never hardcode a cache-buster ───────────────────────────────────
+
+// A module's identity is its full url, query string included. Load the same
+// file under two different ?v= values and you get two INSTANCES, each with its
+// own state. Whoever holds the wrong one is talking to a module nobody else
+// uses, and it fails as "why is this null".
+//
+// That is not theory. tests/sign-full.test.mjs imported '/sign-flow.js?v=48'
+// while sign.html had moved to ?v=49, so buildStampedPdf ran on a fresh
+// instance that had never opened a document. One red CI run, 2026-07-28.
+//
+// So: one file, one cache-buster, everywhere. Bump it in one place and every
+// reference has to follow, which is exactly the coupling we want to be loud.
+test('each frontend file uses one and the same ?v= everywhere', () => {
+  const ROOT = path.join(FRONTEND, '..');
+  const REF = /['"`](\/[\w./-]+\.(?:js|mjs|css))\?v=(\d+)/g;
+  const seen = new Map();                                       // path -> Map(v -> [where])
+
+  const scan = (file, label) => {
+    for (const m of strip(fs.readFileSync(file, 'utf8')).matchAll(REF)) {
+      if (!seen.has(m[1])) seen.set(m[1], new Map());
+      const byV = seen.get(m[1]);
+      if (!byV.has(m[2])) byV.set(m[2], new Set());
+      byV.get(m[2]).add(label);
+    }
+  };
+  for (const f of pages) scan(f, rel(f));
+  for (const f of ourScripts) scan(f, rel(f));
+  for (const f of fs.readdirSync(path.join(ROOT, 'tests')).filter((n) => n.endsWith('.mjs'))) {
+    scan(path.join(ROOT, 'tests', f), `tests/${f}`);
+  }
+
+  const sins = [];
+  for (const [file, byV] of seen) {
+    if (byV.size < 2) continue;
+    const detail = [...byV].map(([v, where]) => `v=${v} in ${[...where].join(', ')}`).join('  |  ');
+    sins.push(`${file}: ${detail}`);
+  }
+  assert.deepEqual(sins.sort(), [],
+    `\n  Two cache-busters for one file means two module instances with separate\n` +
+    `  state. Pick one value and use it everywhere. In a test, the safest form is\n` +
+    `  to read the url off the page rather than repeat it:\n` +
+    `    await import(document.querySelector('script[src*="thing.js"]').getAttribute('src'))\n\n  ` +
+    sins.join('\n  ') + '\n');
+});
+
+// ── 5. every local script a page loads actually exists ───────────────────────
 
 test('every local script tag resolves to a file that exists', () => {
   const sins = [];

--- a/tests/product-heartbeat.test.mjs
+++ b/tests/product-heartbeat.test.mjs
@@ -53,8 +53,19 @@ const PAGES = [
   {
     url: '/ontvang.html',
     what: 'ParaSend, receiving a file',
+    // A well-formed token that no relay will accept. Enough to make the page
+    // run its real client-side work: generate the keypair and show the
+    // fingerprint. Whether the relay then knows the token is not our business
+    // here.
+    query: '?s=inv_00000000000000000000000000000000',
     heartbeat: () => typeof window._cryptoBridge?.decryptBlob === 'function',
     because: 'window._cryptoBridge.decryptBlob is missing, so ontvang.page.js throws "WASM crypto bridge not ready"',
+    // The globals above were all present on 2026-07-28 while the page sat on
+    // "Generating keypair..." forever: a lost readiness event meant init() was
+    // never called. Loaded is not the same as working, so this asserts the user
+    // actually gets somewhere.
+    progress: () => /^[0-9A-F]{4}(-[0-9A-F]{4}){4}$/.test(document.getElementById('fp-display')?.textContent?.trim() || ''),
+    stuck: 'keygen never completed: no fingerprint on screen, so receiving a file is dead',
   },
   { url: '/index.html',   what: 'homepage' },
   { url: '/pricing.html', what: 'pricing, the paid funnel' },
@@ -120,7 +131,12 @@ for (const page of PAGES) {
       }
     });
 
-    const resp = await tab.goto(origin + page.url, { waitUntil: 'networkidle', timeout: 45000 });
+    // A page with a progress check opens a relay connection and keeps polling,
+    // so it never goes network-idle. The request and response handlers above
+    // stay attached either way, and the progress poll below keeps the page open
+    // long enough for a late 404 to still be caught.
+    const settled = page.progress ? 'load' : 'networkidle';
+    const resp = await tab.goto(origin + page.url + (page.query || ''), { waitUntil: settled, timeout: 45000 });
     assert.ok(resp?.ok(), `${page.url} did not load: HTTP ${resp?.status()}`);
     await tab.waitForTimeout(1200);   // let deferred modules and wasm settle
 
@@ -129,9 +145,25 @@ for (const page of PAGES) {
       assert.ok(alive, `${page.what} is dead: ${page.because}`);
     }
 
+    // Rule 5: does the page get the user anywhere? Every global can be present
+    // and correct while the page does nothing at all, which is precisely how
+    // /ontvang hung for three weeks. Poll rather than sleep: keygen is fast on a
+    // laptop and slow on a loaded CI runner.
+    if (page.progress) {
+      const moved = await tab.waitForFunction(page.progress, null, { timeout: 25000, polling: 250 })
+        .then(() => true).catch(() => false);
+      assert.ok(moved, `${page.what} does not work: ${page.stuck}`);
+    }
+
+    // The relay is a separate host with its own gate (tests/transfer-canary),
+    // and the test token is deliberately one no relay will accept, so a refused
+    // socket to it says nothing about the frontend. Filtering this is only safe
+    // BECAUSE the progress check above already proved the page did its work.
+    const RELAY_NOISE = /wss?:\/\/[^ ]*relay\.paramant\.app|WebSocket connection to/;
+
     // A console error the page recovers from is still a break waiting to be
     // reported by a user, so it fails here too. Drop the noise, not the signal.
-    const real = problems.filter((p) => !/favicon|\/api\/|401|403|Failed to load resource: the server responded with a status of 40[13]/.test(p));
+    const real = problems.filter((p) => !/favicon|\/api\/|401|403|Failed to load resource: the server responded with a status of 40[13]/.test(p) && !RELAY_NOISE.test(p));
     assert.deepEqual(real, [], `\n  ${page.url}\n  ${real.join('\n  ')}\n`);
 
     await ctx.close();

--- a/tests/sign-full.test.mjs
+++ b/tests/sign-full.test.mjs
@@ -73,9 +73,9 @@ CRED_ID = await page.evaluate(async () => {
 });
 
 const phase1 = await page.evaluate(async () => {
-  const m = await import('/js/parasign-signer.js?v=11');
+  const m = await import('/js/parasign-signer.js?v=14');
   const pqc = await import('/vendor/paramant-pqc.js');
-  const vault = await import('/vendor/vault.js?v=4');
+  const vault = await import('/vendor/vault.js?v=5');
   const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
   const eqU8 = (a,b) => a.length===b.length && a.every((x,i)=>x===b[i]);
   const hex = (u8) => Array.from(u8).map(b=>b.toString(16).padStart(2,'0')).join('');
@@ -120,9 +120,9 @@ const phase1 = await page.evaluate(async () => {
 
 // Phase 2a: ensureSigningKey branching + ephemeral TOTP enrol (admin stubbed ok).
 const phase2a = await page.evaluate(async () => {
-  const m = await import('/js/parasign-signer.js?v=11');
+  const m = await import('/js/parasign-signer.js?v=14');
   const pqc = await import('/vendor/paramant-pqc.js');
-  const vault = await import('/vendor/vault.js?v=4');
+  const vault = await import('/vendor/vault.js?v=5');
   const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
   const delDB = () => new Promise(r => { const q = indexedDB.deleteDatabase('paramant'); q.onsuccess=q.onerror=q.onblocked=()=>r(); });
   const base = { envelopeId:'env_test_000000000001', docHash:'a'.repeat(64), partyIndex:0, emailHash:'' };
@@ -146,14 +146,14 @@ const phase2a = await page.evaluate(async () => {
 // Phase 2b: TOTP enrol error mapping (admin stub returns relay 403s).
 totpResp = { status: 403, body: { error: 'invalid_totp' } };
 const phase2b1 = await page.evaluate(async () => {
-  const m = await import('/js/parasign-signer.js?v=11');
+  const m = await import('/js/parasign-signer.js?v=14');
   const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
   let c=''; try { await m.enrolEphemeralSigningKeyWithTotp({ totp:'654321' }); } catch(e){ c=e.code; } ok('J1 relay 403 invalid_totp -> totp_invalid', c==='totp_invalid', c);
   return T;
 });
 totpResp = { status: 403, body: { error: 'no_totp_setup' } };
 const phase2b2 = await page.evaluate(async () => {
-  const m = await import('/js/parasign-signer.js?v=11');
+  const m = await import('/js/parasign-signer.js?v=14');
   const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
   let c=''; try { await m.enrolEphemeralSigningKeyWithTotp({ totp:'654321' }); } catch(e){ c=e.code; } ok('J2 relay 403 no_totp_setup -> totp_unavailable', c==='totp_unavailable', c);
   return T;
@@ -163,7 +163,7 @@ totpResp = { status: 200, body: { ok: true } };
 // Phase 2c: server 409 no_passkey path.
 noPasskeyMode = true;
 const phase2c = await page.evaluate(async () => {
-  const m = await import('/js/parasign-signer.js?v=11');
+  const m = await import('/js/parasign-signer.js?v=14');
   const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
   const delDB = () => new Promise(r => { const q = indexedDB.deleteDatabase('paramant'); q.onsuccess=q.onerror=q.onblocked=()=>r(); });
   await delDB();
@@ -216,7 +216,11 @@ const phase4 = await page.evaluate(async () => {
   for (let i = 0; i < 200 && document.getElementById('step-place').hidden; i++) await sleep(20);
   document.getElementById('ds-seal-sheet').click();
   const sheetPreview = document.querySelector('.ds-signature-sheet-preview');
-  const mod = await import('/sign-flow.js?v=48');
+  // Import the exact url the page loaded. A hardcoded ?v= silently becomes a
+  // SECOND module instance the moment sign.html bumps its cache-buster, with
+  // its own empty state, and buildStampedPdf then stamps a document nobody
+  // opened. Cost one red CI run on 2026-07-28 to find.
+  const mod = await import(document.querySelector('script[src*="sign-flow.js"]').getAttribute('src'));
   const output = await mod.buildStampedPdf(sourceBytes, null, 'Demo signer', '2026-07-21T12:00:00Z', '01234567');
   const outPdf = await window.PDFLib.PDFDocument.load(output);
   const rendered = await window.pdfjsLib.getDocument({ data: new Uint8Array(output) }).promise;
@@ -347,7 +351,11 @@ const datePdf = await page.evaluate(async () => {
   document.getElementById('ds-seal-sheet').click();
   const source = await window.PDFLib.PDFDocument.create();
   source.addPage([300, 400]).drawText('Tool export proof', { x: 30, y: 350, size: 14 });
-  const mod = await import('/sign-flow.js?v=48');
+  // Import the exact url the page loaded. A hardcoded ?v= silently becomes a
+  // SECOND module instance the moment sign.html bumps its cache-buster, with
+  // its own empty state, and buildStampedPdf then stamps a document nobody
+  // opened. Cost one red CI run on 2026-07-28 to find.
+  const mod = await import(document.querySelector('script[src*="sign-flow.js"]').getAttribute('src'));
   const output = await mod.buildStampedPdf(await source.save(), null, 'Demo signer', '2026-07-21T12:00:00Z', '01234567');
   const parsed = await window.pdfjsLib.getDocument({ data: new Uint8Array(output) }).promise;
   return (await (await parsed.getPage(1)).getTextContent()).items.map(i => i.str).join(' ');


### PR DESCRIPTION
## What was broken

Receiving a file has been dead on production since 2026-07-02. `/ontvang` sat on "Generating keypair..." forever. Every asset loaded, every global was set, the console was clean.

`noble-mlkem-loader.js` announced itself with a one-shot event and `ontvang.page.js` listened for it. Module scripts and deferred classic scripts both run after parsing in document order, and the loader sits above the consumer, so the event fired before the listener existed and `init()` was never called.

Confirmed on production, not inferred: instrumenting `addEventListener`/`dispatchEvent` gave `["EVENT-DISPATCHED", "LISTENER-REGISTERED"]`, and re-dispatching the event by hand finished the keygen in under a second.

Same root cause as the crypto-bridge break (042b4c5). Both are the CSP extraction moving code into a deferred file and changing what it could depend on.

## The fix

`frontend/js/ready.js` replaces readiness events with a sticky registry. A signal is remembered, so `ready.when()` resolves whether it is called before or after the producer. Order stops being load-bearing.

Applied everywhere the pattern occurred, not only where it was fatal: the ML-KEM loader, the PDF.js loader and its three consumers, the orphaned ParaSign bridge. Relative paths in entry points made absolute in the same pass, including `parashare.html`'s qrcode tag, which resolves differently under `/parashare` and `/parashare/`.

## Why it cannot come back

Both gates were verified failing against the broken code before being written into a passing state.

- `tests/frontend-loading-contract.test.mjs` (no browser, ~200 ms) bans readiness events and relative imports in entry points, and requires `ready.js` to load first and blocking. It found the ParaSign bridge on its first run, which I had missed.
- `product-heartbeat` now asserts `/ontvang` reaches a real fingerprint. Its old check (does `_cryptoBridge` exist) stayed green through the entire outage, because loaded is not the same as working.

`docs/frontend-loading-contract.md` writes down the rule and both breaks.

## Verification

- 114 root suites: 113 pass, 0 fail
- product-heartbeat: 8/8 pass on the fix, `/ontvang` fails with "keygen never completed" on the old code
- `/ontvang` locally reaches the fingerprint step with no errors of our own