### PR TITLE
Stop the hourly relay crash: sweep a Map that no longer exists

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,21 @@ jobs:
           | xargs -0 -n1 bash -n
           echo "All shell scripts parse OK."
 
+  undefined-names:
+    name: static — every name must exist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+      # The sibling of `bash -n`, for JavaScript. bash -n and node --check both
+      # parse; neither resolves names. An hourly setInterval swept a Map that no
+      # longer existed and took production down 425 times before anyone looked.
+      # Config: eslint.config.mjs, one rule, no style opinions.
+      - name: no-undef over the hand-written server code
+        run: npx --yes eslint@9 .
+
   frontend-cache-bust:
     name: frontend — cache-bust guard
     runs-on: ubuntu-latest

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,45 @@
+// One rule, on purpose: no-undef.
+//
+// On 2026-08-08 the production relay had restarted 425 times. The cause was a
+// single line in an hourly setInterval that swept a Map called
+// trialIpRequests, a per-IP trial limiter that had been removed. The name was
+// never declared, so every hour the callback threw a ReferenceError, the
+// uncaughtException handler shut the relay down and the container came back up.
+// The site was briefly dead, every hour, for roughly eighteen days.
+//
+// Nothing caught it. node --check parses, it does not resolve names. The unit
+// suites never run an hourly timer. The heartbeat looks at pages, and a relay
+// that is up again two seconds later looks healthy. A dead name inside a timer
+// is invisible to every gate we had, and loud to a scope analyser.
+//
+// So: no style rules, no opinions, no reformatting of 6000 lines. Just the one
+// question those gates could not answer. Does every name this code uses
+// actually exist?
+export default [
+  {
+    // Hand-written server code only. The vendored bundles (pqc, wasm glue) are
+    // generated, single-line, and full of browser globals: linting them says
+    // nothing about code anyone edits.
+    files: ['relay/*.js', 'relay/lib/*.js', 'admin/*.js', 'admin/lib/*.js'],
+    ignores: ['**/node_modules/**', 'relay/lib/paramant-pqc.js', '**/*.min.js'],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'commonjs',
+      globals: {
+        require: 'readonly', module: 'writable', exports: 'writable',
+        process: 'readonly', console: 'readonly', Buffer: 'readonly',
+        __dirname: 'readonly', __filename: 'readonly', global: 'readonly',
+        setTimeout: 'readonly', clearTimeout: 'readonly',
+        setInterval: 'readonly', clearInterval: 'readonly',
+        setImmediate: 'readonly', queueMicrotask: 'readonly',
+        URL: 'readonly', URLSearchParams: 'readonly', TextEncoder: 'readonly',
+        TextDecoder: 'readonly', AbortController: 'readonly', AbortSignal: 'readonly',
+        fetch: 'readonly', Headers: 'readonly', Request: 'readonly', Response: 'readonly',
+        Blob: 'readonly', FormData: 'readonly', WebAssembly: 'readonly',
+        crypto: 'readonly', structuredClone: 'readonly', performance: 'readonly',
+      },
+    },
+    linterOptions: { reportUnusedDisableDirectives: true },
+    rules: { 'no-undef': 'error' },
+  },
+];

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1326,18 +1326,6 @@ const blobStore  = new Map();  // hash → {blob, ts, ttl, size, sig?}
 const anonInboundIpRequests = new Map(); // ip → [timestamps] for /v2/anon-inbound rate limit
 const invDidIpRequests = new Map(); // ip → [timestamps] for keyless inv_ DID registration
 const sthIngestIpRequests = new Map(); // ip → [timestamps] for /v2/sth/ingest (unauthenticated)
-// Sweep both per-IP rate-limit maps hourly so they cannot grow without bound
-// on attacker-rotated IPs (the limit windows already expire entries logically;
-// this reclaims the memory). Mirrors the dpaIpRequests sweep. Use each map's
-// own window: trial = 24h (DAY_MS at the call site), anon-inbound = 1h.
-setInterval(() => {
-  const now = Date.now();
-  const trialCut = now - 86_400_000; // 24h
-  const anonCut  = now - 3_600_000;  // 1h
-  for (const [k, times] of trialIpRequests) { const kept = times.filter(t => t > trialCut); if (kept.length) trialIpRequests.set(k, kept); else trialIpRequests.delete(k); }
-  for (const [k, times] of anonInboundIpRequests) { const kept = times.filter(t => t > anonCut); if (kept.length) anonInboundIpRequests.set(k, kept); else anonInboundIpRequests.delete(k); }
-}, 3_600_000);
-
 // Team rate limit tracking
 const teamRateLimits = new Map(); // team_id → { count, resetAt }
 


### PR DESCRIPTION
Stop the hourly relay crash: sweep a Map that no longer exists

Production had restarted 425 times. Every hour, on the minute, the relay
logged "trialIpRequests is not defined", shut down on uncaughtException and
came back up. 48 crashes in the last 48 hours, going back roughly 18 days.

The cause is one line in an hourly setInterval. It sweeps trialIpRequests, a
per-IP trial limiter that was removed at some point: the name appears exactly
once in 6411 lines, in that sweep, and is declared nowhere. Trial limits are
tracked per API key (uploads_today), not per IP, so nothing else needs it.

The same interval also swept anonInboundIpRequests, but the second sweep 8
lines below already does that with the same 1h window on the same 1h interval.
The whole block is dead, so it goes rather than getting a declaration.

Impact was a two second outage every hour: in-flight uploads and downloads
cut off, 502s for whoever clicked at that moment.

Why no gate caught it, and the gate that now does:
  bash -n and node --check parse, they do not resolve names.
  The unit suites never run an hourly timer.
  The heartbeat sees pages, and a relay that is back in two seconds looks fine.
A dead name inside a timer is invisible to all three and obvious to a scope
analyser. eslint.config.mjs enables exactly one rule, no-undef, over the
hand-written server code. No style rules, no reformatting. Verified both ways:
green on this branch, and it fails with three errors on the exact line when
the deleted block is put back.
