### PR TITLE
Fix the dead destinations, and gate where every button leads

### DIFF
--- a/.github/workflows/product-heartbeat.yml
+++ b/.github/workflows/product-heartbeat.yml
@@ -47,6 +47,13 @@ jobs:
       - name: Heartbeat against frontend/
         run: node --test tests/product-heartbeat.test.mjs
 
+      # Internal destinations only: resolved against frontend/ on disk, no
+      # network, about a second. It runs before nothing and after nothing, it
+      # just has to run: a typo like /login instead of /auth/login is invisible
+      # to every other gate we have.
+      - name: Where every internal link leads
+        run: node --test tests/links.test.mjs
+
   live:
     name: heartbeat — production
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -86,6 +93,20 @@ jobs:
         env:
           PARAMANT_RELAY_URL: https://relay.paramant.app
           PARAMANT_API_KEY: ${{ secrets.PARAMANT_CANARY_KEY }}
+
+      # External destinations: someone else's uptime, so hourly and never in a
+      # pull request. A third party can also delete a page without telling us,
+      # which is exactly what a scheduled check is for. always(), because a
+      # failing page must not hide a dead download button.
+      #
+      # This is expected to be RED until the /download question is settled: five
+      # installers and three ParamantOS links point at private repositories, so
+      # every visitor gets a 404. That is a real breakage and the alarm should
+      # say so rather than be silenced first.
+      - name: Where every external link leads
+        if: always()
+        shell: bash
+        run: CHECK_EXTERNAL_LINKS=1 node --test tests/links.test.mjs 2>&1 | tee -a /tmp/heartbeat.log
 
       # An hourly job that turns red in a tab nobody opens is not an alarm. A
       # red run opens an issue with the failing output; a green run closes it

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -473,12 +473,26 @@ section p+p{margin-top:14px}
     <div class="aside">
       <div class="label">NSA CNSA 2.0 — September 2022</div>
       <p>
-        <strong>"Organizations should avoid using public-key cryptography based on RSA
-        or elliptic curve for all sensitive data with a secrecy requirement extending
-        beyond approximately five years."</strong><br><br>
+        <!-- This block used to quote the NSA as writing: "Organizations should avoid
+             using public-key cryptography based on RSA or elliptic curve for all
+             sensitive data with a secrecy requirement extending beyond approximately
+             five years." That sentence is not in CNSA 2.0. On 2026-08-08 both the
+             advisory and the FAQ were pulled and searched: the word "secrecy" does
+             not occur in either, and no source for the sentence could be found. A
+             quote we cannot point at is worse than no quote, so it is replaced by
+             what the advisory does say, word for word, checked against the document.
+
+             The advisory PDF is gone from media.defense.gov (404; a 403 to curl and
+             to Chromium made it look alive, which is why this was checked with more
+             than one client). NSA's own resources page now links only the FAQ, so
+             the link goes there and the archived advisory is noted here:
+             http://web.archive.org/web/20241215203633/https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF -->
+        <strong>"Note that this will effectively deprecate the use of RSA,
+        Diffie-Hellman (DH), and elliptic curve cryptography (ECDH and ECDSA)
+        when mandated."</strong><br><br>
         CISA, NCSC-UK, and the BSI issue the same guidance: begin migration now.
         Waiting for Q-Day means the archive is already complete.
-        <a href="https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF" target="_blank" rel="noopener">NSA CNSA 2.0 (PDF) &rarr;</a>
+        <a href="https://www.nsa.gov/Cybersecurity/Post-Quantum-Cybersecurity-Resources/" target="_blank" rel="noopener">NSA post-quantum resources &rarr;</a>
       </p>
     </div>
   </section>

--- a/frontend/js/pricing-billing.js
+++ b/frontend/js/pricing-billing.js
@@ -89,11 +89,17 @@
         var msg = String((err && err.message) || '');
         /* No session: send them to sign-in and straight back here. An account
          * is what makes the payment attributable, so it is a precondition, not
-         * an obstacle to route around. */
+         * an obstacle to route around.
+         *
+         * The route is /auth/login (frontend/auth/login.html). It was written
+         * as /login here, which is a 404, so from the day this file shipped
+         * every signed-out visitor who clicked a price button landed on the
+         * error page. The rest of the site already linked /auth/login; this
+         * one line was the odd one out. */
         if (msg.indexOf('key_http_401') === 0 || msg.indexOf('key_http_403') === 0 ||
             msg === 'key_unavailable' || msg.indexOf('checkout_http_401') === 0 ||
             msg.indexOf('checkout_http_403') === 0) {
-          window.location.href = '/login?next=' + encodeURIComponent(location.pathname + location.search);
+          window.location.href = '/auth/login?next=' + encodeURIComponent(location.pathname + location.search);
           return;
         }
         showError(btn, 'Could not start checkout. Nothing has been charged. ' +

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -374,12 +374,17 @@
           <li>Email notifications via Resend</li>
           <li>No IP rate limit</li>
         </ul>
-<!-- Mollie payment links (Fase A, one-off, amounts incl. 21% btw):
-     ParaSend Pro   monthly 18.15 zvsE7pxE5kLaYxC8j4rDH | yearly 181.50 drRnrb7hky6bjkvea5ipk
-     ParaSign Pro   monthly 59.29 tY9CRhMfcJSi4s9nU3s6D | yearly 603.79 iYKTBMtf9WeWZMc3HSTWj
-     ParaSign Bus.  monthly 361.79 L9iVQXjtxwjrF9M8qdGYm | yearly 3617.90 Npj56fkDJ8npWprUYnXBN -->
-        <a href="https://payment-links.mollie.com/payment/zvsE7pxE5kLaYxC8j4rDH" data-billing-product="parasend" data-billing-plan="pro" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center">Get ParaSend Pro &rarr; <span style="font-weight:400;opacity:.85">&euro;18,15/mo incl.</span></a>
-        <div style="text-align:center"><a href="https://payment-links.mollie.com/payment/drRnrb7hky6bjkvea5ipk" data-billing-product="parasend" data-billing-plan="pro" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; &euro;181,50/yr incl. &rarr;</a></div>
+<!-- Prices live in relay/lib/billing-catalog.js, server side, and the button
+     only carries product/plan/interval. pricing-billing.js turns a click into
+     POST /v2/billing/checkout, which creates the Mollie payment WITH the
+     metadata the webhook needs to grant the tier.
+
+     The href is the no-JS fallback and points at sign-in, not at a payment.
+     It used to hold six static Mollie payment links; all six returned 404 on
+     2026-08-08, and even alive they carried no metadata, which is how the
+     first paying customer got nothing on 2026-07-21. -->
+        <a href="/auth/login?next=/pricing" data-billing-product="parasend" data-billing-plan="pro" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center">Get ParaSend Pro &rarr; <span style="font-weight:400;opacity:.85">&euro;18,15/mo incl.</span></a>
+        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasend" data-billing-plan="pro" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; &euro;181,50/yr incl. &rarr;</a></div>
       </div>
 
       <div class="tier-card">
@@ -442,8 +447,8 @@
           <li>Unlimited transfers - API access</li>
           <li>Annual: EUR 499 (two months free)</li>
         </ul>
-        <a href="https://payment-links.mollie.com/payment/tY9CRhMfcJSi4s9nU3s6D" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Pro &rarr; <span style="font-weight:400;opacity:.85">EUR 59,29/mo incl.</span></a>
-        <div style="text-align:center"><a href="https://payment-links.mollie.com/payment/iYKTBMtf9WeWZMc3HSTWj" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; EUR 603,79/yr incl. &rarr;</a></div>
+        <a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Pro &rarr; <span style="font-weight:400;opacity:.85">EUR 59,29/mo incl.</span></a>
+        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; EUR 603,79/yr incl. &rarr;</a></div>
       </div>
 
       <div class="tier-card">
@@ -457,8 +462,8 @@
           <li>Exportable audit log with CT tree head (CSV or JSON)</li>
           <li>Annual: EUR 2,990 (two months free)</li>
         </ul>
-        <a href="https://payment-links.mollie.com/payment/L9iVQXjtxwjrF9M8qdGYm" data-billing-product="parasign" data-billing-plan="business" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Business &rarr; <span style="font-weight:400;opacity:.85">EUR 361,79/mo incl.</span></a>
-        <div style="text-align:center"><a href="https://payment-links.mollie.com/payment/Npj56fkDJ8npWprUYnXBN" data-billing-product="parasign" data-billing-plan="business" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; EUR 3.617,90/yr incl. &rarr;</a></div>
+        <a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="business" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Business &rarr; <span style="font-weight:400;opacity:.85">EUR 361,79/mo incl.</span></a>
+        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="business" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; EUR 3.617,90/yr incl. &rarr;</a></div>
       </div>
 
       <div class="tier-card">

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -2,7 +2,7 @@
 // The pricing page shows the four ParaSign tiers (Free / Pro / Business /
 // Enterprise) with the agreed copy, keeps all six paid checkout links wired
 // for the API-first billing flow (data-billing-* attributes resolvable in the
-// server catalog, static Mollie link as fallback), states that checkout
+// server catalog, no-JS href pointing at sign-in), states that checkout
 // charges incl. 21% btw, shows the incl-btw amount up-front on every paid card,
 // keeps one primary monthly CTA per tier with the yearly option demoted to a
 // secondary link, and no longer claims a 5 MB file limit. It also checks the
@@ -29,12 +29,26 @@ const VARIANTS = [
   { product: 'parasign', plan: 'business', interval: 'yearly',  excl: 2990 },
 ];
 
-// One annotated checkout button per variant, static Mollie link as fallback.
-const btnRe = /<a\s+href="(https:\/\/payment-links\.mollie\.com\/payment\/[A-Za-z0-9]+)"\s+data-billing-product="([a-z]+)"\s+data-billing-plan="([a-z]+)"\s+data-billing-interval="([a-z]+)"/g;
+// One annotated checkout button per variant. The href is the no-JS fallback and
+// must NOT be a static Mollie payment link: those carry no metadata, so the
+// webhook cannot attribute the payment and the buyer gets nothing, which is what
+// happened to the first paying customer on 2026-07-21. All six were 404 by
+// 2026-08-08 as well. The fallback is sign-in, because an account is what makes
+// a payment attributable. This regex used to require the Mollie URL, so it kept
+// the bug in place instead of the rule.
+const btnRe = /<a\s+href="([^"]+)"\s+data-billing-product="([a-z]+)"\s+data-billing-plan="([a-z]+)"\s+data-billing-interval="([a-z]+)"/g;
 const buttons = [];
 for (let m; (m = btnRe.exec(html)); ) buttons.push({ href: m[1], product: m[2], plan: m[3], interval: m[4] });
 assert.strictEqual(buttons.length, 6, 'expected 6 annotated checkout buttons, got ' + buttons.length);
-ok('6 checkout buttons with data-billing-* and a static Mollie fallback href');
+ok('6 checkout buttons with data-billing-*');
+
+for (const b of buttons) {
+  assert(!/payment-links\.mollie\.com/.test(b.href),
+    'checkout button falls back to a static Mollie link (no metadata, unattributable): ' + b.href);
+  assert(b.href.startsWith('/auth/login'),
+    'no-JS fallback must be sign-in, got ' + b.href + ' for ' + b.product + '/' + b.plan + '/' + b.interval);
+}
+ok('no-JS fallback on every button is sign-in, never a metadata-less payment link');
 
 for (const v of VARIANTS) {
   const btn = buttons.find(b => b.product === v.product && b.plan === v.plan && b.interval === v.interval);

--- a/tests/links.test.mjs
+++ b/tests/links.test.mjs
@@ -97,12 +97,36 @@ test('every external link answers', { skip: !process.env.CHECK_EXTERNAL_LINKS &&
   // 403 without a browser is how several big hosts answer any bot, so it says
   // nothing about the link. A 404 says the thing is gone, which is what we are
   // hunting: a download button that hands the visitor an error page.
-  const dood = [];
-  await Promise.all(extern.map(async (url) => {
-    const status = await fetch(url, { method: 'GET', redirect: 'follow', signal: AbortSignal.timeout(20000) })
+  //
+  // A 404 alone is still not enough. On 2026-08-08 media.defense.gov answered
+  // 404 to this test and 403 to both curl and Chromium, which looked like a
+  // blocked client rather than a missing file. It was not: the host's root
+  // answers 200, the FAQ next to it downloads fine, and the factsheet really
+  // was withdrawn. The 403 was the misleading half.
+  //
+  // So each 404 is weighed against that host's own root. Root reachable means
+  // the page is genuinely gone. Root turning us away too means we are being
+  // filtered and cannot tell, and the run says so out loud instead of failing
+  // on nothing. Never conclude "dead" from one client's word.
+  const status = (url) =>
+    fetch(url, { method: 'GET', redirect: 'follow', signal: AbortSignal.timeout(20000) })
       .then((r) => r.status).catch((e) => `unreachable (${e.name})`);
-    if (status === 404 || status === 410) dood.push(`${status}  ${url}   (from ${bron.get(url)})`);
+
+  const dood = [];
+  const onmeetbaar = [];
+  await Promise.all(extern.map(async (url) => {
+    const s = await status(url);
+    if (s !== 404 && s !== 410) return;
+    const root = await status(new URL(url).origin + '/');
+    if (typeof root === 'number' && root < 400) dood.push(`${s}  ${url}   (from ${bron.get(url)})`);
+    else onmeetbaar.push(`${s}  ${url}   (host root answers ${root})`);
   }));
+
+  if (onmeetbaar.length) {
+    console.log(`\n  Not measurable, the host turns us away on its own root too:\n  ` +
+      onmeetbaar.sort().join('\n  ') +
+      `\n  Open these by hand before treating them as broken.\n`);
+  }
 
   assert.deepEqual(dood.sort(), [],
     `\n  These external destinations are gone:\n  ` + dood.sort().join('\n  ') +

--- a/tests/links.test.mjs
+++ b/tests/links.test.mjs
@@ -1,0 +1,110 @@
+// Where every button leads. The gate the site did not have.
+//
+// On 2026-08-08 a sweep of the live site found 18 dead destinations out of 144,
+// and every gate we had was green while it was true:
+//
+//   /login                     404. pricing-billing.js sent every signed-out
+//                              visitor there when they clicked a price. The
+//                              page is /auth/login; the rest of the site knew
+//                              that, this one line did not.
+//   6 Mollie payment links     404. The no-JS route out of /pricing.
+//   5 installer downloads      404. /download offers deb, rpm, AppImage, exe
+//                              and apk from a private repo, so every asset is
+//                              404 for anyone who is not us.
+//   3 ParamantOS links         404, same cause.
+//
+// None of it is visible from inside a page. The heartbeat proves a page loads
+// and initialises; this proves the page leads somewhere. Two questions, two
+// gates.
+//
+// Internal targets resolve against frontend/ the way nginx resolves them, with
+// no network, so this runs on every pull request in about a second. External
+// targets need the network and a third party's uptime, which has no place in a
+// pull request gate: they run hourly against production instead, where a real
+// 404 is a real problem and a slow host is not a red PR.
+//
+//   node --test tests/links.test.mjs                       internal only
+//   CHECK_EXTERNAL_LINKS=1 node --test tests/links.test.mjs internal + external
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+
+// Routes the relay serves, which have no file in frontend/ and cannot be
+// resolved on disk. Everything NOT on this list must exist as a file, which is
+// exactly what makes a typo like /login fail here.
+const SERVER_ROUTES = [
+  /^\/api\//,
+  /^\/v1\//,
+  /^\/v2\//,
+  /^\/\.well-known\//,
+  /^\/admin\//,      // the admin container, behind its own gate
+];
+
+function htmlFiles(dir) {
+  const uit = [];
+  for (const naam of fs.readdirSync(dir)) {
+    const p = path.join(dir, naam);
+    const st = fs.statSync(p);
+    if (st.isDirectory()) { if (naam !== 'node_modules') uit.push(...htmlFiles(p)); }
+    else if (/\.(html|js)$/.test(naam)) uit.push(p);
+  }
+  return uit;
+}
+
+// Every absolute destination the site hands a visitor: markup links, form
+// actions, and the paths a script navigates to on click.
+function destinations(file) {
+  const src = fs.readFileSync(file, 'utf8');
+  const uit = new Set();
+  for (const m of src.matchAll(/(?:href|src|action)="([^"]+)"/g)) uit.add(m[1]);
+  for (const m of src.matchAll(/(?:location\.href|location\.assign|window\.open)\s*\(?\s*=?\s*['"]([^'"]+)['"]/g)) uit.add(m[1]);
+  return [...uit];
+}
+
+function resolvesOnDisk(route) {
+  const clean = route.split('?')[0].split('#')[0];
+  const base = path.join(ROOT, clean);
+  if (!base.startsWith(ROOT)) return false;
+  return [base, base + '.html', path.join(base, 'index.html')]
+    .some((f) => fs.existsSync(f) && fs.statSync(f).isFile());
+}
+
+const alle = htmlFiles(ROOT).flatMap((f) => destinations(f).map((d) => ({ d, f })));
+
+test('every internal link resolves to a page that exists', () => {
+  const dood = [];
+  for (const { d, f } of alle) {
+    if (!d.startsWith('/') || d.startsWith('//')) continue;       // relative and protocol-relative: out of scope
+    if (SERVER_ROUTES.some((r) => r.test(d))) continue;
+    if (resolvesOnDisk(d)) continue;
+    dood.push(`${d}   (from ${path.relative(ROOT, f)})`);
+  }
+  assert.deepEqual([...new Set(dood)].sort(), [],
+    `\n  These destinations do not exist. A visitor following them gets the 404 page:\n  ` +
+    [...new Set(dood)].sort().join('\n  ') +
+    `\n\n  Add the page, fix the path, or add the route to SERVER_ROUTES if the relay serves it.\n`);
+});
+
+test('every external link answers', { skip: !process.env.CHECK_EXTERNAL_LINKS && 'set CHECK_EXTERNAL_LINKS=1 (runs hourly against production, not in pull requests)' }, async () => {
+  const extern = [...new Set(alle.map(({ d }) => d).filter((d) => /^https?:\/\//.test(d)))];
+  const bron = new Map();
+  for (const { d, f } of alle) if (extern.includes(d) && !bron.has(d)) bron.set(d, path.relative(ROOT, f));
+
+  // 403 without a browser is how several big hosts answer any bot, so it says
+  // nothing about the link. A 404 says the thing is gone, which is what we are
+  // hunting: a download button that hands the visitor an error page.
+  const dood = [];
+  await Promise.all(extern.map(async (url) => {
+    const status = await fetch(url, { method: 'GET', redirect: 'follow', signal: AbortSignal.timeout(20000) })
+      .then((r) => r.status).catch((e) => `unreachable (${e.name})`);
+    if (status === 404 || status === 410) dood.push(`${status}  ${url}   (from ${bron.get(url)})`);
+  }));
+
+  assert.deepEqual(dood.sort(), [],
+    `\n  These external destinations are gone:\n  ` + dood.sort().join('\n  ') +
+    `\n\n  A download button or a payment link that 404s is worse than not offering it.\n`);
+});

--- a/tests/product-heartbeat.test.mjs
+++ b/tests/product-heartbeat.test.mjs
@@ -151,8 +151,14 @@ let origin = BASE;
 if (!BASE) {
   server = http.createServer((req, res) => {
     const p = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
-    const file = path.join(ROOT, p);
-    if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+    const base = path.join(ROOT, p);
+    if (!base.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+    // Production serves /auth/login from auth/login.html. Without the same
+    // extension-less resolution here, a link that works locally can still 404
+    // for the visitor, and the reverse. Try what nginx tries, in that order.
+    const file = [base, base + '.html', path.join(base, 'index.html')]
+      .find((f) => f.startsWith(ROOT) && fs.existsSync(f) && fs.statSync(f).isFile());
+    if (!file) { res.writeHead(404); return res.end(); }
     fs.readFile(file, (e, b) => {
       if (e) { res.writeHead(404); return res.end(); }
       res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
@@ -241,6 +247,49 @@ for (const page of PAGES) {
     await ctx.close();
   });
 }
+
+// The paid funnel is the one page where "it loaded fine" is worth nothing. On
+// 2026-08-08 /pricing.html passed every rule above while both ways out of it
+// were dead: the six static hrefs were Mollie payment links that all returned
+// 404, and pricing-billing.js sent signed-out visitors to /login, which does
+// not exist either (the page is /auth/login). Anyone who wanted to pay hit an
+// error page, and the suite stayed green because nothing on /pricing itself
+// was broken. So follow the buttons out of the page, not just into it.
+test('/pricing.html — every way out of the paid funnel exists', async () => {
+  const ctx = await browser.newContext();
+  const tab = await ctx.newPage();
+  await tab.goto(origin + '/pricing.html', { waitUntil: 'load', timeout: 45000 });
+
+  // Route 1: the href, which is what a visitor without JS follows.
+  const hrefs = await tab.$$eval('a[data-billing-product]', (els) =>
+    els.map((e) => e.getAttribute('href')).filter(Boolean));
+  assert.ok(hrefs.length >= 1, 'no price buttons found on /pricing.html at all');
+
+  // Route 2: where the script sends a signed-out visitor. Read it from the
+  // source rather than clicking: the click needs a real 401 from the relay,
+  // which a local run cannot produce, and this must hold in both modes.
+  const src = await (await fetch(origin + '/js/pricing-billing.js')).text();
+  const jump = [...src.matchAll(/location\.href\s*=\s*['"]([^'"]+)['"]/g)]
+    .map((m) => m[1].replace(/['"]?\s*\+.*$/, ''))     // strip the concatenated next= tail
+    .filter((u) => u.startsWith('/'));
+  assert.ok(jump.length >= 1, 'pricing-billing.js no longer redirects anywhere; has the flow changed?');
+
+  const dead = [];
+  for (const target of [...new Set([...hrefs, ...jump])]) {
+    const url = target.startsWith('http') ? target : origin + target;
+    // Same-origin targets resolve like any page; an external one (a payment
+    // provider) has to answer for itself. Either way, 4xx means the visitor
+    // is looking at an error page instead of paying.
+    const status = await fetch(url, { redirect: 'follow' })
+      .then((r) => r.status).catch((e) => `unreachable (${e.message})`);
+    if (typeof status !== 'number' || status >= 400) dead.push(`${target} -> ${status}`);
+  }
+  assert.deepEqual(dead, [],
+    `\n  A price button leads nowhere:\n  ` + dead.join('\n  ') +
+    `\n  Every route out of /pricing must reach a real page, with or without JS.\n`);
+
+  await ctx.close();
+});
 
 // Coverage, stated out loud. A page with neither a progress check nor a written
 // reason is a page nobody decided about, and that silence is what let /ontvang


### PR DESCRIPTION
A sweep of the live site found 18 dead destinations out of 144 while every gate we had was green. The gates all looked inside a page: does it load, does it initialise. None asked where a button leads.

## What was broken

| Destination | Effect |
|---|---|
| `/login` | `pricing-billing.js` sent every signed-out visitor who clicked a price to a 404. The page is `/auth/login`, which the rest of the site already knew. |
| 6 Mollie payment links | The no-JS `href` on each price button. All six 404, and even alive they carried no metadata, so the webhook could not grant the tier. That is how the first paying customer got nothing on 21 July. |
| NSA CNSA 2.0 link + quote | The link was dead, and the quoted sentence is not in CNSA 2.0 at all. |
| 5 installers, 3 ParamantOS links | Still open, see below. |

Checkout now goes through `POST /v2/billing/checkout`, which carries the metadata; the `href` is sign-in as the no-JS fallback.

## The gate

`tests/links.test.mjs` asks the one question no existing gate asked. Internal destinations resolve against `frontend/` the way nginx does, no network, about a second, so it runs on every pull request. External destinations run hourly against production instead, because a third party's uptime has no place in a merge gate.

One lesson is baked in: a single client's 404 is not evidence. `media.defense.gov` answered 404 to node and 403 to both curl and Chromium. Every 404 is now weighed against that host's own root, and an unmeasurable host is printed rather than failed on.

## Still open, needs a decision

The hourly external check **will be red** on merge: five installers on `/download` and three ParamantOS links point at private repositories, so every visitor gets a 404. That is a real breakage, and silencing the alarm before deciding would hide it.