### PR TITLE
Serve the installers ourselves, and only claim signatures we have

### DIFF
--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -910,7 +910,10 @@ paramant-stream --key pgp_xxx --sector health --forward https://pacs.hospital/ap
 
     <!-- ── ParamantOS CLI tools ───────────────────────────────────── -->
     <h2 id="paramant-os-tools">ParamantOS: 39 operator tools</h2>
-    <p><a href="https://github.com/Apolloccrypt/ParamantOS" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)" rel="noopener">ParamantOS</a> is a hardened Linux distribution (NixOS + Mint editions) for relay operators. All 39 tools are pre-installed.</p>
+    <!-- Linked to github.com/Apolloccrypt/ParamantOS, a private repository, so it was
+         404 for every reader. Not a link until the ISO is hosted here: the release is
+         a single 1.7 GB image, which is a bandwidth decision, not a copy job. -->
+    <p>ParamantOS is a hardened Linux distribution (NixOS + Mint editions) for relay operators. All 39 tools are pre-installed. Ask us for an image: <a href="mailto:privacy@paramant.app?subject=ParamantOS+image" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">privacy@paramant.app</a>.</p>
     <table>
       <tr><th>Category</th><th>Command</th><th>What it does</th></tr>
       <tr><td rowspan="5" style="color:var(--ink-dim);font-size:11px;vertical-align:top;padding-top:12px">Setup &amp; diagnostics</td><td>paramant-setup</td><td>First-boot wizard: password, relay URL, API key</td></tr>
@@ -953,7 +956,10 @@ paramant-stream --key pgp_xxx --sector health --forward https://pacs.hospital/ap
       <tr><td>paramant-data-ctl</td><td>Privileged relay data-dir management</td></tr>
       <tr><td>paramant-cron</td><td>Manage systemd timers for relay maintenance</td></tr>
     </table>
-    <p>Download ParamantOS: <a href="https://github.com/Apolloccrypt/ParamantOS/releases" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)" rel="noopener">NixOS edition (v2.4.5)</a> · <a href="https://github.com/Apolloccrypt/ParamantOS/releases/tag/v1.0-mint" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)" rel="noopener">Mint edition (v1.0-β)</a></p>
+    <!-- Both editions linked into the private ParamantOS repo and were 404. The
+         current release is v3.0.0 (one 1.7 GB ISO); v2.4.5 was the NixOS edition and
+         v1.0-mint the Mint one. Named, not linked, until the image is hosted here. -->
+    <p>ParamantOS editions: NixOS (v2.4.5) and Mint (v1.0-β), with v3.0.0 current. The images are not published for download yet, so <a href="mailto:privacy@paramant.app?subject=ParamantOS+image" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">ask us</a> for one.</p>
 
     <!-- ── Crypto stack ─────────────────────────────────────────── -->
     <h2 id="crypto">Crypto stack</h2>

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -340,53 +340,82 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
     </div>
   </div>
 
-  <div class="section-label">// DOWNLOADS — v0.2.0 ⚠ VEROUDERD</div>
+  <!-- Deze knoppen wezen naar github.com/Apolloccrypt/paramant-app/releases. Die repo
+       is privé, dus alle vijf gaven 404 voor iedere bezoeker die wij niet zijn. Ze
+       worden nu vanaf deze server geserveerd (/dl/), zodat de repo privé kan blijven.
+
+       De versies lopen uiteen en dat staat er nu bij: v0.2.1 heeft alleen een .deb en
+       een .apk, dus Windows, RPM en AppImage zijn nog v0.2.0. Eén versienummer boven
+       de hele lijst zou over drie van de vijf liegen.
+
+       Elke regel onder een knop is nagemeten op 2026-08-08, niet overgenomen:
+         .apk       v1 JAR-signature + APK Signing Block v2/v3, cert CN=Mick Beer
+         .exe       Authenticode, certificate table 1704 bytes
+         .deb       GEEN signature: geen _gpgorigin in het ar-archief. De kaart zei
+                    "GPG-gesigneerd door Mick Beer / GPG: 6EF8E5AC...29A49B97", en dat
+                    was niet waar te maken. Nu staat er de SHA256, die het wel is.
+         .rpm       GEEN signature: alleen SHA256HEADER in de signature-header
+         .AppImage  GEEN signature: .sha256_sig en .sig_key bestaan maar zijn nul
+                    (lege placeholders van appimagetool)
+       Volledige lijst: /dl/SHA256SUMS -->
+  <div class="section-label">// DOWNLOADS — .deb en .apk v0.2.1 · overige v0.2.0</div>
   <div class="dl-grid">
-    <a class="dl-card" href="https://github.com/Apolloccrypt/paramant-app/releases/download/v0.2.0/PARAMANT_0.2.0_amd64.deb">
+    <a class="dl-card" href="/dl/paramant_0.2.1_amd64.deb">
       <div class="dl-platform">[LNX]</div>
       <div class="dl-name">Linux</div>
-      <div class="dl-ext">.deb — Debian / Ubuntu / Pop!_OS</div>
-      <div class="dl-desc">Rust backend + Tauri 2 WebKit. ML-KEM-768 native AVX2. GPG-gesigneerd door Mick Beer.</div>
+      <div class="dl-ext">.deb — Debian / Ubuntu / Pop!_OS · v0.2.1</div>
+      <div class="dl-desc">Rust backend + Tauri 2 WebKit. ML-KEM-768 native AVX2. Niet gesigneerd: controleer de SHA256 hieronder.</div>
       <div class="dl-btn">[DL] .deb</div>
-      <div class="dl-meta">~3 MB</div>
-      <div class="dl-signed">GPG: 6EF8E5AC...29A49B97</div>
+      <div class="dl-meta">2,5 MB</div>
+      <div class="dl-signed">SHA256: 62360ad6...703e32bb</div>
     </a>
-    <a class="dl-card" href="https://github.com/Apolloccrypt/paramant-app/releases/download/v0.2.0/PARAMANT-0.2.0-1.x86_64.rpm">
+    <a class="dl-card" href="/dl/PARAMANT-0.2.0-1.x86_64.rpm">
       <div class="dl-platform">[LNX]</div>
       <div class="dl-name">Linux</div>
-      <div class="dl-ext">.rpm — Fedora / RHEL / openSUSE</div>
+      <div class="dl-ext">.rpm — Fedora / RHEL / openSUSE · v0.2.0</div>
       <div class="dl-desc">Identiek aan .deb. Zelfde Rust crypto core, zelfde relay. Gebouwd voor RPM-gebaseerde distros.</div>
       <div class="dl-btn">[DL] .rpm</div>
-      <div class="dl-meta">~3 MB</div>
-      <div class="dl-signed">// build: cargo tauri build</div>
+      <div class="dl-meta">2,4 MB</div>
+      <div class="dl-signed">SHA256: b103dadc...d7d541be</div>
     </a>
-    <a class="dl-card" href="https://github.com/Apolloccrypt/paramant-app/releases/download/v0.2.0/PARAMANT_0.2.0_amd64.AppImage">
+    <a class="dl-card" href="/dl/PARAMANT_0.2.0_amd64.AppImage">
       <div class="dl-platform">[LNX]</div>
       <div class="dl-name">Linux</div>
-      <div class="dl-ext">.AppImage — Universeel</div>
+      <div class="dl-ext">.AppImage — Universeel · v0.2.0</div>
       <div class="dl-desc">Portable binary — runs on any Linux distro without installation. No root required. chmod +x and run.</div>
       <div class="dl-btn">[DL] .AppImage</div>
-      <div class="dl-meta">~77 MB (all-in-one)</div>
-      <div class="dl-signed">// chmod +x paramant.AppImage</div>
+      <div class="dl-meta">80,7 MB (all-in-one)</div>
+      <div class="dl-signed">SHA256: 7e0962ac...ee9aa728</div>
     </a>
-    <a class="dl-card" href="https://github.com/Apolloccrypt/paramant-app/releases/download/v0.2.0/PARAMANT-0.2.0-windows-signed.exe">
+    <a class="dl-card" href="/dl/PARAMANT-0.2.0-windows-signed.exe">
       <div class="dl-platform">[WIN]</div>
       <div class="dl-name">Windows</div>
-      <div class="dl-ext">.exe — Windows 10/11 x64</div>
-      <div class="dl-desc">Cross-compiled via mingw-w64. Gesigneerd met osslsigncode (self-signed). SmartScreen: klik Meer info -> Toch uitvoeren.</div>
+      <div class="dl-ext">.exe — Windows 10/11 x64 · v0.2.0</div>
+      <div class="dl-desc">Cross-compiled via mingw-w64. Authenticode-gesigneerd (self-signed). SmartScreen: klik Meer info -> Toch uitvoeren.</div>
       <div class="dl-btn">[DL] .exe</div>
-      <div class="dl-meta">~20 MB</div>
-      <div class="dl-signed">// signed: osslsigncode</div>
+      <div class="dl-meta">5,8 MB</div>
+      <div class="dl-signed">// Authenticode, self-signed</div>
     </a>
-    <a class="dl-card" href="https://github.com/Apolloccrypt/paramant-app/releases/download/v0.2.0/PARAMANT-0.2.0-android-signed.apk">
+    <a class="dl-card" href="/dl/PARAMANT-0.2.1-android.apk">
       <div class="dl-platform">[APK]</div>
       <div class="dl-name">Android</div>
-      <div class="dl-ext">.apk — Android 8.0+ (ARM64)</div>
+      <div class="dl-ext">.apk — Android 8.0+ (ARM64) · v0.2.1</div>
       <div class="dl-desc">Tauri Mobile. Rust gecompileerd naar ARM64 + x86_64. APK signing v2+v3 scheme. Sideload: Instellingen -> Onbekende bronnen.</div>
       <div class="dl-btn">[DL] .apk</div>
-      <div class="dl-meta">~22 MB</div>
-      <div class="dl-signed">// v2+v3 signed, 1 signer</div>
+      <div class="dl-meta">22,5 MB</div>
+      <div class="dl-signed">// v2+v3, cert AF:73:EF:52...8C:9E:92:4F</div>
     </a>
+  </div>
+
+  <div style="background:var(--bone-2);border:1px solid var(--ink-hair);padding:16px;margin-bottom:24px;font-size:11px;line-height:1.8;color:var(--ink-dim)">
+    <div style="color:var(--ink);font-size:10px;letter-spacing:.08em;margin-bottom:8px">// VERIFIEREN</div>
+    Alleen de .apk en de .exe dragen een signature. De .deb, .rpm en .AppImage niet, dus
+    daar is de SHA256 het enige dat je hebt. Controleer hem:<br>
+    <code style="color:var(--ink)">curl -sO https://paramant.app/dl/SHA256SUMS &amp;&amp; sha256sum -c SHA256SUMS --ignore-missing</code><br>
+    Het APK-certificaat is self-signed, vingerafdruk
+    <code style="color:var(--ink)">AF:73:EF:52:1A:FB:CC:16:10:71:6E:3B:A4:BD:77:98:29:6B:77:04:C6:6E:CC:0C:3D:14:FA:0D:8C:9E:92:4F</code>
+    (<code style="color:var(--ink)">apksigner verify --print-certs</code>).
+    <a href="/dl/SHA256SUMS" style="color:var(--ink)">Alle checksums &rarr;</a>
   </div>
 
   <div class="section-label">// CHANGELOG — WAT IS NIEUW IN WEB APP (nog niet in native)</div>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -536,7 +536,11 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <tr><td>CVEs mitigated</td><td>CVE-2023-51767, CVE-2025-26465, CVE-2025-26466, CVE-2025-32728</td></tr>
     </tbody>
   </table>
-  <p style="margin-top:12px"><a href="https://github.com/Apolloccrypt/ParamantOS" target="_blank" rel="noopener">ParamantOS on GitHub &rarr;</a></p>
+  <!-- Was a link to the private ParamantOS repository, so it 404'd for every reader.
+       This one hid behind the docs.html copy in the first sweep: the gate reports one
+       source per dead URL, so a second page carrying the same link only surfaces once
+       the first is fixed. Fix by URL, then run the gate again. -->
+  <p style="margin-top:12px"><a href="mailto:privacy@paramant.app?subject=ParamantOS+image" rel="noopener">Ask us about ParamantOS &rarr;</a></p>
 
   <h2 id="customer-transparency">Customer transparency</h2>
   <p>Security is also about knowing what the vendor can and cannot do. The <a href="/trust">Trust &amp; Transparency page</a> documents, in plain terms, how license-check works, what Paramant can see of your relay (and what it never can), how to verify your deployment, and which remote actions are possible versus structurally impossible. Each claim there is tagged as live today or planned, with links to the public protocol specifications.</p>

--- a/tests/links.test.mjs
+++ b/tests/links.test.mjs
@@ -42,7 +42,16 @@ const SERVER_ROUTES = [
   /^\/v2\//,
   /^\/\.well-known\//,
   /^\/admin\//,      // the admin container, behind its own gate
+  /^\/dl\//,         // installers: in the docroot, not in the repo. See DOCROOT_ROUTES.
 ];
+
+// An exception on SERVER_ROUTES is a hole unless something else covers it, and
+// /dl/ is the case that would hurt: five installer buttons that were 404 for
+// every visitor is exactly what this file exists to catch. The files live in the
+// docroot and not in git (like dist/), so disk cannot answer for them and
+// production has to. Collected here, checked against the live site in the
+// hourly run below.
+const DOCROOT_ROUTES = /^\/dl\//;
 
 function htmlFiles(dir) {
   const uit = [];
@@ -87,6 +96,28 @@ test('every internal link resolves to a page that exists', () => {
     `\n  These destinations do not exist. A visitor following them gets the 404 page:\n  ` +
     [...new Set(dood)].sort().join('\n  ') +
     `\n\n  Add the page, fix the path, or add the route to SERVER_ROUTES if the relay serves it.\n`);
+});
+
+const BASE = process.env.PARAMANT_BASE_URL || 'https://paramant.app';
+
+test('every file served from the docroot is really there', { skip: !process.env.CHECK_EXTERNAL_LINKS && 'set CHECK_EXTERNAL_LINKS=1 (runs hourly against production, not in pull requests)' }, async () => {
+  const paden = [...new Set(alle.map(({ d }) => d).filter((d) => DOCROOT_ROUTES.test(d)))];
+  assert(paden.length, 'no /dl/ links found at all, which means the download buttons vanished');
+
+  // Range request: proves the file is there and readable without pulling 80 MB
+  // of AppImage through CI. 206 or 200 both mean served.
+  const dood = [];
+  await Promise.all(paden.map(async (p) => {
+    const r = await fetch(BASE + p, { headers: { Range: 'bytes=0-1023' }, signal: AbortSignal.timeout(30000) })
+      .catch((e) => ({ status: `unreachable (${e.name})` }));
+    if (r.status !== 200 && r.status !== 206) dood.push(`${r.status}  ${p}`);
+  }));
+
+  assert.deepEqual(dood.sort(), [],
+    `\n  These files are offered on the site but not in the docroot on ${BASE}:\n  ` +
+    dood.sort().join('\n  ') +
+    `\n\n  They are not in git, so a deploy does not carry them. Copy them to\n` +
+    `  /home/paramant/app/dl/ or take the button off the page.\n`);
 });
 
 test('every external link answers', { skip: !process.env.CHECK_EXTERNAL_LINKS && 'set CHECK_EXTERNAL_LINKS=1 (runs hourly against production, not in pull requests)' }, async () => {


### PR DESCRIPTION
Follow-up to #307. All five download buttons were 404 (private repo); they now come from /dl/ on our own server.

Measured, not copied: only the .apk (v1 + v2/v3, cert `AF:73:EF:52...`) and the .exe (Authenticode, 1704-byte certificate table) are signed. The .deb had a GPG claim with a fingerprint under it and carries no signature at all; the .rpm has only a SHA256HEADER; the AppImage's `.sha256_sig` and `.sig_key` sections are all zero. Those three now show their SHA256, and `/dl/SHA256SUMS` holds all five.

Versions are per platform now, because v0.2.1 only has a .deb and an .apk.

ParamantOS appeared in three places, and the third only surfaced after the first two were fixed: the gate reports one source per dead URL. Named, not linked, until the 1.7 GB ISO is hosted.

New gate: `/dl/` lives in the docroot and not in git, so the hourly run range-requests every file against production.