### PR TITLE
Drop the Android APK and ParamantOS: nobody uses either

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -67,7 +67,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -150,7 +149,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -111,7 +111,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -194,7 +193,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -150,7 +150,6 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -233,7 +232,6 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -277,7 +277,6 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -360,7 +359,6 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -134,7 +134,6 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -217,7 +216,6 @@ section p+p{margin-top:14px}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -179,7 +179,6 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -262,7 +261,6 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -109,7 +109,6 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -192,7 +191,6 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -225,7 +225,6 @@ section h2{display:flex;align-items:baseline;gap:11px}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -308,7 +307,6 @@ section h2{display:flex;align-items:baseline;gap:11px}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -271,7 +271,6 @@ body { min-height:100vh; }
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -354,7 +353,6 @@ body { min-height:100vh; }
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -282,7 +282,6 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -381,7 +380,6 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -222,7 +222,6 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -305,7 +304,6 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -208,7 +208,6 @@ tr:last-child td{border-bottom:none}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -291,7 +290,6 @@ tr:last-child td{border-bottom:none}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>
@@ -372,7 +370,6 @@ tr:last-child td{border-bottom:none}
     <h3>paramant-client</h3>
     <a href="#client-deb">.deb install</a>
     <a href="#client-cli">CLI reference</a>
-    <a href="#paramant-os-tools">ParamantOS tools</a>
     <h3>Protocol</h3>
     <a href="#crypto">Crypto stack</a>
     <a href="#burn">Burn-on-read</a>
@@ -907,59 +904,6 @@ paramant-send --key pgp_xxx --sector health --ack scan.dcm
 
 <span class="cm"># Example: stream mode (process persists, receives all blobs)</span>
 paramant-stream --key pgp_xxx --sector health --forward https://pacs.hospital/api</pre>
-
-    <!-- ── ParamantOS CLI tools ───────────────────────────────────── -->
-    <h2 id="paramant-os-tools">ParamantOS: 39 operator tools</h2>
-    <!-- Linked to github.com/Apolloccrypt/ParamantOS, a private repository, so it was
-         404 for every reader. Not a link until the ISO is hosted here: the release is
-         a single 1.7 GB image, which is a bandwidth decision, not a copy job. -->
-    <p>ParamantOS is a hardened Linux distribution (NixOS + Mint editions) for relay operators. All 39 tools are pre-installed. Ask us for an image: <a href="mailto:privacy@paramant.app?subject=ParamantOS+image" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">privacy@paramant.app</a>.</p>
-    <table>
-      <tr><th>Category</th><th>Command</th><th>What it does</th></tr>
-      <tr><td rowspan="5" style="color:var(--ink-dim);font-size:11px;vertical-align:top;padding-top:12px">Setup &amp; diagnostics</td><td>paramant-setup</td><td>First-boot wizard: password, relay URL, API key</td></tr>
-      <tr><td>paramant-help</td><td>Full command reference</td></tr>
-      <tr><td>paramant-info</td><td>System overview: OS, relay version, uptime</td></tr>
-      <tr><td>paramant-doctor</td><td>Automated health check for relay + security</td></tr>
-      <tr><td>paramant-install</td><td>Interactive disk installer</td></tr>
-      <tr><td rowspan="7" style="color:var(--ink-dim);font-size:11px;vertical-align:top;padding-top:12px">Relay control</td><td>paramant-status</td><td>Relay health, version, edition, uptime</td></tr>
-      <tr><td>paramant-relay-setup</td><td>Clone relay repo + configure .env + start Docker</td></tr>
-      <tr><td>paramant-relay-ctl</td><td>Privileged relay service control (start/stop/reload)</td></tr>
-      <tr><td>paramant-restart</td><td>Restart the relay</td></tr>
-      <tr><td>paramant-dashboard</td><td>Live TUI dashboard: stats, connections, throughput</td></tr>
-      <tr><td>paramant-logs</td><td>Live relay log stream</td></tr>
-      <tr><td>paramant-update</td><td>Check for relay updates and show upgrade path</td></tr>
-      <tr><td rowspan="7" style="color:var(--ink-dim);font-size:11px;vertical-align:top;padding-top:12px">Sector tools</td><td>paramant-referral</td><td>Healthcare referral: NEN 7510, HL7 FHIR, DICOM</td></tr>
-      <tr><td>paramant-notary</td><td>Legal document transport: eIDAS, KNB notary</td></tr>
-      <tr><td>paramant-legal</td><td>Court document relay (replaces Zivver/e-Court)</td></tr>
-      <tr><td>paramant-payslip</td><td>HR payslip distribution: GDPR compliant bulk send</td></tr>
-      <tr><td>paramant-firmware</td><td>IoT/body cam firmware updates: IEC 62443</td></tr>
-      <tr><td>paramant-cra</td><td>Software supply chain relay: EU CRA 2027, SBOM</td></tr>
-      <tr><td>paramant-ticket</td><td>One-time transit ticket issuer and verifier</td></tr>
-      <tr><td rowspan="3" style="color:var(--ink-dim);font-size:11px;vertical-align:top;padding-top:12px">CT log &amp; verification</td><td>paramant-verify-sth</td><td>Verify ML-DSA-65 signed tree head against relay</td></tr>
-      <tr><td>paramant-receipt</td><td>View or verify a delivery receipt</td></tr>
-      <tr><td>paramant-verify-peers</td><td>Cross-check STH consistency across all peer relays</td></tr>
-      <tr><td rowspan="4" style="color:var(--ink-dim);font-size:11px;vertical-align:top;padding-top:12px">Key management</td><td>paramant-keys</td><td>List all API keys</td></tr>
-      <tr><td>paramant-key-add</td><td>Add a new API key</td></tr>
-      <tr><td>paramant-key-revoke</td><td>Revoke an API key</td></tr>
-      <tr><td>paramant-license</td><td>Show license status and upgrade path</td></tr>
-      <tr><td rowspan="4" style="color:var(--ink-dim);font-size:11px;vertical-align:top;padding-top:12px">Network</td><td>paramant-ip</td><td>IP addresses, interfaces, relay accessibility</td></tr>
-      <tr><td>paramant-ports</td><td>Firewall rules and listening ports</td></tr>
-      <tr><td>paramant-wifi</td><td>Interactive WiFi manager</td></tr>
-      <tr><td>paramant-scan</td><td>Discover paramant relay nodes via registry</td></tr>
-      <tr><td rowspan="4" style="color:var(--ink-dim);font-size:11px;vertical-align:top;padding-top:12px">Security</td><td>security-status</td><td>All security layers at a glance</td></tr>
-      <tr><td>paramant-security</td><td>Firewall, SSH, kernel hardening status</td></tr>
-      <tr><td>paramant-verify</td><td>Out-of-band TOFU fingerprint verification</td></tr>
-      <tr><td>paramant-hybrid-check</td><td>Verify relay hybrid post-quantum mode support</td></tr>
-      <tr><td rowspan="5" style="color:var(--ink-dim);font-size:11px;vertical-align:top;padding-top:12px">Backup &amp; data</td><td>paramant-backup</td><td>Backup relay keys and CT log</td></tr>
-      <tr><td>paramant-restore</td><td>Restore from backup</td></tr>
-      <tr><td>paramant-export</td><td>Export audit log to USB drive</td></tr>
-      <tr><td>paramant-data-ctl</td><td>Privileged relay data-dir management</td></tr>
-      <tr><td>paramant-cron</td><td>Manage systemd timers for relay maintenance</td></tr>
-    </table>
-    <!-- Both editions linked into the private ParamantOS repo and were 404. The
-         current release is v3.0.0 (one 1.7 GB ISO); v2.4.5 was the NixOS edition and
-         v1.0-mint the Mint one. Named, not linked, until the image is hosted here. -->
-    <p>ParamantOS editions: NixOS (v2.4.5) and Mint (v1.0-β), with v3.0.0 current. The images are not published for download yet, so <a href="mailto:privacy@paramant.app?subject=ParamantOS+image" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">ask us</a> for one.</p>
 
     <!-- ── Crypto stack ─────────────────────────────────────────── -->
     <h2 id="crypto">Crypto stack</h2>

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -160,7 +160,6 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -243,7 +242,6 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>
@@ -339,17 +337,19 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
     <div class="cmp-col" style="border-left:1px solid var(--ink-hair)">
       <!-- This column listed five things native does better and nothing it does
            worse, so it read as "native is the safe choice". It is not: the build
-           predates the traffic-analysis work. Two rows added for what it costs,
-           and the signing row corrected. Measured 2026-08-08: the .apk carries a
-           v1 + v2/v3 signature, the .exe is Authenticode-signed, and the .deb has
-           no _gpgorigin at all, so "GPG signed" was not true for it. -->
-      <div class="cmp-title native">NATIVE — March 2026 build</div>
+           predates the traffic-analysis work. Rows added for what it costs, and the
+           signing row corrected. Measured 2026-08-08: the .exe is Authenticode-signed
+           and the .deb has no _gpgorigin at all, so "GPG signed" was not true for it.
+           Desktop only now: the Android APK is gone, because there the app runs in
+           the Android System WebView and the "own process, no browser" argument does
+           not apply. -->
+      <div class="cmp-title native">NATIVE DESKTOP — March 2026 build</div>
       <div class="cmp-row"><span class="cmp-ok">OK</span>Rust drop() wist sleutels uit RAM</div>
       <div class="cmp-row"><span class="cmp-ok">OK</span>Geen browser — geen extensies</div>
       <div class="cmp-row"><span class="cmp-ok">OK</span>ML-KEM-768 + AES-256-GCM identiek</div>
       <div class="cmp-row"><span class="cmp-no">NO</span>Geen padding, geen jitter — verkeersanalyse mogelijk</div>
       <div class="cmp-row"><span class="cmp-no">NO</span>Mist 21 beschermingen die de web app heeft</div>
-      <div class="cmp-row"><span class="cmp-warn">!</span>.apk en .exe gesigneerd, .deb en .rpm niet</div>
+      <div class="cmp-row"><span class="cmp-warn">!</span>Alleen .exe gesigneerd, .deb en .rpm niet</div>
     </div>
   </div>
 
@@ -357,12 +357,11 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
        is privé, dus alle vijf gaven 404 voor iedere bezoeker die wij niet zijn. Ze
        worden nu vanaf deze server geserveerd (/dl/), zodat de repo privé kan blijven.
 
-       De versies lopen uiteen en dat staat er nu bij: v0.2.1 heeft alleen een .deb en
-       een .apk, dus Windows, RPM en AppImage zijn nog v0.2.0. Eén versienummer boven
-       de hele lijst zou over drie van de vijf liegen.
+       De versies lopen uiteen en dat staat er nu bij: v0.2.1 leverde alleen een .deb,
+       dus Windows en RPM en AppImage zijn nog v0.2.0. Eén versienummer boven de hele
+       lijst zou over drie van de vier liegen.
 
        Elke regel onder een knop is nagemeten op 2026-08-08, niet overgenomen:
-         .apk       v1 JAR-signature + APK Signing Block v2/v3, cert CN=Mick Beer
          .exe       Authenticode, certificate table 1704 bytes
          .deb       GEEN signature: geen _gpgorigin in het ar-archief. De kaart zei
                     "GPG-gesigneerd door Mick Beer / GPG: 6EF8E5AC...29A49B97", en dat
@@ -370,12 +369,13 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
          .rpm       GEEN signature: alleen SHA256HEADER in de signature-header
          .AppImage  GEEN signature: .sha256_sig en .sig_key bestaan maar zijn nul
                     (lege placeholders van appimagetool)
-       Volledige lijst: /dl/SHA256SUMS -->
-  <!-- Deze kop zei "v0.2.0 ⚠ VEROUDERD". Bij het uitsplitsen van de versies per
+       Volledige lijst: /dl/SHA256SUMS
+
+       Deze kop zei "v0.2.0 ⚠ VEROUDERD". Bij het uitsplitsen van de versies per
        platform is dat woord verdwenen, waardoor de enige waarschuwing nog boven de
        vergelijking stond. Terug, en met de reden erbij: de versienummers zijn het
        punt niet, de ontbrekende beschermingen zijn het. -->
-  <div class="section-label">// DOWNLOADS — ⚠ VEROUDERDE BUILD · .deb en .apk v0.2.1 · overige v0.2.0</div>
+  <div class="section-label">// DOWNLOADS DESKTOP — ⚠ VEROUDERDE BUILD · .deb v0.2.1 · overige v0.2.0</div>
   <div class="dl-grid">
     <a class="dl-card" href="/dl/paramant_0.2.1_amd64.deb">
       <div class="dl-platform">[LNX]</div>
@@ -413,25 +413,34 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
       <div class="dl-meta">5,8 MB</div>
       <div class="dl-signed">// Authenticode, self-signed</div>
     </a>
-    <a class="dl-card" href="/dl/PARAMANT-0.2.1-android.apk">
-      <div class="dl-platform">[APK]</div>
-      <div class="dl-name">Android</div>
-      <div class="dl-ext">.apk — Android 8.0+ (ARM64) · v0.2.1</div>
-      <div class="dl-desc">Tauri Mobile. Rust gecompileerd naar ARM64 + x86_64. APK signing v2+v3 scheme. Sideload: Instellingen -> Onbekende bronnen.</div>
-      <div class="dl-btn">[DL] .apk</div>
-      <div class="dl-meta">22,5 MB</div>
-      <div class="dl-signed">// v2+v3, cert AF:73:EF:52...8C:9E:92:4F</div>
+    <!-- De Android-knop wees naar de APK. Die is eraf, en niet omdat hij stuk was:
+         op Android draait de Tauri-app in de Android System WebView, net als de
+         browser, dus daar valt het argument "eigen proces, geen browser" weg. Wat
+         blijft is een build van maart die 21 beschermingen mist tegenover een
+         installeerbare web-app die ze alle heeft. Er is ook niemand die er iets aan
+         verliest: de knop gaf 404 zolang hij bestond, dus via deze site heeft nooit
+         iemand een APK gekregen.
+
+         Op desktop staat de afweging anders. Daar is het een eigen proces zonder
+         browser-extensies, en Rust drop() wist de sleutels uit RAM. Die drie knoppen
+         blijven dus staan. -->
+    <a class="dl-card" href="/" style="border:1px solid var(--cobalt)">
+      <div class="dl-platform">[PWA]</div>
+      <div class="dl-name">Android &amp; iOS</div>
+      <div class="dl-ext">geen installer — vanaf de site</div>
+      <div class="dl-desc">Open paramant.app op je telefoon en kies "Toevoegen aan beginscherm". Je krijgt een eigen app-venster zonder browserbalk, met alle beschermingen van de web app. Op mobiel is dit de actuele versie, niet een oudere build.</div>
+      <div class="dl-btn">Naar paramant.app &rarr;</div>
+      <div class="dl-meta">altijd actueel</div>
+      <div class="dl-signed">// via HTTPS, geen sideload nodig</div>
     </a>
   </div>
 
   <div style="background:var(--bone-2);border:1px solid var(--ink-hair);padding:16px;margin-bottom:24px;font-size:11px;line-height:1.8;color:var(--ink-dim)">
     <div style="color:var(--ink);font-size:10px;letter-spacing:.08em;margin-bottom:8px">// VERIFIEREN</div>
-    Alleen de .apk en de .exe dragen een signature. De .deb, .rpm en .AppImage niet, dus
-    daar is de SHA256 het enige dat je hebt. Controleer hem:<br>
-    <code style="color:var(--ink)">curl -sO https://paramant.app/dl/SHA256SUMS &amp;&amp; sha256sum -c SHA256SUMS --ignore-missing</code><br>
-    Het APK-certificaat is self-signed, vingerafdruk
-    <code style="color:var(--ink)">AF:73:EF:52:1A:FB:CC:16:10:71:6E:3B:A4:BD:77:98:29:6B:77:04:C6:6E:CC:0C:3D:14:FA:0D:8C:9E:92:4F</code>
-    (<code style="color:var(--ink)">apksigner verify --print-certs</code>).
+    Van de drie installers draagt alleen de .exe een signature (Authenticode,
+    self-signed). De .deb en de .rpm niet, dus daar is de SHA256 het enige dat je
+    hebt. Controleer hem:<br>
+    <code style="color:var(--ink)">curl -sO https://paramant.app/dl/SHA256SUMS &amp;&amp; sha256sum -c SHA256SUMS --ignore-missing</code>
     <a href="/dl/SHA256SUMS" style="color:var(--ink)">Alle checksums &rarr;</a>
   </div>
 
@@ -485,8 +494,8 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
       <div class="install-code">chmod +x paramant_0.2.0_amd64.AppImage<br>./paramant_0.2.0_amd64.AppImage</div>
     </div>
     <div class="install-card">
-      <div class="install-title">[APK] Android</div>
-      <div class="install-code">Instellingen -> Beveiliging -><br>Onbekende bronnen -> APK installeren</div>
+      <div class="install-title">[PWA] Android &amp; iOS</div>
+      <div class="install-code">paramant.app openen -><br>menu -> Toevoegen aan beginscherm</div>
     </div>
   </div>
 

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -185,7 +185,6 @@ input:focus{border-color:var(--cobalt)}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -268,7 +267,6 @@ input:focus{border-color:var(--cobalt)}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -175,7 +175,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -258,7 +257,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -234,7 +234,6 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -317,7 +316,6 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -134,7 +134,6 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -217,7 +216,6 @@ section p+p{margin-top:14px}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -193,7 +193,6 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -276,7 +275,6 @@ section p+p{margin-top:14px}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -297,7 +297,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -380,7 +379,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>
@@ -549,7 +547,7 @@
       <span class="p-job">Developers</span>
       <h3>Build on the core.</h3>
       <p>Open SDK in JavaScript and Python (Apache-2.0), a /v1 signing API, and a self-host installer. Run your own relay, or the whole OS.</p>
-      <p class="p-tags">paramant-sdk npm + PyPI &#183; /v1 signing API &#183; ParamantOS</p>
+      <p class="p-tags">paramant-sdk npm + PyPI &#183; /v1 signing API</p>
       <a class="p-link" href="/developer">Get an API key <span aria-hidden="true">&rarr;</span></a>
       <a class="p-link" href="/docs#v1-envelopes">Read the /v1 API docs <span aria-hidden="true">&rarr;</span></a>
     </li>

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -134,7 +134,6 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -217,7 +216,6 @@ section p+p{margin-top:14px}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -165,7 +165,6 @@ footer a{color:var(--cobalt)}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -248,7 +247,6 @@ footer a{color:var(--cobalt)}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/liveness.html
+++ b/frontend/liveness.html
@@ -100,7 +100,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -183,7 +182,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -134,7 +134,6 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -217,7 +216,6 @@ section p+p{margin-top:14px}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -162,7 +162,6 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -245,7 +244,6 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/ot-vs-data-diodes.html
+++ b/frontend/ot-vs-data-diodes.html
@@ -147,7 +147,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -230,7 +229,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -207,7 +207,6 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -290,7 +289,6 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/paraid-app.html
+++ b/frontend/paraid-app.html
@@ -100,7 +100,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -183,7 +182,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/paraid-document.html
+++ b/frontend/paraid-document.html
@@ -100,7 +100,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -183,7 +182,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/paraid.html
+++ b/frontend/paraid.html
@@ -100,7 +100,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -183,7 +182,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/pararules.html
+++ b/frontend/pararules.html
@@ -175,7 +175,6 @@ footer a{color:var(--ink);text-decoration:none}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -258,7 +257,6 @@ footer a{color:var(--ink);text-decoration:none}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -328,7 +328,6 @@ select:focus{border-color:var(--cobalt)}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -411,7 +410,6 @@ select:focus{border-color:var(--cobalt)}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -127,7 +127,6 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -210,7 +209,6 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -189,7 +189,6 @@ td{color:var(--cobalt)}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -272,7 +271,6 @@ td{color:var(--cobalt)}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -188,7 +188,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -271,7 +270,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -174,7 +174,6 @@ footer a{color:var(--ink);text-decoration:none}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -257,7 +256,6 @@ footer a{color:var(--ink);text-decoration:none}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/quantum-urgency.html
+++ b/frontend/quantum-urgency.html
@@ -147,7 +147,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -230,7 +229,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -111,7 +111,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -194,7 +193,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -197,7 +197,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -280,7 +279,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>
@@ -521,26 +519,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </div>
 
   <hr class="divider">
-
-  <h2>ParamantOS</h2>
-  <p>The official installer image for self-hosted relay deployments. Hardened NixOS with the relay pre-installed.</p>
-  <table class="table" style="margin-top:16px">
-    <thead><tr><th>Component</th><th>Configuration</th></tr></thead>
-    <tbody>
-      <tr><td>SSH KEX</td><td>mlkem768x25519-sha256 + curve25519 (ML-KEM FIPS 203)</td></tr>
-      <tr><td>SSH host key</td><td>Ed25519 only: no RSA, no ECDSA</td></tr>
-      <tr><td>SSH auth</td><td>Public key only: no passwords, no GSSAPI, no forwarding</td></tr>
-      <tr><td>Kernel</td><td>unprivileged_bpf_disabled=1, kptr_restrict=2, bpf_jit_harden=2</td></tr>
-      <tr><td>Firewall</td><td>Ports 22 + 3000–3004 only</td></tr>
-      <tr><td>Service isolation</td><td>Dedicated system user, systemd NoNewPrivileges, ProtectSystem=strict</td></tr>
-      <tr><td>CVEs mitigated</td><td>CVE-2023-51767, CVE-2025-26465, CVE-2025-26466, CVE-2025-32728</td></tr>
-    </tbody>
-  </table>
-  <!-- Was a link to the private ParamantOS repository, so it 404'd for every reader.
-       This one hid behind the docs.html copy in the first sweep: the gate reports one
-       source per dead URL, so a second page carrying the same link only surfaces once
-       the first is fixed. Fix by URL, then run the gate again. -->
-  <p style="margin-top:12px"><a href="mailto:privacy@paramant.app?subject=ParamantOS+image" rel="noopener">Ask us about ParamantOS &rarr;</a></p>
 
   <h2 id="customer-transparency">Customer transparency</h2>
   <p>Security is also about knowing what the vendor can and cannot do. The <a href="/trust">Trust &amp; Transparency page</a> documents, in plain terms, how license-check works, what Paramant can see of your relay (and what it never can), how to verify your deployment, and which remote actions are possible versus structurally impossible. Each claim there is tagged as live today or planned, with links to the public protocol specifications.</p>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -336,7 +336,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -419,7 +418,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -158,7 +158,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -241,7 +240,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -184,7 +184,6 @@ a:hover{opacity:.8}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -267,7 +266,6 @@ a:hover{opacity:.8}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -159,7 +159,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -242,7 +241,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -141,7 +141,6 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -224,7 +223,6 @@ section p+p{margin-top:14px}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -197,7 +197,6 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -280,7 +279,6 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -212,7 +212,6 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -295,7 +294,6 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -100,7 +100,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -183,7 +182,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -147,7 +147,6 @@
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -230,7 +229,6 @@
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -134,7 +134,6 @@ section p+p{margin-top:14px}
         <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
         <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
         <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="/download" role="menuitem">ParamantOS</a></li>
         <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
       </ul>
     </li>
@@ -217,7 +216,6 @@ section p+p{margin-top:14px}
       <a href="/install-pi.sh">install-pi.sh</a>
       <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
       <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="/download">ParamantOS</a>
       <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
     </div>
   </div>


### PR DESCRIPTION
Both were offered and neither was reachable: the buttons pointed into private repos and 404'd for every visitor.

**Android APK is gone, not fixed.** On Android the Tauri app runs in the Android System WebView, so the desktop argument (own process, no extensions, `Rust drop()`) does not apply. What remains is a March build missing 21 protections versus an installable web app that has all of them. Manifest, service worker and both icons are live, so the PWA card replaces the APK. The three desktop installers stay.

**ParamantOS out completely:** 48 nav entries, 48 plain links, the docs CLI-tools section, the security-page hardening table, one tag on the home page. That table described the image, so it went with it. If those SSH/kernel settings also describe our own relay it is worth saying, but only after measuring production.

APK removed from the server, SHA256SUMS regenerated for the four remaining files.