### PR TITLE
billing: collect a second period, and make paid_until survive a restart

### DIFF
--- a/relay/lib/billing-recurring.js
+++ b/relay/lib/billing-recurring.js
@@ -1,0 +1,204 @@
+'use strict';
+// The collecting half of billing. billing.js decides what a payment BOUGHT;
+// this decides whether the buyer will be asked again, and when.
+//
+// Why it is a separate file: billing.js is pure w.r.t. its dependencies and
+// runs on every webhook, including ones that grant nothing. Subscription
+// management is a different question with different failure modes (a network
+// call that may fail without costing the buyer his entitlement), so it lives
+// next to it rather than inside it, and the relay calls it after a grant.
+//
+// The whole point is one date. A first payment already covers the first period,
+// so a subscription created without an explicit startDate collects again
+// immediately and charges twice for a month the buyer has paid for. Every
+// function here exists to make that impossible to get wrong by accident.
+
+const catalog = require('./billing-catalog');
+
+// One Mollie customer per Paramant account, and one subscription per PRODUCT.
+// Per product, because ParaSend Pro and ParaSign Pro are bought separately and
+// cancelled separately; a single subscription field would make cancelling one
+// silently stop collecting for the other.
+const CUSTOMER_FIELD = 'mollie_customer_id';
+const PRODUCT_SUBSCRIPTION_FIELD = Object.freeze({
+  parasend: 'mollie_subscription_parasend',
+  parasign: 'mollie_subscription_parasign',
+});
+
+function subscriptionFieldOf(product) {
+  return PRODUCT_SUBSCRIPTION_FIELD[product] || null;
+}
+
+// Mollie wants YYYY-MM-DD in its own timezone terms. The paid period ends at an
+// instant; the subscription starts on that calendar day. Taking the UTC date is
+// deliberate: paid_until is computed in UTC by billing.periodEnd, so any other
+// reading would shift the first collection by a day.
+//
+// Two refusals, both of which produce a date that LOOKS fine and bills twice:
+//   * null/undefined/empty. `new Date(null)` is not NaN, it is 1 January 1970,
+//     so the naive check passes and the subscription starts 56 years ago.
+//   * any date not in the future. Mollie collects immediately on a startDate
+//     that has passed, which is the double charge this whole file exists to
+//     prevent. A period that has already ended cannot be the start of the next
+//     one, so this is always a bug upstream, never a case to paper over.
+function startDateFor(paidUntil, now) {
+  if (paidUntil === null || paidUntil === undefined || paidUntil === '') return null;
+  const d = paidUntil instanceof Date ? paidUntil : new Date(paidUntil);
+  if (Number.isNaN(d.getTime())) return null;
+  const at = now instanceof Date ? now.getTime() : (typeof now === 'number' ? now : Date.now());
+  if (d.getTime() <= at) return null;
+  return d.toISOString().slice(0, 10);
+}
+
+// The payload for POST /v2/customers/:id/subscriptions.
+//
+// Returns { error } instead of throwing when the order or the date cannot carry
+// a subscription, so a caller can refuse to create one rather than create a
+// wrong one. There is no default startDate on purpose: a missing paid_until is
+// an error, never "start today".
+function subscriptionPayload({ order, paidUntil, accountId, webhookUrl, mollieInterval, now }) {
+  if (!order || order.error) return { error: 'bad_order' };
+  const interval = mollieInterval(order.interval);
+  if (!interval) return { error: `no_interval:${order.interval}` };
+  const startDate = startDateFor(paidUntil, now);
+  if (!startDate) return { error: 'no_start_date' };
+  if (!accountId) return { error: 'no_account' };
+
+  return {
+    payload: {
+      amount: { currency: order.currency, value: order.amount },
+      interval,
+      startDate,
+      description: `Paramant ${order.product} ${order.plan} (${order.interval})`,
+      webhookUrl,
+      // The metadata a renewal webhook is attributed by. A subscription payment
+      // carries the subscription's metadata, not the first payment's, so
+      // leaving this out would make every renewal land as 'missing_metadata'
+      // and grant nothing: the customer would be charged and get nothing.
+      metadata: {
+        accountId,
+        product: order.product,
+        plan: order.plan,
+        interval: order.interval,
+      },
+    },
+  };
+}
+
+// Is this payment the one that creates the mandate? Mollie marks it, but an
+// older payment made before this code existed has no sequenceType at all, and
+// those must not be treated as recurring collections.
+function isFirstPayment(payment) {
+  const seq = payment && payment.sequenceType;
+  return seq === 'first' || seq === undefined || seq === null;
+}
+
+function isRecurringPayment(payment) {
+  return !!(payment && payment.sequenceType === 'recurring');
+}
+
+// After a grant: make sure the buyer will be asked again when the period ends.
+//
+// deps: {
+//   getAccount(accountId) -> record | null
+//   saveSubscription(accountId, product, subscriptionId) -> void   (async ok)
+//   mollie: { validMandates, createSubscription, mollieInterval }
+//   mode, webhookUrl
+// }
+// Returns { result, reason, subscriptionId? } and NEVER throws: a failure here
+// must not undo an entitlement the buyer has already paid for. The caller logs
+// the reason; 'error' level cases are the ones where money will not come in.
+async function ensureSubscription(payment, grant, deps) {
+  const d = deps || {};
+  const m = d.mollie || {};
+  const accountId = grant && grant.account;
+  const product = grant && grant.product;
+  if (!accountId || !product) return { result: 'skipped', reason: 'no_grant' };
+
+  // A renewal collected BY the subscription must never create a second one.
+  if (isRecurringPayment(payment)) return { result: 'skipped', reason: 'recurring_collection' };
+  if (!isFirstPayment(payment)) return { result: 'skipped', reason: `sequence_${payment && payment.sequenceType}` };
+
+  const field = subscriptionFieldOf(product);
+  if (!field) return { result: 'skipped', reason: 'unknown_product' };
+
+  const rec = typeof d.getAccount === 'function' ? await d.getAccount(accountId) : null;
+  if (rec && rec[field]) return { result: 'skipped', reason: 'already_subscribed', subscriptionId: rec[field] };
+
+  // The customer id can come from the payment itself (the checkout put it
+  // there) or from the account. The payment wins: it is what Mollie actually
+  // billed, so a stale account field can never point the subscription at the
+  // wrong customer.
+  const customerId = (payment && payment.customerId) || (rec && rec[CUSTOMER_FIELD]) || null;
+  if (!customerId) {
+    // Paid, granted, but nothing will ever be collected again. This is the case
+    // that quietly turns a subscription business back into a one-off shop.
+    return { result: 'failed', level: 'error', reason: 'no_customer_on_payment' };
+  }
+
+  // No mandate means no authority to collect. Creating the subscription anyway
+  // gives Mollie a 422 and leaves a broken record behind.
+  let mandates = [];
+  try { mandates = await m.validMandates(d.mode, customerId); }
+  catch (e) { return { result: 'failed', level: 'error', reason: `mandates_failed:${e.message}` }; }
+  if (!mandates.length) return { result: 'failed', level: 'error', reason: 'no_valid_mandate' };
+
+  const order = catalog.resolveOrder({
+    product,
+    plan: (payment && payment.metadata && payment.metadata.plan),
+    interval: (payment && payment.metadata && payment.metadata.interval),
+  });
+  const built = subscriptionPayload({
+    order,
+    paidUntil: grant.paidUntil,
+    accountId,
+    webhookUrl: d.webhookUrl,
+    mollieInterval: m.mollieInterval,
+    now: d.now,
+  });
+  if (built.error) return { result: 'failed', level: 'error', reason: `payload:${built.error}` };
+
+  let sub;
+  try { sub = await m.createSubscription(d.mode, customerId, built.payload); }
+  catch (e) { return { result: 'failed', level: 'error', reason: `create_failed:${e.message}` }; }
+  if (!sub || !sub.id) return { result: 'failed', level: 'error', reason: 'no_subscription_id' };
+
+  try { if (typeof d.saveSubscription === 'function') await d.saveSubscription(accountId, product, sub.id); }
+  catch (e) { return { result: 'created_unsaved', level: 'error', reason: `save_failed:${e.message}`, subscriptionId: sub.id }; }
+
+  return { result: 'created', level: 'info', subscriptionId: sub.id, startDate: built.payload.startDate };
+}
+
+// Cancelling stops the NEXT collection. It must not touch paid_until: the buyer
+// paid for the period he is in and keeps it to the end. Anything else would be
+// charging for time and then taking it back, which no EU consumer rule allows
+// and no customer would forgive.
+async function cancelForProduct(accountId, product, deps) {
+  const d = deps || {};
+  const m = d.mollie || {};
+  const field = subscriptionFieldOf(product);
+  if (!field) return { result: 'refused', reason: 'unknown_product' };
+
+  const rec = typeof d.getAccount === 'function' ? await d.getAccount(accountId) : null;
+  if (!rec) return { result: 'refused', reason: 'unknown_account' };
+  const subId = rec[field];
+  const customerId = rec[CUSTOMER_FIELD];
+  if (!subId) return { result: 'noop', reason: 'no_subscription' };
+  if (!customerId) return { result: 'refused', level: 'error', reason: 'no_customer' };
+
+  try { await m.cancelSubscription(d.mode, customerId, subId); }
+  catch (e) { return { result: 'failed', level: 'error', reason: `cancel_failed:${e.message}` }; }
+
+  // Clear the pointer only after Mollie confirmed, so a failed cancel does not
+  // leave the account thinking it has nothing to cancel.
+  try { if (typeof d.saveSubscription === 'function') await d.saveSubscription(accountId, product, null); }
+  catch (e) { return { result: 'cancelled_unsaved', level: 'error', reason: `save_failed:${e.message}` }; }
+
+  return { result: 'cancelled', level: 'info', reason: 'subscription_cancelled' };
+}
+
+module.exports = {
+  CUSTOMER_FIELD, PRODUCT_SUBSCRIPTION_FIELD, subscriptionFieldOf,
+  startDateFor, subscriptionPayload, isFirstPayment, isRecurringPayment,
+  ensureSubscription, cancelForProduct,
+};

--- a/relay/lib/billing.js
+++ b/relay/lib/billing.js
@@ -15,6 +15,36 @@
 
 const catalog = require('./billing-catalog');
 
+// How far a paid interval carries the entitlement. Calendar months and years,
+// not 30 or 365 days: a customer who pays on the 31st should renew on a date
+// they recognise, and the yearly plan must not drift a day per leap year.
+// Clamped to the last day of the target month, so 31 January plus one month is
+// 28 February and never 3 March.
+function periodEnd(from, interval) {
+  const start = from instanceof Date ? new Date(from.getTime()) : new Date(from);
+  if (Number.isNaN(start.getTime())) return null;
+  const months = interval === 'yearly' ? 12 : interval === 'monthly' ? 1 : 0;
+  if (!months) return null;
+  const day = start.getUTCDate();
+  const end = new Date(Date.UTC(
+    start.getUTCFullYear(), start.getUTCMonth() + months, 1,
+    start.getUTCHours(), start.getUTCMinutes(), start.getUTCSeconds(), start.getUTCMilliseconds(),
+  ));
+  const lastDay = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth() + 1, 0)).getUTCDate();
+  end.setUTCDate(Math.min(day, lastDay));
+  return end;
+}
+
+// A renewal extends from where the paid period currently ends, not from the day
+// the money happened to land. Paying three days early must add a month, not
+// throw three days away; a payment after a lapse starts from now, so a gap is
+// never retroactively covered.
+function extendFrom(currentPaidUntil, now) {
+  const cur = currentPaidUntil ? new Date(currentPaidUntil) : null;
+  if (!cur || Number.isNaN(cur.getTime())) return now;
+  return cur.getTime() > now.getTime() ? cur : now;
+}
+
 // deps: {
 //   setProductPlan(accountId, product, tier) -> { ok, ... }  (sync or async)
 //   isProcessed(paymentId) -> boolean                        (async; optional)
@@ -57,22 +87,41 @@ async function processPayment(payment, deps) {
         reason: `amount_mismatch paid=${paid}/${cur} expected=${order.amount}/${order.currency}`,
       };
     }
+    // The period this payment bought. Without it the grant never ends: Mollie is
+    // asked for a one-off payment, so no second collection follows, and the
+    // entitlement used to stay on the paid tier forever. An interval we cannot
+    // turn into a date is refused rather than granted open-endedly.
+    const now = d.now instanceof Date ? d.now : new Date();
+    const paidUntil = periodEnd(extendFrom(
+      typeof d.currentPaidUntil === 'function' ? await d.currentPaidUntil(accountId, product) : null,
+      now,
+    ), interval);
+    if (!paidUntil) {
+      return { result: 'refused', level: 'error', account: accountId, product, reason: `no_period_for_interval:${interval}` };
+    }
+
     // Grant ONLY this product's tier. setProductPlan never touches the other
     // product (rule: product A must not move product B).
     let set;
-    try { set = await d.setProductPlan(accountId, product, order.tier); }
+    try { set = await d.setProductPlan(accountId, product, order.tier, paidUntil); }
     catch (e) { set = { ok: false, reason: e.message }; }
     if (!set || !set.ok) {
       return { result: 'refused', level: 'error', account: accountId, product, reason: `grant_failed:${set && set.reason}` };
     }
     if (typeof d.markProcessed === 'function') { try { await d.markProcessed(payment.id, 'granted'); } catch { /* best effort */ } }
-    return { result: 'granted', level: 'info', account: accountId, product, tier: order.tier, reason: `${product}->${order.tier}` };
+    return {
+      result: 'granted', level: 'info', account: accountId, product, tier: order.tier,
+      paidUntil: paidUntil.toISOString(),
+      reason: `${product}->${order.tier} until ${paidUntil.toISOString().slice(0, 10)}`,
+    };
   }
 
   if (status === 'chargeback' || status === 'charged_back') {
     // Money reclaimed. Revoke: drop this product to its floor tier.
     const floor = catalog.floorTier(product);
-    try { await d.setProductPlan(accountId, product, floor); } catch { /* logged by caller via reason */ }
+    // null clears the period along with the tier: money reclaimed leaves no
+    // paid time on record.
+    try { await d.setProductPlan(accountId, product, floor, null); } catch { /* logged by caller via reason */ }
     if (typeof d.markProcessed === 'function') { try { await d.markProcessed(payment.id, 'revoked'); } catch { /* best effort */ } }
     return { result: 'revoked', level: 'warn', account: accountId, product, tier: floor, reason: 'chargeback' };
   }
@@ -107,4 +156,4 @@ function classifyFetchError(err) {
   return { retry: true, level: 'warn', reason: status ? `mollie_${status}` : (msg || 'fetch_error') };
 }
 
-module.exports = { processPayment, classifyFetchError };
+module.exports = { processPayment, classifyFetchError, periodEnd, extendFrom };

--- a/relay/lib/entitlements.js
+++ b/relay/lib/entitlements.js
@@ -87,6 +87,59 @@ const PRODUCT_PLAN_FIELD = Object.freeze({
   parasign: 'plan_parasign',
 });
 
+// The date a paid tier stops being paid for, per product. A tier without one is
+// a grant that never ends: before this field, a single 15 euro payment set
+// plan_parasend to 'pro' and nothing ever took it back, because Mollie is asked
+// for a one-off payment and there is no second collection. Both halves are
+// needed. The subscription makes the money come in again; this field makes the
+// entitlement stop when it does not. Without it, cancelling an subscription
+// leaves the buyer on the paid tier forever.
+//
+// Absent means "no paid period on record", which is the correct reading for a
+// free account and for every account that predates billing. It is NEVER read as
+// expired, so a missing field can not silently downgrade anyone.
+const PRODUCT_PAID_UNTIL_FIELD = Object.freeze({
+  parasend: 'paid_until_parasend',
+  parasign: 'paid_until_parasign',
+});
+
+// The tier a product falls back to when a paid period runs out. Mirrors
+// billing-catalog.floorTier; kept here too so the entitlement layer can answer
+// without importing the billing layer (the dependency runs the other way).
+function floorTierOf(product) {
+  return product === 'parasign' ? 'free' : 'community';
+}
+
+// Parse a stored paid-until value. Anything unparseable is treated as absent
+// rather than as expired, on the same no-silent-downgrade rule as the migration
+// helpers below: a corrupt date must not cost a paying customer their tier.
+function parsePaidUntil(value) {
+  if (!value) return null;
+  const t = Date.parse(value);
+  return Number.isNaN(t) ? null : t;
+}
+
+// The tier an account ACTUALLY has right now, which is the stored tier unless
+// its paid period has passed. Read paths should use this instead of reading
+// PRODUCT_PLAN_FIELD directly, so an expired subscription stops granting even
+// if no webhook, cron or admin ever came along to write the downgrade.
+// Returns { tier, expired, paidUntil }.
+function effectiveProductTier(rec, product, now) {
+  const field = PRODUCT_PLAN_FIELD[product];
+  if (!rec || !field) return { tier: floorTierOf(product), expired: false, paidUntil: null };
+  const stored = product === 'parasign'
+    ? normaliseParasignTier(rec[field])
+    : normaliseParasendTier(rec[field]);
+  const floor = floorTierOf(product);
+  const paidUntil = parsePaidUntil(rec[PRODUCT_PAID_UNTIL_FIELD[product]]);
+  // A floor tier can not expire, and no recorded period means no expiry to
+  // enforce (free accounts, and every account from before billing existed).
+  if (stored === floor || paidUntil === null) return { tier: stored, expired: false, paidUntil };
+  const at = typeof now === 'number' ? now : Date.now();
+  if (at >= paidUntil) return { tier: floor, expired: true, paidUntil };
+  return { tier: stored, expired: false, paidUntil };
+}
+
 // ── Admin per-product grant primitives ───────────────────────────────────────
 // These back the fine-grained admin path (POST /v2/admin/keys/set-product-plan)
 // so exactly ONE product's tier moves, with the unified `plan` and the other
@@ -113,14 +166,26 @@ function validateProductPlan(product, tier) {
 // normalised (idempotent), so passing an already-normalised value is safe.
 // Returns { field, tier, changed, parasignGranted }; `changed` reflects the
 // plan-field move only (an already-set access flag is not a plan change).
-function applyProductTier(rec, product, tier) {
+function applyProductTier(rec, product, tier, paidUntil) {
   const field = PRODUCT_PLAN_FIELD[product];
   const norm = product === 'parasign' ? normaliseParasignTier(tier) : normaliseParasendTier(tier);
   let changed = false;
   if (rec[field] !== norm) { rec[field] = norm; changed = true; }
   let parasignGranted = false;
   if (product === 'parasign' && norm !== 'free' && rec.parasign !== true) { rec.parasign = true; parasignGranted = true; }
-  return { field, tier: norm, changed, parasignGranted };
+  // The paid period travels with the tier it paid for. Landing on the floor
+  // clears it, so a revoked or lapsed account carries no stale date; passing
+  // undefined leaves whatever is there alone, which keeps every existing caller
+  // (admin grants, migrations) behaving exactly as before.
+  const untilField = PRODUCT_PAID_UNTIL_FIELD[product];
+  if (norm === floorTierOf(product)) {
+    if (rec[untilField] !== undefined) { delete rec[untilField]; changed = true; }
+  } else if (paidUntil !== undefined) {
+    const iso = paidUntil === null ? null : new Date(paidUntil).toISOString();
+    if (iso === null) { if (rec[untilField] !== undefined) { delete rec[untilField]; changed = true; } }
+    else if (rec[untilField] !== iso) { rec[untilField] = iso; changed = true; }
+  }
+  return { field, tier: norm, changed, parasignGranted, paidUntil: rec[untilField] || null };
 }
 
 // ── Migration: legacy single `plan` (+ parasign flag) -> per-product plan ─────
@@ -314,8 +379,10 @@ module.exports = {
   normaliseParasendTier,
   normaliseParasignTier,
   PRODUCT_PLAN_FIELD,
+  PRODUCT_PAID_UNTIL_FIELD,
   validateProductPlan,
   applyProductTier,
+  effectiveProductTier,
   getEntitlements,
   mergeAccountRecord,
   transfersQuota,

--- a/relay/lib/entitlements.js
+++ b/relay/lib/entitlements.js
@@ -291,11 +291,21 @@ const PARASIGN = Object.freeze(Object.fromEntries(
 // Missing per-product plan falls back to derivation from the legacy plan, so an
 // account never accidentally lands on the floor tier just because migration has
 // not run yet.
-function getEntitlements(account) {
+function getEntitlements(account, now) {
   const acct = (account && typeof account === 'object') ? account : { plan: account };
   const legacyPlan = acct.plan;
-  const psTier = normaliseParasendTier(acct.plan_parasend || derivePlanParasend(legacyPlan));
-  const pgTier = normaliseParasignTier(acct.plan_parasign || derivePlanParasign(legacyPlan, acct.parasign));
+  const psStored = normaliseParasendTier(acct.plan_parasend || derivePlanParasend(legacyPlan));
+  const pgStored = normaliseParasignTier(acct.plan_parasign || derivePlanParasign(legacyPlan, acct.parasign));
+  // The paid period decides here, at the one place every gate reads. Writing the
+  // date on the record is not enough on its own: without this the tier field
+  // still grants after the period is over, and an expired subscription keeps
+  // working until somebody happens to write a downgrade.
+  //
+  // A record with no period is never expired, so the legacy paths above and
+  // every account from before billing keep exactly the tier they had. Only a
+  // tier that was paid for, with a date that has passed, falls to its floor.
+  const psTier = effectiveProductTier({ plan_parasend: psStored, [PRODUCT_PAID_UNTIL_FIELD.parasend]: acct[PRODUCT_PAID_UNTIL_FIELD.parasend] }, 'parasend', now).tier;
+  const pgTier = effectiveProductTier({ plan_parasign: pgStored, [PRODUCT_PAID_UNTIL_FIELD.parasign]: acct[PRODUCT_PAID_UNTIL_FIELD.parasign] }, 'parasign', now).tier;
   return {
     parasend: PARASEND[psTier],
     parasign: PARASIGN[pgTier],

--- a/relay/lib/mollie.js
+++ b/relay/lib/mollie.js
@@ -70,4 +70,88 @@ async function getPayment(mode, id) {
   return r.body;
 }
 
-module.exports = { MOLLIE_HOST, billingMode, apiKeyFor, createPayment, getPayment };
+// ── Recurring ────────────────────────────────────────────────────────────────
+// A one-off payment collects once and never again. To bill every month or year
+// Mollie needs three things in order: a customer to hang the mandate on, a first
+// payment marked as such (paying it creates the mandate), and a subscription
+// that does the collecting from then on. Missing any one of them means the money
+// arrives exactly once, which is what happened here.
+
+// POST /v2/customers. The email is what the buyer sees on the Mollie receipt and
+// what support searches on; the account id in metadata is how a webhook without
+// payment metadata can still be attributed.
+async function createCustomer(mode, payload) {
+  const key = apiKeyFor(mode);
+  if (!key) throw new Error(`mollie_key_missing:${mode}`);
+  const r = await _request('POST', '/v2/customers', key, payload);
+  if (r.status !== 201) { const e = new Error('mollie_customer_failed'); e.status = r.status; e.body = r.body; throw e; }
+  return r.body;
+}
+
+// GET /v2/customers/:id. Used to check a stored customer id still exists before
+// reusing it; a deleted or foreign id must not silently break a checkout.
+async function getCustomer(mode, id) {
+  const key = apiKeyFor(mode);
+  if (!key) throw new Error(`mollie_key_missing:${mode}`);
+  const r = await _request('GET', `/v2/customers/${encodeURIComponent(id)}`, key, null);
+  if (r.status !== 200) { const e = new Error('mollie_customer_get_failed'); e.status = r.status; e.body = r.body; throw e; }
+  return r.body;
+}
+
+// GET /v2/customers/:id/mandates. Returns only the usable ones. A mandate is
+// what authorises collection; without a valid one a subscription cannot be
+// created, and 'pending' is not yet good enough to bill against.
+async function validMandates(mode, customerId) {
+  const key = apiKeyFor(mode);
+  if (!key) throw new Error(`mollie_key_missing:${mode}`);
+  const r = await _request('GET', `/v2/customers/${encodeURIComponent(customerId)}/mandates?limit=50`, key, null);
+  if (r.status !== 200) { const e = new Error('mollie_mandates_failed'); e.status = r.status; e.body = r.body; throw e; }
+  const list = (r.body && r.body._embedded && r.body._embedded.mandates) || [];
+  return list.filter((m) => m && m.status === 'valid');
+}
+
+// Mollie's interval vocabulary. Kept here so the rest of the codebase keeps
+// speaking 'monthly'/'yearly' and only this file knows the wire format.
+function mollieInterval(interval) {
+  if (interval === 'monthly') return '1 month';
+  if (interval === 'yearly') return '12 months';
+  return null;
+}
+
+// POST /v2/customers/:id/subscriptions.
+//
+// startDate matters more than it looks. The buyer has ALREADY paid for the first
+// period through the first payment. Without a startDate Mollie collects again
+// immediately and charges twice for the same month. So the subscription starts
+// on the day the paid period ends, which is exactly the paid_until the webhook
+// just computed.
+async function createSubscription(mode, customerId, payload) {
+  const key = apiKeyFor(mode);
+  if (!key) throw new Error(`mollie_key_missing:${mode}`);
+  const r = await _request('POST', `/v2/customers/${encodeURIComponent(customerId)}/subscriptions`, key, payload);
+  if (r.status !== 201) { const e = new Error('mollie_subscription_failed'); e.status = r.status; e.body = r.body; throw e; }
+  return r.body;
+}
+
+// DELETE /v2/customers/:id/subscriptions/:id. Cancelling stops future
+// collections; it does NOT refund or shorten the period already paid for, which
+// is why the entitlement keeps running until paid_until.
+async function cancelSubscription(mode, customerId, subscriptionId) {
+  const key = apiKeyFor(mode);
+  if (!key) throw new Error(`mollie_key_missing:${mode}`);
+  const r = await _request(
+    'DELETE',
+    `/v2/customers/${encodeURIComponent(customerId)}/subscriptions/${encodeURIComponent(subscriptionId)}`,
+    key, null);
+  // 200 is the cancel; 404 means it is already gone, which is the same outcome.
+  if (r.status !== 200 && r.status !== 404) {
+    const e = new Error('mollie_cancel_failed'); e.status = r.status; e.body = r.body; throw e;
+  }
+  return r.body || { status: 'canceled' };
+}
+
+module.exports = {
+  MOLLIE_HOST, billingMode, apiKeyFor, createPayment, getPayment,
+  createCustomer, getCustomer, validMandates, mollieInterval,
+  createSubscription, cancelSubscription,
+};

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -95,6 +95,7 @@ const parasignOpenApi = require('./lib/parasign-open-api'); // ParaSign Open Dev
 const billingCatalog  = require('./lib/billing-catalog');   // server-side price + entitlement map
 const mollie          = require('./lib/mollie');            // Mollie Payments API client
 const billing         = require('./lib/billing');           // Mollie webhook decision state machine
+const billingRecurring = require('./lib/billing-recurring'); // subscription + mandate layer
 const parasignStoreMod = require('./lib/parasign-store');    // durable encrypted /v1 side-store
 const parasignStamp = require('./lib/parasign-stamp');       // server-side PDF stamp-worker
 const tierGate         = require('./lib/tier-gate');         // per-tier feature gate (billing hardening)
@@ -1703,10 +1704,15 @@ function setProductPlan(accountId, product, tier, paidUntil) {
     entitlements.applyProductTier(_acct, product, norm, paidUntil);
     _acct.plan_updated = new Date().toISOString();
   }
+  // paidUntil is passed on to the DISK write as well. Without it the period
+  // lived only in memory: applyProductTier leaves the field alone when it is
+  // undefined, so users.json kept a bare tier and a relay restart handed every
+  // paying account an unbounded grant again. That is the bug this branch is
+  // for, surviving the very restart it was supposed to end.
   _mutateUsersJson(ud => {
     for (const entry of ud.api_keys) {
       if ((entry.account_id || entry.key) === accountId) {
-        entitlements.applyProductTier(entry, product, norm);
+        entitlements.applyProductTier(entry, product, norm, paidUntil);
         entry.plan_updated = new Date().toISOString();
       }
     }
@@ -1714,6 +1720,44 @@ function setProductPlan(accountId, product, tier, paidUntil) {
   }).then(() => log('info', 'billing_entitlement_set', { account: String(accountId).slice(0, 12), product, tier: norm, keys: members.size, changed, persisted: true }))
     .catch(we => log('warn', 'billing_entitlement_persist_failed', { err: we.message }));
   return { ok: true, product, tier: norm, keys: members.size, changed };
+}
+
+// ── Mollie pointers (customer + per-product subscription) ────────────────────
+// Where the recurring layer keeps its two ids. They live on the same records as
+// the entitlement fields, and on the same serialized users.json queue, so a
+// restart does not lose the link between an account and what it is subscribed
+// to. Written per ACCOUNT (every member key gets the same pointer), because a
+// customer belongs to the buyer, not to one of his keys.
+function _setMolliePointer(accountId, field, value) {
+  if (!accountId || !field) return { ok: false, reason: 'bad_args' };
+  const members = accountKeys.get(accountId) || (apiKeys.has(accountId) ? new Set([accountId]) : new Set());
+  for (const m of members) {
+    const mv = apiKeys.get(m);
+    if (!mv) continue;
+    if (value === null || value === undefined) delete mv[field];
+    else mv[field] = value;
+  }
+  const acct = accounts.get(accountId);
+  if (acct) { if (value === null || value === undefined) delete acct[field]; else acct[field] = value; }
+  _mutateUsersJson(ud => {
+    for (const entry of (ud.api_keys || [])) {
+      if ((entry.account_id || entry.key) === accountId) {
+        if (value === null || value === undefined) delete entry[field];
+        else entry[field] = value;
+      }
+    }
+    ud.updated = new Date().toISOString();
+  }).catch(we => log('warn', 'billing_pointer_persist_failed', { field, err: we.message }));
+  return { ok: true };
+}
+
+// The record the recurring layer reads its pointers from. Same resolution as
+// the entitlement path: the per-key record carries the fields, the accounts
+// summary is only a mirror.
+function _billingRecordOf(accountId) {
+  const members = accountKeys.get(accountId) || (apiKeys.has(accountId) ? new Set([accountId]) : new Set());
+  for (const m of members) { const mv = apiKeys.get(m); if (mv) return mv; }
+  return accounts.get(accountId) || null;
 }
 
 // Per-key persistence for the ParaSign entitlement toggle. Injected into
@@ -5094,13 +5138,45 @@ const server = http.createServer(async (req, res) => {
     const mode = mollie.billingMode();
     const origin = process.env.PARASIGN_PUBLIC_ORIGIN || 'https://paramant.app';
     try {
-      const payment = await mollie.createPayment(mode, {
+      // A Mollie customer, and a payment marked as the FIRST of a series. Both
+      // are required before Mollie will create a mandate, and without a mandate
+      // there is no authority to collect a second time: the payment succeeds,
+      // the tier is granted, and the money never comes in again. That is what
+      // made every sale a one-off.
+      //
+      // The customer is reused when the account already has one and Mollie still
+      // knows it. A stale or foreign id must not break a checkout, so a failed
+      // lookup falls through to creating a new one rather than erroring out: the
+      // buyer's payment matters more than tidiness in our own records.
+      let customerId = null;
+      try {
+        const _rec = _billingRecordOf(accountId);
+        const stored = _rec && _rec[billingRecurring.CUSTOMER_FIELD];
+        if (stored) {
+          try { const c = await mollie.getCustomer(mode, stored); if (c && c.id) customerId = c.id; }
+          catch { customerId = null; }
+        }
+        if (!customerId) {
+          const created = await mollie.createCustomer(mode, {
+            name: (_rec && _rec.label) || undefined,
+            email: (_rec && _rec.email) || undefined,
+            metadata: { accountId },
+          });
+          if (created && created.id) { customerId = created.id; _setMolliePointer(accountId, billingRecurring.CUSTOMER_FIELD, created.id); }
+        }
+      } catch (ce) {
+        // No customer means no mandate means no renewal. The sale still goes
+        // through as a one-off rather than failing in the buyer's face, but this
+        // is an alert: money will come in once and never again.
+        log('error', 'billing_customer_failed', { account: String(accountId).slice(0, 12), err: ce.message, status: ce.status });
+      }
+      const payment = await mollie.createPayment(mode, Object.assign({
         amount: { currency: order.currency, value: order.amount },
         description: `Paramant ${order.product} ${order.plan} (${order.interval})`,
         redirectUrl: `${origin}/dashboard?billing=return`,
         webhookUrl: `${origin}/v2/billing/webhook`,
         metadata: { accountId, product: order.product, plan: order.plan, interval: order.interval },
-      });
+      }, customerId ? { customerId, sequenceType: 'first' } : {}));
       const checkoutUrl = payment && payment._links && payment._links.checkout && payment._links.checkout.href;
       log('info', 'billing_checkout_created', { account: String(accountId).slice(0, 12), product: order.product, plan: order.plan, interval: order.interval, payment_id: payment && payment.id, mode });
       res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -5156,6 +5232,27 @@ const server = http.createServer(async (req, res) => {
       isProcessed: async (id) => { if (!_rok()) return false; try { return !!(await redisClient.get(_idemKey(id))); } catch { return false; } },
       markProcessed: async (id, val) => { if (!_rok()) return; try { await redisClient.set(_idemKey(id), String(val), { EX: 60 * 86400 }); } catch { /* best effort */ } },
     });
+    // The collecting half. A grant only says what this payment bought; without
+    // a subscription nothing asks for the next period. Deliberately AFTER the
+    // grant and never able to undo it: a buyer who paid keeps what he paid for
+    // even if Mollie refuses the subscription, and the error level is the
+    // signal that this account will not renew by itself.
+    if (outcome.result === 'granted') {
+      const sub = await billingRecurring.ensureSubscription(payment, outcome, {
+        mode,
+        webhookUrl: `${process.env.PARASIGN_PUBLIC_ORIGIN || 'https://paramant.app'}/v2/billing/webhook`,
+        getAccount: (aid) => _billingRecordOf(aid),
+        saveSubscription: (aid, product, id) => _setMolliePointer(aid, billingRecurring.subscriptionFieldOf(product), id),
+        mollie,
+      });
+      if (sub.result !== 'skipped') {
+        log(sub.level || 'info', 'billing_subscription', {
+          payment_id: paymentId, account: String(outcome.account).slice(0, 12),
+          product: outcome.product, result: sub.result, reason: sub.reason,
+          subscription_id: sub.subscriptionId, start_date: sub.startDate,
+        });
+      }
+    }
     // Monitoring: log every webhook with payment-id, status and outcome. The
     // 'error' level marks the alert cases (paid but no entitlement: amount
     // mismatch, missing metadata, or a grant that failed).
@@ -5165,6 +5262,44 @@ const server = http.createServer(async (req, res) => {
       product: outcome.product, reason: outcome.reason,
     });
     res.writeHead(200, { 'Content-Type': 'application/json' }); return res.end(J({ ok: true }));
+  }
+
+  // ── POST /v2/billing/cancel — stop the next collection (authenticated) ──────
+  // Selling a subscription without a way to end it is not allowed in the EU, and
+  // it is the first thing a buyer looks for before he buys. Cancelling stops the
+  // NEXT collection only: paid_until is untouched, so the period already paid
+  // for runs to its end and the tier goes with it. Anything else would be taking
+  // back time that was bought.
+  if (path === '/v2/billing/cancel' && req.method === 'POST') {
+    if (!keyData) { res.writeHead(401, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'unauthorized' })); }
+    const accountId = acctOf(apiKey);
+    let body;
+    try { body = JSON.parse((await readBody(req, 1024)).toString() || '{}'); }
+    catch { res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'bad_json' })); }
+    const product = body && body.product;
+    if (!billingRecurring.subscriptionFieldOf(product)) {
+      res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'unknown_product' }));
+    }
+    const mode = mollie.billingMode();
+    const out = await billingRecurring.cancelForProduct(accountId, product, {
+      mode,
+      getAccount: (aid) => _billingRecordOf(aid),
+      saveSubscription: (aid, p, id) => _setMolliePointer(aid, billingRecurring.subscriptionFieldOf(p), id),
+      mollie,
+    });
+    log(out.level || 'info', 'billing_cancel', {
+      account: String(accountId).slice(0, 12), product, result: out.result, reason: out.reason, mode,
+    });
+    if (out.result === 'failed' || out.result === 'refused') {
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      return res.end(J({ error: 'cancel_failed', reason: out.reason }));
+    }
+    // What the buyer needs to see: nothing more will be collected, and until
+    // when he still has what he paid for.
+    const _rec = _billingRecordOf(accountId);
+    const until = (_rec && _rec[entitlements.PRODUCT_PAID_UNTIL_FIELD[product]]) || null;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    return res.end(J({ ok: true, cancelled: out.result === 'cancelled', product, access_until: until }));
   }
 
   // ── POST /v2/admin/keys/update-plan ─────────────────────────────────────────

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1676,7 +1676,10 @@ function grantParasignOnPaidPlan(accountId) {
 // fan-out + users.json persistence. Idempotent (a repeat call with the same tier
 // changes nothing -> changed:0). For parasign it also flips the `parasign` access
 // flag on when the tier is paid (non-free). NEVER touches the other product.
-function setProductPlan(accountId, product, tier) {
+// paidUntil travels with the tier: a Date (or ISO string) sets the period this
+// grant is paid for, null clears it, and undefined leaves whatever is on record
+// alone. That last case keeps every admin grant behaving exactly as before.
+function setProductPlan(accountId, product, tier, paidUntil) {
   if (!accountId || (product !== 'parasend' && product !== 'parasign')) return { ok: false, reason: 'bad_args' };
   const norm = product === 'parasign'
     ? entitlements.normaliseParasignTier(tier)
@@ -1689,7 +1692,7 @@ function setProductPlan(accountId, product, tier) {
     if (!mv) continue;
     // Single field-level rule (writes only this product's field + the parasign
     // access flag; never the other product or the unified `plan`).
-    if (entitlements.applyProductTier(mv, product, norm).changed) changed++;
+    if (entitlements.applyProductTier(mv, product, norm, paidUntil).changed) changed++;
   }
   // Mirror onto the accounts summary too. Readers that only hold an account_id
   // (the ParaSign web sign gate among them) resolve through entitlementRecordOf,
@@ -1697,7 +1700,7 @@ function setProductPlan(accountId, product, tier) {
   // outvote a paid grant on any future read path either.
   const _acct = accounts.get(accountId);
   if (_acct) {
-    entitlements.applyProductTier(_acct, product, norm);
+    entitlements.applyProductTier(_acct, product, norm, paidUntil);
     _acct.plan_updated = new Date().toISOString();
   }
   _mutateUsersJson(ud => {
@@ -5144,6 +5147,12 @@ const server = http.createServer(async (req, res) => {
     const _idemKey = (id) => `paramant:billing:done:${id}`;
     const outcome = await billing.processPayment(payment, {
       setProductPlan,
+      // Lets a renewal extend from where the paid period ends instead of from
+      // the day the money landed, so paying early never costs the buyer days.
+      currentPaidUntil: async (accountId, product) => {
+        const rec = accounts.get(accountId);
+        return (rec && rec[entitlements.PRODUCT_PAID_UNTIL_FIELD[product]]) || null;
+      },
       isProcessed: async (id) => { if (!_rok()) return false; try { return !!(await redisClient.get(_idemKey(id))); } catch { return false; } },
       markProcessed: async (id, val) => { if (!_rok()) return; try { await redisClient.set(_idemKey(id), String(val), { EX: 60 * 86400 }); } catch { /* best effort */ } },
     });

--- a/relay/test/billing-recurring.test.js
+++ b/relay/test/billing-recurring.test.js
@@ -1,0 +1,301 @@
+'use strict';
+// Unit tests for the collecting half of billing (relay/lib/billing-recurring.js).
+// The rules this guards, in the order they cost money if broken:
+//   1. a subscription starts on the day the paid period ENDS, never today
+//   2. a renewal collected by the subscription never creates a second one
+//   3. cancelling stops the next collection and leaves the paid period alone
+//   4. a renewal webhook extends the period instead of overwriting it
+//   5. a chargeback wipes the period with the tier
+// Rules 4 and 5 live in billing.js; they are asserted here too because the two
+// halves only work as a pair, and a change to either one breaks the pair.
+// Run: node relay/test/billing-recurring.test.js (exits non-zero on failure).
+
+const assert = require('assert');
+const rec = require('../lib/billing-recurring');
+const billing = require('../lib/billing');
+const catalog = require('../lib/billing-catalog');
+
+let passed = 0;
+const pending = [];
+function test(name, fn) {
+  const run = async () => {
+    try { await fn(); passed++; console.log(`ok   ${name}`); }
+    catch (e) { console.error(`FAIL ${name}\n     ${e.message}`); process.exitCode = 1; }
+  };
+  pending.push(run);
+}
+
+const PLAN = { product: 'parasign', plan: 'pro', interval: 'monthly' };
+const ORDER = catalog.resolveOrder(PLAN);
+const PAID_UNTIL = new Date('2026-10-01T12:00:00.000Z');
+
+const mollieFake = (over) => Object.assign({
+  mollieInterval: (i) => (i === 'monthly' ? '1 month' : i === 'yearly' ? '12 months' : null),
+  validMandates: async () => [{ id: 'mdt_1', status: 'valid' }],
+  createSubscription: async (mode, cust, payload) => ({ id: 'sub_1', _payload: payload, _cust: cust }),
+  cancelSubscription: async () => ({ status: 'canceled' }),
+}, over);
+
+const paidPayment = (over) => Object.assign({
+  id: 'tr_first', status: 'paid', sequenceType: 'first', customerId: 'cst_1',
+  amount: { value: ORDER.amount, currency: 'EUR' },
+  metadata: { accountId: 'acct_1', ...PLAN },
+}, over);
+
+const grant = (over) => Object.assign({
+  result: 'granted', account: 'acct_1', product: 'parasign', tier: 'pro', paidUntil: PAID_UNTIL,
+}, over);
+
+// ── 1. the date that costs a double charge ───────────────────────────────────
+
+test('the subscription starts on the day the paid period ends, not today', () => {
+  const built = rec.subscriptionPayload({
+    order: ORDER, paidUntil: PAID_UNTIL, accountId: 'acct_1',
+    webhookUrl: 'https://paramant.app/v2/billing/webhook',
+    mollieInterval: mollieFake().mollieInterval,
+  });
+  assert.ok(!built.error, `payload refused: ${built.error}`);
+  assert.strictEqual(built.payload.startDate, '2026-10-01');
+  assert.strictEqual(built.payload.interval, '1 month');
+});
+
+test('a missing paid_until refuses the payload instead of starting today', () => {
+  const built = rec.subscriptionPayload({
+    order: ORDER, paidUntil: null, accountId: 'acct_1',
+    mollieInterval: mollieFake().mollieInterval,
+  });
+  assert.strictEqual(built.error, 'no_start_date');
+  assert.strictEqual(built.payload, undefined);
+});
+
+test('an unparseable paid_until refuses too', () => {
+  assert.strictEqual(rec.startDateFor('not a date'), null);
+  const built = rec.subscriptionPayload({
+    order: ORDER, paidUntil: 'not a date', accountId: 'acct_1',
+    mollieInterval: mollieFake().mollieInterval,
+  });
+  assert.strictEqual(built.error, 'no_start_date');
+});
+
+// The trap that the first version of this file walked straight into: new
+// Date(null) is 1 January 1970, not an invalid date, so a NaN check alone lets
+// a startDate 56 years in the past through and Mollie collects at once.
+test('null is refused because new Date(null) is 1970, not an invalid date', () => {
+  assert.strictEqual(new Date(null).getTime(), 0, 'sanity: new Date(null) is the epoch, not NaN');
+  assert.strictEqual(rec.startDateFor(null), null);
+  assert.strictEqual(rec.startDateFor(undefined), null);
+  assert.strictEqual(rec.startDateFor(''), null);
+});
+
+test('a startDate that is not in the future is refused: Mollie would collect at once', () => {
+  const now = new Date('2026-09-01T00:00:00.000Z');
+  assert.strictEqual(rec.startDateFor(new Date('2026-08-31T23:59:59.000Z'), now), null);
+  assert.strictEqual(rec.startDateFor(now, now), null, 'the exact present is not a future start');
+  assert.strictEqual(rec.startDateFor(new Date('2026-09-01T00:00:01.000Z'), now), '2026-09-01');
+});
+
+test('an already expired period cannot become the start of the next one', async () => {
+  let created = 0;
+  const r = await rec.ensureSubscription(paidPayment(), grant({ paidUntil: new Date('2026-01-01T00:00:00.000Z') }), {
+    mode: 'test', now: new Date('2026-09-01T00:00:00.000Z'),
+    getAccount: async () => ({}), saveSubscription: async () => {},
+    mollie: mollieFake({ createSubscription: async () => { created++; return { id: 'sub_x' }; } }),
+  });
+  assert.strictEqual(r.result, 'failed');
+  assert.strictEqual(r.reason, 'payload:no_start_date');
+  assert.strictEqual(created, 0, 'a subscription was created that would bill immediately');
+});
+
+test('the subscription carries the metadata a renewal is attributed by', () => {
+  const built = rec.subscriptionPayload({
+    order: ORDER, paidUntil: PAID_UNTIL, accountId: 'acct_1',
+    mollieInterval: mollieFake().mollieInterval,
+  });
+  assert.deepStrictEqual(built.payload.metadata, {
+    accountId: 'acct_1', product: 'parasign', plan: 'pro', interval: 'monthly',
+  });
+});
+
+test('an interval Mollie does not speak refuses the payload', () => {
+  const built = rec.subscriptionPayload({
+    order: { ...ORDER, interval: 'weekly' }, paidUntil: PAID_UNTIL, accountId: 'acct_1',
+    mollieInterval: mollieFake().mollieInterval,
+  });
+  assert.strictEqual(built.error, 'no_interval:weekly');
+});
+
+// ── 2. never a second subscription ───────────────────────────────────────────
+
+test('a recurring collection does not create another subscription', async () => {
+  let created = 0;
+  const r = await rec.ensureSubscription(
+    paidPayment({ id: 'tr_renewal', sequenceType: 'recurring' }), grant(),
+    { mode: 'test', getAccount: async () => ({}), mollie: mollieFake({ createSubscription: async () => { created++; return { id: 'sub_x' }; } }) },
+  );
+  assert.strictEqual(r.result, 'skipped');
+  assert.strictEqual(r.reason, 'recurring_collection');
+  assert.strictEqual(created, 0, 'a renewal created a second subscription');
+});
+
+test('an account that already has a subscription for this product is left alone', async () => {
+  let created = 0;
+  const r = await rec.ensureSubscription(paidPayment(), grant(), {
+    mode: 'test',
+    getAccount: async () => ({ mollie_subscription_parasign: 'sub_existing' }),
+    mollie: mollieFake({ createSubscription: async () => { created++; return { id: 'sub_x' }; } }),
+  });
+  assert.strictEqual(r.result, 'skipped');
+  assert.strictEqual(r.subscriptionId, 'sub_existing');
+  assert.strictEqual(created, 0);
+});
+
+test('a subscription for the OTHER product does not block this one', async () => {
+  const r = await rec.ensureSubscription(paidPayment(), grant(), {
+    mode: 'test',
+    getAccount: async () => ({ mollie_subscription_parasend: 'sub_send' }),
+    saveSubscription: async () => {},
+    mollie: mollieFake(),
+  });
+  assert.strictEqual(r.result, 'created');
+  assert.strictEqual(r.subscriptionId, 'sub_1');
+});
+
+// ── 3. the failure modes that must not cost an entitlement ───────────────────
+
+test('a first payment without a customer id is flagged, not thrown', async () => {
+  const r = await rec.ensureSubscription(paidPayment({ customerId: null }), grant(), {
+    mode: 'test', getAccount: async () => ({}), mollie: mollieFake(),
+  });
+  assert.strictEqual(r.result, 'failed');
+  assert.strictEqual(r.level, 'error');
+  assert.strictEqual(r.reason, 'no_customer_on_payment');
+});
+
+test('no valid mandate refuses rather than creating a subscription Mollie will reject', async () => {
+  let created = 0;
+  const r = await rec.ensureSubscription(paidPayment(), grant(), {
+    mode: 'test', getAccount: async () => ({}),
+    mollie: mollieFake({
+      validMandates: async () => [],
+      createSubscription: async () => { created++; return { id: 'sub_x' }; },
+    }),
+  });
+  assert.strictEqual(r.result, 'failed');
+  assert.strictEqual(r.reason, 'no_valid_mandate');
+  assert.strictEqual(created, 0);
+});
+
+test('a Mollie failure is reported, never thrown at the webhook', async () => {
+  const r = await rec.ensureSubscription(paidPayment(), grant(), {
+    mode: 'test', getAccount: async () => ({}),
+    mollie: mollieFake({ createSubscription: async () => { throw new Error('mollie_subscription_failed'); } }),
+  });
+  assert.strictEqual(r.result, 'failed');
+  assert.ok(r.reason.startsWith('create_failed:'), r.reason);
+});
+
+test('the customer id on the payment beats a stale one on the account', async () => {
+  let billedCustomer = null;
+  await rec.ensureSubscription(paidPayment({ customerId: 'cst_fresh' }), grant(), {
+    mode: 'test',
+    getAccount: async () => ({ mollie_customer_id: 'cst_stale' }),
+    saveSubscription: async () => {},
+    mollie: mollieFake({ createSubscription: async (m, cust) => { billedCustomer = cust; return { id: 'sub_1' }; } }),
+  });
+  assert.strictEqual(billedCustomer, 'cst_fresh');
+});
+
+// ── 4. cancelling ────────────────────────────────────────────────────────────
+
+test('cancelling stops the collection and leaves the paid period untouched', async () => {
+  const account = { mollie_customer_id: 'cst_1', mollie_subscription_parasign: 'sub_1', paid_until_parasign: PAID_UNTIL.toISOString(), plan_parasign: 'pro' };
+  const r = await rec.cancelForProduct('acct_1', 'parasign', {
+    mode: 'test',
+    getAccount: async () => account,
+    saveSubscription: async (a, p, id) => { account[rec.subscriptionFieldOf(p)] = id; },
+    mollie: mollieFake(),
+  });
+  assert.strictEqual(r.result, 'cancelled');
+  assert.strictEqual(account.mollie_subscription_parasign, null, 'the subscription pointer was not cleared');
+  assert.strictEqual(account.paid_until_parasign, PAID_UNTIL.toISOString(), 'cancelling shortened the paid period');
+  assert.strictEqual(account.plan_parasign, 'pro', 'cancelling downgraded the tier immediately');
+});
+
+test('a failed cancel keeps the pointer, so the next attempt still finds it', async () => {
+  const account = { mollie_customer_id: 'cst_1', mollie_subscription_parasign: 'sub_1' };
+  const r = await rec.cancelForProduct('acct_1', 'parasign', {
+    mode: 'test',
+    getAccount: async () => account,
+    saveSubscription: async (a, p, id) => { account[rec.subscriptionFieldOf(p)] = id; },
+    mollie: mollieFake({ cancelSubscription: async () => { throw new Error('mollie_cancel_failed'); } }),
+  });
+  assert.strictEqual(r.result, 'failed');
+  assert.strictEqual(account.mollie_subscription_parasign, 'sub_1');
+});
+
+test('cancelling what was never subscribed is a no-op, not an error', async () => {
+  const r = await rec.cancelForProduct('acct_1', 'parasign', {
+    mode: 'test', getAccount: async () => ({ mollie_customer_id: 'cst_1' }), mollie: mollieFake(),
+  });
+  assert.strictEqual(r.result, 'noop');
+  assert.strictEqual(r.reason, 'no_subscription');
+});
+
+// ── 5. the pair: what billing.js must keep doing for this to hold ────────────
+
+test('a renewal webhook extends the period instead of overwriting it', async () => {
+  // Paying three days before the period ends must add a month to the END, not
+  // throw those three days away.
+  const current = new Date('2026-10-01T12:00:00.000Z');
+  const now = new Date('2026-09-28T09:00:00.000Z');
+  let granted = null;
+  const out = await billing.processPayment(paidPayment({ id: 'tr_renew', sequenceType: 'recurring' }), {
+    now,
+    currentPaidUntil: async () => current.toISOString(),
+    setProductPlan: async (a, p, t, until) => { granted = until; return { ok: true }; },
+  });
+  assert.strictEqual(out.result, 'granted');
+  assert.strictEqual(granted.toISOString(), '2026-11-01T12:00:00.000Z',
+    'the renewal did not extend from the end of the running period');
+});
+
+test('a payment after a lapse starts from today, not from the old end', async () => {
+  const lapsed = new Date('2026-07-01T12:00:00.000Z');
+  const now = new Date('2026-09-28T09:00:00.000Z');
+  let granted = null;
+  await billing.processPayment(paidPayment({ id: 'tr_late' }), {
+    now,
+    currentPaidUntil: async () => lapsed.toISOString(),
+    setProductPlan: async (a, p, t, until) => { granted = until; return { ok: true }; },
+  });
+  assert.strictEqual(granted.toISOString(), '2026-10-28T09:00:00.000Z',
+    'a gap was retroactively covered');
+});
+
+test('a chargeback wipes the paid period along with the tier', async () => {
+  let seen = { tier: undefined, until: undefined };
+  const out = await billing.processPayment(paidPayment({ id: 'tr_cb', status: 'chargeback' }), {
+    setProductPlan: async (a, p, tier, until) => { seen = { tier, until }; return { ok: true }; },
+  });
+  assert.strictEqual(out.result, 'revoked');
+  assert.strictEqual(seen.tier, catalog.floorTier('parasign'));
+  assert.strictEqual(seen.until, null, 'a chargeback left paid time on record');
+});
+
+test('the same payment id twice grants once', async () => {
+  const done = new Set();
+  let grants = 0;
+  const deps = {
+    setProductPlan: async () => { grants++; return { ok: true }; },
+    isProcessed: async (id) => done.has(id),
+    markProcessed: async (id) => { done.add(id); },
+  };
+  await billing.processPayment(paidPayment({ id: 'tr_dup' }), deps);
+  await billing.processPayment(paidPayment({ id: 'tr_dup' }), deps);
+  assert.strictEqual(grants, 1, 'a replayed webhook granted twice');
+});
+
+(async () => {
+  for (const run of pending) await run();
+  console.log(`\nbilling-recurring: ${passed} checks passed`);
+})();

--- a/relay/test/entitlements-paid-until.test.js
+++ b/relay/test/entitlements-paid-until.test.js
@@ -184,3 +184,38 @@ test('a chargeback clears the period along with the tier', async () => {
   assert.strictEqual(got.t, 'community');
   assert.strictEqual(got.until, null);
 });
+
+// ── The gate: getEntitlements must honour the period ─────────────────────────
+// Writing the date on the record is not enough. Every quota and limit in the
+// product comes out of getEntitlements, so if that function ignores the period,
+// an expired subscription keeps working until somebody writes a downgrade.
+
+test('an expired paid tier grants free-tier quotas at the gate', () => {
+  const at = Date.parse('2026-10-01T00:00:00Z');
+  const live = ent.getEntitlements({ plan_parasend: 'pro', paid_until_parasend: '2026-11-01T00:00:00.000Z' }, at);
+  const dead = ent.getEntitlements({ plan_parasend: 'pro', paid_until_parasend: '2026-09-01T00:00:00.000Z' }, at);
+  assert.strictEqual(live.parasend.tier, 'pro');
+  assert.strictEqual(dead.parasend.tier, 'community');
+  assert.ok(dead.parasend.quotas.transfers_month < live.parasend.quotas.transfers_month);
+});
+
+test('an account from before billing keeps its tier at the gate', () => {
+  const at = Date.parse('2026-10-01T00:00:00Z');
+  assert.strictEqual(ent.getEntitlements({ plan_parasend: 'pro' }, at).parasend.tier, 'pro');
+  assert.strictEqual(ent.getEntitlements({ plan: 'pro' }, at).parasend.tier, 'pro');
+});
+
+test('expiry on one product leaves the other alone at the gate', () => {
+  const at = Date.parse('2026-10-01T00:00:00Z');
+  const e = ent.getEntitlements({
+    plan_parasend: 'pro', paid_until_parasend: '2026-09-01T00:00:00.000Z',
+    plan_parasign: 'business', paid_until_parasign: '2026-11-01T00:00:00.000Z',
+  }, at);
+  assert.strictEqual(e.parasend.tier, 'community');
+  assert.strictEqual(e.parasign.tier, 'business');
+});
+
+test('the gate without a clock still answers, using now', () => {
+  const e = ent.getEntitlements({ plan_parasign: 'pro' });
+  assert.strictEqual(e.parasign.tier, 'pro');
+});

--- a/relay/test/entitlements-paid-until.test.js
+++ b/relay/test/entitlements-paid-until.test.js
@@ -13,9 +13,13 @@ const assert = require('assert');
 const ent = require('../lib/entitlements');
 
 let passed = 0;
+const pending = [];
 function test(name, fn) {
-  try { fn(); passed++; console.log(`ok   ${name}`); }
-  catch (e) { console.error(`FAIL ${name}\n     ${e.message}`); process.exitCode = 1; }
+  const run = async () => {
+    try { await fn(); passed++; console.log(`ok   ${name}`); }
+    catch (e) { console.error(`FAIL ${name}\n     ${e.message}`); process.exitCode = 1; }
+  };
+  pending.push(run);
 }
 
 const T0 = Date.parse('2026-09-01T00:00:00Z');
@@ -102,4 +106,81 @@ test('the other product is never moved by a period on this one', () => {
   assert.strictEqual(ent.effectiveProductTier(rec, 'parasign', MONTH).tier, 'business');
 });
 
-console.log(`\n${passed} passed`);
+(async () => {
+  for (const run of pending) await run();
+  console.log(`\n${passed} passed`);
+})();
+
+// ── The webhook half: a payment must buy a bounded period ────────────────────
+const billing = require('../lib/billing');
+
+function payment(over) {
+  return Object.assign({
+    id: 'tr_demo', status: 'paid', amount: { value: '18.15', currency: 'EUR' },
+    metadata: { accountId: 'acct_demo', product: 'parasend', plan: 'pro', interval: 'monthly' },
+  }, over || {});
+}
+
+test('a paid webhook grants a tier AND an end date', async () => {
+  let got = null;
+  const out = await billing.processPayment(payment(), {
+    now: new Date('2026-09-15T10:00:00Z'),
+    setProductPlan: (a, p, t, until) => { got = { a, p, t, until }; return { ok: true }; },
+  });
+  assert.strictEqual(out.result, 'granted');
+  assert.strictEqual(got.t, 'pro');
+  assert.strictEqual(got.until.toISOString(), '2026-10-15T10:00:00.000Z');
+});
+
+// 29 February exists only in a leap year, so the start date here must be a real
+// one: 2024. Renewing lands on 28 February 2025, the last day of that month,
+// never 1 March.
+test('yearly buys twelve months and clamps a leap day to the month end', async () => {
+  let got = null;
+  await billing.processPayment(payment({
+    amount: { value: '181.50', currency: 'EUR' },
+    metadata: { accountId: 'acct_demo', product: 'parasend', plan: 'pro', interval: 'yearly' },
+  }), {
+    now: new Date('2024-02-29T00:00:00Z'),
+    setProductPlan: (a, p, t, until) => { got = until; return { ok: true }; },
+  });
+  assert.strictEqual(got.toISOString().slice(0, 10), '2025-02-28');
+});
+
+test('renewing early extends from the end of the period, not from today', async () => {
+  let got = null;
+  await billing.processPayment(payment(), {
+    now: new Date('2026-09-10T00:00:00Z'),
+    currentPaidUntil: async () => '2026-09-15T00:00:00.000Z',
+    setProductPlan: (a, p, t, until) => { got = until; return { ok: true }; },
+  });
+  assert.strictEqual(got.toISOString().slice(0, 10), '2026-10-15');
+});
+
+test('paying after a lapse starts from now, so a gap is not covered backwards', async () => {
+  let got = null;
+  await billing.processPayment(payment(), {
+    now: new Date('2026-11-01T00:00:00Z'),
+    currentPaidUntil: async () => '2026-09-15T00:00:00.000Z',
+    setProductPlan: (a, p, t, until) => { got = until; return { ok: true }; },
+  });
+  assert.strictEqual(got.toISOString().slice(0, 10), '2026-12-01');
+});
+
+test('an interval with no period is refused, never granted open-ended', async () => {
+  let called = false;
+  const out = await billing.processPayment(payment({
+    metadata: { accountId: 'acct_demo', product: 'parasend', plan: 'pro', interval: 'weekly' },
+  }), { setProductPlan: () => { called = true; return { ok: true }; } });
+  assert.strictEqual(out.result, 'refused');
+  assert.strictEqual(called, false);
+});
+
+test('a chargeback clears the period along with the tier', async () => {
+  let got = 'untouched';
+  await billing.processPayment(payment({ status: 'chargeback' }), {
+    setProductPlan: (a, p, t, until) => { got = { t, until }; return { ok: true }; },
+  });
+  assert.strictEqual(got.t, 'community');
+  assert.strictEqual(got.until, null);
+});

--- a/relay/test/entitlements-paid-until.test.js
+++ b/relay/test/entitlements-paid-until.test.js
@@ -1,0 +1,105 @@
+'use strict';
+// Unit tests for the paid-until axis on the entitlement layer
+// (relay/lib/entitlements.js). The rule this guards: a paid tier stops granting
+// when the period it was paid for has passed, and an account with no recorded
+// period is never treated as expired.
+//
+// Why it matters: a one-off payment used to set the tier and nothing ever took
+// it back, so one payment bought the tier forever. The date makes the grant
+// bounded; the read path honours it even if no webhook or cron ever runs.
+// Run: node relay/test/entitlements-paid-until.test.js (exits non-zero on failure).
+
+const assert = require('assert');
+const ent = require('../lib/entitlements');
+
+let passed = 0;
+function test(name, fn) {
+  try { fn(); passed++; console.log(`ok   ${name}`); }
+  catch (e) { console.error(`FAIL ${name}\n     ${e.message}`); process.exitCode = 1; }
+}
+
+const T0 = Date.parse('2026-09-01T00:00:00Z');
+const MONTH = Date.parse('2026-10-01T00:00:00Z');
+
+test('a tier without a recorded period keeps granting', () => {
+  const rec = { plan_parasend: 'pro' };
+  const r = ent.effectiveProductTier(rec, 'parasend', MONTH);
+  assert.strictEqual(r.tier, 'pro');
+  assert.strictEqual(r.expired, false);
+});
+
+test('a grant writes the period it was paid for', () => {
+  const rec = {};
+  const out = ent.applyProductTier(rec, 'parasend', 'pro', MONTH);
+  assert.strictEqual(rec.plan_parasend, 'pro');
+  assert.strictEqual(rec.paid_until_parasend, new Date(MONTH).toISOString());
+  assert.strictEqual(out.changed, true);
+});
+
+test('inside the paid period the tier stands', () => {
+  const rec = {};
+  ent.applyProductTier(rec, 'parasend', 'pro', MONTH);
+  assert.strictEqual(ent.effectiveProductTier(rec, 'parasend', T0).tier, 'pro');
+});
+
+test('past the paid period the tier falls to its floor', () => {
+  const rec = {};
+  ent.applyProductTier(rec, 'parasend', 'pro', MONTH);
+  const r = ent.effectiveProductTier(rec, 'parasend', MONTH + 1);
+  assert.strictEqual(r.tier, 'community');
+  assert.strictEqual(r.expired, true);
+});
+
+test('expiry is exact: at the boundary the period is over', () => {
+  const rec = {};
+  ent.applyProductTier(rec, 'parasign', 'pro', MONTH);
+  assert.strictEqual(ent.effectiveProductTier(rec, 'parasign', MONTH - 1).tier, 'pro');
+  assert.strictEqual(ent.effectiveProductTier(rec, 'parasign', MONTH).tier, 'free');
+});
+
+test('parasign floor is free, parasend floor is community', () => {
+  const a = {}; ent.applyProductTier(a, 'parasign', 'business', T0);
+  const b = {}; ent.applyProductTier(b, 'parasend', 'pro', T0);
+  assert.strictEqual(ent.effectiveProductTier(a, 'parasign', MONTH).tier, 'free');
+  assert.strictEqual(ent.effectiveProductTier(b, 'parasend', MONTH).tier, 'community');
+});
+
+test('dropping to the floor clears the period', () => {
+  const rec = {};
+  ent.applyProductTier(rec, 'parasend', 'pro', MONTH);
+  ent.applyProductTier(rec, 'parasend', 'community');
+  assert.strictEqual(rec.paid_until_parasend, undefined);
+});
+
+test('an omitted period leaves an existing one alone', () => {
+  const rec = {};
+  ent.applyProductTier(rec, 'parasend', 'pro', MONTH);
+  ent.applyProductTier(rec, 'parasend', 'pro');
+  assert.strictEqual(rec.paid_until_parasend, new Date(MONTH).toISOString());
+});
+
+test('an unparseable period is read as absent, never as expired', () => {
+  const rec = { plan_parasign: 'business', paid_until_parasign: 'niet-een-datum' };
+  const r = ent.effectiveProductTier(rec, 'parasign', MONTH);
+  assert.strictEqual(r.tier, 'business');
+  assert.strictEqual(r.expired, false);
+});
+
+test('renewal extends the period without touching the tier', () => {
+  const rec = {};
+  ent.applyProductTier(rec, 'parasign', 'pro', MONTH);
+  const next = Date.parse('2026-11-01T00:00:00Z');
+  ent.applyProductTier(rec, 'parasign', 'pro', next);
+  assert.strictEqual(rec.plan_parasign, 'pro');
+  assert.strictEqual(ent.effectiveProductTier(rec, 'parasign', MONTH + 1).tier, 'pro');
+});
+
+test('the other product is never moved by a period on this one', () => {
+  const rec = { plan_parasign: 'business' };
+  ent.applyProductTier(rec, 'parasend', 'pro', T0);
+  assert.strictEqual(rec.plan_parasign, 'business');
+  assert.strictEqual(rec.paid_until_parasign, undefined);
+  assert.strictEqual(ent.effectiveProductTier(rec, 'parasign', MONTH).tier, 'business');
+});
+
+console.log(`\n${passed} passed`);


### PR DESCRIPTION
Two separate things, and reading them as one makes the diff look wrong. The first is a fix to behaviour that already ships. The second is a feature that does not exist yet.

## 1. A fix: paid_until never reached the disk

`setProductPlan` wrote the paid period onto the in-memory records and then persisted with three arguments where four are needed:

```js
entitlements.applyProductTier(entry, product, norm);   // paidUntil missing
```

`applyProductTier` leaves the period field alone when `paidUntil` is `undefined`, on purpose, so that admin grants and migrations keep behaving as they always did. The consequence here is that `users.json` kept a bare tier. Every relay restart therefore reloaded paying accounts with a tier and no end date, and an account with no recorded period is deliberately never read as expired, so it granted forever again.

This matters for #314. The billing half of that release computes a period, stores it, and loses it on the next restart. On its own it changes nothing durable. That is not an argument against merging #314, it is the reason this fix belongs next to it.

One line, in the users.json write inside `setProductPlan`.

## 2. A feature: the mandate, so a second period is collected

b93a928 added the Mollie calls. Nothing called them. Checkout still asked for a one-off payment with no customer and no `sequenceType`, so no mandate was ever created and the webhook had nothing to subscribe against.

**Checkout** creates or reuses a Mollie customer for the account and marks the payment as the first of a series. A stored customer id is verified against Mollie before reuse; a stale or foreign one falls through to creating a new customer rather than failing the checkout, because the buyer's payment matters more than tidiness in our own records. A customer that cannot be created at all is logged at error level and the sale still completes as a one-off: money once beats money never, and that log line is the signal that this account will not renew.

**The webhook**, after a grant and never able to undo one, creates the subscription through the new `relay/lib/billing-recurring.js`. It is a separate file from `billing.js` because it answers a different question with different failure modes: `billing.js` decides what a payment bought and must stay pure w.r.t. its dependencies, this decides whether the buyer will be asked again. A buyer who paid keeps what he paid for even when Mollie refuses the subscription.

**`POST /v2/billing/cancel`** stops the next collection and leaves `paid_until` alone. The period was bought and runs to its end, with the tier. Selling a subscription without a way to end it is not allowed in the EU and is the first thing a buyer looks for before he buys. The pointer is cleared only after Mollie confirms, so a failed cancel does not leave an account thinking it has nothing to cancel.

**Pointers** are stored per account on the same serialized `users.json` queue as the entitlements: one customer id, and one subscription id *per product*. Per product because ParaSend and ParaSign are bought and cancelled separately, and a single field would make cancelling one silently stop collecting for the other.

## The date, which is the whole point

A first payment already covers the first period. A subscription created without an explicit `startDate` collects again immediately and charges twice for a month the buyer has paid for.

The first version of this file walked into that trap. `new Date(null)` is not an invalid date, it is 1 January 1970, so a `Number.isNaN` check alone lets a missing `paid_until` through as a start date 56 years in the past, and Mollie collects at once on a start date that has passed. `startDateFor` now refuses `null`, `undefined`, the empty string, and any date that is not in the future. `relay/test/billing-recurring.test.js` holds that line in four checks.

## Evidence

```
billing-recurring suite   22 checks passed
relay unit suite          173/173
root integration          96 pass, 2 declared skips, 0 failed
shell parse               clean
```

The two checks that cost real money if they ever go the other way: a recurring collection must not create a second subscription, and cancelling must not shorten a paid period.

## What has deliberately not happened

Nothing here has run against Mollie. Every test drives a fake. This needs to be proven under `BILLING_MODE=test` with a test key before it goes anywhere near live, and that needs a key.

`feat/mollie-mandaat` was not force-updated: a worktree holds it. This branch is a fast-forward from b93a928, so that branch can be moved onto it whenever it is free.
