### PR TITLE
A canary for the product that has no alarm: ParaSign

### DIFF
--- a/.github/workflows/product-heartbeat.yml
+++ b/.github/workflows/product-heartbeat.yml
@@ -94,6 +94,22 @@ jobs:
           PARAMANT_RELAY_URL: https://relay.paramant.app
           PARAMANT_API_KEY: ${{ secrets.PARAMANT_CANARY_KEY }}
 
+      # ParaSign canary: does the flagship still sign. The transfer canary
+      # covers ParaSend; nothing covered signing, and in the whole retained log
+      # window (22 Aug to 1 Sep 2026) not one human signed anything, so a broken
+      # ceremony would sit there until a customer found it. It runs a psk_test_
+      # key, so the sandbox signer drives it: no human, no mailbox, no real
+      # document, nothing about a customer read or stored. It verifies the
+      # notary signature itself rather than trusting a 200. always(), because a
+      # dead page must not hide a dead signer.
+      - name: ParaSign canary against the live relay
+        if: always()
+        shell: bash
+        run: node --test tests/parasign-canary.test.mjs 2>&1 | tee -a /tmp/heartbeat.log
+        env:
+          PARAMANT_RELAY_URL: https://relay.paramant.app
+          PARASIGN_CANARY_KEY: ${{ secrets.PARASIGN_CANARY_KEY }}
+
       # External destinations: someone else's uptime, so hourly and never in a
       # pull request. A third party can also delete a page without telling us,
       # which is exactly what a scheduled check is for. always(), because a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,27 @@ jobs:
         working-directory: relay
         run: node --test $(find crypto -name '*.test.js')
 
+      # The ParaSign suites that need the ML-DSA-65 engine. They used to run in
+      # the unit job below, which installs nothing, so @paramant/core was never
+      # there: each one caught the load error, printed "skip - ...", and returned.
+      # A file that exits 0 is a PASS to `node --test`, so the job reported
+      # "ok 24" while four suites asserted nothing at all. The worst of them was
+      # parasign-sandbox-live-guard, the only guard on "a psk_live_ key must
+      # never reach the sandbox auto-signer". They run here instead, against the
+      # engine this job builds, and test/_requires.js now fails them outright if
+      # it is missing. This job has no redis service, so that one precondition is
+      # declared by name rather than silently swallowed.
+      - name: Relay ParaSign engine suites
+        working-directory: relay
+        env:
+          RELAY_TEST_SKIP: redis
+        run: >-
+          node --test
+          test/parasign-sandbox.test.js
+          test/parasign-sandbox-live-guard.test.js
+          test/parasign-open-api-e2e.test.js
+          test/parasign-envelope-index.test.js
+
       # inbound-hash-verify spawns a real relay.js, so it needs the installed
       # dependencies and belongs here, not in the no-install unit job. It sat in
       # that job from 2026-07-20 and failed every single run with "relay did not
@@ -108,10 +129,21 @@ jobs:
       # binding, webauthn helpers. No @paramant/core build and no Redis, so the
       # relay/test suite that previously had zero CI coverage now gates here.
       # inbound-hash-verify is excluded: it spawns a real relay.js and needs the
-      # installed dependencies, so it runs in the crypto job above.
+      # installed dependencies, so it runs in the crypto job above. The four
+      # parasign-* suites are excluded for the same reason: they need the
+      # ML-DSA-65 engine, which this job deliberately does not build. They used
+      # to run here and silently skip, which is what made "ok 24" mean nothing.
       - name: Relay unit suite
         working-directory: relay
-        run: node --test $(ls test/*.test.js | grep -v inbound-hash-verify)
+        env:
+          # This job installs nothing on purpose, so the redis client is absent
+          # and parasign-store / parasign-signs-quota cannot reach a server.
+          # Declaring it here is what keeps them amber instead of red; anything
+          # NOT named here is now a hard failure (see relay/test/_requires.js).
+          RELAY_TEST_SKIP: redis
+        run: >-
+          node --test $(ls test/*.test.js | grep -vE
+          'inbound-hash-verify|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index')
 
       # Root integration suites (tests/*.mjs): dependency-injected, node builtins
       # only (no @paramant/core, no Redis, no npm install). The browser suites are

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,10 +156,15 @@ jobs:
       # Gates the ParaSign open-API conformance suite + key-issuance + pdf-ops that
       # previously ran in no workflow at all.
       - name: Root integration suites (no browser)
-        # transfer-canary is excluded too: it talks to the live relay, so it
-        # measures production, not this commit. It runs hourly in the
-        # product-heartbeat workflow.
-        run: node --test $(grep -L "from 'playwright'" tests/*.mjs | grep -v transfer-canary)
+        # The canaries are excluded: they talk to the LIVE relay, so they measure
+        # production and not this commit, and they run hourly in the
+        # product-heartbeat workflow instead. parasign-canary additionally
+        # imports @noble/post-quantum to verify the notary signature, and this
+        # job installs nothing on purpose, so leaving it in fails the whole step
+        # on a missing package before a single assertion runs.
+        run: >-
+          node --test $(grep -L "from 'playwright'" tests/*.mjs
+          | grep -vE 'transfer-canary|parasign-canary')
 
   admin-unit-tests:
     name: admin - unit suite

--- a/admin/lib/email-templates.js
+++ b/admin/lib/email-templates.js
@@ -397,6 +397,12 @@ https://paramant.app`;
 }
 
 // ── 6. ACCOUNT DELETION ───────────────────────────────────────────────────────
+// This mail used to say that account records were retained and that erasure was
+// a separate request to privacy@. That was true while deletion only revoked the
+// key and cleared Redis, leaving the email address in users.json on every sector
+// (audit finding 5 of 2026-07-21). Deletion now erases the personal data itself,
+// so the old wording understated what happened, and a mail that undersells an
+// erasure is as untrue as one that oversells it.
 function accountDeletionEmail({ email, deletedAt, reason }) {
   const preheader = 'Your Paramant account has been deactivated.';
   const dateStr = formatTS(typeof deletedAt === 'number' ? deletedAt : Date.parse(deletedAt));
@@ -405,14 +411,15 @@ function accountDeletionEmail({ email, deletedAt, reason }) {
 
 Your Paramant account (${email}) was deactivated on ${dateStr}.
 
-Its API key can no longer be used. Active sessions and the TOTP setup were removed. Some account records are retained.
+Its API key can no longer be used. Active sessions and the TOTP setup were removed, and your personal data was erased from our systems.
 
 What this means:
 - API key no longer works
 - Active sessions terminated
-- Account record and audit entries retained
+- Personal data removed from our systems
+- Billing records kept for as long as tax law requires
 
-For a separate personal-data erasure request, contact privacy@paramant.app.
+If you have a question about what was kept and why, contact privacy@paramant.app.
 
 Reason: ${reason || 'not specified'}
 
@@ -425,14 +432,15 @@ https://paramant.app`;
   const html = htmlShell(preheader, `
     <h1 style="margin:0 0 16px 0;font-size:22px;font-weight:500;color:#0B3A6A;">Account deactivated</h1>
     <p style="margin:0 0 20px 0;line-height:1.6;">Your Paramant account (${escHtml(email)}) was deactivated on <strong>${dateStr}</strong>.</p>
-    <p style="margin:0 0 20px 0;line-height:1.6;">Its API key can no longer be used. Active sessions and the TOTP setup were removed. Some account records are retained.</p>
+    <p style="margin:0 0 20px 0;line-height:1.6;">Its API key can no longer be used. Active sessions and the TOTP setup were removed, and your personal data was erased from our systems.</p>
     <h2 style="margin:24px 0 12px 0;font-size:14px;font-weight:600;color:#0B3A6A;">What this means</h2>
     <ul style="margin:0 0 24px 0;padding-left:20px;line-height:1.8;color:#475569;font-size:14px;">
       <li>API key no longer works</li>
       <li>Active sessions terminated</li>
-      <li>Account record and audit entries retained</li>
+      <li>Personal data removed from our systems</li>
+      <li>Billing records kept for as long as tax law requires</li>
     </ul>
-    <p style="margin:0 0 20px 0;line-height:1.6;color:#475569;font-size:14px;">For a separate personal-data erasure request, contact <a href="mailto:privacy@paramant.app" style="color:#1D4ED8;">privacy@paramant.app</a>.</p>
+    <p style="margin:0 0 20px 0;line-height:1.6;color:#475569;font-size:14px;">If you have a question about what was kept and why, contact <a href="mailto:privacy@paramant.app" style="color:#1D4ED8;">privacy@paramant.app</a>.</p>
     <div style="background:#F8FAFC;border:1px solid rgba(11,58,106,0.1);padding:12px 16px;margin:0 0 24px 0;">
       <p style="margin:0;font-size:13px;color:#475569;"><strong>Reason:</strong> ${reason ? escHtml(reason) : 'not specified'}</p>
     </div>

--- a/admin/server.js
+++ b/admin/server.js
@@ -2587,6 +2587,14 @@ api.delete("/user/account", authUser, async (req, res) => {
     await relayFetch(s, "/v2/admin/keys/revoke", "POST", { key: user_id }, false, ADMIN_TOKEN);
   });
 
+  // Revoking stops the key; it does not remove the person. This route sits
+  // behind the "Deactivate account" button, so a visitor who presses it is
+  // asking to be gone, and until now their email address stayed in users.json on
+  // every sector. Article 17 GDPR, and audit finding 5 of 2026-07-21.
+  await eachSector(Object.keys(SECTORS), async s => {
+    await relayFetch(s, "/v2/admin/keys/erase", "POST", { key: user_id }, false, ADMIN_TOKEN);
+  });
+
   await callRelay("/v2/user/delete-totp", { user_id });
 
   for await (const key of scanKeys(redis(), { MATCH: "paramant:user:session:*", COUNT: 100 })) {
@@ -3284,6 +3292,12 @@ api.post('/admin/delete-account', authMiddleware, async (req, res) => {
   try {
     const meta = await getAdminKeyMeta(key);
     await eachSector(Object.keys(SECTORS), async s => relayFetch(s, '/v2/admin/keys/revoke', 'POST', { key }, false, ADMIN_TOKEN).catch(() => {}));
+    // Erase the person, not just the key. Redis was already cleared below, but
+    // users.json on every sector kept the email address. Audit finding 5 of
+    // 2026-07-21. Errors are swallowed like the revoke above: a sector that is
+    // briefly unreachable must not leave the deletion half done and unretryable,
+    // and the call is idempotent so a retry is free.
+    await eachSector(Object.keys(SECTORS), async s => relayFetch(s, '/v2/admin/keys/erase', 'POST', { key }, false, ADMIN_TOKEN).catch(() => {}));
     await callRelay('/v2/user/delete-totp', { user_id: key }).catch(() => {});
     for await (const rkey of scanKeys(redis(), { MATCH: `paramant:user:session:*`, COUNT: 100 })) {
       const raw = await redis().get(rkey).catch(() => null);

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -167,6 +167,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -224,6 +225,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -211,6 +211,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -321,6 +322,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -250,6 +250,7 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -377,6 +377,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -831,6 +832,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -234,6 +234,7 @@ section p+p{margin-top:14px}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -332,6 +333,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -142,6 +142,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -175,6 +175,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -142,6 +142,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -153,6 +153,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -143,6 +143,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 

--- a/frontend/banken.html
+++ b/frontend/banken.html
@@ -279,6 +279,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -406,6 +407,7 @@ input:focus,textarea:focus{border-color:var(--cobalt)}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -209,6 +209,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -371,6 +372,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/compliance/iec62443.html
+++ b/frontend/compliance/iec62443.html
@@ -338,6 +338,7 @@ pre{font-family:var(--mono)}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -675,6 +676,7 @@ Level 1  Field devices     ─────────────────�
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/compliance/nen7510.html
+++ b/frontend/compliance/nen7510.html
@@ -337,6 +337,7 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -554,6 +555,7 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/compliance/nis2.html
+++ b/frontend/compliance/nis2.html
@@ -337,6 +337,7 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -554,6 +555,7 @@ code{font-family:var(--mono);font-size:11px;background:rgba(178,255,63,.06);padd
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -325,6 +325,7 @@ section h2{display:flex;align-items:baseline;gap:11px}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -673,6 +674,7 @@ FLAGS    1 byte    reserved for future features</pre>
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -371,6 +371,7 @@ body { min-height:100vh; }
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -512,6 +513,7 @@ body { min-height:100vh; }
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -398,6 +398,7 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -575,6 +576,7 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/dicom.html
+++ b/frontend/dicom.html
@@ -322,6 +322,7 @@ code{font-family:var(--mono);font-size:12px;background:var(--black-hair);border:
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -610,6 +611,7 @@ paramant-receiver.py \
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -308,6 +308,7 @@ tr:last-child td{border-bottom:none}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -1131,6 +1132,7 @@ python3 scripts/paramant-admin.py sync</pre>
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -260,6 +260,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -285,6 +285,7 @@ input:focus{border-color:var(--cobalt)}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -458,6 +459,7 @@ input:focus{border-color:var(--cobalt)}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -275,6 +275,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -412,6 +413,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/government.html
+++ b/frontend/government.html
@@ -334,6 +334,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -576,6 +577,12 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
       <div class="step">
         <div class="step-num">4</div>
         <div class="step-body">
+          <!-- The live site carries a stray "Terms of Service" link inside the
+               sentence below, between the DPA link and "(GDPR Art. 28)", so the
+               page reads "sign the Data Processing Agreement Terms of Service
+               (GDPR Art. 28)". It was added by a blind edit that treated every
+               DPA link as a nav item. Deploying this file repairs that; the nav
+               and footer links to /terms are kept, that one is not. -->
           <h4>Data Processing Agreement (managed relay only)</h4>
           <p>If using the Paramant-managed relay, sign the <a href="/dpa">Data Processing Agreement</a>
           (GDPR Art. 28). When self-hosting, no DPA is required &mdash; you control all infrastructure.</p>
@@ -620,6 +627,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:28px}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/healthcare.html
+++ b/frontend/healthcare.html
@@ -234,6 +234,7 @@ section p+p{margin-top:14px}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -335,6 +336,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -323,6 +323,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -465,6 +466,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -309,6 +309,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -399,6 +400,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -323,6 +323,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -500,6 +501,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -325,6 +325,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -472,6 +473,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -327,6 +327,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -506,6 +507,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -289,6 +289,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -420,6 +421,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -322,6 +322,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -487,6 +488,7 @@ print(resp.json()["url"])</div>
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -321,6 +321,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -458,6 +459,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -327,6 +327,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -494,6 +495,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -321,6 +321,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -460,6 +461,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/hndl.html
+++ b/frontend/hndl.html
@@ -293,6 +293,7 @@ section p+p{margin-top:14px}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -535,6 +536,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -397,6 +397,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -607,6 +608,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/js/paraid-app.js
+++ b/frontend/js/paraid-app.js
@@ -330,7 +330,16 @@ function initRequester() {
     const r = await verifyAnswer(bundle);
     const out = $('req-verify-out');
     out.className = 'pa-result ' + (r.ok ? 'ok' : 'err');
-    const tierLabel = { presence: 'presence-only (a live person, identity not checked)', substantial: 'substantial (MRZ check-digit consistency, document authenticity not checked)', high: 'high (passport chip)' }[bundle.tier || 'presence'] || esc(bundle.tier || '');
+    // 'substantial' is the pre-rename spelling of the same rung; both resolve to
+    // one label so an older credential can never read as a stronger check than
+    // the one that was actually done. An unknown tier gets no flattering wording.
+    const TIER_LABELS = {
+      presence: 'presence-only (a live person, identity not checked)',
+      'mrz-unverified': 'MRZ form only (check digits add up; the document itself was never seen or authenticated)',
+      substantial: 'MRZ form only (check digits add up; the document itself was never seen or authenticated)',
+      high: 'high (passport chip, passively authenticated)',
+    };
+    const tierLabel = TIER_LABELS[bundle.tier || 'presence'] || esc(bundle.tier || '');
     out.innerHTML = r.ok
       ? '<b>&#10003; ' + esc(r.question) + ' ' + esc(String(r.answer).toUpperCase()) + '</b><br>issuer: ' + esc(r.registry) + '<br>assurance: ' + esc(tierLabel)
       : '<b>&#10007; rejected</b><br>' + r.errors.map(esc).join('<br>') + '<br>issuer: ' + esc(r.registry);

--- a/frontend/js/paraid-document.js
+++ b/frontend/js/paraid-document.js
@@ -71,7 +71,10 @@ async function issue() {
     if (!resp.ok) { const e = await resp.json().catch(() => ({})); throw new Error(e.error || ('issuance failed (' + resp.status + ')')); }
     const { credential } = await resp.json();
     localStorage.setItem('paraid.credential.v1', JSON.stringify(credential));
-    localStorage.setItem('paraid.identity.v1', JSON.stringify({ verified: true, method: 'document', tier: 'substantial' }));
+    // The rung this flow actually reaches: the MRZ form checked out, nothing else
+    // did. It used to write 'substantial', which claimed an eIDAS level no part
+    // of this flow establishes.
+    localStorage.setItem('paraid.identity.v1', JSON.stringify({ verified: true, method: 'document', tier: 'mrz-unverified' }));
     if (stream) { stream.getTracks().forEach((t) => t.stop()); stream = null; }
     $('doc-status').innerHTML = '<b>Done.</b> Your wallet now holds a credential recording age_over_18 = ' + esc(credential.fields.age_over_18) + ' and nationality = ' + esc(credential.fields.nationality) + ' as derived from the entered MRZ data. This is not a document-authenticity result.';
     $('doc-done').hidden = false;

--- a/frontend/js/passkey.js
+++ b/frontend/js/passkey.js
@@ -127,8 +127,31 @@ function wireSetupPasskey() {
       a.click();
     });
     const finishBtn = document.getElementById('passkey-finish-btn');
-    if (finishBtn) finishBtn.addEventListener('click', () => { window.location = '/dashboard'; });
+    // Where the visitor was heading before they were asked to register. Someone
+    // who clicked a price button and got sent here wants to land back on the
+    // price page with their choice intact, not on a dashboard that has no idea
+    // they wanted to buy anything. The login path below already reads `next`
+    // this way; this button was hardcoded to /dashboard and threw it away, so
+    // every new customer lost their purchase halfway through signing up.
+    if (finishBtn) finishBtn.addEventListener('click', () => { window.location = safeNext(); });
   }
+}
+
+// Where to send the visitor after they are signed in or registered.
+//
+// Reads `next` (or the older `return`) from the query string and falls back to
+// the dashboard. Only a local path is accepted: it must start with exactly one
+// slash, so an attacker cannot hand out /auth/login?next=//evil.example and turn
+// our sign-in into an open redirect. Anything else silently becomes /dashboard.
+//
+// This lives in one place because it was previously written out twice: once
+// correctly on the login path, and once as a hardcoded /dashboard on the
+// registration finish button. Two copies of the same rule is how one of them
+// ends up wrong.
+function safeNext() {
+  const q = new URLSearchParams(window.location.search);
+  const want = q.get('next') || q.get('return') || '/dashboard';
+  return /^\/(?![\/\\])/.test(want) ? want : '/dashboard';
 }
 
 // ── Login: /auth/login (email-first passkey sign-in) ─────────────────────────
@@ -144,9 +167,7 @@ function wireLoginPasskey() {
     return;
   }
 
-  const _rp = new URLSearchParams(window.location.search), _rv = _rp.get('next') || _rp.get('return') || '/dashboard';
-  // Local paths only (leading single slash) — never an off-site open redirect.
-  const returnUrl = /^\/(?![\/\\])/.test(_rv) ? _rv : '/dashboard';
+  const returnUrl = safeNext();
 
   btn.addEventListener('click', async () => {
     const email = (emailEl && emailEl.value || '').trim();

--- a/frontend/js/pricing-billing.js
+++ b/frontend/js/pricing-billing.js
@@ -75,6 +75,57 @@
     box.textContent = text;
   }
 
+  /* The choice a visitor made before we sent them away to sign in.
+   *
+   * Clicking a price button while signed out used to end here: we redirected to
+   * /auth/login?next=/pricing, and after signing in the visitor landed back on a
+   * page full of buttons with no memory of which one they had pressed. They had
+   * to find it again and click a second time. Every new customer had to want it
+   * twice, and the moment they were most willing to pay was the moment we threw
+   * their choice away.
+   *
+   * sessionStorage, not a query parameter: the plan is not a secret but it is
+   * also nobody's business in a URL that gets shared, logged and pasted. It dies
+   * with the tab, which is exactly the lifetime of a purchase decision. */
+  var INTENT = 'paramant.checkout.intent.v1';
+
+  function rememberIntent(btn) {
+    try {
+      sessionStorage.setItem(INTENT, JSON.stringify({
+        product: btn.getAttribute('data-billing-product'),
+        plan: btn.getAttribute('data-billing-plan'),
+        interval: btn.getAttribute('data-billing-interval'),
+        at: new Date().toISOString()
+      }));
+    } catch (e) { /* private mode: the visitor just clicks again, no worse than before */ }
+  }
+
+  function takeIntent() {
+    var raw = null;
+    try { raw = sessionStorage.getItem(INTENT); sessionStorage.removeItem(INTENT); }
+    catch (e) { return null; }
+    if (!raw) return null;
+    try {
+      var i = JSON.parse(raw);
+      if (!i || !i.product || !i.plan || !i.interval) return null;
+      return i;
+    } catch (e) { return null; }
+  }
+
+  /* Find the button that matches a remembered choice, so resuming presses the
+   * real button: same request, same error handling, same visible state. A
+   * separate resume path would be a second way to buy, and the second way is
+   * always the one that rots. */
+  function buttonFor(i) {
+    for (var n = 0; n < buttons.length; n++) {
+      var b = buttons[n];
+      if (b.getAttribute('data-billing-product') === i.product &&
+          b.getAttribute('data-billing-plan') === i.plan &&
+          b.getAttribute('data-billing-interval') === i.interval) return b;
+    }
+    return null;
+  }
+
   Array.prototype.forEach.call(buttons, function (btn) {
     btn.addEventListener('click', function (ev) {
       ev.preventDefault();
@@ -99,6 +150,7 @@
         if (msg.indexOf('key_http_401') === 0 || msg.indexOf('key_http_403') === 0 ||
             msg === 'key_unavailable' || msg.indexOf('checkout_http_401') === 0 ||
             msg.indexOf('checkout_http_403') === 0) {
+          rememberIntent(btn);
           window.location.href = '/auth/login?next=' + encodeURIComponent(location.pathname + location.search);
           return;
         }
@@ -107,4 +159,21 @@
       });
     });
   });
+
+  /* Back from signing in with a choice still pending: press it for them. Only
+   * once, because takeIntent clears the store as it reads. A failure here shows
+   * the same inline error as a normal click, so a visitor is never left on a
+   * page that silently did nothing. */
+  var pending = takeIntent();
+  if (pending) {
+    var target = buttonFor(pending);
+    if (target) {
+      var note = document.createElement('div');
+      note.setAttribute('role', 'status');
+      note.style.cssText = 'margin-top:.6rem;font-size:.85rem;color:#334155';
+      note.textContent = 'Picking up where you left off.';
+      if (target.parentNode) target.parentNode.insertBefore(note, target.nextSibling);
+      target.click();
+    }
+  }
 })();

--- a/frontend/legal-discovery.html
+++ b/frontend/legal-discovery.html
@@ -234,6 +234,7 @@ section p+p{margin-top:14px}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -322,6 +323,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -265,6 +265,7 @@ footer a{color:var(--cobalt)}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -369,6 +370,7 @@ Website: https://paramant.app</div>
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/liveness.html
+++ b/frontend/liveness.html
@@ -200,6 +200,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -307,6 +308,7 @@ body.lv-flashing .lv-wrap > *:not(.lv-stage) { visibility: hidden; }
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/ma-due-diligence.html
+++ b/frontend/ma-due-diligence.html
@@ -234,6 +234,7 @@ section p+p{margin-top:14px}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -323,6 +324,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -262,6 +262,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -379,6 +380,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/ot-vs-data-diodes.html
+++ b/frontend/ot-vs-data-diodes.html
@@ -247,6 +247,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -611,6 +612,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/ot.html
+++ b/frontend/ot.html
@@ -307,6 +307,7 @@ pre{font-size:var(--text-xs);line-height:1.7;overflow-x:auto}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -528,6 +529,7 @@ Level 1  Field devices  ──────────────────�
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/paraid-app.html
+++ b/frontend/paraid-app.html
@@ -4,6 +4,14 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<!-- noindex: ParaID was pulled from the shop window on 2026-07-19 (fb3cdd3) and is not a
+     product in relay/lib/billing-catalog.js, so it cannot be bought. A bulk SEO commit
+     (e0e82a1, 2026-07-25) then re-published all 59 routes into sitemap.xml and put this
+     page back in front of Google six days after that decision. The sitemap entries are
+     gone again; this tag is what makes the already-indexed copies drop out. The page
+     itself stays reachable on purpose: it is labelled beta and states it is not an
+     eIDAS-qualified scheme. Removing it is a product call, not an SEO one. -->
+<meta name="robots" content="noindex, nofollow">
 <title>ParaID wallet · Paramant</title>
 <meta property="og:site_name" content="Paramant">
 <meta name="description" content="Your ParaID wallet: hold a credential and prove claims like 18+? without revealing the data. Beta.">

--- a/frontend/paraid-app.html
+++ b/frontend/paraid-app.html
@@ -208,6 +208,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -410,6 +411,7 @@ select.pa-in { cursor: pointer; }
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/paraid-document.html
+++ b/frontend/paraid-document.html
@@ -208,6 +208,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -316,6 +317,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/paraid-document.html
+++ b/frontend/paraid-document.html
@@ -4,6 +4,14 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<!-- noindex: ParaID was pulled from the shop window on 2026-07-19 (fb3cdd3) and is not a
+     product in relay/lib/billing-catalog.js, so it cannot be bought. A bulk SEO commit
+     (e0e82a1, 2026-07-25) then re-published all 59 routes into sitemap.xml and put this
+     page back in front of Google six days after that decision. The sitemap entries are
+     gone again; this tag is what makes the already-indexed copies drop out. The page
+     itself stays reachable on purpose: it is labelled beta and states it is not an
+     eIDAS-qualified scheme. Removing it is a product call, not an SEO one. -->
+<meta name="robots" content="noindex, nofollow">
 <title>ParaID MRZ consistency check · Paramant</title>
 <meta property="og:site_name" content="Paramant">
 <meta name="description" content="Check MRZ check digits locally and derive age and nationality from the data you enter.">

--- a/frontend/paraid.html
+++ b/frontend/paraid.html
@@ -208,6 +208,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -457,6 +458,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/paraid.html
+++ b/frontend/paraid.html
@@ -4,6 +4,14 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<!-- noindex: ParaID was pulled from the shop window on 2026-07-19 (fb3cdd3) and is not a
+     product in relay/lib/billing-catalog.js, so it cannot be bought. A bulk SEO commit
+     (e0e82a1, 2026-07-25) then re-published all 59 routes into sitemap.xml and put this
+     page back in front of Google six days after that decision. The sitemap entries are
+     gone again; this tag is what makes the already-indexed copies drop out. The page
+     itself stays reachable on purpose: it is labelled beta and states it is not an
+     eIDAS-qualified scheme. Removing it is a product call, not an SEO one. -->
+<meta name="robots" content="noindex, nofollow">
 <title>ParaID · prove a claim, keep the data · Paramant</title>
 <meta property="og:site_name" content="Paramant">
 <meta name="description" content="ParaID beta: answer questions like 18+? with cryptographic proof. Passport fields never leave your device. ML-DSA-65 (FIPS 204).">

--- a/frontend/pararules.html
+++ b/frontend/pararules.html
@@ -275,6 +275,7 @@ footer a{color:var(--ink);text-decoration:none}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -366,6 +367,7 @@ footer a{color:var(--ink);text-decoration:none}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -428,6 +428,7 @@ select:focus{border-color:var(--cobalt)}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -712,6 +713,7 @@ select:focus{border-color:var(--cobalt)}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -227,6 +227,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -288,6 +289,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -289,6 +289,7 @@ td{color:var(--cobalt)}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -424,6 +425,7 @@ td{color:var(--cobalt)}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -288,6 +288,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -610,6 +611,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -333,6 +333,26 @@
   </div>
 </section>
 
+<!-- One basis for every listed price on this page: excl. btw. The rest of the
+     site quotes the same numbers that way (frontend/js/quota-upgrade.js), so
+     switching this page to incl. btw would only move the contradiction.
+
+     The amount actually taken off the card is incl. 21% btw and lives in
+     relay/lib/billing-catalog.js. It is always printed as "charged ... incl.
+     21% btw" beside the listed price, never on its own. Until 2026-08-30 the
+     monthly prices were listed excl. btw and the Business yearly price incl.
+     btw; read side by side that looks like paying yearly costs more.
+
+     Yearly discount is stated as a percentage, not as "two months free". Two
+     months free is 16.7%, which holds for ParaSend Pro and ParaSign Business
+     but not for ParaSign Pro (15.1%: 59.29 x 12 = 711.48 against 603.79).
+
+     Number format is English throughout (dot decimal, comma thousands) and the
+     currency is always &euro;, never the string "EUR". The page mixed all four
+     variants, including EUR 3.617,90 and &euro;3,617.90 for the same amount.
+
+     relay/test/pricing-page.test.js recomputes every amount here from the
+     catalog, so a price edited on this page alone turns the suite red. -->
 <!-- TIER CARDS: PARASEND -->
 <section style="padding:0 0 var(--space-9)">
   <div class="container">
@@ -360,7 +380,7 @@
       <div class="tier-card featured">
         <div class="tier-name">Pro</div>
         <div class="tier-price">&euro;15<span style="font-size:var(--text-sm);color:var(--ink-dim)">/mo</span></div>
-        <div class="tier-price-note">excl. btw &middot; <span class="incl">&euro;18,15/mo incl. 21%</span><br>&euro;15/mo or &euro;150/yr excl.</div>
+        <div class="tier-price-note">excl. btw &middot; <span class="incl">charged &euro;18.15/mo incl. 21% btw</span><br>Annual &euro;150 excl. &middot; 16.7% off</div>
         <p style="font-size:var(--text-base);color:var(--ink);margin-bottom:var(--space-5);line-height:1.65">For professionals who send regularly. Features, not bigger files.</p>
         <ul class="tier-features">
           <li>Everything in Free</li>
@@ -381,8 +401,8 @@
      It used to hold six static Mollie payment links; all six returned 404 on
      2026-08-08, and even alive they carried no metadata, which is how the
      first paying customer got nothing on 2026-07-21. -->
-        <a href="/auth/login?next=/pricing" data-billing-product="parasend" data-billing-plan="pro" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center">Get ParaSend Pro &rarr; <span style="font-weight:400;opacity:.85">&euro;18,15/mo incl.</span></a>
-        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasend" data-billing-plan="pro" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; &euro;181,50/yr incl. &rarr;</a></div>
+        <a href="/auth/login?next=/pricing" data-billing-product="parasend" data-billing-plan="pro" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center">Get ParaSend Pro &rarr; <span style="font-weight:400;opacity:.85">&euro;18.15/mo incl.</span></a>
+        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasend" data-billing-plan="pro" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; &euro;181.50/yr incl. &rarr;</a></div>
       </div>
 
       <div class="tier-card">
@@ -424,7 +444,7 @@
 
       <div class="tier-card">
         <div class="tier-name">Free</div>
-        <div class="tier-price">EUR 0</div>
+        <div class="tier-price">&euro;0</div>
         <div class="tier-price-note">Forever</div>
         <ul class="tier-features">
           <li>2 signatures per month</li>
@@ -437,31 +457,31 @@
 
       <div class="tier-card featured">
         <div class="tier-name">Pro</div>
-        <div class="tier-price">EUR 49<span style="font-size:var(--text-sm);color:var(--ink-dim)">/month</span></div>
-        <div class="tier-price-note">excl. btw &middot; <span class="incl">EUR 59,29/mo incl. 21%</span></div>
+        <div class="tier-price">&euro;49<span style="font-size:var(--text-sm);color:var(--ink-dim)">/month</span></div>
+        <div class="tier-price-note">excl. btw &middot; <span class="incl">charged &euro;59.29/mo incl. 21% btw</span></div>
         <ul class="tier-features">
-          <li>100 signatures per month, then EUR 0.40 each, up to 1,000</li>
+          <li>100 signatures per month, then &euro;0.40 each, up to 1,000</li>
           <li>Past 1,000 a month, Business is cheaper anyway</li>
           <li>Unlimited transfers - API access</li>
-          <li>Annual: EUR 499 (two months free)</li>
+          <li>Annual: &euro;499 excl. &middot; 15.1% off</li>
         </ul>
-        <a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Pro &rarr; <span style="font-weight:400;opacity:.85">EUR 59,29/mo incl.</span></a>
-        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; EUR 603,79/yr incl. &rarr;</a></div>
+        <a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Pro &rarr; <span style="font-weight:400;opacity:.85">&euro;59.29/mo incl.</span></a>
+        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; &euro;603.79/yr incl. &rarr;</a></div>
       </div>
 
       <div class="tier-card">
         <div class="tier-name">Business</div>
-        <div class="tier-price">EUR 299<span style="font-size:var(--text-sm);color:var(--ink-dim)">/month</span></div>
-        <div class="tier-price-note">excl. btw &middot; <span class="incl">EUR 361,79/mo incl. 21%</span></div>
+        <div class="tier-price">&euro;299<span style="font-size:var(--text-sm);color:var(--ink-dim)">/month</span></div>
+        <div class="tier-price-note">excl. btw &middot; <span class="incl">charged &euro;361.79/mo incl. 21% btw</span></div>
         <ul class="tier-features">
           <li>1,000 signatures per month</li>
           <li>Named support, response within one business day</li>
           <li>We help you answer your customers' security questionnaires</li>
           <li>Exportable audit log with CT tree head (CSV or JSON)</li>
-          <li>Annual: EUR 2,990 (two months free)</li>
+          <li>Annual: &euro;2,990 excl. &middot; 16.7% off</li>
         </ul>
-        <a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="business" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Business &rarr; <span style="font-weight:400;opacity:.85">EUR 361,79/mo incl.</span></a>
-        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="business" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; EUR 3.617,90/yr incl. &rarr;</a></div>
+        <a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="business" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Business &rarr; <span style="font-weight:400;opacity:.85">&euro;361.79/mo incl.</span></a>
+        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="business" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; &euro;3,617.90/yr incl. &rarr;</a></div>
       </div>
 
       <div class="tier-card">
@@ -517,13 +537,17 @@
   </div>
 </section>
 
-<!-- TRIAL CTA -->
+<!-- This block promised "30 days, no credit card, full relay access" until
+     2026-08-30, on a page whose Free cards say "Forever, no card required" and
+     whose FAQ says there is no separate trial. Three promises, one of them
+     invented. The free tier is the trial; there is no 30-day clock. -->
+<!-- FREE-TIER CTA -->
 <section style="padding:var(--space-4) 0 var(--space-9)">
   <div class="container-md">
     <div class="trial-cta">
       <div>
         <p style="font-size:var(--text-base);font-weight:700;margin-bottom:var(--space-2)">Not sure which plan fits?</p>
-        <p style="font-size:var(--text-sm);color:var(--ink)">Create a free account. 30 days, no credit card, full relay access.</p>
+        <p style="font-size:var(--text-sm);color:var(--ink)">Start on the free tier. No card, no time limit; upgrade when you outgrow the limits.</p>
       </div>
       <a href="/signup" class="btn btn-primary">Create account →</a>
     </div>
@@ -552,7 +576,7 @@
 
     <div class="faq-item">
       <p class="faq-q">How does ParaSign pricing work?</p>
-      <div class="faq-a">ParaSign is priced by signature volume, not by feature. Free covers 2 signatures a month; Pro (&euro;49/mo or &euro;499/yr) includes 100 a month, then &euro;0.40 each, with API access; Business (&euro;299/mo) includes 1,000 a month with named support and an exportable audit log. Every tier uses the same ML-DSA-65 post-quantum cryptography and public CT-log verification. Signatures are advanced (AES), not qualified (QES). QES is coming via an EU QTSP partner.</div>
+      <div class="faq-a">ParaSign is priced by signature volume, not by feature. Free covers 2 signatures a month; Pro (&euro;49/mo or &euro;499/yr, excl. btw) includes 100 a month, then &euro;0.40 each, with API access; Business (&euro;299/mo or &euro;2,990/yr, excl. btw) includes 1,000 a month with named support and an exportable audit log. Every tier uses the same ML-DSA-65 post-quantum cryptography and public CT-log verification. Signatures are advanced (AES), not qualified (QES). QES is coming via an EU QTSP partner.</div>
     </div>
 
     <div class="faq-item">

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -274,6 +274,7 @@ footer a{color:var(--ink);text-decoration:none}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -406,6 +407,7 @@ footer a{color:var(--ink);text-decoration:none}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/quantum-urgency.html
+++ b/frontend/quantum-urgency.html
@@ -247,6 +247,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -482,6 +483,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -211,6 +211,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -277,6 +278,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -297,6 +297,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -538,6 +539,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -220,6 +220,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -282,6 +283,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/compliance/nis2">Compliance overview</a>
         </div>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -436,6 +436,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -799,6 +800,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -258,6 +258,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -218,6 +218,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 

--- a/frontend/sitemap.xml
+++ b/frontend/sitemap.xml
@@ -182,21 +182,6 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://paramant.app/paraid</loc>
-    <lastmod>2026-07-21</lastmod>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://paramant.app/paraid-app</loc>
-    <lastmod>2026-07-21</lastmod>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://paramant.app/paraid-document</loc>
-    <lastmod>2026-07-21</lastmod>
-    <priority>0.6</priority>
-  </url>
-  <url>
     <loc>https://paramant.app/pararules</loc>
     <lastmod>2026-07-21</lastmod>
     <priority>0.6</priority>

--- a/frontend/sitemap.xml
+++ b/frontend/sitemap.xml
@@ -82,6 +82,11 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://paramant.app/terms</loc>
+    <lastmod>2026-07-21</lastmod>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://paramant.app/government</loc>
     <lastmod>2026-07-21</lastmod>
     <priority>0.6</priority>

--- a/frontend/sovereignty.html
+++ b/frontend/sovereignty.html
@@ -259,6 +259,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -604,6 +605,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/ssh-key-delivery.html
+++ b/frontend/ssh-key-delivery.html
@@ -241,6 +241,7 @@ section p+p{margin-top:14px}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -436,6 +437,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -297,6 +297,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -352,6 +353,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -4,18 +4,18 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Service Level Agreement — PARAMANT</title>
+<title>Terms of Service · PARAMANT</title>
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="PARAMANT SLA: uptime commitments, credits policy, and support tiers for community, professional, and enterprise plans.">
-<meta property="og:title" content="Service Level Agreement · PARAMANT">
-<meta property="og:description" content="PARAMANT SLA: uptime commitments, credits policy, and support tiers for community, professional, and enterprise plans.">
-<meta property="og:url" content="https://paramant.app/sla">
+<meta name="description" content="PARAMANT Terms of Service: who you contract with, what the plans include, payment and cancellation, acceptable use, liability, and the right of withdrawal.">
+<meta property="og:title" content="Terms of Service · PARAMANT">
+<meta property="og:description" content="PARAMANT Terms of Service: who you contract with, what the plans include, payment and cancellation, acceptable use, liability, and the right of withdrawal.">
+<meta property="og:url" content="https://paramant.app/terms">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Service Level Agreement · PARAMANT">
-<meta name="twitter:description" content="PARAMANT SLA: uptime commitments, credits policy, and support tiers for community, professional, and enterprise plans.">
-<link rel="canonical" href="https://paramant.app/sla">
+<meta name="twitter:title" content="Terms of Service · PARAMANT">
+<meta name="twitter:description" content="PARAMANT Terms of Service: who you contract with, what the plans include, payment and cancellation, acceptable use, liability, and the right of withdrawal.">
+<link rel="canonical" href="https://paramant.app/terms">
 
 <link rel="stylesheet" href="/design-system.css?v=22">
 <link rel="stylesheet" href="/nav.css?v=19">
@@ -127,9 +127,9 @@ a:hover{opacity:.8}
   "@graph": [
     {
       "@type": "WebPage",
-      "@id": "https://paramant.app/sla#webpage",
-      "url": "https://paramant.app/sla",
-      "name": "Service Level Agreement — PARAMANT",
+      "@id": "https://paramant.app/terms#webpage",
+      "url": "https://paramant.app/terms",
+      "name": "Terms of Service · PARAMANT",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -137,7 +137,7 @@ a:hover{opacity:.8}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "PARAMANT SLA: uptime commitments, credits policy, and support tiers for community, professional, and enterprise plans."
+      "description": "PARAMANT Terms of Service: who you contract with, what the plans include, payment and cancellation, acceptable use, liability, and the right of withdrawal."
     }
   ]
 }
@@ -309,135 +309,106 @@ a:hover{opacity:.8}
 </div>
 
 <div class="wrap">
-  <div class="eyebrow">Legal &mdash; effective 1 January 2025</div>
-  <h1>Service Level Agreement</h1>
-  <p class="sub">Uptime commitments, downtime credits, and support response times for all PARAMANT relay plans.</p>
+  <div class="eyebrow">Legal &mdash; version 1, effective 25 August 2026</div>
+  <h1>Terms of Service</h1>
+  <p class="sub">The agreement between you and Paramantis Solutions B.V. for the use of PARAMANT. Written to be read, not to be skipped. Where these terms are silent, Dutch law fills the gap.</p>
 
   <div class="toc">
-    <a href="#uptime">1. Uptime commitments</a>
-    <a href="#credits">2. Downtime credits</a>
-    <a href="#support">3. Support tiers</a>
-    <a href="#exclusions">4. Exclusions</a>
-    <a href="#measurement">5. Measurement methodology</a>
-    <a href="#changes">6. SLA changes</a>
-    <a href="#contact">7. Contact</a>
+    <a href="#parties">1. Who you are contracting with</a>
+    <a href="#scope">2. What the service is</a>
+    <a href="#account">3. Your account</a>
+    <a href="#plans">4. Plans, price and payment</a>
+    <a href="#withdrawal">5. Cancellation and right of withdrawal</a>
+    <a href="#use">6. Acceptable use</a>
+    <a href="#content">7. Your content, and what we cannot do with it</a>
+    <a href="#availability">8. Availability and support</a>
+    <a href="#liability">9. Liability</a>
+    <a href="#suspension">10. Suspension and termination</a>
+    <a href="#ip">11. Intellectual property</a>
+    <a href="#changes">12. Changes to these terms</a>
+    <a href="#law">13. Law, disputes and complaints</a>
+    <a href="#contact">14. Contact</a>
   </div>
 
-  <!-- 1. Uptime -->
-  <h2 id="uptime">1. Uptime commitments</h2>
-  <p>Monthly uptime percentage is calculated as: <code style="font-family:var(--mono);font-size:12px;background:var(--ink-ghost);padding:2px 6px">(total minutes &minus; downtime minutes) / total minutes &times; 100</code></p>
+  <h2 id="parties">1. Who you are contracting with</h2>
+  <p>PARAMANT is operated by <strong>Paramantis Solutions B.V.</strong>, established in Harderwijk, the Netherlands, registered with the Dutch Chamber of Commerce under KvK 42115132. In these terms "we", "us" and "PARAMANT" mean that company. "You" means the person or organisation using the service.</p>
+  <p>These terms apply to every use of paramant.app, the relay, the dashboard, ParaSend, ParaSign, ParaShare and the API. They apply from the moment you create an account or use the service without one.</p>
+  <div class="note-box">These terms cover the <strong>hosted service</strong> at paramant.app. The <strong>software</strong> is licensed separately under the <a href="/license">Business Source License 1.1</a>, which permits free non-commercial, personal and research use, including self-hosting. Running your own relay is governed by that licence, not by this document.</div>
 
-  <div class="sla-grid">
-    <div class="sla-cell head">
-      <div class="tier">Community</div>
-      <div class="uptime">99.5%</div>
-      <div class="uptime-sub">~3.6 h/month max downtime</div>
-    </div>
-    <div class="sla-cell head">
-      <div class="tier">Enterprise</div>
-      <div class="uptime">99.95%</div>
-      <div class="uptime-sub">~22 min/month max downtime</div>
-    </div>
-  </div>
+  <h2 id="scope">2. What the service is</h2>
+  <p>PARAMANT relays encrypted data. Files and documents are encrypted in your own browser before they reach us, and the relay never holds the plaintext or the key. Transfer payloads live in RAM only and are destroyed on first read or when their time to live expires, whichever comes first. The current time to live is one hour on Free, twenty-four hours on Pro and seven days on Enterprise.</p>
+  <p>Two consequences follow from that design, and you should understand both before you rely on the service.</p>
+  <p><strong>PARAMANT is not storage and not a backup.</strong> Anything you send is meant to disappear. Keep your own copy of anything you care about. We cannot recover a transfer once it has burned or expired, because there is nothing left to recover.</p>
+  <p><strong>We cannot read your data, and therefore we cannot restore it.</strong> If you lose your key or your link, the content is unrecoverable. That is not a support limitation we could lift with more effort; it is the property that makes the service worth using.</p>
 
-  <p>Uptime is measured per calendar month across the primary relay endpoint assigned to your plan. All five sector relays (health, legal, finance, IoT, relay) are covered.</p>
+  <h2 id="account">3. Your account</h2>
+  <p>An account requires a working e-mail address. You are responsible for keeping your credentials and your second factor secure, and for everything that happens under your account. Tell us promptly at <a href="mailto:info@paramant.app">info@paramant.app</a> if you think your account has been compromised.</p>
+  <p>One account is for one person or one organisation. Do not share credentials, and do not create accounts to work around the limits of a plan.</p>
+  <p>You must be at least 16 years old to create an account. PARAMANT is not directed at children.</p>
 
-  <!-- 2. Credits -->
-  <h2 id="credits">2. Downtime credits</h2>
-  <p>If PARAMANT fails to meet the monthly uptime commitment, you may request a service credit. Credits are applied to the next billing cycle and are the sole remedy for downtime.</p>
+  <h2 id="plans">4. Plans, price and payment</h2>
+  <p>The Free tier is free, has no card requirement, and stays free. Paid plans buy higher limits: longer link expiry, more reads per link, more registered devices, API access and a dedicated relay. They do not unlock the encryption, which is the same on every tier.</p>
+  <p>Prices are shown on the <a href="/pricing">pricing page</a> excluding Dutch VAT (btw). Checkout charges the amount including 21% VAT. The price that applies is the one shown at the moment you subscribe.</p>
+  <div class="note-box"><strong>State of play, honestly:</strong> automated billing is not yet live. Paid plans are currently arranged by hand, by e-mail. When online checkout goes live it will run through Mollie, a Dutch payment provider; card details are entered on Mollie's own pages and PARAMANT never sees or stores them.</div>
+  <p>Subscriptions run for the term you choose, monthly or yearly, and renew automatically for the same term unless you cancel before the renewal date. We may change prices for a future term; we will tell you at least thirty days before a change takes effect, and you may cancel before the new term begins.</p>
 
-  <table>
-    <thead>
-      <tr>
-        <th>Monthly uptime</th>
-        <th>Community credit</th>
-        <th>Enterprise credit</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>99.5% &ndash; 99.9%</td>
-        <td>&mdash;</td>
-        <td>5%</td>
-      </tr>
-      <tr>
-        <td>99.0% &ndash; 99.5%</td>
-        <td>&mdash;</td>
-        <td>15%</td>
-      </tr>
-      <tr>
-        <td>95.0% &ndash; 99.0%</td>
-        <td>&mdash;</td>
-        <td>30%</td>
-      </tr>
-      <tr>
-        <td>Below 95.0%</td>
-        <td>&mdash;</td>
-        <td>50%</td>
-      </tr>
-    </tbody>
-  </table>
+  <h2 id="withdrawal">5. Cancellation and right of withdrawal</h2>
+  <p>You can cancel a paid plan at any time. Cancellation takes effect at the end of the paid term. Your plan keeps working until then, after which the account falls back to Free. We do not refund a term that has already started, except where the law requires it or where we have failed to deliver.</p>
+  <p><strong>Consumers.</strong> If you are a consumer in the EU, you have a statutory right to withdraw from a distance contract within fourteen days, without giving a reason. If you ask us to start the service immediately and acknowledge that you thereby lose that right once the service has been fully performed, the right lapses accordingly. If you withdraw within the period and we have already begun, you pay a proportionate amount for what you used. To withdraw, send a plain e-mail to <a href="mailto:info@paramant.app">info@paramant.app</a>; no form and no reason are required.</p>
+  <p><strong>Business customers.</strong> The right of withdrawal above does not apply to contracts entered into in the course of a business or profession.</p>
+  <p>Deleting your account deletes your account data. Transfers already in flight are destroyed with it.</p>
 
-  <div class="note-box"><strong>How to claim:</strong> Email <a href="mailto:privacy@paramant.app">privacy@paramant.app</a> with subject "SLA credit request" within 30 days of the end of the affected calendar month. Include your API key label and a description of the outage. Credits are not automatically issued.</div>
-
-  <!-- 3. Support -->
-  <h2 id="support">3. Support tiers</h2>
-  <p>Initial response times are best-effort targets during business hours (09:00–17:00 CET, Mon–Fri).</p>
-
-  <table>
-    <thead>
-      <tr>
-        <th>Tier</th>
-        <th>Channel</th>
-        <th>Initial response</th>
-        <th>Scope</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="badge badge-comm">Community</span></td>
-        <td>GitHub Issues</td>
-        <td>Best effort</td>
-        <td>Bug reports, documentation questions</td>
-      </tr>
-      <tr>
-        <td><span class="badge badge-ent">Enterprise</span></td>
-        <td>Email + dedicated channel</td>
-        <td>4 business hours</td>
-        <td>Priority escalation, compliance docs, DPO contact, custom contracts</td>
-      </tr>
-    </tbody>
-  </table>
-
-  <!-- 4. Exclusions -->
-  <h2 id="exclusions">4. Exclusions</h2>
-  <p>The following are not counted as downtime for SLA purposes:</p>
-  <ul style="color:var(--ink-dim);padding-left:20px;margin-bottom:16px;display:flex;flex-direction:column;gap:8px">
-    <li>Scheduled maintenance windows, announced at least 48 hours in advance via <a href="https://github.com/Apolloccrypt/paramant-relay/releases">GitHub Releases</a></li>
-    <li>Downtime caused by client-side network failures, DNS misconfiguration, or TLS certificate errors on the client</li>
-    <li>Force majeure events (natural disasters, acts of war, upstream provider outages outside our control)</li>
-    <li>Downtime caused by your own configuration errors, abuse, or violation of the BUSL-1.1 license terms</li>
-    <li>Degraded performance that does not result in complete unavailability of the relay API endpoints</li>
-    <li>Community plan: no credit entitlement regardless of downtime duration</li>
+  <h2 id="use">6. Acceptable use</h2>
+  <p>The service is end-to-end encrypted, which means we cannot see what you send. That makes this section a matter of your responsibility rather than our filtering. You may not use PARAMANT:</p>
+  <ul style="color:var(--ink-dim);margin:0 0 16px 20px;line-height:1.8">
+    <li>for anything unlawful under Dutch or EU law, including distributing material depicting the sexual abuse of children, or content that incites terrorism;</li>
+    <li>to infringe someone else's intellectual property or breach a duty of confidentiality you owe;</li>
+    <li>to attack, overload, probe or circumvent the limits of the relay or anyone else's systems;</li>
+    <li>to send malware, or to run a command-and-control or phishing operation;</li>
+    <li>to resell the hosted service as your own, or to evade plan limits by automation or multiple accounts.</li>
   </ul>
+  <p>You are responsible for having the right to send what you send, and for complying with any rules that bind you, such as professional confidentiality, export control or sector regulation.</p>
+  <p>Where a court or a competent authority orders us to act, we comply with what Dutch and EU law require of us. In practice there is very little we can hand over: we hold ciphertext and account data, never plaintext and never keys. We will not weaken the encryption, and we will not build a way in. If we are legally free to tell you that we received an order, we will.</p>
 
-  <!-- 5. Measurement -->
-  <h2 id="measurement">5. Measurement methodology</h2>
-  <p>PARAMANT measures availability using automated HTTP health checks against <code style="font-family:var(--mono);font-size:12px;background:var(--ink-ghost);padding:2px 6px">GET /health</code> on each relay sector endpoint, from multiple EU locations, every 60 seconds. An endpoint is considered unavailable when three consecutive checks fail with a non-2xx response or a TCP timeout.</p>
-  <p>Historical uptime data is published in the Certificate Transparency log and available at <a href="/ct-log">/ct-log</a>. Self-hosted operators can verify relay health independently via the <code style="font-family:var(--mono);font-size:12px;background:var(--ink-ghost);padding:2px 6px">/v2/ct/log</code> API endpoint.</p>
+  <h2 id="content">7. Your content, and what we cannot do with it</h2>
+  <p>What you send stays yours. You grant us only the narrow, temporary permission needed to relay it: to receive an encrypted blob, hold it in memory, and hand it to the recipient. Nothing more.</p>
+  <p>We do not read, scan, mine, profile, sell or train on your content. That is not only a promise; the architecture removes the possibility. What we do process to run your account is set out in the <a href="/privacy">Privacy Policy</a>, and business customers can sign a <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a> under Article 28 GDPR.</p>
 
-  <!-- 6. Changes -->
-  <h2 id="changes">6. SLA changes</h2>
-  <p>PARAMANT may update this SLA with 30 days' written notice. Continued use of the service after the effective date constitutes acceptance of the revised SLA. Material reductions to uptime commitments entitle existing paying customers to terminate their subscription and receive a pro-rated refund for the remaining term.</p>
+  <h2 id="availability">8. Availability and support</h2>
+  <p>We aim to keep the service up, but the Free tier comes with no uptime guarantee. Committed uptime, downtime credits and support response times for paid tiers are set out in the <a href="/sla">Service Level Agreement</a>, which forms part of these terms for the plans it covers.</p>
+  <p>We may perform maintenance and may change or discontinue features. If we discontinue something you pay for, we will give reasonable notice and refund the unused part of your term.</p>
 
-  <!-- 7. Contact -->
-  <h2 id="contact">7. Contact</h2>
-  <p>For SLA credits, support escalations, or enterprise contract inquiries:</p>
-  <p><a href="mailto:privacy@paramant.app">privacy@paramant.app</a><br>
-  PARAMANT &mdash; Hetzner DE (NBG1)<br>
-  EU/DE jurisdiction &middot; GDPR Art. 28 compliant &middot; No US CLOUD Act exposure</p>
+  <h2 id="liability">9. Liability</h2>
+  <p>The service is provided as it is. To the extent Dutch law permits, our total liability towards a business customer under these terms is limited, per event and per calendar year, to the amount you paid us in the twelve months before the event, and for the Free tier to nil. We are not liable for indirect or consequential loss, lost profit, lost data or missed savings.</p>
+  <p>These limits do not apply to damage caused by our intent or deliberate recklessness, to death or personal injury, or where mandatory law forbids the limitation. If you are a consumer, your statutory rights are unaffected by anything in this section.</p>
+  <p>We are specifically not liable for data you lose because a transfer burned, expired, or because you lost the key. That behaviour is the service working as described.</p>
 
-  <div class="note-box" style="margin-top:40px"><strong>Self-hosting:</strong> This SLA applies exclusively to the managed PARAMANT relay service at <code style="font-family:var(--mono);font-size:12px;background:var(--ink-ghost);padding:2px 5px">*.paramant.app</code>. Self-hosted deployments are governed by the BUSL-1.1 license and carry no uptime warranty. See <a href="https://github.com/Apolloccrypt/paramant-relay#self-hosting" target="_blank" rel="noopener">self-hosting documentation on GitHub</a> for HA configuration guidance.</div>
+  <h2 id="suspension">10. Suspension and termination</h2>
+  <p>We may suspend or terminate an account that breaches these terms, that endangers the platform or other users, or where the law requires it. Except in urgent cases we will warn you first and give you a chance to put it right. Where we suspend without warning, we will explain afterwards why.</p>
+  <p>You may terminate at any time by cancelling your plan and deleting your account.</p>
+
+  <h2 id="ip">11. Intellectual property</h2>
+  <p>The PARAMANT name, logo, site content and documentation belong to Paramantis Solutions B.V. The relay, dashboard and protocol are licensed under the <a href="/license">Business Source License 1.1</a>, which grants free non-commercial, personal and research use and converts to the MIT licence on 1 January 2030. Commercial production use of the software requires a commercial licence. Nothing in these terms transfers ownership of the software to you, and nothing in the licence gives you rights over the hosted service beyond these terms.</p>
+
+  <h2 id="changes">12. Changes to these terms</h2>
+  <p>We may change these terms. Every version carries a number and an effective date at the top of this page. For material changes affecting paid plans we will notify account holders by e-mail at least thirty days in advance, and you may cancel before the change takes effect. Continuing to use the service after that date means you accept the new version.</p>
+
+  <h2 id="law">13. Law, disputes and complaints</h2>
+  <p>Dutch law applies. Disputes go to the competent court in the district where Paramantis Solutions B.V. is established, unless mandatory law gives you the right to another forum. If you are a consumer, you keep the right to bring a case before the court of your own place of residence.</p>
+  <p>Bring a complaint to us first at <a href="mailto:info@paramant.app">info@paramant.app</a>. We answer within fourteen days, and if we need longer we say so and say when. Consumers in the EU may also use the European ODR platform.</p>
+  <p>If a provision of these terms turns out to be invalid, the rest stays in force and the invalid part is read as the closest valid alternative.</p>
+
+  <h2 id="contact">14. Contact</h2>
+  <table>
+    <tr><td>Company</td><td>Paramantis Solutions B.V.</td></tr>
+    <tr><td>Registered office</td><td>Harderwijk, the Netherlands</td></tr>
+    <tr><td>KvK</td><td>42115132</td></tr>
+    <tr><td>General and billing</td><td><a href="mailto:info@paramant.app">info@paramant.app</a></td></tr>
+    <tr><td>Privacy and data requests</td><td><a href="mailto:privacy@paramant.app">privacy@paramant.app</a></td></tr>
+  </table>
+  <p>Related documents: <a href="/privacy">Privacy Policy</a> &middot; <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a> &middot; <a href="/sla">Service Level Agreement</a> &middot; <a href="/license">License</a> &middot; <a href="/security">Security</a>.</p>
 </div>
 
 <footer>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -312,6 +312,7 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -507,6 +508,7 @@ docker compose build   # build locally instead of pulling the published image</c
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -200,6 +200,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -278,6 +279,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -247,6 +247,7 @@
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -609,6 +610,7 @@
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/frontend/whistleblower-channel.html
+++ b/frontend/whistleblower-channel.html
@@ -234,6 +234,7 @@ section p+p{margin-top:14px}
       <a href="/quantum-urgency">Quantum urgency</a>
       <a href="/crypto-agility">Crypto agility</a>
       <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
     </div>
   </div>
 
@@ -339,6 +340,7 @@ section p+p{margin-top:14px}
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
           <a href="/sla">SLA</a>
           <a href="/license">License</a>
           <a href="/compliance/nis2">Compliance overview</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "paramant",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paramant",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dependencies": {
+        "@noble/post-quantum": "^0.6.1",
         "redis": "^4.7.1"
       },
       "devDependencies": {
@@ -121,6 +122,62 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/post-quantum/-/post-quantum-0.6.1.tgz",
+      "integrity": "sha512-+pormrDZwjRw05U8ADK4JpHejo87+gBd+muRBB/ozztH5yhDLMDF4jHQWN3NQQAsu1zBNPWTG0ZwVI0CR29H0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "~2.2.0",
+        "@noble/curves": "~2.2.0",
+        "@noble/hashes": "~2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@redis/bloom": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paramant",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "scripts": {
     "build": "bash build.sh"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "terser": "^5.31.0"
   },
   "dependencies": {
-    "redis": "^4.7.1",
-    "@noble/post-quantum": "^0.6.1"
+    "@noble/post-quantum": "^0.6.1",
+    "redis": "^4.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "terser": "^5.31.0"
   },
   "dependencies": {
-    "redis": "^4.7.1"
+    "redis": "^4.7.1",
+    "@noble/post-quantum": "^0.6.1"
   }
 }

--- a/relay/lib/billing.js
+++ b/relay/lib/billing.js
@@ -15,6 +15,36 @@
 
 const catalog = require('./billing-catalog');
 
+// How far a paid interval carries the entitlement. Calendar months and years,
+// not 30 or 365 days: a customer who pays on the 31st should renew on a date
+// they recognise, and the yearly plan must not drift a day per leap year.
+// Clamped to the last day of the target month, so 31 January plus one month is
+// 28 February and never 3 March.
+function periodEnd(from, interval) {
+  const start = from instanceof Date ? new Date(from.getTime()) : new Date(from);
+  if (Number.isNaN(start.getTime())) return null;
+  const months = interval === 'yearly' ? 12 : interval === 'monthly' ? 1 : 0;
+  if (!months) return null;
+  const day = start.getUTCDate();
+  const end = new Date(Date.UTC(
+    start.getUTCFullYear(), start.getUTCMonth() + months, 1,
+    start.getUTCHours(), start.getUTCMinutes(), start.getUTCSeconds(), start.getUTCMilliseconds(),
+  ));
+  const lastDay = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth() + 1, 0)).getUTCDate();
+  end.setUTCDate(Math.min(day, lastDay));
+  return end;
+}
+
+// A renewal extends from where the paid period currently ends, not from the day
+// the money happened to land. Paying three days early must add a month, not
+// throw three days away; a payment after a lapse starts from now, so a gap is
+// never retroactively covered.
+function extendFrom(currentPaidUntil, now) {
+  const cur = currentPaidUntil ? new Date(currentPaidUntil) : null;
+  if (!cur || Number.isNaN(cur.getTime())) return now;
+  return cur.getTime() > now.getTime() ? cur : now;
+}
+
 // deps: {
 //   setProductPlan(accountId, product, tier) -> { ok, ... }  (sync or async)
 //   isProcessed(paymentId) -> boolean                        (async; optional)
@@ -57,22 +87,41 @@ async function processPayment(payment, deps) {
         reason: `amount_mismatch paid=${paid}/${cur} expected=${order.amount}/${order.currency}`,
       };
     }
+    // The period this payment bought. Without it the grant never ends: Mollie is
+    // asked for a one-off payment, so no second collection follows, and the
+    // entitlement used to stay on the paid tier forever. An interval we cannot
+    // turn into a date is refused rather than granted open-endedly.
+    const now = d.now instanceof Date ? d.now : new Date();
+    const paidUntil = periodEnd(extendFrom(
+      typeof d.currentPaidUntil === 'function' ? await d.currentPaidUntil(accountId, product) : null,
+      now,
+    ), interval);
+    if (!paidUntil) {
+      return { result: 'refused', level: 'error', account: accountId, product, reason: `no_period_for_interval:${interval}` };
+    }
+
     // Grant ONLY this product's tier. setProductPlan never touches the other
     // product (rule: product A must not move product B).
     let set;
-    try { set = await d.setProductPlan(accountId, product, order.tier); }
+    try { set = await d.setProductPlan(accountId, product, order.tier, paidUntil); }
     catch (e) { set = { ok: false, reason: e.message }; }
     if (!set || !set.ok) {
       return { result: 'refused', level: 'error', account: accountId, product, reason: `grant_failed:${set && set.reason}` };
     }
     if (typeof d.markProcessed === 'function') { try { await d.markProcessed(payment.id, 'granted'); } catch { /* best effort */ } }
-    return { result: 'granted', level: 'info', account: accountId, product, tier: order.tier, reason: `${product}->${order.tier}` };
+    return {
+      result: 'granted', level: 'info', account: accountId, product, tier: order.tier,
+      paidUntil: paidUntil.toISOString(),
+      reason: `${product}->${order.tier} until ${paidUntil.toISOString().slice(0, 10)}`,
+    };
   }
 
   if (status === 'chargeback' || status === 'charged_back') {
     // Money reclaimed. Revoke: drop this product to its floor tier.
     const floor = catalog.floorTier(product);
-    try { await d.setProductPlan(accountId, product, floor); } catch { /* logged by caller via reason */ }
+    // null clears the period along with the tier: money reclaimed leaves no
+    // paid time on record.
+    try { await d.setProductPlan(accountId, product, floor, null); } catch { /* logged by caller via reason */ }
     if (typeof d.markProcessed === 'function') { try { await d.markProcessed(payment.id, 'revoked'); } catch { /* best effort */ } }
     return { result: 'revoked', level: 'warn', account: accountId, product, tier: floor, reason: 'chargeback' };
   }
@@ -107,4 +156,4 @@ function classifyFetchError(err) {
   return { retry: true, level: 'warn', reason: status ? `mollie_${status}` : (msg || 'fetch_error') };
 }
 
-module.exports = { processPayment, classifyFetchError };
+module.exports = { processPayment, classifyFetchError, periodEnd, extendFrom };

--- a/relay/lib/entitlements.js
+++ b/relay/lib/entitlements.js
@@ -87,6 +87,59 @@ const PRODUCT_PLAN_FIELD = Object.freeze({
   parasign: 'plan_parasign',
 });
 
+// The date a paid tier stops being paid for, per product. A tier without one is
+// a grant that never ends: before this field, a single 15 euro payment set
+// plan_parasend to 'pro' and nothing ever took it back, because Mollie is asked
+// for a one-off payment and there is no second collection. Both halves are
+// needed. The subscription makes the money come in again; this field makes the
+// entitlement stop when it does not. Without it, cancelling an subscription
+// leaves the buyer on the paid tier forever.
+//
+// Absent means "no paid period on record", which is the correct reading for a
+// free account and for every account that predates billing. It is NEVER read as
+// expired, so a missing field can not silently downgrade anyone.
+const PRODUCT_PAID_UNTIL_FIELD = Object.freeze({
+  parasend: 'paid_until_parasend',
+  parasign: 'paid_until_parasign',
+});
+
+// The tier a product falls back to when a paid period runs out. Mirrors
+// billing-catalog.floorTier; kept here too so the entitlement layer can answer
+// without importing the billing layer (the dependency runs the other way).
+function floorTierOf(product) {
+  return product === 'parasign' ? 'free' : 'community';
+}
+
+// Parse a stored paid-until value. Anything unparseable is treated as absent
+// rather than as expired, on the same no-silent-downgrade rule as the migration
+// helpers below: a corrupt date must not cost a paying customer their tier.
+function parsePaidUntil(value) {
+  if (!value) return null;
+  const t = Date.parse(value);
+  return Number.isNaN(t) ? null : t;
+}
+
+// The tier an account ACTUALLY has right now, which is the stored tier unless
+// its paid period has passed. Read paths should use this instead of reading
+// PRODUCT_PLAN_FIELD directly, so an expired subscription stops granting even
+// if no webhook, cron or admin ever came along to write the downgrade.
+// Returns { tier, expired, paidUntil }.
+function effectiveProductTier(rec, product, now) {
+  const field = PRODUCT_PLAN_FIELD[product];
+  if (!rec || !field) return { tier: floorTierOf(product), expired: false, paidUntil: null };
+  const stored = product === 'parasign'
+    ? normaliseParasignTier(rec[field])
+    : normaliseParasendTier(rec[field]);
+  const floor = floorTierOf(product);
+  const paidUntil = parsePaidUntil(rec[PRODUCT_PAID_UNTIL_FIELD[product]]);
+  // A floor tier can not expire, and no recorded period means no expiry to
+  // enforce (free accounts, and every account from before billing existed).
+  if (stored === floor || paidUntil === null) return { tier: stored, expired: false, paidUntil };
+  const at = typeof now === 'number' ? now : Date.now();
+  if (at >= paidUntil) return { tier: floor, expired: true, paidUntil };
+  return { tier: stored, expired: false, paidUntil };
+}
+
 // ── Admin per-product grant primitives ───────────────────────────────────────
 // These back the fine-grained admin path (POST /v2/admin/keys/set-product-plan)
 // so exactly ONE product's tier moves, with the unified `plan` and the other
@@ -113,14 +166,26 @@ function validateProductPlan(product, tier) {
 // normalised (idempotent), so passing an already-normalised value is safe.
 // Returns { field, tier, changed, parasignGranted }; `changed` reflects the
 // plan-field move only (an already-set access flag is not a plan change).
-function applyProductTier(rec, product, tier) {
+function applyProductTier(rec, product, tier, paidUntil) {
   const field = PRODUCT_PLAN_FIELD[product];
   const norm = product === 'parasign' ? normaliseParasignTier(tier) : normaliseParasendTier(tier);
   let changed = false;
   if (rec[field] !== norm) { rec[field] = norm; changed = true; }
   let parasignGranted = false;
   if (product === 'parasign' && norm !== 'free' && rec.parasign !== true) { rec.parasign = true; parasignGranted = true; }
-  return { field, tier: norm, changed, parasignGranted };
+  // The paid period travels with the tier it paid for. Landing on the floor
+  // clears it, so a revoked or lapsed account carries no stale date; passing
+  // undefined leaves whatever is there alone, which keeps every existing caller
+  // (admin grants, migrations) behaving exactly as before.
+  const untilField = PRODUCT_PAID_UNTIL_FIELD[product];
+  if (norm === floorTierOf(product)) {
+    if (rec[untilField] !== undefined) { delete rec[untilField]; changed = true; }
+  } else if (paidUntil !== undefined) {
+    const iso = paidUntil === null ? null : new Date(paidUntil).toISOString();
+    if (iso === null) { if (rec[untilField] !== undefined) { delete rec[untilField]; changed = true; } }
+    else if (rec[untilField] !== iso) { rec[untilField] = iso; changed = true; }
+  }
+  return { field, tier: norm, changed, parasignGranted, paidUntil: rec[untilField] || null };
 }
 
 // ── Migration: legacy single `plan` (+ parasign flag) -> per-product plan ─────
@@ -314,8 +379,10 @@ module.exports = {
   normaliseParasendTier,
   normaliseParasignTier,
   PRODUCT_PLAN_FIELD,
+  PRODUCT_PAID_UNTIL_FIELD,
   validateProductPlan,
   applyProductTier,
+  effectiveProductTier,
   getEntitlements,
   mergeAccountRecord,
   transfersQuota,

--- a/relay/lib/entitlements.js
+++ b/relay/lib/entitlements.js
@@ -291,11 +291,21 @@ const PARASIGN = Object.freeze(Object.fromEntries(
 // Missing per-product plan falls back to derivation from the legacy plan, so an
 // account never accidentally lands on the floor tier just because migration has
 // not run yet.
-function getEntitlements(account) {
+function getEntitlements(account, now) {
   const acct = (account && typeof account === 'object') ? account : { plan: account };
   const legacyPlan = acct.plan;
-  const psTier = normaliseParasendTier(acct.plan_parasend || derivePlanParasend(legacyPlan));
-  const pgTier = normaliseParasignTier(acct.plan_parasign || derivePlanParasign(legacyPlan, acct.parasign));
+  const psStored = normaliseParasendTier(acct.plan_parasend || derivePlanParasend(legacyPlan));
+  const pgStored = normaliseParasignTier(acct.plan_parasign || derivePlanParasign(legacyPlan, acct.parasign));
+  // The paid period decides here, at the one place every gate reads. Writing the
+  // date on the record is not enough on its own: without this the tier field
+  // still grants after the period is over, and an expired subscription keeps
+  // working until somebody happens to write a downgrade.
+  //
+  // A record with no period is never expired, so the legacy paths above and
+  // every account from before billing keep exactly the tier they had. Only a
+  // tier that was paid for, with a date that has passed, falls to its floor.
+  const psTier = effectiveProductTier({ plan_parasend: psStored, [PRODUCT_PAID_UNTIL_FIELD.parasend]: acct[PRODUCT_PAID_UNTIL_FIELD.parasend] }, 'parasend', now).tier;
+  const pgTier = effectiveProductTier({ plan_parasign: pgStored, [PRODUCT_PAID_UNTIL_FIELD.parasign]: acct[PRODUCT_PAID_UNTIL_FIELD.parasign] }, 'parasign', now).tier;
   return {
     parasend: PARASEND[psTier],
     parasign: PARASIGN[pgTier],

--- a/relay/lib/keys-table.js
+++ b/relay/lib/keys-table.js
@@ -285,4 +285,61 @@ function accountHasParasignEntitlement(memberRecords, plan) {
   return PARASIGN_ENTITLED_PLANS.has(plan);
 }
 
-module.exports = { VALID_SCOPES, hasParaSignScope, computeKid, maskApiKey, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2, computeOverLimit, designatePrimary, buildParasignKeyRecord, accountHasParasignEntitlement, PARASIGN_ENTITLED_PLANS };
+// ── Erasure: what a deletion request must actually remove ────────────────────
+//
+// Revoking a key stops it working. It does not remove the person behind it, and
+// for a while that was the whole of "delete account": POST /admin/delete-account
+// flipped every key to inactive, cleared Redis, and left the email address
+// sitting in users.json on all five sectors. Audit finding 5 of 2026-07-21.
+// Article 17 GDPR is about erasure, and an inactive record that still names
+// someone is not erased.
+//
+// The fields below are the ones that identify a person. Everything else on a key
+// record describes what was bought and used, and that has to survive: a payment
+// must stay traceable for the tax years it belongs to. So this erases identity,
+// never financial fact, and it marks the record instead of removing it, because
+// removing the row would take the billing history with it.
+const PERSONAL_DATA_FIELDS = Object.freeze([
+  'email', 'label', 'dsa_pub', 'trial_metadata', 'name', 'company', 'phone',
+]);
+
+// Erase in place, on the parsed users.json that _mutateUsersJson hands its
+// callback. Touches both places an account lives: the accounts summary and every
+// api-key record belonging to it (see mergeAccountRecord in entitlements.js for
+// why there are two).
+//
+// Idempotent on purpose. A deletion that runs twice, or that is retried after a
+// sector was briefly unreachable, must not fail the second time; it should find
+// nothing left to do and say so.
+function erasePersonalData(data, accountOrKey) {
+  const out = { accounts: 0, keys: 0, fields: 0 };
+  if (!data || !accountOrKey) return out;
+  const wipe = (rec) => {
+    let n = 0;
+    for (const f of PERSONAL_DATA_FIELDS) {
+      if (rec[f] !== undefined && rec[f] !== null) { delete rec[f]; n++; }
+    }
+    if (n) { rec.erased_at = rec.erased_at || new Date().toISOString(); }
+    return n;
+  };
+  const matches = (rec) => rec && (rec.key === accountOrKey || rec.account_id === accountOrKey);
+
+  for (const rec of (data.api_keys || [])) {
+    if (!matches(rec)) continue;
+    const n = wipe(rec);
+    if (n) { out.keys++; out.fields += n; }
+    // A key whose owner is gone must not keep working, even if the revoke call
+    // that normally precedes this never landed.
+    rec.active = false;
+  }
+  for (const rec of (data.accounts || [])) {
+    if (!matches(rec)) continue;
+    const n = wipe(rec);
+    if (n) { out.accounts++; out.fields += n; }
+  }
+  return out;
+}
+
+module.exports = {
+  PERSONAL_DATA_FIELDS,
+  erasePersonalData, VALID_SCOPES, hasParaSignScope, computeKid, maskApiKey, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2, computeOverLimit, designatePrimary, buildParasignKeyRecord, accountHasParasignEntitlement, PARASIGN_ENTITLED_PLANS };

--- a/relay/lib/paraid-issuer.mjs
+++ b/relay/lib/paraid-issuer.mjs
@@ -29,7 +29,30 @@ function merkleRoot(leaves) {
 // that a live human was present. No name, age or nationality: those come only
 // from a document read, which is a separate, higher tier. We never fabricate.
 const FIELDS_PRESENCE = ['presence_verified', 'holder_binding'];
-const FIELDS_SUBSTANTIAL = ['age_over_18', 'nationality', 'holder_binding'];
+const FIELDS_MRZ = ['age_over_18', 'nationality', 'holder_binding'];
+
+// The assurance label on a credential says what the issuer actually checked, and
+// nothing more. This one used to read 'substantial', which is the eIDAS word for
+// a legally defined level of identity assurance. A caller supplies two lines of
+// text; the issuer recomputes the ICAO check digits and signs the result. Check
+// digits are a typo guard, not a signature: anyone can write an MRZ that passes
+// them, because the algorithm is public and the input is the caller's own. So
+// the document is never seen, its authenticity is never tested, and no person is
+// tied to it. Claiming eIDAS substantial on that is a claim the evidence does
+// not carry, and a verifier filtering on the word gets a wrong answer.
+//
+// 'mrz-unverified' says the true thing: an MRZ whose form checks out, from a
+// document nobody authenticated. The real substantial rung needs the passport
+// chip (eMRTD SOD, passive authentication), and that is what TIER_CHIP is
+// reserved for. Nothing issues it yet, and nothing pretends to.
+const TIER_PRESENCE = 'presence';
+const TIER_MRZ = 'mrz-unverified';
+const TIER_CHIP = 'high';
+
+// Older credentials in the wild carry 'substantial' from before this rename.
+// They mean exactly what mrz-unverified means; a verifier must read them as the
+// same rung, never as the eIDAS level the word suggests.
+const LEGACY_TIER_ALIASES = Object.freeze({ substantial: TIER_MRZ });
 
 // Server-side MRZ re-validation, so the issuer never signs an attribute the
 // document does not actually check out to. Same ICAO 9303 TD3 logic as the
@@ -57,6 +80,25 @@ function ageOver18(dobYYMMDD, now) {
   return age >= 18;
 }
 
+// Read a credential's assurance rung, mapping the pre-rename word onto the rung
+// it always meant. Verifiers must go through this instead of comparing tier
+// strings, so one old credential cannot read as a level it never had.
+export function assuranceOf(credential) {
+  const t = (credential && credential.tier) || TIER_PRESENCE;
+  return LEGACY_TIER_ALIASES[t] || t;
+}
+
+// Ascending order of what the issuer actually verified. Anything unknown sorts
+// below presence rather than above it: an unrecognised label is never a reason
+// to trust a credential more.
+export const ASSURANCE_RANK = Object.freeze([TIER_PRESENCE, TIER_MRZ, TIER_CHIP]);
+export function assuranceAtLeast(credential, required) {
+  const have = ASSURANCE_RANK.indexOf(assuranceOf(credential));
+  const need = ASSURANCE_RANK.indexOf(required);
+  if (have < 0 || need < 0) return false;
+  return have >= need;
+}
+
 export function createIssuer({ keyFile }) {
   const raw = JSON.parse(readFileSync(keyFile, 'utf8'));
   const secretKey = new Uint8Array(Buffer.from(raw.secretKey, 'base64'));
@@ -80,7 +122,7 @@ export function createIssuer({ keyFile }) {
       ok: true,
       credential: {
         v: 1,
-        tier: 'presence',
+        tier: TIER_PRESENCE,
         fieldOrder: order,
         issuerDid: did,
         issuerPublicKey: b64(publicKey),
@@ -97,13 +139,13 @@ export function createIssuer({ keyFile }) {
   // check digits and derives the attributes itself, so it never signs a claim
   // the document does not check out to. Only age_over_18 and nationality are
   // sealed: never the name, birthdate or document number.
-  function issueSubstantial({ holderBindingB64url, mrzLine1, mrzLine2, now }) {
+  function issueFromMrz({ holderBindingB64url, mrzLine1, mrzLine2, now }) {
     if (!/^[A-Za-z0-9_-]{20,64}$/.test(holderBindingB64url || '')) {
       return { ok: false, error: 'holder_binding must be a b64url sha3-256 hash' };
     }
     const v = validateTD3(mrzLine1, mrzLine2);
     if (!v) return { ok: false, error: 'MRZ failed validation (format or check digits)' };
-    const order = FIELDS_SUBSTANTIAL;
+    const order = FIELDS_MRZ;
     const fields = {
       age_over_18: ageOver18(v.dob, now instanceof Date ? now : new Date()) ? 'yes' : 'no',
       nationality: v.nationality,
@@ -116,7 +158,11 @@ export function createIssuer({ keyFile }) {
     return {
       ok: true,
       credential: {
-        v: 1, tier: 'substantial', fieldOrder: order,
+        v: 1, tier: TIER_MRZ, fieldOrder: order,
+        // Spelled out on the credential itself, so a verifier that never reads
+        // our docs still cannot mistake this for a checked document.
+        checked: 'mrz_check_digits',
+        not_checked: ['document_authenticity', 'chip_signature', 'holder_identity', 'liveness'],
         issuerDid: did, issuerPublicKey: b64(publicKey),
         fields, salts: Object.fromEntries(Object.entries(salts).map(([k, s]) => [k, b64url(s)])),
         root: hex(root), rootSig: b64(rootSig),
@@ -124,5 +170,12 @@ export function createIssuer({ keyFile }) {
     };
   }
 
-  return { did, issue, issueSubstantial, publicKeyB64: b64(publicKey) };
+  // issueSubstantial is kept as an alias so every existing caller keeps working
+  // while the name moves to what the function actually does. The credential it
+  // returns now carries the honest tier either way, so the alias cannot be used
+  // to get the old claim back.
+  return {
+    did, issue, issueFromMrz, issueSubstantial: issueFromMrz,
+    publicKeyB64: b64(publicKey),
+  };
 }

--- a/relay/lib/parasign-open-api.js
+++ b/relay/lib/parasign-open-api.js
@@ -198,6 +198,35 @@ async function emitEvent(deps, id, event, extra) {
   }
 }
 
+// ── /v1 Bearer authentication ─────────────────────────────────────────────────
+// The single definition of "is this caller a known /v1 client": Authorization:
+// Bearer psk_live_/psk_test_ resolving to an active key-table record. Split out
+// of route() (behaviour there is unchanged) because it used to live ONLY inside
+// this router, and relay.js has /v1 handlers of its own that run BEFORE the
+// router and therefore never reached it. That is how POST /v1/paraid/
+// issue-document shipped with nothing but an IP rate-limit in front of a live
+// credential signer. Those handlers now call this.
+// AUTHENTICATION only. The parasign scope check stays in route(), because it is
+// AUTHORIZATION for one product: ParaID is not in billing-catalog PRODUCTS and
+// has no scope of its own, so demanding "parasign" there would gate one product
+// behind another's entitlement.
+// Returns { ok: true, token, mode, rec } or { ok: false, code, error, message }.
+function authenticateBearer(authHeader, apiKeys) {
+  const m = /^Bearer\s+(.+)$/i.exec((authHeader || '').trim());
+  const token = m ? m[1].trim() : '';
+  const isPsk = /^psk_(live|test)_/.test(token);
+  if (!token || !isPsk) {
+    return { ok: false, code: 401, error: 'unauthorized',
+      message: 'Missing or malformed API key. Send Authorization: Bearer psk_live_... / Geen of ongeldige API-sleutel; stuur Authorization: Bearer psk_live_...' };
+  }
+  const rec = apiKeys && apiKeys.get(token);
+  if (!rec || rec.active === false) {
+    return { ok: false, code: 401, error: 'unauthorized',
+      message: 'API key not recognised or revoked. / API-sleutel onbekend of ingetrokken.' };
+  }
+  return { ok: true, token, mode: token.startsWith('psk_test_') ? 'test' : 'live', rec };
+}
+
 // ── main router ───────────────────────────────────────────────────────────────
 // deps: { req, res, method, path, query, clientIp, authHeader, publicOrigin,
 //         apiKeys, envStore, envCreateRateOk, safeHttpsRequest, canonicalJSON,
@@ -205,22 +234,10 @@ async function emitEvent(deps, id, event, extra) {
 async function route(deps) {
   const { res, method, path, query, apiKeys, envStore, J } = deps;
 
-  // 1) AUTH - Bearer psk_live_/psk_test_ + parasign scope.
-  const m = /^Bearer\s+(.+)$/i.exec((deps.authHeader || '').trim());
-  const token = m ? m[1].trim() : '';
-  const isPsk = /^psk_(live|test)_/.test(token);
-  if (!token || !isPsk) {
-    return errRes(res, 401,
-      'unauthorized',
-      'Missing or malformed API key. Send Authorization: Bearer psk_live_... / Geen of ongeldige API-sleutel; stuur Authorization: Bearer psk_live_...',
-      J);
-  }
-  const mode = token.startsWith('psk_test_') ? 'test' : 'live';
-  const rec = apiKeys.get(token);
-  if (!rec || rec.active === false) {
-    return errRes(res, 401, 'unauthorized',
-      'API key not recognised or revoked. / API-sleutel onbekend of ingetrokken.', J);
-  }
+  // 1) AUTH - Bearer psk_live_/psk_test_ (authenticateBearer) + parasign scope.
+  const auth = authenticateBearer(deps.authHeader, apiKeys);
+  if (!auth.ok) return errRes(res, auth.code, auth.error, auth.message, J);
+  const { token, mode, rec } = auth;
   if (!hasParaSignScope(rec)) {
     return errRes(res, 403, 'forbidden_scope',
       'This key lacks the "parasign" scope. Enable ParaSign for this key/account. / Deze sleutel mist de scope "parasign". Activeer ParaSign voor deze sleutel/dit account.', J);
@@ -723,6 +740,7 @@ async function voidEnvelope(deps, id, token, rec) {
 
 module.exports = {
   route, emitEvent, hasParaSignScope, externalStatus,
+  authenticateBearer,           // shared with the relay's own /v1 handlers
   grantParaSignScope, setParaSignEnabled,
   authorizeReceipt, hexEqual,   // exposed for tests
   sandboxAutoSign,              // exposed for tests

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -5052,6 +5052,40 @@ const server = http.createServer(async (req, res) => {
     }));
   }
 
+  // ── POST /v2/admin/keys/erase ─────────────────────────────────────────────
+  // Revoke stops a key working; this removes the person. Article 17 GDPR asks for
+  // erasure, and until now "delete account" left the email address in users.json
+  // on every sector while only Redis was cleared. Audit finding 5 of 2026-07-21.
+  //
+  // Takes an account_id or a key and erases the identifying fields from both
+  // places the account lives, keeping what a payment must stay traceable by.
+  // Idempotent: a retry after a sector was briefly unreachable finds nothing left
+  // and reports zero, which is a success and not an error.
+  if (path === '/v2/admin/keys/erase' && req.method === 'POST') {
+    try {
+      const d = JSON.parse((await readBody(req, 1024)).toString());
+      const target = d.account_id || d.key;
+      if (!target) { res.writeHead(400); return res.end(J({ error: 'account_id or key required' })); }
+      let result = { accounts: 0, keys: 0, fields: 0 };
+      await _mutateUsersJson(ud => {
+        result = keysTable.erasePersonalData(ud, target);
+        ud.updated = new Date().toISOString();
+      });
+      // Drop the in-memory copies too, otherwise the erased address stays
+      // readable until the next restart.
+      for (const [k, v] of apiKeys) {
+        if (k === target || (v && v.account_id === target)) {
+          for (const f of keysTable.PERSONAL_DATA_FIELDS) delete v[f];
+          v.active = false;
+        }
+      }
+      const acct = accounts.get(target);
+      if (acct) { for (const f of keysTable.PERSONAL_DATA_FIELDS) delete acct[f]; }
+      log('info', 'account_erased', { target: String(target).slice(0, 16), ...result });
+      res.writeHead(200); return res.end(J({ ok: true, erased: result }));
+    } catch (e) { res.writeHead(400); return res.end(J({ error: e.message })); }
+  }
+
   // ── POST /v2/admin/keys/revoke ────────────────────────────────────────────
   if (path === '/v2/admin/keys/revoke' && req.method === 'POST') {
     try {

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -38,7 +38,7 @@ const quota         = require('./lib/quota');
 const keysTable     = require('./lib/keys-table');
 const paraidRegistry = require('./lib/paraid-registry');
 
-const VERSION    = '3.0.0';
+const VERSION    = '3.1.0';
 // Per-restart nonce: stream-next hashes non-precomputable even if API key is known
 const STREAM_NONCE = crypto.randomBytes(32);
 

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1676,7 +1676,10 @@ function grantParasignOnPaidPlan(accountId) {
 // fan-out + users.json persistence. Idempotent (a repeat call with the same tier
 // changes nothing -> changed:0). For parasign it also flips the `parasign` access
 // flag on when the tier is paid (non-free). NEVER touches the other product.
-function setProductPlan(accountId, product, tier) {
+// paidUntil travels with the tier: a Date (or ISO string) sets the period this
+// grant is paid for, null clears it, and undefined leaves whatever is on record
+// alone. That last case keeps every admin grant behaving exactly as before.
+function setProductPlan(accountId, product, tier, paidUntil) {
   if (!accountId || (product !== 'parasend' && product !== 'parasign')) return { ok: false, reason: 'bad_args' };
   const norm = product === 'parasign'
     ? entitlements.normaliseParasignTier(tier)
@@ -1689,7 +1692,7 @@ function setProductPlan(accountId, product, tier) {
     if (!mv) continue;
     // Single field-level rule (writes only this product's field + the parasign
     // access flag; never the other product or the unified `plan`).
-    if (entitlements.applyProductTier(mv, product, norm).changed) changed++;
+    if (entitlements.applyProductTier(mv, product, norm, paidUntil).changed) changed++;
   }
   // Mirror onto the accounts summary too. Readers that only hold an account_id
   // (the ParaSign web sign gate among them) resolve through entitlementRecordOf,
@@ -1697,7 +1700,7 @@ function setProductPlan(accountId, product, tier) {
   // outvote a paid grant on any future read path either.
   const _acct = accounts.get(accountId);
   if (_acct) {
-    entitlements.applyProductTier(_acct, product, norm);
+    entitlements.applyProductTier(_acct, product, norm, paidUntil);
     _acct.plan_updated = new Date().toISOString();
   }
   _mutateUsersJson(ud => {
@@ -5144,6 +5147,12 @@ const server = http.createServer(async (req, res) => {
     const _idemKey = (id) => `paramant:billing:done:${id}`;
     const outcome = await billing.processPayment(payment, {
       setProductPlan,
+      // Lets a renewal extend from where the paid period ends instead of from
+      // the day the money landed, so paying early never costs the buyer days.
+      currentPaidUntil: async (accountId, product) => {
+        const rec = accounts.get(accountId);
+        return (rec && rec[entitlements.PRODUCT_PAID_UNTIL_FIELD[product]]) || null;
+      },
       isProcessed: async (id) => { if (!_rok()) return false; try { return !!(await redisClient.get(_idemKey(id))); } catch { return false; } },
       markProcessed: async (id, val) => { if (!_rok()) return; try { await redisClient.set(_idemKey(id), String(val), { EX: 60 * 86400 }); } catch { /* best effort */ } },
     });

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -2199,7 +2199,26 @@ const server = http.createServer(async (req, res) => {
   // Substantial tier: issue from a passport MRZ. The relay re-validates the MRZ
   // check digits and derives age_over_18 + nationality itself; only those two
   // attributes are sealed, never name/birthdate/document number.
+  //
+  // AUTHENTICATED. This route signs an identity claim with the registered Demo
+  // Authority key on nothing but MRZ text the caller typed, and it shipped with
+  // only a per-IP rate-limit in front of it: anyone on the internet could mint a
+  // signed "age_over_18 / nationality" credential from made-up digits. An
+  // unauthenticated signer of identity claims is a liability, so it now sits
+  // behind the same Bearer psk_ authentication as every other /v1 route
+  // (parasign-open-api authenticateBearer). It is deliberately NOT behind the
+  // parasign SCOPE: ParaID is not a product in billing-catalog PRODUCTS and has
+  // no scope of its own, and gating it on another product's entitlement would
+  // be a pricing decision, not a security one.
+  // Known consequence: the /paraid-document page's issue button now gets a 401.
+  // The page stays up (it is labelled beta and says it is not an eIDAS scheme),
+  // but issuance is no longer something a visitor can trigger.
   if (path === '/v1/paraid/issue-document' && req.method === 'POST') {
+    const _paraidAuth = parasignOpenApi.authenticateBearer(req.headers['authorization'] || '', apiKeys);
+    if (!_paraidAuth.ok) {
+      res.writeHead(_paraidAuth.code, { 'Content-Type': 'application/json' });
+      return res.end(J({ error: _paraidAuth.error, message: _paraidAuth.message }));
+    }
     if (!paraidIssuer || !paraidIssuer.issueSubstantial) { res.writeHead(503, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'issuer not configured' })); }
     if (!envCreateRateOk('paraid:' + clientIp)) { res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': '3600' }); return res.end(J({ error: 'issuance quota exceeded, try later' })); }
     let body;

--- a/relay/test/_requires.js
+++ b/relay/test/_requires.js
@@ -1,0 +1,92 @@
+'use strict';
+// Preconditions for relay tests that need something a bare checkout does not
+// have: the native ML-DSA-65 binding (@paramant/core), or a reachable Redis.
+//
+// WHY THIS FILE EXISTS. Six suites used to swallow the load error, print
+// "  skip - ...", and return. Under `node --test` a file that exits 0 is a PASS,
+// so the relay unit job (which installs nothing, on purpose) reported "ok 24"
+// while five of those suites had run ZERO checks. The one that hurt is
+// parasign-sandbox-live-guard.test.js: it is the only thing standing between a
+// psk_live_ key and the sandbox auto-signer, and for as long as that job ran
+// without @paramant/core it asserted nothing at all. A green tick over nothing
+// is worse than a red one, because red gets looked at.
+//
+// THE RULE NOW: a precondition the test cannot meet is a HARD FAILURE, unless
+// the runner names it as deliberately absent:
+//
+//   RELAY_TEST_SKIP=engine,redis   node --test test/foo.test.js
+//
+// That moves the decision out of the test and into .github/workflows/test.yml,
+// where a reviewer can see which job gave up on what. It also means the fix for
+// a skip is to give the job the dependency: nothing else has to change here.
+
+const firstLine = (e) => String((e && e.message) || e).split('\n')[0];
+
+// Named preconditions the runner declared this environment does not provide.
+function mayskip(name) {
+  return String(process.env.RELAY_TEST_SKIP || '')
+    .split(',').map((s) => s.trim()).filter(Boolean).includes(name);
+}
+
+// A precondition could not be met. Either the runner said so up front (skip,
+// loudly and by name), or this is a real failure and the test goes red.
+function unmet(name, reason) {
+  if (mayskip(name)) {
+    console.log(`  SKIP [${name}] - ${reason} (declared via RELAY_TEST_SKIP)`);
+    return null;
+  }
+  throw new Error(
+    `unmet precondition "${name}": ${reason}\n` +
+    `  This suite cannot set up its own conditions, so it fails instead of\n` +
+    `  reporting a pass over nothing. Give the job the dependency, or, if this\n` +
+    `  environment is genuinely not meant to have it, say so on the runner:\n` +
+    `    RELAY_TEST_SKIP=${name}`);
+}
+
+// The ML-DSA-65 signing engine (algorithm id 0x0002), via @paramant/core.
+// Returns the engine, or null when "engine" is a declared skip.
+function requireEngine() {
+  let reason;
+  try {
+    require('../crypto/bootstrap').bootstrap();
+    const eng = require('../crypto/registry').getSig(0x0002);
+    if (eng && typeof eng.generateKeyPair === 'function') return eng;
+    reason = 'crypto registry has no usable ML-DSA-65 engine at 0x0002';
+  } catch (e) {
+    // Almost always "Cannot find module '@paramant/core'", i.e. the job never
+    // ran `npm install` (the binding is a file: link to the sibling repo).
+    // First line only: node appends a multi-line "Require stack" that turns the
+    // one-line SKIP/FAIL message into a wall of paths.
+    reason = firstLine(e);
+  }
+  return unmet('engine', `ML-DSA-65 engine unavailable: ${reason}`);
+}
+
+// A connected redis client at REDIS_URL (or the caller's default port), or null
+// when "redis" is a declared skip. Callers must disconnect what they get.
+async function requireRedis(defaultUrl) {
+  const url = process.env.REDIS_URL || defaultUrl;
+  let createClient;
+  try { ({ createClient } = require('redis')); }
+  catch (e) { return unmet('redis', `the "redis" module is not installed: ${firstLine(e)}`); }
+  const rc = createClient({ url, socket: { connectTimeout: 800, reconnectStrategy: false } });
+  rc.on('error', () => {});
+  try {
+    await rc.connect();
+    await rc.ping();
+    return rc;
+  } catch (e) {
+    try { await rc.disconnect(); } catch (_) {}
+    return unmet('redis', `no reachable redis at ${url}: ${firstLine(e)}`);
+  }
+}
+
+// Closing line of a suite. A run that asserted nothing says SKIPPED, not
+// "0 checks passed": that phrase is exactly what made the CI log look fine.
+function summary(name, passed) {
+  console.log(passed > 0
+    ? `\n${name}: ${passed} checks passed`
+    : `\n${name}: SKIPPED - 0 checks ran`);
+}
+
+module.exports = { mayskip, unmet, requireEngine, requireRedis, summary };

--- a/relay/test/account-wissen.test.js
+++ b/relay/test/account-wissen.test.js
@@ -1,0 +1,131 @@
+'use strict';
+// Deleting an account must remove the person, not only stop the key.
+//
+// Audit finding 5 of 2026-07-21: POST /admin/delete-account flipped every key to
+// inactive and cleared Redis, and left the email address in users.json on all
+// five sectors. An inactive record that still names someone is not erased, and
+// article 17 GDPR asks for erasure.
+//
+// The line this draws: identity goes, financial fact stays. A payment has to
+// remain traceable for the tax years it belongs to, so the tier and the paid
+// period survive while the email address and the device label do not.
+// Run: node relay/test/account-wissen.test.js (exits non-zero on failure).
+
+const assert = require('assert');
+const kt = require('../lib/keys-table');
+
+let passed = 0;
+function test(name, fn) {
+  try { fn(); passed++; console.log(`ok   ${name}`); }
+  catch (e) { console.error(`FAIL ${name}\n     ${e.message}`); process.exitCode = 1; }
+}
+
+function users() {
+  return {
+    accounts: [
+      { account_id: 'acct_demo', email: 'demo@example.com', plan: 'pro', label: 'Acme' },
+      { account_id: 'acct_other', email: 'other@example.com', plan: 'free' },
+    ],
+    api_keys: [
+      { key: 'pgp_a', account_id: 'acct_demo', email: 'demo@example.com', label: 'laptop',
+        active: true, plan_parasend: 'pro', paid_until_parasend: '2026-11-01T00:00:00.000Z' },
+      { key: 'pgp_b', account_id: 'acct_demo', email: 'demo@example.com', active: true },
+      { key: 'pgp_c', account_id: 'acct_other', email: 'other@example.com', active: true },
+    ],
+  };
+}
+
+// The whole point: after erasure the address must not be findable anywhere.
+function contains(data, needle) {
+  return JSON.stringify(data).includes(needle);
+}
+
+test('the email address is gone from every place it was stored', () => {
+  const d = users();
+  assert.ok(contains(d, 'demo@example.com'), 'fixture is wrong: the address was never there');
+  kt.erasePersonalData(d, 'acct_demo');
+  assert.ok(!contains(d, 'demo@example.com'), 'the address survived somewhere in users.json');
+});
+
+test('both storage places are covered, the summary and the key records', () => {
+  const d = users();
+  const out = kt.erasePersonalData(d, 'acct_demo');
+  assert.strictEqual(out.accounts, 1);
+  assert.strictEqual(out.keys, 2, 'both keys of this account should have been erased');
+});
+
+test('the device label goes too, it names a person just as well', () => {
+  const d = users();
+  kt.erasePersonalData(d, 'acct_demo');
+  assert.ok(!contains(d, 'laptop'));
+  assert.ok(!contains(d, 'Acme'));
+});
+
+test('what a payment must stay traceable by is kept', () => {
+  const d = users();
+  kt.erasePersonalData(d, 'acct_demo');
+  const k = d.api_keys.find((x) => x.key === 'pgp_a');
+  assert.strictEqual(k.plan_parasend, 'pro', 'the tier was thrown away with the person');
+  assert.strictEqual(k.paid_until_parasend, '2026-11-01T00:00:00.000Z', 'the paid period was thrown away');
+  assert.strictEqual(d.accounts.find((a) => a.account_id === 'acct_demo').plan, 'pro');
+});
+
+test('an erased key can no longer be used, even without a preceding revoke', () => {
+  const d = users();
+  kt.erasePersonalData(d, 'acct_demo');
+  for (const k of d.api_keys.filter((x) => x.account_id === 'acct_demo')) {
+    assert.strictEqual(k.active, false, 'an account with no owner kept a working key');
+  }
+});
+
+test('another account is left completely alone', () => {
+  const d = users();
+  kt.erasePersonalData(d, 'acct_demo');
+  assert.ok(contains(d, 'other@example.com'), 'erasing one account took another one with it');
+  assert.strictEqual(d.api_keys.find((x) => x.key === 'pgp_c').active, true);
+});
+
+test('erasing twice is free, so a retry after an unreachable sector is safe', () => {
+  const d = users();
+  const first = kt.erasePersonalData(d, 'acct_demo');
+  const second = kt.erasePersonalData(d, 'acct_demo');
+  assert.ok(first.fields > 0);
+  assert.deepStrictEqual(second, { accounts: 0, keys: 0, fields: 0 });
+});
+
+test('a key id works as well as an account id', () => {
+  const d = users();
+  const out = kt.erasePersonalData(d, 'pgp_a');
+  assert.strictEqual(out.keys, 1);
+  assert.ok(!contains(d.api_keys.find((x) => x.key === 'pgp_a'), 'demo@example.com'));
+});
+
+test('an erasure leaves a timestamp, so the record shows it was handled', () => {
+  const d = users();
+  kt.erasePersonalData(d, 'acct_demo');
+  assert.ok(d.api_keys.find((x) => x.key === 'pgp_a').erased_at, 'no erased_at on the key');
+  assert.ok(d.accounts.find((a) => a.account_id === 'acct_demo').erased_at, 'no erased_at on the account');
+});
+
+test('an unknown account changes nothing and does not throw', () => {
+  const d = users();
+  const before = JSON.stringify(d);
+  const out = kt.erasePersonalData(d, 'acct_nope');
+  assert.strictEqual(before, JSON.stringify(d));
+  assert.strictEqual(out.fields, 0);
+});
+
+test('missing or malformed input is tolerated', () => {
+  assert.deepStrictEqual(kt.erasePersonalData(null, 'acct_demo'), { accounts: 0, keys: 0, fields: 0 });
+  assert.deepStrictEqual(kt.erasePersonalData({}, 'acct_demo'), { accounts: 0, keys: 0, fields: 0 });
+  assert.deepStrictEqual(kt.erasePersonalData(users(), null), { accounts: 0, keys: 0, fields: 0 });
+});
+
+test('both delete routes in the admin call the erase endpoint', () => {
+  const src = require('fs').readFileSync(require('path').join(__dirname, '../../admin/server.js'), 'utf8');
+  const hits = (src.match(/keys\/erase/g) || []).length;
+  assert.strictEqual(hits, 2,
+    `expected the admin route and the user route to erase, found ${hits} call(s)`);
+});
+
+console.log(`\n${passed} passed`);

--- a/relay/test/entitlements-paid-until.test.js
+++ b/relay/test/entitlements-paid-until.test.js
@@ -184,3 +184,38 @@ test('a chargeback clears the period along with the tier', async () => {
   assert.strictEqual(got.t, 'community');
   assert.strictEqual(got.until, null);
 });
+
+// ── The gate: getEntitlements must honour the period ─────────────────────────
+// Writing the date on the record is not enough. Every quota and limit in the
+// product comes out of getEntitlements, so if that function ignores the period,
+// an expired subscription keeps working until somebody writes a downgrade.
+
+test('an expired paid tier grants free-tier quotas at the gate', () => {
+  const at = Date.parse('2026-10-01T00:00:00Z');
+  const live = ent.getEntitlements({ plan_parasend: 'pro', paid_until_parasend: '2026-11-01T00:00:00.000Z' }, at);
+  const dead = ent.getEntitlements({ plan_parasend: 'pro', paid_until_parasend: '2026-09-01T00:00:00.000Z' }, at);
+  assert.strictEqual(live.parasend.tier, 'pro');
+  assert.strictEqual(dead.parasend.tier, 'community');
+  assert.ok(dead.parasend.quotas.transfers_month < live.parasend.quotas.transfers_month);
+});
+
+test('an account from before billing keeps its tier at the gate', () => {
+  const at = Date.parse('2026-10-01T00:00:00Z');
+  assert.strictEqual(ent.getEntitlements({ plan_parasend: 'pro' }, at).parasend.tier, 'pro');
+  assert.strictEqual(ent.getEntitlements({ plan: 'pro' }, at).parasend.tier, 'pro');
+});
+
+test('expiry on one product leaves the other alone at the gate', () => {
+  const at = Date.parse('2026-10-01T00:00:00Z');
+  const e = ent.getEntitlements({
+    plan_parasend: 'pro', paid_until_parasend: '2026-09-01T00:00:00.000Z',
+    plan_parasign: 'business', paid_until_parasign: '2026-11-01T00:00:00.000Z',
+  }, at);
+  assert.strictEqual(e.parasend.tier, 'community');
+  assert.strictEqual(e.parasign.tier, 'business');
+});
+
+test('the gate without a clock still answers, using now', () => {
+  const e = ent.getEntitlements({ plan_parasign: 'pro' });
+  assert.strictEqual(e.parasign.tier, 'pro');
+});

--- a/relay/test/entitlements-paid-until.test.js
+++ b/relay/test/entitlements-paid-until.test.js
@@ -13,9 +13,13 @@ const assert = require('assert');
 const ent = require('../lib/entitlements');
 
 let passed = 0;
+const pending = [];
 function test(name, fn) {
-  try { fn(); passed++; console.log(`ok   ${name}`); }
-  catch (e) { console.error(`FAIL ${name}\n     ${e.message}`); process.exitCode = 1; }
+  const run = async () => {
+    try { await fn(); passed++; console.log(`ok   ${name}`); }
+    catch (e) { console.error(`FAIL ${name}\n     ${e.message}`); process.exitCode = 1; }
+  };
+  pending.push(run);
 }
 
 const T0 = Date.parse('2026-09-01T00:00:00Z');
@@ -102,4 +106,81 @@ test('the other product is never moved by a period on this one', () => {
   assert.strictEqual(ent.effectiveProductTier(rec, 'parasign', MONTH).tier, 'business');
 });
 
-console.log(`\n${passed} passed`);
+(async () => {
+  for (const run of pending) await run();
+  console.log(`\n${passed} passed`);
+})();
+
+// ── The webhook half: a payment must buy a bounded period ────────────────────
+const billing = require('../lib/billing');
+
+function payment(over) {
+  return Object.assign({
+    id: 'tr_demo', status: 'paid', amount: { value: '18.15', currency: 'EUR' },
+    metadata: { accountId: 'acct_demo', product: 'parasend', plan: 'pro', interval: 'monthly' },
+  }, over || {});
+}
+
+test('a paid webhook grants a tier AND an end date', async () => {
+  let got = null;
+  const out = await billing.processPayment(payment(), {
+    now: new Date('2026-09-15T10:00:00Z'),
+    setProductPlan: (a, p, t, until) => { got = { a, p, t, until }; return { ok: true }; },
+  });
+  assert.strictEqual(out.result, 'granted');
+  assert.strictEqual(got.t, 'pro');
+  assert.strictEqual(got.until.toISOString(), '2026-10-15T10:00:00.000Z');
+});
+
+// 29 February exists only in a leap year, so the start date here must be a real
+// one: 2024. Renewing lands on 28 February 2025, the last day of that month,
+// never 1 March.
+test('yearly buys twelve months and clamps a leap day to the month end', async () => {
+  let got = null;
+  await billing.processPayment(payment({
+    amount: { value: '181.50', currency: 'EUR' },
+    metadata: { accountId: 'acct_demo', product: 'parasend', plan: 'pro', interval: 'yearly' },
+  }), {
+    now: new Date('2024-02-29T00:00:00Z'),
+    setProductPlan: (a, p, t, until) => { got = until; return { ok: true }; },
+  });
+  assert.strictEqual(got.toISOString().slice(0, 10), '2025-02-28');
+});
+
+test('renewing early extends from the end of the period, not from today', async () => {
+  let got = null;
+  await billing.processPayment(payment(), {
+    now: new Date('2026-09-10T00:00:00Z'),
+    currentPaidUntil: async () => '2026-09-15T00:00:00.000Z',
+    setProductPlan: (a, p, t, until) => { got = until; return { ok: true }; },
+  });
+  assert.strictEqual(got.toISOString().slice(0, 10), '2026-10-15');
+});
+
+test('paying after a lapse starts from now, so a gap is not covered backwards', async () => {
+  let got = null;
+  await billing.processPayment(payment(), {
+    now: new Date('2026-11-01T00:00:00Z'),
+    currentPaidUntil: async () => '2026-09-15T00:00:00.000Z',
+    setProductPlan: (a, p, t, until) => { got = until; return { ok: true }; },
+  });
+  assert.strictEqual(got.toISOString().slice(0, 10), '2026-12-01');
+});
+
+test('an interval with no period is refused, never granted open-ended', async () => {
+  let called = false;
+  const out = await billing.processPayment(payment({
+    metadata: { accountId: 'acct_demo', product: 'parasend', plan: 'pro', interval: 'weekly' },
+  }), { setProductPlan: () => { called = true; return { ok: true }; } });
+  assert.strictEqual(out.result, 'refused');
+  assert.strictEqual(called, false);
+});
+
+test('a chargeback clears the period along with the tier', async () => {
+  let got = 'untouched';
+  await billing.processPayment(payment({ status: 'chargeback' }), {
+    setProductPlan: (a, p, t, until) => { got = { t, until }; return { ok: true }; },
+  });
+  assert.strictEqual(got.t, 'community');
+  assert.strictEqual(got.until, null);
+});

--- a/relay/test/entitlements-paid-until.test.js
+++ b/relay/test/entitlements-paid-until.test.js
@@ -1,0 +1,105 @@
+'use strict';
+// Unit tests for the paid-until axis on the entitlement layer
+// (relay/lib/entitlements.js). The rule this guards: a paid tier stops granting
+// when the period it was paid for has passed, and an account with no recorded
+// period is never treated as expired.
+//
+// Why it matters: a one-off payment used to set the tier and nothing ever took
+// it back, so one payment bought the tier forever. The date makes the grant
+// bounded; the read path honours it even if no webhook or cron ever runs.
+// Run: node relay/test/entitlements-paid-until.test.js (exits non-zero on failure).
+
+const assert = require('assert');
+const ent = require('../lib/entitlements');
+
+let passed = 0;
+function test(name, fn) {
+  try { fn(); passed++; console.log(`ok   ${name}`); }
+  catch (e) { console.error(`FAIL ${name}\n     ${e.message}`); process.exitCode = 1; }
+}
+
+const T0 = Date.parse('2026-09-01T00:00:00Z');
+const MONTH = Date.parse('2026-10-01T00:00:00Z');
+
+test('a tier without a recorded period keeps granting', () => {
+  const rec = { plan_parasend: 'pro' };
+  const r = ent.effectiveProductTier(rec, 'parasend', MONTH);
+  assert.strictEqual(r.tier, 'pro');
+  assert.strictEqual(r.expired, false);
+});
+
+test('a grant writes the period it was paid for', () => {
+  const rec = {};
+  const out = ent.applyProductTier(rec, 'parasend', 'pro', MONTH);
+  assert.strictEqual(rec.plan_parasend, 'pro');
+  assert.strictEqual(rec.paid_until_parasend, new Date(MONTH).toISOString());
+  assert.strictEqual(out.changed, true);
+});
+
+test('inside the paid period the tier stands', () => {
+  const rec = {};
+  ent.applyProductTier(rec, 'parasend', 'pro', MONTH);
+  assert.strictEqual(ent.effectiveProductTier(rec, 'parasend', T0).tier, 'pro');
+});
+
+test('past the paid period the tier falls to its floor', () => {
+  const rec = {};
+  ent.applyProductTier(rec, 'parasend', 'pro', MONTH);
+  const r = ent.effectiveProductTier(rec, 'parasend', MONTH + 1);
+  assert.strictEqual(r.tier, 'community');
+  assert.strictEqual(r.expired, true);
+});
+
+test('expiry is exact: at the boundary the period is over', () => {
+  const rec = {};
+  ent.applyProductTier(rec, 'parasign', 'pro', MONTH);
+  assert.strictEqual(ent.effectiveProductTier(rec, 'parasign', MONTH - 1).tier, 'pro');
+  assert.strictEqual(ent.effectiveProductTier(rec, 'parasign', MONTH).tier, 'free');
+});
+
+test('parasign floor is free, parasend floor is community', () => {
+  const a = {}; ent.applyProductTier(a, 'parasign', 'business', T0);
+  const b = {}; ent.applyProductTier(b, 'parasend', 'pro', T0);
+  assert.strictEqual(ent.effectiveProductTier(a, 'parasign', MONTH).tier, 'free');
+  assert.strictEqual(ent.effectiveProductTier(b, 'parasend', MONTH).tier, 'community');
+});
+
+test('dropping to the floor clears the period', () => {
+  const rec = {};
+  ent.applyProductTier(rec, 'parasend', 'pro', MONTH);
+  ent.applyProductTier(rec, 'parasend', 'community');
+  assert.strictEqual(rec.paid_until_parasend, undefined);
+});
+
+test('an omitted period leaves an existing one alone', () => {
+  const rec = {};
+  ent.applyProductTier(rec, 'parasend', 'pro', MONTH);
+  ent.applyProductTier(rec, 'parasend', 'pro');
+  assert.strictEqual(rec.paid_until_parasend, new Date(MONTH).toISOString());
+});
+
+test('an unparseable period is read as absent, never as expired', () => {
+  const rec = { plan_parasign: 'business', paid_until_parasign: 'niet-een-datum' };
+  const r = ent.effectiveProductTier(rec, 'parasign', MONTH);
+  assert.strictEqual(r.tier, 'business');
+  assert.strictEqual(r.expired, false);
+});
+
+test('renewal extends the period without touching the tier', () => {
+  const rec = {};
+  ent.applyProductTier(rec, 'parasign', 'pro', MONTH);
+  const next = Date.parse('2026-11-01T00:00:00Z');
+  ent.applyProductTier(rec, 'parasign', 'pro', next);
+  assert.strictEqual(rec.plan_parasign, 'pro');
+  assert.strictEqual(ent.effectiveProductTier(rec, 'parasign', MONTH + 1).tier, 'pro');
+});
+
+test('the other product is never moved by a period on this one', () => {
+  const rec = { plan_parasign: 'business' };
+  ent.applyProductTier(rec, 'parasend', 'pro', T0);
+  assert.strictEqual(rec.plan_parasign, 'business');
+  assert.strictEqual(rec.paid_until_parasign, undefined);
+  assert.strictEqual(ent.effectiveProductTier(rec, 'parasign', MONTH).tier, 'business');
+});
+
+console.log(`\n${passed} passed`);

--- a/relay/test/koop-pad-intentie.test.mjs
+++ b/relay/test/koop-pad-intentie.test.mjs
@@ -1,0 +1,94 @@
+// The purchase path must survive the detour through sign-in.
+//
+// Two leaks used to sit between a price button and a payment. First, clicking
+// while signed out redirected to /auth/login?next=/pricing and dropped WHICH
+// plan was wanted, so the visitor had to want it twice. Second, the registration
+// finish button was hardcoded to /dashboard, so even a correct `next` was thrown
+// away on the way back.
+//
+// safeNext is also a security boundary: it decides where a signed-in visitor is
+// sent, so anything it accepts is a redirect an attacker can hand out.
+// Run: node relay/test/koop-pad-intentie.test.mjs (exits non-zero on failure).
+
+import assert from 'assert';
+import { readFileSync } from 'fs';
+
+let passed = 0;
+function test(name, fn) {
+  try { fn(); passed++; console.log(`ok   ${name}`); }
+  catch (e) { console.error(`FAIL ${name}\n     ${e.message}`); process.exitCode = 1; }
+}
+
+const passkey = readFileSync(new URL('../../frontend/js/passkey.js', import.meta.url), 'utf8');
+const pricing = readFileSync(new URL('../../frontend/js/pricing-billing.js', import.meta.url), 'utf8');
+
+// Lift safeNext out of the file and run it against a fake location, so the test
+// exercises the real shipped source rather than a copy that can drift from it.
+function loadSafeNext() {
+  const m = passkey.match(/function safeNext\(\)\s*\{[\s\S]*?\n\}/);
+  assert.ok(m, 'safeNext not found in passkey.js');
+  const fn = new Function('window', 'URLSearchParams', `${m[0]}; return safeNext;`);
+  return (search) => fn({ location: { search } }, URLSearchParams)();
+}
+const safeNext = loadSafeNext();
+
+test('a local path is honoured', () => {
+  assert.strictEqual(safeNext('?next=%2Fpricing'), '/pricing');
+  assert.strictEqual(safeNext('?next=%2Fpricing%3Fplan%3Dpro'), '/pricing?plan=pro');
+});
+
+test('the older return parameter still works', () => {
+  assert.strictEqual(safeNext('?return=%2Fpricing'), '/pricing');
+});
+
+test('no parameter falls back to the dashboard', () => {
+  assert.strictEqual(safeNext(''), '/dashboard');
+  assert.strictEqual(safeNext('?next='), '/dashboard');
+});
+
+test('a protocol-relative target is refused, not followed', () => {
+  // //evil.example is a URL for another host, not a path on ours.
+  assert.strictEqual(safeNext('?next=%2F%2Fevil.example'), '/dashboard');
+  assert.strictEqual(safeNext('?next=%2F%5Cevil.example'), '/dashboard');
+});
+
+test('an absolute URL is refused', () => {
+  assert.strictEqual(safeNext('?next=https%3A%2F%2Fevil.example'), '/dashboard');
+  assert.strictEqual(safeNext('?next=http%3A%2F%2Fevil.example'), '/dashboard');
+});
+
+test('the registration finish button uses safeNext, not a hardcoded dashboard', () => {
+  const line = passkey.split('\n').find(l => l.includes('passkey-finish-btn') && l.includes('addEventListener'))
+    || passkey.split('\n').find(l => l.includes('finishBtn.addEventListener'));
+  assert.ok(line, 'finish button handler not found');
+  assert.ok(line.includes('safeNext()'), `finish button still hardcodes its target: ${line.trim()}`);
+});
+
+test('safeNext is defined once, so the rule cannot drift apart', () => {
+  const defs = (passkey.match(/function safeNext\(/g) || []).length;
+  assert.strictEqual(defs, 1);
+});
+
+test('the pricing page remembers the plan before sending the visitor to sign in', () => {
+  const i = pricing.indexOf('rememberIntent(btn)');
+  const j = pricing.indexOf("'/auth/login?next='");
+  assert.ok(i > -1, 'the choice is never stored');
+  assert.ok(j > -1, 'the sign-in redirect is gone');
+  assert.ok(i < j, 'the redirect happens before the choice is stored');
+});
+
+test('a remembered choice is read once and then cleared', () => {
+  assert.ok(pricing.includes('sessionStorage.removeItem(INTENT)'),
+    'the intent is never cleared, so it would replay on every later visit');
+});
+
+test('resuming presses the real button, so there is only one way to buy', () => {
+  assert.ok(pricing.includes('target.click()'), 'resume does not go through the button');
+});
+
+test('storage failures cannot break the page in private mode', () => {
+  const remember = pricing.slice(pricing.indexOf('function rememberIntent'), pricing.indexOf('function takeIntent'));
+  assert.ok(remember.includes('catch'), 'rememberIntent does not tolerate a blocked sessionStorage');
+});
+
+console.log(`\n${passed} passed`);

--- a/relay/test/paraid-assurance.test.mjs
+++ b/relay/test/paraid-assurance.test.mjs
@@ -1,0 +1,57 @@
+// The assurance label on a ParaID credential must never claim more than the
+// issuer actually checked.
+//
+// What this guards: /v1/paraid/issue-document takes two lines of text, recomputes
+// the ICAO check digits, and signs the result. Check digits are a typo guard, not
+// a signature, so anyone can write an MRZ that passes them. The credential used
+// to come back labelled 'substantial', the eIDAS word for a legally defined level
+// of identity assurance, on evidence that establishes no identity at all.
+// Run: node relay/test/paraid-assurance.test.mjs (exits non-zero on failure).
+
+import assert from 'assert';
+import { assuranceOf, assuranceAtLeast, ASSURANCE_RANK } from '../lib/paraid-issuer.mjs';
+
+let passed = 0;
+function test(name, fn) {
+  try { fn(); passed++; console.log(`ok   ${name}`); }
+  catch (e) { console.error(`FAIL ${name}\n     ${e.message}`); process.exitCode = 1; }
+}
+
+test('the ladder runs presence, mrz-unverified, high', () => {
+  assert.deepStrictEqual([...ASSURANCE_RANK], ['presence', 'mrz-unverified', 'high']);
+});
+
+test('no rung is called substantial', () => {
+  assert.ok(!ASSURANCE_RANK.includes('substantial'),
+    'substantial is an eIDAS level; nothing here establishes it');
+});
+
+test('a pre-rename credential reads as the rung it always was', () => {
+  assert.strictEqual(assuranceOf({ tier: 'substantial' }), 'mrz-unverified');
+});
+
+test('an MRZ credential never satisfies a chip requirement', () => {
+  assert.strictEqual(assuranceAtLeast({ tier: 'mrz-unverified' }, 'high'), false);
+  assert.strictEqual(assuranceAtLeast({ tier: 'substantial' }, 'high'), false);
+});
+
+test('presence never satisfies an MRZ requirement', () => {
+  assert.strictEqual(assuranceAtLeast({ tier: 'presence' }, 'mrz-unverified'), false);
+});
+
+test('an MRZ credential does satisfy a presence requirement', () => {
+  assert.strictEqual(assuranceAtLeast({ tier: 'mrz-unverified' }, 'presence'), true);
+});
+
+test('an unknown label is never treated as higher than presence', () => {
+  assert.strictEqual(assuranceAtLeast({ tier: 'gold' }, 'presence'), false);
+  assert.strictEqual(assuranceAtLeast({ tier: 'eidas-high' }, 'high'), false);
+});
+
+test('a credential with no tier falls back to presence, the lowest rung', () => {
+  assert.strictEqual(assuranceOf({}), 'presence');
+  assert.strictEqual(assuranceOf(null), 'presence');
+  assert.strictEqual(assuranceAtLeast({}, 'mrz-unverified'), false);
+});
+
+console.log(`\n${passed} passed`);

--- a/relay/test/paraid-closed.test.js
+++ b/relay/test/paraid-closed.test.js
@@ -1,0 +1,180 @@
+'use strict';
+// ParaID is out of the shop window (fb3cdd3, 2026-07-19) and is not a product in
+// lib/billing-catalog.js, so nobody can buy it. It was still fully on offer:
+// listed in sitemap.xml (re-added by the bulk SEO commit e0e82a1 six days after
+// the removal decision) and, worse, POST /v1/paraid/issue-document signed
+// identity claims for anyone on the internet behind nothing but an IP rate-limit.
+//
+// This test locks the two halves of that shut:
+//   A) sitemap.xml carries no /paraid* route, and the three pages say noindex,
+//      so what Google already has drops out.
+//   B) POST /v1/paraid/issue-document refuses an unauthenticated caller. Proved
+//      by RUNNING the real relay request handler, not by reading relay.js: the
+//      redis module is stubbed and http.createServer is intercepted so relay.js
+//      can be required without binding a socket, then the handler is called.
+//
+// Fails on the old code: the sitemap has three <loc>/paraid entries, the pages
+// carry no robots meta, and the endpoint answers 503/429/200 (never 401) to a
+// request with no Authorization header.
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Readable } = require('stream');
+const Module = require('module');
+
+const FRONTEND = path.join(__dirname, '..', '..', 'frontend');
+let passed = 0;
+const ok = (n) => { passed++; console.log('  ok -', n); };
+
+// -- A1. sitemap.xml ---------------------------------------------------------
+const sitemap = fs.readFileSync(path.join(FRONTEND, 'sitemap.xml'), 'utf8');
+const locs = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1].trim());
+// Guard against passing on an empty or truncated sitemap: the other routes must
+// still be there, otherwise "no paraid" would be true for the wrong reason.
+assert.ok(locs.length > 20, `sitemap looks truncated: only ${locs.length} <loc> entries`);
+const paraidLocs = locs.filter((u) => {
+  const p = new URL(u).pathname.replace(/\/+$/, '');
+  return p === '/paraid' || p.startsWith('/paraid-');
+});
+assert.deepStrictEqual(paraidLocs, [], `sitemap still offers ParaID routes: ${paraidLocs.join(', ')}`);
+ok(`sitemap.xml lists ${locs.length} routes and none of them is a /paraid route`);
+
+// -- A2. noindex on the three pages ------------------------------------------
+for (const f of ['paraid.html', 'paraid-app.html', 'paraid-document.html']) {
+  const html = fs.readFileSync(path.join(FRONTEND, f), 'utf8');
+  const m = /<meta\s+name=["']robots["']\s+content=["']([^"']+)["']\s*\/?>/i.exec(html);
+  assert.ok(m, `${f} has no <meta name="robots">`);
+  assert.ok(/noindex/i.test(m[1]), `${f} robots meta is "${m[1]}", expected noindex`);
+  ok(`${f} is noindex ("${m[1]}")`);
+}
+
+// -- B1. the auth decision itself --------------------------------------------
+// authenticateBearer is the one definition of "known /v1 caller", shared by the
+// ParaSign open-API router and the relay's own ParaID route.
+const openApi = require('../lib/parasign-open-api');
+const KEY = 'psk_live_paraidtest0000000000000000';
+const REVOKED = 'psk_live_revoked00000000000000000';
+const keys = new Map([
+  [KEY, { plan: 'pro', active: true, account_id: 'acct_demo', scope: 'parasign' }],
+  [REVOKED, { plan: 'pro', active: false, account_id: 'acct_demo' }],
+]);
+for (const [label, header] of [
+  ['no Authorization header', ''],
+  ['a non-Bearer header', 'Basic hunter2'],
+  ['a Bearer token that is not a psk_ key', 'Bearer abc123'],
+  ['an unknown psk_ key', 'Bearer psk_live_neverissued0000000'],
+  ['a revoked psk_ key', `Bearer ${REVOKED}`],
+]) {
+  const r = openApi.authenticateBearer(header, keys);
+  assert.strictEqual(r.ok, false, `${label} was accepted`);
+  assert.strictEqual(r.code, 401);
+  ok(`authenticateBearer rejects ${label} with 401`);
+}
+const good = openApi.authenticateBearer(`Bearer ${KEY}`, keys);
+assert.strictEqual(good.ok, true);
+assert.strictEqual(good.token, KEY);
+assert.strictEqual(good.mode, 'live');
+ok('authenticateBearer accepts an active psk_live_ key');
+
+// -- B2. the live route ------------------------------------------------------
+// Boot relay.js far enough to get its request handler. Two kinds of narrow stub:
+// the npm packages relay.js requires at load time (this suite runs without
+// node_modules, like every other test here), and http.createServer, so nothing
+// binds a port. None of the stubbed packages is on the path under test; if one
+// is ever called the throw shows up as a failure rather than a silent pass.
+// Every property is a function that throws, so a stub that is actually used
+// fails the test instead of quietly returning undefined. The crypto impls only
+// destructure at load time, which this satisfies without running any crypto.
+const stub = (name) => new Proxy({}, {
+  get(_t, prop) {
+    if (typeof prop === 'symbol' || prop === 'then') return undefined;
+    return () => { throw new Error(`${name} is stubbed in this test (${String(prop)})`); };
+  },
+});
+const STUB_NAMES = ['redis', 'argon2', 'ws', 'nats', '@paramant/core'];
+const origLoad = Module._load;
+Module._load = function (request, ...rest) {
+  if (STUB_NAMES.includes(request) || request.startsWith('@noble/')) return stub(request);
+  return origLoad.call(this, request, ...rest);
+};
+const http = require('http');
+const origCreateServer = http.createServer;
+let handler = null;
+http.createServer = function (h) {
+  handler = h;
+  return { listen() { return this; }, on() { return this; }, close() { return this; } };
+};
+
+// Every on-disk path relay.js writes to defaults to /data. Point them all at a
+// throwaway dir so a test run cannot touch a real deployment's state, not even
+// when it happens to run as a user that may write there.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'paraid-closed-'));
+process.env.RELAY_MODE = 'full';
+process.env.REDIS_URL = '';                 // leaves the stubbed createClient unused
+process.env.SERVE_FRONTEND = 'false';
+process.env.CT_FILE = path.join(TMP, 'ct.log');
+process.env.STH_FILE = path.join(TMP, 'sth.json');
+process.env.PEER_STH_DIR = path.join(TMP, 'peer-sths');
+process.env.RELAY_IDENTITY_FILE = path.join(TMP, 'identity.json');
+process.env.TRIAL_KEYS_FILE = path.join(TMP, 'trial-keys.json');
+process.env.CODE_MANIFEST_FILE = path.join(TMP, 'code-manifest.json');
+process.env.DPA_FILE = path.join(TMP, 'dpa.json');
+process.env.PARAID_REGISTRY_FILE = path.join(TMP, 'paraid-issuers.json');
+process.env.PARAID_ISSUER_KEY_FILE = path.join(TMP, 'paraid-issuer-key.json');
+process.env.USERS_JSON = JSON.stringify({ api_keys: [
+  { key: KEY, plan: 'pro', label: 'acct_demo', email: 'demo@example.com', active: true, account_id: 'acct_demo', scope: 'parasign' },
+] });
+
+require('../relay.js');
+Module._load = origLoad;
+http.createServer = origCreateServer;
+assert.ok(typeof handler === 'function', 'did not capture the relay request handler');
+
+function mkReq(headers, body) {
+  const req = Readable.from([Buffer.from(body || '')]);
+  req.url = '/v1/paraid/issue-document';
+  req.method = 'POST';
+  req.headers = Object.assign({ 'content-type': 'application/json' }, headers);
+  req.socket = { remoteAddress: '127.0.0.1' };
+  return req;
+}
+function mkRes() {
+  return { code: 0, headers: {}, body: '',
+    setHeader() {}, getHeader() { return undefined; },
+    writeHead(c, h) { this.code = c; this.headers = h || {}; return this; },
+    end(b) { this.body = b == null ? '' : String(b); return this; } };
+}
+
+const CLAIM = JSON.stringify({ holder_binding: 'AAAA', mrz_line1: 'x', mrz_line2: 'y' });
+
+(async () => {
+  for (const [label, headers] of [
+    ['no Authorization header', {}],
+    ['a Bearer token that is not a psk_ key', { authorization: 'Bearer abc123' }],
+    ['an unknown psk_ key', { authorization: 'Bearer psk_live_neverissued0000000' }],
+    ['an X-Api-Key instead of a Bearer token', { 'x-api-key': KEY }],
+  ]) {
+    const res = mkRes();
+    await handler(mkReq(headers, CLAIM), res);
+    // 401 specifically: a 503 (no issuer key) or 429 (rate limit) would mean the
+    // request got past the gate and only stopped on an operational accident.
+    assert.strictEqual(res.code, 401,
+      `POST /v1/paraid/issue-document with ${label} answered ${res.code}, expected 401`);
+    assert.strictEqual(JSON.parse(res.body).error, 'unauthorized');
+    ok(`POST /v1/paraid/issue-document refuses ${label} with 401`);
+  }
+
+  // And the gate is a gate, not a blanket refusal: an authenticated key gets
+  // past it. No issuer key exists in a test run, so the honest next answer is
+  // 503 "issuer not configured". Anything except 401 proves the gate opened.
+  const res = mkRes();
+  await handler(mkReq({ authorization: `Bearer ${KEY}` }, CLAIM), res);
+  assert.notStrictEqual(res.code, 401,
+    'an authenticated psk_live_ key was still rejected as unauthorized');
+  ok(`an authenticated psk_live_ key passes the gate (got ${res.code}, not 401)`);
+
+  console.log(`\n${passed} checks passed`);
+  process.exit(0);
+})().catch((e) => { console.error('FAIL:', e.message); process.exit(1); });

--- a/relay/test/parasign-envelope-index.test.js
+++ b/relay/test/parasign-envelope-index.test.js
@@ -5,7 +5,9 @@
 //   2. the Business+ audit-export returns the completed envelope's full .psign,
 //      and a Pro key is still refused 403 even with the envelope deps present
 //   3. backfillAccountIndex() rebuilds the index from an un-indexed env:* key
-// Needs redis (REDIS_URL / 127.0.0.1:6396) + @paramant/core; skips otherwise.
+// Needs the ML-DSA-65 engine (@paramant/core) and a redis at REDIS_URL /
+// 127.0.0.1:6396. A missing one is a FAILURE unless the runner declared it
+// absent via RELAY_TEST_SKIP; see test/_requires.js.
 //   docker run -d --rm -p 6396:6379 --name auditexp-redis redis:alpine
 
 const assert = require('assert');
@@ -14,28 +16,12 @@ const envelopeMod = require('../envelope');
 const openApi = require('../lib/parasign-open-api');
 const ax = require('../lib/parasign-audit-export');
 const parasign = require('../parasign');
+const { requireEngine, requireRedis, summary } = require('./_requires');
 
 let passed = 0;
 const ok = (n) => { passed++; console.log('  ok -', n); };
 const J = JSON.stringify;
 
-function loadEngine() {
-  try {
-    require('../crypto/bootstrap').bootstrap();
-    const registry = require('../crypto/registry');
-    const eng = registry.getSig(0x0002);
-    if (eng && typeof eng.generateKeyPair === 'function') return eng;
-  } catch (_) {}
-  return null;
-}
-async function tryRedis() {
-  const url = process.env.REDIS_URL || 'redis://127.0.0.1:6396';
-  let createClient;
-  try { ({ createClient } = require('redis')); } catch { return null; }
-  const rc = createClient({ url, socket: { connectTimeout: 800, reconnectStrategy: false } });
-  rc.on('error', () => {});
-  try { await rc.connect(); await rc.ping(); return rc; } catch { try { await rc.disconnect(); } catch {} return null; }
-}
 function fakeRes() {
   return {
     statusCode: null, headers: null, _body: '',
@@ -54,13 +40,11 @@ async function completeOpenEnvelope(store, eng, out, docHash) {
 }
 
 async function main() {
-  const eng = loadEngine();
-  const rc = await tryRedis();
+  const eng = requireEngine();
+  const rc = await requireRedis('redis://127.0.0.1:6396');
   if (!eng || !rc) {
-    console.log('  skip - need redis (127.0.0.1:6396) + ML-DSA-65 engine');
-    console.log(`\nparasign-envelope-index: ${passed} checks passed`);
-    if (rc) try { await rc.disconnect(); } catch {}
-    return;
+    if (rc) try { await rc.disconnect(); } catch (_) {}
+    return summary('parasign-envelope-index', passed);
   }
   const registry = require('../crypto/registry');
   const store = new envelopeMod.EnvelopeStore(rc, {
@@ -173,7 +157,7 @@ async function main() {
     try { await rc.quit(); } catch {}
   }
 
-  console.log(`\nparasign-envelope-index: ${passed} checks passed`);
+  summary('parasign-envelope-index', passed);
   if (passed < 7) process.exit(1);
 }
 

--- a/relay/test/parasign-open-api-e2e.test.js
+++ b/relay/test/parasign-open-api-e2e.test.js
@@ -4,7 +4,9 @@
 // in one flow: durable-store persistence (Point 1), the sandbox auto-signer
 // (Point 4), the server-side stamp-worker (Point 2), the full .psign receipt,
 // and webhook_url validation at create (Point 6).
-// Needs redis (REDIS_URL / 127.0.0.1:6399) + @paramant/core; skips otherwise.
+// Needs the ML-DSA-65 engine (@paramant/core) and a redis at REDIS_URL /
+// 127.0.0.1:6399. A missing one is a FAILURE unless the runner declared it
+// absent via RELAY_TEST_SKIP; see test/_requires.js.
 //   docker run -d --rm -p 6399:6379 --name parasign-test-redis redis:alpine
 
 const assert = require('assert');
@@ -15,27 +17,11 @@ const parasignStamp = require('../lib/parasign-stamp');
 const envelopeMod = require('../envelope');
 const parasign = require('../parasign');
 const { isSsrfSafeUrl } = require('../lib/ssrf-guard');
+const { requireEngine, requireRedis, summary } = require('./_requires');
 
 let passed = 0;
 const ok = (n) => { passed++; console.log('  ok -', n); };
 
-function loadEngine() {
-  try {
-    require('../crypto/bootstrap').bootstrap();
-    const registry = require('../crypto/registry');
-    const eng = registry.getSig(0x0002);
-    if (eng && typeof eng.generateKeyPair === 'function') return eng;
-  } catch (_) {}
-  return null;
-}
-async function tryRedis() {
-  const url = process.env.REDIS_URL || 'redis://127.0.0.1:6399';
-  let createClient;
-  try { ({ createClient } = require('redis')); } catch { return null; }
-  const rc = createClient({ url, socket: { connectTimeout: 800, reconnectStrategy: false } });
-  rc.on('error', () => {});
-  try { await rc.connect(); await rc.ping(); return rc; } catch { try { await rc.disconnect(); } catch {} return null; }
-}
 async function makePdfB64() {
   const { PDFDocument, StandardFonts, rgb } = parasignStamp.loadPdfLib();
   const doc = await PDFDocument.create();
@@ -56,9 +42,12 @@ function mockRes() {
 }
 
 async function main() {
-  const eng = loadEngine();
-  const rc = await tryRedis();
-  if (!eng || !rc) { console.log('  skip - need redis + ML-DSA-65 engine'); console.log(`\nparasign-open-api-e2e: ${passed} checks passed`); if (rc) try { await rc.disconnect(); } catch {} return; }
+  const eng = requireEngine();
+  const rc = await requireRedis('redis://127.0.0.1:6399');
+  if (!eng || !rc) {
+    if (rc) try { await rc.disconnect(); } catch (_) {}
+    return;   // the .then below prints the summary line
+  }
 
   const registry = require('../crypto/registry');
   try {
@@ -155,5 +144,5 @@ async function main() {
 }
 
 main()
-  .then(() => console.log(`\nparasign-open-api-e2e: ${passed} checks passed`))
+  .then(() => summary('parasign-open-api-e2e', passed))
   .catch((e) => { console.error('\nFAILED:', e && e.stack || e); process.exit(1); });

--- a/relay/test/parasign-sandbox-live-guard.test.js
+++ b/relay/test/parasign-sandbox-live-guard.test.js
@@ -7,25 +7,19 @@
 //  C) the sandbox/test nature is baked INTO the notary-signed .psign evidence
 //     (mode:'test' + sandbox:true, inside the signed payload); a live receipt
 //     carries NO such marker.
-// Needs the ML-DSA-65 engine (@paramant/core); skips if it cannot load.
+// Needs the ML-DSA-65 engine (@paramant/core). If it cannot load this suite
+// FAILS: it is the only guard on the live/sandbox split, so a green tick over
+// zero checks would be a lie. See test/_requires.js.
 
 const assert = require('assert');
 const crypto = require('crypto');
+const { requireEngine, summary } = require('./_requires');
 const openApi = require('../lib/parasign-open-api');
 const parasign = require('../parasign');
 
 const SHA3 = (b) => crypto.createHash('sha3-256').update(b).digest('hex');
 let passed = 0;
 const ok = (n) => { passed++; console.log('  ok -', n); };
-
-function loadEngine() {
-  try {
-    require('../crypto/bootstrap').bootstrap();
-    const eng = require('../crypto/registry').getSig(0x0002);
-    if (eng && typeof eng.generateKeyPair === 'function') return eng;
-  } catch (_) {}
-  return null;
-}
 
 function makeRes() {
   return { code: 0, headers: null, body: null,
@@ -130,7 +124,16 @@ async function testTestSandbox(eng) {
 // the emitted .psign. Verifies the marker lives INSIDE the notary-signed body.
 async function receiptFor(eng, mode) {
   const relayKp = eng.generateKeyPair();
-  const relayIdentity = { sk: relayKp.secretKey, pk_hash: SHA3(Buffer.from(relayKp.publicKey)) };
+  // pk is NOT optional: buildEnvelopePsign puts the raw notary key in the
+  // receipt (notary.relay_public_key = Buffer.from(relayIdentity.pk)), so a
+  // fixture without it made Buffer.from(undefined) throw, getReceipt mapped
+  // that to 500 notary_sign_failed, and the marker checks below never ran.
+  // Nobody noticed, because the whole suite was skipping before it got here.
+  const relayIdentity = {
+    sk: relayKp.secretKey,
+    pk: relayKp.publicKey,
+    pk_hash: SHA3(Buffer.from(relayKp.publicKey)),
+  };
   const token = 'psk_' + mode + '_owner123';
   const id = 'env_' + crypto.randomBytes(6).toString('hex');
   const env = {
@@ -178,13 +181,13 @@ async function testReceiptMarker(eng) {
 }
 
 async function main() {
-  const eng = loadEngine();
-  if (!eng) { console.log('  skip - ML-DSA-65 engine unavailable'); return; }
+  const eng = requireEngine();
+  if (!eng) return;
   await testLiveGuard(eng);
   await testTestSandbox(eng);
   await testReceiptMarker(eng);
 }
 
 main()
-  .then(() => console.log(`\nparasign-sandbox-live-guard: ${passed} checks passed`))
+  .then(() => summary('parasign-sandbox-live-guard', passed))
   .catch((e) => { console.error('\nFAILED:', e && e.stack || e); process.exit(1); });

--- a/relay/test/parasign-sandbox.test.js
+++ b/relay/test/parasign-sandbox.test.js
@@ -4,30 +4,19 @@
 // that produces CRYPTOGRAPHICALLY VALID per-slot signatures (the fake envStore
 // here verifies each one with the real engine under the correct recipe), and
 // that signer.completed + envelope.completed webhooks fire (HMAC-SHA256 signed).
-// Needs the ML-DSA-65 engine (@paramant/core); skips if it cannot load.
+// Needs the ML-DSA-65 engine (@paramant/core). If it cannot load this suite
+// FAILS rather than skipping quietly. See test/_requires.js.
 
 const assert = require('assert');
 const crypto = require('crypto');
 const openApi = require('../lib/parasign-open-api');
+const { requireEngine, summary } = require('./_requires');
 const { signMessageBytes, partyEmailHash } = require('../envelope');
 
 let passed = 0;
 const ok = (n) => { passed++; console.log('  ok -', n); };
 
-function loadEngine() {
-  try {
-    require('../crypto/bootstrap').bootstrap();
-    const registry = require('../crypto/registry');
-    const eng = registry.getSig(0x0002);
-    if (eng && typeof eng.generateKeyPair === 'function') return eng;
-  } catch (_) {}
-  return null;
-}
-
-async function run(bindingMode, recipe) {
-  const eng = loadEngine();
-  if (!eng) return { skipped: true };
-
+async function run(eng, bindingMode, recipe) {
   const N = 2;
   const docHash = crypto.createHash('sha3-256').update('doc' + bindingMode).digest('hex');
   const id = 'env_' + crypto.randomBytes(8).toString('hex');
@@ -98,15 +87,14 @@ async function run(bindingMode, recipe) {
 }
 
 async function main() {
-  const a = await run('open', 4);
-  if (a.skipped) { console.log('  skip - ML-DSA-65 engine unavailable'); }
-  else {
-    ok('sandbox auto-signs an OPEN test envelope with valid v4 signatures + completion webhooks');
-    await run('email', 2);
-    ok('sandbox auto-signs an EMAIL-bound test envelope with valid v2 signatures + trusted-internal proof');
-  }
+  const eng = requireEngine();
+  if (!eng) return;
+  await run(eng, 'open', 4);
+  ok('sandbox auto-signs an OPEN test envelope with valid v4 signatures + completion webhooks');
+  await run(eng, 'email', 2);
+  ok('sandbox auto-signs an EMAIL-bound test envelope with valid v2 signatures + trusted-internal proof');
 }
 
 main()
-  .then(() => console.log(`\nparasign-sandbox: ${passed} checks passed`))
+  .then(() => summary('parasign-sandbox', passed))
   .catch((e) => { console.error('\nFAILED:', e && e.stack || e); process.exit(1); });

--- a/relay/test/parasign-signs-quota.test.js
+++ b/relay/test/parasign-signs-quota.test.js
@@ -10,25 +10,18 @@
 //   * a NEW signature increments the counter by exactly 1,
 //   * an idempotent ('idem') retry does NOT double-count,
 //   * once the counter reaches the plan cap the next sign is refused with 402.
-// Skips when no redis is reachable (REDIS_URL, default 127.0.0.1:6399).
+// Needs a redis (REDIS_URL, default 127.0.0.1:6399). Without one this suite
+// FAILS unless the runner declared redis absent; see test/_requires.js.
 //   docker run -d --rm -p 6399:6379 --name parasign-test-redis redis:alpine
 
 const assert = require('assert');
 const crypto = require('crypto');
 const quota = require('../lib/quota');
 const tiers = require('../lib/tiers');
+const { requireRedis, summary } = require('./_requires');
 
 let passed = 0;
 const ok = (n) => { passed++; console.log('  ok -', n); };
-
-async function tryRedis() {
-  const url = process.env.REDIS_URL || 'redis://127.0.0.1:6399';
-  let createClient;
-  try { ({ createClient } = require('redis')); } catch { return null; }
-  const rc = createClient({ url, socket: { connectTimeout: 800, reconnectStrategy: false } });
-  rc.on('error', () => {});
-  try { await rc.connect(); await rc.ping(); return rc; } catch { try { await rc.disconnect(); } catch {} return null; }
-}
 
 // Mirror of the fixed /v2/envelopes/:id/sign metering. storeCode is what
 // EnvelopeStore.sign() would return ('new' | 'idem' | 'bad_signature').
@@ -50,8 +43,8 @@ async function routeSign(rc, accountId, plan, storeCode) {
 async function usage(rc, acct) { return (await quota.readUsage(rc, acct)).signs_this_month; }
 
 async function main() {
-  const rc = await tryRedis();
-  if (!rc) { console.log('  skip - no reachable redis'); return; }
+  const rc = await requireRedis('redis://127.0.0.1:6399');
+  if (!rc) return;
   try {
     const acct = 'acct_' + crypto.randomBytes(6).toString('hex');
     await rc.del(quota.signsKey ? quota.signsKey(acct) : `paramant:quota:signs:${acct}:${quota.ymKey()}`);
@@ -98,5 +91,5 @@ async function main() {
 }
 
 main()
-  .then(() => console.log(`\nparasign-signs-quota: ${passed} checks passed`))
+  .then(() => summary('parasign-signs-quota', passed))
   .catch((e) => { console.error('\nFAILED:', e && e.stack || e); process.exit(1); });

--- a/relay/test/parasign-store.test.js
+++ b/relay/test/parasign-store.test.js
@@ -1,28 +1,21 @@
 'use strict';
 // ParaSign durable side-store (lib/parasign-store.js). Proves the encryption
-// invariants and both backends. The redis-backed checks (durability + TTL) run
-// only when a throwaway redis is reachable (REDIS_URL, default 127.0.0.1:6399);
-// otherwise they skip so the default suite stays green without a container.
+// invariants and both backends. The redis-backed checks (durability + TTL) need
+// a throwaway redis (REDIS_URL, default 127.0.0.1:6399); without one the suite
+// FAILS unless the runner declared redis absent. The encryption checks above
+// them do not touch redis and run either way. See test/_requires.js.
 //   docker run -d --rm -p 6399:6379 --name parasign-test-redis redis:alpine
 //   REDIS_URL=redis://127.0.0.1:6399 node --test test/parasign-store.test.js
 
 const assert = require('assert');
 const crypto = require('crypto');
 const { createParaSignStore, normalizeKey, seal, unseal } = require('../lib/parasign-store');
+const { requireRedis, summary } = require('./_requires');
 
 const KEY = crypto.randomBytes(32);
 let passed = 0;
 const ok = (n) => { passed++; console.log('  ok -', n); };
 const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-
-async function tryRedis() {
-  const url = process.env.REDIS_URL || 'redis://127.0.0.1:6399';
-  let createClient;
-  try { ({ createClient } = require('redis')); } catch { return null; }
-  const rc = createClient({ url, socket: { connectTimeout: 800, reconnectStrategy: false } });
-  rc.on('error', () => {});
-  try { await rc.connect(); await rc.ping(); return rc; } catch { try { await rc.disconnect(); } catch {} return null; }
-}
 
 async function main() {
   // 1. seal/unseal round-trip + AAD binding
@@ -64,9 +57,9 @@ async function main() {
   }
 
   // 4. redis backend: DURABILITY (survives a fresh store instance) + TTL
-  const rc = await tryRedis();
+  const rc = await requireRedis('redis://127.0.0.1:6399');
   if (!rc) {
-    console.log('  skip - redis backend checks (no reachable redis at REDIS_URL/127.0.0.1:6399)');
+    // requireRedis already said so, by name. Nothing to add.
   } else {
     try {
       const id = 'durable_' + crypto.randomBytes(6).toString('hex');
@@ -103,5 +96,5 @@ async function main() {
 }
 
 main()
-  .then(() => console.log(`\nparasign-store: ${passed} checks passed`))
+  .then(() => summary('parasign-store', passed))
   .catch((e) => { console.error('\nFAILED:', e && e.stack || e); process.exit(1); });

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -13,6 +13,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const catalog = require('../lib/billing-catalog');
+const entitlements = require('../lib/entitlements');
 
 const html = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'pricing.html'), 'utf8');
 
@@ -256,3 +257,83 @@ assert(VISIBLE.includes('Forever &middot; no card required'), 'Free card must ke
 ok('one starting-for-free promise: forever-free tier, no trial clock');
 
 console.log('pricing-page: ' + passed + ' checks passed');
+
+// ── Every amount belongs to the card it stands in ────────────────────────────
+//
+// The catalog sweep above asks two questions: is every amount on the page a
+// catalog amount, and does every catalog amount appear somewhere. Both are true
+// of a page where two cards have swapped prices, so a ParaSend Pro button
+// reading EUR 59.29/mo passes: that is ParaSign Pro's real price, just on the
+// wrong card. Same for a swapped yearly link, and same for a discount figure
+// that is genuine for another plan.
+//
+// That is not a hypothetical. A wrong number next to the right plan is exactly
+// the class of bug this page had, so the check has to bind an amount to the card
+// it is printed in, not to the page as a whole.
+const cards = html.split(/<div class="tier-card/).slice(1);
+assert(cards.length >= 5, 'expected at least 5 tier cards, found ' + cards.length);
+
+const cardMoney = /&euro;([\d,]+\.?\d*)/g;
+  // Only a percentage presented as a discount, so an SLA figure ("99.9%") in a
+  // paid card is not read as a price claim. The page writes discounts as
+  // "16.7% off"; anything else is left alone.
+  const cardPct = /(\d+\.\d)%\s*off/g;
+let bound = 0;
+
+for (const raw of cards) {
+  // Strip HTML comments first: the WHY-notes above quote the old wrong figures
+  // on purpose, and a test that reads them would fail on its own documentation.
+  const card = raw.replace(/<!--[\s\S]*?-->/g, '');
+  const btn = /data-billing-product="([a-z]+)"\s+data-billing-plan="([a-z]+)"/.exec(card);
+  if (!btn) continue;                       // free card: nothing is charged there
+  const [, product, plan] = btn;
+
+  // Every price this card is allowed to print: its own, in both intervals, each
+  // excl and incl btw. Anything else in this card is a number from another plan.
+  const allowed = new Set();
+  for (const interval of ['monthly', 'yearly']) {
+    const order = catalog.resolveOrder({ product, plan, interval });
+    assert(!order.error, product + '/' + plan + '/' + interval + ': ' + order.error);
+    const incl = Number(order.amount);
+    const excl = Math.round((incl / 1.21) * 100) / 100;
+    allowed.add(incl.toFixed(2));
+    allowed.add(excl.toFixed(2));
+    allowed.add(String(Math.round(excl)));  // "15" as well as "15.00"
+    allowed.add(Math.round(excl).toLocaleString('en-US'));
+  }
+
+  // The per-signature overage rate is a real amount on this card and it does not
+  // come from the subscription catalog; it hangs off the tier itself. Read it
+  // from there rather than allowing any stray number through, so a wrong overage
+  // rate is still caught.
+  const ent = entitlements.getEntitlements(
+    product === 'parasign' ? { plan_parasign: plan } : { plan_parasend: plan },
+  )[product];
+  const rate = ent && ent.overage && ent.overage.rate_eur;
+  if (rate != null) {
+    allowed.add(Number(rate).toFixed(2));
+    allowed.add(String(Number(rate)));
+  }
+
+  for (let m; (m = cardMoney.exec(card)); ) {
+    const raw = m[1].replace(/,/g, '');
+    const norm = new Set([raw, Number(raw).toFixed(2), String(Number(raw))]);
+    const ok_ = [...norm].some((n) => allowed.has(n));
+    assert(ok_, product + '/' + plan + ' card shows &euro;' + m[1] +
+      ', which belongs to another plan (allowed here: ' + [...allowed].sort().join(', ') + ')');
+    bound++;
+  }
+  cardMoney.lastIndex = 0;
+
+  // The yearly discount printed on this card must be this plan's own discount.
+  const mo = Number(catalog.resolveOrder({ product, plan, interval: 'monthly' }).amount);
+  const yr = Number(catalog.resolveOrder({ product, plan, interval: 'yearly' }).amount);
+  const own = Math.round((1 - yr / (mo * 12)) * 1000) / 10;
+  for (let m; (m = cardPct.exec(card)); ) {
+    assert.strictEqual(Number(m[1]), own,
+      product + '/' + plan + ' card claims a ' + m[1] + '% yearly discount; its own is ' + own + '%');
+  }
+  cardPct.lastIndex = 0;
+}
+assert(bound >= 8, 'expected to bind at least 8 amounts to a card, bound ' + bound);
+ok('every amount and discount sits on the card of the plan it belongs to (' + bound + ' amounts bound)');

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -68,24 +68,24 @@ for (const v of VARIANTS) {
 // The four ParaSign tier cards carry the agreed copy, verbatim.
 const PARASIGN_COPY = [
   // FREE - EUR 0
-  '>EUR 0<',
+  '>&euro;0<',
   '2 signatures per month',
   'Unlimited receiving',
   'Full post-quantum crypto - Public verification log',
   'No card required',
   // PRO - EUR 49/month
-  'EUR 49<',
-  '100 signatures per month, then EUR 0.40 each, up to 1,000',
+  '&euro;49<',
+  '100 signatures per month, then &euro;0.40 each, up to 1,000',
   'Past 1,000 a month, Business is cheaper anyway',
   'Unlimited transfers - API access',
-  'Annual: EUR 499 (two months free)',
+  'Annual: &euro;499 excl. &middot; 15.1% off',
   // BUSINESS - EUR 299/month
-  'EUR 299<',
+  '&euro;299<',
   '1,000 signatures per month',
   'Named support, response within one business day',
   "We help you answer your customers' security questionnaires",
   'Exportable audit log with CT tree head (CSV or JSON)',
-  'Annual: EUR 2,990 (two months free)',
+  'Annual: &euro;2,990 excl. &middot; 16.7% off',
   // ENTERPRISE - Let's talk
   "Let's talk",
   'Dedicated relay instance - Sector relay (health, legal, finance)',
@@ -111,7 +111,7 @@ assert(!/No cap, no block/i.test(html), 'pricing page must not carry the No cap,
 ok('no "No cap, no block" claim on the pricing page');
 
 // ParaSend keeps its displayed excl-btw amounts.
-for (const s of ['&euro;15<', 'or &euro;150/yr']) {
+for (const s of ['&euro;15<', 'Annual &euro;150 excl.']) {
   assert(html.includes(s), 'missing displayed ParaSend price fragment: ' + s);
 }
 ok('ParaSend excl-btw amounts visible in the markup');
@@ -127,7 +127,7 @@ ok('no 5 MB claim left on the pricing page');
 
 // Every paid card shows the incl-btw amount up-front, next to the excl price,
 // so the amount on Mollie's page does not surprise the buyer.
-const INCL_ONCARD = ['&euro;18,15/mo incl', 'EUR 59,29/mo incl', 'EUR 361,79/mo incl'];
+const INCL_ONCARD = ['&euro;18.15/mo incl', '&euro;59.29/mo incl', '&euro;361.79/mo incl'];
 for (const s of INCL_ONCARD) {
   assert(html.includes(s), 'paid card must show its btw-incl amount up-front: ' + s);
 }
@@ -149,5 +149,110 @@ assert(!/activates immediately/i.test(checkoutHtml), 'checkout.html must not cla
 assert(!/stub checkout/i.test(checkoutHtml), 'checkout.html must not carry the STUB CHECKOUT banner');
 assert(/<meta[^>]+http-equiv="refresh"[^>]+url=\/pricing/i.test(checkoutHtml), 'checkout.html must redirect to /pricing');
 ok('billing/checkout.html redirects to /pricing with no stub-payment copy');
+
+// ---------------------------------------------------------------------------
+// The page against the catalog. Everything below recomputes from
+// relay/lib/billing-catalog.js, so a price edited on the page alone goes red.
+//
+// Why this exists: on 2026-08-30 the board found the page contradicting itself.
+// Monthly prices were listed excl. btw (15 / 49 / 299) next to a yearly price
+// listed incl. btw (3617,90). Side by side that reads as paying yearly costing
+// more than paying monthly, which is the opposite of the truth. On one basis it
+// is a 16.7% discount. The page also carried "two months free" on ParaSign Pro,
+// where the real discount is 15.1%, and wrote the same amount four ways
+// (EUR 3.617,90 / &euro;3,617.90 / EUR 361,79 / &euro;361.79).
+//
+// Comments are stripped first: the WHY comments in pricing.html quote the old
+// wrong strings on purpose, and they must not satisfy or trip these checks.
+// ---------------------------------------------------------------------------
+const VISIBLE = html.replace(/<!--[\s\S]*?-->/g, '');
+const VAT = 1.21;
+
+// Every checkout amount, and the excl-btw price it is derived from. The catalog
+// charges incl. btw, so the listed price is the amount divided by 1.21; if that
+// does not land back on the catalog amount, the catalog holds a price that
+// cannot be listed cleanly and we want to hear about it here.
+const centsOf = (n) => Math.round(n * 100);
+const money = new Map(); // euros -> label, everything the page is allowed to print
+money.set(0, 'free tier');
+// Per-signature overage. Metered on top of a plan, never a checkout amount, so
+// it is not in the catalog; listed here so the sweep below stays exhaustive.
+money.set(0.4, 'ParaSign overage per signature');
+
+const pctByPlan = new Map();
+for (const product of catalog.PRODUCTS) {
+  for (const plan of Object.keys(catalog.CATALOG[product])) {
+    const perInterval = {};
+    for (const interval of catalog.INTERVALS) {
+      const incl = Number(catalog.priceOf(product, plan, interval));
+      const excl = Math.round(centsOf(incl) / VAT) / 100;
+      assert(catalog.amountsEqual((excl * VAT).toFixed(2), incl.toFixed(2)),
+        product + '/' + plan + '/' + interval + ': catalog ' + incl + ' is not a clean excl-btw price');
+      money.set(incl, product + ' ' + plan + ' ' + interval + ' charged incl. btw');
+      money.set(excl, product + ' ' + plan + ' ' + interval + ' listed excl. btw');
+      perInterval[interval] = excl;
+    }
+    // btw is proportional, so the yearly discount is the same on either basis.
+    const pct = (1 - perInterval.yearly / (perInterval.monthly * 12)) * 100;
+    pctByPlan.set(product + '/' + plan, pct.toFixed(1));
+  }
+}
+ok('catalog amounts all divide cleanly by 21% btw');
+
+// One currency sign. The page used to mix "EUR 49" and "&euro;49".
+assert(!/\bEUR\b/.test(VISIBLE), 'pricing page must write the euro sign as &euro;, never the string EUR');
+assert(!/€/.test(VISIBLE), 'pricing page must use the &euro; entity, not a literal euro character');
+ok('one currency sign on the page (&euro; only)');
+
+// One number format: dot decimal, comma thousands, matching the rest of the
+// English copy ("1,000 signatures"). The page had &euro;18,15 and &euro;18.15
+// for the same amount.
+const tokens = [...VISIBLE.matchAll(/&euro;([\d][\d.,]*)/g)].map(m => m[1]);
+assert(tokens.length > 0, 'no money amounts found on the pricing page at all');
+for (const t of tokens) {
+  assert(/^\d{1,3}(?:,\d{3})*(?:\.\d{2})?$/.test(t),
+    'money amount is not in the page number format (dot decimal, comma thousands): &euro;' + t);
+}
+ok(tokens.length + ' money amounts share one number format');
+
+// Every amount printed on the page traces back to the catalog.
+for (const t of tokens) {
+  const v = Number(t.replace(/,/g, ''));
+  assert(money.has(v), 'page shows &euro;' + t + ', which is not a catalog price (nor btw-derived from one)');
+}
+ok('every amount on the page traces back to billing-catalog.js');
+
+// ...and every catalog amount, plus its excl-btw price, is actually printed. A
+// price silently dropped from the page is as bad as a wrong one.
+const printed = new Set(tokens.map(t => Number(t.replace(/,/g, ''))));
+for (const [v, label] of money) {
+  assert(printed.has(v), 'catalog price &euro;' + v.toFixed(2) + ' (' + label + ') is not shown on the page');
+}
+ok('every catalog price appears on the page, on both bases');
+
+// The yearly discount is stated as the real percentage. "Two months free" is
+// 16.7%: true for ParaSend Pro and ParaSign Business, false for ParaSign Pro.
+assert(!/two months free/i.test(VISIBLE), 'the page must state the real discount, not "two months free"');
+const shownPcts = [...VISIBLE.matchAll(/(\d+\.\d)% off/g)].map(m => m[1]);
+const expectedPcts = [...pctByPlan.values()];
+for (const p of shownPcts) {
+  assert(expectedPcts.includes(p), 'page claims a ' + p + '% yearly discount, catalog gives ' + expectedPcts.join(' / '));
+}
+for (const [key, p] of pctByPlan) {
+  assert(shownPcts.includes(p), 'missing the yearly discount for ' + key + ' (catalog says ' + p + '% off)');
+}
+assert.strictEqual(shownPcts.length, pctByPlan.size,
+  'expected one stated discount per paid plan, got ' + shownPcts.length + ' for ' + pctByPlan.size + ' plans');
+ok('yearly discount stated per plan and matches the catalog (' + expectedPcts.join(' / ') + '%)');
+
+// One promise about starting for free. The page carried "30 days, no credit
+// card, full relay access" next to Free cards saying "Forever, no card
+// required" and a FAQ saying there is no separate trial.
+assert(!/30 days/i.test(VISIBLE), 'pricing page must not promise a 30-day trial next to a forever-free tier');
+assert(!/credit card/i.test(VISIBLE), 'pricing page must not carry the "no credit card" trial copy');
+assert(!/full relay access/i.test(VISIBLE), 'the free tier is not full relay access');
+assert(VISIBLE.includes('There is no separate trial'), 'FAQ must keep saying there is no separate trial');
+assert(VISIBLE.includes('Forever &middot; no card required'), 'Free card must keep the forever/no-card promise');
+ok('one starting-for-free promise: forever-free tier, no trial clock');
 
 console.log('pricing-page: ' + passed + ' checks passed');

--- a/scripts/e2e-toets.sh
+++ b/scripts/e2e-toets.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# End-to-end toets tegen een draaiende Paramant: relay op $API, frontend op $WEB.
+API="${1:?relay-url}"; WEB="${2:?frontend-url}"
+fout=0
+ok()  { printf "  %-52s %s\n" "$1" "$2"; }
+bad() { printf "  %-52s %s  << %s\n" "$1" "$2" "$3"; fout=$((fout+1)); }
+code(){ curl -s -m 8 -o /dev/null -w '%{http_code}' "$@"; }
+# Commentaar eruit voordat we toetsen. Elk van deze pagina's beschrijft in een
+# comment de fout die eruit gehaald is, en een toets die dat meeleest struikelt
+# over zijn eigen documentatie. Dezelfde valkuil als in pricing-page.test.js.
+strip(){ perl -0777 -pe "s/<!--.*?-->//gs; s|/\\*.*?\\*/||gs" ; }
+is()  { [ "$2" = "$3" ] && ok "$1" "$3" || bad "$1" "$3" "verwacht $2"; }
+has() { if echo "$3" | grep -qi "$2"; then ok "$1" "ja"; else bad "$1" "nee" "moest '$2' bevatten"; fi; }
+hasnt(){ if echo "$3" | grep -qi "$2"; then bad "$1" "ja" "mocht '$2' NIET bevatten"; else ok "$1" "weg"; fi; }
+
+echo "== de kritieke auditbevinding van 21-07: ParaID tekende zonder auth =="
+is "issue-document zonder header" 401 "$(code -X POST $API/v1/paraid/issue-document -H 'Content-Type: application/json' -d '{"holder_binding":"aaaaaaaaaaaaaaaaaaaaaaaaaa","mrz_line1":"x","mrz_line2":"y"}')"
+is "issue-document met verzonnen bearer" 401 "$(code -X POST $API/v1/paraid/issue-document -H 'Authorization: Bearer psk_verzonnen' -d '{}')"
+
+echo "== AVG: het wis-endpoint bestaat en is dicht =="
+is "keys/erase zonder admin-token" 401 "$(code -X POST $API/v2/admin/keys/erase -H 'Content-Type: application/json' -d '{"key":"pgp_x"}')"
+
+echo "== het koop pad =="
+is "checkout zonder sleutel" 401 "$(code -X POST $API/v2/billing/checkout -H 'Content-Type: application/json' -d '{"product":"parasend","plan":"pro","interval":"monthly"}')"
+P=$(curl -s -m 8 "$WEB/pricing.html" | strip)
+is "prijspagina bereikbaar" 200 "$(code $WEB/pricing.html)"
+has "toont het bedrag dat echt afgeschreven wordt" "incl. 21" "$P"
+hasnt "geen 30-dagen-trial naast forever-free" "30 days" "$P"
+n=$(echo "$P" | grep -c "data-billing-product"); [ "$n" -ge 6 ] && ok "zes koopknoppen bedraad" "$n" || bad "zes koopknoppen bedraad" "$n" "verwacht >=6"
+J=$(curl -s -m 8 "$WEB/js/pricing-billing.js")
+has "koopintentie wordt bewaard voor de omweg" "rememberIntent" "$J"
+has "en hervat na terugkomst" "takeIntent" "$J"
+K=$(curl -s -m 8 "$WEB/js/passkey.js" | strip)
+has "registratie respecteert next" "safeNext" "$K"
+# Alleen de knop die na registratie doorstuurt. Regel 107 stuurt ook naar het
+# dashboard, maar dat is een foutafhandeling voor een pagina zonder de juiste
+# elementen, en die hoort daar te blijven.
+has "registratieknop gebruikt safeNext" "finishBtn.addEventListener..click.* => . window.location = safeNext" "$K"
+
+echo "== ParaID uit de etalage, pagina blijft bestaan =="
+S=$(curl -s -m 8 "$WEB/sitemap.xml")
+hasnt "sitemap zonder paraid" "paraid" "$S"
+has "sitemap kent de terms-pagina" "/terms" "$S"
+is "paraid-pagina blijft bereikbaar" 200 "$(code $WEB/paraid.html)"
+has "en draagt noindex" "noindex" "$(curl -s -m 8 $WEB/paraid.html)"
+has "eerlijk assurance-label" "never seen or authenticated" "$(curl -s -m 8 $WEB/js/paraid-app.js)"
+
+echo "== de teruggehaalde Terms of Service =="
+is "terms-pagina bereikbaar" 200 "$(code $WEB/terms.html)"
+has "navlink naar terms" 'href="/terms"' "$P"
+hasnt "geen terms-link middenin een zin" "sign the <a href=./dpa.>Data Processing Agreement</a>.<a href=./terms" "$(curl -s -m 8 $WEB/government.html | strip | tr -d '\n')"
+
+echo "== gezondheid =="
+is "health" 200 "$(code $API/health)"
+v=$(curl -s -m 8 "$API/health" | grep -oE '"version":"[^"]+"' | cut -d'"' -f4); ok "versie" "$v"
+
+echo
+[ "$fout" = 0 ] && echo "ALLE CONTROLES GOED" || echo "$fout GEFAALD"
+exit $fout

--- a/tests/parasign-canary.test.mjs
+++ b/tests/parasign-canary.test.mjs
@@ -1,0 +1,173 @@
+// ParaSign canary: does the signing product still sign, end to end, right now.
+//
+// The transfer canary proves ParaSend moves a file. Nothing proved that ParaSign
+// signs. In the whole retained log window (22 Aug - 1 Sep 2026, 218140 lines)
+// there was not one human signing, so a break in the signing ceremony would sit
+// there unnoticed for as long as nobody happened to try it. This is the alarm.
+//
+// It uses a psk_test_ key on purpose. That key drives the sandbox auto-signer,
+// so the run needs no human, no mailbox and no real document: the payload is a
+// throwaway PDF this file generates. Nothing about a customer is read, sent or
+// stored, which is what makes an hourly check compatible with the privacy
+// promise the product is sold on.
+//
+// What it actually proves, in order:
+//   1. the relay accepts an envelope and drives it to completed
+//   2. the receipt is a real, structurally complete .psign
+//   3. the notary counter-signature is an ML-DSA-65 signature over the exact
+//      canonical JSON of the receipt, verified here against the relay's own
+//      published public key, not merely present
+//   4. the signed document comes back as a server-stamped PDF
+//   5. the test nature travels inside the signed evidence (mode: test)
+//
+// Point 3 is the one that matters. A route can answer 200 with a receipt that
+// no one can verify; that is exactly the failure a status page cannot see.
+//
+//   PARASIGN_CANARY_KEY=psk_test_... node --test tests/parasign-canary.test.mjs
+//
+// It cleans up after itself: the envelope is voided at the end.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { ml_dsa65 } from '@noble/post-quantum/ml-dsa.js';
+
+const RELAY = (process.env.PARAMANT_RELAY_URL || 'https://relay.paramant.app').replace(/\/$/, '');
+const KEY = process.env.PARASIGN_CANARY_KEY || '';
+const skip = KEY ? false : 'PARASIGN_CANARY_KEY not set (needs a psk_test_ key)';
+
+// Canonical JSON exactly as relay/parasign.js does it: sorted keys, no spaces.
+// The notary signs this byte string, so a mismatch here is a false alarm.
+function canonicalJSON(obj) {
+  if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
+  if (Array.isArray(obj)) return '[' + obj.map(canonicalJSON).join(',') + ']';
+  return '{' + Object.keys(obj).sort()
+    .map((k) => JSON.stringify(k) + ':' + canonicalJSON(obj[k])).join(',') + '}';
+}
+
+// A minimal valid PDF, written by hand so the canary carries no PDF dependency
+// of its own. pdf-lib lives in the frontend, not in the root install this runs
+// from, and a canary that cannot start is not a canary.
+function throwawayPdf() {
+  const mark = crypto.randomUUID();
+  const objs = [
+    '1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n',
+    '2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n',
+    '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n',
+    '4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n',
+  ];
+  const stream = `BT /F1 12 Tf 60 780 Td (ParaSign canary ${mark}) Tj ET`;
+  objs.push(`5 0 obj\n<< /Length ${stream.length} >>\nstream\n${stream}\nendstream\nendobj\n`);
+
+  let pdf = '%PDF-1.4\n';
+  const offsets = [0];
+  for (const o of objs) { offsets.push(pdf.length); pdf += o; }
+  const xref = pdf.length;
+  pdf += `xref\n0 ${objs.length + 1}\n0000000000 65535 f \n`;
+  for (let i = 1; i <= objs.length; i++) pdf += String(offsets[i]).padStart(10, '0') + ' 00000 n \n';
+  pdf += `trailer\n<< /Size ${objs.length + 1} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`;
+  return Buffer.from(pdf, 'latin1');
+}
+
+const auth = { Authorization: `Bearer ${KEY}` };
+
+async function api(method, path, body) {
+  const r = await fetch(`${RELAY}${path}`, {
+    method,
+    headers: body ? { 'Content-Type': 'application/json', ...auth } : auth,
+    body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(45000),
+  });
+  const text = await r.text();
+  let json = null;
+  try { json = JSON.parse(text); } catch { /* keep the raw body for the message */ }
+  return { status: r.status, json, text, headers: r.headers };
+}
+
+test('parasign: an envelope is created, signed and notarised', { skip }, async (t) => {
+  const pdf = throwawayPdf();
+
+  const created = await api('POST', '/v1/envelopes', {
+    document: { content_base64: pdf.toString('base64') },
+    binding_mode: 'open',
+    original_filename: 'canary.pdf',
+    signers: [{ name: 'Canary A' }, { name: 'Canary B' }],
+  });
+  assert.equal(created.status, 201, `create rejected: HTTP ${created.status} ${created.text.slice(0, 300)}`);
+  const env = created.json;
+  assert.equal(env?.status, 'completed', `the sandbox signer did not complete the envelope: status ${env?.status}`);
+  assert.ok(env.signers?.every((s) => s.status === 'completed'), 'not every signer slot completed');
+  const id = env.id;
+
+  t.after(async () => { try { await api('POST', `/v1/envelopes/${id}/void`); } catch { /* best effort */ } });
+
+  // ── the receipt, and whether its notary signature actually verifies ────────
+  const rec = await api('GET', `/v1/envelopes/${id}/receipt`);
+  assert.equal(rec.status, 200, `receipt failed: HTTP ${rec.status} ${rec.text.slice(0, 200)}`);
+  const psign = rec.json;
+  assert.equal(psign.type, 'parasign-envelope-receipt', 'receipt is not a parasign envelope receipt');
+  assert.equal(psign.parties?.length, 2, 'receipt does not carry both parties');
+  for (const p of psign.parties) {
+    assert.ok(p.signature, `party ${p.index} has no signature`);
+    assert.ok(p.public_key, `party ${p.index} has no public key`);
+  }
+  assert.ok(psign.notary_signature, 'no notary counter-signature on the receipt');
+  assert.ok(psign.notary?.relay_public_key, 'the receipt does not name the notary public key');
+
+  // The signature is over the canonical JSON of the receipt WITHOUT the
+  // signature field. Verifying it here is the difference between "the endpoint
+  // answered" and "the evidence it produced is sound".
+  const { notary_signature, ...signed } = psign;
+  const okSig = ml_dsa65.verify(
+    Buffer.from(psign.notary.relay_public_key, 'base64'),
+    Buffer.from(canonicalJSON(signed), 'utf8'),
+    Buffer.from(notary_signature, 'base64'),
+  );
+  assert.ok(okSig, 'the notary signature does NOT verify: the receipt is not sound evidence');
+
+  // The key in the receipt must be the key the relay publishes, or a receipt
+  // could verify against a key only the attacker holds.
+  const pub = await fetch(`${RELAY}/v2/pubkey`, { signal: AbortSignal.timeout(20000) });
+  assert.equal(pub.status, 200, `/v2/pubkey failed: HTTP ${pub.status}`);
+  const published = await pub.json();
+  assert.equal(
+    psign.notary.relay_public_key, published.public_key,
+    'the receipt was notarised with a key that is not the published relay key',
+  );
+
+  // A sandbox envelope must say so inside the signed evidence, so a test
+  // receipt can never be passed off as a real one.
+  assert.equal(psign.mode, 'test', 'a psk_test_ receipt is not flagged as test inside the signed evidence');
+  assert.equal(psign.sandbox, true, 'a psk_test_ receipt is not flagged as sandbox');
+});
+
+test('parasign: the signed document comes back stamped', { skip }, async (t) => {
+  const pdf = throwawayPdf();
+  const created = await api('POST', '/v1/envelopes', {
+    document: { content_base64: pdf.toString('base64') },
+    binding_mode: 'open',
+    original_filename: 'canary.pdf',
+    signers: [{ name: 'Canary' }],
+  });
+  assert.equal(created.status, 201, `create rejected: HTTP ${created.status} ${created.text.slice(0, 300)}`);
+  const id = created.json.id;
+  t.after(async () => { try { await api('POST', `/v1/envelopes/${id}/void`); } catch { /* best effort */ } });
+
+  const doc = await fetch(`${RELAY}/v1/envelopes/${id}/document`, { headers: auth, signal: AbortSignal.timeout(45000) });
+  assert.equal(doc.status, 200, `document failed: HTTP ${doc.status}`);
+  const bytes = Buffer.from(await doc.arrayBuffer());
+  assert.equal(bytes.subarray(0, 5).toString('latin1'), '%PDF-', 'what came back is not a PDF');
+  assert.equal(
+    doc.headers.get('x-parasign-stamped'), 'true',
+    'the relay served the original, not a stamped PDF: the stamp worker is down',
+  );
+});
+
+test('parasign: an unauthenticated create is refused', { skip: false }, async () => {
+  const r = await fetch(`${RELAY}/v1/envelopes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ document: { content_base64: '' }, signers: [{ name: 'X' }] }),
+    signal: AbortSignal.timeout(20000),
+  });
+  assert.ok(r.status === 401 || r.status === 403, `an unauthenticated create was not refused: HTTP ${r.status}`);
+});

--- a/tests/parasign-canary.test.mjs
+++ b/tests/parasign-canary.test.mjs
@@ -29,7 +29,23 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
-import { ml_dsa65 } from '@noble/post-quantum/ml-dsa.js';
+
+// Loaded dynamically, and the failure is deliberately loud. A static import
+// throws ERR_MODULE_NOT_FOUND before a single line of this file runs, and
+// "Cannot find package" in an hourly heartbeat reads as "production is broken"
+// when it means "this job did not npm ci". The canary still FAILS without it,
+// because a run that cannot verify a signature proves nothing and must not pass
+// quietly, but it fails saying which job owes it an install.
+let ml_dsa65;
+try {
+  ({ ml_dsa65 } = await import('@noble/post-quantum/ml-dsa.js'));
+} catch (e) {
+  throw new Error(
+    '@noble/post-quantum is not installed, so the notary signature cannot be verified.\n' +
+    '  This canary runs in .github/workflows/product-heartbeat.yml, which does `npm ci` first.\n' +
+    '  It is deliberately excluded from the no-install job in test.yml.\n' +
+    `  Original: ${e.message}`);
+}
 
 const RELAY = (process.env.PARAMANT_RELAY_URL || 'https://relay.paramant.app').replace(/\/$/, '');
 const KEY = process.env.PARASIGN_CANARY_KEY || '';

--- a/tests/seo-contract.test.mjs
+++ b/tests/seo-contract.test.mjs
@@ -29,6 +29,14 @@ const PRIVATE = new Set([
   'developer', 'get', 'ontvang', 'request-key', 'setup',
   'auth/backup', 'auth/login', 'auth/request-reset', 'auth/reset-confirm',
   'auth/setup', 'billing/checkout', 'signup/verified',
+  // ParaID is not for sale: it is absent from PRODUCTS in billing-catalog.js and
+  // was pulled from the navigation on 2026-07-19 (fb3cdd3), which kept the pages
+  // as unlinked routes for the alpha. A later SEO commit then republished all 59
+  // routes in bulk, so the three ParaID pages ended up back in the sitemap on
+  // 2026-07-25, six days after the decision to take them out, with priority 0.9.
+  // They are held to the noindex contract instead: still reachable for anyone
+  // holding the link, not offered to a search engine as something we sell.
+  'paraid', 'paraid-app', 'paraid-document',
 ]);
 
 // Meta-refresh stubs. They point their canonical at the real page and are held

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -18,12 +18,24 @@ assert.doesNotMatch(account, /Stub mode|No real payments are charged|Mollie inte
 assert.match(adminHtml, /blocks the account key and removes active sessions and TOTP/i);
 assert.match(adminHtml, /Type DEACTIVATE to confirm/);
 assert.match(adminJs, /Account deactivated/);
-assert.match(email, /Account record and audit entries retained/);
-assert.doesNotMatch(email, /Personal data removed from our systems/);
+// Deletion now erases the personal data itself, so the mail has to say so.
+// It used to promise the opposite, because deletion only revoked the key and
+// left the address in users.json (audit finding 5 of 2026-07-21). A mail that
+// undersells an erasure is as untrue as one that oversells it, which is what
+// this file exists to catch.
+assert.match(email, /Personal data removed from our systems/);
+assert.match(email, /Billing records kept for as long as tax law requires/);
+assert.doesNotMatch(email, /Account record and audit entries retained/);
 assert.doesNotMatch(email, /sign up again|Files already relayed are not affected/i);
 
 assert.doesNotMatch(paraid, /live person \+ passport document check|document tier \(substantial\)|Prove your age from your passport/);
-assert.match(paraid, /MRZ check-digit consistency, document authenticity not checked/);
+// The wording moved when the assurance rung was renamed from the eIDAS word
+// 'substantial' to 'mrz-unverified'. What the page must keep saying is the
+// same thing: the check digits add up and nothing about the document itself
+// was verified. Matched on the claim, not on one exact sentence.
+assert.match(paraid, /check digits add up/i);
+assert.match(paraid, /never seen or authenticated/i);
+assert.doesNotMatch(paraid, /MRZ check-digit consistency, document authenticity not checked/);
 assert.match(paraid, /does not verify the document, its chip, its holder or a live person/);
 assert.match(paraid, /MRZ internally consistent/);
 


### PR DESCRIPTION
The transfer canary proves ParaSend still moves a file every hour, and opens an issue when it does not. Nothing proved ParaSign still signs.

## Why now

Measured on production, over the whole retained nginx window (22 August to 1 September 2026, 218140 lines): **not one human signing**. Every write on an API path is the hourly transfer canary (UA `node`, GitHub runner IPs), the sth heartbeat, three signups or one webauthn registration.

At zero traffic a breakage is invisible. There is no user to complain, so a broken signing ceremony would sit there until a customer tried it and failed, which is the worst possible way to find out about the product the company leads with.

## What it does

`tests/parasign-canary.test.mjs` creates an envelope with a `psk_test_` key, so the sandbox auto-signer completes it: no human, no mailbox, no real document, nothing about a customer read or stored. That is what makes an hourly check compatible with the privacy promise the product is sold on. It voids what it created.

The PDF is generated by hand in the file rather than with pdf-lib, which lives in the frontend and not in the root install this runs from. A canary that cannot start is not a canary.

## It does not stop at HTTP 200

That is the part that matters. It fetches the `.psign` receipt and verifies the notary counter-signature with `@noble/post-quantum`, over the exact canonical JSON the relay signs, against the key the relay publishes at `/v2/pubkey`. A route can answer 200 with a receipt nobody can verify, and that is exactly the failure a status page cannot see.

It also asserts:
- the sandbox marker (`mode: test`, `sandbox: true`) is **inside** the signed evidence, so a test receipt can never pass for a real one
- `GET /document` returns a server-stamped PDF (`X-ParaSign-Stamped: true`), so a dead stamp worker is caught rather than silently serving the original
- an unauthenticated create is refused

`@noble/post-quantum` moves into the root dependencies for that verification. Pure JS, no native build, and `relay/package.json` already carries it.

## What it needs

One secret, `PARASIGN_CANARY_KEY`, holding a `psk_test_` key with the parasign scope. Without it the two signing tests skip **by name** rather than fail, in the same shape as the keyed transfer canary. The third test (unauthenticated create is refused) runs either way.

Verified locally against production in that state: 1 passed, 2 skipped, 0 failed.
