### PR TITLE
Hold the line on suites that assert nothing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,12 @@ jobs:
       # parasign-* suites are excluded for the same reason: they need the
       # ML-DSA-65 engine, which this job deliberately does not build. They used
       # to run here and silently skip, which is what made "ok 24" mean nothing.
+      # A declared skip is better than a silent one, but it still exits 0 and
+      # still shows up as a green check. Two suites assert nothing at all in this
+      # job, by name and on purpose, and that is fine as long as it stays two and
+      # stays those two. What is not fine is a third joining them quietly, which
+      # is exactly how four ParaSign suites came to report "ok" over nothing for
+      # weeks. So the skips are counted, named, and held to a list.
       - name: Relay unit suite
         working-directory: relay
         env:
@@ -141,9 +147,31 @@ jobs:
           # Declaring it here is what keeps them amber instead of red; anything
           # NOT named here is now a hard failure (see relay/test/_requires.js).
           RELAY_TEST_SKIP: redis
-        run: >-
-          node --test $(ls test/*.test.js | grep -vE
-          'inbound-hash-verify|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index')
+        run: |
+          set -o pipefail
+          node --test $(ls test/*.test.js | grep -vE \
+            'inbound-hash-verify|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index') \
+            2>&1 | tee /tmp/relay-units.log
+          # Which suites ran and asserted nothing. The line comes from
+          # summary() in test/_requires.js.
+          silent=$(grep -oE '^# [a-z0-9-]+: SKIPPED - 0 checks ran' /tmp/relay-units.log \
+                   | sed 's/^# //; s/: SKIPPED.*//' | sort)
+          # ONE suite, not two. parasign-store also lacks redis here, but it has a
+          # memory fallback and still runs three checks, so it is not silent.
+          # Measured, not assumed: the first version of this list said two and
+          # this gate caught it on the first run.
+          expected=$'parasign-signs-quota'
+          echo "--- suites that asserted nothing in this job:"
+          echo "${silent:-(none)}" | sed 's/^/      /'
+          if [ "$silent" != "$expected" ]; then
+            echo "::error::the set of suites that assert nothing has changed."
+            echo "expected:"; echo "$expected" | sed 's/^/      /'
+            echo "got:";      echo "${silent:-(none)}" | sed 's/^/      /'
+            echo "A suite that asserts nothing still reports green. If a new one"
+            echo "is here, give it its dependency or say why it may stay silent;"
+            echo "if one left, remove it from the expected list in test.yml."
+            exit 1
+          fi
 
       # Root integration suites (tests/*.mjs): dependency-injected, node builtins
       # only (no @paramant/core, no Redis, no npm install). The browser suites are


### PR DESCRIPTION
Hold the line on suites that assert nothing

A declared skip is better than a silent one, but it still exits 0 and still
shows up as a green check. In the relay unit job, one suite runs and asserts
nothing at all: parasign-signs-quota, which needs a redis this job deliberately
does not install. That is fine. What is not fine is a second one joining it
quietly, because that is exactly how four ParaSign suites came to report "ok"
over nothing for weeks (fixed in #314, found by accident).

The job now collects the names of every suite that ended with "SKIPPED - 0
checks ran", prints them pass or fail, and compares them against a list. A new
silent suite fails the build with what changed and what to do about it: give it
its dependency, or say why it may stay silent.

MEASURED, NOT ASSUMED, AND THE GATE CAUGHT ME FIRST

The first version of that list held two names. parasign-store also lacks redis
here, so it looked like a match. It is not: it has a memory fallback and still
runs three checks, so it is not silent. Running the gate before committing it is
what surfaced that, on the first try. A list of expected-silent suites that is
itself wrong is worse than no list, because it passes while describing something
that is not there.

WHAT THE AUDIT FOUND ELSEWHERE, so far

Every relay/test suite and every non-browser tests/*.mjs was run in isolation and
its assertion count read. No suite exits 0 with zero assertions except the one
named above. The five that looked suspicious (billing, ct-receipt,
parasign-void-guard, parasign-open-api, entitlement-record-merge) report between
5 and 19 confirmations each; they use bare asserts without a counter, which reads
as empty to a crude scan and is not.

Still open, and worth doing next: static imports in conditional tests. Nine files
carry top-level imports alongside skip logic, and a static import throws before
the skip can run, which is the failure that took the ParaSign canary red earlier
tonight. Whether the other eight can actually hit it depends on whether their
imports are ever absent in the job that runs them; that needs measuring per file,
not assuming.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
