### PR TITLE
Production gets its deep readiness check back, behind internal auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,10 @@ jobs:
       # main, and a suite nobody trusts is a suite nobody reads.
       - name: Relay integration suite (needs deps)
         working-directory: relay
-        run: node --test test/inbound-hash-verify.test.js
+        # deep-health-gate boots relay.js three times (two modes and a
+        # missing-token case), so like inbound-hash-verify it needs the
+        # installed dependencies and lives here, not in the no-install job.
+        run: node --test test/inbound-hash-verify.test.js test/deep-health-gate.test.js
 
   relay-unit-tests:
     name: relay - unit suite (no native deps)
@@ -150,7 +153,7 @@ jobs:
         run: |
           set -o pipefail
           node --test $(ls test/*.test.js | grep -vE \
-            'inbound-hash-verify|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index') \
+            'inbound-hash-verify|deep-health-gate|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index') \
             2>&1 | tee /tmp/relay-units.log
           # Which suites ran and asserted nothing. The line comes from
           # summary() in test/_requires.js.

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -174,7 +174,7 @@ const ALLOWED = {
                '/v2/did','/v2/ct','/v2/attest','/v2/admin','/metrics','/v2/dl',
                '/v2/key-sector','/v2/team','/v2/reload-users','/v2/session',
                '/v2/ws-ticket','/v2/fingerprint','/v2/relays','/v2/sign-dpa',
-               '/v2/sth','/v2/verify-receipt','/v2/capabilities','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
+               '/v2/sth','/v2/verify-receipt','/v2/capabilities','/v2/health','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
                '/v2/sign','/v2/verify','/v2/lookup-signer','/v2/envelopes','/v2/billing','/v2/claim','/v2/parasign','/v1'],
   iot:        ['/health','/v2/pubkey','/v2/inbound','/v2/anon-inbound','/v2/outbound','/v2/status',
                '/v2/webhook','/v2/audit','/v2/check-key','/v2/stream','/v2/stream-next',
@@ -182,7 +182,7 @@ const ALLOWED = {
                '/v2/did','/v2/ct','/v2/attest','/v2/admin','/metrics','/v2/dl',
                '/v2/key-sector','/v2/team','/v2/reload-users','/v2/session',
                '/v2/relays','/v2/sign-dpa','/v2/sth','/v2/verify-receipt',
-               '/v2/capabilities','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
+               '/v2/capabilities','/v2/health','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
                '/v2/sign','/v2/verify','/v2/lookup-signer','/v2/envelopes','/v2/billing','/v2/claim','/v2/parasign','/v1'],
   full:       null,
 };
@@ -2500,8 +2500,16 @@ const server = http.createServer(async (req, res) => {
   }
 
   // GET /v2/health/deep -- aggregated readiness check for the post-setup page.
-  // Public read (no auth) so the setup wizard and /all-systems-go can show it.
+  // In full mode this is a public read (no auth) so the setup wizard and
+  // /all-systems-go can show it. In ghost_pipe and iot the same payload is an
+  // information leak (version, key count, free disk, cert age), so there it
+  // sits behind the X-Internal-Auth header that already gates the user
+  // endpoints: monitoring on the host can read it, the open internet cannot.
+  // With no INTERNAL_AUTH_TOKEN configured the route stays closed (the gate
+  // treats missing config as closed), which is the pre-existing behaviour of
+  // every internal endpoint.
   if (req.method === 'GET' && path === '/v2/health/deep') {
+    if (RELAY_MODE !== 'full' && !_internalOk()) return _internalReject();
     const checks = [];
     const add = (name, status, detail) => checks.push({ name, status, detail });
 

--- a/relay/test/deep-health-gate.test.js
+++ b/relay/test/deep-health-gate.test.js
@@ -1,0 +1,107 @@
+'use strict';
+// /v2/health/deep across relay modes. The handler aggregates version, loaded
+// key count, free disk and cert age. In `full` mode that is deliberately
+// public (the setup wizard and /all-systems-go read it); in `ghost_pipe` and
+// `iot` the same payload is an information leak, and before this gate existed
+// the mode allowlist simply dropped the route ("Not available in this relay
+// mode") — so production had NO deep readiness check at all, which is what the
+// 2026-09-01 audit found. The fix: the route is mode-allowed everywhere, but
+// outside `full` it sits behind the X-Internal-Auth header that already gates
+// the user endpoints. Missing token config keeps it closed.
+//
+// Boots relay.js three times (ghost_pipe+token, ghost_pipe without token,
+// full) and asserts: authed internal read works in production mode, the open
+// internet gets 401 (not a silent drop, not the old "Not available" error),
+// unconfigured token stays closed, and full mode stays public.
+// Run: node relay/test/deep-health-gate.test.js
+
+const { test, after } = require('node:test');
+const assert = require('assert');
+const { spawn } = require('child_process');
+const path = require('path');
+
+const RELAY_DIR = path.join(__dirname, '..');
+const TOKEN = 'deephealth-test-token';
+const children = [];
+
+function boot(port, extraEnv) {
+  const child = spawn('node', ['relay.js'], {
+    cwd: RELAY_DIR,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      USERS_JSON: '{"api_keys":[]}',
+      RELAY_REDIS_URL: '',
+      NATS_URL: '',
+      ...extraEnv,
+    },
+    stdio: ['ignore', 'ignore', 'ignore'],
+  });
+  children.push(child);
+  return child;
+}
+
+async function waitHealthy(port) {
+  const deadline = Date.now() + 15000;
+  for (;;) {
+    try { const r = await fetch(`http://127.0.0.1:${port}/health`); if (r.ok) return; } catch (_) { /* not up yet */ }
+    if (Date.now() > deadline) throw new Error('relay did not become healthy in time');
+    await new Promise((r) => setTimeout(r, 250));
+  }
+}
+
+async function deep(port, headers) {
+  const r = await fetch(`http://127.0.0.1:${port}/v2/health/deep`, { headers: headers || {} });
+  let j = null;
+  try { j = await r.json(); } catch (_) { /* non-JSON */ }
+  return { status: r.status, body: j };
+}
+
+after(() => { for (const c of children) c.kill('SIGKILL'); });
+
+test('ghost_pipe: internal auth reads the deep check, the open internet gets 401', async () => {
+  const port = 34500 + (process.pid % 400);
+  boot(port, { RELAY_MODE: 'ghost_pipe', INTERNAL_AUTH_TOKEN: TOKEN });
+  await waitHealthy(port);
+
+  // Unauthenticated: closed, and closed the RIGHT way — a 401 from the gate,
+  // not the old mode-allowlist drop that said "Not available in this relay
+  // mode" and left production without any readiness signal.
+  const anon = await deep(port);
+  assert.strictEqual(anon.status, 401, 'unauthenticated read must be refused');
+  assert.strictEqual(anon.body.error, 'unauthorized');
+
+  // Authenticated: the full aggregated check, same shape full mode serves.
+  const authed = await deep(port, { 'X-Internal-Auth': TOKEN });
+  assert.strictEqual(authed.status, 200, 'internal-authed read must work in production mode');
+  assert.ok(['green', 'yellow', 'red'].includes(authed.body.overall), 'overall verdict present');
+  assert.ok(Array.isArray(authed.body.checks) && authed.body.checks.length > 0, 'checks array present');
+  const names = authed.body.checks.map((c) => c.name);
+  for (const expected of ['relay', 'crypto', 'storage', 'memory']) {
+    assert.ok(names.includes(expected), `check "${expected}" present`);
+  }
+
+  // A wrong token is not a lucky token.
+  const wrong = await deep(port, { 'X-Internal-Auth': TOKEN + 'x' });
+  assert.strictEqual(wrong.status, 401, 'wrong token must be refused');
+});
+
+test('ghost_pipe without INTERNAL_AUTH_TOKEN: stays closed, never open-by-default', async () => {
+  const port = 34900 + (process.pid % 400);
+  boot(port, { RELAY_MODE: 'ghost_pipe', INTERNAL_AUTH_TOKEN: '' });
+  await waitHealthy(port);
+  const anon = await deep(port);
+  assert.strictEqual(anon.status, 401, 'missing token config must read as closed');
+  // Even presenting the header cannot open a gate with no configured token.
+  const tried = await deep(port, { 'X-Internal-Auth': '' });
+  assert.strictEqual(tried.status, 401, 'empty token must not match empty config');
+});
+
+test('full mode: stays public for the setup wizard', async () => {
+  const port = 35300 + (process.pid % 400);
+  boot(port, { RELAY_MODE: 'full' });
+  await waitHealthy(port);
+  const anon = await deep(port);
+  assert.strictEqual(anon.status, 200, 'full mode must keep the public read');
+  assert.ok(Array.isArray(anon.body.checks) && anon.body.checks.length > 0);
+});


### PR DESCRIPTION
## Wat er mis was

`/v2/health/deep` is de geaggregeerde readiness check (crypto geladen, storage schrijfbaar, geheugen, disk, cert-leeftijd, keys). De mode-allowlist van `ghost_pipe` en `iot` droeg wel `/health` maar niet `/v2/health`, dus de route werd vóór de handler afgekapt en productie antwoordde `{"error":"Not available in this relay mode","mode":"ghost_pipe"}`.

Het instrument dat moet bevestigen dat alle onderdelen gezond zijn stond dus uit, precies in de modus waarin productie draait. Vondst uit de audit van 01-09 ("wat is bevestigd en wat is gewaarborgd").

## Waarom niet gewoon de route openzetten

De payload (versie, aantal geladen keys, vrije disk, cert-dagen) is in `full`-modus bewust publiek voor de setup-wizard. Op het open internet is het informatieprijsgave. Dus: de route is overal mode-allowed, maar buiten `full` zit de handler achter de bestaande `X-Internal-Auth`-header die ook de user-endpoints bewaakt. Monitoring op de host kan hem lezen, het open internet krijgt 401. Zonder geconfigureerde `INTERNAL_AUTH_TOKEN` blijft de poort dicht (bestaand contract van elk intern endpoint).

## Bewijs

Nieuwe suite `relay/test/deep-health-gate.test.js` boot relay.js drie keer en pint alle vier de randen:
- `ghost_pipe` + token: 200 met de checks-array
- `ghost_pipe` anoniem: **401**, niet de oude stille drop
- `ghost_pipe` zonder geconfigureerde token: dicht, ook met lege header
- `full`: publiek, wizard blijft werken

Suite spawnt een echte relay en staat daarom in de crypto-job naast `inbound-hash-verify`, uitgesloten van de no-install glob. Relay-units 175/175, integratie 4/4.

## Voor de uitrol

Wil host-monitoring dit lezen, dan moet `INTERNAL_AUTH_TOKEN` in de relay-env staan (staat vermoedelijk al voor de user-endpoints; controleren bij de deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbVV3KNNnE4oTnW9Kswmxn