### PR TITLE
Give ParaSign a product page at /parasign so the signing product can be found

### DIFF
--- a/bron-seo/apply_seo_head.py
+++ b/bron-seo/apply_seo_head.py
@@ -37,7 +37,7 @@ PRIVATE = {
 # SoftwareApplication; the rest stay WebPage. Claiming SoftwareApplication on a
 # policy page is the kind of over-tagging that gets structured data ignored.
 SOFTWARE = {
-    "index", "parashare", "sign", "verify", "vault", "download",
+    "index", "parashare", "parasign", "sign", "verify", "vault", "download",
     "co-sign"}
 
 

--- a/bron-seo/build_sitemap.py
+++ b/bron-seo/build_sitemap.py
@@ -33,7 +33,7 @@ PRIVATE = {
 # Crawl priority. Not a ranking factor, but it tells a crawler where to spend
 # its budget on a 60-page site: the product and the money pages first.
 PRIORITY = [
-    (0.9, {"index", "pricing", "sign", "verify", "vault", "download"}),
+    (0.9, {"index", "pricing", "parasign", "sign", "verify", "vault", "download"}),
     (0.8, {"security", "trust", "architecture", "docs", "vs", "about"}),
 ]
 DEFAULT_PRIORITY = 0.6

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>ParaSign &middot; Post-quantum e-signing by Paramant</title>
+<meta property="og:site_name" content="Paramant">
+<meta name="description" content="Post-quantum e-signing in your browser: ML-DSA-65 (FIPS 204), a key that never leaves your device, and a .psign receipt anyone can verify offline.">
+<meta property="og:title" content="ParaSign &middot; Post-quantum e-signing by Paramant">
+<meta property="og:description" content="Post-quantum e-signing in your browser: ML-DSA-65 (FIPS 204), a key that never leaves your device, and a .psign receipt anyone can verify offline.">
+<meta property="og:url" content="https://paramant.app/parasign">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="ParaSign &middot; Post-quantum e-signing by Paramant">
+<meta name="twitter:description" content="Post-quantum e-signing in your browser: ML-DSA-65 (FIPS 204), a key that never leaves your device, and a .psign receipt anyone can verify offline.">
+<link rel="canonical" href="https://paramant.app/parasign">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="manifest" href="/manifest.json">
+<meta name="theme-color" content="#0B3A6A">
+
+<link rel="stylesheet" href="/design-system.css?v=22">
+<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<style>
+.ps-band{padding:var(--space-8) 0;border-top:1px solid var(--ink-hair)}
+.ps-band h2{font-size:var(--text-2xl);letter-spacing:-.02em;margin-bottom:var(--space-2)}
+.mono-eyebrow{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)}
+.ps-lede{font-size:var(--text-md);color:var(--ink);line-height:1.7;max-width:680px;margin-top:var(--space-4)}
+.ps-band p{font-size:var(--text-base);color:var(--ink);line-height:1.8;max-width:680px;margin-top:var(--space-4)}
+.ps-band p a,.ps-band li a{color:var(--cobalt)}
+.ps-band p strong{color:var(--navy)}
+.ps-actions{display:flex;gap:var(--space-3);flex-wrap:wrap;margin-top:var(--space-6)}
+.check-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1px;background:var(--ink-hair);border:1px solid var(--ink-hair);margin-top:var(--space-5)}
+.check-card{background:var(--bone);padding:var(--space-5) var(--space-5)}
+.check-card .k{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.14em;text-transform:uppercase;color:var(--cobalt);font-weight:700}
+.check-card p{margin-top:var(--space-2);font-size:var(--text-sm);color:var(--ink);line-height:1.65;max-width:none}
+.check-card a{color:var(--cobalt)}
+.tier-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--ink-hair);border:1px solid var(--ink-hair);margin-top:var(--space-5)}
+.tier-card{background:var(--bone);padding:var(--space-5);display:flex;flex-direction:column}
+.tier-card.featured{background:var(--lime)}
+.tier-name{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;font-weight:700;color:var(--cobalt)}
+.tier-price{font-family:var(--mono);font-size:var(--text-2xl);font-weight:700;color:var(--navy);margin-top:var(--space-2)}
+.tier-price span{font-size:var(--text-sm);color:var(--ink-dim);font-weight:400}
+.tier-note{font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-1);line-height:1.5}
+.tier-note .incl{color:var(--navy);font-weight:700}
+.tier-card ul{list-style:none;margin:var(--space-4) 0 0;padding:0}
+.tier-card li{font-family:var(--mono);font-size:var(--text-xs);color:var(--navy);padding:var(--space-2) 0;border-bottom:1px solid var(--ink-hair);line-height:1.5}
+.tier-card li:last-child{border-bottom:none}
+.tier-card li::before{content:'+ ';font-weight:700;color:var(--cobalt)}
+.ps-fine{font-family:var(--mono);font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-4);max-width:none}
+.ps-steps{list-style:none;counter-reset:step;margin-top:var(--space-5);padding:0;max-width:680px}
+.ps-steps li{counter-increment:step;position:relative;padding:var(--space-4) 0 var(--space-4) var(--space-8);border-top:1px solid var(--ink-hair);font-size:var(--text-base);color:var(--ink);line-height:1.7}
+.ps-steps li:last-child{border-bottom:1px solid var(--ink-hair)}
+.ps-steps li::before{content:counter(step,decimal-leading-zero);position:absolute;left:0;top:var(--space-4);font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.14em;font-weight:700;color:var(--cobalt)}
+.ps-steps strong{color:var(--navy)}
+.scope-note{background:var(--bone);border:1px solid var(--ink-hair);border-left:3px solid var(--lime);padding:var(--space-4) var(--space-5);margin-top:var(--space-5);max-width:680px}
+.scope-note p{margin-top:0}
+@media(max-width:1023px){.tier-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:640px){.check-grid,.tier-grid{grid-template-columns:1fr}}
+</style>
+<script type="application/ld+json" data-paramant-seo="1">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": "https://paramant.app/parasign#webpage",
+      "url": "https://paramant.app/parasign",
+      "name": "ParaSign - Post-quantum e-signing by Paramant",
+      "isPartOf": {
+        "@id": "https://paramant.app/#website"
+      },
+      "publisher": {
+        "@id": "https://paramant.app/#organization"
+      },
+      "inLanguage": "en",
+      "description": "Post-quantum e-signing in your browser: ML-DSA-65 (FIPS 204), a key that never leaves your device, and a .psign receipt anyone can verify offline."
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://paramant.app/parasign#software",
+      "name": "Paramant",
+      "applicationCategory": "SecurityApplication",
+      "operatingSystem": "Web browser",
+      "url": "https://paramant.app/parasign",
+      "publisher": {
+        "@id": "https://paramant.app/#organization"
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+
+<div class="meta-bar">
+  <span class="">build 3.0.0</span>
+  <span class="sep">·</span>
+  <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
+  <span class="sep">·</span>
+  <span class="">eu/de · ram only</span>
+</div>
+<nav class="nav">
+  <a href="/" class="nav-logo" aria-label="Paramant"><img src="/favicon-32.png" alt="" class="nav-logo-mark">aramant</a>
+
+  <ul class="nav-links">
+
+    <li><a href="/#products" class="nav-link">Products</a></li>
+
+    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
+
+    <li><a href="/pricing" class="nav-link">Pricing</a></li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Developers</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/docs" role="menuitem">Docs</a></li>
+        <li role="none"><a href="/docs#api" role="menuitem">API reference</a></li>
+        <li role="none"><a href="/ct-log" role="menuitem">CT Log</a></li>
+        <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay" role="menuitem">GitHub</a></li>
+        <li role="none"><a href="https://hub.docker.com/r/mtty001/relay" role="menuitem">Docker Hub</a></li>
+        <li role="none"><a href="/changelog" role="menuitem">Changelog</a></li>
+      </ul>
+    </li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
+        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
+        <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
+        <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
+        <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
+        <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
+        <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
+      </ul>
+    </li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Compliance</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li class="nav-subheader" role="presentation">Post-quantum</li>
+        <li role="none"><a href="/crypto-agility" role="menuitem">Crypto agility</a></li>
+        <li class="nav-subheader" role="presentation">Legal</li>
+        <li role="none"><a href="/dpa" role="menuitem">Data Processing Agreement</a></li>
+      </ul>
+    </li>
+
+    <li><a href="/vs" class="nav-link">Compare</a></li>
+
+    <li class="nav-dropdown">
+      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">About</button>
+      <ul class="nav-dropdown-menu" role="menu">
+        <li role="none"><a href="/status" role="menuitem">Status</a></li>
+        <li role="none"><a href="/security" role="menuitem">Security</a></li>
+        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
+        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
+        <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
+        <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
+        <li role="none"><a href="/license" role="menuitem">License</a></li>
+        <li role="none"><a href="/press" role="menuitem">Press kit</a></li>
+        <li role="none"><a href="mailto:privacy@paramant.app" role="menuitem">Contact</a></li>
+      </ul>
+    </li>
+
+  </ul>
+
+  <div class="nav-auth" id="nav-auth">
+    <a href="/auth/login" class="nav-signin">Sign in</a>
+    <a href="/signup" class="nav-cta">Create account</a>
+  </div>
+
+  <button class="nav-hamburger" id="nav-hamburger" aria-label="Open menu" aria-expanded="false">
+    <span></span><span></span><span></span>
+  </button>
+</nav>
+<div class="nav-mobile" id="nav-mobile">
+  <a href="/#products" class="nav-mobile-standalone">Products</a>
+
+  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
+
+  <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
+
+  <div class="nav-mobile-group">
+    <button class="nav-mobile-group-btn" aria-expanded="false">Developers</button>
+    <div class="nav-mobile-group-items">
+      <a href="/docs">Docs</a>
+      <a href="/docs#api">API reference</a>
+      <a href="/ct-log">CT Log</a>
+      <a href="https://github.com/Apolloccrypt/paramant-relay">GitHub</a>
+      <a href="https://hub.docker.com/r/mtty001/relay">Docker Hub</a>
+      <a href="/changelog">Changelog</a>
+    </div>
+  </div>
+
+  <div class="nav-mobile-group">
+    <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
+    <div class="nav-mobile-group-items">
+      <a href="/docs#self-hosting">Deploy guide</a>
+      <a href="/setup">Relay setup wizard</a>
+      <a href="/install.sh">install.sh</a>
+      <a href="/install-pi.sh">install-pi.sh</a>
+      <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
+      <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
+      <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
+    </div>
+  </div>
+
+  <div class="nav-mobile-group">
+    <button class="nav-mobile-group-btn" aria-expanded="false">Compliance</button>
+    <div class="nav-mobile-group-items">
+      <a href="/crypto-agility">Crypto agility</a>
+      <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
+    </div>
+  </div>
+
+  <a href="/vs" class="nav-mobile-standalone">Compare</a>
+
+  <div class="nav-mobile-group">
+    <button class="nav-mobile-group-btn" aria-expanded="false">About</button>
+    <div class="nav-mobile-group-items">
+      <a href="/status">Status</a>
+      <a href="/security">Security</a>
+      <a href="/trust">Trust</a>
+      <a href="/pararules">ParaRules</a>
+      <a href="/sla">SLA</a>
+      <a href="/partners">Partners</a>
+      <a href="/license">License</a>
+      <a href="/press">Press kit</a>
+      <a href="mailto:privacy@paramant.app">Contact</a>
+    </div>
+  </div>
+
+  <a href="/help" class="nav-mobile-standalone">Help</a>
+</div>
+
+<!-- HERO -->
+<section style="padding:var(--space-10) 0 var(--space-6)" id="main-content" tabindex="-1">
+  <div class="container-md">
+    <div class="sec-head">
+      <span class="num">00</span>
+      <h1 class="paramant-h2">ParaSign</h1>
+      <span class="mono-eyebrow">Post-quantum e-signing by Paramant</span>
+    </div>
+    <p class="ps-lede">Sign PDFs in your browser with an ML-DSA-65 (FIPS 204) signature. Your key never leaves your device, and every completed signature comes with a .psign receipt that anyone can verify offline, with or without the Paramant relay.</p>
+    <div class="ps-actions">
+      <a href="/sign" class="btn btn-primary">Sign a document &rarr;</a>
+      <a href="/pricing" class="btn btn-secondary">See pricing &rarr;</a>
+    </div>
+  </div>
+</section>
+
+<!-- WHAT IT DOES -->
+<section class="ps-band">
+  <div class="container-md">
+    <span class="mono-eyebrow">01 / What it does</span>
+    <h2 style="margin-top:var(--space-2)">Sign, co-sign, prove</h2>
+    <p>ParaSign is the signing half of Paramant. It runs on the same post-quantum core as ParaSend, and the document you sign stays private: the plaintext and the private key never leave your browser.</p>
+    <div class="check-grid">
+      <div class="check-card">
+        <div class="k">PDF editor and visible seal</div>
+        <p>Place text, dates and annotations, manage pages, then drop the signature stamp on any page. The stamp is what readers see; the .psign envelope is the proof.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Co-signing with routing order</div>
+        <p>Add each person who needs to sign. Every invitation is bound to the exact email address you enter, and the encrypted document travels with the request.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Any file type, by hash</div>
+        <p>Files that are not PDFs get a hash-only attestation: you sign the SHA3-256 of the bytes and recipients verify by re-hashing the same file.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Public transparency log</div>
+        <p>Every signature is entered into a public, append-only log. Inspect it on the <a href="/ct-log">CT Log</a>.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Offline verification</div>
+        <p>A signed document verifies without contacting us. Check one on the <a href="/verify">verify page</a>: no account, no API key.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Developer API from Pro</div>
+        <p>Plug signing into your own apps and quotes with the developer API and webhooks. See the <a href="/docs#parasign">documentation</a>.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- WHAT IT COSTS -->
+<section class="ps-band">
+  <div class="container-md">
+    <span class="mono-eyebrow">02 / What it costs</span>
+    <h2 style="margin-top:var(--space-2)">Priced by signature volume, not by feature</h2>
+    <p>Every plan gets the same encryption, the same post-quantum signatures and the same public proof log. Pay for volume, never for security. And pay per organisation, not per user.</p>
+    <div class="tier-grid">
+      <div class="tier-card">
+        <div class="tier-name">Free</div>
+        <div class="tier-price">&euro;0</div>
+        <div class="tier-note">Forever &middot; no card required</div>
+        <ul>
+          <li>2 signatures per month</li>
+          <li>Unlimited receiving</li>
+          <li>Full post-quantum crypto</li>
+          <li>Public verification log</li>
+        </ul>
+      </div>
+      <div class="tier-card featured">
+        <div class="tier-name">Pro</div>
+        <div class="tier-price">&euro;49<span>/month</span></div>
+        <div class="tier-note">excl. btw &middot; <span class="incl">charged &euro;59.29/mo incl. 21% btw</span><br>Annual &euro;499 excl.</div>
+        <ul>
+          <li>100 signatures per month, then &euro;0.40 each, up to 1,000</li>
+          <li>Unlimited transfers</li>
+          <li>API access</li>
+        </ul>
+      </div>
+      <div class="tier-card">
+        <div class="tier-name">Business</div>
+        <div class="tier-price">&euro;299<span>/month</span></div>
+        <div class="tier-note">excl. btw &middot; <span class="incl">charged &euro;361.79/mo incl. 21% btw</span><br>Annual &euro;2,990 excl.</div>
+        <ul>
+          <li>1,000 signatures per month</li>
+          <li>Named support, response within one business day</li>
+          <li>Exportable audit log with CT tree head</li>
+        </ul>
+      </div>
+      <div class="tier-card">
+        <div class="tier-name">Enterprise</div>
+        <div class="tier-price">Let's talk</div>
+        <div class="tier-note">Per organisation</div>
+        <ul>
+          <li>Dedicated relay instance</li>
+          <li>Sector relay (health, legal, finance)</li>
+          <li>SLA with service credits</li>
+          <li>Self-hosting licence</li>
+        </ul>
+      </div>
+    </div>
+    <p class="ps-fine">Prices shown excl. btw (VAT). Checkout charges incl. 21% btw: Pro &euro;59.29/mo or &euro;603.79/yr, Business &euro;361.79/mo or &euro;3,617.90/yr. Checkout and the full comparison are on the <a href="/pricing">pricing page</a>.</p>
+  </div>
+</section>
+
+<!-- HOW TO BEGIN -->
+<section class="ps-band">
+  <div class="container-md">
+    <span class="mono-eyebrow">03 / How to begin</span>
+    <h2 style="margin-top:var(--space-2)">Three steps to a signed document</h2>
+    <p>Signing a document needs a Paramant account, because the signing key is bound to it. Opening a signing request someone sent you does not: invited signers follow the personal link in their email.</p>
+    <ol class="ps-steps">
+      <li><strong><a href="/signup">Create a free account</a>.</strong> No card, no time limit. The free tier covers 2 signatures a month.</li>
+      <li><strong><a href="/sign">Open ParaSign</a> and pick your document.</strong> PDFs get a visible signature stamp you place on any page; other file types are attested by hash. Add co-signers if you need them, then sign. Your key is unlocked with Face ID, Touch ID or a security key the moment you sign, and it is never exported.</li>
+      <li><strong>Download and share.</strong> You get the stamped PDF and the .psign envelope. Anyone can check them on the <a href="/verify">verify page</a>, offline, without an account.</li>
+    </ol>
+  </div>
+</section>
+
+<!-- WHY TRUST IT -->
+<section class="ps-band">
+  <div class="container-md">
+    <span class="mono-eyebrow">04 / Why you can trust it</span>
+    <h2 style="margin-top:var(--space-2)">Every claim has a place to check it</h2>
+    <p>You should not have to trust us. You should be able to check. Each point below links to where you can.</p>
+    <div class="check-grid">
+      <div class="check-card">
+        <div class="k">Post-quantum signatures</div>
+        <p>ML-DSA-65 (FIPS 204), generated in your browser. The private key never reaches the relay. Test vectors on the <a href="/crypto-agility">crypto agility page</a>.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">You own your keys</div>
+        <p>Generated on your device, never sent. We see only the public half. How that works is on the <a href="/security">security page</a>.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Verifiable, not trust-me</div>
+        <p>A public CT log and receipts anyone can check offline. Open the <a href="/ct-log">CT Log</a> or the <a href="/verify">verify page</a>.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Source-available, EU jurisdiction</div>
+        <p>The relay is source-available on <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>, and runs under EU jurisdiction. Who is behind it is on the <a href="/about">about page</a>.</p>
+      </div>
+    </div>
+    <div class="scope-note">
+      <p><strong>Post-quantum, zero-knowledge. Not eIDAS-qualified.</strong> A ParaSign signature is a Simple Electronic Signature (SES): an ML-DSA-65 cryptographic attestation produced in your browser. It is not a notarised legal signature under eIDAS or any qualified-trust regime (QES). We state exactly what it is and what it is not.</p>
+    </div>
+    <div class="ps-actions">
+      <a href="/sign" class="btn btn-primary">Sign a document &rarr;</a>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container-lg">
+    <div class="footer-grid footer-slim">
+      <div>
+        <div class="logo" style="margin-bottom:var(--space-3)"><span class="a">Para</span><span class="b">MANT</span></div>
+        <p style="font-size:var(--text-xs);color:var(--ink-dim);line-height:1.8;max-width:320px">Paramant is a product of <strong>Paramantis Solutions B.V.</strong><br>Harderwijk, the Netherlands<br>KvK 42115132<br><a href="mailto:privacy@paramant.app">privacy@paramant.app</a></p>
+        <p style="font-family:var(--mono);font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-4);line-height:1.8">BUSL-1.1 &middot; &copy; 2026 PARAMANTIS SOLUTIONS B.V.</p>
+      </div>
+      <div>
+        <div class="footer-col-label">Legal</div>
+        <div class="footer-links">
+          <a href="/privacy">Privacy Policy</a>
+          <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
+          <a href="/sla">SLA</a>
+          <a href="/license">License</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<script src="/nav.js?v=14" defer></script>
+<script src="/js/nav-auth.js?v=4" defer></script>
+</body>
+</html>

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -4,17 +4,17 @@
 <meta charset="utf-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>ParaSign &middot; Post-quantum e-signing by Paramant</title>
+<title>ParaSign &middot; get documents signed, by Paramant</title>
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Post-quantum e-signing in your browser: ML-DSA-65 (FIPS 204), a key that never leaves your device, and a .psign receipt anyone can verify offline.">
-<meta property="og:title" content="ParaSign &middot; Post-quantum e-signing by Paramant">
-<meta property="og:description" content="Post-quantum e-signing in your browser: ML-DSA-65 (FIPS 204), a key that never leaves your device, and a .psign receipt anyone can verify offline.">
+<meta name="description" content="Send a document out for signature and get a receipt anyone can check, from your browser. Free on the Community plan, business plans for firms that sign more.">
+<meta property="og:title" content="ParaSign &middot; get documents signed, by Paramant">
+<meta property="og:description" content="Send a document out for signature and get a receipt anyone can check, from your browser. Free on the Community plan, business plans for firms that sign more.">
 <meta property="og:url" content="https://paramant.app/parasign">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="ParaSign &middot; Post-quantum e-signing by Paramant">
-<meta name="twitter:description" content="Post-quantum e-signing in your browser: ML-DSA-65 (FIPS 204), a key that never leaves your device, and a .psign receipt anyone can verify offline.">
+<meta name="twitter:title" content="ParaSign &middot; get documents signed, by Paramant">
+<meta name="twitter:description" content="Send a document out for signature and get a receipt anyone can check, from your browser. Free on the Community plan, business plans for firms that sign more.">
 <link rel="canonical" href="https://paramant.app/parasign">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -23,7 +23,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=22">
+<link rel="stylesheet" href="/design-system.css?v=23">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
@@ -40,9 +40,15 @@
 .check-card .k{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.14em;text-transform:uppercase;color:var(--cobalt);font-weight:700}
 .check-card p{margin-top:var(--space-2);font-size:var(--text-sm);color:var(--ink);line-height:1.65;max-width:none}
 .check-card a{color:var(--cobalt)}
-.tier-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--ink-hair);border:1px solid var(--ink-hair);margin-top:var(--space-5)}
+.tier-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--ink-hair);border:1px solid var(--ink-hair);margin-top:var(--space-5)}
 .tier-card{background:var(--bone);padding:var(--space-5);display:flex;flex-direction:column}
-.tier-card.featured{background:var(--lime)}
+.community{background:var(--lime);border:1px solid var(--ink-hair);padding:var(--space-6);margin-top:var(--space-5);display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1.3fr);gap:var(--space-6)}
+.community h3{font-size:var(--text-xl);letter-spacing:-.01em;color:var(--navy);margin:var(--space-2) 0 0}
+.community p{max-width:none;margin-top:var(--space-3);font-size:var(--text-sm);line-height:1.75}
+.community ul{list-style:none;margin:var(--space-4) 0 0;padding:0}
+.community li{font-family:var(--mono);font-size:var(--text-xs);color:var(--navy);padding:var(--space-2) 0;border-bottom:1px solid rgba(11,58,106,.18);line-height:1.5}
+.community li:last-child{border-bottom:none}
+.community li::before{content:'+ ';font-weight:700}
 .tier-name{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;font-weight:700;color:var(--cobalt)}
 .tier-price{font-family:var(--mono);font-size:var(--text-2xl);font-weight:700;color:var(--navy);margin-top:var(--space-2)}
 .tier-price span{font-size:var(--text-sm);color:var(--ink-dim);font-weight:400}
@@ -60,7 +66,7 @@
 .ps-steps strong{color:var(--navy)}
 .scope-note{background:var(--bone);border:1px solid var(--ink-hair);border-left:3px solid var(--lime);padding:var(--space-4) var(--space-5);margin-top:var(--space-5);max-width:680px}
 .scope-note p{margin-top:0}
-@media(max-width:1023px){.tier-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:1023px){.community{grid-template-columns:1fr;gap:var(--space-4)}}
 @media(max-width:640px){.check-grid,.tier-grid{grid-template-columns:1fr}}
 </style>
 <script type="application/ld+json" data-paramant-seo="1">
@@ -71,7 +77,7 @@
       "@type": "WebPage",
       "@id": "https://paramant.app/parasign#webpage",
       "url": "https://paramant.app/parasign",
-      "name": "ParaSign - Post-quantum e-signing by Paramant",
+      "name": "ParaSign - get documents signed, by Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -79,7 +85,7 @@
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Post-quantum e-signing in your browser: ML-DSA-65 (FIPS 204), a key that never leaves your device, and a .psign receipt anyone can verify offline."
+      "description": "Send a document out for signature and get a receipt anyone can check, from your browser. Free on the Community plan, business plans for firms that sign more."
     },
     {
       "@type": "SoftwareApplication",
@@ -107,71 +113,17 @@
   <span class="">eu/de · ram only</span>
 </div>
 <nav class="nav">
-  <a href="/" class="nav-logo" aria-label="Paramant"><img src="/favicon-32.png" alt="" class="nav-logo-mark">aramant</a>
+  <a href="/" class="nav-logo"><span class="logo-para">Para</span><span class="logo-mant">MANT</span></a>
 
   <ul class="nav-links">
-
-    <li><a href="/#products" class="nav-link">Products</a></li>
-
-    <li><a href="/dashboard" class="nav-link nav-link-strong">Dashboard</a></li>
-
+    <li><a href="/#products" class="nav-link">Product</a></li>
+    <li><a href="/security" class="nav-link">Security</a></li>
     <li><a href="/pricing" class="nav-link">Pricing</a></li>
-
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Developers</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/docs" role="menuitem">Docs</a></li>
-        <li role="none"><a href="/docs#api" role="menuitem">API reference</a></li>
-        <li role="none"><a href="/ct-log" role="menuitem">CT Log</a></li>
-        <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay" role="menuitem">GitHub</a></li>
-        <li role="none"><a href="https://hub.docker.com/r/mtty001/relay" role="menuitem">Docker Hub</a></li>
-        <li role="none"><a href="/changelog" role="menuitem">Changelog</a></li>
-      </ul>
-    </li>
-
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Self-host</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/docs#self-hosting" role="menuitem">Deploy guide</a></li>
-        <li role="none"><a href="/setup" role="menuitem">Relay setup wizard</a></li>
-        <li role="none"><a href="/install.sh" role="menuitem">install.sh</a></li>
-        <li role="none"><a href="/install-pi.sh" role="menuitem">install-pi.sh</a></li>
-        <li role="none"><a href="https://pypi.org/project/paramant-sdk/" role="menuitem">SDK · PyPI</a></li>
-        <li role="none"><a href="https://www.npmjs.com/package/paramant-sdk" role="menuitem">SDK · npm</a></li>
-        <li role="none"><a href="https://github.com/Apolloccrypt/paramant-relay/releases" role="menuitem">Releases</a></li>
-      </ul>
-    </li>
-
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">Compliance</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li class="nav-subheader" role="presentation">Post-quantum</li>
-        <li role="none"><a href="/crypto-agility" role="menuitem">Crypto agility</a></li>
-        <li class="nav-subheader" role="presentation">Legal</li>
-        <li role="none"><a href="/dpa" role="menuitem">Data Processing Agreement</a></li>
-      </ul>
-    </li>
-
-    <li><a href="/vs" class="nav-link">Compare</a></li>
-
-    <li class="nav-dropdown">
-      <button class="nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">About</button>
-      <ul class="nav-dropdown-menu" role="menu">
-        <li role="none"><a href="/status" role="menuitem">Status</a></li>
-        <li role="none"><a href="/security" role="menuitem">Security</a></li>
-        <li role="none"><a href="/pararules" role="menuitem">ParaRules</a></li>
-        <li role="none"><a href="/trust" role="menuitem">Trust</a></li>
-        <li role="none"><a href="/sla" role="menuitem">SLA</a></li>
-        <li role="none"><a href="/partners" role="menuitem">Partners</a></li>
-        <li role="none"><a href="/license" role="menuitem">License</a></li>
-        <li role="none"><a href="/press" role="menuitem">Press kit</a></li>
-        <li role="none"><a href="mailto:privacy@paramant.app" role="menuitem">Contact</a></li>
-      </ul>
-    </li>
-
+    <li><a href="/docs" class="nav-link">Docs</a></li>
   </ul>
 
   <div class="nav-auth" id="nav-auth">
+    <a href="/help" class="nav-help">HELP</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -181,64 +133,10 @@
   </button>
 </nav>
 <div class="nav-mobile" id="nav-mobile">
-  <a href="/#products" class="nav-mobile-standalone">Products</a>
-
-  <a href="/dashboard" class="nav-mobile-standalone">Dashboard</a>
-
+  <a href="/#products" class="nav-mobile-standalone">Product</a>
+  <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
-
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Developers</button>
-    <div class="nav-mobile-group-items">
-      <a href="/docs">Docs</a>
-      <a href="/docs#api">API reference</a>
-      <a href="/ct-log">CT Log</a>
-      <a href="https://github.com/Apolloccrypt/paramant-relay">GitHub</a>
-      <a href="https://hub.docker.com/r/mtty001/relay">Docker Hub</a>
-      <a href="/changelog">Changelog</a>
-    </div>
-  </div>
-
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Self-host</button>
-    <div class="nav-mobile-group-items">
-      <a href="/docs#self-hosting">Deploy guide</a>
-      <a href="/setup">Relay setup wizard</a>
-      <a href="/install.sh">install.sh</a>
-      <a href="/install-pi.sh">install-pi.sh</a>
-      <a href="https://pypi.org/project/paramant-sdk/">SDK · PyPI</a>
-      <a href="https://www.npmjs.com/package/paramant-sdk">SDK · npm</a>
-      <a href="https://github.com/Apolloccrypt/paramant-relay/releases">Releases</a>
-    </div>
-  </div>
-
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">Compliance</button>
-    <div class="nav-mobile-group-items">
-      <a href="/crypto-agility">Crypto agility</a>
-      <a href="/dpa">Data Processing Agreement</a>
-          <a href="/terms">Terms of Service</a>
-    </div>
-  </div>
-
-  <a href="/vs" class="nav-mobile-standalone">Compare</a>
-
-  <div class="nav-mobile-group">
-    <button class="nav-mobile-group-btn" aria-expanded="false">About</button>
-    <div class="nav-mobile-group-items">
-      <a href="/status">Status</a>
-      <a href="/security">Security</a>
-      <a href="/trust">Trust</a>
-      <a href="/pararules">ParaRules</a>
-      <a href="/sla">SLA</a>
-      <a href="/partners">Partners</a>
-      <a href="/license">License</a>
-      <a href="/press">Press kit</a>
-      <a href="mailto:privacy@paramant.app">Contact</a>
-    </div>
-  </div>
-
-  <a href="/help" class="nav-mobile-standalone">Help</a>
+  <a href="/docs" class="nav-mobile-standalone">Docs</a>
 </div>
 
 <!-- HERO -->
@@ -247,9 +145,10 @@
     <div class="sec-head">
       <span class="num">00</span>
       <h1 class="paramant-h2">ParaSign</h1>
-      <span class="mono-eyebrow">Post-quantum e-signing by Paramant</span>
+      <span class="mono-eyebrow">Get documents signed, by Paramant</span>
     </div>
-    <p class="ps-lede">Sign PDFs in your browser with an ML-DSA-65 (FIPS 204) signature. Your key never leaves your device, and every completed signature comes with a .psign receipt that anyone can verify offline, with or without the Paramant relay.</p>
+    <p class="ps-lede">Send a contract, a quote or a consent form out for signature and get it back signed, without leaving your browser and without the document passing through anyone else's cloud. Everyone you send it to can check the result later, on their own, without an account and without us.</p>
+    <p class="ps-fine">Free on the <a href="#plans">Community plan</a> &middot; business plans from &euro;49 a month &middot; the person you invite needs no account, only the link in their email.</p>
     <div class="ps-actions">
       <a href="/sign" class="btn btn-primary">Sign a document &rarr;</a>
       <a href="/pricing" class="btn btn-secondary">See pricing &rarr;</a>
@@ -262,7 +161,7 @@
   <div class="container-md">
     <span class="mono-eyebrow">01 / What it does</span>
     <h2 style="margin-top:var(--space-2)">Sign, co-sign, prove</h2>
-    <p>ParaSign is the signing half of Paramant. It runs on the same post-quantum core as ParaSend, and the document you sign stays private: the plaintext and the private key never leave your browser.</p>
+    <p>ParaSign is the signing half of Paramant. The document you sign stays private: the plaintext and your signing key never leave your browser, so there is no copy of the contract sitting on our side waiting to be asked for.</p>
     <div class="check-grid">
       <div class="check-card">
         <div class="k">PDF editor and visible seal</div>
@@ -270,19 +169,11 @@
       </div>
       <div class="check-card">
         <div class="k">Co-signing with routing order</div>
-        <p>Add each person who needs to sign. Every invitation is bound to the exact email address you enter, and the encrypted document travels with the request.</p>
+        <p>Add each person who needs to sign, in the order they should sign. Every invitation is bound to the exact email address you enter, and the encrypted document travels with the request.</p>
       </div>
       <div class="check-card">
-        <div class="k">Any file type, by hash</div>
-        <p>Files that are not PDFs get a hash-only attestation: you sign the SHA3-256 of the bytes and recipients verify by re-hashing the same file.</p>
-      </div>
-      <div class="check-card">
-        <div class="k">Public transparency log</div>
-        <p>Every signature is entered into a public, append-only log. Inspect it on the <a href="/ct-log">CT Log</a>.</p>
-      </div>
-      <div class="check-card">
-        <div class="k">Offline verification</div>
-        <p>A signed document verifies without contacting us. Check one on the <a href="/verify">verify page</a>: no account, no API key.</p>
+        <div class="k">Any file type, by fingerprint</div>
+        <p>Files that are not PDFs get a hash-only attestation: you sign a fingerprint of the bytes and recipients verify by re-hashing the same file.</p>
       </div>
       <div class="check-card">
         <div class="k">Developer API from Pro</div>
@@ -293,24 +184,39 @@
 </section>
 
 <!-- WHAT IT COSTS -->
-<section class="ps-band">
+<section class="ps-band" id="plans">
   <div class="container-md">
     <span class="mono-eyebrow">02 / What it costs</span>
-    <h2 style="margin-top:var(--space-2)">Priced by signature volume, not by feature</h2>
-    <p>Every plan gets the same encryption, the same post-quantum signatures and the same public proof log. Pay for volume, never for security. And pay per organisation, not per user.</p>
-    <div class="tier-grid">
-      <div class="tier-card">
-        <div class="tier-name">Free</div>
-        <div class="tier-price">&euro;0</div>
-        <div class="tier-note">Forever &middot; no card required</div>
+    <h2 style="margin-top:var(--space-2)">Community is free. Companies pay.</h2>
+    <p>Two halves, and the split is the point. Individuals sign for nothing on the Community plan. Organisations that sign at volume buy a business plan, and those plans are what pay for the free one.</p>
+
+    <div class="community">
+      <div>
+        <span class="mono-eyebrow">Community</span>
+        <h3>&euro;0, forever</h3>
+        <p>No card, no clock, no trial that quietly ends. On the <a href="/pricing">pricing page</a> this plan is the tier named <strong>Free</strong>.</p>
         <ul>
           <li>2 signatures per month</li>
           <li>Unlimited receiving</li>
           <li>Full post-quantum crypto</li>
           <li>Public verification log</li>
+          <li>No card required</li>
         </ul>
+        <div class="ps-actions">
+          <a href="/signup" class="btn btn-primary">Start free &rarr;</a>
+        </div>
       </div>
-      <div class="tier-card featured">
+      <div>
+        <div class="k" style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.14em;text-transform:uppercase;font-weight:700;color:var(--navy)">Why it is free</div>
+        <p>Paramant is built by <strong>Mick Beer</strong>, privacy and security researcher and founder of Paramantis Solutions B.V. (see the <a href="/about">about page</a>). The Community plan is his way of giving something back: whoever needs to sign a document without handing it to an American cloud can do that here, at no cost, with the same cryptography a paying customer gets.</p>
+        <p>It is not a limited edition of the product. Community gets the same signatures, the same encryption and the same public proof log as Business. What a paid plan buys is volume, an API, support and accountability. Never security.</p>
+      </div>
+    </div>
+
+    <h3 style="font-size:var(--text-md);margin-top:var(--space-8);color:var(--navy)">Business plans</h3>
+    <p>For firms that sign at volume, need the API, or have to answer to an auditor. Names and prices are the ones on the <a href="/pricing">pricing page</a>; checkout lives there.</p>
+    <div class="tier-grid">
+      <div class="tier-card">
         <div class="tier-name">Pro</div>
         <div class="tier-price">&euro;49<span>/month</span></div>
         <div class="tier-note">excl. btw &middot; <span class="incl">charged &euro;59.29/mo incl. 21% btw</span><br>Annual &euro;499 excl.</div>
@@ -342,7 +248,7 @@
         </ul>
       </div>
     </div>
-    <p class="ps-fine">Prices shown excl. btw (VAT). Checkout charges incl. 21% btw: Pro &euro;59.29/mo or &euro;603.79/yr, Business &euro;361.79/mo or &euro;3,617.90/yr. Checkout and the full comparison are on the <a href="/pricing">pricing page</a>.</p>
+    <p class="ps-fine">Prices shown excl. btw (VAT). Checkout charges incl. 21% btw: Pro &euro;59.29/mo or &euro;603.79/yr, Business &euro;361.79/mo or &euro;3,617.90/yr. Pricing is per organisation, not per user. Checkout and the full comparison are on the <a href="/pricing">pricing page</a>.</p>
   </div>
 </section>
 
@@ -353,31 +259,39 @@
     <h2 style="margin-top:var(--space-2)">Three steps to a signed document</h2>
     <p>Signing a document needs a Paramant account, because the signing key is bound to it. Opening a signing request someone sent you does not: invited signers follow the personal link in their email.</p>
     <ol class="ps-steps">
-      <li><strong><a href="/signup">Create a free account</a>.</strong> No card, no time limit. The free tier covers 2 signatures a month.</li>
-      <li><strong><a href="/sign">Open ParaSign</a> and pick your document.</strong> PDFs get a visible signature stamp you place on any page; other file types are attested by hash. Add co-signers if you need them, then sign. Your key is unlocked with Face ID, Touch ID or a security key the moment you sign, and it is never exported.</li>
+      <li><strong><a href="/signup">Create a free account</a>.</strong> No card, no time limit. The Community plan covers 2 signatures a month.</li>
+      <li><strong><a href="/sign">Open ParaSign</a> and pick your document.</strong> PDFs get a visible signature stamp you place on any page; other file types are attested by fingerprint. Add co-signers if you need them, then sign. Your key is unlocked with Face ID, Touch ID or a security key the moment you sign, and it is never exported.</li>
       <li><strong>Download and share.</strong> You get the stamped PDF and the .psign envelope. Anyone can check them on the <a href="/verify">verify page</a>, offline, without an account.</li>
     </ol>
   </div>
 </section>
 
-<!-- WHY TRUST IT -->
+<!-- THE PROOF, LAST -->
 <section class="ps-band">
   <div class="container-md">
-    <span class="mono-eyebrow">04 / Why you can trust it</span>
-    <h2 style="margin-top:var(--space-2)">Every claim has a place to check it</h2>
-    <p>You should not have to trust us. You should be able to check. Each point below links to where you can.</p>
+    <span class="mono-eyebrow">04 / How it works, and how to check it</span>
+    <h2 style="margin-top:var(--space-2)">The technique is the evidence, not the pitch</h2>
+    <p>None of the above is worth anything if you have to take our word for it. This is the machinery underneath, and next to every claim is the place you can go and check it yourself.</p>
     <div class="check-grid">
       <div class="check-card">
-        <div class="k">Post-quantum signatures</div>
-        <p>ML-DSA-65 (FIPS 204), generated in your browser. The private key never reaches the relay. The algorithm register on the <a href="/crypto-agility">crypto agility page</a> lists it as the loaded default.</p>
+        <div class="k">ML-DSA-65 (FIPS 204)</div>
+        <p>Signatures are post-quantum, generated in your browser. The algorithm register on the <a href="/crypto-agility">crypto agility page</a> lists ML-DSA-65 as the loaded default.</p>
       </div>
       <div class="check-card">
         <div class="k">You own your keys</div>
-        <p>Generated on your device, never sent. We see only the public half. How that works is on the <a href="/security">security page</a>.</p>
+        <p>The private key is generated on your device and never sent. We see only the public half. How that works is on the <a href="/security">security page</a>.</p>
       </div>
       <div class="check-card">
-        <div class="k">Verifiable, not trust-me</div>
-        <p>A public CT log and receipts anyone can check offline. Open the <a href="/ct-log">CT Log</a> or the <a href="/verify">verify page</a>.</p>
+        <div class="k">SHA3-256 for non-PDF files</div>
+        <p>A hash-only attestation signs the SHA3-256 digest of the bytes. Re-hash the same file and the signature either matches or it does not.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Public transparency log</div>
+        <p>Every signature is entered into a public, append-only log. Inspect it on the <a href="/ct-log">CT Log</a>.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Verification without us</div>
+        <p>A .psign envelope verifies offline, against the published key. Check one on the <a href="/verify">verify page</a>: no account, no API key, no call home.</p>
       </div>
       <div class="check-card">
         <div class="k">Source-available, EU jurisdiction</div>
@@ -402,6 +316,13 @@
         <p style="font-family:var(--mono);font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-4);line-height:1.8">BUSL-1.1 &middot; &copy; 2026 PARAMANTIS SOLUTIONS B.V.</p>
       </div>
       <div>
+        <div class="footer-col-label">Company</div>
+        <div class="footer-links">
+          <a href="/about">About</a>
+          <a href="/changelog">Changelog</a>
+        </div>
+      </div>
+      <div>
         <div class="footer-col-label">Legal</div>
         <div class="footer-links">
           <a href="/privacy">Privacy Policy</a>
@@ -416,6 +337,6 @@
 </footer>
 
 <script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=4" defer></script>
+<script src="/js/nav-auth.js?v=5" defer></script>
 </body>
 </html>

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -286,7 +286,7 @@
       </div>
       <div class="check-card">
         <div class="k">Developer API from Pro</div>
-        <p>Plug signing into your own apps and quotes with the developer API and webhooks. See the <a href="/docs#parasign">documentation</a>.</p>
+        <p>Plug signing into your own apps and quotes with the developer API and webhooks. See the <a href="/docs#parasign-api">documentation</a>.</p>
       </div>
     </div>
   </div>
@@ -369,7 +369,7 @@
     <div class="check-grid">
       <div class="check-card">
         <div class="k">Post-quantum signatures</div>
-        <p>ML-DSA-65 (FIPS 204), generated in your browser. The private key never reaches the relay. Test vectors on the <a href="/crypto-agility">crypto agility page</a>.</p>
+        <p>ML-DSA-65 (FIPS 204), generated in your browser. The private key never reaches the relay. The algorithm register on the <a href="/crypto-agility">crypto agility page</a> lists it as the loaded default.</p>
       </div>
       <div class="check-card">
         <div class="k">You own your keys</div>

--- a/frontend/sitemap.xml
+++ b/frontend/sitemap.xml
@@ -183,7 +183,7 @@
   </url>
   <url>
     <loc>https://paramant.app/vault</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-09-02</lastmod>
     <priority>0.9</priority>
   </url>
   <url>

--- a/frontend/sitemap.xml
+++ b/frontend/sitemap.xml
@@ -117,6 +117,11 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://paramant.app/parasign</loc>
+    <lastmod>2026-09-02</lastmod>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://paramant.app/partners</loc>
     <lastmod>2026-09-02</lastmod>
     <priority>0.6</priority>

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -143,7 +143,6 @@ assert.strictEqual(yearlyAlts, 3, 'expected 3 yearly options demoted to secondar
 assert(!/data-billing-interval="yearly"\s+class="btn/.test(html), 'no yearly variant may still be an equal btn');
 ok('one primary monthly CTA per tier, yearly demoted to a secondary link');
 
-// The dead stub checkout page no longer serves the "no charge" lie; it redirects.
 // /parasign is the product page and quotes the ParaSign prices a second time.
 // relay/test/pricing-page.test.js is the only thing that ties a listed price to
 // the catalog, so the product page is held to the same numbers here: an edit
@@ -165,6 +164,7 @@ for (const s of ['2 signatures per month', '100 signatures per month, then &euro
 assert(/excl\. btw/.test(parasignHtml) && /incl\. 21% btw/.test(parasignHtml), 'parasign.html must state excl. btw and the incl. 21% btw checkout amount');
 ok('parasign.html carries the same quota lines and the btw convention');
 
+// The dead stub checkout page no longer serves the "no charge" lie; it redirects.
 const checkoutHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'billing', 'checkout.html'), 'utf8');
 assert(!/no charge/i.test(checkoutHtml), 'checkout.html must not claim "no charge"');
 assert(!/activates immediately/i.test(checkoutHtml), 'checkout.html must not claim "activates immediately"');
@@ -277,8 +277,6 @@ assert(VISIBLE.includes('There is no separate trial'), 'FAQ must keep saying the
 assert(VISIBLE.includes('Forever &middot; no card required'), 'Free card must keep the forever/no-card promise');
 ok('one starting-for-free promise: forever-free tier, no trial clock');
 
-console.log('pricing-page: ' + passed + ' checks passed');
-
 // ── Every amount belongs to the card it stands in ────────────────────────────
 //
 // The catalog sweep above asks two questions: is every amount on the page a
@@ -358,3 +356,5 @@ for (const raw of cards) {
 }
 assert(bound >= 8, 'expected to bind at least 8 amounts to a card, bound ' + bound);
 ok('every amount and discount sits on the card of the plan it belongs to (' + bound + ' amounts bound)');
+
+console.log('pricing-page: ' + passed + ' checks passed');

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -164,6 +164,45 @@ for (const s of ['2 signatures per month', '100 signatures per month, then &euro
 assert(/excl\. btw/.test(parasignHtml) && /incl\. 21% btw/.test(parasignHtml), 'parasign.html must state excl. btw and the incl. 21% btw checkout amount');
 ok('parasign.html carries the same quota lines and the btw convention');
 
+// The free plan is called Community on /parasign, because that is what it is:
+// a give-back, not a trial. /pricing lists the same plan under the name Free
+// (PR #328 introduces the Community wording on the homepage the same way). Two
+// names for one plan is fine only while the page says so; a visitor who goes
+// looking for "Community" on the pricing page and finds four tiers, none of
+// them called that, has been sent on a walk. So: if /parasign says Community,
+// it must also name the tier /pricing sells, and /pricing must still sell it.
+if (/\bCommunity\b/.test(parasignHtml)) {
+  assert(/tier named <strong>Free<\/strong>/.test(parasignHtml),
+    'parasign.html calls the free plan Community, so it must also name the /pricing tier it maps to');
+  assert(/>\s*Free\s*</.test(html),
+    '/pricing must actually carry a tier named Free for that bridge to be true');
+  ok('parasign.html bridges Community to the tier /pricing calls Free');
+}
+
+// Every tier name the product page prints must be a tier /pricing sells, so the
+// two pages cannot drift into different product line-ups.
+const parasignTiers = [...parasignHtml.matchAll(/<div class="tier-name">([^<]+)<\/div>/g)].map(m => m[1].trim());
+assert(parasignTiers.length >= 3, 'expected the business tiers on parasign.html, found ' + parasignTiers.length);
+for (const name of parasignTiers) {
+  assert(new RegExp('>\\s*' + name + '\\s*<').test(html),
+    'parasign.html shows the tier "' + name + '", but /pricing does not sell it');
+}
+ok('parasign.html only names tiers /pricing sells (' + parasignTiers.join(', ') + ')');
+
+// A biography is the easiest thing on a sales page to embellish and the hardest
+// for a reader to check. The founder line may say what /about already says and
+// nothing more, and naming him obliges the page to name the accountable company.
+const aboutHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'about.html'), 'utf8');
+for (const claim of ['Mick Beer', 'privacy and security researcher', 'Paramantis Solutions B.V.']) {
+  if (parasignHtml.includes(claim)) {
+    assert(aboutHtml.includes(claim),
+      'parasign.html claims "' + claim + '" about the founder, but /about does not say it');
+  }
+}
+assert(!/\bMick Beer\b/.test(parasignHtml) || /KvK 42115132/.test(parasignHtml),
+  'if parasign.html names the founder it must also name the accountable company registration');
+ok('the founder line on parasign.html matches /about and carries the registration');
+
 // The dead stub checkout page no longer serves the "no charge" lie; it redirects.
 const checkoutHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'billing', 'checkout.html'), 'utf8');
 assert(!/no charge/i.test(checkoutHtml), 'checkout.html must not claim "no charge"');

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -144,6 +144,27 @@ assert(!/data-billing-interval="yearly"\s+class="btn/.test(html), 'no yearly var
 ok('one primary monthly CTA per tier, yearly demoted to a secondary link');
 
 // The dead stub checkout page no longer serves the "no charge" lie; it redirects.
+// /parasign is the product page and quotes the ParaSign prices a second time.
+// relay/test/pricing-page.test.js is the only thing that ties a listed price to
+// the catalog, so the product page is held to the same numbers here: an edit
+// to one page without the other turns this suite red instead of leaving two
+// prices on the site.
+const parasignHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'parasign.html'), 'utf8');
+for (const v of VARIANTS.filter(x => x.product === 'parasign')) {
+  const order = catalog.resolveOrder({ product: v.product, plan: v.plan, interval: v.interval });
+  assert(!order.error, 'catalog rejects ' + v.plan + '/' + v.interval + ': ' + order.error);
+  const excl = '&euro;' + v.excl.toLocaleString('en-US');
+  assert(parasignHtml.includes(excl), 'parasign.html no longer shows ' + excl + ' for ' + v.plan + '/' + v.interval);
+  const incl = '&euro;' + Number(order.amount).toLocaleString('en-US', { minimumFractionDigits: 2 });
+  assert(parasignHtml.includes(incl), 'parasign.html no longer shows the catalog amount ' + incl + ' incl. btw for ' + v.plan + '/' + v.interval);
+  ok('parasign.html ' + v.plan + ' ' + v.interval + ': shows ' + excl + ' excl and ' + incl + ' incl');
+}
+for (const s of ['2 signatures per month', '100 signatures per month, then &euro;0.40 each, up to 1,000', '1,000 signatures per month']) {
+  assert(parasignHtml.includes(s), 'parasign.html lost the quota line: ' + s);
+}
+assert(/excl\. btw/.test(parasignHtml) && /incl\. 21% btw/.test(parasignHtml), 'parasign.html must state excl. btw and the incl. 21% btw checkout amount');
+ok('parasign.html carries the same quota lines and the btw convention');
+
 const checkoutHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'billing', 'checkout.html'), 'utf8');
 assert(!/no charge/i.test(checkoutHtml), 'checkout.html must not claim "no charge"');
 assert(!/activates immediately/i.test(checkoutHtml), 'checkout.html must not claim "activates immediately"');


### PR DESCRIPTION
## Why

Measured on 2026-09-01 against the live site (vault: "Bevinding - ParaSign is onvindbaar"): `/parasign` answered 404 and was not in `sitemap.xml`; of the 59 sitemap pages, zero named ParaSign or ParaSend in `<title>`. The only indexable page about signing was `/verify`, which is for someone who already holds a signature. Block B3 of the snoeiplan.

## What the page says now, in the order it says it

The order is the argument:

1. **Hero.** What the reader gets: a document out for signature, back signed, checkable later. No algorithm names in the title, the description, the H1 or the first paragraph. One line under it sets up the split: free on Community, business plans from &euro;49, the person you invite needs no account.
2. **01 / What it does.** Four capabilities: PDF editor and visible seal, co-signing with routing order, non-PDF files attested by fingerprint, developer API from Pro.
3. **02 / What it costs.** Community first, then the business plans.
4. **03 / How to begin.** Three steps.
5. **04 / How it works, and how to check it.** Only here do ML-DSA-65, FIPS 204 and SHA3-256 appear, each next to the page you can go and check it on. Heading: *The technique is the evidence, not the pitch*. Plus the SES-not-QES scope note.

Rendered at 1280 and 390 CSS pixels with Playwright: one h1, no horizontal scroll, the string "Community" first occurs at character 396 of the body text and "ML-DSA-65" at character 4543. The technique is below the plans, not above them. The only console line is the stubbed 401 on `/api/user/session/verify`, the same as on every page.

## Community, and the business plans

**Community, &euro;0, forever.** No card, no clock, no trial that quietly ends. The card says why it is free in the words `about.html` already carries: Paramant is built by Mick Beer, privacy and security researcher and founder of Paramantis Solutions B.V., and the Community plan is his way of giving something back. It is not a cut-down edition: Community gets the same signatures, the same encryption and the same public proof log as Business. What a paid plan buys is volume, an API, support and accountability. Never security.

**The naming leans on #328.** `/pricing` today lists this plan as the tier named **Free**. PR #328 (`feat/homepage-koper`) is the branch that introduces the Community wording, on the homepage and the dashboard, and it does *not* rename the tier on `frontend/pricing.html` either. So both pages carry the same bridge instead of a rename: this page says in plain sight that on `/pricing` the plan is *the tier named Free*, and a test fails if that sentence ever disappears while the word Community stays. Whichever of the two PRs lands first, no visitor goes looking for a plan name that is not on the pricing page. If #328 later does rename the tier, the gate below is the thing to update.

**Business plans**, presented as what they are: what pays for the free one. Names and amounts lifted from `/pricing`:

| Tier | Excl. btw | Charged incl. 21% btw | Annual |
|---|---|---|---|
| Pro | &euro;49/mo | &euro;59.29/mo | &euro;499 excl. / &euro;603.79 incl. |
| Business | &euro;299/mo | &euro;361.79/mo | &euro;2,990 excl. / &euro;3,617.90 incl. |
| Enterprise | Let's talk | | Per organisation |

`relay/test/pricing-page.test.js` resolves each of those four variants through `relay/lib/billing-catalog.js` and asserts both bases appear on `parasign.html`, so the product page cannot drift away from the catalog or from `/pricing`.

## Rebase onto main

`git rebase origin/main`, **no conflicts**. Main had moved on by three PRs since the review: #324 (navigation), #326 (billing stance off unless `BILLING_MODE` says otherwise) and #330 (directie signals script). This branch touches none of the files those changed except through the generator.

- `python3 frontend/apply-nav.py` stamped the page: the seven-item nav shell (Product, Security, Pricing, Docs, plus HELP, Sign in, Create account), the slim Company/Legal footer that replaced the site-map footer, and `design-system.css?v=23` / `nav.css?v=19` / `nav.js?v=14` / `js/nav-auth.js?v=5`. Net effect on `parasign.html`: 118 lines out, 17 in. **A second run reports `Updated 0 files`.**
- `python3 bron-seo/apply_seo_head.py` re-stamped the JSON-LD after the title and description changed; `--check` then reports `would change: 0 pages`.
- `python3 bron-seo/build_sitemap.py --check` said **out of date**, so the sitemap was regenerated with the existing generator. The whole diff is one line: the `lastmod` of `/vault`, which #324 touched. `/parasign` itself is unchanged in the sitemap (0.9 priority group, next to `/pricing` and `/sign`). `--check` is green afterwards.

## The two review findings, still fixed

- **No test-vector promise.** `grep -in vector frontend/parasign.html` returns nothing, and `grep -ci vector frontend/crypto-agility.html` is 0, so the claim and the page agree. What the page says instead is that the algorithm register on `/crypto-agility` lists ML-DSA-65 as the loaded default, which is `crypto-agility.html` line 318: `0x0002 | ML-DSA-65 | cat 3 | loaded (default)`.
- **The docs link resolves.** The page links `/docs#parasign-api`, and `docs.html` line 508 defines `id="parasign-api"`. (`/pricing` still links the older `/docs#parasign`, which has no anchor. Not this PR's file; worth a follow-up.)

## New gates in this PR

Three assertions added to `relay/test/pricing-page.test.js`. Deliberately in that file and **not** in `tests/ui-truthfulness.test.mjs`, because #328 is rewriting the tail of that file and two PRs appending to the same tail is a conflict for no gain:

1. If `parasign.html` contains the word Community, it must also contain `tier named <strong>Free</strong>`, **and** `/pricing` must still carry a tier named Free. Both halves have to hold, so neither page can quietly move without the other going red.
2. Every `tier-name` printed on `parasign.html` must be a tier `/pricing` sells. Today: Pro, Business, Enterprise.
3. The founder line may claim only what `/about` claims (`Mick Beer`, `privacy and security researcher`, `Paramantis Solutions B.V.`), and naming him obliges the page to name `KvK 42115132`, which the stamped footer carries.

## Tests, local, this worktree

```
node --test tests/links.test.mjs tests/seo-contract.test.mjs \
  tests/frontend-loading-contract.test.mjs tests/navigation-shell.test.mjs
                                           # pass 18, fail 0, skipped 2
node tests/ui-truthfulness.test.mjs        # ok
node relay/test/pricing-page.test.js       # 34 checks passed (was 31, +3 new gates)
scripts/check-csp-inline.sh                # OK: geen inline JS onder de CSP
scripts/check-cache-bust.sh                # OK, 335 links, single consistent ?v=
npx eslint@9 .                             # clean
python3 bron-seo/build_sitemap.py --check   # up to date
python3 bron-seo/apply_seo_head.py --check  # would change: 0 pages
python3 frontend/apply-nav.py               # second run: Updated 0 files
```

The two skips in `links` are `CHECK_EXTERNAL_LINKS=1` only; that suite runs hourly against production, not in pull requests.

## `tests/static-sanity.sh`: all ten checks pass

Checks 1 to 9 were already green. Check 10 (`scripts/check-commit-style.sh`) is now green too.

It was red on the earlier revision, and only for one reason: the `Co-Authored-By` trailer on all three commits. The decision has been taken the other way round from last time. `AGENTS.md` is unambiguous ("Alles in Micks naam. Geen co-author-trailer (in welke schrijfwijze dan ook), geen generated-with-regel, geen enkele AI-attributie"), the guard enforces it, and the repo rule wins. So the trailer is gone from all three commit messages, the `Claude-Session` line with it, and this description carries no attribution block either.

The three commits were rewritten with `git filter-branch --msg-filter` over `origin/main..HEAD`, messages only. `git diff` between the old head and the new one is empty: same tree, same three commits, three shorter messages.

What check 10 scans, and the result on this branch:

| Rule | Scanned in | Result |
|---|---|---|
| AI attribution (`Co-authored`, `Generated with`) | commit messages and added diff lines | 0 hits |
| Em-dash, U+2014 | commit messages and added diff lines | 0 hits |
| Emoji | commit messages and added diff lines | 0 hits |
| `.style-denylist` terms | commit messages and added diff lines | skipped, no denylist file in this checkout |

```
bash scripts/check-commit-style.sh origin/main..HEAD
OK: commit-message(s) en toegevoegde regels voldoen aan de stijlregels

bash tests/static-sanity.sh
10. Commit/GitHub style guard (scripts/check-commit-style.sh)...
   OK  last commit message + added lines are style-clean
PASS (all hard checks clear)
```

The guard is still local only: no workflow under `.github/workflows/` runs `static-sanity.sh` or `check-commit-style.sh`, and `core.hooksPath` is unset in this checkout. Merged commits on main still carry the old trailer (`c9cec7c` #322, `0fc8648` #323); this branch does not, and this is the rule from here.

## Deliberately not done

- No deploy. Production stays on the 08-08 image.
- No merge.
- No rename of the tier on `/pricing`. That is #328's call to make or not make; this page bridges to whatever `/pricing` says today.
- No checkout buttons (`data-billing-*`) on this page. Checkout stays on `/pricing`.
- No nav link to `/parasign`. That is the nav generator's territory.
- `/pricing`'s dead `/docs#parasign` link left alone. Different file, different PR.
