### PR TITLE
Keep the recurring billing layer off until BILLING_MODE says otherwise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,10 @@ jobs:
         # deep-health-gate boots relay.js three times (two modes and a
         # missing-token case), so like inbound-hash-verify it needs the
         # installed dependencies and lives here, not in the no-install job.
-        run: node --test test/inbound-hash-verify.test.js test/deep-health-gate.test.js
+        # billing-stance-boot boots it four more times and reads the
+        # billing_config line, the one that says whether the relay bills
+        # one-off (BILLING_MODE empty, production) or opens subscriptions.
+        run: node --test test/inbound-hash-verify.test.js test/deep-health-gate.test.js test/billing-stance-boot.test.js
 
   relay-unit-tests:
     name: relay - unit suite (no native deps)
@@ -153,7 +156,7 @@ jobs:
         run: |
           set -o pipefail
           node --test $(ls test/*.test.js | grep -vE \
-            'inbound-hash-verify|deep-health-gate|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index') \
+            'inbound-hash-verify|deep-health-gate|billing-stance-boot|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index') \
             2>&1 | tee /tmp/relay-units.log
           # Which suites ran and asserted nothing. The line comes from
           # summary() in test/_requires.js.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,16 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   implementation deferred to later phases.
 
 ### Changed
+- **Recurring billing needs an explicit `BILLING_MODE`.** The customer, mandate
+  and subscription layer (`relay/lib/billing-recurring.js`) now runs only when
+  `BILLING_MODE` is set by hand to `live` or `test`. With it empty, as production
+  has run since billing exists, `billingMode()` still infers the mode from the
+  key, but the relay creates plain one-off payments exactly as the 2026-08-08
+  code did: no customer, no `sequenceType`, no subscription. The `billing_config`
+  line at boot now carries `mode_source`, `recurring` and a one-sentence
+  `stance`, at `warn` when the mode is inferred. Pinned by
+  `relay/test/billing-stance.test.js` and `billing-stance-boot.test.js`.
+  Deploy runbook: `deploy/DEPLOY-3.1.md`.
 - `mldsa65.js` migrated to the `@paramant/core` binding (matches the `mlkem768.js`
   M5b pattern). Byte-compatible via paramant-core ADR-0021 cross-impl KAT. Covers
   all ML-DSA-65 use in the relay (STH-signing + receipt/signature verify) through

--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -84,7 +84,17 @@ test key plus mode, then deploy) collapsed to: deploy now, decide later.
    cd relay && RELAY_TEST_SKIP=redis node --test $(ls test/*.test.js | grep -vE 'inbound-hash-verify|deep-health-gate|billing-stance-boot|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index')
    node --test test/billing-stance-boot.test.js             # needs relay/node_modules
    ```
-   Expected on 2026-09-02: static sanity `PASS`, units 176 pass, boot suite 4 pass.
+   Expected on 2026-09-02: static sanity checks 1 to 9 `OK` and check 10
+   `FAIL`, units 176 pass, boot suite 4 pass.
+
+   **Check 10 is red on main and stays red for this deploy.** It runs
+   `scripts/check-commit-style.sh` on the last commit only, and the squash
+   commits of #322 and #323 (and of this PR) carry `Co-Authored-By` trailers
+   that the guard flags; #323 also has an em-dash in an added line. Measured
+   on `0fc8648`: exit 1, 36 `OK` lines, the one `FAIL` is check 10. So the
+   gate for this deploy is checks 1 to 9: every one of them `OK`, and the
+   only `FAIL` line the one under `10. Commit/GitHub style guard`. Any other
+   `FAIL` blocks. Do not rewrite main's history to make check 10 green.
 3. Frontend drift: `scripts/check-prod-drift.sh origin/main`. It lists what the
    docroot would receive. Anything marked as present on the server and absent
    in git that is not in its `IGNORE` list is a hand edit: find out before you
@@ -160,9 +170,15 @@ git status                                                   # clean, or stash a
 git fetch origin && git pull --ff-only origin main
 git rev-parse --short HEAD                                   # the commit you tested locally
 
-tests/static-sanity.sh                                       # step 1 of deploy.sh; a FAIL blocks
+tests/static-sanity.sh; echo "exit $?"                       # expect exit 1: checks 1 to 9 OK, only check 10 FAIL
 docker compose build                                         # relays and admin from source, containers untouched
 ```
+
+Read the sanity output the way "Before you start" step 2 says: checks 1 to 9
+are the gate, check 10 (the commit style guard on the last commit) is known
+red on main and does not block. Anything else red blocks. This is also why
+this runbook does not call `deploy.sh`: its step 1 runs the same script and
+exits on the same check 10, so it would stop before building anything.
 
 `.env` stays as it was, plus the `INTERNAL_AUTH_TOKEN` line from step 1 if it
 was missing. **`BILLING_MODE` stays empty.**

--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -1,0 +1,371 @@
+# Deploy runbook: main (3.1.0) to production
+
+Target: `116.203.86.81` (Hetzner). Mick runs this by hand over SSH, from the
+NUC, where the production key lives (`~/.ssh/paramant_prod_claude`, see
+`scripts/check-prod-drift.sh`). Nothing in this file runs on its own. Every
+step says what it changes; the read-only steps say so.
+
+This runbook supersedes `docs/RUNBOOK-DEPLOY-3.0.0.md` on one point: that file
+assumed the compose checkout lived in `/home/paramant/app`. On production
+`/home/paramant/app` is the **frontend docroot** that nginx serves, and the
+relay checkout with `docker-compose.yml` is `/opt/paramant-relay`
+(`scripts/check-prod-drift.sh`; vault sessions of 2026-06-24, 2026-07-17 and
+2026-09-01). Confirm it in step 1 before trusting either.
+
+## Where we start
+
+Measured on 2026-09-01 from the NUC, read-only (vault: *Bevinding - een deploy
+van main zou tegen de echte Mollie draaien*, *Bevinding - de
+ParaID-uitgifteroute staat open op productie*):
+
+| what | production now | main |
+|---|---|---|
+| relay checkout | `41501bb`, 8 August 2026 | `0fc8648` and later, 3.1.0 |
+| relay containers | image of 8 August (`grep -c _paraidAuth /app/relay.js` gives 0) | rebuilt from source |
+| `BILLING_MODE` | empty, in every relay container | may stay empty, see step 3 |
+| `MOLLIE_API_KEY` | present, prefix `live_` | unchanged |
+| `MOLLIE_TEST_API_KEY` | not set | there is none, and none is coming for now |
+| `/v1/paraid/issue-*` | 404 from nginx, all six server blocks (server-side edit of 01-09) | route removed in the relay (#319) |
+| `/v2/health/deep` | `{"error":"Not available in this relay mode"}` | 200 behind `X-Internal-Auth` (#322) |
+
+What main brings that touches the deploy, with the PR that did it:
+
+- **#314** release 3.1.0, ParaID auth, billing with an end date.
+- **#315** `paid_until` survives a restart, Mollie mandate and subscription layer.
+- **#316** ParaSign canary (`tests/parasign-canary.test.mjs`, needs a `psk_test_` key).
+- **#317** `/sign` served without login (nginx change in `deploy/nginx-paramant-live.conf`).
+- **#319** ParaID removed: 3339 lines, 26 files.
+- **#322** `/v2/health/deep` in `ghost_pipe` and `iot`, behind `INTERNAL_AUTH_TOKEN`.
+- **#323** seventeen norms and sector pages removed (nginx: the `/compliance/*` locations go).
+- this PR: the recurring layer needs an explicit `BILLING_MODE`.
+
+`docker-compose.yml` is byte-identical between `41501bb` and main
+(`git diff 41501bb origin/main -- docker-compose.yml` is empty). Every
+environment variable this runbook mentions already has its line in the
+`x-relay-env` block; nothing has to be added to the compose file, only to `.env`.
+
+## The brake, and why the deploy is now allowed
+
+Before this PR a deploy of main with `BILLING_MODE` empty and a `live_` key
+would have created a Mollie customer, a `sequenceType: first` payment and a
+subscription on the first sale, against the real account, with code that has
+never seen a real Mollie answer. `billingMode()` inferred `live` from the key
+prefix and that inference was enough for the new layer.
+
+Now (`relay/lib/mollie.js`, `billingStance()`): the recurring layer runs only
+when `BILLING_MODE` is set by hand to `live` or `test`. With it empty the relay
+bills exactly as the 08-08 code did: a one-off payment, no customer, no
+`sequenceType`, no subscription, and the webhook grants and stops there. The
+one-off path itself has been live since 08-08 and is not new code.
+
+The three stances, pinned by `relay/test/billing-stance.test.js` and
+`relay/test/billing-stance-boot.test.js`:
+
+| `.env` | mode | recurring | boot line level |
+|---|---|---|---|
+| `BILLING_MODE=` (empty) + `MOLLIE_API_KEY=live_...` | live | off | `warn` |
+| `BILLING_MODE=test` + `MOLLIE_TEST_API_KEY=test_...` | test | on | `info` |
+| `BILLING_MODE=live` + `MOLLIE_API_KEY=live_...` | live | on | `info` |
+
+An explicit mode without its key boots at `error` and no checkout works, which
+is the existing `mollie_key_missing` contract.
+
+So: **leave `BILLING_MODE` empty for this deploy.** Turning the recurring
+layer on is a separate decision, taken when there is a Mollie test key to
+prove it against first. That is step 3 in the vault's order (deny, then
+test key plus mode, then deploy) collapsed to: deploy now, decide later.
+
+## Before you start (laptop or NUC, read-only)
+
+1. CI on main is green: `gh run list --branch main -L 5`.
+2. Local suites on the commit you will deploy, from the repo root:
+   ```bash
+   tests/static-sanity.sh                                   # the gate deploy.sh runs first
+   cd relay && RELAY_TEST_SKIP=redis node --test $(ls test/*.test.js | grep -vE 'inbound-hash-verify|deep-health-gate|billing-stance-boot|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index')
+   node --test test/billing-stance-boot.test.js             # needs relay/node_modules
+   ```
+   Expected on 2026-09-02: static sanity `PASS`, units 176 pass, boot suite 4 pass.
+3. Frontend drift: `scripts/check-prod-drift.sh origin/main`. It lists what the
+   docroot would receive. Anything marked as present on the server and absent
+   in git that is not in its `IGNORE` list is a hand edit: find out before you
+   overwrite it.
+4. Note the time. The rollback tag in step 2 is named by it.
+
+## Step 1: confirm the layout and the environment (server, read-only)
+
+```bash
+ssh -i ~/.ssh/paramant_prod_claude root@116.203.86.81
+
+cd /opt/paramant-relay && git rev-parse --short HEAD        # expect 41501bb
+docker compose ls                                            # which compose project, which file
+docker compose ps                                            # six containers plus redis, all healthy
+
+# Presence only, never the values. Same shape as the 01-09 measurement.
+for v in BILLING_MODE MOLLIE_API_KEY MOLLIE_TEST_API_KEY INTERNAL_AUTH_TOKEN ADMIN_TOKEN PARAMANT_TOTP_MASTER_KEY RELAY_REDIS_URL; do
+  printf '%-26s ' "$v"
+  docker compose exec -T relay-main sh -c "v=\$(printenv $v); if [ -z \"\$v\" ]; then echo empty; else echo set, prefix \$(echo \$v | cut -c1-5); fi"
+done
+grep -c '^INTERNAL_AUTH_TOKEN=' .env
+```
+
+What has to be true before step 2:
+
+| variable | needed for | required state |
+|---|---|---|
+| `INTERNAL_AUTH_TOKEN` | `/v2/health/deep` outside `full` mode (#322), and every internal user endpoint that already existed | set, in `.env`, so the compose `x-relay-env` block passes it to all five relays and to admin. Empty keeps `/v2/health/deep` closed, which is the #322 contract, but then step 5 cannot read it. |
+| `BILLING_MODE` | the recurring layer | **empty**. Do not set it in this deploy. |
+| `MOLLIE_API_KEY` | one-off checkout, as since 08-08 | set, `live_` prefix, unchanged |
+| `PARASIGN_CANARY_KEY` | the hourly ParaSign canary in `product-heartbeat.yml` | not a relay variable: a GitHub Actions secret holding a `psk_test_` key with the parasign scope. See step 7. |
+
+If `INTERNAL_AUTH_TOKEN` is empty: generate one (`openssl rand -hex 32`), add
+`INTERNAL_AUTH_TOKEN=...` to `/opt/paramant-relay/.env`, and know that the
+containers only pick it up when recreated in step 4. Do not restart anything
+for it now.
+
+## Step 2: tag the rollback images and back up the state (server)
+
+This is what makes step 8 possible. Same procedure as the 3.0.0 runbook, with
+the real compose directory.
+
+```bash
+cd /opt/paramant-relay
+TS=$(date +%Y%m%d-%H%M)
+mkdir -p /home/paramant/backups
+MANIFEST=/home/paramant/backups/rollback-images-$TS.txt
+: > "$MANIFEST"
+for svc in relay-main relay-health relay-finance relay-legal relay-iot admin; do
+  cid=$(docker compose ps -q "$svc" 2>/dev/null)
+  [ -z "$cid" ] && { echo "skip $svc (not running)"; continue; }
+  img=$(docker inspect --format '{{.Config.Image}}' "$cid")
+  docker tag "$img" "paramant-rollback/$svc:$TS"
+  echo "$svc|$img|paramant-rollback/$svc:$TS" >> "$MANIFEST"
+done
+ln -sfn "$MANIFEST" /home/paramant/backups/rollback-images-latest.txt
+cat "$MANIFEST"                                              # six lines, or stop here
+
+cp .env /home/paramant/backups/.env-pre-3.1-$TS && chmod 600 /home/paramant/backups/.env-pre-3.1-$TS
+docker compose ps > /home/paramant/backups/state-pre-3.1-$TS.txt
+tar czf /home/paramant/backups/docroot-pre-3.1-$TS.tgz -C /home/paramant app
+cp /etc/nginx/sites-enabled/paramant-public.conf /etc/nginx/backups/paramant-public.conf.pre-3.1-$TS
+```
+
+`deploy/ops/backup-full-state.sh` exists for the data volumes; run it too if
+the users file or the CT log matter to you today (they should).
+
+## Step 3: pull main, run the sanity gate, build (server)
+
+```bash
+cd /opt/paramant-relay
+git status                                                   # clean, or stash and note what it was
+git fetch origin && git pull --ff-only origin main
+git rev-parse --short HEAD                                   # the commit you tested locally
+
+tests/static-sanity.sh                                       # step 1 of deploy.sh; a FAIL blocks
+docker compose build                                         # relays and admin from source, containers untouched
+```
+
+`.env` stays as it was, plus the `INTERNAL_AUTH_TOKEN` line from step 1 if it
+was missing. **`BILLING_MODE` stays empty.**
+
+## Step 4: recreate, one canary relay first (server)
+
+The 06-24 deploy did `relay-iot` first, then the fleet; that order is kept. The
+health wait is the loop from `deploy.sh` step 3 (`docker inspect` on
+`.State.Health.Status`, compose healthcheck is `wget http://127.0.0.1:3000/health`).
+
+```bash
+cd /opt/paramant-relay
+wait_healthy() {  # container name, max seconds
+  local w=0; while [ $w -lt ${2:-60} ]; do
+    s=$(docker inspect --format='{{.State.Health.Status}}' "$1" 2>/dev/null || echo unknown)
+    [ "$s" = healthy ] && { echo "$1 healthy after ${w}s"; return 0; }
+    [ "$s" = unhealthy ] && { echo "$1 UNHEALTHY"; docker logs "$1" 2>&1 | tail -20; return 1; }
+    sleep 5; w=$((w+5)); done; echo "$1 not healthy after ${2:-60}s"; return 1; }
+
+docker compose up -d --no-deps relay-iot
+wait_healthy paramant-relay-iot || exit 1
+docker logs paramant-relay-iot 2>&1 | grep -E '"relay_started"|"billing_config"'
+```
+
+The `billing_config` line is the first thing to read. Expected, verbatim in
+shape:
+
+```
+{"level":"warn","msg":"billing_config","mode":"live","mode_source":"inferred","recurring":false,"key_present":true,"key_prefix":"live_","stance":"live: one-off payments only, no customers or subscriptions (BILLING_MODE not set)"}
+```
+
+`recurring:false` and `mode_source:inferred` are the brake. If it says
+`recurring:true`, `BILLING_MODE` is set somewhere: stop, find it, and do not
+continue until the line reads as above. `relay_started` must say
+`version:"3.1.0"`.
+
+Then the rest:
+
+```bash
+docker compose up -d --no-deps relay-main
+wait_healthy paramant-relay-main || exit 1
+docker compose up -d --no-deps relay-health relay-finance relay-legal admin
+for c in health finance legal admin; do wait_healthy paramant-relay-$c || exit 1; done
+```
+
+## Step 5: frontend and nginx (server)
+
+The docroot is a copy, not the checkout. Without `--delete`, on purpose:
+`dist/`, `paramant-mark.svg`, `developer.js` and the investor brief live only
+on the server (`scripts/check-prod-drift.sh`).
+
+```bash
+rsync -rc --no-times /opt/paramant-relay/frontend/ /home/paramant/app/
+```
+
+nginx: main changes three things in `deploy/nginx-paramant-live.conf`
+(`/sign` no longer behind `auth_request`, the three `/compliance/*` locations
+gone, `/dicom` now `return 404`) and removes the `/compliance` lines from
+`deploy/nginx-paramant-public.conf`. The server files carry the 01-09 ParaID
+deny that the repo files do not, so **do not copy the repo files over them**.
+Apply the three changes by hand and keep the deny:
+
+```bash
+nginx -T 2>/dev/null | grep -n 'paraid/issue\|location = /sign\|/compliance\|location = /dicom'
+# edit /etc/nginx/sites-enabled/paramant-public.conf and the live conf accordingly
+nginx -t && systemctl reload nginx
+```
+
+The ParaID deny may stay: the route is gone from the relay (#319), so the
+deny answers 404 for a path that would answer 404 anyway. Remove it in a later
+round, not in this one.
+
+## Step 6: smoke tests
+
+In the order `deploy.sh` runs them, plus the two the 3.0.0 runbook used.
+
+```bash
+# 6a. deploy.sh step 4, from anywhere: public auth surface, never a 5xx
+tests/auth-smoke.sh https://paramant.app
+
+# 6b. the 3.0.0 verify suite, on the server so the local relay is reachable
+bash scripts/post-deploy-verify.sh https://paramant.app http://127.0.0.1:3000
+```
+
+`post-deploy-verify.sh` still probes `/health/deep`, a path main does not
+serve (the route is `/v2/health/deep`). That check is marked non-critical in
+the script; expect it red and read the real one by hand:
+
+```bash
+# 6c. the deep check from #322: 200 with the token, 401 without
+T=$(grep '^INTERNAL_AUTH_TOKEN=' /opt/paramant-relay/.env | cut -d= -f2-)
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/v2/health/deep                       # 401
+curl -s -H "X-Internal-Auth: $T" http://127.0.0.1:3000/v2/health/deep | python3 -m json.tool | head  # overall green or yellow
+unset T
+
+# 6d. what #319 removed, on the public host and on a sector host
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://paramant.app/v1/paraid/issue-document       # 404
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://iot.paramant.app/v1/paraid/issue-document   # 404
+
+# 6e. what #317 changed: /sign answers itself, no redirect to /auth/login
+curl -s -o /dev/null -w '%{http_code}\n' https://paramant.app/sign                                   # 200
+
+# 6f. the version the relay reports
+curl -s https://paramant.app/health | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version"))'   # 3.1.0
+
+# 6g. billing stance on every relay, once more, from the logs
+for c in main health finance legal iot; do printf '%-8s' $c; docker logs paramant-relay-$c 2>&1 | grep '"billing_config"' | tail -1 | grep -o '"recurring":[a-z]*'; done
+```
+
+Stop and roll back (step 8) on: a relay that does not reach `healthy`,
+`auth-smoke.sh` exit 1, `post-deploy-verify.sh` exit 2, `/health` without
+`3.1.0`, or a `billing_config` line with `recurring:true`.
+
+## Step 7: after the deploy
+
+1. **Watch thirty minutes**: `docker compose logs -f --tail=200 relay-main`.
+   5xx spikes are code, 4xx spikes are config, memory growth is a leak.
+2. **The ParaSign canary.** On 2026-09-02 `gh api repos/Apolloccrypt/paramant-relay/actions/secrets`
+   lists neither `PARASIGN_CANARY_KEY` nor `PARAMANT_CANARY_KEY`, so both keyed
+   canary tests skip by name every hour. Mint a `psk_test_` key on the new
+   relay, from the server, with the admin token:
+   ```bash
+   A=$(grep '^ADMIN_TOKEN=' /opt/paramant-relay/.env | cut -d= -f2-)
+   curl -s -X POST http://127.0.0.1:3000/v2/admin/keys/mint-parasign \
+     -H "X-Admin-Token: $A" -H 'Content-Type: application/json' \
+     -d '{"account_id":"<the canary account>","test":true,"label":"parasign-canary"}'
+   unset A
+   ```
+   The key is shown once (`relay.js`, `/v2/admin/keys/mint-parasign`). Then
+   `gh secret set PARASIGN_CANARY_KEY` and trigger `product-heartbeat.yml` once
+   with `workflow_dispatch`: expected 3 pass, 0 skip on the ParaSign canary.
+   Every `/v2/admin` path is behind `X-Admin-Token` (`relay.js`, `isAdminPath`),
+   and nginx answers 404 for it on the public host, so this only works on the
+   server against `127.0.0.1:3000`.
+3. **Drift guard** from the NUC: `scripts/check-prod-drift.sh origin/main` must
+   print `OK`.
+4. Tag it: `git tag v3.1.0 <commit> && git push origin v3.1.0`, and put the live
+   date in `CHANGELOG.md`.
+5. Write the deploy down in the vault (`Sessies/2026-09/`), with the
+   `billing_config` line as it was logged.
+
+## Deciding on the recurring layer, later, not today
+
+This is a separate change with its own PR-free procedure, because it is one
+line in `.env` and a recreate:
+
+1. Get a Mollie test key. Set `MOLLIE_TEST_API_KEY=test_...` and
+   `BILLING_MODE=test` in `.env`, `docker compose up -d --no-deps relay-main`,
+   read the boot line (`mode:test`, `recurring:true`, `key_prefix:test_`), buy
+   a plan on the test account, watch `billing_subscription` in the log, cancel
+   it through `/v2/billing/cancel`. While `BILLING_MODE=test` no real customer
+   can pay: this is a maintenance window, keep it short.
+2. Only then `BILLING_MODE=live`, recreate, read the boot line again.
+
+Never set `BILLING_MODE=live` as the first step: that is exactly the deploy
+this brake exists to prevent.
+
+## Step 8: rollback
+
+Trigger: any of the stop conditions in step 6, or clear breakage in the first
+thirty minutes.
+
+```bash
+cd /opt/paramant-relay
+COMPOSE_DIR=/opt/paramant-relay BACKUP_DIR=/home/paramant/backups bash scripts/rollback-3.0.0.sh
+```
+
+The script reads `rollback-images-latest.txt` from step 2, retags the saved
+images onto the compose image names, recreates the containers **without
+rebuilding**, waits for `:3000/health`, and offers to restore `.env`. It does
+not touch git; the checkout stays on main, which is fine, because the images
+are what run. Confirm afterwards:
+
+```bash
+docker exec paramant-relay-main grep -c _paraidAuth /app/relay.js     # 0 again on the 08-08 image
+curl -s http://127.0.0.1:3000/health | grep -o '"version":"[^"]*"'
+```
+
+Frontend and nginx, if step 5 was reached:
+
+```bash
+tar xzf /home/paramant/backups/docroot-pre-3.1-$TS.tgz -C /home/paramant
+cp /etc/nginx/backups/paramant-public.conf.pre-3.1-$TS /etc/nginx/sites-enabled/paramant-public.conf
+nginx -t && systemctl reload nginx
+```
+
+Manual fallback for a single service, from the 3.0.0 runbook:
+
+```bash
+docker images | grep paramant-rollback
+IMG=$(docker inspect --format '{{.Config.Image}}' paramant-relay-main)
+docker tag paramant-rollback/relay-main:<TS> "$IMG"
+docker compose up -d --no-deps --force-recreate relay-main
+```
+
+`deploy.sh` itself prints `git revert HEAD && ./deploy.sh <container>` as its
+rollback. That rebuilds from source and is slower; the tagged images are the
+fast path.
+
+## What this runbook does not do
+
+- It does not deploy. Every command above is for Mick to run.
+- It does not set `BILLING_MODE`. The recurring layer stays off until there is
+  a test key and a deliberate second change.
+- It does not remove the ParaID nginx deny. Harmless while it stays, and its
+  removal is a separate, reversible edit.

--- a/docs/api.md
+++ b/docs/api.md
@@ -754,7 +754,7 @@ curl -X POST https://relay.paramant.app/v2/billing/checkout \
 | `plan` | `pro` (parasend); `pro` or `business` (parasign) |
 | `interval` | `monthly`, `yearly` |
 
-Redirect the buyer to `checkout_url` to complete the payment; Mollie then redirects back to `/dashboard?billing=return`. `mode` is `live` or `test`, controlled by `BILLING_MODE` and which Mollie key (`MOLLIE_API_KEY` / `MOLLIE_TEST_API_KEY`) is configured.
+Redirect the buyer to `checkout_url` to complete the payment; Mollie then redirects back to `/dashboard?billing=return`. `mode` is `live` or `test`, controlled by `BILLING_MODE` and which Mollie key (`MOLLIE_API_KEY` / `MOLLIE_TEST_API_KEY`) is configured. The recurring layer (a Mollie customer, a `sequenceType: first` payment and a subscription created after the grant) runs only when `BILLING_MODE` is set explicitly to `live` or `test`; with `BILLING_MODE` empty the relay creates plain one-off payments, and the `billing_config` log line at boot says which stance is active.
 
 Errors: `401 unauthorized` (missing or invalid API key), `400 bad_json` / `unknown_product` / `unknown_plan` / `unknown_interval`, `502 checkout_failed` (Mollie unreachable or rejected the payment).
 

--- a/relay/lib/billing-recurring.js
+++ b/relay/lib/billing-recurring.js
@@ -97,13 +97,63 @@ function isRecurringPayment(payment) {
   return !!(payment && payment.sequenceType === 'recurring');
 }
 
+// The switch on this whole file. deps.recurring comes from mollie.billingStance()
+// and is only true when BILLING_MODE was set by hand. When it is false the relay
+// bills exactly as it did on 2026-08-08: a one-off payment, no customer, no
+// sequenceType, no subscription. Production has run with BILLING_MODE empty and
+// a live key since billing exists, so an inferred 'live' must never be enough
+// to start opening mandates against a real account.
+function recurringAllowed(deps) {
+  return !!(deps && deps.recurring === true);
+}
+
+// Before a checkout: the Mollie customer the mandate will hang on. A payment
+// without a customerId cannot become a mandate, so this is the first of the
+// three things a subscription needs, and the one that decides whether the
+// checkout is recurring at all.
+//
+// deps: { recurring, mode, getAccount(accountId), saveCustomer(accountId, id),
+//         mollie: { getCustomer, createCustomer } }
+// Returns { customerId: string|null, result, reason? } and NEVER throws: the
+// buyer's payment matters more than tidiness in our own records, so a failed
+// lookup or create falls through to a one-off checkout and the caller logs it.
+async function ensureCustomer(accountId, deps) {
+  const d = deps || {};
+  const m = d.mollie || {};
+  if (!recurringAllowed(d)) return { customerId: null, result: 'skipped', reason: 'recurring_disabled' };
+  if (!accountId) return { customerId: null, result: 'skipped', reason: 'no_account' };
+  try {
+    const rec = typeof d.getAccount === 'function' ? await d.getAccount(accountId) : null;
+    // Reuse the stored customer when Mollie still knows it. A stale or foreign
+    // id must not break a checkout, so a failed lookup creates a new one.
+    const stored = rec && rec[CUSTOMER_FIELD];
+    if (stored) {
+      try { const c = await m.getCustomer(d.mode, stored); if (c && c.id) return { customerId: c.id, result: 'reused' }; }
+      catch { /* fall through to create */ }
+    }
+    const created = await m.createCustomer(d.mode, {
+      name: (rec && rec.label) || undefined,
+      email: (rec && rec.email) || undefined,
+      metadata: { accountId },
+    });
+    if (!created || !created.id) return { customerId: null, result: 'failed', level: 'error', reason: 'no_customer_id' };
+    if (typeof d.saveCustomer === 'function') await d.saveCustomer(accountId, created.id);
+    return { customerId: created.id, result: 'created' };
+  } catch (e) {
+    // No customer means no mandate means no renewal. The sale still goes through
+    // as a one-off rather than failing in the buyer's face, but this is an
+    // alert: money will come in once and never again.
+    return { customerId: null, result: 'failed', level: 'error', reason: e.message, status: e.status };
+  }
+}
+
 // After a grant: make sure the buyer will be asked again when the period ends.
 //
 // deps: {
 //   getAccount(accountId) -> record | null
 //   saveSubscription(accountId, product, subscriptionId) -> void   (async ok)
 //   mollie: { validMandates, createSubscription, mollieInterval }
-//   mode, webhookUrl
+//   mode, webhookUrl, recurring (from mollie.billingStance(); false = 08-08 behaviour)
 // }
 // Returns { result, reason, subscriptionId? } and NEVER throws: a failure here
 // must not undo an entitlement the buyer has already paid for. The caller logs
@@ -114,6 +164,9 @@ async function ensureSubscription(payment, grant, deps) {
   const accountId = grant && grant.account;
   const product = grant && grant.product;
   if (!accountId || !product) return { result: 'skipped', reason: 'no_grant' };
+  // Not a failure and not logged as one: the grant stands, and nothing
+  // recurring was promised in this stance.
+  if (!recurringAllowed(d)) return { result: 'skipped', reason: 'recurring_disabled' };
 
   // A renewal collected BY the subscription must never create a second one.
   if (isRecurringPayment(payment)) return { result: 'skipped', reason: 'recurring_collection' };
@@ -200,5 +253,5 @@ async function cancelForProduct(accountId, product, deps) {
 module.exports = {
   CUSTOMER_FIELD, PRODUCT_SUBSCRIPTION_FIELD, subscriptionFieldOf,
   startDateFor, subscriptionPayload, isFirstPayment, isRecurringPayment,
-  ensureSubscription, cancelForProduct,
+  recurringAllowed, ensureCustomer, ensureSubscription, cancelForProduct,
 };

--- a/relay/lib/mollie.js
+++ b/relay/lib/mollie.js
@@ -26,6 +26,34 @@ function apiKeyFor(mode) {
   return (mode === 'test' ? process.env.MOLLIE_TEST_API_KEY : process.env.MOLLIE_API_KEY) || '';
 }
 
+// The stance this deployment bills in: which Mollie account (mode) and whether
+// the recurring layer (customer, first payment, subscription) may run at all.
+//
+// billingMode() infers 'live' from the mere presence of a live key. That
+// inference was fine for the code of 2026-08-08, which only ever created
+// one-off payments. It is not enough to open mandates and subscriptions
+// against a real Mollie account, because nobody decided that: production runs
+// with BILLING_MODE empty and a live_ key, and a deploy of the recurring layer
+// would have started collecting money on an inference, with code that has
+// never seen a real Mollie answer.
+//
+// So the recurring layer needs BILLING_MODE set by hand. 'live' means real
+// money, 'test' means the test account. Empty (or anything else) means exactly
+// what it meant on 08-08: one-off payments in the inferred mode, no customer,
+// no sequenceType, no subscription. Flipping it is a deploy-time decision, made
+// in .env, and the boot log says which stance is active.
+function billingStance() {
+  const explicit = (process.env.BILLING_MODE || '').toLowerCase();
+  const recurring = explicit === 'live' || explicit === 'test';
+  const mode = billingMode();
+  return {
+    mode,
+    recurring,
+    source: recurring ? 'explicit' : 'inferred',
+    key_present: !!apiKeyFor(mode),
+  };
+}
+
 function _request(method, path, apiKey, bodyObj) {
   return new Promise((resolve, reject) => {
     const body = bodyObj ? JSON.stringify(bodyObj) : null;
@@ -151,7 +179,7 @@ async function cancelSubscription(mode, customerId, subscriptionId) {
 }
 
 module.exports = {
-  MOLLIE_HOST, billingMode, apiKeyFor, createPayment, getPayment,
+  MOLLIE_HOST, billingMode, billingStance, apiKeyFor, createPayment, getPayment,
   createCustomer, getCustomer, validMandates, mollieInterval,
   createSubscription, cancelSubscription,
 };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -5080,7 +5080,8 @@ const server = http.createServer(async (req, res) => {
     catch { res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'bad_json' })); }
     const order = billingCatalog.resolveOrder({ product: body.product, plan: body.plan, interval: body.interval });
     if (order.error) { res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: order.error })); }
-    const mode = mollie.billingMode();
+    const stance = mollie.billingStance();
+    const mode = stance.mode;
     const origin = process.env.PARASIGN_PUBLIC_ORIGIN || 'https://paramant.app';
     try {
       // A Mollie customer, and a payment marked as the FIRST of a series. Both
@@ -5089,32 +5090,21 @@ const server = http.createServer(async (req, res) => {
       // the tier is granted, and the money never comes in again. That is what
       // made every sale a one-off.
       //
-      // The customer is reused when the account already has one and Mollie still
-      // knows it. A stale or foreign id must not break a checkout, so a failed
-      // lookup falls through to creating a new one rather than erroring out: the
-      // buyer's payment matters more than tidiness in our own records.
-      let customerId = null;
-      try {
-        const _rec = _billingRecordOf(accountId);
-        const stored = _rec && _rec[billingRecurring.CUSTOMER_FIELD];
-        if (stored) {
-          try { const c = await mollie.getCustomer(mode, stored); if (c && c.id) customerId = c.id; }
-          catch { customerId = null; }
-        }
-        if (!customerId) {
-          const created = await mollie.createCustomer(mode, {
-            name: (_rec && _rec.label) || undefined,
-            email: (_rec && _rec.email) || undefined,
-            metadata: { accountId },
-          });
-          if (created && created.id) { customerId = created.id; _setMolliePointer(accountId, billingRecurring.CUSTOMER_FIELD, created.id); }
-        }
-      } catch (ce) {
-        // No customer means no mandate means no renewal. The sale still goes
-        // through as a one-off rather than failing in the buyer's face, but this
-        // is an alert: money will come in once and never again.
-        log('error', 'billing_customer_failed', { account: String(accountId).slice(0, 12), err: ce.message, status: ce.status });
+      // Only when BILLING_MODE was set by hand (stance.recurring). With it
+      // empty, as production has run since billing exists, the customer step is
+      // skipped and the payload below is byte for byte the one-off payment of
+      // 2026-08-08. See mollie.billingStance for why an inferred mode is not
+      // enough to open mandates against a real account.
+      const cust = await billingRecurring.ensureCustomer(accountId, {
+        recurring: stance.recurring, mode,
+        getAccount: (aid) => _billingRecordOf(aid),
+        saveCustomer: (aid, id) => _setMolliePointer(aid, billingRecurring.CUSTOMER_FIELD, id),
+        mollie,
+      });
+      if (cust.result === 'failed') {
+        log('error', 'billing_customer_failed', { account: String(accountId).slice(0, 12), err: cust.reason, status: cust.status });
       }
+      const customerId = cust.customerId;
       const payment = await mollie.createPayment(mode, Object.assign({
         amount: { currency: order.currency, value: order.amount },
         description: `Paramant ${order.product} ${order.plan} (${order.interval})`,
@@ -5123,7 +5113,7 @@ const server = http.createServer(async (req, res) => {
         metadata: { accountId, product: order.product, plan: order.plan, interval: order.interval },
       }, customerId ? { customerId, sequenceType: 'first' } : {}));
       const checkoutUrl = payment && payment._links && payment._links.checkout && payment._links.checkout.href;
-      log('info', 'billing_checkout_created', { account: String(accountId).slice(0, 12), product: order.product, plan: order.plan, interval: order.interval, payment_id: payment && payment.id, mode });
+      log('info', 'billing_checkout_created', { account: String(accountId).slice(0, 12), product: order.product, plan: order.plan, interval: order.interval, payment_id: payment && payment.id, mode, recurring: !!customerId });
       res.writeHead(200, { 'Content-Type': 'application/json' });
       return res.end(J({ ok: true, payment_id: payment && payment.id, checkout_url: checkoutUrl, mode }));
     } catch (e) {
@@ -5150,7 +5140,8 @@ const server = http.createServer(async (req, res) => {
       log('warn', 'billing_webhook_bad_id', { raw_id: String(paymentId).slice(0, 24) });
       res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'bad_payment_id' }));
     }
-    const mode = mollie.billingMode();
+    const stance = mollie.billingStance();
+    const mode = stance.mode;
     let payment;
     try { payment = await mollie.getPayment(mode, paymentId); }
     catch (e) {
@@ -5181,9 +5172,12 @@ const server = http.createServer(async (req, res) => {
     // a subscription nothing asks for the next period. Deliberately AFTER the
     // grant and never able to undo it: a buyer who paid keeps what he paid for
     // even if Mollie refuses the subscription, and the error level is the
-    // signal that this account will not renew by itself.
+    // signal that this account will not renew by itself. With BILLING_MODE
+    // empty (stance.recurring false) this is a silent skip: the 08-08 webhook
+    // granted and stopped there, and so does this one.
     if (outcome.result === 'granted') {
       const sub = await billingRecurring.ensureSubscription(payment, outcome, {
+        recurring: stance.recurring,
         mode,
         webhookUrl: `${process.env.PARASIGN_PUBLIC_ORIGIN || 'https://paramant.app'}/v2/billing/webhook`,
         getAccount: (aid) => _billingRecordOf(aid),
@@ -6442,11 +6436,22 @@ server.listen(PORT, process.env.HOST || '0.0.0.0', () => {
   // Say it once, loudly, at boot: without a key for the active billing mode
   // every checkout and every webhook fails, and the only earlier symptom was a
   // 503 on a public endpoint that nobody watches. Never log the key itself.
+  //
+  // The stance is the second half of that line. BILLING_MODE empty means
+  // one-off payments only, as on 2026-08-08; 'live' or 'test' by hand turns on
+  // customers, mandates and subscriptions. warn, not info, when it is inferred:
+  // it is a legitimate stance, but one nobody has decided on yet, and the
+  // decision belongs in .env at deploy time, not in a key prefix.
   {
-    const _bm = mollie.billingMode();
-    const _bk = mollie.apiKeyFor(_bm);
-    log(_bk ? 'info' : 'error', 'billing_config', {
-      mode: _bm, key_present: !!_bk, key_prefix: _bk ? _bk.slice(0, 5) : null });
+    const _bs = mollie.billingStance();
+    const _bk = mollie.apiKeyFor(_bs.mode);
+    log(!_bk ? 'error' : (_bs.recurring ? 'info' : 'warn'), 'billing_config', {
+      mode: _bs.mode, mode_source: _bs.source, recurring: _bs.recurring,
+      key_present: !!_bk, key_prefix: _bk ? _bk.slice(0, 5) : null,
+      stance: _bs.recurring
+        ? `${_bs.mode}: one-off payments plus customers, mandates and subscriptions (BILLING_MODE=${_bs.mode})`
+        : `${_bs.mode}: one-off payments only, no customers or subscriptions (BILLING_MODE not set)`,
+    });
   }
   // Register to the relay registry after a short delay to let the server fully bind
   if (relayIdentity && RELAY_SELF_URL) setTimeout(registerSelf, 500);

--- a/relay/test/billing-recurring.test.js
+++ b/relay/test/billing-recurring.test.js
@@ -29,6 +29,10 @@ const PLAN = { product: 'parasign', plan: 'pro', interval: 'monthly' };
 const ORDER = catalog.resolveOrder(PLAN);
 const PAID_UNTIL = new Date('2026-10-01T12:00:00.000Z');
 
+// Every ensureSubscription call below passes recurring: true. That flag is the
+// brake from mollie.billingStance(): it is only true when BILLING_MODE was set
+// by hand, and without it the layer is a no-op (see billing-stance.test.js).
+// This suite tests the layer in its enabled state.
 const mollieFake = (over) => Object.assign({
   mollieInterval: (i) => (i === 'monthly' ? '1 month' : i === 'yearly' ? '12 months' : null),
   validMandates: async () => [{ id: 'mdt_1', status: 'valid' }],
@@ -97,7 +101,7 @@ test('a startDate that is not in the future is refused: Mollie would collect at 
 test('an already expired period cannot become the start of the next one', async () => {
   let created = 0;
   const r = await rec.ensureSubscription(paidPayment(), grant({ paidUntil: new Date('2026-01-01T00:00:00.000Z') }), {
-    mode: 'test', now: new Date('2026-09-01T00:00:00.000Z'),
+    recurring: true, mode: 'test', now: new Date('2026-09-01T00:00:00.000Z'),
     getAccount: async () => ({}), saveSubscription: async () => {},
     mollie: mollieFake({ createSubscription: async () => { created++; return { id: 'sub_x' }; } }),
   });
@@ -130,7 +134,7 @@ test('a recurring collection does not create another subscription', async () => 
   let created = 0;
   const r = await rec.ensureSubscription(
     paidPayment({ id: 'tr_renewal', sequenceType: 'recurring' }), grant(),
-    { mode: 'test', getAccount: async () => ({}), mollie: mollieFake({ createSubscription: async () => { created++; return { id: 'sub_x' }; } }) },
+    { recurring: true, mode: 'test', getAccount: async () => ({}), mollie: mollieFake({ createSubscription: async () => { created++; return { id: 'sub_x' }; } }) },
   );
   assert.strictEqual(r.result, 'skipped');
   assert.strictEqual(r.reason, 'recurring_collection');
@@ -140,7 +144,7 @@ test('a recurring collection does not create another subscription', async () => 
 test('an account that already has a subscription for this product is left alone', async () => {
   let created = 0;
   const r = await rec.ensureSubscription(paidPayment(), grant(), {
-    mode: 'test',
+    recurring: true, mode: 'test',
     getAccount: async () => ({ mollie_subscription_parasign: 'sub_existing' }),
     mollie: mollieFake({ createSubscription: async () => { created++; return { id: 'sub_x' }; } }),
   });
@@ -151,7 +155,7 @@ test('an account that already has a subscription for this product is left alone'
 
 test('a subscription for the OTHER product does not block this one', async () => {
   const r = await rec.ensureSubscription(paidPayment(), grant(), {
-    mode: 'test',
+    recurring: true, mode: 'test',
     getAccount: async () => ({ mollie_subscription_parasend: 'sub_send' }),
     saveSubscription: async () => {},
     mollie: mollieFake(),
@@ -164,7 +168,7 @@ test('a subscription for the OTHER product does not block this one', async () =>
 
 test('a first payment without a customer id is flagged, not thrown', async () => {
   const r = await rec.ensureSubscription(paidPayment({ customerId: null }), grant(), {
-    mode: 'test', getAccount: async () => ({}), mollie: mollieFake(),
+    recurring: true, mode: 'test', getAccount: async () => ({}), mollie: mollieFake(),
   });
   assert.strictEqual(r.result, 'failed');
   assert.strictEqual(r.level, 'error');
@@ -174,7 +178,7 @@ test('a first payment without a customer id is flagged, not thrown', async () =>
 test('no valid mandate refuses rather than creating a subscription Mollie will reject', async () => {
   let created = 0;
   const r = await rec.ensureSubscription(paidPayment(), grant(), {
-    mode: 'test', getAccount: async () => ({}),
+    recurring: true, mode: 'test', getAccount: async () => ({}),
     mollie: mollieFake({
       validMandates: async () => [],
       createSubscription: async () => { created++; return { id: 'sub_x' }; },
@@ -187,7 +191,7 @@ test('no valid mandate refuses rather than creating a subscription Mollie will r
 
 test('a Mollie failure is reported, never thrown at the webhook', async () => {
   const r = await rec.ensureSubscription(paidPayment(), grant(), {
-    mode: 'test', getAccount: async () => ({}),
+    recurring: true, mode: 'test', getAccount: async () => ({}),
     mollie: mollieFake({ createSubscription: async () => { throw new Error('mollie_subscription_failed'); } }),
   });
   assert.strictEqual(r.result, 'failed');
@@ -197,7 +201,7 @@ test('a Mollie failure is reported, never thrown at the webhook', async () => {
 test('the customer id on the payment beats a stale one on the account', async () => {
   let billedCustomer = null;
   await rec.ensureSubscription(paidPayment({ customerId: 'cst_fresh' }), grant(), {
-    mode: 'test',
+    recurring: true, mode: 'test',
     getAccount: async () => ({ mollie_customer_id: 'cst_stale' }),
     saveSubscription: async () => {},
     mollie: mollieFake({ createSubscription: async (m, cust) => { billedCustomer = cust; return { id: 'sub_1' }; } }),
@@ -210,7 +214,7 @@ test('the customer id on the payment beats a stale one on the account', async ()
 test('cancelling stops the collection and leaves the paid period untouched', async () => {
   const account = { mollie_customer_id: 'cst_1', mollie_subscription_parasign: 'sub_1', paid_until_parasign: PAID_UNTIL.toISOString(), plan_parasign: 'pro' };
   const r = await rec.cancelForProduct('acct_1', 'parasign', {
-    mode: 'test',
+    recurring: true, mode: 'test',
     getAccount: async () => account,
     saveSubscription: async (a, p, id) => { account[rec.subscriptionFieldOf(p)] = id; },
     mollie: mollieFake(),
@@ -224,7 +228,7 @@ test('cancelling stops the collection and leaves the paid period untouched', asy
 test('a failed cancel keeps the pointer, so the next attempt still finds it', async () => {
   const account = { mollie_customer_id: 'cst_1', mollie_subscription_parasign: 'sub_1' };
   const r = await rec.cancelForProduct('acct_1', 'parasign', {
-    mode: 'test',
+    recurring: true, mode: 'test',
     getAccount: async () => account,
     saveSubscription: async (a, p, id) => { account[rec.subscriptionFieldOf(p)] = id; },
     mollie: mollieFake({ cancelSubscription: async () => { throw new Error('mollie_cancel_failed'); } }),
@@ -235,7 +239,7 @@ test('a failed cancel keeps the pointer, so the next attempt still finds it', as
 
 test('cancelling what was never subscribed is a no-op, not an error', async () => {
   const r = await rec.cancelForProduct('acct_1', 'parasign', {
-    mode: 'test', getAccount: async () => ({ mollie_customer_id: 'cst_1' }), mollie: mollieFake(),
+    recurring: true, mode: 'test', getAccount: async () => ({ mollie_customer_id: 'cst_1' }), mollie: mollieFake(),
   });
   assert.strictEqual(r.result, 'noop');
   assert.strictEqual(r.reason, 'no_subscription');

--- a/relay/test/billing-stance-boot.test.js
+++ b/relay/test/billing-stance-boot.test.js
@@ -1,0 +1,89 @@
+'use strict';
+// The boot line that says which stance billing is in. The brake in
+// mollie.billingStance() is only useful if an operator can see, in the first
+// seconds of a container's log, whether the relay will bill one-off or open
+// subscriptions. So the line itself is pinned here, on a real relay.js, in the
+// three stances: BILLING_MODE empty with a live key (production on 2026-09-02),
+// BILLING_MODE=test, BILLING_MODE=live. Never the key: only its prefix.
+//
+// Boots relay.js with stdout captured, three times. Needs the installed relay
+// dependencies (relay.js requires redis at load), so this runs in the crypto
+// job next to deep-health-gate, not in the no-install unit job.
+// Run: node relay/test/billing-stance-boot.test.js
+
+const { test, after } = require('node:test');
+const assert = require('assert');
+const { spawn } = require('child_process');
+const path = require('path');
+
+const RELAY_DIR = path.join(__dirname, '..');
+const children = [];
+after(() => { for (const c of children) c.kill('SIGKILL'); });
+
+// Boot until the billing_config line appears (it is logged right after
+// relay_started), then return it parsed. Fails loudly if it never comes.
+function bootForBillingLine(port, extraEnv) {
+  return new Promise((resolve, reject) => {
+    const env = { ...process.env, PORT: String(port), USERS_JSON: '{"api_keys":[]}', RELAY_REDIS_URL: '', NATS_URL: '' };
+    for (const k of ['BILLING_MODE', 'MOLLIE_API_KEY', 'MOLLIE_TEST_API_KEY']) delete env[k];
+    Object.assign(env, extraEnv);
+    const child = spawn('node', ['relay.js'], { cwd: RELAY_DIR, env, stdio: ['ignore', 'pipe', 'ignore'] });
+    children.push(child);
+    let buf = '';
+    const timer = setTimeout(() => reject(new Error(`no billing_config line within 15s; stdout so far:\n${buf.slice(-2000)}`)), 15000);
+    child.stdout.on('data', (d) => {
+      buf += d.toString();
+      for (const line of buf.split('\n')) {
+        if (!line.includes('"billing_config"')) continue;
+        let j = null;
+        try { j = JSON.parse(line); } catch (_) { continue; }
+        if (j && j.msg === 'billing_config') { clearTimeout(timer); child.kill('SIGKILL'); return resolve(j); }
+      }
+    });
+    child.on('exit', (code) => { clearTimeout(timer); reject(new Error(`relay exited (${code}) before logging billing_config:\n${buf.slice(-2000)}`)); });
+  });
+}
+
+const port = () => 34900 + (process.pid % 400) + children.length;
+
+test('stance 1: BILLING_MODE empty with a live key boots one-off only, and says so at warn', async () => {
+  const j = await bootForBillingLine(port(), { MOLLIE_API_KEY: 'live_bootcheck_0123456789' });
+  assert.strictEqual(j.level, 'warn', 'an inferred stance is legitimate but undecided, so it warns');
+  assert.strictEqual(j.mode, 'live');
+  assert.strictEqual(j.mode_source, 'inferred');
+  assert.strictEqual(j.recurring, false);
+  assert.strictEqual(j.key_present, true);
+  assert.strictEqual(j.key_prefix, 'live_');
+  assert.match(j.stance, /^live: one-off payments only/);
+  assert.match(j.stance, /BILLING_MODE not set/);
+  assert.ok(!JSON.stringify(j).includes('bootcheck'), 'the key itself must never reach the log');
+});
+
+test('stance 2: BILLING_MODE=test boots the recurring layer against the test key', async () => {
+  const j = await bootForBillingLine(port(), { BILLING_MODE: 'test', MOLLIE_TEST_API_KEY: 'test_bootcheck_0123456789', MOLLIE_API_KEY: 'live_bootcheck_0123456789' });
+  assert.strictEqual(j.level, 'info');
+  assert.strictEqual(j.mode, 'test');
+  assert.strictEqual(j.mode_source, 'explicit');
+  assert.strictEqual(j.recurring, true);
+  assert.strictEqual(j.key_present, true);
+  assert.strictEqual(j.key_prefix, 'test_', 'a test stance must pick the test key even when a live key is present');
+  assert.match(j.stance, /^test: one-off payments plus customers, mandates and subscriptions \(BILLING_MODE=test\)/);
+});
+
+test('stance 3: BILLING_MODE=live boots the recurring layer against the live key', async () => {
+  const j = await bootForBillingLine(port(), { BILLING_MODE: 'live', MOLLIE_API_KEY: 'live_bootcheck_0123456789' });
+  assert.strictEqual(j.level, 'info');
+  assert.strictEqual(j.mode, 'live');
+  assert.strictEqual(j.mode_source, 'explicit');
+  assert.strictEqual(j.recurring, true);
+  assert.strictEqual(j.key_prefix, 'live_');
+  assert.match(j.stance, /BILLING_MODE=live\)$/);
+});
+
+test('an explicit stance without its key boots red: nothing can bill, and the log says so first', async () => {
+  const j = await bootForBillingLine(port(), { BILLING_MODE: 'test', MOLLIE_API_KEY: 'live_bootcheck_0123456789' });
+  assert.strictEqual(j.level, 'error');
+  assert.strictEqual(j.mode, 'test');
+  assert.strictEqual(j.key_present, false);
+  assert.strictEqual(j.key_prefix, null);
+});

--- a/relay/test/billing-stance-boot.test.js
+++ b/relay/test/billing-stance-boot.test.js
@@ -6,7 +6,8 @@
 // three stances: BILLING_MODE empty with a live key (production on 2026-09-02),
 // BILLING_MODE=test, BILLING_MODE=live. Never the key: only its prefix.
 //
-// Boots relay.js with stdout captured, three times. Needs the installed relay
+// Boots relay.js with stdout captured, four times: the three stances plus an
+// explicit mode without its key, which must boot red. Needs the installed relay
 // dependencies (relay.js requires redis at load), so this runs in the crypto
 // job next to deep-health-gate, not in the no-install unit job.
 // Run: node relay/test/billing-stance-boot.test.js

--- a/relay/test/billing-stance.test.js
+++ b/relay/test/billing-stance.test.js
@@ -1,0 +1,209 @@
+'use strict';
+// The brake on the recurring layer. Production runs with BILLING_MODE empty and
+// a live_ key; billingMode() infers 'live' from that key, which was fine while
+// the relay only made one-off payments (the code of 2026-08-08) and is not
+// fine for opening mandates and subscriptions against a real Mollie account
+// with code that has never seen a real Mollie answer. So the recurring layer
+// runs only when BILLING_MODE was set by hand, and an inferred mode bills
+// exactly as 08-08 did. Three stances are pinned here, plus the edges:
+//   1. empty + live key    -> live, one-off only (the production stance today)
+//   2. BILLING_MODE=test   -> test, recurring on
+//   3. BILLING_MODE=live   -> live, recurring on
+// Run: node relay/test/billing-stance.test.js (exits non-zero on failure).
+
+const assert = require('assert');
+const mollie = require('../lib/mollie');
+const rec = require('../lib/billing-recurring');
+const catalog = require('../lib/billing-catalog');
+
+let passed = 0;
+const pending = [];
+function test(name, fn) {
+  pending.push(async () => {
+    try { await fn(); passed++; console.log(`ok   ${name}`); }
+    catch (e) { console.error(`FAIL ${name}\n     ${e.message}`); process.exitCode = 1; }
+  });
+}
+
+// Every test sets the three variables it cares about and clears the rest, so
+// the runner's own environment can never leak a stance into a check.
+function env(vars) {
+  for (const k of ['BILLING_MODE', 'MOLLIE_API_KEY', 'MOLLIE_TEST_API_KEY']) delete process.env[k];
+  Object.assign(process.env, vars);
+}
+
+// ── the three stances ────────────────────────────────────────────────────────
+
+test('stance 1: BILLING_MODE empty with a live key is live, one-off only (production today)', () => {
+  env({ MOLLIE_API_KEY: 'live_abcdef' });
+  const s = mollie.billingStance();
+  assert.deepStrictEqual(s, { mode: 'live', recurring: false, source: 'inferred', key_present: true });
+  // And the mode is the same one 08-08 computed, so checkout and webhook still
+  // talk to the same Mollie account.
+  assert.strictEqual(mollie.billingMode(), 'live');
+});
+
+test('stance 2: BILLING_MODE=test with a test key is test, recurring on', () => {
+  env({ BILLING_MODE: 'test', MOLLIE_TEST_API_KEY: 'test_abcdef' });
+  const s = mollie.billingStance();
+  assert.deepStrictEqual(s, { mode: 'test', recurring: true, source: 'explicit', key_present: true });
+});
+
+test('stance 3: BILLING_MODE=live with a live key is live, recurring on', () => {
+  env({ BILLING_MODE: 'live', MOLLIE_API_KEY: 'live_abcdef' });
+  const s = mollie.billingStance();
+  assert.deepStrictEqual(s, { mode: 'live', recurring: true, source: 'explicit', key_present: true });
+});
+
+// ── the edges ────────────────────────────────────────────────────────────────
+
+test('a live key alone never turns recurring on, whatever else is set', () => {
+  env({ MOLLIE_API_KEY: 'live_abcdef', MOLLIE_TEST_API_KEY: 'test_abcdef' });
+  assert.strictEqual(mollie.billingStance().recurring, false);
+  env({ BILLING_MODE: 'yes', MOLLIE_API_KEY: 'live_abcdef' });
+  const s = mollie.billingStance();
+  assert.strictEqual(s.recurring, false, 'an unknown BILLING_MODE value must not count as explicit');
+  assert.strictEqual(s.mode, 'live', 'and the mode still falls back on the key, as billingMode() always did');
+  assert.strictEqual(s.source, 'inferred');
+});
+
+test('BILLING_MODE is case-insensitive, as billingMode() already was', () => {
+  env({ BILLING_MODE: 'LIVE', MOLLIE_API_KEY: 'live_abcdef' });
+  assert.deepStrictEqual(mollie.billingStance(), { mode: 'live', recurring: true, source: 'explicit', key_present: true });
+});
+
+test('an explicit mode without its key is explicit and keyless: the boot log turns red, nothing bills', () => {
+  env({ BILLING_MODE: 'test', MOLLIE_API_KEY: 'live_abcdef' });
+  const s = mollie.billingStance();
+  assert.strictEqual(s.mode, 'test');
+  assert.strictEqual(s.recurring, true);
+  assert.strictEqual(s.key_present, false, 'a live key must never serve a test stance');
+  assert.strictEqual(mollie.apiKeyFor('test'), '');
+});
+
+test('no mode and no key at all: live, inferred, keyless', () => {
+  env({});
+  assert.deepStrictEqual(mollie.billingStance(), { mode: 'live', recurring: false, source: 'inferred', key_present: false });
+});
+
+// ── what the stance does to a checkout ───────────────────────────────────────
+
+const calls = () => {
+  const c = { getCustomer: 0, createCustomer: 0, validMandates: 0, createSubscription: 0 };
+  const m = {
+    getCustomer: async (mode, id) => { c.getCustomer++; return { id }; },
+    createCustomer: async () => { c.createCustomer++; return { id: 'cst_new' }; },
+    validMandates: async () => { c.validMandates++; return [{ id: 'mdt_1', status: 'valid' }]; },
+    createSubscription: async () => { c.createSubscription++; return { id: 'sub_1' }; },
+    mollieInterval: mollie.mollieInterval,
+  };
+  return { c, m };
+};
+
+test('one-off stance: the checkout asks Mollie for no customer, even when one is stored', async () => {
+  const { c, m } = calls();
+  let saved = null;
+  const out = await rec.ensureCustomer('acct_1', {
+    recurring: false, mode: 'live',
+    getAccount: () => ({ [rec.CUSTOMER_FIELD]: 'cst_stored', email: 'a@b.c' }),
+    saveCustomer: (aid, id) => { saved = id; },
+    mollie: m,
+  });
+  assert.deepStrictEqual(out, { customerId: null, result: 'skipped', reason: 'recurring_disabled' });
+  assert.strictEqual(c.getCustomer + c.createCustomer, 0, 'no Mollie call may be made');
+  assert.strictEqual(saved, null);
+  // The payload the relay builds from that is the 08-08 one: no customerId, no
+  // sequenceType. This mirrors the exact expression in relay.js.
+  const extras = out.customerId ? { customerId: out.customerId, sequenceType: 'first' } : {};
+  assert.deepStrictEqual(extras, {});
+});
+
+test('explicit stance: the checkout reuses the stored customer, or creates and saves one', async () => {
+  const { c, m } = calls();
+  const reused = await rec.ensureCustomer('acct_1', {
+    recurring: true, mode: 'live',
+    getAccount: () => ({ [rec.CUSTOMER_FIELD]: 'cst_stored' }),
+    mollie: m,
+  });
+  assert.deepStrictEqual(reused, { customerId: 'cst_stored', result: 'reused' });
+  assert.strictEqual(c.getCustomer, 1);
+
+  let saved = null;
+  const created = await rec.ensureCustomer('acct_2', {
+    recurring: true, mode: 'live',
+    getAccount: () => ({ email: 'a@b.c' }),
+    saveCustomer: (aid, id) => { saved = `${aid}:${id}`; },
+    mollie: m,
+  });
+  assert.deepStrictEqual(created, { customerId: 'cst_new', result: 'created' });
+  assert.strictEqual(saved, 'acct_2:cst_new');
+  assert.strictEqual(c.createCustomer, 1);
+});
+
+test('explicit stance: a stale stored customer falls through to a new one, a failing Mollie falls back to one-off', async () => {
+  const { c, m } = calls();
+  m.getCustomer = async () => { c.getCustomer++; const e = new Error('mollie_customer_get_failed'); e.status = 404; throw e; };
+  const out = await rec.ensureCustomer('acct_1', {
+    recurring: true, mode: 'live', getAccount: () => ({ [rec.CUSTOMER_FIELD]: 'cst_gone' }), mollie: m,
+  });
+  assert.strictEqual(out.customerId, 'cst_new');
+  assert.strictEqual(c.createCustomer, 1);
+
+  m.createCustomer = async () => { const e = new Error('mollie_customer_failed'); e.status = 500; throw e; };
+  const failed = await rec.ensureCustomer('acct_1', { recurring: true, mode: 'live', getAccount: () => null, mollie: m });
+  assert.strictEqual(failed.customerId, null, 'the sale must still go through as a one-off');
+  assert.strictEqual(failed.result, 'failed');
+  assert.strictEqual(failed.level, 'error');
+  assert.strictEqual(failed.status, 500);
+});
+
+// ── what the stance does to a webhook ────────────────────────────────────────
+
+const PLAN = { product: 'parasign', plan: 'pro', interval: 'monthly' };
+const ORDER = catalog.resolveOrder(PLAN);
+const payment = { id: 'tr_1', status: 'paid', sequenceType: 'first', customerId: 'cst_1',
+  amount: { value: ORDER.amount, currency: 'EUR' }, metadata: { accountId: 'acct_1', ...PLAN } };
+const grant = { result: 'granted', account: 'acct_1', product: 'parasign', tier: 'pro',
+  paidUntil: new Date(Date.now() + 30 * 86400e3) };
+
+test('one-off stance: after a grant no mandate is read and no subscription is created, and the grant stands', async () => {
+  const { c, m } = calls();
+  let saved = 0;
+  const sub = await rec.ensureSubscription(payment, grant, {
+    recurring: false, mode: 'live', webhookUrl: 'https://paramant.app/v2/billing/webhook',
+    getAccount: () => ({}), saveSubscription: () => { saved++; }, mollie: m,
+  });
+  assert.deepStrictEqual(sub, { result: 'skipped', reason: 'recurring_disabled' });
+  assert.strictEqual(c.validMandates + c.createSubscription, 0, 'no Mollie call may be made');
+  assert.strictEqual(saved, 0);
+  // 'skipped' is what the relay stays silent on; anything else would log an
+  // error for a stance that is deliberate.
+  assert.notStrictEqual(sub.level, 'error');
+});
+
+test('explicit stance: the same webhook creates the subscription', async () => {
+  const { c, m } = calls();
+  const sub = await rec.ensureSubscription(payment, grant, {
+    recurring: true, mode: 'live', webhookUrl: 'https://paramant.app/v2/billing/webhook',
+    getAccount: () => ({}), saveSubscription: () => {}, mollie: m,
+  });
+  assert.strictEqual(sub.result, 'created');
+  assert.strictEqual(c.validMandates, 1);
+  assert.strictEqual(c.createSubscription, 1);
+});
+
+test('a deps object without the flag is one-off: the switch defaults to closed', async () => {
+  assert.strictEqual(rec.recurringAllowed({}), false);
+  assert.strictEqual(rec.recurringAllowed(null), false);
+  assert.strictEqual(rec.recurringAllowed({ recurring: 'true' }), false, 'only the boolean true opens it');
+  assert.strictEqual(rec.recurringAllowed({ recurring: true }), true);
+  const { c, m } = calls();
+  const sub = await rec.ensureSubscription(payment, grant, { mode: 'live', getAccount: () => ({}), mollie: m });
+  assert.strictEqual(sub.reason, 'recurring_disabled');
+  assert.strictEqual(c.createSubscription, 0);
+});
+
+(async () => {
+  for (const run of pending) await run();
+  console.log(`\nbilling-stance: ${passed} checks passed`);
+})();


### PR DESCRIPTION
## Wat er mis was

Productie draait met `BILLING_MODE` leeg en een `live_`-sleutel. `billingMode()` leidt daar `live` uit af, en dat was genoeg voor de eenmalige betalingen van de code van 08-08. Het was ook genoeg voor de mandaat- en abonnementslaag uit #315: een deploy van main zou bij de eerste verkoop een echte incasso-afspraak openen, met code die nooit een echt antwoord van Mollie heeft gezien. Er is geen testsleutel om het eerst tegen te bewijzen. Vondst: vault, *Bevinding - een deploy van main zou tegen de echte Mollie draaien* (01-09).

## Wat het oude gedrag exact was

Gemeten in `git show 41501bb:relay/relay.js` (de commit die productie draait):
- checkout: `createPayment(mode, { amount, description, redirectUrl, webhookUrl, metadata })`, geen customer, geen `sequenceType`
- webhook: `getPayment`, `processPayment`, log, klaar; geen `ensureSubscription`
- `billingMode()` zelf is ongewijzigd tussen 41501bb en main

## De rem

`mollie.billingStance()` zegt of de terugkerende laag mag draaien, en dat mag alleen als `BILLING_MODE` met de hand op `live` of `test` staat. Bij lege mode slaat de checkout de customer-stap over, zodat de payload byte voor byte die van 08-08 is (`customerId ? {...} : {}` blijft staan, `customerId` is dan `null`), en de webhook kent toe en stopt. `ensureCustomer` en `ensureSubscription` in `billing-recurring.js` krijgen de vlag en staan standaard dicht. De `billing_config`-regel bij het opstarten draagt nu `mode_source`, `recurring` en een `stance`-zin, op `warn` als de mode afgeleid is:

```
{"level":"warn","msg":"billing_config","mode":"live","mode_source":"inferred","recurring":false,"key_present":true,"key_prefix":"live_","stance":"live: one-off payments only, no customers or subscriptions (BILLING_MODE not set)"}
```

`/v2/billing/cancel` is niet gegate: hij werkt alleen op een opgeslagen abonnements-id en stoppen van een incasso is altijd veilig.

## Bewijs

- `relay/test/billing-stance.test.js`: de drie standen (leeg+live-sleutel, test, live) plus de randen (onbekende waarde, hoofdletters, expliciet zonder sleutel, niets gezet), en wat de stand doet met `ensureCustomer` en `ensureSubscription` tegen een fake die elke Mollie-call telt. 13 checks.
- `relay/test/billing-stance-boot.test.js`: boot een echte `relay.js` vier keer en leest de `billing_config`-regel. Staat in de crypto-job naast `deep-health-gate` (heeft de redis-module nodig). 4 pass.
- `relay/test/billing-recurring.test.js` geeft nu `recurring: true` mee: die suite toetst de laag in ingeschakelde stand. 22 checks, ongewijzigd in inhoud.
- Relay-unitsuite lokaal met dezelfde glob als CI: 176 pass, 0 fail, `parasign-signs-quota` de enige stille suite (zoals de poort in test.yml eist).
- `eslint@9` over de gewijzigde bestanden: schoon.
- `tests/static-sanity.sh`: checks 1 t/m 9 OK (36 OK-regels), exit 1 door check 10 alleen. Check 10 (`check-commit-style.sh` op de laatste commit) blokkeert op de `Co-Authored-By`-trailer; die staat er op instructie. Gemeten op `origin/main` 0fc8648 in een verse worktree: dezelfde uitkomst, exit 1, 36 OK, alleen check 10 rood (trailers van de squash-commits van #322 en #323 plus een em-dash in een toegevoegde regel van #323). Main is dus al rood op deze check, onafhankelijk van deze PR.

## Runbook

`deploy/DEPLOY-3.1.md`: de deploy van main naar productie, stap voor stap. Corrigeert het 3.0.0-runbook op de compose-map (`/opt/paramant-relay`, niet de docroot `/home/paramant/app`), noemt de env-variabelen (`INTERNAL_AUTH_TOKEN` voor `/v2/health/deep` uit #322, `BILLING_MODE` leeg laten, `PARASIGN_CANARY_KEY` als GitHub-secret met een `psk_test_`-sleutel via `/v2/admin/keys/mint-parasign`), de sanity- en smoketests uit `deploy.sh`, de kanarie-eerst-volgorde uit de deploy van 06-24, de nginx-wijzigingen die main meebrengt zonder de ParaID-deny van 01-09 te overschrijven, en het rollback-pad over de getagde images. `docker-compose.yml` is byte-gelijk tussen 41501bb en main, dus er komt geen compose-regel bij.

Het runbook is eerlijk over die rode check 10 (tweede commit, e28e77a): "Before you start" stap 2 verwacht checks 1 t/m 9 OK en check 10 FAIL, stap 3 laat `tests/static-sanity.sh` op de server draaien met die leesregel (alleen een andere FAIL blokkeert), en het legt uit waarom het runbook `deploy.sh` niet aanroept (stap 1 daarvan stopt op dezelfde check). Zonder die passage stond je op de server bij stap 3 stil.

Gemeten op 02-09: `gh api repos/Apolloccrypt/paramant-relay/actions/secrets` noemt `PARASIGN_CANARY_KEY` noch `PARAMANT_CANARY_KEY`; de kanaries slaan de gesleutelde tests dus nog op naam over.

## Niet gedaan

- Geen deploy. Niets op productie aangeraakt, ook niet gelezen.
- `BILLING_MODE` niet gezet en geen advies om dat nu te doen. Het runbook beschrijft de latere procedure (test-sleutel, `test`, dan pas `live`).
- `scripts/post-deploy-verify.sh` niet aangepast; het runbook benoemt dat de `/health/deep`-check daarin verouderd en niet-kritiek is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJk2nCLCLmi3F71qkCUn7N

