### PR TITLE
Build the crypto binding on rust:1.98-alpine by adopting the paramant-core with bindgen 0.72

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       # (and review the diff) when adopting a new paramant-core.
       - name: Build @paramant/core (sibling checkout, pinned)
         env:
-          PARAMANT_CORE_SHA: 45a3d3521adda7924692d58be5db60d5b094371f
+          PARAMANT_CORE_SHA: b90b3c52af5c3c30053766bfa108924aff4f9eec
         run: |
           git clone --no-checkout https://github.com/Apolloccrypt/paramant-core.git "${GITHUB_WORKSPACE}/../paramant-core"
           cd "${GITHUB_WORKSPACE}/../paramant-core"

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -7,13 +7,13 @@
 # node:22-alpine runtime (a glibc build would not). Pinned to a paramant-core
 # commit for reproducibility; bump PARAMANT_CORE_COMMIT when upgrading.
 #
-# Pinned to rust:1.95-alpine. The 1.96-alpine bump (#222) moved to a newer Alpine
-# whose clang/liboqs toolchain makes the vendored `oqs` crate fail to compile
-# (E0609: no field `alg_version`/`length_signature`/… on `OQS_SIG` — bindgen no
-# longer generates those fields). 1.95-alpine is the exact base that built the
-# live relay images; revert until paramant-core's oqs crate supports the newer
-# liboqs. NOTE: CI's crypto suite does not build via this musl Dockerfile, so it
-# stayed green through the bump — this base must be verified by an actual image build.
+# rust:1.98-alpine (Alpine 3.24, libclang 22). Earlier bumps past 1.95 (#222,
+# #313) failed here with E0609 "no field `alg_version`/… on `OQS_SIG`": bindgen
+# 0.71 turns the forward-declared OQS_SIG into an opaque struct under libclang
+# 22. paramant-core now builds oqs-sys with bindgen 0.72 (oqs 0.11.0, liboqs
+# 0.13.0), which resolves it. NOTE: CI's crypto suite builds on ubuntu/glibc,
+# not via this musl Dockerfile; paramant-core's `musl-node-binding` job pins
+# the same digest, and any base bump must still be verified by an image build.
 FROM rust:1.98-alpine@sha256:a10e64dd139b7387337c7fbe8aca31b959b57b2fd4c8ae20a02cf1d6ea424dce AS paramant-core-binding
 
 RUN apk add --no-cache musl-dev gcc g++ make cmake ninja clang clang-dev llvm-dev perl nasm git bash
@@ -23,12 +23,12 @@ ENV LIBCLANG_PATH=/usr/lib
 # (also-musl) node:22-alpine runtime.
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 
-ARG PARAMANT_CORE_COMMIT=dc454d47880ab54e6f1483433580abab894b854e
+ARG PARAMANT_CORE_COMMIT=b90b3c52af5c3c30053766bfa108924aff4f9eec
 WORKDIR /build
 RUN git clone https://github.com/Apolloccrypt/paramant-core.git \
  && cd paramant-core && git checkout "${PARAMANT_CORE_COMMIT}" \
- # --locked: build against paramant-core's committed Cargo.lock (oqs 0.10.1 +
- # vendored liboqs 0.12.0) so a transitive bump can't silently drift the crypto
+ # --locked: build against paramant-core's committed Cargo.lock (oqs 0.11.0 +
+ # vendored liboqs 0.13.0) so a transitive bump can't silently drift the crypto
  # build. paramant-core's CI has a musl job pinned to this same base that proves
  # the lockfile builds here; keep the two in lockstep when bumping the base.
  && cargo build --locked --release -p paramant-core-node \

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -14,7 +14,7 @@
 # live relay images; revert until paramant-core's oqs crate supports the newer
 # liboqs. NOTE: CI's crypto suite does not build via this musl Dockerfile, so it
 # stayed green through the bump — this base must be verified by an actual image build.
-FROM rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS paramant-core-binding
+FROM rust:1.98-alpine@sha256:a10e64dd139b7387337c7fbe8aca31b959b57b2fd4c8ae20a02cf1d6ea424dce AS paramant-core-binding
 
 RUN apk add --no-cache musl-dev gcc g++ make cmake ninja clang clang-dev llvm-dev perl nasm git bash
 ENV LIBCLANG_PATH=/usr/lib


### PR DESCRIPTION
Supersedes #313 (the rust 1.95-alpine -> 1.98-alpine bump; its commit is cherry-picked here unchanged). Depends on Apolloccrypt/paramant-core#24, which this PR pins by commit.

## Why #313 failed

Not the Rust version: paramant-core's `rust-toolchain.toml` pins 1.95.0 and the failure reproduces with that toolchain inside the 1.98 image. `rust:1.98-alpine` is Alpine 3.24 with libclang 22.1.3, and bindgen 0.71 (what `oqs-sys` <= 0.11.0 requires) emits the forward-declared `OQS_SIG` as an opaque `{ _address: u8 }` under libclang 22, hence `E0609: no field alg_version on type &OQS_SIG`. Two-line reproduction and the bindgen/libclang matrix are in paramant-core#24.

## Change

- `relay/Dockerfile`: base `rust:1.98-alpine@sha256:a10e64dd...` (from #313); `PARAMANT_CORE_COMMIT` `dc454d4` -> `b90b3c5` (paramant-core#24: oqs 0.11.0 / liboqs 0.13.0, oqs-sys patched to bindgen 0.72); the comment block that documented the 1.95 pin now documents the cause.
- `.github/workflows/test.yml`: `PARAMANT_CORE_SHA` `45a3d35` -> `b90b3c5`, so the relay crypto-suite gate runs against the same paramant-core the image ships.

No relay source changes.

## Verification (local, NUC, Docker 29.6.1)

- `docker build` of `relay/` with this Dockerfile, `--no-cache`: binding stage `Finished release [optimized] target(s) in 1m 57s`, full image built.
- In the built runtime image: `require('@paramant/core')` loads the musl binding; `mldsaKeygen` / `mldsaSign` / `mldsaVerify` round-trip (signature 3309 bytes, verify `true`).
- Relay crypto suite on the host against the binding built from paramant-core `b90b3c5` (`node --test crypto/*.test.js`): 144 pass, 0 fail.
- paramant-core#24 CI: all five jobs green, including `musl build - paramant-core-node` on this exact `rust:1.98-alpine` digest, and the ML-DSA-65 / ML-KEM-768 KAT suites.

## Byte-compatibility

Algorithm identifiers (`ML-DSA-65`, `ML-KEM-768`, `SPHINCS+-SHA2-128f-simple`, `Falcon-512`) are unchanged between liboqs 0.12.0 and 0.13.0; the 50 @noble-anchored ML-DSA-65 KAT vectors and the relay crypto suite verify unchanged. No wire-format or version-id changes.

## Not done here

- No merge, no deploy. Production stays on the 08-08 image.
- paramant-core#24 should merge first. If it is squash-merged, its commit hash changes and both pins here must be re-pointed at the merge commit before this PR merges (`b90b3c5` stays fetchable only while the branch exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJk2nCLCLmi3F71qkCUn7N
