### PR TITLE
feat(directie): a signals script that says what is red, without a model

### DIFF
--- a/docs/directie.md
+++ b/docs/directie.md
@@ -15,8 +15,10 @@ python3 scripts/directie/signalen.py --repo eigenaar/repo
 ```
 
 Exitcode 0 als niets rood is, 1 als er iets rood is, 2 als het script zelf
-struikelt. Een volledige run duurt ongeveer twintig seconden, vrijwel helemaal
-wachten op GitHub.
+struikelt. Een volledige run duurde hier gemeten 12 tot 17 seconden over vier
+runs, vrijwel helemaal wachten op GitHub. Dat loopt op met het aantal open
+pull requests en met het aantal runs dat langsgelopen moet worden voor een
+kanarie-uitslag: elk daarvan kost een API-aanroep.
 
 Nodig: Python 3, `gh` (ingelogd) en `curl`. Verder niets, met opzet. Zonder
 `gh`-login sterft het script niet, maar worden de GitHub-signalen oranje met
@@ -54,9 +56,16 @@ De drie kanaries zijn geen losse workflows. Ze zijn stappen in de `live`-job van
 `.github/workflows/product-heartbeat.yml`. Het script leest daarom de
 workflowbestanden, zoekt op naam naar de stappen, pakt per kanarie de laatste
 afgeronde run waarin die stap echt een uitslag gaf (een overgeslagen stap telt
-niet mee), en rapporteert die conclusie met het tijdstip. Wordt een kanarie ooit
-een eigen workflow, dan blijft dat werken. Verdwijnt hij helemaal, dan wordt het
-signaal oranje in plaats van stilletjes groen.
+niet mee), en rapporteert die conclusie met het tijdstip.
+
+Het kijkt daarvoor eerst naar de `schedule`- en `workflow_dispatch`-runs, want
+alleen daar draait de live-job. Een kale lijst van de laatste twintig runs
+bestaat op een drukke dag bijna helemaal uit pull-request-runs waarin de
+kanariestappen zijn overgeslagen, en dan zou een levende kanarie vals oranje
+worden gemeld. Levert die eerste ronde niets op, dan volgt een breed net over
+alle events. Wordt een kanarie ooit een eigen workflow, dan blijft dat werken.
+Verdwijnt hij helemaal, dan wordt het signaal oranje in plaats van stilletjes
+groen.
 
 ## Drempels
 
@@ -68,8 +77,9 @@ iets rood is hoort daar gevoerd te worden, niet verspreid over de code.
 
 ## JSON
 
-De JSON-uitvoer heeft `gegenereerd`, `repo`, `samenvatting` (aantallen per
-ernst) en `signalen`. Elk signaal heeft `sleutel`, `naam`, `ernst`, `meting`,
+De JSON-uitvoer heeft `gegenereerd` (UTC), `repo`, `wortel` (het pad naar de
+werkkopie waarin `.github/workflows` gelezen is), `samenvatting` (aantallen
+per ernst) en `signalen`. Elk signaal heeft `sleutel`, `naam`, `ernst`, `meting`,
 `voorstel` en `details`. In `details` staat onder meer `bron`: het commando
 waar de meting vandaan komt, zodat elke regel terug te leiden is naar iets wat
 je zelf kunt nadraaien.

--- a/docs/directie.md
+++ b/docs/directie.md
@@ -1,0 +1,75 @@
+# Directiesignalen
+
+`scripts/directie/signalen.py` meet de staat van Paramant en zegt wat rood is.
+Geen model, geen oordeel achteraf: een vaste lijst vragen aan GitHub (via `gh`)
+en aan productie (via `curl`), en per vraag een ernst, een meting en een
+voorstel van een zin. Bedoeld voor een mens die in tien seconden wil weten of er
+iets aan de hand is, en voor een latere ronde die op de exitcode kan sturen.
+
+## Draaien
+
+```
+python3 scripts/directie/signalen.py            # JSON naar stdout
+python3 scripts/directie/signalen.py --tekst    # leesbare tekst
+python3 scripts/directie/signalen.py --repo eigenaar/repo
+```
+
+Exitcode 0 als niets rood is, 1 als er iets rood is, 2 als het script zelf
+struikelt. Een volledige run duurt ongeveer twintig seconden, vrijwel helemaal
+wachten op GitHub.
+
+Nodig: Python 3, `gh` (ingelogd) en `curl`. Verder niets, met opzet. Zonder
+`gh`-login sterft het script niet, maar worden de GitHub-signalen oranje met
+"niet gemeten" als meting.
+
+## Wat het meet
+
+| Signaal | Vraag | Rood als |
+| --- | --- | --- |
+| `pr-<nummer>` | Elke open pull request: leeftijd in uren en de status van zijn checks. | Een check is gefaald. |
+| `dependabot` | Hoeveel dependabot-PRs staan open en hoe oud is de oudste. | De oudste staat langer dan 14 dagen open. |
+| `workflow-runs` | Gefaalde workflow-runs van de laatste 24 uur (`gh run list`). | Er faalde iets op `main`. |
+| `kanarie-transfer-kanarie` | De laatste uitslag van de transfer-kanarie tegen de live relay, met tijdstip. | De stap faalde, of de laatste uitslag is ouder dan 24 uur. |
+| `kanarie-parasign-kanarie` | Idem voor de ParaSign-kanarie. | Idem. |
+| `kanarie-heartbeat` | Idem voor de heartbeat tegen `paramant.app` (de productievariant, niet die tegen de checkout). | Idem. |
+| `productie-health` | Statuscode van `https://paramant.app/health`. | Niet 2xx of 3xx, of onbereikbaar. |
+| `productie-homepage` | Responstijd en statuscode van de homepage. | Boven 2,5 s of een foutstatus. |
+| `paraid-deny-<host>` | `POST` met een lege JSON-body naar `/v1/paraid/issue-document` op `paramant.app`, `relay.`, `health.`, `legal.`, `finance.` en `iot.paramant.app`. | De host antwoordt met iets anders dan 404, 401, 403, 405 of 410. |
+
+Oranje betekent bijna overal hetzelfde: het is niet kapot, maar het is ook niet
+gemeten of het staat te lang stil. Een signaal dat het script niet kon meten is
+oranje, nooit groen. Groen betekent: gemeten en in orde.
+
+## Waarom de ParaID-ingangen erin zitten
+
+ParaID is uit het product gehaald. De route `/v1/paraid/issue-document` hoort op
+alle zes de hosts een kale 404 te geven. Antwoordt er een host anders, dan
+draait daar oude code of stuurt een proxy verkeer naar iets wat er niet meer
+hoort te zijn. Dat is de reden dat dit zes losse signalen zijn en niet een: je
+wilt weten welke host afwijkt, niet dat er ergens een afwijkt.
+
+## Hoe de kanaries gevonden worden
+
+De drie kanaries zijn geen losse workflows. Ze zijn stappen in de `live`-job van
+`.github/workflows/product-heartbeat.yml`. Het script leest daarom de
+workflowbestanden, zoekt op naam naar de stappen, pakt per kanarie de laatste
+afgeronde run waarin die stap echt een uitslag gaf (een overgeslagen stap telt
+niet mee), en rapporteert die conclusie met het tijdstip. Wordt een kanarie ooit
+een eigen workflow, dan blijft dat werken. Verdwijnt hij helemaal, dan wordt het
+signaal oranje in plaats van stilletjes groen.
+
+## Drempels
+
+De grenzen staan als constanten bovenaan het script, met een regel uitleg per
+stuk: `PR_OUD_UREN` (72), `DEPENDABOT_OUD_UREN` (14 dagen), `RUNS_VENSTER_UREN`
+(24), `KANARIE_ORANJE_UREN` (6) en `KANARIE_ROOD_UREN` (24),
+`HOMEPAGE_ORANJE_S` (1,0) en `HOMEPAGE_ROOD_S` (2,5). Discussie over wanneer
+iets rood is hoort daar gevoerd te worden, niet verspreid over de code.
+
+## JSON
+
+De JSON-uitvoer heeft `gegenereerd`, `repo`, `samenvatting` (aantallen per
+ernst) en `signalen`. Elk signaal heeft `sleutel`, `naam`, `ernst`, `meting`,
+`voorstel` en `details`. In `details` staat onder meer `bron`: het commando
+waar de meting vandaan komt, zodat elke regel terug te leiden is naar iets wat
+je zelf kunt nadraaien.

--- a/scripts/directie/signalen.py
+++ b/scripts/directie/signalen.py
@@ -1,0 +1,706 @@
+#!/usr/bin/env python3
+"""Directiesignalen: de staat van Paramant in een oogopslag, zonder model.
+
+Dit script meet, het oordeelt niet met een taalmodel. Het stelt een vaste lijst
+vragen aan GitHub (via gh) en aan productie (via curl), zet elke uitkomst om in
+een ernst (rood, oranje, groen), een meting en een voorstel van een zin, en
+schrijft dat als JSON naar stdout. Met --tekst komt er leesbare tekst uit.
+
+Exit 0 als er niets rood is, 1 als er wel iets rood is, 2 bij een fout in het
+script zelf. Zo kan een cron of een latere ronde op de exitcode sturen.
+
+Gebruik:
+    python3 scripts/directie/signalen.py            # JSON
+    python3 scripts/directie/signalen.py --tekst    # leesbaar
+    python3 scripts/directie/signalen.py --repo eigenaar/repo
+
+Afhankelijkheden: Python 3 standaardbibliotheek, plus de commando's gh en curl.
+Meer niet, met opzet: dit moet ook draaien op een kale machine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# Drempels. Bewust bovenaan en met een reden, zodat een discussie over "wanneer
+# is iets rood" hier gevoerd wordt en niet verstopt zit in een if.
+
+# Een pull request die langer dan dit open staat is geen werk meer maar voorraad.
+PR_OUD_UREN = 72
+# Dependabot: een openstaande update is hinder, een oude is een risico.
+DEPENDABOT_OUD_UREN = 14 * 24
+# Gefaalde workflow-runs tellen we over dit venster.
+RUNS_VENSTER_UREN = 24
+# De kanarie-workflow draait per uur. Wordt de laatste uitslag ouder dan dit,
+# dan meet niemand meer mee.
+KANARIE_ORANJE_UREN = 6
+KANARIE_ROOD_UREN = 24
+# Responstijd van de homepage.
+HOMEPAGE_ORANJE_S = 1.0
+HOMEPAGE_ROOD_S = 2.5
+
+GH_TIMEOUT = 60
+CURL_TIMEOUT = 15
+
+PRODUCTIE_HEALTH = "https://paramant.app/health"
+PRODUCTIE_HOME = "https://paramant.app/"
+
+# De zes hosts waar de ParaID-uitgifteroute dicht hoort te zijn. ParaID is uit
+# het product gehaald; blijft de route ergens antwoorden, dan draait daar oude
+# code of stuurt een proxy verkeer naar iets wat er niet meer hoort te zijn.
+PARAID_DENY_PAD = "/v1/paraid/issue-document"
+PARAID_HOSTS = [
+    "paramant.app",
+    "relay.paramant.app",
+    "health.paramant.app",
+    "legal.paramant.app",
+    "finance.paramant.app",
+    "iot.paramant.app",
+]
+
+# De kanaries zoals ze in .github/workflows heten. Het script zoekt ze op naam
+# op, in de workflow-namen, de job-namen en de stapnamen, zodat het blijft
+# werken als een kanarie ooit een eigen workflow wordt.
+KANARIES = [
+    ("transfer-kanarie", re.compile(r"transfer[\s_-]*(canary|kanarie)", re.I)),
+    ("parasign-kanarie", re.compile(r"parasign[\s_-]*(canary|kanarie)", re.I)),
+    # Alleen de kanarie tegen productie, niet de heartbeat tegen de checkout.
+    ("heartbeat", re.compile(r"heartbeat\s+(against|tegen)\s+\S*paramant", re.I)),
+]
+
+ROOD, ORANJE, GROEN = "rood", "oranje", "groen"
+ERNST_ORDE = {ROOD: 0, ORANJE: 1, GROEN: 2}
+
+# Conclusies van GitHub Actions die we als kapot lezen.
+KAPOT = {"failure", "timed_out", "startup_failure", "action_required"}
+
+
+# ---------------------------------------------------------------- hulpmiddelen
+
+def nu() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def tijdstip(waarde: str | None) -> datetime | None:
+    """ISO-8601 uit de GitHub-API naar een datetime, of None."""
+    if not waarde:
+        return None
+    tekst = waarde.strip().replace("Z", "+00:00")
+    try:
+        stempel = datetime.fromisoformat(tekst)
+    except ValueError:
+        return None
+    if stempel.tzinfo is None:
+        stempel = stempel.replace(tzinfo=timezone.utc)
+    if stempel.year < 1970:  # GitHub schrijft 0001-01-01 voor "nog niet"
+        return None
+    return stempel
+
+
+def uren_geleden(stempel: datetime | None) -> float | None:
+    if stempel is None:
+        return None
+    return (nu() - stempel).total_seconds() / 3600.0
+
+
+def duur(uren: float | None) -> str:
+    if uren is None:
+        return "onbekend"
+    if uren < 1:
+        return f"{uren * 60:.0f} min"
+    if uren < 48:
+        return f"{uren:.1f} uur"
+    return f"{uren / 24:.1f} dagen"
+
+
+def gh_json(args: list[str]) -> tuple[object | None, str | None]:
+    """Draai gh met een --json-vlag en geef de geparste uitvoer terug."""
+    try:
+        klaar = subprocess.run(
+            ["gh", *args],
+            capture_output=True, text=True, timeout=GH_TIMEOUT,
+        )
+    except FileNotFoundError:
+        return None, "gh is niet geinstalleerd"
+    except subprocess.TimeoutExpired:
+        return None, f"gh gaf geen antwoord binnen {GH_TIMEOUT}s"
+    if klaar.returncode != 0:
+        fout = (klaar.stderr or klaar.stdout or "").strip().splitlines()
+        return None, fout[-1] if fout else f"gh eindigde met code {klaar.returncode}"
+    if not klaar.stdout.strip():
+        return None, "gh gaf een lege uitvoer"
+    try:
+        return json.loads(klaar.stdout), None
+    except json.JSONDecodeError as exc:
+        return None, f"gh gaf geen geldige JSON ({exc})"
+
+
+def curl_meting(url: str, methode: str = "GET", body: str | None = None) -> dict:
+    """Statuscode en responstijd van een URL. Geen redirects volgen: we willen
+    weten wat deze host zelf antwoordt, niet waar hij naartoe wijst."""
+    cmd = [
+        "curl", "-s", "-S", "-o", os.devnull,
+        "-w", "%{http_code} %{time_total}",
+        "--max-time", str(CURL_TIMEOUT),
+    ]
+    if methode != "GET":
+        cmd += ["-X", methode]
+    if body is not None:
+        cmd += ["-H", "Content-Type: application/json", "--data", body]
+    cmd.append(url)
+    try:
+        klaar = subprocess.run(cmd, capture_output=True, text=True, timeout=CURL_TIMEOUT + 10)
+    except FileNotFoundError:
+        return {"url": url, "status": None, "seconden": None, "fout": "curl is niet geinstalleerd"}
+    except subprocess.TimeoutExpired:
+        return {"url": url, "status": None, "seconden": None, "fout": "curl liep vast"}
+    if klaar.returncode != 0:
+        fout = (klaar.stderr or "").strip().splitlines()
+        return {
+            "url": url, "status": None, "seconden": None,
+            "fout": fout[-1] if fout else f"curl eindigde met code {klaar.returncode}",
+        }
+    delen = klaar.stdout.split()
+    if len(delen) != 2:
+        return {"url": url, "status": None, "seconden": None, "fout": "curl gaf een onleesbare meting"}
+    try:
+        return {"url": url, "status": int(delen[0]), "seconden": float(delen[1]), "fout": None}
+    except ValueError:
+        return {"url": url, "status": None, "seconden": None, "fout": "curl gaf een onleesbare meting"}
+
+
+def signaal(sleutel: str, naam: str, ernst: str, meting: str, voorstel: str, **details) -> dict:
+    return {
+        "sleutel": sleutel,
+        "naam": naam,
+        "ernst": ernst,
+        "meting": meting,
+        "voorstel": voorstel,
+        "details": details,
+    }
+
+
+# ------------------------------------------------------------------ pull requests
+
+def check_rollup(pr: dict) -> dict:
+    """Tel de checks van een pull request. gh levert CheckRun (conclusion) en
+    StatusContext (state) door elkaar, dus beide lezen."""
+    telling = {"gefaald": [], "loopt": [], "geslaagd": 0, "overgeslagen": 0, "totaal": 0}
+    for check in pr.get("statusCheckRollup") or []:
+        telling["totaal"] += 1
+        naam = check.get("name") or check.get("context") or "naamloze check"
+        staat = (check.get("status") or "").upper()
+        uitkomst = (check.get("conclusion") or check.get("state") or "").upper()
+        if uitkomst in {"FAILURE", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED", "ERROR"}:
+            telling["gefaald"].append(naam)
+        elif uitkomst in {"SUCCESS", "NEUTRAL"}:
+            telling["geslaagd"] += 1
+        elif uitkomst in {"SKIPPED", "CANCELLED"}:
+            telling["overgeslagen"] += 1
+        elif staat in {"IN_PROGRESS", "QUEUED", "WAITING", "PENDING", "REQUESTED"} or not uitkomst:
+            telling["loopt"].append(naam)
+        else:
+            telling["loopt"].append(naam)
+    return telling
+
+
+def signalen_pull_requests(repo: str) -> list[dict]:
+    velden = "number,title,author,createdAt,isDraft,headRefName,url,statusCheckRollup"
+    data, fout = gh_json([
+        "pr", "list", "--repo", repo, "--state", "open", "--limit", "100", "--json", velden,
+    ])
+    if fout is not None:
+        return [signaal(
+            "pull-requests", "open pull requests", ORANJE,
+            f"niet gemeten: {fout}",
+            "Controleer of gh is ingelogd op deze machine en draai het script opnieuw.",
+            bron="gh pr list",
+        )]
+
+    prs = data or []
+    dependabot, mensen = [], []
+    for pr in prs:
+        login = ((pr.get("author") or {}).get("login") or "").lower()
+        (dependabot if "dependabot" in login else mensen).append(pr)
+
+    uit: list[dict] = []
+
+    for pr in sorted(mensen, key=lambda p: p.get("createdAt") or ""):
+        nummer = pr.get("number")
+        leeftijd = uren_geleden(tijdstip(pr.get("createdAt")))
+        telling = check_rollup(pr)
+        titel = (pr.get("title") or "").strip()
+
+        if telling["gefaald"]:
+            ernst = ROOD
+            meting = (
+                f"PR #{nummer} staat {duur(leeftijd)} open, "
+                f"{len(telling['gefaald'])} van {telling['totaal']} checks rood "
+                f"({', '.join(telling['gefaald'][:3])})"
+            )
+            voorstel = f"Repareer de gefaalde checks van PR #{nummer} of sluit hem."
+        elif telling["loopt"]:
+            ernst = ORANJE
+            meting = (
+                f"PR #{nummer} staat {duur(leeftijd)} open, "
+                f"{len(telling['loopt'])} van {telling['totaal']} checks lopen nog"
+            )
+            voorstel = f"Wacht de lopende checks van PR #{nummer} af en beoordeel daarna."
+        elif telling["totaal"] == 0:
+            ernst = ORANJE
+            meting = f"PR #{nummer} staat {duur(leeftijd)} open zonder enige check"
+            voorstel = f"Zoek uit waarom PR #{nummer} geen checks heeft voordat je hem beoordeelt."
+        elif leeftijd is not None and leeftijd > PR_OUD_UREN:
+            ernst = ORANJE
+            meting = (
+                f"PR #{nummer} is groen maar staat al {duur(leeftijd)} open "
+                f"(drempel {PR_OUD_UREN} uur)"
+            )
+            voorstel = f"Merge PR #{nummer} of sluit hem, groen en oud is voorraad."
+        else:
+            ernst = GROEN
+            meting = f"PR #{nummer} is groen en {duur(leeftijd)} oud"
+            voorstel = f"Beoordeel PR #{nummer} wanneer het uitkomt."
+
+        if pr.get("isDraft"):
+            meting += " (concept)"
+
+        uit.append(signaal(
+            f"pr-{nummer}", f"PR #{nummer} {titel[:60]}", ernst, meting, voorstel,
+            nummer=nummer, url=pr.get("url"), branch=pr.get("headRefName"),
+            concept=bool(pr.get("isDraft")),
+            leeftijd_uren=None if leeftijd is None else round(leeftijd, 2),
+            checks={
+                "totaal": telling["totaal"], "geslaagd": telling["geslaagd"],
+                "overgeslagen": telling["overgeslagen"],
+                "gefaald": telling["gefaald"], "loopt": telling["loopt"],
+            },
+            auteur=(pr.get("author") or {}).get("login"),
+            bron="gh pr list --json statusCheckRollup",
+        ))
+
+    # Dependabot als een signaal, niet als tien. De vraag is niet welke update,
+    # de vraag is of er updates staan te wachten en hoe lang al.
+    if not dependabot:
+        uit.append(signaal(
+            "dependabot", "open dependabot-PRs", GROEN,
+            "geen open dependabot-PRs",
+            "Niets doen, de afhankelijkheden zijn bij.",
+            aantal=0, bron="gh pr list --json author",
+        ))
+    else:
+        leeftijden = [uren_geleden(tijdstip(pr.get("createdAt"))) for pr in dependabot]
+        oudste = max([u for u in leeftijden if u is not None], default=None)
+        nummers = [pr.get("number") for pr in dependabot]
+        rood = oudste is not None and oudste > DEPENDABOT_OUD_UREN
+        uit.append(signaal(
+            "dependabot", "open dependabot-PRs", ROOD if rood else ORANJE,
+            f"{len(dependabot)} open, oudste {duur(oudste)} "
+            f"(#{', #'.join(str(n) for n in nummers[:6])})",
+            (
+                "Werk de dependabot-PRs weg, de oudste ligt over de "
+                f"{DEPENDABOT_OUD_UREN // 24} dagen."
+                if rood else
+                "Loop de dependabot-PRs langs en merge wat groen is."
+            ),
+            aantal=len(dependabot), nummers=nummers,
+            oudste_uren=None if oudste is None else round(oudste, 2),
+            bron="gh pr list --json author",
+        ))
+
+    return uit
+
+
+# --------------------------------------------------------------- workflow-runs
+
+def signaal_gefaalde_runs(repo: str) -> dict:
+    velden = "databaseId,workflowName,conclusion,status,createdAt,headBranch,event,url"
+    data, fout = gh_json([
+        "run", "list", "--repo", repo, "--limit", "100", "--json", velden,
+    ])
+    if fout is not None:
+        return signaal(
+            "workflow-runs", f"gefaalde runs laatste {RUNS_VENSTER_UREN} uur", ORANJE,
+            f"niet gemeten: {fout}",
+            "Controleer of gh is ingelogd op deze machine en draai het script opnieuw.",
+            bron="gh run list",
+        )
+
+    gefaald = []
+    for run in data or []:
+        if (run.get("conclusion") or "").lower() not in KAPOT:
+            continue
+        leeftijd = uren_geleden(tijdstip(run.get("createdAt")))
+        if leeftijd is None or leeftijd > RUNS_VENSTER_UREN:
+            continue
+        gefaald.append({
+            "workflow": run.get("workflowName"),
+            "branch": run.get("headBranch"),
+            "event": run.get("event"),
+            "conclusie": run.get("conclusion"),
+            "uren_geleden": round(leeftijd, 2),
+            "url": run.get("url"),
+        })
+
+    if not gefaald:
+        return signaal(
+            "workflow-runs", f"gefaalde runs laatste {RUNS_VENSTER_UREN} uur", GROEN,
+            f"0 gefaalde runs in {RUNS_VENSTER_UREN} uur",
+            "Niets doen, CI is schoon.",
+            aantal=0, bron="gh run list --json conclusion",
+        )
+
+    op_main = [r for r in gefaald if r["branch"] in {"main", "master"}]
+    namen = sorted({r["workflow"] or "onbekend" for r in gefaald})
+    if op_main:
+        ernst, voorstel = ROOD, (
+            f"Zoek uit waarom {op_main[0]['workflow']} op main faalt, main hoort altijd groen te zijn."
+        )
+    else:
+        ernst, voorstel = ORANJE, (
+            "Laat de eigenaar van de branch de gefaalde runs oppakken, main is niet geraakt."
+        )
+    return signaal(
+        "workflow-runs", f"gefaalde runs laatste {RUNS_VENSTER_UREN} uur", ernst,
+        f"{len(gefaald)} gefaalde run{'' if len(gefaald) == 1 else 's'}, "
+        f"{len(op_main)} op main ({', '.join(namen[:4])})",
+        voorstel,
+        aantal=len(gefaald), aantal_op_main=len(op_main), runs=gefaald[:20],
+        bron="gh run list --json conclusion",
+    )
+
+
+# -------------------------------------------------------------------- kanaries
+
+def workflow_map(repo_wortel: str) -> str:
+    return os.path.join(repo_wortel, ".github", "workflows")
+
+
+def lees_workflows(repo_wortel: str) -> list[dict]:
+    """Lees de workflowbestanden en haal er de namen uit die we nodig hebben:
+    de workflownaam, de jobnamen en de stapnamen. Geen YAML-bibliotheek in de
+    standaardbibliotheek, dus dit is een bewust simpele scanner op inspringing.
+    Hij hoeft maar een ding te kunnen: name-regels vinden."""
+    map_pad = workflow_map(repo_wortel)
+    if not os.path.isdir(map_pad):
+        return []
+    bestanden = []
+    for naam in sorted(os.listdir(map_pad)):
+        if not naam.endswith((".yml", ".yaml")):
+            continue
+        pad = os.path.join(map_pad, naam)
+        try:
+            with open(pad, "r", encoding="utf-8") as fh:
+                regels = fh.read().splitlines()
+        except OSError:
+            continue
+        workflow_naam, namen = None, []
+        for regel in regels:
+            treffer = re.match(r"^(\s*)(?:-\s+)?name:\s*(.+?)\s*$", regel)
+            if not treffer:
+                continue
+            inspringing, waarde = len(treffer.group(1)), treffer.group(2).strip()
+            waarde = waarde.strip("'\"")
+            if inspringing == 0 and workflow_naam is None:
+                workflow_naam = waarde
+            namen.append(waarde)
+        bestanden.append({
+            "bestand": naam,
+            "workflow": workflow_naam or naam,
+            "namen": namen,
+        })
+    return bestanden
+
+
+def jobs_van_run(repo: str, run_id: int, cache: dict) -> list[dict]:
+    if run_id in cache:
+        return cache[run_id]
+    data, fout = gh_json(["api", f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100"])
+    jobs = []
+    if fout is None and isinstance(data, dict):
+        jobs = data.get("jobs") or []
+    cache[run_id] = jobs
+    return jobs
+
+
+def signalen_kanaries(repo: str, repo_wortel: str) -> list[dict]:
+    workflows = lees_workflows(repo_wortel)
+    cache_runs: dict[str, list] = {}
+    cache_jobs: dict[int, list] = {}
+    uit: list[dict] = []
+
+    for sleutel, patroon in KANARIES:
+        treffers = [wf for wf in workflows if any(patroon.search(n) for n in wf["namen"])]
+        if not treffers:
+            uit.append(signaal(
+                f"kanarie-{sleutel}", f"kanarie {sleutel}", ORANJE,
+                "geen workflow of stap met deze naam in .github/workflows",
+                f"Bevestig of {sleutel} bewust weg is, en haal hem anders uit dit script.",
+                bron=".github/workflows",
+            ))
+            continue
+
+        wf = treffers[0]
+        bestand = wf["bestand"]
+        if bestand not in cache_runs:
+            data, fout = gh_json([
+                "run", "list", "--repo", repo, "--workflow", bestand, "--limit", "20",
+                "--json", "databaseId,conclusion,status,createdAt,updatedAt,event,url",
+            ])
+            cache_runs[bestand] = [] if fout is not None else (data or [])
+        runs = cache_runs[bestand]
+
+        gevonden = None
+        for run in runs:
+            if (run.get("status") or "") != "completed":
+                continue
+            for job in jobs_van_run(repo, run.get("databaseId"), cache_jobs):
+                for stap in job.get("steps") or []:
+                    if not patroon.search(stap.get("name") or ""):
+                        continue
+                    conclusie = (stap.get("conclusion") or "").lower()
+                    if conclusie in {"", "skipped"}:
+                        continue
+                    gevonden = {
+                        "run_id": run.get("databaseId"),
+                        "url": run.get("url"),
+                        "event": run.get("event"),
+                        "job": job.get("name"),
+                        "stap": stap.get("name"),
+                        "conclusie": conclusie,
+                        "afgerond": stap.get("completed_at") or job.get("completed_at"),
+                        "workflow": bestand,
+                    }
+                    break
+                if gevonden:
+                    break
+            if gevonden:
+                break
+
+        if gevonden is None:
+            uit.append(signaal(
+                f"kanarie-{sleutel}", f"kanarie {sleutel}", ORANJE,
+                f"staat in {bestand} maar heeft in de laatste 20 runs geen uitslag gegeven",
+                f"Start {bestand} handmatig met gh workflow run en kijk of {sleutel} weer meet.",
+                workflow=bestand, bron="gh api actions/runs/<id>/jobs",
+            ))
+            continue
+
+        leeftijd = uren_geleden(tijdstip(gevonden["afgerond"]))
+        conclusie = gevonden["conclusie"]
+        if conclusie in KAPOT:
+            ernst = ROOD
+            voorstel = f"Open de run van {sleutel} en repareer wat er kapot is voordat een klant het merkt."
+        elif leeftijd is not None and leeftijd > KANARIE_ROOD_UREN:
+            ernst = ROOD
+            voorstel = f"De kanarie {sleutel} meet al {duur(leeftijd)} niet meer, zet de geplande run weer aan."
+        elif leeftijd is not None and leeftijd > KANARIE_ORANJE_UREN:
+            ernst = ORANJE
+            voorstel = f"Controleer waarom {sleutel} niet per uur draait, de laatste uitslag is {duur(leeftijd)} oud."
+        elif conclusie == "success":
+            ernst = GROEN
+            voorstel = "Niets doen, de kanarie leeft."
+        else:
+            ernst = ORANJE
+            voorstel = f"Kijk waarom {sleutel} eindigde als {conclusie} in plaats van success."
+
+        uit.append(signaal(
+            f"kanarie-{sleutel}", f"kanarie {sleutel}", ernst,
+            f"{conclusie}, {duur(leeftijd)} geleden (run {gevonden['run_id']}, {bestand})",
+            voorstel,
+            **gevonden,
+            leeftijd_uren=None if leeftijd is None else round(leeftijd, 2),
+            bron="gh api actions/runs/<id>/jobs",
+        ))
+
+    return uit
+
+
+# ------------------------------------------------------------------- productie
+
+def signaal_health() -> dict:
+    meting = curl_meting(PRODUCTIE_HEALTH)
+    if meting["fout"]:
+        return signaal(
+            "productie-health", "productie /health", ROOD,
+            f"onbereikbaar: {meting['fout']}",
+            "Controleer of paramant.app en de relay draaien, productie antwoordt niet.",
+            url=PRODUCTIE_HEALTH, bron="curl",
+        )
+    status, seconden = meting["status"], meting["seconden"]
+    if status == 200:
+        ernst, voorstel = GROEN, "Niets doen, productie antwoordt gezond."
+    elif 200 <= status < 400:
+        ernst, voorstel = ORANJE, f"/health geeft {status} in plaats van 200, kijk of daar een redirect voor staat."
+    else:
+        ernst, voorstel = ROOD, f"/health geeft {status}, behandel productie als down tot het tegendeel blijkt."
+    return signaal(
+        "productie-health", "productie /health", ernst,
+        f"HTTP {status} in {seconden:.2f} s", voorstel,
+        url=PRODUCTIE_HEALTH, status=status, seconden=round(seconden, 3), bron="curl",
+    )
+
+
+def signaal_homepage() -> dict:
+    meting = curl_meting(PRODUCTIE_HOME)
+    if meting["fout"]:
+        return signaal(
+            "productie-homepage", "responstijd homepage", ROOD,
+            f"onbereikbaar: {meting['fout']}",
+            "Controleer de webserver van paramant.app, de homepage laadt niet.",
+            url=PRODUCTIE_HOME, bron="curl",
+        )
+    status, seconden = meting["status"], meting["seconden"]
+    if status >= 400 or status is None:
+        ernst, voorstel = ROOD, f"De homepage geeft {status}, repareer dat voor alles anders."
+    elif seconden > HOMEPAGE_ROOD_S:
+        ernst, voorstel = ROOD, f"De homepage doet er {seconden:.2f} s over, zoek uit wat er traag is."
+    elif seconden > HOMEPAGE_ORANJE_S:
+        ernst, voorstel = ORANJE, f"De homepage zit boven {HOMEPAGE_ORANJE_S:.1f} s, houd de laadtijd in de gaten."
+    else:
+        ernst, voorstel = GROEN, "Niets doen, de homepage laadt snel."
+    return signaal(
+        "productie-homepage", "responstijd homepage", ernst,
+        f"HTTP {status} in {seconden:.2f} s "
+        f"(oranje boven {HOMEPAGE_ORANJE_S:.1f} s, rood boven {HOMEPAGE_ROOD_S:.1f} s)",
+        voorstel,
+        url=PRODUCTIE_HOME, status=status, seconden=round(seconden, 3), bron="curl",
+    )
+
+
+def signalen_paraid_deny() -> list[dict]:
+    uit = []
+    for host in PARAID_HOSTS:
+        url = f"https://{host}{PARAID_DENY_PAD}"
+        meting = curl_meting(url, methode="POST", body="{}")
+        if meting["fout"]:
+            uit.append(signaal(
+                f"paraid-deny-{host}", f"ParaID dicht op {host}", ORANJE,
+                f"niet gemeten: {meting['fout']}",
+                f"Meet {host} opnieuw, zonder antwoord weten we niet of de route dicht is.",
+                url=url, verwacht=404, bron="curl -X POST",
+            ))
+            continue
+        status = meting["status"]
+        if status == 404:
+            ernst = GROEN
+            voorstel = "Niets doen, de route is dicht."
+        elif status in {401, 403, 405, 410}:
+            ernst = ORANJE
+            voorstel = f"{host} geeft {status} in plaats van 404, de route bestaat daar nog in een of andere vorm."
+        else:
+            ernst = ROOD
+            voorstel = f"Sluit {PARAID_DENY_PAD} op {host}, hij antwoordt met {status} en hoort 404 te geven."
+        uit.append(signaal(
+            f"paraid-deny-{host}", f"ParaID dicht op {host}", ernst,
+            f"POST met lege body geeft HTTP {status} in {meting['seconden']:.2f} s (verwacht 404)",
+            voorstel,
+            url=url, status=status, verwacht=404,
+            seconden=round(meting["seconden"], 3), bron="curl -X POST",
+        ))
+    return uit
+
+
+# ---------------------------------------------------------------------- uitvoer
+
+def tekst_rapport(rapport: dict) -> str:
+    samen = rapport["samenvatting"]
+    regels = [
+        f"PARAMANT directiesignalen  {rapport['gegenereerd']}",
+        f"repo {rapport['repo']}",
+        f"rood {samen['rood']}   oranje {samen['oranje']}   groen {samen['groen']}",
+        "",
+    ]
+    op_ernst = sorted(rapport["signalen"], key=lambda s: (ERNST_ORDE[s["ernst"]], s["sleutel"]))
+    for sig in op_ernst:
+        regels.append(f"[{sig['ernst'].upper():<6}] {sig['naam']}")
+        regels.append(f"           meting:   {sig['meting']}")
+        regels.append(f"           voorstel: {sig['voorstel']}")
+        regels.append("")
+    if samen["rood"]:
+        regels.append(f"Er is {samen['rood']} signaal rood, exitcode 1."
+                      if samen["rood"] == 1 else
+                      f"Er zijn {samen['rood']} signalen rood, exitcode 1.")
+    else:
+        regels.append("Niets rood, exitcode 0.")
+    return "\n".join(regels)
+
+
+def repo_wortel() -> str:
+    try:
+        klaar = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=15,
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+        )
+        if klaar.returncode == 0 and klaar.stdout.strip():
+            return klaar.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    # scripts/directie/signalen.py -> twee mappen omhoog is de wortel
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def huidige_repo(wortel: str) -> str:
+    data, fout = gh_json(["repo", "view", "--json", "nameWithOwner"])
+    if fout is None and isinstance(data, dict) and data.get("nameWithOwner"):
+        return data["nameWithOwner"]
+    return "Apolloccrypt/paramant-relay"
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Meet de staat van Paramant en meld wat rood is.",
+    )
+    parser.add_argument("--tekst", action="store_true",
+                        help="leesbare tekst in plaats van JSON")
+    parser.add_argument("--repo", default=None,
+                        help="eigenaar/repo voor gh (standaard: de repo van deze werkkopie)")
+    args = parser.parse_args(argv)
+
+    wortel = repo_wortel()
+    repo = args.repo or huidige_repo(wortel)
+
+    signalen: list[dict] = []
+    signalen += signalen_pull_requests(repo)
+    signalen.append(signaal_gefaalde_runs(repo))
+    signalen += signalen_kanaries(repo, wortel)
+    signalen.append(signaal_health())
+    signalen.append(signaal_homepage())
+    signalen += signalen_paraid_deny()
+
+    samenvatting = {
+        ROOD: sum(1 for s in signalen if s["ernst"] == ROOD),
+        ORANJE: sum(1 for s in signalen if s["ernst"] == ORANJE),
+        GROEN: sum(1 for s in signalen if s["ernst"] == GROEN),
+    }
+    rapport = {
+        "gegenereerd": nu().replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "repo": repo,
+        "wortel": wortel,
+        "samenvatting": samenvatting,
+        "signalen": signalen,
+    }
+
+    if args.tekst:
+        print(tekst_rapport(rapport))
+    else:
+        print(json.dumps(rapport, indent=2, ensure_ascii=False, sort_keys=False))
+
+    return 1 if samenvatting[ROOD] else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except KeyboardInterrupt:
+        sys.exit(130)
+    except Exception as exc:  # noqa: BLE001 - een meetscript mag nooit stil sterven
+        print(f"signalen.py brak af: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/scripts/directie/signalen.py
+++ b/scripts/directie/signalen.py
@@ -429,9 +429,75 @@ def jobs_van_run(repo: str, run_id: int, cache: dict) -> list[dict]:
     return jobs
 
 
+def kanarie_runs(repo: str, bestand: str, cache: dict, breed: bool = False) -> list[dict]:
+    """De runs waarin een kanarie een uitslag kan hebben gegeven.
+
+    De kanaries hangen in de live-job, en die draait alleen op schedule en op
+    workflow_dispatch. Een kale --limit 20 bestaat op een drukke dag bijna
+    helemaal uit pull_request-runs waarin de kanariestappen zijn overgeslagen,
+    en dan wordt een levende kanarie vals oranje gemeld. Daarom eerst die twee
+    eventlijsten. Het brede net (limiet 50, alle events) is de terugval voor
+    het geval een kanarie ooit ergens anders gaat draaien, en wordt alleen
+    getrokken als de eerste ronde niets oplevert."""
+    sleutel = (bestand, breed)
+    if sleutel in cache:
+        return cache[sleutel]
+    velden = "databaseId,conclusion,status,createdAt,updatedAt,event,url"
+    vragen = (
+        [["--limit", "50"]] if breed else
+        [["--event", "schedule", "--limit", "25"],
+         ["--event", "workflow_dispatch", "--limit", "25"]]
+    )
+    gezien: set = set()
+    runs: list[dict] = []
+    for extra in vragen:
+        data, fout = gh_json([
+            "run", "list", "--repo", repo, "--workflow", bestand,
+            *extra, "--json", velden,
+        ])
+        if fout is not None:
+            continue
+        for run in data or []:
+            nummer = run.get("databaseId")
+            if nummer in gezien:
+                continue
+            gezien.add(nummer)
+            runs.append(run)
+    runs.sort(key=lambda r: r.get("createdAt") or "", reverse=True)
+    cache[sleutel] = runs
+    return runs
+
+
+def zoek_uitslag(repo: str, patroon, runs: list[dict], bestand: str, cache_jobs: dict) -> dict | None:
+    """De jongste afgeronde run waarin de stap echt een uitslag gaf. Een
+    overgeslagen stap telt niet: die zegt alleen dat de job niet aan de beurt
+    was, niet dat de kanarie leeft."""
+    for run in runs:
+        if (run.get("status") or "") != "completed":
+            continue
+        for job in jobs_van_run(repo, run.get("databaseId"), cache_jobs):
+            for stap in job.get("steps") or []:
+                if not patroon.search(stap.get("name") or ""):
+                    continue
+                conclusie = (stap.get("conclusion") or "").lower()
+                if conclusie in {"", "skipped"}:
+                    continue
+                return {
+                    "run_id": run.get("databaseId"),
+                    "url": run.get("url"),
+                    "event": run.get("event"),
+                    "job": job.get("name"),
+                    "stap": stap.get("name"),
+                    "conclusie": conclusie,
+                    "afgerond": stap.get("completed_at") or job.get("completed_at"),
+                    "workflow": bestand,
+                }
+    return None
+
+
 def signalen_kanaries(repo: str, repo_wortel: str) -> list[dict]:
     workflows = lees_workflows(repo_wortel)
-    cache_runs: dict[str, list] = {}
+    cache_runs: dict = {}
     cache_jobs: dict[int, list] = {}
     uit: list[dict] = []
 
@@ -446,47 +512,20 @@ def signalen_kanaries(repo: str, repo_wortel: str) -> list[dict]:
             ))
             continue
 
-        wf = treffers[0]
-        bestand = wf["bestand"]
-        if bestand not in cache_runs:
-            data, fout = gh_json([
-                "run", "list", "--repo", repo, "--workflow", bestand, "--limit", "20",
-                "--json", "databaseId,conclusion,status,createdAt,updatedAt,event,url",
-            ])
-            cache_runs[bestand] = [] if fout is not None else (data or [])
-        runs = cache_runs[bestand]
-
-        gevonden = None
-        for run in runs:
-            if (run.get("status") or "") != "completed":
-                continue
-            for job in jobs_van_run(repo, run.get("databaseId"), cache_jobs):
-                for stap in job.get("steps") or []:
-                    if not patroon.search(stap.get("name") or ""):
-                        continue
-                    conclusie = (stap.get("conclusion") or "").lower()
-                    if conclusie in {"", "skipped"}:
-                        continue
-                    gevonden = {
-                        "run_id": run.get("databaseId"),
-                        "url": run.get("url"),
-                        "event": run.get("event"),
-                        "job": job.get("name"),
-                        "stap": stap.get("name"),
-                        "conclusie": conclusie,
-                        "afgerond": stap.get("completed_at") or job.get("completed_at"),
-                        "workflow": bestand,
-                    }
-                    break
-                if gevonden:
-                    break
-            if gevonden:
-                break
+        bestand = treffers[0]["bestand"]
+        gevonden = zoek_uitslag(
+            repo, patroon, kanarie_runs(repo, bestand, cache_runs), bestand, cache_jobs,
+        )
+        if gevonden is None:
+            gevonden = zoek_uitslag(
+                repo, patroon,
+                kanarie_runs(repo, bestand, cache_runs, breed=True), bestand, cache_jobs,
+            )
 
         if gevonden is None:
             uit.append(signaal(
                 f"kanarie-{sleutel}", f"kanarie {sleutel}", ORANJE,
-                f"staat in {bestand} maar heeft in de laatste 20 runs geen uitslag gegeven",
+                f"staat in {bestand} maar gaf in geen van de recente runs een uitslag",
                 f"Start {bestand} handmatig met gh workflow run en kijk of {sleutel} weer meet.",
                 workflow=bestand, bron="gh api actions/runs/<id>/jobs",
             ))
@@ -557,7 +596,7 @@ def signaal_homepage() -> dict:
             url=PRODUCTIE_HOME, bron="curl",
         )
     status, seconden = meting["status"], meting["seconden"]
-    if status >= 400 or status is None:
+    if status is None or status >= 400:
         ernst, voorstel = ROOD, f"De homepage geeft {status}, repareer dat voor alles anders."
     elif seconden > HOMEPAGE_ROOD_S:
         ernst, voorstel = ROOD, f"De homepage doet er {seconden:.2f} s over, zoek uit wat er traag is."


### PR DESCRIPTION
Een meetscript zonder model dat in een oogopslag laat zien wat rood is.
`scripts/directie/signalen.py` stelt een vaste lijst vragen aan GitHub (via
`gh`) en aan productie (via `curl`), en geeft per vraag een ernst, een meting
en een voorstel van een zin. JSON naar stdout, leesbare tekst met `--tekst`,
exitcode 1 als er iets rood is.

## Wat het meet

- Elke open pull request: check-status en leeftijd in uren.
- Open dependabot-PRs als een signaal, met de leeftijd van de oudste.
- Gefaalde workflow-runs van de laatste 24 uur. Rood alleen als main geraakt is.
- De laatste uitkomst van de drie kanaries met tijdstip. Ze zijn geen losse
  workflows maar stappen in de live-job van `product-heartbeat.yml`, dus het
  script zoekt ze op naam in `.github/workflows`. Het kijkt daarbij eerst naar
  de `schedule`- en `workflow_dispatch`-runs, want alleen daar draait de
  live-job; een kale lijst van de laatste twintig runs bestaat op een drukke dag
  bijna helemaal uit pull-request-runs waarin de kanariestappen zijn
  overgeslagen. Levert dat niets op, dan volgt een breed net over alle events.
  Verhuist een kanarie naar een eigen workflow, dan blijft dat werken.
  Verdwijnt hij, dan wordt het signaal oranje in plaats van stil groen.
- Statuscode van `https://paramant.app/health` en de responstijd van de homepage.
- De zes ParaID-deny-ingangen: `POST` met lege JSON-body naar
  `/v1/paraid/issue-document` moet op alle zes de hosts 404 geven.

Een signaal dat niet gemeten kon worden is oranje, nooit groen. De drempels
staan als constanten bovenaan het bestand.

Geen extra afhankelijkheden: Python 3 standaardbibliotheek plus `gh` en `curl`.
Een volledige run duurde hier 12 tot 17 seconden over vier runs, vrijwel
helemaal wachten op GitHub. `docs/directie.md` legt uit wat elk signaal meet en
wanneer het rood wordt.

## Getest

- `python3 -m py_compile scripts/directie/signalen.py`
- Echte runs tegen deze repo en tegen productie (laatste uitvoer hieronder).
- Foutpad: met `--repo` naar een niet bestaande repo worden de GitHub-signalen
  oranje met "niet gemeten" in plaats van dat het script sterft.
- Rood pad: met `/health` naar een 404-pad gaat het signaal rood en eindigt het
  script met exitcode 1. In een eerdere run hier ving het script ook een echt
  rood signaal: `sign-e2e` faalde toen op PR #328.

## Uitvoer van `python3 scripts/directie/signalen.py --tekst`

```
PARAMANT directiesignalen  2026-09-02T14:07:55Z
repo Apolloccrypt/paramant-relay
rood 0   oranje 2   groen 17

[ORANJE] open dependabot-PRs
           meting:   1 open, oudste 6.7 dagen (#313)
           voorstel: Loop de dependabot-PRs langs en merge wat groen is.

[ORANJE] gefaalde runs laatste 24 uur
           meting:   1 gefaalde run, 0 op main (sign-e2e)
           voorstel: Laat de eigenaar van de branch de gefaalde runs oppakken, main is niet geraakt.

[GROEN ] kanarie heartbeat
           meting:   success, 2.7 uur geleden (run 33624449015, product-heartbeat.yml)
           voorstel: Niets doen, de kanarie leeft.

[GROEN ] kanarie parasign-kanarie
           meting:   success, 2.7 uur geleden (run 33624449015, product-heartbeat.yml)
           voorstel: Niets doen, de kanarie leeft.

[GROEN ] kanarie transfer-kanarie
           meting:   success, 2.7 uur geleden (run 33624449015, product-heartbeat.yml)
           voorstel: Niets doen, de kanarie leeft.

[GROEN ] ParaID dicht op finance.paramant.app
           meting:   POST met lege body geeft HTTP 404 in 0.08 s (verwacht 404)
           voorstel: Niets doen, de route is dicht.

[GROEN ] ParaID dicht op health.paramant.app
           meting:   POST met lege body geeft HTTP 404 in 0.07 s (verwacht 404)
           voorstel: Niets doen, de route is dicht.

[GROEN ] ParaID dicht op iot.paramant.app
           meting:   POST met lege body geeft HTTP 404 in 0.07 s (verwacht 404)
           voorstel: Niets doen, de route is dicht.

[GROEN ] ParaID dicht op legal.paramant.app
           meting:   POST met lege body geeft HTTP 404 in 0.06 s (verwacht 404)
           voorstel: Niets doen, de route is dicht.

[GROEN ] ParaID dicht op paramant.app
           meting:   POST met lege body geeft HTTP 404 in 0.07 s (verwacht 404)
           voorstel: Niets doen, de route is dicht.

[GROEN ] ParaID dicht op relay.paramant.app
           meting:   POST met lege body geeft HTTP 404 in 0.06 s (verwacht 404)
           voorstel: Niets doen, de route is dicht.

[GROEN ] PR #325 Give ParaSign a product page at /parasign so the signing pro
           meting:   PR #325 is groen en 42 min oud
           voorstel: Beoordeel PR #325 wanneer het uitkomt.

[GROEN ] PR #326 Keep the recurring billing layer off until BILLING_MODE says
           meting:   PR #326 is groen en 38 min oud
           voorstel: Beoordeel PR #326 wanneer het uitkomt.

[GROEN ] PR #327 Pin the site's ten heaviest claims to the code that makes th
           meting:   PR #327 is groen en 37 min oud
           voorstel: Beoordeel PR #327 wanneer het uitkomt.

[GROEN ] PR #328 Homepage speaks to a buyer: what it does, what it costs, why
           meting:   PR #328 is groen en 18 min oud
           voorstel: Beoordeel PR #328 wanneer het uitkomt.

[GROEN ] PR #329 Build the crypto binding on rust:1.98-alpine by adopting the
           meting:   PR #329 is groen en 14 min oud
           voorstel: Beoordeel PR #329 wanneer het uitkomt.

[GROEN ] PR #330 feat(directie): a signals script that says what is red, with
           meting:   PR #330 is groen en 10 min oud
           voorstel: Beoordeel PR #330 wanneer het uitkomt.

[GROEN ] productie /health
           meting:   HTTP 200 in 0.07 s
           voorstel: Niets doen, productie antwoordt gezond.

[GROEN ] responstijd homepage
           meting:   HTTP 200 in 0.10 s (oranje boven 1.0 s, rood boven 2.5 s)
           voorstel: Niets doen, de homepage laadt snel.

Niets rood, exitcode 0.
```
