### PR TITLE
Signed in, the free plan is called Community, and the page answers what a buyer asks

### DIFF
--- a/frontend/about.html
+++ b/frontend/about.html
@@ -166,6 +166,7 @@
     <h2 style="margin-top:var(--space-2)">Behind Paramant</h2>
     <div class="person-card">
       <p>Paramant is a product of <strong>Paramantis Solutions B.V.</strong> in Harderwijk, the Netherlands, founded by Mick Beer, privacy and security researcher. Paramantis Solutions B.V. is the contracting and responsible party; the founder is the origin of the work, not the service itself.</p>
+      <p>The Community plan is his way of giving something back to society; the business plans pay for it. That is the whole arrangement, and it is why the Community plan is not a trial and has no end date.</p>
       <p>That background shapes the choices: post-quantum signatures (ML-DSA-65), a public transparency log, offline-verifiable documents, and source code you can inspect yourself. You do not have to take us at our word, you can verify it. The code is source-available and the transparency log is public: the product stands apart from the person and stays checkable.</p>
     </div>
   </div>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -22,6 +22,22 @@
 <meta name="twitter:description" content="Your account — Paramant">
 <link rel="canonical" href="https://paramant.app/account">
 <style>
+/* Plan bands in the billing section: what this plan is, in one line. The
+   Community band is dark like the dashboard band so the same message reads as
+   the same message on both pages. */
+.acct-plan-band { border-radius: 10px; padding: 18px 20px; margin: 0 0 20px; }
+.acct-plan-band.free { background: #0a1626; box-shadow: inset 0 0 0 1px rgba(178,255,63,.18); }
+.acct-plan-band.paid { background: rgba(255,255,255,.76); border: 1px solid rgba(11,58,106,.09); }
+.acct-plan-kicker { margin: 0 0 8px; font-family: IBM Plex Mono, monospace; font-size: 11px; letter-spacing: .16em; text-transform: uppercase; }
+.acct-plan-band.free .acct-plan-kicker { color: #B2FF3F; }
+.acct-plan-band.paid .acct-plan-kicker { color: #1D4ED8; }
+.acct-plan-lede { margin: 0 0 10px; font-size: 15px; line-height: 1.6; }
+.acct-plan-band.free .acct-plan-lede { color: #F8FAFC; }
+.acct-plan-band.paid .acct-plan-lede { color: #0B3A6A; }
+.acct-plan-adds { margin: 0 0 14px; font-size: 13px; line-height: 1.6; color: rgba(248,250,252,.72); }
+.acct-plan-band.free a.acct-plan-cta { display: inline-block; font-family: IBM Plex Mono, monospace; font-size: 12px; letter-spacing: .06em; text-transform: uppercase; color: #0a1626; background: #B2FF3F; text-decoration: none; padding: 10px 16px; border-radius: 4px; }
+.acct-plan-band.free a.acct-plan-cta:hover { background: #F8FAFC; }
+.acct-plan-band.free .acct-plan-lede a { color: #B2FF3F; }
 .nav-help {
   display: inline-flex;
   align-items: center;
@@ -296,6 +312,21 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
   <div id="billing-loading" style="color:var(--ink-dim);font-size:var(--text-sm)">Loading billing status…</div>
 
   <div id="billing-content" class="hidden">
+    <!-- Shown by js/account.inline1.js only while the account pays for neither
+         product. Same message the dashboard leads with: Community is given, the
+         business plans pay for it, and one link is the whole upgrade path. -->
+    <div class="acct-plan-band free" id="billing-community" hidden>
+      <p class="acct-plan-kicker">Community &middot; &euro;0</p>
+      <p class="acct-plan-lede">You are on the Community plan and it stays free. It is Mick Beer, privacy and security researcher and founder of Paramantis Solutions B.V., giving something back to society; the business plans pay for it.</p>
+      <p class="acct-plan-adds">They raise 2 signatures a month to 100 or 1,000, keep links open longer, keep a record of what you sent, give you support with a name on it, and an audit trail you can export and hand over.</p>
+      <a class="acct-plan-cta" href="/pricing">See the business plans &rarr;</a>
+    </div>
+    <!-- Shown on a paid plan. No link to a higher tier: a customer who pays is
+         reading his own subscription, not an offer. -->
+    <div class="acct-plan-band paid" id="billing-paid" hidden>
+      <p class="acct-plan-kicker">Your subscription &middot; active</p>
+      <p class="acct-plan-lede">Thank you. Your subscription is what keeps the Community plan free for everyone else. Your plan, renewal date and invoices are below.</p>
+    </div>
     <div class="info-row">
       <div class="info-label">Current plan</div>
       <div class="info-value">
@@ -337,7 +368,7 @@ main.acct { max-width: 880px; margin: 0 auto; padding: var(--space-6) var(--spac
 
 <script src="/nav.js?v=14" defer></script>
 <script src="/js/nav-auth.js?v=5" defer></script>
-<script src="/js/account.inline1.js?v=1"></script>
+<script src="/js/account.inline1.js?v=2"></script>
 
 <script type="module" src="/js/account.inline2.js?v=2"></script>
 <script type="module" src="/js/passkey.js?v=3"></script>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -47,6 +47,25 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
 .dh-community-cta { flex: 0 0 auto; font-family: var(--mono); font-size: 12px; letter-spacing: .06em; text-transform: uppercase; color: #0a1626; background: #B2FF3F; text-decoration: none; padding: 10px 16px; border-radius: 4px; }
 .dh-community-cta:hover { background: #F8FAFC; }
 .dh-start-kicker { display: block; margin-bottom: 6px; font-family: var(--mono); font-size: 10px; letter-spacing: .16em; text-transform: uppercase; opacity: .75; }
+.dh-paid { border: 1px solid rgba(11,58,106,.09); border-radius: 10px; background: rgba(255,255,255,.76); padding: var(--space-4) var(--space-5); margin-bottom: var(--space-6); }
+.dh-paid-kicker { margin: 0 0 var(--space-2); font-family: var(--mono); font-size: 11px; letter-spacing: .16em; text-transform: uppercase; color: var(--cobalt); }
+.dh-paid-lede { margin: 0 0 var(--space-2); font: 15px/1.6 var(--sans); color: var(--ink); }
+.dh-paid-foot { margin: 0; font: 13px/1.6 var(--sans); color: var(--ink-dim); }
+.dh-paid-foot a { color: var(--cobalt); }
+
+/* Buyer questions -- the three things someone asks before he trusts this with
+   a contract, each answered in one line that links to the page that proves it. */
+.dh-ask { border: 1px solid rgba(11,58,106,.09); border-radius: 18px; background: rgba(255,255,255,.72); padding: var(--space-5); margin-bottom: var(--space-7); }
+.dh-ask h2 { margin: 0 0 var(--space-4); font: 600 18px/1.25 var(--sans); letter-spacing: -.01em; color: var(--ink); }
+.dh-ask-list { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: var(--space-4); margin: 0 0 var(--space-4); }
+.dh-ask-item { margin: 0; }
+.dh-ask-item dt { margin: 0 0 4px; font: 600 15px/1.35 var(--sans); color: var(--ink); }
+.dh-ask-item dd { margin: 0; font: 14px/1.55 var(--sans); color: var(--ink-dim); }
+.dh-ask-item dd a { color: var(--cobalt); font-weight: 600; text-decoration: none; }
+.dh-ask-item dd a:hover { text-decoration: underline; text-underline-offset: 3px; }
+.dh-ask-foot { margin: 0; padding-top: var(--space-3); border-top: 1px solid var(--ink-hair); font: 14px/1.55 var(--sans); color: var(--ink-dim); }
+.dh-ask-foot a { color: var(--cobalt); font-weight: 600; text-decoration: none; }
+.dh-ask-foot a:hover { text-decoration: underline; text-underline-offset: 3px; }
 
 /* Onboarding hint (ParaPear, dismissible once) */
 .dh-onb { display: flex; align-items: center; gap: var(--space-4); padding: var(--space-3) var(--space-5); border-radius: 16px; background: var(--bone); border: 1px solid var(--ink-hair); margin-bottom: var(--space-5); box-shadow: 0 1px 2px rgba(11,58,106,0.04); }
@@ -153,6 +172,16 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
 @media (max-width: 760px) {
   .dh-start { grid-template-columns: 1fr; }
   .dh-start-card { min-height: 148px; }
+  /* Two flagship products first, at full size. The third card is the same
+     action in a smaller shape, so a phone reads Sign and Send before it reads
+     anything else. */
+  .dh-start-card:nth-child(-n+2) h2 { font-size: 22px; }
+  .dh-start-card:nth-child(n+3) { min-height: 0; padding: 16px 18px; border-radius: 14px; }
+  .dh-start-card:nth-child(n+3) .dh-start-icon { width: 30px; height: 30px; font-size: 16px; border-radius: 9px; }
+  .dh-start-card:nth-child(n+3) h2 { margin: 12px 0 4px; font-size: 16px; }
+  .dh-start-card:nth-child(n+3) p { font-size: 13px; }
+  .dh-start-card:nth-child(n+3) .dh-start-link { margin-top: 10px; }
+  .dh-ask { padding: var(--space-4); }
   .dh-document { grid-template-columns: minmax(0,1fr) auto; gap: 12px; padding: 16px 18px; }
   .dh-document-progress { grid-column: 1 / -1; display: flex; align-items: center; gap: 10px; }
   .dh-document-progress span { margin: 0; }
@@ -304,6 +333,30 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
       <span class="dh-plan"><strong data-dh="plan-strong">--</strong><span>plan</span></span>
     </header>
 
+    <section class="dh-start" aria-label="Start a document workflow">
+      <a class="dh-start-card primary" href="/sign?mode=invite" aria-label="Request signatures">
+        <span class="dh-start-icon" aria-hidden="true">&#9993;</span>
+        <span class="dh-start-kicker">ParaSign</span>
+        <h2>Request signatures</h2>
+        <p>Send a secure document, invite the right people and follow every signature. They sign with the link from that email and need no account.</p>
+        <span class="dh-start-link">Start a request &rarr;</span>
+      </a>
+      <a class="dh-start-card" href="/parashare" aria-label="Send a file securely">
+        <span class="dh-start-icon" aria-hidden="true">&uarr;</span>
+        <span class="dh-start-kicker">ParaSend</span>
+        <h2>Send a file that disappears</h2>
+        <p>The file is encrypted in your browser before it leaves. The recipient gets one link, and the file is gone the moment it has been read. No signature workflow attached.</p>
+        <span class="dh-start-link">Send a file &rarr;</span>
+      </a>
+      <a class="dh-start-card" href="/sign?mode=alone" aria-label="Sign a document yourself">
+        <span class="dh-start-icon" aria-hidden="true">&#9998;</span>
+        <span class="dh-start-kicker">ParaSign</span>
+        <h2>Sign it yourself</h2>
+        <p>Add your signature and download the result immediately.</p>
+        <span class="dh-start-link">Open signing &rarr;</span>
+      </a>
+    </section>
+
     <!-- The one thing a free account should be told, in the words the homepage
          uses: this is the Community plan, it is a gift and not a trial, and the
          business plans are what pays for it. Shown by dashboard.js only while
@@ -311,10 +364,19 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
     <aside class="dh-community" id="dh-community" aria-label="Your plan" hidden>
       <div>
         <p class="dh-community-kicker">Community &middot; &euro;0</p>
-        <p class="dh-community-lede">You are on the Community plan, and it stays free. It is Paramant's contribution back: signing and sending that does not route through an American cloud. Same name on <a href="/pricing">the pricing page</a>.</p>
-        <p class="dh-community-adds">The business plans add volume (100 or 1,000 signatures a month instead of 2), longer link expiry, send history and webhooks, named support, an exportable audit log, and on Enterprise a dedicated relay with a signed DPA.</p>
+        <p class="dh-community-lede">You are on the Community plan and it stays free. It is Mick Beer, privacy and security researcher and founder of Paramantis Solutions B.V., giving something back to society; the business plans pay for it.</p>
+        <p class="dh-community-adds">They raise 2 signatures a month to 100 or 1,000, keep links open longer, keep a record of what you sent, give you support with a name on it, and an audit trail you can export and hand over.</p>
       </div>
       <a class="dh-community-cta" href="/pricing">See the business plans &rarr;</a>
+    </aside>
+
+    <!-- What a paying customer bought, in the words /pricing sells it in. Shown
+         by dashboard.js only on Pro, Business or Enterprise, and it carries no
+         link to a higher tier: someone who already pays is not a lead. -->
+    <aside class="dh-paid" id="dh-plan-paid" aria-label="Your plan" hidden>
+      <p class="dh-paid-kicker"><span data-dh="paid-name">--</span> plan &middot; active</p>
+      <p class="dh-paid-lede" data-dh="paid-includes">--</p>
+      <p class="dh-paid-foot">Your subscription and invoices are under <a href="/account#billing-section">Plan &amp; billing</a>.</p>
     </aside>
 
     <!-- One-time question: shown by dashboard.js only while /api/user/me returns
@@ -336,35 +398,11 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
       </div>
     </aside>
 
-    <section class="dh-start" aria-label="Start a document workflow">
-      <a class="dh-start-card primary" href="/sign?mode=invite" aria-label="Request signatures">
-        <span class="dh-start-icon" aria-hidden="true">&#9993;</span>
-        <span class="dh-start-kicker">ParaSign</span>
-        <h2>Request signatures</h2>
-        <p>Send a secure document, invite the right people and follow every signature. They sign with the link from that email and need no account.</p>
-        <span class="dh-start-link">Start a request &rarr;</span>
-      </a>
-      <a class="dh-start-card" href="/parashare" aria-label="Send a file securely">
-        <span class="dh-start-icon" aria-hidden="true">&uarr;</span>
-        <span class="dh-start-kicker">ParaSend</span>
-        <h2>Send a file that disappears</h2>
-        <p>Encrypted in your browser, held in RAM, burned on the first read. No signature workflow attached.</p>
-        <span class="dh-start-link">Send a file &rarr;</span>
-      </a>
-      <a class="dh-start-card" href="/sign?mode=alone" aria-label="Sign a document yourself">
-        <span class="dh-start-icon" aria-hidden="true">&#9998;</span>
-        <span class="dh-start-kicker">ParaSign</span>
-        <h2>Sign it yourself</h2>
-        <p>Add your signature and download the result immediately.</p>
-        <span class="dh-start-link">Open signing &rarr;</span>
-      </a>
-    </section>
-
     <section class="dh-workspace" aria-labelledby="dh-documents-title">
       <div class="dh-workspace-head">
         <div>
           <h2 id="dh-documents-title">Open documents</h2>
-          <p>Signing requests you created, with the status the relay actually reports.</p>
+          <p>Every signing request you started, and exactly how far each one is.</p>
         </div>
         <button class="dh-refresh" type="button" id="dh-documents-refresh">Refresh</button>
       </div>
@@ -389,6 +427,28 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
         <div class="dh-doc-dialog-body" id="dh-document-dialog-body"></div>
       </div>
     </div>
+
+    <!-- The three questions someone asks before he puts a real contract through
+         this. Each answer links to the page that carries the proof, so nothing
+         here is a claim this file has to be trusted on. -->
+    <section class="dh-ask" aria-labelledby="dh-ask-title">
+      <h2 id="dh-ask-title">Questions people ask before they trust this</h2>
+      <dl class="dh-ask-list">
+        <div class="dh-ask-item">
+          <dt>What does it cost?</dt>
+          <dd>Community is free forever, with no card. Paid plans start at &euro;15 a month excl. btw, which is ParaSend Pro. <a href="/pricing">See the plans</a></dd>
+        </div>
+        <div class="dh-ask-item">
+          <dt>Who can read what I send?</dt>
+          <dd>Files are encrypted in your browser, and the relay runs on Hetzner in Nuremberg, Germany. <a href="/security">Read how</a></dd>
+        </div>
+        <div class="dh-ask-item">
+          <dt>Can the other side check a signature?</dt>
+          <dd>Signed documents verify without an account. Older envelope formats need the relay. <a href="/verify">Try the verifier</a></dd>
+        </div>
+      </dl>
+      <p class="dh-ask-foot">Anything else is answered in the <a href="/help">help centre</a>.</p>
+    </section>
 
     <nav class="dh-quiet-links" aria-label="Other document actions">
       <a href="/verify">Verify a signed document</a>
@@ -471,6 +531,6 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
 
 <script src="/nav.js?v=14" defer></script>
 <script src="/js/nav-auth.js?v=5" defer></script>
-<script src="/js/dashboard.js?v=5" defer></script>
+<script src="/js/dashboard.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/js/account.inline1.js
+++ b/frontend/js/account.inline1.js
@@ -1,5 +1,83 @@
 
 (function() {
+  // Plan resolution, the same shape js/dashboard.js uses, because a customer
+  // who wants to know what he pays comes here rather than to the dashboard and
+  // must not read a different answer. relay/lib/tiers.js is the declared single
+  // source of truth: TIER_LIMITS holds the canonical rows and normalisePlan
+  // folds every other ID onto one of them ('free' and 'dev' to community,
+  // 'licensed' to enterprise, anything unknown to community). That last rule is
+  // why 'standard', which the API returns for a record with no plan at all,
+  // resolves to Community instead of printing a machine string on the page.
+  // tests/ui-truthfulness.test.mjs reads the rows and aliases out of tiers.js
+  // and fails if this drifts from it.
+  var PLAN_ALIASES = { free: 'community', dev: 'community', licensed: 'enterprise' };
+  var PLAN_NAMES = {
+    community: 'Community',
+    pro:       'Pro',
+    business:  'Business',
+    enterprise:'Enterprise',
+  };
+
+  function normalisePlan(plan) {
+    var id = String(plan == null ? '' : plan).toLowerCase();
+    if (PLAN_ALIASES[id]) return PLAN_ALIASES[id];
+    return PLAN_NAMES[id] ? id : 'community';
+  }
+
+  // Per-product ladders, lowest first. Mirrors PARASEND_TIERS / PARASIGN_TIERS
+  // in relay/lib/entitlements.js, where the two products do NOT share a floor:
+  // PARASEND_TIERS starts at 'community' and PARASIGN_TIERS at 'free'. Both
+  // words therefore have to count as unpaid.
+  // Only the rungs you can pay for. The two products do NOT share a floor in
+  // relay/lib/entitlements.js: PARASEND_TIERS starts at 'community' and
+  // PARASIGN_TIERS at 'free'. Rather than list both floor words and hope the
+  // list stays complete, this reads the other way round and fails closed: a
+  // tier counts as paid only when it is one of these three. A floor word, a
+  // renamed tier or a typo all come out unpaid, which is the safe direction.
+  var PRODUCT_LADDER = ['pro', 'business', 'enterprise'];
+  var PRODUCT_NAMES = { pro: 'Pro', business: 'Business', enterprise: 'Enterprise' };
+
+  // A product tier counts as paid only while its period still runs, the rule
+  // effectiveProductTier() applies server-side: the floor tier never expires,
+  // and a missing paid_until means no period was ever recorded.
+  function paidProductTier(tier, paidUntil) {
+    var t = String(tier || 'free').toLowerCase();
+    if (PRODUCT_LADDER.indexOf(t) < 0) return null;
+    if (!paidUntil) return t;
+    var ends = Date.parse(paidUntil);
+    if (!isNaN(ends) && Date.now() >= ends) return null;
+    return t;
+  }
+
+  // The highest tier this account actually pays for, across both products, or
+  // null when it pays for neither. A self-serve purchase moves one product
+  // ladder and leaves the unified plan on community, so testing the unified
+  // plan alone showed a paying customer the free band and the upgrade link.
+  function topPaidTier(data) {
+    var top = null;
+    var tiers = [
+      paidProductTier(data.plan_parasign, data.paid_until_parasign),
+      paidProductTier(data.plan_parasend, data.paid_until_parasend)
+    ];
+    for (var i = 0; i < tiers.length; i++) {
+      if (tiers[i] && (!top || PRODUCT_LADDER.indexOf(tiers[i]) > PRODUCT_LADDER.indexOf(top))) top = tiers[i];
+    }
+    return top;
+  }
+
+  // The name to put on screen: the unified plan, unless a product purchase
+  // outranks it while the unified plan is still the free row.
+  function planName(data, plan) {
+    var id = normalisePlan(plan);
+    var top = topPaidTier(data);
+    if (top && id === 'community') return PRODUCT_NAMES[top] || PLAN_NAMES[id];
+    return PLAN_NAMES[id];
+  }
+
+  function isFreeAccount(data, plan) {
+    return normalisePlan(plan) === 'community' && !topPaidTier(data);
+  }
+
   function show(id) {
     document.querySelectorAll('[id^="state-"]').forEach(function(el) {
       el.classList.add('hidden');
@@ -17,9 +95,9 @@
       const data = await res.json();
       document.getElementById('account-email').textContent = data.email;
       document.getElementById('api-key').textContent = data.api_key_masked;
-      document.getElementById('plan').textContent = data.plan;
+      document.getElementById('plan').textContent = planName(data, data.plan);
       var planChip = document.getElementById('plan-chip');
-      if (planChip) planChip.textContent = data.plan;
+      if (planChip) planChip.textContent = planName(data, data.plan);
       document.getElementById('label').textContent = data.label || '—';
       document.getElementById('created').textContent = data.created_at ? new Date(data.created_at).toLocaleDateString() : 'Unknown';
       document.getElementById('backup-count').textContent = data.backup_codes_remaining;
@@ -164,11 +242,26 @@
       document.getElementById('billing-content').classList.remove('hidden');
 
       const planEl = document.getElementById('billing-plan');
-      planEl.textContent = d.current_plan.charAt(0).toUpperCase() + d.current_plan.slice(1);
-      if (d.current_plan !== 'community') {
+      planEl.textContent = planName(d, d.current_plan);
+      // Paying is not one string. ParaSend's floor tier is 'community' and
+      // ParaSign's is 'free' (relay/lib/entitlements.js), the API answers
+      // 'standard' for a record with no plan at all, and a self-serve purchase
+      // moves only its own product ladder while the unified plan stays on
+      // community. Comparing against 'community' therefore both offered a free
+      // account a Cancel button for a subscription it does not have, and hid
+      // the badge from a customer who really was paying.
+      const free = isFreeAccount(d, d.current_plan);
+      if (!free) {
         document.getElementById('billing-active-badge').classList.remove('hidden');
         document.getElementById('billing-cancel-btn').classList.remove('hidden');
       }
+      // One calm line about what this plan is. On Community it says whose gift
+      // it is and what the paid plans add, with a single way up. On a paid plan
+      // it says what was bought and stops there.
+      const band = document.getElementById('billing-community');
+      if (band) band.hidden = !free;
+      const bought = document.getElementById('billing-paid');
+      if (bought) bought.hidden = free;
       if (d.next_billing_date) {
         document.getElementById('billing-next-row').style.display = 'flex';
         document.getElementById('billing-next').textContent = new Date(d.next_billing_date).toLocaleDateString();

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -84,8 +84,16 @@
 
   // Per-product ladders, lowest first, so the badge can show the highest tier a
   // customer actually pays for. Mirrors PARASEND_TIERS / PARASIGN_TIERS in
-  // relay/lib/entitlements.js; 'free' is the floor of both.
-  var PRODUCT_LADDER = ['free', 'pro', 'business', 'enterprise'];
+  // relay/lib/entitlements.js. The two products do NOT share a floor there:
+  // PARASEND_TIERS starts at 'community' and PARASIGN_TIERS at 'free', so both
+  // words have to count as unpaid.
+  // Only the rungs you can pay for. The two products do NOT share a floor in
+  // relay/lib/entitlements.js: PARASEND_TIERS starts at 'community' and
+  // PARASIGN_TIERS at 'free'. Rather than list both floor words and hope the
+  // list stays complete, this reads the other way round and fails closed: a
+  // tier counts as paid only when it is one of these three. A floor word, a
+  // renamed tier or a typo all come out unpaid, which is the safe direction.
+  var PRODUCT_LADDER = ['pro', 'business', 'enterprise'];
   var PRODUCT_NAMES = { pro: 'Pro', business: 'Business', enterprise: 'Enterprise' };
 
   // A product tier counts as paid only while its period still runs, which is
@@ -93,12 +101,28 @@
   // expires, and a missing paid_until means no period was ever recorded.
   function paidProductTier(tier, paidUntil) {
     var t = String(tier || 'free').toLowerCase();
-    if (PRODUCT_LADDER.indexOf(t) < 1) return null;
+    if (PRODUCT_LADDER.indexOf(t) < 0) return null;
     if (!paidUntil) return t;
     var ends = Date.parse(paidUntil);
     if (!isNaN(ends) && Date.now() >= ends) return null;
     return t;
   }
+
+  // What a paying customer already has, per product, quoted from /pricing. It
+  // is per product because a self-serve purchase moves one ladder only: someone
+  // who bought ParaSend Pro has no signature allowance to read about. Nothing
+  // here is an upsell. A customer who has paid should read what he bought.
+  var PRODUCT_INCLUDES = {
+    parasign: {
+      pro: 'ParaSign Pro: 100 signatures a month, then \u20ac0.40 each up to 1,000, unlimited transfers, and a connection you can plug into your own systems.',
+      business: 'ParaSign Business: 1,000 signatures a month, support with a name on it that answers within one business day, help answering your customers\u2019 security questionnaires, and an audit trail you can export as a file.',
+      enterprise: 'ParaSign Enterprise: your own dedicated relay, a sector relay for health, legal or finance, a service level agreement with credits, a self-hosting licence and audit support.'
+    },
+    parasend: {
+      pro: 'ParaSend Pro: links that stay open 24 hours, up to 10 reads each, up to 50 registered devices, a record of what you sent, and no rate limit.',
+      enterprise: 'ParaSend Enterprise: links that stay open 7 days, up to 100 reads each, unlimited devices, your own dedicated relay, a signed Data Processing Agreement and 99.95% uptime.'
+    }
+  };
 
   function render(data) {
     var email = data.email || '';
@@ -128,6 +152,32 @@
     // pays for it. A paying customer never sees the band.
     var community = root.querySelector('#dh-community');
     if (community) community.hidden = !isFree;
+
+    // The other half of the same rule: a paying account reads what it bought.
+    // Per product, so a ParaSend customer is not told about signatures he has
+    // no allowance for, and with a plain sentence for an account whose unified
+    // plan was granted by hand rather than bought through a product ladder.
+    var paid = root.querySelector('#dh-plan-paid');
+    if (paid) {
+      var lines = [];
+      var bought = [
+        ['parasign', paidProductTier(data.plan_parasign, data.paid_until_parasign)],
+        ['parasend', paidProductTier(data.plan_parasend, data.paid_until_parasend)]
+      ];
+      for (var bi = 0; bi < bought.length; bi++) {
+        var copy = bought[bi][1] && PRODUCT_INCLUDES[bought[bi][0]][bought[bi][1]];
+        if (copy) lines.push(copy);
+      }
+      if (!lines.length && planId !== 'community') {
+        lines.push('Your account is on the ' + planName + ' plan, with the ' + planName +
+                   ' limits on both ParaSign and ParaSend.');
+      }
+      paid.hidden = isFree || !lines.length;
+      if (!paid.hidden) {
+        txt('paid-name', planName);
+        txt('paid-includes', lines.join(' '));
+      }
+    }
     txt('created',      fmtDate(data.created_at));
     txt('backup',       String(data.backup_codes_remaining != null ? data.backup_codes_remaining : '--'));
     txt('session',      fmtMinutesUntil(data.session_expires_at));

--- a/scripts/shot-dashboard.mjs
+++ b/scripts/shot-dashboard.mjs
@@ -1,0 +1,109 @@
+/* Screenshot helper for the signed-in surfaces at 390px.
+ *
+ * Serves frontend/ over a throwaway http server, stubs the session and account
+ * endpoints so the signed-in view renders without a live relay, and writes
+ * full-page PNGs. Used to produce the before/after images on a pull request.
+ *
+ *   node scripts/shot-dashboard.mjs <out-dir> [plan] [parasign] [parasend]
+ */
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const OUT = process.argv[2] || '/tmp/shots';
+// plan = the unified account plan. parasign / parasend = the per-product tiers
+// a self-serve purchase moves, which is how a paying customer can hold the
+// unified plan 'community' and still owe no upgrade band.
+const PLAN = process.argv[3] || 'community';
+const PARASIGN = process.argv[4] || 'free';
+const PARASEND = process.argv[5] || 'free';
+const LABEL = process.env.SHOT_LABEL || PLAN;
+const PAID_UNTIL = new Date(Date.now() + 30 * 86400000).toISOString();
+const productFields = {
+  plan_parasign: PARASIGN,
+  plan_parasend: PARASEND,
+  paid_until_parasign: PARASIGN === 'free' ? null : PAID_UNTIL,
+  paid_until_parasend: PARASEND === 'free' ? null : PAID_UNTIL,
+};
+const EMAIL = 'mickbr@protonmail.com';
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = { '.js': 'text/javascript', '.css': 'text/css', '.html': 'text/html', '.svg': 'image/svg+xml', '.png': 'image/png', '.woff2': 'font/woff2', '.json': 'application/json' };
+const aliases = { '/': '/index.html', '/dashboard': '/dashboard.html', '/account': '/account.html', '/developer': '/developer.html' };
+
+fs.mkdirSync(OUT, { recursive: true });
+
+const server = http.createServer((req, res) => {
+  let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+  pathname = aliases[pathname] || pathname;
+  const file = path.join(ROOT, pathname);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+  fs.readFile(file, (error, body) => {
+    if (error) { res.writeHead(404); return res.end(); }
+    res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  });
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const ORIGIN = `http://localhost:${server.address().port}`;
+
+const json = (body) => ({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+const page = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 1 });
+
+// Playwright tries handlers newest-first, so the catch-alls go on FIRST and the
+// specific stubs on top of them. The other way round the catch-all answers {}
+// to every call and the page renders a signed-out shell.
+await page.route('**/api/**', (r) => r.fulfill(json({})));
+await page.route('**/api/user/**', (r) => r.fulfill(json({})));
+await page.route('**/api/user/billing/history', (r) => r.fulfill(json({ history: [] })));
+await page.route('**/api/user/billing/status', (r) => r.fulfill(json({ current_plan: PLAN, ...productFields })));
+await page.route('**/api/user/documents**', (r) => r.fulfill(json({ documents: [] })));
+await page.route('**/api/user/account', (r) => r.fulfill(json({
+  email: EMAIL, plan: PLAN, api_key_masked: 'pk_live_****', label: 'primary',
+  created_at: '2026-03-04T10:00:00Z', backup_codes_remaining: 8, sessions: [],
+  ...productFields,
+})));
+await page.route('**/api/user/me', (r) => r.fulfill(json({
+  email: EMAIL, plan: PLAN, created_at: '2026-03-04T10:00:00Z',
+  backup_codes_remaining: 8, session_expires_at: new Date(Date.now() + 42 * 60000).toISOString(),
+  usage_purpose: 'personal', api_key: 'pk_live_demo', label: 'primary',
+  ...productFields,
+})));
+await page.route('**/api/user/session/verify', (r) => r.fulfill(json({ authenticated: true, email: EMAIL })));
+
+// JPEG, because these go straight into a pull request body and a full-page PNG
+// of a long dashboard runs to several hundred kB. One step, one extension: the
+// body used to link .jpg files a PNG-only script had never written.
+const measured = {};
+for (const [name, route] of [['dashboard', '/dashboard'], ['account', '/account']]) {
+  await page.goto(ORIGIN + route, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(700);
+  const file = path.join(OUT, `390-${name}-${LABEL}.jpg`);
+  await page.screenshot({ path: file, fullPage: true, type: 'jpeg', quality: 82 });
+  console.log('wrote', file);
+  // What the customer can actually see without scrolling. Point 9 of the
+  // review was measured this way: the first action sat at y=677 on a 844px
+  // screen, half out of view, because the plan band came before it.
+  measured[name] = await page.evaluate(() => {
+    const top = (sel) => {
+      const el = document.querySelector(sel);
+      if (!el || el.hidden || !el.getClientRects().length) return null;
+      return Math.round(el.getBoundingClientRect().top + window.scrollY);
+    };
+    return {
+      firstAction: top('.dh-start-card'),
+      secondAction: top('.dh-start-card:nth-child(2)'),
+      planBand: top('#dh-community') ?? top('#dh-plan-paid') ?? top('#billing-community') ?? top('#billing-paid'),
+      upgradeLink: top('.dh-community-cta') ?? top('.acct-plan-cta'),
+      planChip: top('.dh-plan') ?? top('.acct-plan'),
+      viewport: window.innerHeight,
+    };
+  });
+}
+console.log('offsets(px from top of page):', JSON.stringify(measured));
+
+await browser.close();
+server.close();

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -113,11 +113,14 @@ assert.deepEqual(drifted, [],
   `these prices are on the homepage but not on /pricing: ${drifted.join(', ')}`);
 
 // ── The dashboard, which is the homepage for anyone who signed up ────────────
-// Mick's phone showed a badge reading "COMMUNITY PLAN" over a Start card, while
-// /pricing sells Free, Pro, Business and Enterprise and never once says
-// Community. The badge was the raw relay plan ID leaking into the interface, so
-// the one number a customer wants to check (which plan am I on, what does the
-// next one cost) could not be looked up on the page that sells it.
+// Mick's phone showed a badge reading "COMMUNITY PLAN" over a Start card, and
+// the word was the raw relay plan ID leaking through. The fix is not to hide
+// the word: Community is what relay/lib/tiers.js calls the free row, what /sla
+// calls the plan, what the account mail calls it, and it is the one thing
+// Paramant sells on. What was actually broken is that /pricing labels the same
+// tier Free, so a customer who read COMMUNITY on the dashboard could not find
+// it on the page that sells it. So the dashboard says Community AND names the
+// pricing tier, and every OTHER name it shows has to exist on /pricing.
 const dashboardJs = read('frontend/js/dashboard.js');
 const planMap = (dashboardJs.match(/var PLAN_NAMES = \{[\s\S]*?\};/) || [''])[0];
 const planEntries = [...planMap.matchAll(/^\s*([a-z_]+):\s*'([^']+)',?$/gm)].map((m) => [m[1], m[2]]);
@@ -175,6 +178,48 @@ const verifyCount = (guarantees.match(/class="rule-verify"/g) || []).length;
 assert.equal(verifyCount, ruleCount,
   `pararules.html has ${ruleCount} rules but ${verifyCount} verify links; the homepage promises one each`);
 assert.ok(ruleCount >= 9, `expected at least nine ParaRules, found ${ruleCount}`);
+
+// ── The same answer on the account page ──────────────────────────────────────
+// A customer who wants to know what he pays goes to /account, not /dashboard,
+// so account.inline1.js resolves plans too. It has to obey the same source of
+// truth: name every canonical row, fold every alias the same way. Two maps that
+// drift apart is how 'standard' reached a customer's screen in the first place.
+const accountJsPlans = read('frontend/js/account.inline1.js');
+const acctIds = [...((accountJsPlans.match(/var PLAN_NAMES = \{[\s\S]*?\};/) || [''])[0])
+  .matchAll(/^\s*([a-z_]+):\s*'([^']+)',?$/gm)].map((m) => m[1]);
+const acctUnnamed = canonicalPlans.filter((id) => !acctIds.includes(id));
+assert.deepEqual(acctUnnamed, [],
+  `relay/lib/tiers.js has these canonical plans but account.inline1.js has no display name: ${acctUnnamed.join(', ')}`);
+
+const acctAliasBlock = (accountJsPlans.match(/var PLAN_ALIASES = \{[^}]*\}/) || [''])[0];
+const acctWrongAlias = tierAliases.filter(([from, to]) => !new RegExp(`${from}:\\s*'${to}'`).test(acctAliasBlock));
+assert.deepEqual(acctWrongAlias.map(([f, t]) => `${f}->${t}`), [],
+  'account.inline1.js must fold the same plan aliases normalisePlan does');
+
+// ── Both signed-in surfaces, on the message itself ───────────────────────────
+const dashboardHtml = read('frontend/dashboard.html');
+const accountHtml = read('frontend/account.html');
+
+// A paying customer is not a lead. The band a paid plan sees says what was
+// bought and stops there; it may not carry a link to the pricing page.
+for (const [file, html] of [['dashboard.html', dashboardHtml], ['account.html', accountHtml]]) {
+  const paid = (html.match(/id="(dh-plan-paid|billing-paid)"[\s\S]*?<\/(aside|div)>/) || [''])[0];
+  assert.ok(paid, `${file} must carry the paid-plan band`);
+  assert.doesNotMatch(paid, /href="\/pricing"/,
+    `${file} must not sell a higher tier to someone who already pays`);
+}
+
+// The free band is the one upgrade path, so it gets exactly one link to
+// /pricing. Two was the old bridge sentence explaining that Community was
+// called Free over there; /pricing says Community now and the sentence is gone.
+for (const [file, html, id] of [['dashboard.html', dashboardHtml, 'dh-community'], ['account.html', accountHtml, 'billing-community']]) {
+  const band = (html.match(new RegExp(`id="${id}"[\\s\\S]*?<\\/(aside|div)>\\s*<\\/?(aside|div|p)`)) || [''])[0];
+  assert.ok(band, `${file} must carry the free-plan band`);
+  assert.equal((band.match(/href="\/pricing"/g) || []).length, 1,
+    `${file} must offer exactly one upgrade link in the free band`);
+  assert.doesNotMatch(band, /called Free|tier is called|Same name on/i,
+    `${file} must not still explain a Free/Community mismatch that no longer exists`);
+}
 
 // The signed-in address is in the nav. A second copy in the hero was the first
 // thing under the H1 on a phone, above both product actions.
@@ -282,9 +327,20 @@ assert.ok(aboutText.includes(`Mick Beer, ${SANCTIONED_TITLE}`),
 // Direction two: the qualifier that follows his name must use only words
 // /about itself uses, so no new credential can be smuggled in beside it.
 const ABOUT_WORDS = new Set(aboutText.toLowerCase().match(/[a-z]+/g) || []);
-for (const slug of ['index', 'pricing', 'parasign']) {
+// Pages that SELL on the founder. On these the line is required, not optional:
+// an if-includes gate lets the sentence be deleted and stays green, and the
+// give-back promise is the one thing the signed-in pages are there to make.
+const FOUNDER_REQUIRED = ['index', 'dashboard', 'account'];
+// Pages that MAY name him. If they do, the same rules apply.
+const FOUNDER_OPTIONAL = ['pricing', 'parasign'];
+for (const slug of [...FOUNDER_REQUIRED, ...FOUNDER_OPTIONAL]) {
   const text = flatten(read(`frontend/${slug}.html`));
-  if (!text.includes('Mick Beer')) continue;
+  if (FOUNDER_REQUIRED.includes(slug)) {
+    assert.ok(text.includes('Mick Beer'),
+      `${slug}.html sells on the founder, so it must name him; the line may not quietly disappear`);
+  } else if (!text.includes('Mick Beer')) {
+    continue;
+  }
   assert.ok(text.includes(`Mick Beer , ${SANCTIONED_TITLE}`) || text.includes(`Mick Beer, ${SANCTIONED_TITLE}`),
     `${slug}.html names the founder, so it must use the title /about gives him: "${SANCTIONED_TITLE}"`);
   // Everything between his name and the end of the qualifying clause.
@@ -301,3 +357,4 @@ assert.ok(!/\bMick Beer\b/.test(home) || /KvK 42115132/.test(home),
 console.log('ui-truthfulness: the homepage does not overclaim signatures and quotes the real prices');
 console.log('ui-truthfulness: the free plan is Community everywhere and the founder line matches /about');
 console.log('ui-truthfulness: the dashboard names the plans /pricing actually sells');
+console.log('ui-truthfulness: the account page resolves plans from the same source and never upsells a customer');

--- a/tests/user-dashboard-documents.test.mjs
+++ b/tests/user-dashboard-documents.test.mjs
@@ -12,6 +12,7 @@ const MIME = { '.js':'text/javascript','.css':'text/css','.html':'text/html','.s
 const server = http.createServer((req, res) => {
   let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
   if (pathname === '/dashboard') pathname = '/dashboard.html';
+  if (pathname === '/account') pathname = '/account.html';
   const file = path.join(ROOT, pathname);
   if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
   fs.readFile(file, (error, body) => {
@@ -161,6 +162,85 @@ ok('a paid ParaSend tier counts too', sendPlan.badge === 'Pro' && sendPlan.band 
 
 const licensedPlan = await planCase({ plan:'licensed' });
 ok('a licensed account reads as Enterprise, not as a machine string', licensedPlan.badge === 'Enterprise' && licensedPlan.band === false, JSON.stringify(licensedPlan));
+
+// ── /account tells the same story, and gates the same way ────────────────────
+// This is the page a customer opens to find out what he pays, so the answer has
+// to match the dashboard's. It also carries two affordances the dashboard does
+// not: the Active badge and the Cancel button. Those used to be decided by
+// `current_plan !== 'community'`, one string, which got it wrong in BOTH
+// directions: a free ParaSign account sits on the tier called 'free', so it was
+// offered a cancel button for a subscription it does not have, and a self-serve
+// customer keeps the unified plan 'community' while only his product tier
+// moves, so the person actually paying never saw the badge.
+//
+// Tested through the rendered page rather than by reading the source for a
+// forbidden string, because the next wrong gate will not be spelled the same.
+const acctPage = await browser.newPage({ viewport:{ width:390, height:844 } });
+let acctState = {};
+const acctBody = () => JSON.stringify({
+  email:'demo@example.com', api_key_masked:'pgp_****', label:'Demo',
+  created_at:'2026-06-01T10:00:00.000Z', backup_codes_remaining:8, sessions:[],
+  plan_parasign:null, plan_parasend:null, paid_until_parasign:null, paid_until_parasend:null,
+  ...acctState,
+});
+// Playwright tries handlers newest-first, so the catch-all is registered FIRST
+// and the specific stubs land on top of it. The other way round it answers {}
+// to everything and every case renders as a signed-out, planless page, which
+// makes three of the four assertions below pass for the wrong reason.
+await acctPage.route('**/api/user/**', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{}' }));
+await acctPage.route('**/api/user/session/verify', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"authenticated":true,"email":"demo@example.com"}' }));
+await acctPage.route('**/api/user/billing/history', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"history":[]}' }));
+await acctPage.route('**/api/user/billing/status', (route) => route.fulfill({ status:200, contentType:'application/json', body:JSON.stringify({ current_plan: acctState.plan || 'community', ...JSON.parse(acctBody()) }) }));
+await acctPage.route('**/api/user/account', (route) => route.fulfill({ status:200, contentType:'application/json', body:acctBody() }));
+
+async function acctCase(state) {
+  acctState = state;
+  await acctPage.goto(ORIGIN + '/account', { waitUntil:'domcontentloaded' });
+  await acctPage.locator('#billing-content:not(.hidden)').waitFor();
+  return {
+    chip: (await acctPage.locator('#plan-chip').textContent()).trim(),
+    current: (await acctPage.locator('#billing-plan').textContent()).trim(),
+    active: await acctPage.locator('#billing-active-badge').isVisible(),
+    cancel: await acctPage.locator('#billing-cancel-btn').isVisible(),
+    giveBack: await acctPage.locator('#billing-community').isVisible(),
+    bought: await acctPage.locator('#billing-paid').isVisible(),
+  };
+}
+
+const acctFree = await acctCase({ plan:'community' });
+ok('a Community account is not offered a cancel button',
+  acctFree.chip === 'Community' && acctFree.current === 'Community' &&
+  acctFree.active === false && acctFree.cancel === false &&
+  acctFree.giveBack === true && acctFree.bought === false, JSON.stringify(acctFree));
+
+// ParaSign's floor tier is the word 'free', not 'community'
+// (relay/lib/entitlements.js PARASIGN_TIERS). The old gate read that as paid.
+const acctFloor = await acctCase({ plan:'community', plan_parasign:'free' });
+ok('the ParaSign floor tier is still free of charge',
+  acctFloor.current === 'Community' && acctFloor.cancel === false && acctFloor.giveBack === true, JSON.stringify(acctFloor));
+
+// ParaSend's floor is the word 'community', ParaSign's is 'free', and a tier
+// nobody recognises must not be luckier than either. paidProductTier() reads
+// the paid rungs rather than listing the floors, so all three come out unpaid.
+const acctSendFloor = await acctCase({ plan:'community', plan_parasend:'community' });
+ok('the ParaSend floor tier is free of charge as well',
+  acctSendFloor.current === 'Community' && acctSendFloor.cancel === false, JSON.stringify(acctSendFloor));
+
+const acctUnknown = await acctCase({ plan:'community', plan_parasign:'platinum', paid_until_parasign:future });
+ok('an unrecognised tier fails closed rather than unlocking a subscription',
+  acctUnknown.current === 'Community' && acctUnknown.active === false && acctUnknown.cancel === false, JSON.stringify(acctUnknown));
+
+const acctPaid = await acctCase({ plan:'community', plan_parasign:'pro', paid_until_parasign:future });
+ok('a self-serve customer gets the badge and the cancel button he pays for',
+  acctPaid.chip === 'Pro' && acctPaid.current === 'Pro' &&
+  acctPaid.active === true && acctPaid.cancel === true &&
+  acctPaid.giveBack === false && acctPaid.bought === true, JSON.stringify(acctPaid));
+
+const acctLapsed = await acctCase({ plan:'community', plan_parasign:'pro', paid_until_parasign:past });
+ok('an expired paid period falls back to Community on /account too',
+  acctLapsed.chip === 'Community' && acctLapsed.current === 'Community' &&
+  acctLapsed.active === false && acctLapsed.cancel === false &&
+  acctLapsed.giveBack === true, JSON.stringify(acctLapsed));
 
 for (const check of checks) console.log(`${check.pass ? 'PASS' : 'FAIL'} ${check.name}${check.detail ? ' :: ' + check.detail : ''}`);
 await browser.close();


### PR DESCRIPTION
Rebased onto `main` at `4ccee0c`. One commit, eight files.

The earlier run failed `relay - crypto suite` on
`relay/test/billing-stance-boot`, which this branch does not touch: the diff
contains no `relay/` file at all. The branch was sitting on `2329aa4` and missed
#342, `fix(relay): the bugs the critical-path tests found`, which is the fix.
Rebasing picked it up. For completeness the same test fails 4/4 on unmodified
`origin/main` in my checkout as well, because the relay cannot boot there without
the native `@paramant/core` dependency that CI installs separately, so a local
green was never available to confirm it either way.

That push also cleared a stale merge base: while the PR was retargeted from
`feat/homepage-koper` to `main`, GitHub kept reporting 53 changed files and
attributed 224/300 lines of `index.html` to this PR. Its own compare API said
`ahead 1, behind 0, 8 files` throughout. The new head SHA forced the
recomputation and the PR now reports 8.

## Review points, each with its evidence

**1. Base and CI.** `git rebase --onto origin/main origin/feat/homepage-koper`.
Zero conflicts: #328 was squash-merged, so my branch is `origin/main` plus one
commit and `git merge-base origin/main HEAD` is the current main tip.
`index.html` and `pararules.html` are not in the diff, so the Resend disclosure
and the corrected EU claim are untouched. Base is now `main` and the full suite
runs on this PR.

**2. The give-back sentence now has a source.** It was on the dashboard but not
on /about, so it was unsourced. `frontend/about.html`, section
"Behind Paramant", now carries one sentence in Mick's words: *the Community plan
is his way of giving something back to society; the business plans pay for it.*
The dashboard and account bands reuse that wording.

The founder gate is genuinely two-way now:

- `FOUNDER_REQUIRED = ['index', 'dashboard', 'account']`, no `if (includes)`
  gate. Delete the sentence and the suite goes red.
- The title must be the one /about gives.
- Every word in the clause beside his name must be a word /about uses. This is
  what forced the band's wording to match /about rather than paraphrase it: the
  first draft said "gives back to society, paid for by" and the gate rejected
  `gives` and `paid`.

Sabotage: title swapped to "award winning cryptographer" → red. Sentence deleted
from dashboard → red. Sentence deleted from account → red.

**3. Neither gate was broken.** Checked rather than assumed:
`git diff origin/main...HEAD -- tests/ui-truthfulness.test.mjs | grep '^-'`
removes exactly five lines, all of them one stale comment about /pricing selling
Free. Nothing was removed from `TIER_NAME_SHAPES`, `tierNameHits`,
`SANCTIONED_TITLE` or the `ABOUT_WORDS` filter. Both are live on this branch:
putting "Everything in Free" on the dashboard → red; adding "cryptographer,"
beside his name on /account → red.

**4. Behaviour instead of strings.** The `assert.doesNotMatch` on
`current_plan !== 'community'` is gone. `tests/user-dashboard-documents.test.mjs`
now drives **/account** in Chromium across six plan shapes and reads the plan
chip, the Current plan row, the Active badge, the Cancel button and which band
is visible:

| stub | chip | Active | Cancel | band |
| --- | --- | --- | --- | --- |
| `community` | Community | no | no | give-back |
| `plan_parasign: 'free'` (ParaSign floor) | Community | no | no | give-back |
| `plan_parasend: 'community'` (ParaSend floor) | Community | no | no | give-back |
| `plan_parasign: 'platinum'` (unknown) | Community | no | no | give-back |
| `plan_parasign: 'pro'`, period running | Pro | yes | yes | bought |
| `plan_parasign: 'pro'`, period lapsed | Community | no | no | give-back |

Sabotage, all red: expiry `>=` flipped to `<` in account.inline1.js; the same
flip in dashboard.js; `const free = false`; `const free = true`; the old
one-string gate restored; the paid ladder widened so an unknown tier unlocks a
subscription.

One finding while doing this. My first attempt added `PRODUCT_FLOORS = { free,
community }` and the sabotage did **not** go red: with a combined ladder,
`indexOf(t) < 1` already caught both floor words, so the map was dead code.
`paidProductTier()` now reads the three paid rungs instead of listing the
floors, which fails closed. A floor word, a renamed tier and a typo all come out
unpaid, and the last two rows of the table pin it.

**5. The EUR 15 card is Pro.** Business is EUR 299. The answer now reads
"Paid plans start at EUR 15 a month excl. btw, which is ParaSend Pro."

**6. One story about ParaSend.** `relay.js` decrements `views_remaining` and
burns at zero, so the card says the file is **gone the moment it has been read**,
matching the dashboard hero and the homepage rules grid. "It expires by itself"
was a second, softer story for the same mechanism.

**7. Verification is not unconditional.** `verify.html` says a legacy v1/v2
envelope can only be checked by the relay with an API key. The answer now reads
"Signed documents verify without an account. Older envelope formats need the
relay."

**8. Comment corrected.** `entitlements.js` gives ParaSend the floor
`community` and ParaSign the floor `free`; they do not share one. Both files say
so now, and the code was restructured so the claim is load-bearing rather than
decorative (see point 4).

**9. Order on a phone, measured.** `getBoundingClientRect`, 390x844, px from
the top of the page. `scripts/shot-dashboard.mjs` prints this on every run:

| | plan band | upgrade link | first action | second action |
| --- | --- | --- | --- | --- |
| before (`main`) | 323 | 624 | **718** | **1004** |
| after | 1132 | 1413 | **323** | **612** |

The band came first and pushed both products past the 844px fold. Both actions
are now fully above it and the plan message follows them.

**10. Jargon out of both bands.** Gone: webhooks, exportable audit log, API
access, no IP rate limit, CT tree head as CSV or JSON, link expiry. What a
lawyer reads instead: "keep links open longer", "keep a record of what you sent",
"support with a name on it", "an audit trail you can export and hand over",
"a connection you can plug into your own systems". The exact feature names stay
on /pricing, where they are sold.

**11. One step, one extension.** The script writes `.jpg` directly at 1x with
`type: 'jpeg'`. It used to write PNG while the body linked JPEG.

## Verification

CI on `f23e989`: **11/11 green**, including `relay - crypto suite`, which is the
one that failed on the stale base, and `sign-e2e`, which runs the browser suites
this PR extends.

Green locally: `links`, `seo-contract`, `ui-truthfulness`,
`frontend-loading-contract`, `navigation-shell`, `user-dashboard-documents`
(25 checks), `site-claims`, `cosign-appearance-contract`,
`developer-parasign-dashboard`, `usage-purpose`, `check-csp-inline.sh`,
`check-cache-bust.sh`, `static-sanity.sh`, `eslint .`, `check-commit-style.sh`.

`tests/heartbeat-lib.test.mjs` fails in my checkout for want of
`@noble/post-quantum`, which `test.yml` installs separately. It fails the same
way on unmodified `main`, so it is environmental and not from this branch.

Thirteen sabotages run in total across points 2, 3 and 4. All red, all restored.

## Screenshots, 390px, full page

| Dashboard before (`main`) | Dashboard after (Community) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Apolloccrypt/paramant-relay/review/dashboard-ingelogd-screenshots/390-dashboard-before.jpg" width="330"> | <img src="https://raw.githubusercontent.com/Apolloccrypt/paramant-relay/review/dashboard-ingelogd-screenshots/390-dashboard-community.jpg" width="330"> |

| Account before (`main`) | Account after (Community) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Apolloccrypt/paramant-relay/review/dashboard-ingelogd-screenshots/390-account-before.jpg" width="330"> | <img src="https://raw.githubusercontent.com/Apolloccrypt/paramant-relay/review/dashboard-ingelogd-screenshots/390-account-community.jpg" width="330"> |

Unified plan `pro`, granted rather than bought:

| Dashboard | Account |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Apolloccrypt/paramant-relay/review/dashboard-ingelogd-screenshots/390-dashboard-pro.jpg" width="330"> | <img src="https://raw.githubusercontent.com/Apolloccrypt/paramant-relay/review/dashboard-ingelogd-screenshots/390-account-pro.jpg" width="330"> |

The self-serve case: unified plan still `community`, ParaSign tier `pro` with a
running period. Badge reads Pro, give-back band gone, paid band names only the
product bought, and /account finally shows the Active badge and Cancel button to
the person paying for them.

| Dashboard | Account |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Apolloccrypt/paramant-relay/review/dashboard-ingelogd-screenshots/390-dashboard-selfserve.jpg" width="330"> | <img src="https://raw.githubusercontent.com/Apolloccrypt/paramant-relay/review/dashboard-ingelogd-screenshots/390-account-selfserve.jpg" width="330"> |

Images live on `review/dashboard-ingelogd-screenshots`, which is not for merging.

## Nothing open

I flagged "Everything in Free" on the ParaSend Pro card in my previous report.
It is already fixed: `frontend/pricing.html` line 261 reads "Everything in
Community", corrected inside #328 itself (`0161740`) after I read it. The
site-wide sweep was right and there was nothing for it to catch.


