### PR TITLE
/docs and /help answer a buyer before they answer a developer

### DIFF
--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -19,6 +19,7 @@ body{background:linear-gradient(180deg,#f8faff 0,#f5f7fb 460px)}
 .eyebrow{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:#607896;margin:0 0 10px}
 h1{font-size:clamp(30px,5vw,48px);letter-spacing:-.035em;line-height:1.05;color:#0b3a6a;margin:0 0 12px}
 .lede{max-width:690px;color:#587391;font-size:15px;line-height:1.65;margin:0}
+.lede a{color:#1d4ed8;text-decoration:underline;text-underline-offset:2px}
 .account{display:flex;align-items:center;gap:9px;padding:9px 13px;background:#fff;border:1px solid #dfe7f2;border-radius:999px;font-family:var(--mono);font-size:11px;color:#587391;white-space:nowrap;box-shadow:0 5px 18px rgba(11,58,106,.05)}
 .status-dot{width:8px;height:8px;border-radius:50%;background:#a7b4c5}.status-dot.ok{background:#20a66a}.status-dot.err{background:#d94b4b}
 .grid{display:grid;grid-template-columns:minmax(0,1.35fr) minmax(300px,.65fr);gap:20px;margin-top:20px}
@@ -68,7 +69,7 @@ pre{margin:0;padding:20px;background:#0d1d33;color:#d7e7f8;overflow:auto;font-fa
     <a href="/developer" aria-current="page">Developer settings</a>
   </nav>
   <header class="hero">
-    <div><p class="eyebrow">Settings · ParaSign API</p><h1>Build signing into your product.</h1><p class="lede">Create secure signing requests, follow every signer and retrieve an offline-verifiable proof. Everything needed to connect and operate the ParaSign API is here.</p></div>
+    <div><p class="eyebrow">Settings · ParaSign API</p><h1>Build signing into your product.</h1><p class="lede">Create signing requests, follow every signer and retrieve an offline-verifiable proof. Every endpoint is in the <a href="/docs#v1-envelopes">API reference</a>, so your IT can check everything before you connect anything. API access is included from ParaSign Pro; see <a href="/pricing">pricing</a>.</p></div>
     <div class="account"><span class="status-dot" id="api-status-dot"></span><span data-dv="email">Loading account</span><span>·</span><strong data-dv="plan">--</strong></div>
   </header>
 
@@ -113,6 +114,7 @@ curl -X POST https://paramant.app/v1/envelopes \
       <section class="card" aria-labelledby="links-title">
         <div class="card-head"><div><h2 id="links-title">Build and operate</h2><p class="card-sub">The complete surface for the live API.</p></div></div>
         <div class="links">
+          <a class="link" href="/docs#quickstart">Quick start <span>&rarr;</span></a>
           <a class="link" href="/docs#v1-envelopes">API reference <span>&rarr;</span></a>
           <a class="link" href="/docs#v1-envelopes">Webhooks and signatures <span>&rarr;</span></a>
           <a class="link" href="/verify">Verify a .psign receipt <span>&rarr;</span></a>

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -69,7 +69,7 @@ pre{margin:0;padding:20px;background:#0d1d33;color:#d7e7f8;overflow:auto;font-fa
     <a href="/developer" aria-current="page">Developer settings</a>
   </nav>
   <header class="hero">
-    <div><p class="eyebrow">Settings · ParaSign API</p><h1>Build signing into your product.</h1><p class="lede">Create signing requests, follow every signer and retrieve an offline-verifiable proof. Every ParaSign API endpoint is in the <a href="/docs#v1-envelopes">API reference</a>, so your IT can check everything before you connect anything. API access is included from ParaSign Pro; see <a href="/pricing">pricing</a>.</p></div>
+    <div><p class="eyebrow">Settings · ParaSign API</p><h1>Build signing into your product.</h1><p class="lede">Create signing requests, follow every signer and retrieve an offline-verifiable proof. Every ParaSign API endpoint is in the <a href="/docs#v1-envelopes">API reference</a>, so you can read the whole surface before you connect anything. API access is included from ParaSign Pro; see <a href="/pricing">pricing</a>.</p></div>
     <div class="account"><span class="status-dot" id="api-status-dot"></span><span data-dv="email">Loading account</span><span>·</span><strong data-dv="plan">--</strong></div>
   </header>
 

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -69,7 +69,7 @@ pre{margin:0;padding:20px;background:#0d1d33;color:#d7e7f8;overflow:auto;font-fa
     <a href="/developer" aria-current="page">Developer settings</a>
   </nav>
   <header class="hero">
-    <div><p class="eyebrow">Settings · ParaSign API</p><h1>Build signing into your product.</h1><p class="lede">Create signing requests, follow every signer and retrieve an offline-verifiable proof. Every endpoint is in the <a href="/docs#v1-envelopes">API reference</a>, so your IT can check everything before you connect anything. API access is included from ParaSign Pro; see <a href="/pricing">pricing</a>.</p></div>
+    <div><p class="eyebrow">Settings · ParaSign API</p><h1>Build signing into your product.</h1><p class="lede">Create signing requests, follow every signer and retrieve an offline-verifiable proof. Every ParaSign API endpoint is in the <a href="/docs#v1-envelopes">API reference</a>, so your IT can check everything before you connect anything. API access is included from ParaSign Pro; see <a href="/pricing">pricing</a>.</p></div>
     <div class="account"><span class="status-dot" id="api-status-dot"></span><span data-dv="email">Loading account</span><span>·</span><strong data-dv="plan">--</strong></div>
   </header>
 

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -84,8 +84,14 @@ tr:last-child td{border-bottom:none}
 .docs-hero .docs-buyer{font-size:13px;line-height:1.7;color:#0B3A6A;margin:0 0 12px;max-width:640px;padding-left:10px;border-left:2px solid #B2FF3F}
 .docs-hero .docs-buyer a{color:#1D4ED8;text-decoration:underline;text-decoration-color:#B2FF3F;text-decoration-thickness:2px}
 .docs-hero .lede a{color:#1D4ED8;text-decoration:underline;text-decoration-color:#B2FF3F;text-decoration-thickness:2px}
-.docs-hero-actions{display:flex;flex-wrap:wrap;align-items:center;gap:18px}
-.docs-hero-cta-primary{font-weight:700}
+.docs-hero-actions{display:flex;flex-wrap:wrap;align-items:center;gap:12px;margin-top:4px}
+.docs-hero-btn{display:inline-flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:12px;line-height:1;padding:12px 20px;border:1px solid #1D4ED8;border-radius:2px;text-decoration:none;transition:background .12s,color .12s,border-color .12s}
+.docs-hero-btn-primary{background:#1D4ED8;color:#fff}
+.docs-hero-btn-primary:hover{background:#0B3A6A;border-color:#0B3A6A;color:#fff}
+.docs-hero-btn-secondary{background:#fff;color:#1D4ED8}
+.docs-hero-btn-secondary:hover{background:rgba(29,78,216,0.07);color:#0B3A6A}
+.docs-hero-actions .docs-hero-cta{margin-left:6px}
+@media(max-width:640px){.docs-hero-btn{flex:1 1 100%}.docs-hero-actions .docs-hero-cta{margin-left:0;width:100%}}
 .docs-hero-cta:hover{color:#0B3A6A}
 @media(max-width:900px){.docs-hero-inner{padding:0 24px}}
 </style>
@@ -215,7 +221,8 @@ tr:last-child td{border-bottom:none}
     <p class="docs-buyer">Evaluating Paramant? Your IT can check everything here. Plans and prices are on <a href="/pricing">Pricing</a>.</p>
     <p class="lede">API reference, SDK guide, self-hosting, and compliance docs for PARAMANT v3.0.0. The relay is untrusted by design: it never holds a decryption key. The ParaSign API is available from ParaSign Pro; see <a href="/pricing">pricing</a>.</p>
     <div class="docs-hero-actions">
-      <a href="#quickstart" class="docs-hero-cta docs-hero-cta-primary">Quick start →</a>
+      <a href="#quickstart" class="docs-hero-btn docs-hero-btn-primary">Quick start</a>
+      <a href="/pricing" class="docs-hero-btn docs-hero-btn-secondary">See plans and prices</a>
       <a href="/signup" class="docs-hero-cta">Create account</a>
     </div>
   </div>
@@ -277,7 +284,7 @@ tr:last-child td{border-bottom:none}
   <div class="content">
     <!-- ── What's new in 3.0.0 ──────────────────────────────────── -->
     <h2 id="whats-new">What's new in 3.0.0</h2>
-    <p>Version 3.0.0 keeps the wire format, API surface and crypto guarantees of 2.5.x: every 2.5.x client stays compatible: and focuses on the operator and self-host experience. The headline change is structural: the post-quantum primitives now live in their own audited library.</p>
+    <p>Version 3.0.0 keeps the wire format, API surface and crypto guarantees of 2.5.x, so every 2.5.x client stays compatible. It focuses on the operator and self-host experience. The headline change is structural: the post-quantum primitives now live in their own audited library.</p>
     <ul>
       <li><strong>paramant-core crypto split (M5b).</strong> Server-side ML-DSA-65 signing is now provided by <a href="https://github.com/Apolloccrypt/paramant-core" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">paramant-core</a>: a standalone, audit-ready Rust library (BUSL-1.1) the relay consumes through its <code>@paramant/core</code> NAPI binding. Client-side ML-KEM-768 still runs in the browser/SDK; the relay never holds a key. See <a href="#crypto">Crypto stack</a>.</li>
       <li><strong>Document workspace.</strong> The user dashboard starts document flows, shows account-owned signing requests and exposes owner actions without adding a new trust surface.</li>
@@ -288,7 +295,7 @@ tr:last-child td{border-bottom:none}
       <li><strong>Crypto-mode negotiation (ADR R006, accepted).</strong> <code>/v2/capabilities</code> advertises a compact <em>core</em> mode (2 algorithms) by default; extended algorithm sets are opt-in. See <a href="#crypto">Crypto stack</a>.</li>
       <li><strong>Add-on architecture (ADR R007, draft).</strong> A specification for container-isolated integrations: storage mirrors, SIEM exporters, SSO: that work on ciphertext and metadata only, never plaintext or keys.</li>
       <li><strong>Static front-end serving (ADR R011).</strong> An opt-in <code>SERVE_FRONTEND</code> static handler lets a single relay serve its own UI for plug-and-play self-hosting. See <a href="#selfhost-docker">Self-hosting</a>.</li>
-      <li><strong>Documented design decisions.</strong> Architecture Decision Records R001–R011 capture the choices behind 3.0.0: from the hotfix flow to the crypto split: in the repository under <code>docs/adrs/</code>.</li>
+      <li><strong>Documented design decisions.</strong> Architecture Decision Records R001 to R011 capture the choices behind 3.0.0, from the hotfix flow to the crypto split. They live in the repository under <code>docs/adrs/</code>.</li>
     </ul>
 
     <!-- ── Quick start ──────────────────────────────────────────── -->

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -6,15 +6,15 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PARAMANT · Documentation</title>
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="API reference, SDK guide, self-hosting, and compliance docs for PARAMANT Ghost Pipe v2.">
+<meta name="description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
 <meta property="og:title" content="PARAMANT · Documentation">
-<meta property="og:description" content="API reference, SDK guide, self-hosting, and compliance docs for PARAMANT Ghost Pipe v2.">
+<meta property="og:description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
 <meta property="og:url" content="https://paramant.app/docs">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="PARAMANT · Documentation">
-<meta name="twitter:description" content="API reference, SDK guide, self-hosting, and compliance docs for PARAMANT Ghost Pipe v2.">
+<meta name="twitter:description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
 <link rel="canonical" href="https://paramant.app/docs">
 
 <link rel="stylesheet" href="/design-system.css?v=23">
@@ -31,7 +31,7 @@ a{color:var(--ink);text-decoration:none}
 .sidebar a{display:block;font-size:12px;color:var(--ink-dim);padding:3px 8px 3px 10px;line-height:1.8;transition:color .12s,background .12s,border-left-color .12s;border-left:2px solid transparent}
 .sidebar a:hover{color:#0B3A6A;background:rgba(178,255,63,0.08);border-left-color:#B2FF3F}
 .sidebar a.active{color:#0B3A6A;font-weight:500;background:rgba(29,78,216,0.06);border-left-color:#1D4ED8}
-.content{flex:1;padding:52px 72px 80px;max-width:840px}
+.content{flex:1;min-width:0;padding:52px 72px 80px;max-width:840px}
 .content h1{font-size:26px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 .subtitle{font-size:14px;color:var(--ink-dim);margin-bottom:52px;line-height:1.8}
 .content h2{font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:#0B3A6A;margin:56px 0 18px;padding-top:56px;border-top:2px solid #B2FF3F}
@@ -72,7 +72,7 @@ tr:last-child td{border-bottom:none}
 .faq-q{font-size:13px;font-weight:500;color:var(--ink);margin-bottom:8px}
 .faq-a{font-size:13px;color:var(--ink-dim);line-height:1.8}
 .sector-badge{display:inline-block;font-size:10px;font-family:var(--mono);color:var(--ink);background:var(--ink-ghost);border:1px solid var(--ink-hair);padding:2px 7px;margin-right:6px}
-@media(max-width:900px){.sidebar{display:none}.content{padding:32px 24px 60px}}
+@media(max-width:900px){.sidebar{display:none}.content{padding:32px 24px 60px}.content table{display:block;overflow-x:auto;max-width:100%}}
 
 /* docs-hero */
 .docs-hero{background:linear-gradient(180deg,#F8FAFC 0%,rgba(11,58,106,0.04) 100%);border-bottom:1px solid rgba(11,58,106,0.08);padding:36px 24px 28px;margin-bottom:0}
@@ -81,6 +81,11 @@ tr:last-child td{border-bottom:none}
 .docs-hero h1{font-size:32px;font-weight:700;color:#0B3A6A;margin:0 0 10px;line-height:1.15;letter-spacing:-.02em}
 .docs-hero .lede{font-size:13px;line-height:1.75;color:#475569;margin:0 0 14px;max-width:640px}
 .docs-hero-cta{display:inline-block;font-family:var(--mono);font-size:12px;color:#1D4ED8;text-decoration:underline;text-decoration-color:#B2FF3F;text-decoration-thickness:2px;padding:4px 0}
+.docs-hero .docs-buyer{font-size:13px;line-height:1.7;color:#0B3A6A;margin:0 0 12px;max-width:640px;padding-left:10px;border-left:2px solid #B2FF3F}
+.docs-hero .docs-buyer a{color:#1D4ED8;text-decoration:underline;text-decoration-color:#B2FF3F;text-decoration-thickness:2px}
+.docs-hero .lede a{color:#1D4ED8;text-decoration:underline;text-decoration-color:#B2FF3F;text-decoration-thickness:2px}
+.docs-hero-actions{display:flex;flex-wrap:wrap;align-items:center;gap:18px}
+.docs-hero-cta-primary{font-weight:700}
 .docs-hero-cta:hover{color:#0B3A6A}
 @media(max-width:900px){.docs-hero-inner{padding:0 24px}}
 </style>
@@ -162,7 +167,7 @@ tr:last-child td{border-bottom:none}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "API reference, SDK guide, self-hosting, and compliance docs for PARAMANT Ghost Pipe v2."
+      "description": "API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key."
     }
   ]
 }
@@ -207,8 +212,12 @@ tr:last-child td{border-bottom:none}
   <div class="docs-hero-inner">
     <span class="eyebrow">REFERENCE</span>
     <h1>Documentation</h1>
-    <p class="lede">API reference, SDK guide, self-hosting, and compliance docs for PARAMANT v3.0.0. The relay is untrusted by design: it never holds a decryption key.</p>
-    <a href="/signup" class="docs-hero-cta">Create account →</a>
+    <p class="docs-buyer">Evaluating Paramant? Your IT can check everything here. Plans and prices are on <a href="/pricing">Pricing</a>.</p>
+    <p class="lede">API reference, SDK guide, self-hosting, and compliance docs for PARAMANT v3.0.0. The relay is untrusted by design: it never holds a decryption key. The ParaSign API is available from ParaSign Pro; see <a href="/pricing">pricing</a>.</p>
+    <div class="docs-hero-actions">
+      <a href="#quickstart" class="docs-hero-cta docs-hero-cta-primary">Quick start →</a>
+      <a href="/signup" class="docs-hero-cta">Create account</a>
+    </div>
   </div>
 </section>
 

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -219,7 +219,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
   <h1>API key vs <em>TOTP</em> — what's the difference?</h1>
 
-  <p class="lead">Paramant uses two credential types for different purposes. Understanding which one you need — and when you need both — prevents most authentication problems.</p>
+  <p class="lead">Paramant uses two credential types for different purposes. Knowing which one you need, and when you need both, prevents most authentication problems.</p>
 
   <h2>The short version</h2>
 

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -3,14 +3,14 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>API key vs TOTP — PARAMANT Help</title>
-<meta property="og:title" content="API key vs TOTP — PARAMANT Help">
-<meta property="og:description" content="The difference between Paramant API keys and TOTP codes — when to use each, and how they work together.">
+<title>API key vs TOTP &middot; PARAMANT Help</title>
+<meta property="og:title" content="API key vs TOTP &middot; PARAMANT Help">
+<meta property="og:description" content="The difference between Paramant API keys and TOTP codes: when to use each, and how they work together.">
 <meta property="og:url" content="https://paramant.app/help/api-key-vs-totp">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Paramant">
 <link rel="canonical" href="https://paramant.app/help/api-key-vs-totp">
-<meta name="description" content="The difference between Paramant API keys and TOTP codes — when to use each, and how they work together.">
+<meta name="description" content="The difference between Paramant API keys and TOTP codes: when to use each, and how they work together.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
@@ -138,7 +138,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/help/api-key-vs-totp#webpage",
       "url": "https://paramant.app/help/api-key-vs-totp",
-      "name": "API key vs TOTP — PARAMANT Help",
+      "name": "API key vs TOTP \u00b7 PARAMANT Help",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -146,7 +146,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "The difference between Paramant API keys and TOTP codes — when to use each, and how they work together."
+      "description": "The difference between Paramant API keys and TOTP codes: when to use each, and how they work together."
     },
     {
       "@type": "BreadcrumbList",
@@ -217,7 +217,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     API key vs TOTP
   </div>
 
-  <h1>API key vs <em>TOTP</em> — what's the difference?</h1>
+  <h1>API key vs <em>TOTP</em>: what's the difference?</h1>
 
   <p class="lead">Paramant uses two credential types for different purposes. Knowing which one you need, and when you need both, prevents most authentication problems.</p>
 
@@ -248,7 +248,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
   <h2>When you need just the API key</h2>
 
-  <p>Machine-to-machine calls — IoT devices, CI pipelines, server scripts — use the API key alone. The key goes in the <code>Authorization</code> header on every request. No TOTP code is required because the machine cannot open an authenticator app.</p>
+  <p>Machine-to-machine calls use the API key alone. That covers IoT devices, CI pipelines and server scripts. The key goes in the <code>Authorization</code> header on every request. No TOTP code is required because the machine cannot open an authenticator app.</p>
 
   <div class="tip"><p>Use a <strong>dedicated API key</strong> for each integration so you can revoke one without affecting the others. Create additional keys in <a href="/dashboard">Dashboard &rarr; API keys</a>.</p></div>
 
@@ -266,7 +266,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
   <h2>Why not just use a password?</h2>
 
-  <p>Paramant has no passwords. The API key functions as one — it is long, random, and machine-generated — but it also serves as the credential for API calls. Combining it with TOTP gives you two-factor authentication without a separate password to manage or a password reset flow to abuse.</p>
+  <p>Paramant has no passwords. The API key functions as one, long, random and machine-generated, and it also serves as the credential for API calls. Combining it with TOTP gives you two-factor authentication without a separate password to manage or a password reset flow to abuse.</p>
 
   <h2>Key rotation</h2>
 

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -29,6 +29,7 @@ h2{font-size:18px;font-weight:600;letter-spacing:-.01em;margin-bottom:20px;margi
 .buyer-qa-item{margin-bottom:20px}
 .buyer-qa-q{font-size:15px;font-weight:600;color:var(--ink);margin-bottom:6px}
 .buyer-qa-a{font-size:var(--text-sm);color:var(--ink-dim);line-height:1.7;margin-bottom:6px}
+.buyer-qa-a a.buyer-qa-inline{color:var(--cobalt);text-decoration:underline;text-underline-offset:2px}
 .buyer-qa-link{font-family:IBM Plex Mono,monospace;font-size:12px;color:var(--cobalt);text-decoration:underline;text-decoration-color:#B2FF3F;text-decoration-thickness:2px;text-underline-offset:3px}
 .buyer-qa-link:hover{color:var(--ink)}
 @media(max-width:640px){.buyer-qa{padding:20px 18px 4px;margin-bottom:36px}.buyer-qa-q{font-size:14px}}
@@ -199,13 +200,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
     <div class="buyer-qa-item">
       <div class="buyer-qa-q">What does it cost?</div>
-      <p class="buyer-qa-a">The Community tier is free forever, no card required, and free accounts sign 2 documents a month. Organisations pay for the higher limits. Pay for volume, never for security.</p>
+      <p class="buyer-qa-a">ParaSign Community is free, forever, and no card is required. It covers 2 signatures per month. The first paid plan is ParaSign Pro at &euro;49 a month excl. btw (&euro;59.29 incl.), which includes 100 signatures a month. Every plan gets the same encryption, the same post-quantum signatures and the same public proof log.</p>
       <a class="buyer-qa-link" href="/pricing">See pricing &rarr;</a>
     </div>
 
     <div class="buyer-qa-item">
       <div class="buyer-qa-q">Where does my data live?</div>
-      <p class="buyer-qa-a">Server location: Hetzner Nuremberg, Germany. Legal jurisdiction: EU / Germany (GDPR). US CLOUD Act: Not applicable: no US infrastructure, no US company.</p>
+      <p class="buyer-qa-a">Your documents and keys live on servers at Hetzner Nuremberg, Germany. They stay under EU law and the GDPR, and no US provider is in the data path. Email goes out via Resend, as <a class="buyer-qa-inline" href="/privacy">/privacy</a> sets out.</p>
       <a class="buyer-qa-link" href="/security">Read the security page &rarr;</a>
     </div>
   </section>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -206,7 +206,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
     <div class="buyer-qa-item">
       <div class="buyer-qa-q">Where does my data live?</div>
-      <p class="buyer-qa-a">Your documents and keys live on servers at Hetzner Nuremberg, Germany. They stay under EU law and the GDPR, and no US provider is in the data path. Email goes out via Resend, as <a class="buyer-qa-inline" href="/privacy">/privacy</a> sets out.</p>
+      <p class="buyer-qa-a">Your documents live on servers at Hetzner Nuremberg, Germany, and they sit there as ciphertext. The relay never sees plaintext and never holds a private key. Your files stay under EU law and the GDPR, and no US provider is in the data path. Email goes out via Resend, as <a class="buyer-qa-inline" href="/privacy">/privacy</a> sets out.</p>
       <a class="buyer-qa-link" href="/security">Read the security page &rarr;</a>
     </div>
   </section>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -5,12 +5,12 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Help · PARAMANT</title>
 <meta property="og:title" content="Help · PARAMANT">
-<meta property="og:description" content="Help and documentation for PARAMANT. API keys, TOTP, integrations, and troubleshooting.">
+<meta property="og:description" content="Answers about Paramant: signing without an account, what it costs, where your data lives, plus API keys, TOTP, integrations and troubleshooting.">
 <meta property="og:url" content="https://paramant.app/help">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Paramant">
 <link rel="canonical" href="https://paramant.app/help">
-<meta name="description" content="Help and documentation for PARAMANT. API keys, TOTP, integrations, and troubleshooting.">
+<meta name="description" content="Answers about Paramant: signing without an account, what it costs, where your data lives, plus API keys, TOTP, integrations and troubleshooting.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
@@ -24,6 +24,14 @@ main{max-width:860px;margin:0 auto;padding:80px 48px 120px}
 h1{font-size:36px;font-weight:600;letter-spacing:-.03em;margin-bottom:12px}
 .lead{font-size:var(--text-base);color:var(--ink-dim);line-height:1.7;margin-bottom:48px;max-width:560px}
 h2{font-size:18px;font-weight:600;letter-spacing:-.01em;margin-bottom:20px;margin-top:56px;color:var(--ink)}
+.buyer-qa{border:1px solid var(--ink-hair);border-left:3px solid #B2FF3F;padding:24px 24px 8px;margin:0 0 48px}
+.buyer-qa .buyer-qa-title{margin:0 0 18px;font-family:IBM Plex Mono,monospace;font-size:11px;font-weight:600;letter-spacing:.14em;text-transform:uppercase;color:#64748b}
+.buyer-qa-item{margin-bottom:20px}
+.buyer-qa-q{font-size:15px;font-weight:600;color:var(--ink);margin-bottom:6px}
+.buyer-qa-a{font-size:var(--text-sm);color:var(--ink-dim);line-height:1.7;margin-bottom:6px}
+.buyer-qa-link{font-family:IBM Plex Mono,monospace;font-size:12px;color:var(--cobalt);text-decoration:underline;text-decoration-color:#B2FF3F;text-decoration-thickness:2px;text-underline-offset:3px}
+.buyer-qa-link:hover{color:var(--ink)}
+@media(max-width:640px){.buyer-qa{padding:20px 18px 4px;margin-bottom:36px}.buyer-qa-q{font-size:14px}}
 a{color:var(--ink);text-decoration:none}
 footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:16px}
 .footer-links{display:flex;gap:20px;flex-wrap:wrap}
@@ -117,7 +125,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Help and documentation for PARAMANT. API keys, TOTP, integrations, and troubleshooting."
+      "description": "Answers about Paramant: signing without an account, what it costs, where your data lives, plus API keys, TOTP, integrations and troubleshooting."
     },
     {
       "@type": "BreadcrumbList",
@@ -179,6 +187,28 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
   <h1>Help</h1>
   <p class="lead">Answers to the most common questions about Paramant: authentication, integrations, and troubleshooting.</p>
+
+  <section class="buyer-qa" aria-labelledby="buyer-qa-title">
+    <h2 id="buyer-qa-title" class="buyer-qa-title">Asked most often</h2>
+
+    <div class="buyer-qa-item">
+      <div class="buyer-qa-q">Can I sign without an account?</div>
+      <p class="buyer-qa-a">No. Signing a document needs an account. Without one you can still open a signing request someone sent you.</p>
+      <a class="buyer-qa-link" href="/sign">Go to signing &rarr;</a>
+    </div>
+
+    <div class="buyer-qa-item">
+      <div class="buyer-qa-q">What does it cost?</div>
+      <p class="buyer-qa-a">The Community tier is free forever, no card required, and free accounts sign 2 documents a month. Organisations pay for the higher limits. Pay for volume, never for security.</p>
+      <a class="buyer-qa-link" href="/pricing">See pricing &rarr;</a>
+    </div>
+
+    <div class="buyer-qa-item">
+      <div class="buyer-qa-q">Where does my data live?</div>
+      <p class="buyer-qa-a">Server location: Hetzner Nuremberg, Germany. Legal jurisdiction: EU / Germany (GDPR). US CLOUD Act: Not applicable: no US infrastructure, no US company.</p>
+      <a class="buyer-qa-link" href="/security">Read the security page &rarr;</a>
+    </div>
+  </section>
 
   <aside class="parapear-block" aria-label="A friendly note">
     <img class="parapear-img" src="/assets/parapear/parapear-help.png" alt="" aria-hidden="true" loading="lazy" decoding="async" width="120" height="120">

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Lost authenticator access — PARAMANT Help</title>
-<meta property="og:title" content="Lost authenticator access — PARAMANT Help">
+<title>Lost authenticator access &middot; PARAMANT Help</title>
+<meta property="og:title" content="Lost authenticator access &middot; PARAMANT Help">
 <meta property="og:description" content="How to recover your Paramant account after losing access to your TOTP authenticator app. Backup codes, support recovery, and re-enrollment.">
 <meta property="og:url" content="https://paramant.app/help/lost-authenticator">
 <meta property="og:type" content="website">
@@ -136,7 +136,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/help/lost-authenticator#webpage",
       "url": "https://paramant.app/help/lost-authenticator",
-      "name": "Lost authenticator access — PARAMANT Help",
+      "name": "Lost authenticator access \u00b7 PARAMANT Help",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -235,9 +235,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <h2>Check if your authenticator is still accessible</h2>
       <p>The TOTP secret is often stored in cloud backup by authenticator apps:</p>
       <ul style="margin:12px 0 12px 20px;display:flex;flex-direction:column;gap:8px">
-        <li style="color:var(--ink-dim);font-size:var(--text-sm);line-height:1.6"><strong style="color:var(--ink)">1Password / Bitwarden</strong> — the TOTP key is in your vault. Log in on any device to access it.</li>
-        <li style="color:var(--ink-dim);font-size:var(--text-sm);line-height:1.6"><strong style="color:var(--ink)">Authy</strong> — install Authy on a new phone, sign in with your Authy account, and re-activate multi-device backup.</li>
-        <li style="color:var(--ink-dim);font-size:var(--text-sm);line-height:1.6"><strong style="color:var(--ink)">Raivo (iOS) / Aegis (Android)</strong> &mdash; check iCloud/device backup. If you used encrypted local backup, restore on your new device before signing into Paramant.</li>
+        <li style="color:var(--ink-dim);font-size:var(--text-sm);line-height:1.6"><strong style="color:var(--ink)">1Password / Bitwarden</strong>: the TOTP key is in your vault. Log in on any device to access it.</li>
+        <li style="color:var(--ink-dim);font-size:var(--text-sm);line-height:1.6"><strong style="color:var(--ink)">Authy</strong>: install Authy on a new phone, sign in with your Authy account, and re-activate multi-device backup.</li>
+        <li style="color:var(--ink-dim);font-size:var(--text-sm);line-height:1.6"><strong style="color:var(--ink)">Raivo (iOS) / Aegis (Android)</strong>: check iCloud/device backup. If you used encrypted local backup, restore on your new device before signing into Paramant.</li>
       </ul>
     </div>
   </div>
@@ -255,7 +255,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         <li style="color:var(--ink-dim);font-size:var(--text-sm);line-height:1.6">Any transfer IDs or file names from recent activity to help verify identity</li>
       </ul>
       <p>We respond within 48 hours and will ask follow-up questions to verify your identity before resetting anything.</p>
-      <div class="warn"><p>We cannot reset accounts without identity verification. This is deliberate — it prevents an attacker from using the support channel to take over accounts.</p></div>
+      <div class="warn"><p>We cannot reset accounts without identity verification. This is deliberate. It prevents an attacker from using the support channel to take over accounts.</p></div>
     </div>
   </div>
 
@@ -273,7 +273,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
   <div class="troubleshoot-item">
     <div class="q">How long does the manual reset take?</div>
-    <div class="a">We respond within 48 hours. The verification exchange typically takes one to two rounds of email. Plan for 2–4 days from first contact to restored access if identity questions require extra documentation.</div>
+    <div class="a">We respond within 48 hours. The verification exchange typically takes one to two rounds of email. Plan for 2 to 4 days from first contact to restored access if identity questions require extra documentation.</div>
   </div>
 
   <div class="troubleshoot-item">

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -217,7 +217,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
   <h1>Lost access to your <em>authenticator</em> app.</h1>
 
-  <p class="lead">Work through these steps in order. Most people recover access within a few minutes using backup codes. If you have none left, contact support — we can verify your identity and reset your authenticator manually.</p>
+  <p class="lead">Work through these steps in order. Most people recover access within a few minutes using backup codes. If you have none left, contact support. We can verify your identity and reset your authenticator manually.</p>
 
   <div class="step">
     <div class="step-num">1</div>

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -358,3 +358,62 @@ console.log('ui-truthfulness: the homepage does not overclaim signatures and quo
 console.log('ui-truthfulness: the free plan is Community everywhere and the founder line matches /about');
 console.log('ui-truthfulness: the dashboard names the plans /pricing actually sells');
 console.log('ui-truthfulness: the account page resolves plans from the same source and never upsells a customer');
+
+// ── /docs and /help now answer a buyer, and quote pages instead of paraphrasing ─
+// The messaging guide (docs/brand/messaging.md, section 10) allows a sentence on
+// the site only when it already ships somewhere and a test fails when it stops
+// shipping. These three answers were copied onto /help from /sign, /pricing and
+// /security. A copy drifts silently: the source page can be reworded and the
+// copy keeps promising the old thing. So each assertion is a pair, the quote and
+// the page it was quoted from, and the pair fails together.
+const docsHtml = read('frontend/docs.html');
+const helpHtml = read('frontend/help/index.html');
+const securityHtml = read('frontend/security.html');
+const developerHtml = read('frontend/developer.html');
+
+// /docs is where an evaluating buyer sends their IT, and it must say so before
+// it starts talking about pip install. It absorbed traffic that belonged on
+// /pricing, so it also has to name the price boundary of the API once.
+assert.match(docsHtml, /Your IT can check everything here/,
+  'docs.html must open with the line that tells a buyer what this page is for');
+assert.match(docsHtml, /The ParaSign API is available from ParaSign Pro/,
+  'docs.html must state which plan the ParaSign API needs');
+assert.match(developerHtml, /API access is included from ParaSign Pro/,
+  'developer.html must state which plan the ParaSign API needs');
+// Both of those are only true while /pricing sells API access on ParaSign Pro.
+assert.match(pricing, /Unlimited transfers - API access/,
+  'pricing.html must still list API access on the ParaSign Pro tier');
+
+// Answer 1: signing without an account. Quoted from /sign, which is pinned above.
+assert.match(helpHtml, /Signing a document needs an account/i,
+  'help/index.html must answer whether an account is required');
+assert.match(helpHtml, /open a signing request someone sent you/i,
+  'help/index.html must say what an invited signer can do without an account');
+assert.match(signHtml, /Free accounts sign 2 documents a month/i,
+  'sign.html is the source of the free signing limit quoted on /help');
+assert.match(helpHtml, /free accounts sign 2 documents a month/i,
+  'help/index.html must answer what the free tier gives');
+
+// Answer 2: cost. The sentence the whole free-versus-paid split rests on. If the
+// pricing model ever gates cryptography behind a tier, this is what fails first.
+assert.match(pricing, /Pay for volume, never for security/,
+  'pricing.html must keep the sentence the free-versus-paid split rests on');
+assert.match(helpHtml, /Pay for volume, never for security/,
+  'help/index.html must quote the pricing promise, not paraphrase it');
+
+// Answer 3: where the data lives. Quoted from the Jurisdiction and privacy table
+// on /security, word for word, and never broadened past what that table says.
+assert.match(securityHtml, /Hetzner Nuremberg, Germany/,
+  'security.html must keep the server location row');
+assert.match(securityHtml, /Not applicable: no US infrastructure, no US company/,
+  'security.html must keep the CLOUD Act row');
+assert.match(helpHtml, /Hetzner Nuremberg, Germany/,
+  'help/index.html must answer where the data lives');
+assert.match(helpHtml, /Not applicable: no US infrastructure, no US company/,
+  'help/index.html must quote the CLOUD Act row exactly');
+
+// No sales voice on a support page. Someone here has already signed up.
+assert.doesNotMatch(helpHtml, /revolutionary|seamless|cutting-edge|enterprise-grade|military-grade|trusted by|world-class/i,
+  'help/index.html must stay in support voice');
+
+console.log('ui-truthfulness: /docs and /help answer a buyer with sentences that ship elsewhere');

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -363,57 +363,114 @@ console.log('ui-truthfulness: the account page resolves plans from the same sour
 // The messaging guide (docs/brand/messaging.md, section 10) allows a sentence on
 // the site only when it already ships somewhere and a test fails when it stops
 // shipping. These three answers were copied onto /help from /sign, /pricing and
-// /security. A copy drifts silently: the source page can be reworded and the
-// copy keeps promising the old thing. So each assertion is a pair, the quote and
-// the page it was quoted from, and the pair fails together.
+// / (the rules grid). A copy drifts silently: the source page can be reworded
+// and the copy keeps promising the old thing. So each assertion is a pair, the
+// quote and the page it was quoted from, and the pair fails together.
+//
+// Every quote is matched inside the markup a visitor actually sees. An earlier
+// version of this block asserted the docs buyer line against the whole file, and
+// deleting the visible paragraph left the test green: the same words also sit in
+// four meta tags. A pin that a meta description can satisfy pins nothing.
 const docsHtml = read('frontend/docs.html');
 const helpHtml = read('frontend/help/index.html');
 const securityHtml = read('frontend/security.html');
 const developerHtml = read('frontend/developer.html');
+const homeGrid = read('frontend/index.html');
+// The three answers on /help, without their surrounding page.
+const helpAnswers = [...helpHtml.matchAll(/<p class="buyer-qa-a">([\s\S]*?)<\/p>/g)].map((m) => m[1]).join('\n');
+assert.equal(helpAnswers.split('\n').length, 3,
+  'help/index.html must keep the three buyer answers in the "Asked most often" block');
 
 // /docs is where an evaluating buyer sends their IT, and it must say so before
 // it starts talking about pip install. It absorbed traffic that belonged on
-// /pricing, so it also has to name the price boundary of the API once.
-assert.match(docsHtml, /Your IT can check everything here/,
-  'docs.html must open with the line that tells a buyer what this page is for');
-assert.match(docsHtml, /The ParaSign API is available from ParaSign Pro/,
-  'docs.html must state which plan the ParaSign API needs');
-assert.match(developerHtml, /API access is included from ParaSign Pro/,
-  'developer.html must state which plan the ParaSign API needs');
-// Both of those are only true while /pricing sells API access on ParaSign Pro.
+// /pricing, so it also has to name the price boundary of the API once, and it
+// gives the buyer a button of the same weight as the developer's Quick start.
+assert.match(docsHtml, /<p class="docs-buyer">Evaluating Paramant\? Your IT can check everything here\./,
+  'docs.html must open with the visible line that tells a buyer what this page is for');
+assert.match(docsHtml, /<p class="lede">[^<]*The ParaSign API is available from ParaSign Pro/,
+  'docs.html must state in the visible lede which plan the ParaSign API needs');
+const docsActions = (docsHtml.match(/<div class="docs-hero-actions">[\s\S]*?<\/div>/) || [''])[0];
+assert.match(docsActions, /<a href="#quickstart" class="docs-hero-btn docs-hero-btn-primary">/,
+  'the developer keeps the primary button on /docs: Quick start');
+assert.match(docsActions, /<a href="\/pricing" class="docs-hero-btn docs-hero-btn-secondary">/,
+  'the buyer gets a real button to /pricing beside it, not only a text link');
+assert.match(developerHtml, /<p class="lede">[^<]*(?:<a[^>]*>[^<]*<\/a>[^<]*)*API access is included from ParaSign Pro/,
+  'developer.html must state in its visible lede which plan the ParaSign API needs');
+// /developer is noindex and only reachable once signed in, so it addresses the
+// developer reading it, never the buyer who sent them.
+assert.doesNotMatch(developerHtml, /your IT can check/i,
+  'developer.html talks to the developer on the screen, not to their buyer');
+// Both plan lines are only true while /pricing sells API access on ParaSign Pro.
 assert.match(pricing, /Unlimited transfers - API access/,
   'pricing.html must still list API access on the ParaSign Pro tier');
 
 // Answer 1: signing without an account. Quoted from /sign, which is pinned above.
-assert.match(helpHtml, /Signing a document needs an account/i,
+assert.match(helpAnswers, /Signing a document needs an account/i,
   'help/index.html must answer whether an account is required');
-assert.match(helpHtml, /open a signing request someone sent you/i,
+assert.match(helpAnswers, /open a signing request someone sent you/i,
   'help/index.html must say what an invited signer can do without an account');
-assert.match(signHtml, /Free accounts sign 2 documents a month/i,
-  'sign.html is the source of the free signing limit quoted on /help');
-assert.match(helpHtml, /free accounts sign 2 documents a month/i,
-  'help/index.html must answer what the free tier gives');
 
-// Answer 2: cost. The sentence the whole free-versus-paid split rests on. If the
-// pricing model ever gates cryptography behind a tier, this is what fails first.
-assert.match(pricing, /Pay for volume, never for security/,
+// Answer 2: cost. A support page that will not name a number sends someone back
+// to the search box, so /help names the free allowance and the first paid price
+// exactly as /pricing prints them, and both halves are pinned to that page.
+// Scoped to the ParaSign grid: /help names "ParaSign Community" and quotes its
+// allowance, and pricing.html carries a second Community card for ParaSend. A
+// bare match on the tier name stays green while the ParaSign one is renamed.
+const parasignGrid = pricing.slice(pricing.indexOf('<!-- TIER CARDS: PARASIGN -->'));
+assert.ok(parasignGrid.length > 0 && parasignGrid.length < pricing.length,
+  'pricing.html must keep the ParaSign tier grid this block reads from');
+assert.match(parasignGrid, /<div class="tier-name">Community<\/div>[\s\S]{0,400}?<li>2 signatures per month<\/li>/,
+  'pricing.html is the source of the ParaSign Community allowance quoted on /help');
+assert.match(pricing, /&euro;49<span/,
+  'pricing.html is the source of the ParaSign Pro price quoted on /help');
+assert.match(pricing, /charged &euro;59\.29\/mo incl\. 21% btw/,
+  'pricing.html is the source of the incl. btw figure quoted on /help');
+assert.match(helpAnswers, /ParaSign Community is free, forever, and no card is required\. It covers 2 signatures per month\./,
+  'help/index.html must name the free allowance, not just promise that free exists');
+assert.match(helpAnswers, /ParaSign Pro at &euro;49 a month excl\. btw \(&euro;59\.29 incl\.\)/,
+  'help/index.html must name the first paid price the way /pricing prints it');
+// Proof 3 of the messaging guide, quoted from /pricing. The slogan that follows
+// it there ("Pay for volume, never for security") stays on the page that sells;
+// /help is support voice and an unverifiable sales line is the last thing
+// someone stuck on this page needs.
+assert.match(pricing, /Every plan gets the same encryption, the same post-quantum signatures and the same public proof log\. Pay for volume, never for security\./,
   'pricing.html must keep the sentence the free-versus-paid split rests on');
-assert.match(helpHtml, /Pay for volume, never for security/,
-  'help/index.html must quote the pricing promise, not paraphrase it');
+assert.match(helpAnswers, /Every plan gets the same encryption, the same post-quantum signatures and the same public proof log\./,
+  'help/index.html must quote the same-crypto fact, not paraphrase it');
+assert.doesNotMatch(helpAnswers, /Pay for volume, never for security/,
+  'help/index.html must not carry the sales line; it is a support page');
 
-// Answer 3: where the data lives. Quoted from the Jurisdiction and privacy table
-// on /security, word for word, and never broadened past what that table says.
+// Answer 3: where the data lives. Three sentences a person can read, not the
+// Jurisdiction and privacy table flattened into prose. The claim is scoped to
+// the data path and names the Resend exception in the same breath, exactly as
+// proof 1 of the messaging guide requires. The unqualified "no US company" row
+// on /security is an open contradiction (guide section 9) and is deliberately
+// not repeated here.
 assert.match(securityHtml, /Hetzner Nuremberg, Germany/,
-  'security.html must keep the server location row');
-assert.match(securityHtml, /Not applicable: no US infrastructure, no US company/,
-  'security.html must keep the CLOUD Act row');
-assert.match(helpHtml, /Hetzner Nuremberg, Germany/,
+  'security.html must keep the server location row /help quotes');
+assert.match(homeGrid, /No US provider in the data path\. Email goes out via Resend, as <a href="\/privacy">\/privacy<\/a> sets out\./,
+  'index.html is the source of the data-path wording and its Resend exception');
+assert.match(helpAnswers, /Hetzner Nuremberg, Germany/,
   'help/index.html must answer where the data lives');
-assert.match(helpHtml, /Not applicable: no US infrastructure, no US company/,
-  'help/index.html must quote the CLOUD Act row exactly');
+assert.match(helpAnswers, /no US provider is in the data path/,
+  'help/index.html must scope the claim to the data path');
+assert.match(helpAnswers, /Email goes out via Resend, as <a class="buyer-qa-inline" href="\/privacy">\/privacy<\/a> sets out\./,
+  'help/index.html must name the Resend exception in the same breath, with the /privacy link');
+assert.doesNotMatch(helpAnswers, /no US company/i,
+  'help/index.html must not repeat the unqualified no-US-company row from /security');
 
 // No sales voice on a support page. Someone here has already signed up.
 assert.doesNotMatch(helpHtml, /revolutionary|seamless|cutting-edge|enterprise-grade|military-grade|trusted by|world-class/i,
   'help/index.html must stay in support voice');
+
+// The tone rule is site-wide, but these two articles kept em-dashes in the H1
+// and the tab title after an earlier pass cleaned only their ledes.
+for (const slug of ['index', 'api-key-vs-totp', 'lost-authenticator']) {
+  const html = read(`frontend/help/${slug}.html`);
+  assert.doesNotMatch(html, /\u2014|&mdash;|\u2013|&ndash;/,
+    `help/${slug}.html must carry no em-dash or en-dash, in the H1, the title or anywhere else`);
+}
+assert.doesNotMatch(docsHtml, /\u2014|&mdash;|\u2013|&ndash;/,
+  'docs.html must carry no em-dash or en-dash');
 
 console.log('ui-truthfulness: /docs and /help answer a buyer with sentences that ship elsewhere');

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -376,6 +376,11 @@ const helpHtml = read('frontend/help/index.html');
 const securityHtml = read('frontend/security.html');
 const developerHtml = read('frontend/developer.html');
 const homeGrid = read('frontend/index.html');
+// Everything below </head>: the page a visitor reads, meta tags excluded. The
+// sales-voice and key-location gates below run against this, not against the
+// three answers alone, so a slogan cannot slip back in through the lede, an
+// article card or the footer.
+const helpBody = helpHtml.slice(helpHtml.indexOf('</head>'));
 // The three answers on /help, without their surrounding page.
 const helpAnswers = [...helpHtml.matchAll(/<p class="buyer-qa-a">([\s\S]*?)<\/p>/g)].map((m) => m[1]).join('\n');
 assert.equal(helpAnswers.split('\n').length, 3,
@@ -437,8 +442,8 @@ assert.match(pricing, /Every plan gets the same encryption, the same post-quantu
   'pricing.html must keep the sentence the free-versus-paid split rests on');
 assert.match(helpAnswers, /Every plan gets the same encryption, the same post-quantum signatures and the same public proof log\./,
   'help/index.html must quote the same-crypto fact, not paraphrase it');
-assert.doesNotMatch(helpAnswers, /Pay for volume, never for security/,
-  'help/index.html must not carry the sales line; it is a support page');
+assert.doesNotMatch(helpBody, /Pay for volume, never for security/,
+  'help/index.html must not carry the sales line anywhere in the body; it is a support page');
 
 // Answer 3: where the data lives. Three sentences a person can read, not the
 // Jurisdiction and privacy table flattened into prose. The claim is scoped to
@@ -450,8 +455,8 @@ assert.match(securityHtml, /Hetzner Nuremberg, Germany/,
   'security.html must keep the server location row /help quotes');
 assert.match(homeGrid, /No US provider in the data path\. Email goes out via Resend, as <a href="\/privacy">\/privacy<\/a> sets out\./,
   'index.html is the source of the data-path wording and its Resend exception');
-assert.match(helpAnswers, /Hetzner Nuremberg, Germany/,
-  'help/index.html must answer where the data lives');
+assert.match(helpAnswers, /Your documents live on servers at Hetzner Nuremberg, Germany, and they sit there as ciphertext\./,
+  'help/index.html must answer where the documents live, and say they are ciphertext there');
 assert.match(helpAnswers, /no US provider is in the data path/,
   'help/index.html must scope the claim to the data path');
 assert.match(helpAnswers, /Email goes out via Resend, as <a class="buyer-qa-inline" href="\/privacy">\/privacy<\/a> sets out\./,
@@ -459,8 +464,36 @@ assert.match(helpAnswers, /Email goes out via Resend, as <a class="buyer-qa-inli
 assert.doesNotMatch(helpAnswers, /no US company/i,
   'help/index.html must not repeat the unqualified no-US-company row from /security');
 
+// A private key never reaches a server, and the whole site says so: "Generated
+// on your device, never sent" (index.html), "relay holds only ciphertext, never
+// keys" and "No plaintext, no keys" (security.html), "we never hold decryption
+// keys, anywhere" (trust.html), "The relay never sees plaintext and never holds
+// a private key" (docs.html). An answer that puts keys in a rack in Nuremberg
+// contradicts all five at once, and it is the sentence a security reviewer
+// would quote back. So /help may name a key only in the negative: any sentence
+// that mentions a key and a piece of infrastructure must be saying the key is
+// not there.
+assert.match(homeGrid, /Generated on your device, never sent/,
+  'index.html is the source of the promise that a key never reaches a server');
+assert.match(securityHtml, /relay holds only ciphertext, never keys/,
+  'security.html is the source of the promise that the relay holds no keys');
+assert.match(docsHtml, /The relay never sees plaintext and never holds a private key\./,
+  'docs.html is the source of the sentence /help quotes about plaintext and keys');
+assert.match(helpAnswers, /The relay never sees plaintext and never holds a private key\./,
+  'help/index.html must say where the keys are not, in the words docs.html uses');
+for (const sentence of helpBody.replace(/<[^>]+>/g, ' ').split(/(?<=[.!?])\s+/)) {
+  if (!/\bkeys?\b/i.test(sentence)) continue;
+  if (!/\b(server|servers|relay|Hetzner|Nuremberg|hosted|infrastructure|data centre|data center)\b/i.test(sentence)) continue;
+  assert.match(sentence, /\bnever\b|\bno\b|\bnot\b/i,
+    `help/index.html puts a key on infrastructure without denying it: "${sentence.trim()}"`);
+  assert.doesNotMatch(sentence, /\bkeys?\b[^.]{0,60}?\b(?:live|sit|reside|are stored|are kept|are held|stay)\b/i,
+    `help/index.html must not say a key lives on a server: "${sentence.trim()}"`);
+  assert.doesNotMatch(sentence, /\b(?:live|sit|reside|stored|kept|held)\b[^.]{0,60}?\bkeys?\b/i,
+    `help/index.html must not say a server holds a key: "${sentence.trim()}"`);
+}
+
 // No sales voice on a support page. Someone here has already signed up.
-assert.doesNotMatch(helpHtml, /revolutionary|seamless|cutting-edge|enterprise-grade|military-grade|trusted by|world-class/i,
+assert.doesNotMatch(helpBody, /revolutionary|seamless|cutting-edge|enterprise-grade|military-grade|trusted by|world-class/i,
   'help/index.html must stay in support voice');
 
 // The tone rule is site-wide, but these two articles kept em-dashes in the H1


### PR DESCRIPTION
## What this does

/docs, /developer and /help, rebased on main and reworked after two rounds of review. The rule from `docs/brand/messaging.md`: a sentence ships only when it already ships somewhere else and a test fails the moment it stops shipping. Every claim below is quoted from the page that owns it, and every quote is pinned to the markup a visitor actually sees.

## The review points, one by one

**1. The buyer line on /docs was not pinned.** The old assertion matched `Your IT can check everything here` against the whole file, and the same words sit in four meta tags. Deleting the visible paragraph left the test green. The assertion is now anchored to `<p class="docs-buyer">Evaluating Paramant? ...`. Sabotaged both ways: removing the paragraph is red, and leaving it while breaking only the meta copy is red too.

**2. The buyer had no button on /docs.** Quick start was the only real action and Pricing was a text link. There are now two buttons of the same size in the same row: Quick start (filled, still the primary CTA the guide asks for) and See plans and prices (outlined, straight to /pricing). Create account stays as a text link below them. On 390px both buttons go full width and stack. Pinned on both `href` and class, so demoting either one back to a text link fails.

**3. "What does it cost?" on /help named no amount.** It now names what /pricing prints: ParaSign Community is free, forever, no card required, 2 signatures per month; the first paid plan is ParaSign Pro at &euro;49 a month excl. btw (&euro;59.29 incl.) with 100 signatures a month. Each half is pinned against the card it came from, and the Community pin is scoped to the ParaSign grid because /pricing carries a second Community card for ParaSend.

**4. "Pay for volume, never for security" was a sales line on a support page.** It is gone from /help and stays on /pricing, which is the page that sells. The fact behind it is quoted instead, word for word: "Every plan gets the same encryption, the same post-quantum signatures and the same public proof log." A `doesNotMatch` fails if the slogan comes back. That gate, and the sales-vocabulary gate beside it, run on the whole /help body below `</head>`, not on the three answers alone, so the line cannot return through the lede, an article card or the footer.

**5. "Where does my data live?" was a compliance table flattened into prose**, with two colons in one sentence. It is four short sentences now, and the second round of review caught a real error in the first draft of them: it said the documents *and keys* live on servers at Hetzner. The keys do not. Five places on the site promise the opposite: "Generated on your device, never sent" (index.html), "relay holds only ciphertext, never keys" and "No plaintext, no keys" (security.html), "we never hold decryption keys, anywhere" (trust.html), "The relay never sees plaintext and never holds a private key" (docs.html). The answer now reads:

> Your documents live on servers at Hetzner Nuremberg, Germany, and they sit there as ciphertext. The relay never sees plaintext and never holds a private key. Your files stay under EU law and the GDPR, and no US provider is in the data path. Email goes out via Resend, as /privacy sets out.

That is proof 1 of the messaging guide, scoped to the data path and naming the Resend exception in the same breath, plus the key sentence quoted from docs.html. The unqualified "no US company" row on /security is an open contradiction (guide section 9) and is deliberately not repeated here; a test fails if it appears.

Pinned in both directions. The positive half is a pair, the quote and docs.html. The negative half is a loop over every sentence in the /help body: a sentence naming a key and a piece of infrastructure in the same breath must be denying it, and may never put a locative verb between the two. Sabotage: putting "and keys" back is red, "your keys are stored on the relay" is red, and "Your keys are kept on servers at Hetzner Nuremberg, and there is no US provider" is red as well, so a stray "no" elsewhere in the sentence buys no pass.

**6. The em-dash sweep stopped at the lede.** The H1, the tab title, the meta description and the body of /help/api-key-vs-totp and /help/lost-authenticator still had them: eleven and six. All gone, plus an en-dash range in each of the two pages and one on /docs. A loop over the three help pages and /docs pins it.

**7. /developer spoke to the wrong audience.** The page is noindex and only reachable once signed in, so "so your IT can check everything before you connect anything" was addressing someone who is not there. It now reads "so you can read the whole surface before you connect anything." The plan boundary for API access stays, and a test forbids the buyer phrasing from returning.

**Also fixed while here:** two sentences on /docs that ran on double colons (the "Version 3.0.0 keeps ..." lede and the ADR line) now read as sentences.

## Rebase

Rebased onto main twice. The first pass resolved a conflict in `tests/ui-truthfulness.test.mjs` where main's homepage, dashboard and Community-rename assertions (#327, #328) landed in the same place; both sides kept, the duplicate `pricing.html` read folded into the existing one. main's rename of the free tier to Community also changed the source sentence on /sign, so the /help quote follows it. The second pass took #332, which appends two `console.log` lines at the end of the same file: no name collision, both sides kept. Now current with #352 and #353. `frontend/apply-nav.py` ran after each rebase and produced no further changes.

## Proof

Green: `links`, `seo-contract`, `ui-truthfulness`, `site-claims`, `frontend-loading-contract`, `navigation-shell`, `check-csp-inline.sh`, `check-cache-bust.sh`, `eslint@9 .`, `tests/static-sanity.sh` (PASS, all hard checks clear, 10/10), `scripts/check-commit-style.sh` over the whole range.

Sabotage: 37 mutations, one at a time, each reverted after the run. Every new pin went red, including the ones on the source pages (`pricing.html`, `security.html`, `index.html`, `docs.html`) and the four negative pins. Screenshots at 390x844: no horizontal scroll on either page, scrollWidth 390 = clientWidth 390, and all three /help answers still fit one screen.

Known gap, outside this PR: renaming the *ParaSend* Community card on /pricing stays green, because main's assertion from #328 is satisfied by the remaining ParaSign card. This branch's own pin is scoped and does catch the ParaSign one. That is a pin on main, not a regression here.

Scope: six files, all /docs, /developer, /help and their test. `frontend/apply-nav.py`, `frontend/js/nav-auth.js` and `frontend/index.html` are not edited.
