### PR TITLE
A shared link says what we sell, and names the company behind it

### DIFF
--- a/bron-seo/apply_seo_head.py
+++ b/bron-seo/apply_seo_head.py
@@ -30,6 +30,10 @@ REDIRECTS = {"iot"}
 PRIVATE = {
     "404", "account", "admin", "all-systems-go", "claim", "co-sign", "dashboard",
     "developer", "get", "ontvang", "request-key", "setup",
+    # /parashare sits behind the same nginx auth_request the test's PRIVATE set
+    # names it for. It was in this list's counterpart and not in this list, so
+    # the two files disagreed about one page.
+    "parashare",
     "auth/backup", "auth/login", "auth/request-reset", "auth/reset-confirm",
     "auth/setup", "billing/checkout", "signup/verified"}
 
@@ -39,6 +43,22 @@ PRIVATE = {
 SOFTWARE = {
     "index", "parashare", "parasign", "sign", "verify", "vault", "download",
     "co-sign"}
+
+# Where a page ships a SoftwareApplication node that is more specific than the
+# generic one, it is written down here instead of by hand in the HTML, or the
+# next run of this script quietly reverts it. The homepage sells ParaSign by
+# name (#328) and offers the Community plan at EUR 0, which is what
+# frontend/pricing.html prints on the ParaSign Community card.
+SOFTWARE_OVERRIDES = {
+    "index": {
+        "name": "ParaSign by Paramant",
+        "applicationCategory": "BusinessApplication",
+        "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "EUR",
+            "url": ORIGIN + "/pricing"}},
+}
 
 
 def pages():
@@ -66,7 +86,7 @@ def find(pattern, html, group=1):
 def clean(text):
     """Collapse an HTML fragment into one line of plain sentence text."""
     text = re.sub(r"<[^>]+>", " ", text)
-    text = (text.replace("&mdash;", "-").replace("&middot;", "-")
+    text = (text.replace("&mdash;", "-").replace("&middot;", "\u00b7")
                 .replace("&amp;", "&").replace("&nbsp;", " ")
                 .replace("&quot;", '"').replace("&#39;", "'"))
     return re.sub(r"\s+", " ", text).strip()
@@ -99,13 +119,35 @@ def trim(text, limit=158):
     return cut.rsplit(" ", 1)[0].rstrip(" ,;:-.") + "..."
 
 
+# Every field here is already printed on the site: the legal name, the town and
+# the KvK number come from the footer that apply-nav.py stamps on every page,
+# the founder and his title come from /about, and the server location comes from
+# the jurisdiction table on /security. Nothing is asserted that a reader cannot
+# check on the page itself. The old description said "built and hosted in the
+# Netherlands", which contradicted /security: the company is Dutch, the servers
+# are Hetzner Nuremberg.
 ORG = {
     "@type": "Organization",
     "@id": f"{ORIGIN}/#organization",
     "name": "Paramant",
+    "legalName": "Paramantis Solutions B.V.",
     "url": ORIGIN + "/",
-    "description": "Post-quantum encrypted file transfer and document signing, "
-                   "built and hosted in the Netherlands.",
+    "description": "Document signing and encrypted file transfer for "
+                   "professional firms in the EU. Dutch company, servers in "
+                   "Germany.",
+    "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"},
+    "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"},
+    "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"},
+    "email": "privacy@paramant.app",
     "areaServed": "EU",
     "knowsLanguage": ["nl", "en"]}
 
@@ -143,17 +185,24 @@ def graph_for(slug, title, desc):
         nodes.append({"@type": "BreadcrumbList", "@id": url + "#breadcrumb", "itemListElement": items})
 
     if slug in SOFTWARE:
-        nodes.append({
+        app = {
             "@type": "SoftwareApplication",
             "@id": url + "#software",
             "name": "Paramant",
             "applicationCategory": "SecurityApplication",
             "operatingSystem": "Web browser",
-            "url": url,
-            "publisher": {"@id": f"{ORIGIN}/#organization"}})
+            "url": url}
+        app.update(SOFTWARE_OVERRIDES.get(slug, {}))
+        app["publisher"] = {"@id": f"{ORIGIN}/#organization"}
+        nodes.append(app)
+
+    # The Organization node goes on every public page, not just the homepage.
+    # Every other page already pointed a publisher @id at it while the node
+    # itself existed on one URL only, so a crawler landing on /pricing or
+    # /about saw a dangling reference and no founder at all.
+    nodes.append(ORG)
 
     if slug == "index":
-        nodes.append(ORG)
         nodes.append({
             "@type": "WebSite",
             "@id": f"{ORIGIN}/#website",

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Page not found — PARAMANT</title>
+  <title>Page not found · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/404">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -4,17 +4,20 @@
 <meta charset="utf-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>About &middot; PARAMANT</title>
+<title>About Paramant · Founded by Mick Beer</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Paramant is privacy-first, post-quantum document signing and encrypted transfer under EU jurisdiction. What the product is, how you can check it yourself...">
-<meta property="og:title" content="About &middot; PARAMANT">
-<meta property="og:description" content="Privacy-first, post-quantum document signing and encrypted transfer under EU jurisdiction. What Paramant is, how to verify it, and the company behind it.">
+<meta name="description" content="Paramant is a product of Paramantis Solutions B.V. in Harderwijk, founded by Mick Beer, privacy and security researcher. Company, mission, and how to check us.">
+<meta property="og:title" content="About Paramant · Founded by Mick Beer">
+<meta property="og:description" content="Paramant is a product of Paramantis Solutions B.V. in Harderwijk, founded by Mick Beer, privacy and security researcher. Company, mission, and how to check us.">
 <meta property="og:url" content="https://paramant.app/about">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="About &middot; PARAMANT">
-<meta name="twitter:description" content="Privacy-first, post-quantum document signing and encrypted transfer under EU jurisdiction. What Paramant is, how to verify it, and the company behind it.">
+<meta name="twitter:title" content="About Paramant · Founded by Mick Beer">
+<meta name="twitter:description" content="Paramant is a product of Paramantis Solutions B.V. in Harderwijk, founded by Mick Beer, privacy and security researcher. Company, mission, and how to check us.">
 <link rel="canonical" href="https://paramant.app/about">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -55,7 +58,7 @@
       "@type": "WebPage",
       "@id": "https://paramant.app/about#webpage",
       "url": "https://paramant.app/about",
-      "name": "About - PARAMANT",
+      "name": "About Paramant · Founded by Mick Beer",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -63,7 +66,36 @@
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Paramant is privacy-first, post-quantum document signing and encrypted transfer under EU jurisdiction. What the product is, how you can check it yourself..."
+      "description": "Paramant is a product of Paramantis Solutions B.V. in Harderwijk, founded by Mick Beer, privacy and security researcher. Company, mission, and how to check us."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Your account — Paramant</title>
+<title>Your account · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -13,13 +13,13 @@
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta property="og:title" content="Your account · Paramant">
-<meta property="og:description" content="Your account — Paramant">
+<meta property="og:description" content="Your account · Paramant">
 <meta property="og:url" content="https://paramant.app/account">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Your account · Paramant">
-<meta name="twitter:description" content="Your account — Paramant">
+<meta name="twitter:description" content="Your account · Paramant">
 <link rel="canonical" href="https://paramant.app/account">
 <style>
 /* Plan bands in the billing section: what this plan is, in one line. The

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,system-ui,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>PARAMANT · Admin</title>
+<title>Admin · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
@@ -164,14 +164,14 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
 .chip.required-missing{background:rgba(220,38,38,.08);color:#dc2626;font-weight:600}
 .chip.required-ok{background:rgba(29,78,216,.08);color:#1D4ED8}
 </style>
-<meta property="og:title" content="PARAMANT · Admin">
-<meta property="og:description" content="PARAMANT · Admin">
+<meta property="og:title" content="Admin · Paramant">
+<meta property="og:description" content="Admin · Paramant">
 <meta property="og:url" content="https://paramant.app/admin">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT · Admin">
-<meta name="twitter:description" content="PARAMANT · Admin">
+<meta name="twitter:title" content="Admin · Paramant">
+<meta name="twitter:description" content="Admin · Paramant">
 <link rel="canonical" href="https://paramant.app/admin">
 </head>
 <body>

--- a/frontend/all-systems-go.html
+++ b/frontend/all-systems-go.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Paramant - All systems</title>
+  <title>All systems · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/all-systems-go">
   <link rel="stylesheet" href="/design-system.css?v=23">

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -4,17 +4,20 @@
 <meta charset="utf-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Architecture — PARAMANT</title>
+<title>Architecture · How Paramant works</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="How Paramant works: browser-side encryption, RAM-only relay, burn-on-read, URL fragment key delivery. Shown, not told.">
-<meta property="og:title" content="Architecture · PARAMANT">
-<meta property="og:description" content="How Paramant works: browser-side encryption, RAM-only relay, burn-on-read, URL fragment key delivery. Shown, not told.">
+<meta name="description" content="A plain-language walkthrough: how your file is encrypted in the browser, how it travels, why the relay cannot read it, and what happens when a link opens.">
+<meta property="og:title" content="Architecture · How Paramant works">
+<meta property="og:description" content="A plain-language walkthrough: how your file is encrypted in the browser, how it travels, why the relay cannot read it, and what happens when a link opens.">
 <meta property="og:url" content="https://paramant.app/architecture">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Architecture · PARAMANT">
-<meta name="twitter:description" content="How Paramant works: browser-side encryption, RAM-only relay, burn-on-read, URL fragment key delivery. Shown, not told.">
+<meta name="twitter:title" content="Architecture · How Paramant works">
+<meta name="twitter:description" content="A plain-language walkthrough: how your file is encrypted in the browser, how it travels, why the relay cannot read it, and what happens when a link opens.">
 <link rel="canonical" href="https://paramant.app/architecture">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -221,7 +224,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
       "@type": "WebPage",
       "@id": "https://paramant.app/architecture#webpage",
       "url": "https://paramant.app/architecture",
-      "name": "Architecture — PARAMANT",
+      "name": "Architecture · How Paramant works",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -229,7 +232,36 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "How Paramant works: browser-side encryption, RAM-only relay, burn-on-read, URL fragment key delivery. Shown, not told."
+      "description": "A plain-language walkthrough: how your file is encrypted in the browser, how it travels, why the relay cannot read it, and what happens when a link opens."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -4,11 +4,16 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>PARAMANT - GDPR audit log export with chain of custody</title>
+<title>Send audit logs to a regulator without a second leak · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="Deliver GDPR Article 30 evidence to a supervisory authority or an auditor without a second exposure. The file is destroyed after the first read.">
+<meta name="twitter:title" content="Send audit logs to a regulator without a second leak · Paramant">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Deliver GDPR Article 30 audit evidence to DPAs and auditors without creating new exposure. Burn-on-read delivery with ML-DSA-65 signed receipts for chain-of-custody.">
-<meta property="og:title" content="PARAMANT · GDPR audit log export, chain of custody">
-<meta property="og:description" content="Send audit logs to investigators and auditors over ML-KEM-768 encrypted, burn-on-read channels. The signed receipt is your chain-of-custody record.">
+<meta name="description" content="Deliver GDPR Article 30 evidence to a supervisory authority or an auditor without a second exposure. The file is destroyed after the first read.">
+<meta property="og:title" content="Send audit logs to a regulator without a second leak · Paramant">
+<meta property="og:description" content="Deliver GDPR Article 30 evidence to a supervisory authority or an auditor without a second exposure. The file is destroyed after the first read.">
 <meta property="og:url" content="https://paramant.app/audit-log-export">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
@@ -78,7 +83,7 @@ section p+p{margin-top:14px}
       "@type": "WebPage",
       "@id": "https://paramant.app/audit-log-export#webpage",
       "url": "https://paramant.app/audit-log-export",
-      "name": "PARAMANT - GDPR audit log export with chain of custody",
+      "name": "Send audit logs to a regulator without a second leak · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -86,7 +91,36 @@ section p+p{margin-top:14px}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Deliver GDPR Article 30 audit evidence to DPAs and auditors without creating new exposure. Burn-on-read delivery with ML-DSA-65 signed receipts for chain-of-custody."
+      "description": "Deliver GDPR Article 30 evidence to a supervisory authority or an auditor without a second exposure. The file is destroyed after the first read."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/billing/checkout.html
+++ b/frontend/billing/checkout.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Checkout — Paramant</title>
+<title>Checkout · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="refresh" content="0;url=/pricing">
 <link rel="canonical" href="https://paramant.app/pricing">

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -4,17 +4,20 @@
 <meta charset="utf-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Changelog · Paramant</title>
+<title>Changelog · Paramant release history</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Paramant release history: what changed, when, and why.">
-<meta property="og:title" content="Changelog · Paramant">
-<meta property="og:description" content="Paramant release history: what changed, when, and why.">
+<meta name="description" content="Transparent Paramant release history. What changed, when, and why. Security-relevant items are always listed.">
+<meta property="og:title" content="Changelog · Paramant release history">
+<meta property="og:description" content="Transparent Paramant release history. What changed, when, and why. Security-relevant items are always listed.">
 <meta property="og:url" content="https://paramant.app/changelog">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Changelog · Paramant">
-<meta name="twitter:description" content="Paramant release history: what changed, when, and why.">
+<meta name="twitter:title" content="Changelog · Paramant release history">
+<meta name="twitter:description" content="Transparent Paramant release history. What changed, when, and why. Security-relevant items are always listed.">
 <link rel="canonical" href="https://paramant.app/changelog">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="manifest" href="/manifest.json">
@@ -61,7 +64,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
       "@type": "WebPage",
       "@id": "https://paramant.app/changelog#webpage",
       "url": "https://paramant.app/changelog",
-      "name": "Changelog · Paramant",
+      "name": "Changelog · Paramant release history",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -69,7 +72,36 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Paramant release history: what changed, when, and why."
+      "description": "Transparent Paramant release history. What changed, when, and why. Security-relevant items are always listed."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/claim.html
+++ b/frontend/claim.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Claim your API key — Paramant</title>
+<title>Claim your API key · Paramant</title>
 <link rel="canonical" href="https://paramant.app/claim">
 <meta name="robots" content="noindex, nofollow">
 <meta name="referrer" content="no-referrer">

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -7,19 +7,19 @@
 <script src="/js/ready.js?v=1"></script>
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Co-sign this envelope · Paramant</title>
-<meta name="description" content="Review and sign an encrypted document with ML-DSA-65. The relay never sees document plaintext or your private key.">
-<meta property="og:title" content="Co-sign this envelope · Paramant">
-<meta property="og:description" content="Someone has asked you to co-sign an encrypted document. Review and add your post-quantum signature in your browser.">
+<title>Co-sign this document · Paramant</title>
+<meta name="description" content="Review and sign a document someone sent you. The file and your signing key stay in your browser.">
+<meta property="og:title" content="Co-sign this document · Paramant">
+<meta property="og:description" content="Review and sign a document someone sent you. The file and your signing key stay in your browser.">
 <meta property="og:url" content="https://paramant.app/co-sign">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-cosign.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
-<meta property="og:image:alt" content="Co-sign this envelope: a signed document with a post-quantum verified seal.">
+<meta property="og:image:alt" content="Co-sign this document: a signed document with a post-quantum verified seal.">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Co-sign this envelope · Paramant">
-<meta name="twitter:description" content="Someone has asked you to co-sign an encrypted document. Review and add your post-quantum signature in your browser.">
+<meta name="twitter:title" content="Co-sign this document · Paramant">
+<meta name="twitter:description" content="Review and sign a document someone sent you. The file and your signing key stay in your browser.">
 <meta name="twitter:image" content="https://paramant.app/og-cosign.png">
 <meta name="robots" content="noindex,nofollow">
 <link rel="canonical" href="https://paramant.app/co-sign">

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -5,16 +5,19 @@
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Crypto agility · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:title" content="Crypto agility · Paramant">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="The history of cryptography is a history of algorithms being broken.">
-<meta property="og:description" content="Paramant's crypto agility: 3 KEMs and 17 signatures from NIST FIPS 203, 204, 205, 206, selectable per relay. Clients pick, the relay validates, nothing is hardcoded.">
+<meta name="description" content="Algorithms you can swap without rebuilding. Identifiers travel in the header, not in the code path. NIST FIPS 203, 204, 205 and 206 loaded in production.">
+<meta property="og:description" content="Algorithms you can swap without rebuilding. Identifiers travel in the header, not in the code path. NIST FIPS 203, 204, 205 and 206 loaded in production.">
 <meta property="og:url" content="https://paramant.app/crypto-agility">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT · Crypto Agility">
-<meta name="twitter:description" content="Paramant's crypto agility: 3 KEMs and 17 signatures from NIST FIPS 203, 204, 205, 206, selectable per relay. Clients pick, the relay validates, nothing is hardcoded.">
+<meta name="twitter:title" content="Crypto agility · Paramant">
+<meta name="twitter:description" content="Algorithms you can swap without rebuilding. Identifiers travel in the header, not in the code path. NIST FIPS 203, 204, 205 and 206 loaded in production.">
 <link rel="canonical" href="https://paramant.app/crypto-agility">
 <link rel="stylesheet" href="/design-system.css?v=23">
 <link rel="stylesheet" href="/nav.css?v=19">
@@ -178,7 +181,36 @@ section h2{display:flex;align-items:baseline;gap:11px}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "The history of cryptography is a history of algorithms being broken."
+      "description": "Algorithms you can swap without rebuilding. Identifiers travel in the header, not in the code path. NIST FIPS 203, 204, 205 and 206 loaded in production."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -4,9 +4,12 @@
 <meta charset="utf-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>PARAMANT · Certificate Transparency Log</title>
+<title>Certificate transparency log · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Every public key registration is appended to a tamper-evident Merkle tree. Anyone can verify that a device was registered: without seeing the payload.">
+<meta name="description" content="Every public key registration is appended to a tamper-evident Merkle tree. Anyone can verify that a device was registered, without seeing the payload.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
@@ -17,14 +20,14 @@
 <link rel="stylesheet" href="/design-system.css?v=23">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
-<meta property="og:title" content="PARAMANT · Certificate Transparency Log">
-<meta property="og:description" content="PARAMANT: Certificate Transparency Log">
+<meta property="og:title" content="Certificate transparency log · Paramant">
+<meta property="og:description" content="Every public key registration is appended to a tamper-evident Merkle tree. Anyone can verify that a device was registered, without seeing the payload.">
 <meta property="og:url" content="https://paramant.app/ct-log">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT · Certificate Transparency Log">
-<meta name="twitter:description" content="PARAMANT: Certificate Transparency Log">
+<meta name="twitter:title" content="Certificate transparency log · Paramant">
+<meta name="twitter:description" content="Every public key registration is appended to a tamper-evident Merkle tree. Anyone can verify that a device was registered, without seeing the payload.">
 <link rel="canonical" href="https://paramant.app/ct-log">
   <style>
 * { margin:0; padding:0; box-sizing:border-box; }
@@ -215,7 +218,7 @@ body { min-height:100vh; }
       "@type": "WebPage",
       "@id": "https://paramant.app/ct-log#webpage",
       "url": "https://paramant.app/ct-log",
-      "name": "PARAMANT · Certificate Transparency Log",
+      "name": "Certificate transparency log · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -223,7 +226,36 @@ body { min-height:100vh; }
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Every public key registration is appended to a tamper-evident Merkle tree. Anyone can verify that a device was registered: without seeing the payload."
+      "description": "Every public key registration is appended to a tamper-evident Merkle tree. Anyone can verify that a device was registered, without seeing the payload."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Your Paramant — Dashboard</title>
+<title>Your dashboard · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/dashboard">
 <meta name="description" content="Sign in to your Paramant dashboard.">

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -4,16 +4,19 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>PARAMANT · Documentation</title>
+<title>Documentation · Paramant API and self-hosting</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
 <meta name="description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
-<meta property="og:title" content="PARAMANT · Documentation">
+<meta property="og:title" content="Documentation · Paramant API and self-hosting">
 <meta property="og:description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
 <meta property="og:url" content="https://paramant.app/docs">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT · Documentation">
+<meta name="twitter:title" content="Documentation · Paramant API and self-hosting">
 <meta name="twitter:description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
 <link rel="canonical" href="https://paramant.app/docs">
 
@@ -165,7 +168,7 @@ tr:last-child td{border-bottom:none}
       "@type": "WebPage",
       "@id": "https://paramant.app/docs#webpage",
       "url": "https://paramant.app/docs",
-      "name": "PARAMANT · Documentation",
+      "name": "Documentation · Paramant API and self-hosting",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -174,6 +177,35 @@ tr:last-child td{border-bottom:none}
       },
       "inLanguage": "en",
       "description": "API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/docs/paramant-ot-brief.html
+++ b/frontend/docs/paramant-ot-brief.html
@@ -3,14 +3,21 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>PARAMANT — Industrial OT Brief</title>
-<meta property="og:title" content="PARAMANT — Industrial OT Brief">
-<meta property="og:description" content="The problem with OT/IT data transfer is architectural, not operational.">
+<title>Industrial OT brief · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="The problem with OT and IT data transfer is architectural, not operational. A RAM-only relay for the DMZ zone boundary. No VPN, no persistent storage.">
+<meta name="twitter:title" content="Industrial OT brief · Paramant">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta property="og:title" content="Industrial OT brief · Paramant">
+<meta property="og:description" content="The problem with OT and IT data transfer is architectural, not operational. A RAM-only relay for the DMZ zone boundary. No VPN, no persistent storage.">
 <meta property="og:url" content="https://paramant.app/docs/paramant-ot-brief">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Paramant">
 <link rel="canonical" href="https://paramant.app/docs/paramant-ot-brief">
-<meta name="description" content="The problem with OT/IT data transfer is architectural, not operational.">
+<meta name="description" content="The problem with OT and IT data transfer is architectural, not operational. A RAM-only relay for the DMZ zone boundary. No VPN, no persistent storage.">
 <style>
 :root {
   --doc-bg: #f4efe2; --doc-ink: #0a0a0a; --doc-ink-dim: #444; --doc-ink-ghost: #777;
@@ -144,7 +151,7 @@ footer {
       "@type": "WebPage",
       "@id": "https://paramant.app/docs/paramant-ot-brief#webpage",
       "url": "https://paramant.app/docs/paramant-ot-brief",
-      "name": "PARAMANT — Industrial OT Brief",
+      "name": "Industrial OT brief · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -152,7 +159,7 @@ footer {
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "The problem with OT/IT data transfer is architectural, not operational."
+      "description": "The problem with OT and IT data transfer is architectural, not operational. A RAM-only relay for the DMZ zone boundary. No VPN, no persistent storage."
     },
     {
       "@type": "BreadcrumbList",
@@ -173,8 +180,37 @@ footer {
         {
           "@type": "ListItem",
           "position": 3,
-          "name": "PARAMANT"
+          "name": "Industrial OT brief"
         }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
       ]
     }
   ]

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -4,19 +4,19 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Download Paramant · Native app</title>
+<title>Download the Paramant desktop app</title>
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Download the Paramant native app. Post-quantum encrypted. Rust + Tauri 2 + ML-KEM-768.">
-<meta property="og:title" content="Download Paramant · Native app">
-<meta property="og:description" content="Download the Paramant native app. Post-quantum encrypted. Rust + Tauri 2 + ML-KEM-768.">
+<meta name="description" content="The Paramant desktop app. The current build is from March 2026 and misses 21 protections the web app has, so the web app is the one we recommend.">
+<meta property="og:title" content="Download the Paramant desktop app">
+<meta property="og:description" content="The Paramant desktop app. The current build is from March 2026 and misses 21 protections the web app has, so the web app is the one we recommend.">
 <meta property="og:url" content="https://paramant.app/download">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Download Paramant · Native app">
-<meta name="twitter:description" content="Download the Paramant native app. Post-quantum encrypted. Rust + Tauri 2 + ML-KEM-768.">
+<meta name="twitter:title" content="Download the Paramant desktop app">
+<meta name="twitter:description" content="The Paramant desktop app. The current build is from March 2026 and misses 21 protections the web app has, so the web app is the one we recommend.">
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="canonical" href="https://paramant.app/download">
 <style>
@@ -101,7 +101,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
       "@type": "WebPage",
       "@id": "https://paramant.app/download#webpage",
       "url": "https://paramant.app/download",
-      "name": "Download Paramant · Native app",
+      "name": "Download the Paramant desktop app",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -109,7 +109,7 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Download the Paramant native app. Post-quantum encrypted. Rust + Tauri 2 + ML-KEM-768."
+      "description": "The Paramant desktop app. The current build is from March 2026 and misses 21 protections the web app has, so the web app is the one we recommend."
     },
     {
       "@type": "SoftwareApplication",
@@ -121,6 +121,35 @@ nav.p-nav{position:sticky;top:0;z-index:1000;background:var(--bone);border-botto
       "publisher": {
         "@id": "https://paramant.app/#organization"
       }
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -4,17 +4,20 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Data Processing Agreement — PARAMANT</title>
+<title>Data processing agreement · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="PARAMANT GDPR Art. 28 Data Processing Agreement. Sign electronically. EU/DE jurisdiction.">
-<meta property="og:title" content="Data Processing Agreement · PARAMANT">
-<meta property="og:description" content="PARAMANT GDPR Art. 28 Data Processing Agreement. Sign electronically. EU/DE jurisdiction.">
+<meta name="description" content="The GDPR Article 28 agreement between Paramantis Solutions B.V. as processor and your organisation as controller. Sign it electronically, EU and German law.">
+<meta property="og:title" content="Data processing agreement · Paramant">
+<meta property="og:description" content="The GDPR Article 28 agreement between Paramantis Solutions B.V. as processor and your organisation as controller. Sign it electronically, EU and German law.">
 <meta property="og:url" content="https://paramant.app/dpa">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Data Processing Agreement · PARAMANT">
-<meta name="twitter:description" content="PARAMANT GDPR Art. 28 Data Processing Agreement. Sign electronically. EU/DE jurisdiction.">
+<meta name="twitter:title" content="Data processing agreement · Paramant">
+<meta name="twitter:description" content="The GDPR Article 28 agreement between Paramantis Solutions B.V. as processor and your organisation as controller. Sign it electronically, EU and German law.">
 <link rel="canonical" href="https://paramant.app/dpa">
 <link rel="stylesheet" href="/design-system.css?v=23">
 <link rel="stylesheet" href="/nav.css?v=19">
@@ -130,7 +133,7 @@ input:focus{border-color:var(--cobalt)}
       "@type": "WebPage",
       "@id": "https://paramant.app/dpa#webpage",
       "url": "https://paramant.app/dpa",
-      "name": "Data Processing Agreement — PARAMANT",
+      "name": "Data processing agreement · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -138,7 +141,36 @@ input:focus{border-color:var(--cobalt)}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "PARAMANT GDPR Art. 28 Data Processing Agreement. Sign electronically. EU/DE jurisdiction."
+      "description": "The GDPR Article 28 agreement between Paramantis Solutions B.V. as processor and your organisation as controller. Sign it electronically, EU and German law."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -3,14 +3,21 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>API key vs TOTP &middot; PARAMANT Help</title>
-<meta property="og:title" content="API key vs TOTP &middot; PARAMANT Help">
-<meta property="og:description" content="The difference between Paramant API keys and TOTP codes: when to use each, and how they work together.">
+<title>API key vs TOTP · Paramant Help</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="When to use a Paramant API key and when to use a code from your authenticator app, and how the two work together on one account.">
+<meta name="twitter:title" content="API key vs TOTP · Paramant Help">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta property="og:title" content="API key vs TOTP · Paramant Help">
+<meta property="og:description" content="When to use a Paramant API key and when to use a code from your authenticator app, and how the two work together on one account.">
 <meta property="og:url" content="https://paramant.app/help/api-key-vs-totp">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Paramant">
 <link rel="canonical" href="https://paramant.app/help/api-key-vs-totp">
-<meta name="description" content="The difference between Paramant API keys and TOTP codes: when to use each, and how they work together.">
+<meta name="description" content="When to use a Paramant API key and when to use a code from your authenticator app, and how the two work together on one account.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
@@ -138,7 +145,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/help/api-key-vs-totp#webpage",
       "url": "https://paramant.app/help/api-key-vs-totp",
-      "name": "API key vs TOTP \u00b7 PARAMANT Help",
+      "name": "API key vs TOTP · Paramant Help",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -146,7 +153,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "The difference between Paramant API keys and TOTP codes: when to use each, and how they work together."
+      "description": "When to use a Paramant API key and when to use a code from your authenticator app, and how the two work together on one account."
     },
     {
       "@type": "BreadcrumbList",
@@ -169,6 +176,35 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           "position": 3,
           "name": "API key vs TOTP"
         }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
       ]
     }
   ]

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -3,14 +3,21 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Authenticator apps — PARAMANT Help</title>
-<meta property="og:title" content="Authenticator apps — PARAMANT Help">
-<meta property="og:description" content="Every standard authenticator app works with Paramant, including Google Authenticator. For the strongest setup we recommend a SHA-256 app: Authy, 1Password...">
+<title>Authenticator apps · Paramant Help</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="Every standard authenticator app works with Paramant, including Google Authenticator. For the strongest setup, use a SHA-256 app such as Authy or 1Password.">
+<meta name="twitter:title" content="Authenticator apps · Paramant Help">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta property="og:title" content="Authenticator apps · Paramant Help">
+<meta property="og:description" content="Every standard authenticator app works with Paramant, including Google Authenticator. For the strongest setup, use a SHA-256 app such as Authy or 1Password.">
 <meta property="og:url" content="https://paramant.app/help/authenticator-apps">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Paramant">
 <link rel="canonical" href="https://paramant.app/help/authenticator-apps">
-<meta name="description" content="Every standard authenticator app works with Paramant, including Google Authenticator. For the strongest setup we recommend a SHA-256 app: Authy, 1Password...">
+<meta name="description" content="Every standard authenticator app works with Paramant, including Google Authenticator. For the strongest setup, use a SHA-256 app such as Authy or 1Password.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
@@ -124,7 +131,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/help/authenticator-apps#webpage",
       "url": "https://paramant.app/help/authenticator-apps",
-      "name": "Authenticator apps — PARAMANT Help",
+      "name": "Authenticator apps · Paramant Help",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -132,7 +139,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Every standard authenticator app works with Paramant, including Google Authenticator. For the strongest setup we recommend a SHA-256 app: Authy, 1Password..."
+      "description": "Every standard authenticator app works with Paramant, including Google Authenticator. For the strongest setup, use a SHA-256 app such as Authy or 1Password."
     },
     {
       "@type": "BreadcrumbList",
@@ -155,6 +162,35 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           "position": 3,
           "name": "Authenticator apps"
         }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
       ]
     }
   ]

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -3,14 +3,21 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Set up your authenticator — PARAMANT Help</title>
-<meta property="og:title" content="Set up your authenticator — PARAMANT Help">
-<meta property="og:description" content="How to set up your authenticator app for Paramant. About 3 minutes. Any standard authenticator app works, including Google Authenticator. For the strongest...">
+<title>Set up your authenticator · Paramant Help</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="How to set up your authenticator app for Paramant. About 3 minutes. Any standard authenticator app works, including Google Authenticator.">
+<meta name="twitter:title" content="Set up your authenticator · Paramant Help">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta property="og:title" content="Set up your authenticator · Paramant Help">
+<meta property="og:description" content="How to set up your authenticator app for Paramant. About 3 minutes. Any standard authenticator app works, including Google Authenticator.">
 <meta property="og:url" content="https://paramant.app/help/authenticator-setup">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Paramant">
 <link rel="canonical" href="https://paramant.app/help/authenticator-setup">
-<meta name="description" content="How to set up your authenticator app for Paramant. About 3 minutes. Any standard authenticator app works, including Google Authenticator. For the strongest...">
+<meta name="description" content="How to set up your authenticator app for Paramant. About 3 minutes. Any standard authenticator app works, including Google Authenticator.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
@@ -138,7 +145,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/help/authenticator-setup#webpage",
       "url": "https://paramant.app/help/authenticator-setup",
-      "name": "Set up your authenticator — PARAMANT Help",
+      "name": "Set up your authenticator · Paramant Help",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -146,7 +153,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "How to set up your authenticator app for Paramant. About 3 minutes. Any standard authenticator app works, including Google Authenticator. For the strongest..."
+      "description": "How to set up your authenticator app for Paramant. About 3 minutes. Any standard authenticator app works, including Google Authenticator."
     },
     {
       "@type": "BreadcrumbList",
@@ -169,6 +176,35 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           "position": 3,
           "name": "Set up your authenticator"
         }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
       ]
     }
   ]

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -3,14 +3,21 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Backup codes — PARAMANT Help</title>
-<meta property="og:title" content="Backup codes — PARAMANT Help">
-<meta property="og:description" content="How to generate, store, and use Paramant backup codes. Emergency access when you lose your authenticator app.">
+<title>Backup codes · Paramant Help</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="How to generate, store and use Paramant backup codes. Emergency access when you lose your authenticator app.">
+<meta name="twitter:title" content="Backup codes · Paramant Help">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta property="og:title" content="Backup codes · Paramant Help">
+<meta property="og:description" content="How to generate, store and use Paramant backup codes. Emergency access when you lose your authenticator app.">
 <meta property="og:url" content="https://paramant.app/help/backup-codes">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Paramant">
 <link rel="canonical" href="https://paramant.app/help/backup-codes">
-<meta name="description" content="How to generate, store, and use Paramant backup codes. Emergency access when you lose your authenticator app.">
+<meta name="description" content="How to generate, store and use Paramant backup codes. Emergency access when you lose your authenticator app.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
@@ -140,7 +147,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/help/backup-codes#webpage",
       "url": "https://paramant.app/help/backup-codes",
-      "name": "Backup codes — PARAMANT Help",
+      "name": "Backup codes · Paramant Help",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -148,7 +155,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "How to generate, store, and use Paramant backup codes. Emergency access when you lose your authenticator app."
+      "description": "How to generate, store and use Paramant backup codes. Emergency access when you lose your authenticator app."
     },
     {
       "@type": "BreadcrumbList",
@@ -171,6 +178,35 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           "position": 3,
           "name": "Backup codes"
         }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
       ]
     }
   ]

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -3,8 +3,15 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Gmail extension — PARAMANT Help</title>
-<meta property="og:title" content="Gmail extension — PARAMANT Help">
+<title>Gmail extension · Paramant Help</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="Install and configure the Paramant Chrome extension for sending encrypted attachments from Gmail.">
+<meta name="twitter:title" content="Gmail extension · Paramant Help">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta property="og:title" content="Gmail extension · Paramant Help">
 <meta property="og:description" content="Install and configure the Paramant Chrome extension for sending encrypted attachments from Gmail.">
 <meta property="og:url" content="https://paramant.app/help/gmail-extension">
 <meta property="og:type" content="website">
@@ -142,7 +149,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/help/gmail-extension#webpage",
       "url": "https://paramant.app/help/gmail-extension",
-      "name": "Gmail extension — PARAMANT Help",
+      "name": "Gmail extension · Paramant Help",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -173,6 +180,35 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           "position": 3,
           "name": "Gmail extension"
         }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
       ]
     }
   ]

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -3,14 +3,21 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Help · PARAMANT</title>
-<meta property="og:title" content="Help · PARAMANT">
-<meta property="og:description" content="Answers about Paramant: signing without an account, what it costs, where your data lives, plus API keys, TOTP, integrations and troubleshooting.">
+<title>Help and troubleshooting · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="Answers for people who already have a Paramant account: sign-in codes, authenticator setup, backup codes, session problems, and the Gmail and Outlook extensions.">
+<meta name="twitter:title" content="Help and troubleshooting · Paramant">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta property="og:title" content="Help and troubleshooting · Paramant">
+<meta property="og:description" content="Answers for people who already have a Paramant account: sign-in codes, authenticator setup, backup codes, session problems, and the Gmail and Outlook extensions.">
 <meta property="og:url" content="https://paramant.app/help">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Paramant">
 <link rel="canonical" href="https://paramant.app/help">
-<meta name="description" content="Answers about Paramant: signing without an account, what it costs, where your data lives, plus API keys, TOTP, integrations and troubleshooting.">
+<meta name="description" content="Answers for people who already have a Paramant account: sign-in codes, authenticator setup, backup codes, session problems, and the Gmail and Outlook extensions.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
@@ -118,7 +125,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/help#webpage",
       "url": "https://paramant.app/help",
-      "name": "Help · PARAMANT",
+      "name": "Help and troubleshooting · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -126,7 +133,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Answers about Paramant: signing without an account, what it costs, where your data lives, plus API keys, TOTP, integrations and troubleshooting."
+      "description": "Answers for people who already have a Paramant account: sign-in codes, authenticator setup, backup codes, session problems, and the Gmail and Outlook extensions."
     },
     {
       "@type": "BreadcrumbList",
@@ -144,6 +151,35 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           "name": "Help",
           "item": "https://paramant.app/help"
         }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
       ]
     }
   ]

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -3,14 +3,21 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>IoT &amp; embedded devices — PARAMANT Help</title>
-<meta property="og:title" content="IoT & embedded devices — PARAMANT Help">
-<meta property="og:description" content="Using the Paramant API on constrained devices — Pi Zero, ESP32, OT gateways. Static API key, no TOTP required.">
+<title>IoT and embedded devices · Paramant Help</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="Using the Paramant API on constrained devices: Pi Zero, ESP32, OT gateways. Static API key, no TOTP required.">
+<meta name="twitter:title" content="IoT and embedded devices · Paramant Help">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta property="og:title" content="IoT and embedded devices · Paramant Help">
+<meta property="og:description" content="Using the Paramant API on constrained devices: Pi Zero, ESP32, OT gateways. Static API key, no TOTP required.">
 <meta property="og:url" content="https://paramant.app/help/iot-integration">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Paramant">
 <link rel="canonical" href="https://paramant.app/help/iot-integration">
-<meta name="description" content="Using the Paramant API on constrained devices — Pi Zero, ESP32, OT gateways. Static API key, no TOTP required.">
+<meta name="description" content="Using the Paramant API on constrained devices: Pi Zero, ESP32, OT gateways. Static API key, no TOTP required.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
@@ -137,7 +144,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/help/iot-integration#webpage",
       "url": "https://paramant.app/help/iot-integration",
-      "name": "IoT & embedded devices — PARAMANT Help",
+      "name": "IoT and embedded devices · Paramant Help",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -145,7 +152,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Using the Paramant API on constrained devices — Pi Zero, ESP32, OT gateways. Static API key, no TOTP required."
+      "description": "Using the Paramant API on constrained devices: Pi Zero, ESP32, OT gateways. Static API key, no TOTP required."
     },
     {
       "@type": "BreadcrumbList",
@@ -166,8 +173,37 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         {
           "@type": "ListItem",
           "position": 3,
-          "name": "IoT & embedded devices"
+          "name": "IoT and embedded devices"
         }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
       ]
     }
   ]

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -3,14 +3,21 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Lost authenticator access &middot; PARAMANT Help</title>
-<meta property="og:title" content="Lost authenticator access &middot; PARAMANT Help">
-<meta property="og:description" content="How to recover your Paramant account after losing access to your TOTP authenticator app. Backup codes, support recovery, and re-enrollment.">
+<title>Lost authenticator access · Paramant Help</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="How to get back into your Paramant account after losing your authenticator app. Backup codes, support recovery, and re-enrollment.">
+<meta name="twitter:title" content="Lost authenticator access · Paramant Help">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta property="og:title" content="Lost authenticator access · Paramant Help">
+<meta property="og:description" content="How to get back into your Paramant account after losing your authenticator app. Backup codes, support recovery, and re-enrollment.">
 <meta property="og:url" content="https://paramant.app/help/lost-authenticator">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Paramant">
 <link rel="canonical" href="https://paramant.app/help/lost-authenticator">
-<meta name="description" content="How to recover your Paramant account after losing access to your TOTP authenticator app. Backup codes, support recovery, and re-enrollment.">
+<meta name="description" content="How to get back into your Paramant account after losing your authenticator app. Backup codes, support recovery, and re-enrollment.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
@@ -136,7 +143,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/help/lost-authenticator#webpage",
       "url": "https://paramant.app/help/lost-authenticator",
-      "name": "Lost authenticator access \u00b7 PARAMANT Help",
+      "name": "Lost authenticator access · Paramant Help",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -144,7 +151,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "How to recover your Paramant account after losing access to your TOTP authenticator app. Backup codes, support recovery, and re-enrollment."
+      "description": "How to get back into your Paramant account after losing your authenticator app. Backup codes, support recovery, and re-enrollment."
     },
     {
       "@type": "BreadcrumbList",
@@ -167,6 +174,35 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           "position": 3,
           "name": "Lost authenticator access"
         }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
       ]
     }
   ]

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -3,8 +3,15 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Outlook add-in — PARAMANT Help</title>
-<meta property="og:title" content="Outlook add-in — PARAMANT Help">
+<title>Outlook add-in · Paramant Help</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="Set up the Paramant Outlook add-in for Microsoft 365 and Exchange. Send encrypted attachments from within Outlook.">
+<meta name="twitter:title" content="Outlook add-in · Paramant Help">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta property="og:title" content="Outlook add-in · Paramant Help">
 <meta property="og:description" content="Set up the Paramant Outlook add-in for Microsoft 365 and Exchange. Send encrypted attachments from within Outlook.">
 <meta property="og:url" content="https://paramant.app/help/outlook-extension">
 <meta property="og:type" content="website">
@@ -142,7 +149,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/help/outlook-extension#webpage",
       "url": "https://paramant.app/help/outlook-extension",
-      "name": "Outlook add-in — PARAMANT Help",
+      "name": "Outlook add-in · Paramant Help",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -173,6 +180,35 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           "position": 3,
           "name": "Outlook add-in"
         }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
       ]
     }
   ]

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -3,14 +3,21 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Session and login issues — PARAMANT Help</title>
-<meta property="og:title" content="Session and login issues — PARAMANT Help">
-<meta property="og:description" content="Fix TOTP codes rejected, session expiry, clock drift, and other Paramant login problems.">
+<title>Session and login issues · Paramant Help</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="Fix a sign-in code your account rejects, a session that expires too soon, and clock drift. The most common Paramant login problems, with the fix for each.">
+<meta name="twitter:title" content="Session and login issues · Paramant Help">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta property="og:title" content="Session and login issues · Paramant Help">
+<meta property="og:description" content="Fix a sign-in code your account rejects, a session that expires too soon, and clock drift. The most common Paramant login problems, with the fix for each.">
 <meta property="og:url" content="https://paramant.app/help/session-issues">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Paramant">
 <link rel="canonical" href="https://paramant.app/help/session-issues">
-<meta name="description" content="Fix TOTP codes rejected, session expiry, clock drift, and other Paramant login problems.">
+<meta name="description" content="Fix a sign-in code your account rejects, a session that expires too soon, and clock drift. The most common Paramant login problems, with the fix for each.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
@@ -136,7 +143,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/help/session-issues#webpage",
       "url": "https://paramant.app/help/session-issues",
-      "name": "Session and login issues — PARAMANT Help",
+      "name": "Session and login issues · Paramant Help",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -144,7 +151,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Fix TOTP codes rejected, session expiry, clock drift, and other Paramant login problems."
+      "description": "Fix a sign-in code your account rejects, a session that expires too soon, and clock drift. The most common Paramant login problems, with the fix for each."
     },
     {
       "@type": "BreadcrumbList",
@@ -167,6 +174,35 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
           "position": 3,
           "name": "Session and login issues"
         }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
       ]
     }
   ]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,9 +7,9 @@
 <meta name="theme-color" content="#0B3A6A">
 <title>ParaSign by Paramant &middot; sign and send documents in the EU</title>
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Get documents signed and send files safely, straight from your browser. ParaSign and ParaSend by Paramant, built and hosted in the EU. Free to start.">
+<meta name="description" content="Get documents signed and send files safely, straight from your browser. Built and hosted in the EU by Paramantis Solutions B.V. The Community plan is free, forever.">
 <meta property="og:title" content="ParaSign by Paramant &middot; sign and send documents in the EU">
-<meta property="og:description" content="Get documents signed and send files safely, straight from your browser. Built and hosted in the EU. Free to start.">
+<meta property="og:description" content="Get documents signed and send files safely, straight from your browser. Built and hosted in the EU by Paramantis Solutions B.V. The Community plan is free, forever.">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -17,7 +17,7 @@
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="ParaSign by Paramant &middot; sign and send documents in the EU">
-<meta name="twitter:description" content="Get documents signed and send files safely, straight from your browser. Built and hosted in the EU. Free to start.">
+<meta name="twitter:description" content="Get documents signed and send files safely, straight from your browser. Built and hosted in the EU by Paramantis Solutions B.V. The Community plan is free, forever.">
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="canonical" href="https://paramant.app/">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -145,7 +145,7 @@
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Get documents signed and send files safely, straight from your browser. ParaSign and ParaSend by Paramant, built and hosted in the EU. Free to start."
+      "description": "Get documents signed and send files safely, straight from your browser. Built and hosted in the EU by Paramantis Solutions B.V. The Community plan is free, forever."
     },
     {
       "@type": "SoftwareApplication",
@@ -168,8 +168,25 @@
       "@type": "Organization",
       "@id": "https://paramant.app/#organization",
       "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
       "url": "https://paramant.app/",
       "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
       "areaServed": "EU",
       "knowsLanguage": [
         "nl",

--- a/frontend/iot.html
+++ b/frontend/iot.html
@@ -5,16 +5,16 @@
 <meta http-equiv="refresh" content="0; url=/docs#compliance-iec62443">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <link rel="canonical" href="https://paramant.app/docs">
-<title>PARAMANT IoT / OT &mdash; redirecting…</title>
+<title>Paramant IoT / OT · redirecting…</title>
 <meta property="og:site_name" content="Paramant">
-<meta property="og:title" content="PARAMANT IoT / OT · redirecting…">
-<meta property="og:description" content="PARAMANT IoT / OT &mdash; redirecting…">
+<meta property="og:title" content="Paramant IoT / OT · redirecting…">
+<meta property="og:description" content="Paramant IoT / OT · redirecting…">
 <meta property="og:url" content="https://paramant.app/iot">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PARAMANT IoT / OT · redirecting…">
-<meta name="twitter:description" content="PARAMANT IoT / OT &mdash; redirecting…">
+<meta name="twitter:title" content="Paramant IoT / OT · redirecting…">
+<meta name="twitter:description" content="Paramant IoT / OT · redirecting…">
 
 <style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
 <script type="application/ld+json" data-paramant-seo="1">

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -4,17 +4,20 @@
 <meta charset="utf-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>License — PARAMANT</title>
+<title>License · Paramant Business Source License 1.1</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="PARAMANT Ghost Pipe Protocol — Business Source License 1.1. Free for personal use, MIT on 2030-01-01.">
-<meta property="og:title" content="License · PARAMANT">
-<meta property="og:description" content="PARAMANT Ghost Pipe Protocol — Business Source License 1.1. Free for personal use, MIT on 2030-01-01.">
+<meta name="description" content="Paramant is source-available under the Business Source License 1.1. Free for personal use, and it converts to MIT on 2030-01-01.">
+<meta property="og:title" content="License · Paramant Business Source License 1.1">
+<meta property="og:description" content="Paramant is source-available under the Business Source License 1.1. Free for personal use, and it converts to MIT on 2030-01-01.">
 <meta property="og:url" content="https://paramant.app/license">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="License · PARAMANT">
-<meta name="twitter:description" content="PARAMANT Ghost Pipe Protocol — Business Source License 1.1. Free for personal use, MIT on 2030-01-01.">
+<meta name="twitter:title" content="License · Paramant Business Source License 1.1">
+<meta name="twitter:description" content="Paramant is source-available under the Business Source License 1.1. Free for personal use, and it converts to MIT on 2030-01-01.">
 <link rel="canonical" href="https://paramant.app/license">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -110,7 +113,7 @@ footer a{color:var(--cobalt)}
       "@type": "WebPage",
       "@id": "https://paramant.app/license#webpage",
       "url": "https://paramant.app/license",
-      "name": "License — PARAMANT",
+      "name": "License · Paramant Business Source License 1.1",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -118,7 +121,36 @@ footer a{color:var(--cobalt)}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "PARAMANT Ghost Pipe Protocol — Business Source License 1.1. Free for personal use, MIT on 2030-01-01."
+      "description": "Paramant is source-available under the Business Source License 1.1. Free for personal use, and it converts to MIT on 2030-01-01."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/pararules.html
+++ b/frontend/pararules.html
@@ -4,17 +4,20 @@
 <meta charset="utf-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>ParaRules: What Paramant stands for</title>
+<title>ParaRules · What Paramant stands for</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="The ParaRules: the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by...">
-<meta property="og:title" content="ParaRules: What Paramant stands for">
-<meta property="og:description" content="The ParaRules: the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design, and how we build to keep them.">
+<meta name="description" content="The rules Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design.">
+<meta property="og:title" content="ParaRules · What Paramant stands for">
+<meta property="og:description" content="The rules Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design.">
 <meta property="og:url" content="https://paramant.app/pararules">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="ParaRules: What Paramant stands for">
-<meta name="twitter:description" content="The ParaRules: the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design, and how we build to keep them.">
+<meta name="twitter:title" content="ParaRules · What Paramant stands for">
+<meta name="twitter:description" content="The rules Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design.">
 <link rel="canonical" href="https://paramant.app/pararules">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -119,7 +122,7 @@ footer a{color:var(--ink);text-decoration:none}
       "@type": "WebPage",
       "@id": "https://paramant.app/pararules#webpage",
       "url": "https://paramant.app/pararules",
-      "name": "ParaRules: What Paramant stands for",
+      "name": "ParaRules · What Paramant stands for",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -127,7 +130,36 @@ footer a{color:var(--ink);text-decoration:none}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "The ParaRules: the principles Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by..."
+      "description": "The rules Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -77,7 +77,7 @@
       "@type": "WebPage",
       "@id": "https://paramant.app/parasign#webpage",
       "url": "https://paramant.app/parasign",
-      "name": "ParaSign - get documents signed, by Paramant",
+      "name": "ParaSign · get documents signed, by Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -97,6 +97,35 @@
       "publisher": {
         "@id": "https://paramant.app/#organization"
       }
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -4,17 +4,20 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>In the wild — PARAMANT</title>
+<title>In the wild · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Organisations that have publicly stated they use Paramant in production. Observed deployments in compliance, sovereign infrastructure, and security engagements.">
-<meta property="og:title" content="In the wild · PARAMANT">
-<meta property="og:description" content="Organisations that have publicly stated they use Paramant in production.">
+<meta name="description" content="Organisations that publicly confirm they run Paramant in production will be listed here. For case studies or references, get in touch.">
+<meta property="og:title" content="In the wild · Paramant">
+<meta property="og:description" content="Organisations that publicly confirm they run Paramant in production will be listed here. For case studies or references, get in touch.">
 <meta property="og:url" content="https://paramant.app/partners">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="In the wild · PARAMANT">
-<meta name="twitter:description" content="Organisations that have publicly stated they use Paramant in production.">
+<meta name="twitter:title" content="In the wild · Paramant">
+<meta name="twitter:description" content="Organisations that publicly confirm they run Paramant in production will be listed here. For case studies or references, get in touch.">
 <link rel="canonical" href="https://paramant.app/partners">
 
 <link rel="stylesheet" href="/design-system.css?v=23">
@@ -72,7 +75,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
       "@type": "WebPage",
       "@id": "https://paramant.app/partners#webpage",
       "url": "https://paramant.app/partners",
-      "name": "In the wild — PARAMANT",
+      "name": "In the wild · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -80,7 +83,36 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Organisations that have publicly stated they use Paramant in production. Observed deployments in compliance, sovereign infrastructure, and security engagements."
+      "description": "Organisations that publicly confirm they run Paramant in production will be listed here. For case studies or references, get in touch."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -4,17 +4,20 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Press Kit — PARAMANT</title>
+<title>Press kit · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="PARAMANT press kit — post-quantum encrypted file relay. Blurbs, key facts, brand assets, and press contact.">
-<meta property="og:title" content="Press Kit · PARAMANT">
-<meta property="og:description" content="PARAMANT press kit — post-quantum encrypted file relay. Blurbs, key facts, brand assets, and press contact.">
+<meta name="description" content="Paramant press kit: blurbs, key facts, brand assets and a press contact. Post-quantum document signing and encrypted file transfer from the Netherlands.">
+<meta property="og:title" content="Press kit · Paramant">
+<meta property="og:description" content="Paramant press kit: blurbs, key facts, brand assets and a press contact. Post-quantum document signing and encrypted file transfer from the Netherlands.">
 <meta property="og:url" content="https://paramant.app/press">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Press Kit · PARAMANT">
-<meta name="twitter:description" content="PARAMANT press kit — post-quantum encrypted file relay. Blurbs, key facts, brand assets, and press contact.">
+<meta name="twitter:title" content="Press kit · Paramant">
+<meta name="twitter:description" content="Paramant press kit: blurbs, key facts, brand assets and a press contact. Post-quantum document signing and encrypted file transfer from the Netherlands.">
 <link rel="canonical" href="https://paramant.app/press">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -134,7 +137,7 @@ td{color:var(--cobalt)}
       "@type": "WebPage",
       "@id": "https://paramant.app/press#webpage",
       "url": "https://paramant.app/press",
-      "name": "Press Kit — PARAMANT",
+      "name": "Press kit · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -142,7 +145,36 @@ td{color:var(--cobalt)}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "PARAMANT press kit — post-quantum encrypted file relay. Blurbs, key facts, brand assets, and press contact."
+      "description": "Paramant press kit: blurbs, key facts, brand assets and a press contact. Post-quantum document signing and encrypted file transfer from the Netherlands."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -4,17 +4,20 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Pricing · PARAMANT</title>
+<title>Pricing · What is free, and what businesses pay · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="PARAMANT pricing. Two products on one post-quantum core: ParaSend encrypted transfer (RAM-only, burn-on-read) and ParaSign signing (ML-DSA-65, SES + AES)...">
-<meta property="og:title" content="Pricing · PARAMANT">
-<meta property="og:description" content="PARAMANT pricing. Two products on one post-quantum core: ParaSend encrypted transfer (RAM-only, burn-on-read) and ParaSign signing (ML-DSA-65, SES + AES). Community tiers forever; Pro and Business for higher limits.">
+<meta name="description" content="The Community plan is free, forever. Organisations pay for higher limits: sending from 15 euro a month, signing from 49, excl. btw. From Paramantis Solutions B.V.">
+<meta property="og:title" content="Pricing · What is free, and what businesses pay · Paramant">
+<meta property="og:description" content="The Community plan is free, forever. Organisations pay for higher limits: sending from 15 euro a month, signing from 49, excl. btw. From Paramantis Solutions B.V.">
 <meta property="og:url" content="https://paramant.app/pricing">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Pricing · PARAMANT">
-<meta name="twitter:description" content="PARAMANT pricing. Two products on one post-quantum core: ParaSend encrypted transfer (RAM-only, burn-on-read) and ParaSign signing (ML-DSA-65, SES + AES). Community tiers forever; Pro and Business for higher limits.">
+<meta name="twitter:title" content="Pricing · What is free, and what businesses pay · Paramant">
+<meta name="twitter:description" content="The Community plan is free, forever. Organisations pay for higher limits: sending from 15 euro a month, signing from 49, excl. btw. From Paramantis Solutions B.V.">
 <link rel="canonical" href="https://paramant.app/pricing">
 <link rel="stylesheet" href="/design-system.css?v=23">
 <link rel="stylesheet" href="/nav.css?v=19">
@@ -132,7 +135,7 @@
       "@type": "WebPage",
       "@id": "https://paramant.app/pricing#webpage",
       "url": "https://paramant.app/pricing",
-      "name": "Pricing · PARAMANT",
+      "name": "Pricing · What is free, and what businesses pay · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -140,7 +143,36 @@
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "PARAMANT pricing. Two products on one post-quantum core: ParaSend encrypted transfer (RAM-only, burn-on-read) and ParaSign signing (ML-DSA-65, SES + AES)..."
+      "description": "The Community plan is free, forever. Organisations pay for higher limits: sending from 15 euro a month, signing from 49, excl. btw. From Paramantis Solutions B.V."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -4,17 +4,20 @@
 <meta charset="utf-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Privacy Policy — PARAMANT</title>
+<title>Privacy policy · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="PARAMANT privacy policy. Minimal data: an email to run your account; the encrypted file relay stays RAM-only and burn-on-read. EU/Germany hosting, no...">
-<meta property="og:title" content="Privacy Policy · PARAMANT">
-<meta property="og:description" content="PARAMANT privacy policy. Minimal data: an email to run your account; the encrypted file relay stays RAM-only and burn-on-read. EU/Germany hosting, no trackers, no ads.">
+<meta name="description" content="What Paramant stores and what it does not. An email address to run your account, no phone number, no IP logging for analytics. EU and German hosting.">
+<meta property="og:title" content="Privacy policy · Paramant">
+<meta property="og:description" content="What Paramant stores and what it does not. An email address to run your account, no phone number, no IP logging for analytics. EU and German hosting.">
 <meta property="og:url" content="https://paramant.app/privacy">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Privacy Policy · PARAMANT">
-<meta name="twitter:description" content="PARAMANT privacy policy. Minimal data: an email to run your account; the encrypted file relay stays RAM-only and burn-on-read. EU/Germany hosting, no trackers, no ads.">
+<meta name="twitter:title" content="Privacy policy · Paramant">
+<meta name="twitter:description" content="What Paramant stores and what it does not. An email address to run your account, no phone number, no IP logging for analytics. EU and German hosting.">
 <link rel="canonical" href="https://paramant.app/privacy">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -118,7 +121,7 @@ footer a{color:var(--ink);text-decoration:none}
       "@type": "WebPage",
       "@id": "https://paramant.app/privacy#webpage",
       "url": "https://paramant.app/privacy",
-      "name": "Privacy Policy — PARAMANT",
+      "name": "Privacy policy · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -126,7 +129,36 @@ footer a{color:var(--ink);text-decoration:none}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "PARAMANT privacy policy. Minimal data: an email to run your account; the encrypted file relay stays RAM-only and burn-on-read. EU/Germany hosting, no..."
+      "description": "What Paramant stores and what it does not. An email address to run your account, no phone number, no IP logging for analytics. EU and German hosting."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Create an account — Paramant</title>
+<title>Create an account · Paramant</title>
 <meta name="description" content="Paramant API keys are now issued through account signup with TOTP protection. Create a free account to get started.">
 <meta name="robots" content="noindex">
 <meta http-equiv="refresh" content="8;url=/signup">

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -4,17 +4,20 @@
 <meta charset="utf-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Security · Paramant</title>
+<title>Security · How to check Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="How PARAMANT approaches security: post-quantum crypto, independent audit, responsible disclosure, relay architecture.">
-<meta property="og:title" content="Security · PARAMANT">
-<meta property="og:description" content="How PARAMANT approaches security: post-quantum crypto, independent audit, responsible disclosure, relay architecture.">
+<meta name="description" content="Servers at Hetzner in Nuremberg, Germany, under EU and German law. Post-quantum cryptography, nothing kept on disk, and a disclosure policy you can read.">
+<meta property="og:title" content="Security · How to check Paramant">
+<meta property="og:description" content="Servers at Hetzner in Nuremberg, Germany, under EU and German law. Post-quantum cryptography, nothing kept on disk, and a disclosure policy you can read.">
 <meta property="og:url" content="https://paramant.app/security">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Security · PARAMANT">
-<meta name="twitter:description" content="How PARAMANT approaches security: post-quantum crypto, independent audit, responsible disclosure, relay architecture.">
+<meta name="twitter:title" content="Security · How to check Paramant">
+<meta name="twitter:description" content="Servers at Hetzner in Nuremberg, Germany, under EU and German law. Post-quantum cryptography, nothing kept on disk, and a disclosure policy you can read.">
 <link rel="canonical" href="https://paramant.app/security">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -141,7 +144,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       "@type": "WebPage",
       "@id": "https://paramant.app/security#webpage",
       "url": "https://paramant.app/security",
-      "name": "Security · Paramant",
+      "name": "Security · How to check Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -149,7 +152,36 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "How PARAMANT approaches security: post-quantum crypto, independent audit, responsible disclosure, relay architecture."
+      "description": "Servers at Hetzner in Nuremberg, Germany, under EU and German law. Post-quantum cryptography, nothing kept on disk, and a disclosure policy you can read."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -3,9 +3,16 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Security Acknowledgements — PARAMANT</title>
-<meta property="og:title" content="Security Acknowledgements — PARAMANT">
-<meta property="og:description" content="Security researchers who have contributed to Paramant.">
+  <title>Security acknowledgements · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:description" content="Paramant thanks the researchers who responsibly disclosed security issues. Good-faith research makes Paramant better for everyone.">
+<meta name="twitter:title" content="Security acknowledgements · Paramant">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta property="og:title" content="Security acknowledgements · Paramant">
+<meta property="og:description" content="Paramant thanks the researchers who responsibly disclosed security issues. Good-faith research makes Paramant better for everyone.">
 <meta property="og:url" content="https://paramant.app/security/acknowledgements">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Paramant">
@@ -16,7 +23,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="manifest" href="/manifest.json">
   <meta name="theme-color" content="#0B3A6A">
-  <meta name="description" content="Security researchers who have contributed to Paramant.">
+  <meta name="description" content="Paramant thanks the researchers who responsibly disclosed security issues. Good-faith research makes Paramant better for everyone.">
   <style>
     *{box-sizing:border-box;margin:0;padding:0}
     main{max-width:780px;margin:0 auto;padding:80px 48px 120px}
@@ -43,7 +50,7 @@
       "@type": "WebPage",
       "@id": "https://paramant.app/security/acknowledgements#webpage",
       "url": "https://paramant.app/security/acknowledgements",
-      "name": "Security Acknowledgements — PARAMANT",
+      "name": "Security acknowledgements · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -51,7 +58,7 @@
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Security researchers who have contributed to Paramant."
+      "description": "Paramant thanks the researchers who responsibly disclosed security issues. Good-faith research makes Paramant better for everyone."
     },
     {
       "@type": "BreadcrumbList",
@@ -72,8 +79,37 @@
         {
           "@type": "ListItem",
           "position": 3,
-          "name": "Security Acknowledgements"
+          "name": "Security acknowledgements"
         }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
       ]
     }
   ]

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Paramant - First-time setup</title>
+  <title>First-time setup · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/setup">
   <link rel="stylesheet" href="/design-system.css?v=23">

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -7,19 +7,19 @@
 <script src="/js/ready.js?v=1"></script>
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Sign a document · Paramant</title>
+<title>Sign a PDF in your browser · Paramant</title>
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Sign documents with ML-DSA-65 (FIPS 204). Private keys and document plaintext stay in the browser.">
-<meta property="og:title" content="Sign a document · Paramant">
-<meta property="og:description" content="Sign a document with a post-quantum ML-DSA-65 signature in your browser. Your private key and document plaintext never leave your device.">
+<meta name="description" content="Sign a PDF in your browser. The document text and your signing key never leave it, and anyone can check the finished document afterwards.">
+<meta property="og:title" content="Sign a PDF in your browser · Paramant">
+<meta property="og:description" content="Sign a PDF in your browser. The document text and your signing key never leave it, and anyone can check the finished document afterwards.">
 <meta property="og:url" content="https://paramant.app/sign">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Sign a document · Paramant">
-<meta name="twitter:description" content="Sign a document with a post-quantum ML-DSA-65 signature in your browser. Your private key and document plaintext never leave your device.">
+<meta name="twitter:title" content="Sign a PDF in your browser · Paramant">
+<meta name="twitter:description" content="Sign a PDF in your browser. The document text and your signing key never leave it, and anyone can check the finished document afterwards.">
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="canonical" href="https://paramant.app/sign">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -277,7 +277,7 @@
       "@type": "WebPage",
       "@id": "https://paramant.app/sign#webpage",
       "url": "https://paramant.app/sign",
-      "name": "Sign a document · Paramant",
+      "name": "Sign a PDF in your browser · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -285,7 +285,7 @@
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Sign documents with ML-DSA-65 (FIPS 204). Private keys and document plaintext stay in the browser."
+      "description": "Sign a PDF in your browser. The document text and your signing key never leave it, and anyone can check the finished document afterwards."
     },
     {
       "@type": "SoftwareApplication",
@@ -297,6 +297,35 @@
       "publisher": {
         "@id": "https://paramant.app/#organization"
       }
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -4,17 +4,20 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Create account · Paramant</title>
+<title>Create a free Paramant account</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Create a Paramant account. No password. Sign in with a passkey or an authenticator app.">
-<meta property="og:title" content="Create account · Paramant">
-<meta property="og:description" content="Create a Paramant account. No password. Sign in with a passkey or an authenticator app.">
+<meta name="description" content="Create a Paramant account. ParaSign Community gives 2 signatures a month, unlimited receiving and full post-quantum crypto, forever. No card required.">
+<meta property="og:title" content="Create a free Paramant account">
+<meta property="og:description" content="Create a Paramant account. ParaSign Community gives 2 signatures a month, unlimited receiving and full post-quantum crypto, forever. No card required.">
 <meta property="og:url" content="https://paramant.app/signup">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Create account · Paramant">
-<meta name="twitter:description" content="Create a Paramant account. No password. Sign in with a passkey or an authenticator app.">
+<meta name="twitter:title" content="Create a free Paramant account">
+<meta name="twitter:description" content="Create a Paramant account. ParaSign Community gives 2 signatures a month, unlimited receiving and full post-quantum crypto, forever. No card required.">
 <link rel="canonical" href="https://paramant.app/signup">
 <meta name="robots" content="index, follow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -109,7 +112,7 @@
       "@type": "WebPage",
       "@id": "https://paramant.app/signup#webpage",
       "url": "https://paramant.app/signup",
-      "name": "Create account · Paramant",
+      "name": "Create a free Paramant account",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -117,7 +120,36 @@
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Create a Paramant account. No password. Sign in with a passkey or an authenticator app."
+      "description": "Create a Paramant account. ParaSign Community gives 2 signatures a month, unlimited receiving and full post-quantum crypto, forever. No card required."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -4,17 +4,20 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Service Level Agreement — PARAMANT</title>
+<title>Service level agreement · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="PARAMANT SLA: uptime commitments, credits policy, and support tiers for community, professional, and enterprise plans.">
-<meta property="og:title" content="Service Level Agreement · PARAMANT">
-<meta property="og:description" content="PARAMANT SLA: uptime commitments, credits policy, and support tiers for community, professional, and enterprise plans.">
+<meta name="description" content="Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise.">
+<meta property="og:title" content="Service level agreement · Paramant">
+<meta property="og:description" content="Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise.">
 <meta property="og:url" content="https://paramant.app/sla">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Service Level Agreement · PARAMANT">
-<meta name="twitter:description" content="PARAMANT SLA: uptime commitments, credits policy, and support tiers for community, professional, and enterprise plans.">
+<meta name="twitter:title" content="Service level agreement · Paramant">
+<meta name="twitter:description" content="Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise.">
 <link rel="canonical" href="https://paramant.app/sla">
 
 <link rel="stylesheet" href="/design-system.css?v=23">
@@ -129,7 +132,7 @@ a:hover{opacity:.8}
       "@type": "WebPage",
       "@id": "https://paramant.app/sla#webpage",
       "url": "https://paramant.app/sla",
-      "name": "Service Level Agreement — PARAMANT",
+      "name": "Service level agreement · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -137,7 +140,36 @@ a:hover{opacity:.8}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "PARAMANT SLA: uptime commitments, credits policy, and support tiers for community, professional, and enterprise plans."
+      "description": "Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -4,17 +4,20 @@
 <meta charset="utf-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>System Status — PARAMANT</title>
+<title>System status · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Auto-refreshes every 30s - uptime % calculated from last 24h of checks (stored locally)">
-<meta property="og:title" content="System Status · PARAMANT">
-<meta property="og:description" content="Real-time status of all PARAMANT relay sectors.">
+<meta name="description" content="Live status of the Paramant network. Uptime is calculated from the last 24 hours of checks and the page refreshes every 30 seconds.">
+<meta property="og:title" content="System status · Paramant">
+<meta property="og:description" content="Live status of the Paramant network. Uptime is calculated from the last 24 hours of checks and the page refreshes every 30 seconds.">
 <meta property="og:url" content="https://paramant.app/status">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="System Status · PARAMANT">
-<meta name="twitter:description" content="Real-time status of all PARAMANT relay sectors.">
+<meta name="twitter:title" content="System status · Paramant">
+<meta name="twitter:description" content="Live status of the Paramant network. Uptime is calculated from the last 24 hours of checks and the page refreshes every 30 seconds.">
 <link rel="canonical" href="https://paramant.app/status">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -142,7 +145,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
       "@type": "WebPage",
       "@id": "https://paramant.app/status#webpage",
       "url": "https://paramant.app/status",
-      "name": "System Status — PARAMANT",
+      "name": "System status · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -150,7 +153,36 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Auto-refreshes every 30s - uptime % calculated from last 24h of checks (stored locally)"
+      "description": "Live status of the Paramant network. Uptime is calculated from the last 24 hours of checks and the page refreshes every 30 seconds."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -4,17 +4,20 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Terms of Service · PARAMANT</title>
+<title>Terms of service · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="PARAMANT Terms of Service: who you contract with, what the plans include, payment and cancellation, acceptable use, liability, and the right of withdrawal.">
-<meta property="og:title" content="Terms of Service · PARAMANT">
-<meta property="og:description" content="PARAMANT Terms of Service: who you contract with, what the plans include, payment and cancellation, acceptable use, liability, and the right of withdrawal.">
+<meta name="description" content="The agreement between you and Paramantis Solutions B.V. for the use of Paramant. Plans, payment, cancellation, acceptable use, liability and Dutch law.">
+<meta property="og:title" content="Terms of service · Paramant">
+<meta property="og:description" content="The agreement between you and Paramantis Solutions B.V. for the use of Paramant. Plans, payment, cancellation, acceptable use, liability and Dutch law.">
 <meta property="og:url" content="https://paramant.app/terms">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Terms of Service · PARAMANT">
-<meta name="twitter:description" content="PARAMANT Terms of Service: who you contract with, what the plans include, payment and cancellation, acceptable use, liability, and the right of withdrawal.">
+<meta name="twitter:title" content="Terms of service · Paramant">
+<meta name="twitter:description" content="The agreement between you and Paramantis Solutions B.V. for the use of Paramant. Plans, payment, cancellation, acceptable use, liability and Dutch law.">
 <link rel="canonical" href="https://paramant.app/terms">
 
 <link rel="stylesheet" href="/design-system.css?v=23">
@@ -129,7 +132,7 @@ a:hover{opacity:.8}
       "@type": "WebPage",
       "@id": "https://paramant.app/terms#webpage",
       "url": "https://paramant.app/terms",
-      "name": "Terms of Service · PARAMANT",
+      "name": "Terms of service · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -137,7 +140,36 @@ a:hover{opacity:.8}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "PARAMANT Terms of Service: who you contract with, what the plans include, payment and cancellation, acceptable use, liability, and the right of withdrawal."
+      "description": "The agreement between you and Paramantis Solutions B.V. for the use of Paramant. Plans, payment, cancellation, acceptable use, liability and Dutch law."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -4,17 +4,20 @@
 <meta charset="utf-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Trust &amp; Transparency — PARAMANT</title>
+<title>Trust and verification · Paramant</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="How Paramant works with your relay: how license-check is specified, what we can see, how to verify your deployment, and what we can and cannot do remotely...">
-<meta property="og:title" content="Trust &amp; Transparency · PARAMANT">
-<meta property="og:description" content="How Paramant works with your relay: how license-check is specified, what we can see, how to verify your deployment, and what we can and cannot do remotely. Open-core, customer-verifiable.">
+<meta name="description" content="What Paramant can see on your own server, what it can do, and how you check both yourself. Every claim on the page is tagged live or planned.">
+<meta property="og:title" content="Trust and verification · Paramant">
+<meta property="og:description" content="What Paramant can see on your own server, what it can do, and how you check both yourself. Every claim on the page is tagged live or planned.">
 <meta property="og:url" content="https://paramant.app/trust">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Trust &amp; Transparency · PARAMANT">
-<meta name="twitter:description" content="How Paramant works with your relay: how license-check is specified, what we can see, how to verify your deployment, and what we can and cannot do remotely. Open-core, customer-verifiable.">
+<meta name="twitter:title" content="Trust and verification · Paramant">
+<meta name="twitter:description" content="What Paramant can see on your own server, what it can do, and how you check both yourself. Every claim on the page is tagged live or planned.">
 <link rel="canonical" href="https://paramant.app/trust">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -156,7 +159,7 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
       "@type": "WebPage",
       "@id": "https://paramant.app/trust#webpage",
       "url": "https://paramant.app/trust",
-      "name": "Trust & Transparency — PARAMANT",
+      "name": "Trust and verification · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -164,7 +167,36 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "How Paramant works with your relay: how license-check is specified, what we can see, how to verify your deployment, and what we can and cannot do remotely..."
+      "description": "What Paramant can see on your own server, what it can do, and how you check both yourself. Every claim on the page is tagged live or planned."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/vault.html
+++ b/frontend/vault.html
@@ -4,11 +4,15 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}[hidden]{display:none !important}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Lock a file · Paramant</title>
+<title>Lock a file with a passphrase · Paramant</title>
+<meta name="twitter:description" content="Lock any file with a passphrase before you store or share it. Everything happens on this device; the file and the passphrase never leave your browser.">
+<meta name="twitter:title" content="Lock a file with a passphrase · Paramant">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Encrypt a file into a .prmnt container with a passphrase. Everything happens on your device; the file and key never leave your browser.">
-<meta property="og:title" content="Lock a file · Paramant">
-<meta property="og:description" content="Encrypt a file with a passphrase, right in your browser. The file never leaves your device.">
+<meta name="description" content="Lock any file with a passphrase before you store or share it. Everything happens on this device; the file and the passphrase never leave your browser.">
+<meta property="og:title" content="Lock a file with a passphrase · Paramant">
+<meta property="og:description" content="Lock any file with a passphrase before you store or share it. Everything happens on this device; the file and the passphrase never leave your browser.">
 <meta property="og:url" content="https://paramant.app/vault">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
@@ -56,7 +60,7 @@
       "@type": "WebPage",
       "@id": "https://paramant.app/vault#webpage",
       "url": "https://paramant.app/vault",
-      "name": "Lock a file · Paramant",
+      "name": "Lock a file with a passphrase · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -64,7 +68,7 @@
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Encrypt a file into a .prmnt container with a passphrase. Everything happens on your device; the file and key never leave your browser."
+      "description": "Lock any file with a passphrase before you store or share it. Everything happens on this device; the file and the passphrase never leave your browser."
     },
     {
       "@type": "SoftwareApplication",
@@ -76,6 +80,35 @@
       "publisher": {
         "@id": "https://paramant.app/#organization"
       }
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -4,19 +4,19 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Verify a signature · Paramant</title>
+<title>Check whether a signed document was changed · Paramant</title>
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Verify a .psign envelope against the original document. ML-DSA-65 (FIPS 204).">
-<meta property="og:title" content="Verify a signature · Paramant">
-<meta property="og:description" content="Check a Paramant signature in your browser: who signed, what they signed, and that nothing changed since. No upload, no account.">
+<meta name="description" content="Check whether a signed document was changed after it was signed. It happens in your browser, without an account and without uploading the file.">
+<meta property="og:title" content="Check whether a signed document was changed · Paramant">
+<meta property="og:description" content="Check whether a signed document was changed after it was signed. It happens in your browser, without an account and without uploading the file.">
 <meta property="og:url" content="https://paramant.app/verify">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Verify a signature · Paramant">
-<meta name="twitter:description" content="Check a Paramant signature in your browser: who signed, what they signed, and that nothing changed since. No upload, no account.">
+<meta name="twitter:title" content="Check whether a signed document was changed · Paramant">
+<meta name="twitter:description" content="Check whether a signed document was changed after it was signed. It happens in your browser, without an account and without uploading the file.">
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="canonical" href="https://paramant.app/verify">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -33,7 +33,7 @@
       "@type": "WebPage",
       "@id": "https://paramant.app/verify#webpage",
       "url": "https://paramant.app/verify",
-      "name": "Verify a signature · Paramant",
+      "name": "Check whether a signed document was changed · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -41,7 +41,7 @@
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Verify a .psign envelope against the original document. ML-DSA-65 (FIPS 204)."
+      "description": "Check whether a signed document was changed after it was signed. It happens in your browser, without an account and without uploading the file."
     },
     {
       "@type": "SoftwareApplication",
@@ -53,6 +53,35 @@
       "publisher": {
         "@id": "https://paramant.app/#organization"
       }
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -4,17 +4,20 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Paramant vs alternatives</title>
+<title>Paramant compared to Zivver, Tresorit and WeTransfer</title>
+<meta name="twitter:image" content="https://paramant.app/og-image.png">
+<meta property="og:image:height" content="630">
+<meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="How Paramant compares to Zivver, Tresorit, WeTransfer, and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting.">
-<meta property="og:title" content="Paramant vs alternatives">
-<meta property="og:description" content="How Paramant compares to Zivver, Tresorit, WeTransfer, and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting.">
+<meta name="description" content="How Paramant compares to Zivver, Tresorit, WeTransfer and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting.">
+<meta property="og:title" content="Paramant compared to Zivver, Tresorit and WeTransfer">
+<meta property="og:description" content="How Paramant compares to Zivver, Tresorit, WeTransfer and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting.">
 <meta property="og:url" content="https://paramant.app/vs">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Paramant vs alternatives">
-<meta name="twitter:description" content="How Paramant compares to Zivver, Tresorit, WeTransfer, and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting.">
+<meta name="twitter:title" content="Paramant compared to Zivver, Tresorit and WeTransfer">
+<meta name="twitter:description" content="How Paramant compares to Zivver, Tresorit, WeTransfer and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting.">
 <link rel="canonical" href="https://paramant.app/vs">
 
 <link rel="stylesheet" href="/design-system.css?v=23">
@@ -91,7 +94,7 @@
       "@type": "WebPage",
       "@id": "https://paramant.app/vs#webpage",
       "url": "https://paramant.app/vs",
-      "name": "Paramant vs alternatives",
+      "name": "Paramant compared to Zivver, Tresorit and WeTransfer",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -99,7 +102,36 @@
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "How Paramant compares to Zivver, Tresorit, WeTransfer, and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting."
+      "description": "How Paramant compares to Zivver, Tresorit, WeTransfer and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting."
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/tests/seo-contract.test.mjs
+++ b/tests/seo-contract.test.mjs
@@ -253,3 +253,257 @@ test('robots.txt disallows the login path the redirect points at', () => {
     `${dir} is where the login redirect sends a crawler, so robots.txt must disallow it`,
   );
 });
+
+// ── What a shared link says, and who it says is behind it ────────────────────
+// Added 2026-09-02. Two things had drifted page by page and nothing failed when
+// they did.
+//
+// 1. og:title, twitter:title and <title> disagreed on 20 of 38 public pages,
+//    and og:description/twitter:description disagreed with the meta description
+//    on more. A link pasted in Signal, LinkedIn or WhatsApp then advertised a
+//    different page than the one Google shows. These are the same sentence in
+//    three places, so they are asserted as one.
+//
+// 2. The Organization node named no founder and no legal entity, and it existed
+//    on the homepage only while every other page pointed a publisher @id at it.
+//    The name, the title, the company and the town are all printed on the site:
+//    the footer apply-nav.py stamps carries Paramantis Solutions B.V.,
+//    Harderwijk and KvK 42115132, and /about carries "founded by Mick Beer,
+//    privacy and security researcher". Nothing here is asserted that a reader
+//    cannot check on the page itself, which is why it can be pinned at all.
+//
+// If the founder or the legal name ever has to leave the site, this test is the
+// thing that fails first, and the sentence goes out of the pages and out of
+// here in the same commit.
+const entities = (s) => s
+  .replace(/&middot;/g, '·').replace(/&mdash;/g, String.fromCharCode(0x2014))
+  .replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, ' ')
+  .replace(/&amp;/g, '&').trim();
+
+const attr = (html, re) => entities((html.match(re) || [, ''])[1] || '');
+
+// The JSON-LD WebPage node is the fifth copy of the same sentence and it was
+// the one that drifted: /trust shipped "Trust & Verification" in the title and
+// "Trust & Transparency" in og:title and in the WebPage name at the same time,
+// and nothing failed. Structured data that names the page something else is a
+// second answer to the same question, and the crawler picks.
+function webPageNodes(html) {
+  return [...html.matchAll(rx.ld)].flatMap((m) => {
+    let parsed;
+    try { parsed = JSON.parse(m[1].trim()); } catch { return []; }
+    return (parsed['@graph'] || [parsed]).filter((n) => n['@type'] === 'WebPage');
+  });
+}
+
+test('the title, Open Graph, Twitter cards and JSON-LD say the same thing', () => {
+  const problems = [];
+  for (const slug of publicPages()) {
+    const html = read(slug);
+    const title = entities((html.match(rx.title) || [, ''])[1]);
+    const desc = attr(html, /<meta[^>]+name=["']description["'][^>]+content=["']([^"']*)["']/i);
+    const pairs = [
+      ['og:title', attr(html, /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']*)["']/i), title],
+      ['twitter:title', attr(html, /<meta[^>]+name=["']twitter:title["'][^>]+content=["']([^"']*)["']/i), title],
+      ['og:description', attr(html, /<meta[^>]+property=["']og:description["'][^>]+content=["']([^"']*)["']/i), desc],
+      ['twitter:description', attr(html, /<meta[^>]+name=["']twitter:description["'][^>]+content=["']([^"']*)["']/i), desc],
+    ];
+    for (const [name, got, want] of pairs) {
+      if (!got) problems.push(`${slug}: no ${name}`);
+      else if (got !== want) problems.push(`${slug}: ${name} is "${got}" but the page says "${want}"`);
+    }
+    const pages = webPageNodes(html);
+    if (!pages.length) problems.push(`${slug}: no WebPage node in the JSON-LD`);
+    for (const node of pages) {
+      if (entities(String(node.name || '')) !== title) {
+        problems.push(`${slug}: JSON-LD WebPage name is "${node.name}" but the page says "${title}"`);
+      }
+      if (node.description !== undefined && entities(String(node.description)) !== desc) {
+        problems.push(`${slug}: JSON-LD WebPage description is "${node.description}" but the page says "${desc}"`);
+      }
+    }
+  }
+  assert.deepEqual(problems, [], `\n  ${problems.join('\n  ')}\n`);
+});
+
+test('every public page names the company and the founder in its Organization node', () => {
+  const problems = [];
+  for (const slug of publicPages()) {
+    const html = read(slug);
+    const blocks = [...html.matchAll(rx.ld)].map((m) => m[1].trim());
+    const nodes = blocks.flatMap((b) => {
+      let parsed;
+      try { parsed = JSON.parse(b); } catch { return []; }
+      return parsed['@graph'] || [parsed];
+    });
+    const org = nodes.find((n) => n['@type'] === 'Organization');
+    if (!org) { problems.push(`${slug}: no Organization node in the JSON-LD`); continue; }
+    if (org.legalName !== 'Paramantis Solutions B.V.') {
+      problems.push(`${slug}: Organization legalName is "${org.legalName}", the footer says Paramantis Solutions B.V.`);
+    }
+    if (org.founder?.name !== 'Mick Beer') {
+      problems.push(`${slug}: Organization founder is "${org.founder?.name}", /about says Mick Beer`);
+    }
+    if (org.founder?.jobTitle !== 'Privacy and security researcher') {
+      problems.push(`${slug}: founder jobTitle is "${org.founder?.jobTitle}", /about says privacy and security researcher`);
+    }
+    if (org.address?.addressLocality !== 'Harderwijk' || org.address?.addressCountry !== 'NL') {
+      problems.push(`${slug}: Organization address is not Harderwijk, NL`);
+    }
+  }
+  assert.deepEqual(problems, [], `\n  ${problems.join('\n  ')}\n`);
+});
+
+// ── The sentence itself, not only its consistency ───────────────────────────
+// The gate above pins <title>, og:title and twitter:title to each other. That
+// is not enough on its own: replacing all three with the same false sentence
+// passes it. Measured on 2026-09-02, "Paramant is ISO 27001 certified and free
+// forever" on frontend/index.html kept every test in this file and in
+// ui-truthfulness green. These three gates pin the content.
+
+// The sentence a buyer reads first, on the pages that carry a claim. Pinned
+// word for word on purpose: these are the sentences a search result and a chat
+// preview show, so changing one should be a deliberate edit in two files, not a
+// side effect of editing a page. Every claim below is printed on the site, and
+// the source is named beside it. docs/brand/messaging.md is the guide these
+// follow; it landed in #331 and is on main.
+//
+//   index      "Get documents signed and send files safely, straight from your
+//              browser." is the homepage H1 and lede (#328). "Built and hosted
+//              in the EU" is the same page's rules grid: Hetzner Germany, Bunny
+//              DNS. "Paramantis Solutions B.V." is the footer apply-nav.py
+//              stamps on every page. "The Community plan is free, forever" is
+//              frontend/pricing.html, quoted in the guide, section 3.
+//   pricing    "The Community plan is free, forever" is on
+//              frontend/pricing.html. EUR 15/mo is the ParaSend Pro card and
+//              EUR 49/month the ParaSign Pro card, so the two floors are named
+//              per product: an unsplit "from 15 euro" reads as if signing
+//              starts there, and it starts at 49. Both are excl. btw, which is
+//              the basis the whole page prices on.
+//   about      frontend/about.html: "founded by Mick Beer, privacy and security
+//              researcher", plus the footer entity and town.
+//   sign       frontend/sign.html: "the file and your private key stay in this
+//              browser, and the relay only ever sees a hash" on the account
+//              step, "Private key stays on your device" on the mode chooser,
+//              and the self-contained downloads that verify offline. The
+//              sentence says "the document text", not "the file": in Request
+//              signatures the ENCRYPTED document does go to Paramant, because
+//              that is how a recipient gets it ("Paramant delivers the
+//              encrypted document with the request"). Plaintext and key stay
+//              local in all three modes; the file does not.
+//   verify     frontend/verify.html checks a signature in the browser with no
+//              account and no upload.
+//   download   the banner on frontend/download.html: March 2026 build, 21
+//              protections missing, web app recommended.
+//   trust      frontend/trust.html tags every claim live or planned.
+//   signup     the ParaSign Community card on frontend/pricing.html.
+//
+// The title is pinned as well as the description. A title is the one sentence
+// that gets shared, and the gate above only pins the copies to each other: all
+// four saying the same false thing passed it.
+const PINNED = {
+  index: {
+    title: 'ParaSign by Paramant · sign and send documents in the EU',
+    desc: 'Get documents signed and send files safely, straight from your browser. Built and hosted in the EU by Paramantis Solutions B.V. The Community plan is free, forever.',
+  },
+  pricing: {
+    title: 'Pricing · What is free, and what businesses pay · Paramant',
+    desc: 'The Community plan is free, forever. Organisations pay for higher limits: sending from 15 euro a month, signing from 49, excl. btw. From Paramantis Solutions B.V.',
+  },
+  about: {
+    title: 'About Paramant · Founded by Mick Beer',
+    desc: 'Paramant is a product of Paramantis Solutions B.V. in Harderwijk, founded by Mick Beer, privacy and security researcher. Company, mission, and how to check us.',
+  },
+  sign: {
+    title: 'Sign a PDF in your browser · Paramant',
+    desc: 'Sign a PDF in your browser. The document text and your signing key never leave it, and anyone can check the finished document afterwards.',
+  },
+  verify: {
+    title: 'Check whether a signed document was changed · Paramant',
+    desc: 'Check whether a signed document was changed after it was signed. It happens in your browser, without an account and without uploading the file.',
+  },
+  download: {
+    title: 'Download the Paramant desktop app',
+    desc: 'The Paramant desktop app. The current build is from March 2026 and misses 21 protections the web app has, so the web app is the one we recommend.',
+  },
+  trust: {
+    title: 'Trust and verification · Paramant',
+    desc: 'What Paramant can see on your own server, what it can do, and how you check both yourself. Every claim on the page is tagged live or planned.',
+  },
+  signup: {
+    title: 'Create a free Paramant account',
+    desc: 'Create a Paramant account. ParaSign Community gives 2 signatures a month, unlimited receiving and full post-quantum crypto, forever. No card required.',
+  },
+};
+
+test('the pages that carry the offer say exactly what they are pinned to say', () => {
+  const problems = [];
+  for (const [slug, want] of Object.entries(PINNED)) {
+    const html = read(slug);
+    const title = entities((html.match(rx.title) || [, ''])[1]);
+    const desc = attr(html, /<meta[^>]+name=["']description["'][^>]+content=["']([^"']*)["']/i);
+    if (title !== want.title) problems.push(`${slug}: title is "${title}", pinned to "${want.title}"`);
+    if (desc !== want.desc) problems.push(`${slug}: description is "${desc}", pinned to "${want.desc}"`);
+  }
+  assert.deepEqual(problems, [], `\n  ${problems.join('\n  ')}\n`);
+});
+
+// A certification we do not hold is the cheapest sentence to write and the most
+// expensive one to be caught with. Paramant holds none of these: /about states
+// a ParaSign signature is a Simple Electronic Signature and explicitly not
+// eIDAS-qualified, and no page on the site claims an audit or an ISO number.
+// Anything on this list is a claim the site cannot back, so it may not appear
+// in the one sentence a search result or a chat preview shows.
+const FORBIDDEN_CLAIMS = [
+  /ISO\s?\d{4,5}/i, /SOC\s?2/i, /\bcertified\b/i, /\bcertification\b/i,
+  /\baccredited\b/i, /\bqualified electronic signature\b/i, /\bQES\b/,
+  /\bunbreakable\b/i, /\bmilitary[- ]grade\b/i, /\bguaranteed\b/i,
+  /\b100%\s*(secure|private|safe)\b/i, /\bfully compliant\b/i,
+];
+
+test('no title or description claims something the site cannot back', () => {
+  const problems = [];
+  for (const slug of publicPages()) {
+    const html = read(slug);
+    const title = entities((html.match(rx.title) || [, ''])[1]);
+    const desc = attr(html, /<meta[^>]+name=["']description["'][^>]+content=["']([^"']*)["']/i);
+    for (const re of FORBIDDEN_CLAIMS) {
+      if (re.test(title)) problems.push(`${slug}: title matches ${re}, and nothing on the site backs that`);
+      if (re.test(desc)) problems.push(`${slug}: description matches ${re}, and nothing on the site backs that`);
+    }
+  }
+  assert.deepEqual(problems, [], `\n  ${problems.join('\n  ')}\n`);
+});
+
+// Internal vocabulary. "The relay" is what we call our own server; a buyer
+// reading a Google result or a WhatsApp preview has never seen the word. An
+// algorithm name in the first sentence spends the only line we get on something
+// the reader cannot act on. The names stay on the pages, where there is room to
+// explain them; they stay out of the title and out of the sentence that is read
+// before the page is opened.
+const INTERNAL = [
+  /ML-DSA/i, /ML-KEM/i, /SPHINCS/i, /\bFIPS\b/i, /\.prmnt\b/i,
+  /\brelay\b/i, /open-core/i, /\bAES-\d/i, /\benvelope\b/i,
+];
+
+// Pages whose reader is an engineer by the time they arrive: they are linked
+// from the docs and from /security, not from an ad or a shared link, and the
+// vocabulary is the subject of the page rather than a shortcut in it.
+const TECHNICAL = new Set(['architecture', 'crypto-agility', 'ct-log', 'docs/paramant-ot-brief']);
+
+test('the preview text a buyer reads first is free of internal vocabulary', () => {
+  const problems = [];
+  for (const slug of publicPages()) {
+    if (TECHNICAL.has(slug)) continue;
+    const html = read(slug);
+    const title = entities((html.match(rx.title) || [, ''])[1]);
+    const desc = attr(html, /<meta[^>]+name=["']description["'][^>]+content=["']([^"']*)["']/i);
+    // The first sentence is the part that survives truncation in a search
+    // result; the rest of the description may carry a technical detail.
+    const lead = desc.split(/(?<=\.)\s/)[0] || desc;
+    for (const re of INTERNAL) {
+      if (re.test(title)) problems.push(`${slug}: title carries ${re}, which is our vocabulary and not the reader's`);
+      if (re.test(lead)) problems.push(`${slug}: the first sentence of the description carries ${re}`);
+    }
+  }
+  assert.deepEqual(problems, [], `\n  ${problems.join('\n  ')}\n`);
+});


### PR DESCRIPTION
Head elements only, on 50 of the 60 frontend pages: `<title>`, meta description, Open Graph, Twitter cards and JSON-LD. No body text, no styling. `apply-nav.py` and `js/nav-auth.js` are untouched, and a machine check over all 50 changed HTML files reports **0 diff hunks after `</head>`** in either the old or the new version of the file.

## Rebased on main

Squashed onto `origin/main` (d946752). Main moved a long way while this was open: #328 (homepage head rewritten), #325 (`/parasign` exists), #331 (`docs/brand/messaging.md`, and it is now the authority for titles and descriptions), #338, #340, #341, #342, #352, #332, #353, #337 and #333. The diff against main is 52 files: 50 HTML heads, the generator that writes them, and the test that gates them.

Two conflicts, `frontend/index.html` and `frontend/pricing.html`, both in the head. Resolved the same way each time: **main wins where main already writes to the guide, this branch adds what main does not have.**

- `/index` keeps main's title, main's description sentence, main's `SoftwareApplication` node ("ParaSign by Paramant", `BusinessApplication`, Community at EUR 0) and main's Organization description ("Dutch company, servers in Germany"). This branch adds the founder, the address, the KvK identifier and the contact address to that Organization node, on every public page rather than on the homepage only, and adds one clause to the description (below).
- `/pricing` had no head work on main at all, so the head comes from this branch, rewritten against the guide.

`docs/brand/messaging.md` is on main now, so the earlier round's dead source reference is a live one. The head texts follow the guide, not the current body: three of these pages have a body rewrite open in another PR.

**One drift fixed.** `python3 bron-seo/apply_seo_head.py --check` on plain `origin/main` reports `would change: 1 pages`, because #328 hand-edited the homepage JSON-LD block the generator owns. Left alone, the next run of the generator would have silently reverted it. The generator now carries that shape (`SOFTWARE_OVERRIDES`) and keeps the middot instead of flattening it to a hyphen, so the JSON-LD name is the title character for character. On this branch: `would change: 0 pages`.

## What the review asked for

**1. Who is behind it, in the text a human actually sees.** The founder and the legal entity were in the JSON-LD, which no preview in WhatsApp, LinkedIn, Signal or iMessage renders. `og:description` is pinned to the meta description by the consistency gate, so it had to go in the description itself.

The **legal entity** is now in the description of all three pages that sell on who is behind it. The **founder's name** is in one of them, `/about`, because that is the page whose own sentence backs it; on `/` and `/pricing` he stays in the Organization node, where the same three fields are now present on every public page.

| page | what the description now names |
|---|---|
| `/` | "Built and hosted in the EU by Paramantis Solutions B.V." — entity |
| `/about` | "Paramant is a product of Paramantis Solutions B.V. in Harderwijk, founded by Mick Beer, privacy and security researcher." — entity, town and founder |
| `/pricing` | "From Paramantis Solutions B.V." — entity |

**2. No jargon in a description, and no product name assumed known in its first sentence.** `/verify` said "ML-DSA-65 (FIPS 204)" and now says what you get out of it; `/sign` said the key never reaches "the relay" and now says it stays on your device. "relay", "envelope", `.prmnt`, ML-DSA, ML-KEM, FIPS, AES-n and "open-core" are out of every title and out of the first sentence of every description, except on the four pages whose subject is the architecture. Every description opens with the action, never with ParaSign or ParaSend.

TOTP is out of the first sentence of `/help`, `/help/api-key-vs-totp`, `/help/lost-authenticator` and `/help/session-issues`; they say "a code from your authenticator app", which is what those articles call it themselves. It is **not** added to the `INTERNAL` list: TOTP is RFC 6238 and the word every authenticator app prints, so it is the reader's vocabulary rather than ours, and putting it on the list would force a rename of a page whose own H1 and URL slug are `API key vs TOTP` while #333 is rewriting that body.

**3. A title that promises no more than the page delivers.** The old homepage title was "Sign and send without a US server". `/security` lists third-party services and the guide is explicit (section 4, proof 1) that the claim is about the **data path** and that Resend is the named exception. The title is now main's: "sign and send documents in the EU", which the rules grid backs word for word ("Hetzner Germany, Bunny DNS (Slovenia). No US provider in the data path. Email goes out via Resend"). No head element on any page carries an unqualified no-US claim.

**4. The free plan is Community in the head too.** `/signup` said "ParaSign Free gives 2 signatures a month"; `/pricing` said "Free stays free". Both now say Community, which is what `tests/ui-truthfulness.test.mjs` requires of the body and what the guide fixes as the name.

**5. `/trust` said three different things at once.** `<title>` and `<h1>` said "Trust & Verification" while `og:title`, `twitter:title` and the JSON-LD `WebPage` name said "Trust & Transparency". No test compared a title with its JSON-LD. One does now, and all four agree.

**6. `/parashare` is byte-identical to main.** It is in the PRIVATE set of both `bron-seo/apply_seo_head.py` and `tests/seo-contract.test.mjs`, so both content gates skip it: `git diff origin/main -- frontend/parashare.html` is empty and the page carries no Organization node.

**7. No em-dashes, no `PARAMANT` in caps.** Swept over `<title>`, description, `og:*` and `twitter:*` on all 60 pages, private and redirect pages included: 0 violations.

**8. The sentences are pinned now.** Previous round's gate pinned `<title>`, `og:title` and `twitter:title` to each other, so setting all three to "Paramant is ISO 27001 certified and free forever" passed. Eight pages now have their title and description pinned word for word, with the source of every claim named in the file.

Sabotage, run on this commit:

| change | result |
|---|---|
| `<title>` on `/` to "Paramant, the fastest signing tool in Europe", `og:title` and `twitter:title` and the JSON-LD name pulled along with it | `not ok 12 - the pages that carry the offer say exactly what they are pinned to say` |
| JSON-LD `WebPage.name` on `/trust` to "Trust & Transparency", title and cards left alone | `not ok 10 - the title, Open Graph, Twitter cards and JSON-LD say the same thing` |
| baseline, both reverted | 14 pass, 0 fail |

## Head values, and where each claim comes from

Every claim below is printed on the page it appears on, unless a different file is named.

| page | title | description | source of the claims |
|---|---|---|---|
| `/` | ParaSign by Paramant · sign and send documents in the EU | Get documents signed and send files safely, straight from your browser. Built and hosted in the EU by Paramantis Solutions B.V. The Community plan is free, forever. | H1 and lede on `index.html` ("Get documents signed and send files safely, from your browser", "Everything runs on servers in Germany"); rules grid "EU soil, EU law: Hetzner Germany, Bunny DNS (Slovenia). No US provider in the data path"; footer entity from `apply-nav.py`; "The Community plan is free, forever" from `pricing.html` |
| `/about` | About Paramant · Founded by Mick Beer | Paramant is a product of Paramantis Solutions B.V. in Harderwijk, founded by Mick Beer, privacy and security researcher. Company, mission, and how to check us. | `about.html` "founded by Mick Beer, privacy and security researcher"; footer entity and town from `apply-nav.py` |
| `/pricing` | Pricing · What is free, and what businesses pay · Paramant | The Community plan is free, forever. Organisations pay for higher limits: sending from 15 euro a month, signing from 49, excl. btw. From Paramantis Solutions B.V. | `pricing.html`: "The Community plan is free, forever"; the ParaSend Pro card at EUR 15/mo and the ParaSign Pro card at EUR 49/month, named per product because an unsplit "from 15 euro" reads as if signing starts there; the page-wide "excl. btw" basis |
| `/parasign` | ParaSign · get documents signed, by Paramant | Send a document out for signature and get a receipt anyone can check, from your browser. Free on the Community plan, business plans for firms that sign more. | `parasign.html` (#325): the signing flow, the public verification log, and the Community/Pro/Business split |
| `/sign` | Sign a PDF in your browser · Paramant | Sign a PDF in your browser. The document text and your signing key never leave it, and anyone can check the finished document afterwards. | `sign.html:391` "the file and your private key stay in this browser, and the relay only ever sees a hash"; `sign.html:412` "Private key stays on your device"; `sign.html:686` the downloads verify offline. **"the document text", not "the file"**: `sign.html:514` says "Paramant delivers the encrypted document with the request" and `:708` that it opens in the recipient's browser, so in Request signatures the encrypted file does leave. Plaintext and key stay local in all three modes |
| `/verify` | Check whether a signed document was changed · Paramant | Check whether a signed document was changed after it was signed. It happens in your browser, without an account and without uploading the file. | `verify.html`: in-browser verification, no account, nothing uploaded |
| `/vault` | Lock a file with a passphrase · Paramant | Lock any file with a passphrase before you store or share it. Everything happens on this device; the file and the passphrase never leave your browser. | `vault.html`: the file and the passphrase never leave the browser |
| `/signup` | Create a free Paramant account | Create a Paramant account. ParaSign Community gives 2 signatures a month, unlimited receiving and full post-quantum crypto, forever. No card required. | the ParaSign Community card on `pricing.html`: "2 signatures per month", "unlimited receiving", "Forever · no card required" |
| `/download` | Download the Paramant desktop app | The Paramant desktop app. The current build is from March 2026 and misses 21 protections the web app has, so the web app is the one we recommend. | the banner on `download.html`: "last built in March 2026 and is missing 21 protections the web app has ... Use paramant.app until the native app is rebuilt" |
| `/security` | Security · How to check Paramant | Servers at Hetzner in Nuremberg, Germany, under EU and German law. Post-quantum cryptography, nothing kept on disk, and a disclosure policy you can read. | the jurisdiction table on `security.html` (Hetzner Nuremberg, EU/Germany GDPR) and its disclosure section |
| `/trust` | Trust and verification · Paramant | What Paramant can see on your own server, what it can do, and how you check both yourself. Every claim on the page is tagged live or planned. | `trust.html`: the self-hosting section and the LIVE/PLANNED tags on the page |
| `/status` | System status · Paramant | Live status of the Paramant network. Uptime is calculated from the last 24 hours of checks and the page refreshes every 30 seconds. | `status.html` visible line: "Auto-refreshes every 30s · uptime % calculated from last 24h of checks" |
| `/sla` | Service level agreement · Paramant | Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise. | the plan table on `sla.html`, which runs Community to Enterprise |
| `/pararules` | ParaRules · What Paramant stands for | The rules Paramant holds itself to: zero third-party requests, EU sovereignty, post-quantum by default, you own your keys, honest by design. | the five rule headings on `pararules.html` |
| `/privacy` | Privacy policy · Paramant | What Paramant stores and what it does not. An email address to run your account, no phone number, no IP logging for analytics. EU and German hosting. | `privacy.html`: the stored-data list and the IP retention section |
| `/terms` | Terms of service · Paramant | The agreement between you and Paramantis Solutions B.V. for the use of Paramant. Plans, payment, cancellation, acceptable use, liability and Dutch law. | the section headings of `terms.html`; entity from `apply-nav.py` |
| `/dpa` | Data processing agreement · Paramant | The GDPR Article 28 agreement between Paramantis Solutions B.V. as processor and your organisation as controller. Sign it electronically, EU and German law. | `dpa.html`, which is an Article 28 processor agreement |
| `/license` | License · Paramant Business Source License 1.1 | Paramant is source-available under the Business Source License 1.1. Free for personal use, and it converts to MIT on 2030-01-01. | `license.html`: BSL 1.1 and Change Date 2030-01-01 |
| `/docs` | Documentation · Paramant API and self-hosting | API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key. | the description is #333's own, taken over unchanged because that PR owns the page; the title replaces main's `PARAMANT · Documentation` |
| `/changelog` | Changelog · Paramant release history | Transparent Paramant release history. What changed, when, and why. Security-relevant items are always listed. | `changelog.html` and its security-relevant marker |
| `/ct-log` | Certificate transparency log · Paramant | Every public key registration is appended to a tamper-evident Merkle tree. Anyone can verify that a device was registered, without seeing the payload. | `ct-log.html`: the Merkle tree description |
| `/crypto-agility` | Crypto agility · Paramant | Algorithms you can swap without rebuilding. Identifiers travel in the header, not in the code path. NIST FIPS 203, 204, 205 and 206 loaded in production. | `crypto-agility.html`, the algorithm table (technical page, exempt from the internal-vocabulary gate) |
| `/architecture` | Architecture · How Paramant works | A plain-language walkthrough: how your file is encrypted in the browser, how it travels, why the relay cannot read it, and what happens when a link opens. | `architecture.html` (technical page, exempt from the internal-vocabulary gate) |
| `/docs/paramant-ot-brief` | Industrial OT brief · Paramant | The problem with OT and IT data transfer is architectural, not operational. A RAM-only relay for the DMZ zone boundary. No VPN, no persistent storage. | the OT brief itself (technical page, exempt) |
| `/audit-log-export` | Send audit logs to a regulator without a second leak · Paramant | Deliver GDPR Article 30 evidence to a supervisory authority or an auditor without a second exposure. The file is destroyed after the first read. | `audit-log-export.html`: Article 30 and burn-on-read |
| `/partners` | In the wild · Paramant | Organisations that publicly confirm they run Paramant in production will be listed here. For case studies or references, get in touch. | `partners.html`, which lists nobody; the future tense is the correction |
| `/press` | Press kit · Paramant | Paramant press kit: blurbs, key facts, brand assets and a press contact. Post-quantum document signing and encrypted file transfer from the Netherlands. | `press.html` contents |
| `/vs` | Paramant compared to Zivver, Tresorit and WeTransfer | How Paramant compares to Zivver, Tresorit, WeTransfer and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting. | the comparison table on `vs.html` |
| `/security/acknowledgements` | Security acknowledgements · Paramant | Paramant thanks the researchers who responsibly disclosed security issues. Good-faith research makes Paramant better for everyone. | `security/acknowledgements.html` |
| `/help` | Help and troubleshooting · Paramant | Answers for people who already have a Paramant account: sign-in codes, authenticator setup, backup codes, session problems, and the Gmail and Outlook extensions. | the article list on `help/index.html`, which names authenticator setup, backup codes, "session expired, clock drift" and the two extensions |
| `/help/api-key-vs-totp` | API key vs TOTP · Paramant Help | When to use a Paramant API key and when to use a code from your authenticator app, and how the two work together on one account. | the article: "When you need just the API key", "When you need both", and its own use of "authenticator app" |
| `/help/authenticator-apps` | Authenticator apps · Paramant Help | Every standard authenticator app works with Paramant, including Google Authenticator. For the strongest setup, use a SHA-256 app such as Authy or 1Password. | the article: "a SHA-256 app such as Authy or 1Password" |
| `/help/authenticator-setup` | Set up your authenticator · Paramant Help | How to set up your authenticator app for Paramant. About 3 minutes. Any standard authenticator app works, including Google Authenticator. | the article: "about 3 minutes" |
| `/help/backup-codes` | Backup codes · Paramant Help | How to generate, store and use Paramant backup codes. Emergency access when you lose your authenticator app. | the article itself |
| `/help/gmail-extension` | Gmail extension · Paramant Help | Install and configure the Paramant Chrome extension for sending encrypted attachments from Gmail. | the article itself |
| `/help/iot-integration` | IoT and embedded devices · Paramant Help | Using the Paramant API on constrained devices: Pi Zero, ESP32, OT gateways. Static API key, no TOTP required. | the article: Pi Zero, ESP32, static API key |
| `/help/lost-authenticator` | Lost authenticator access · Paramant Help | How to get back into your Paramant account after losing your authenticator app. Backup codes, support recovery, and re-enrollment. | the article: backup codes, support recovery and re-enrollment are its three sections |
| `/help/outlook-extension` | Outlook add-in · Paramant Help | Set up the Paramant Outlook add-in for Microsoft 365 and Exchange. Send encrypted attachments from within Outlook. | the article itself |
| `/help/session-issues` | Session and login issues · Paramant Help | Fix a sign-in code your account rejects, a session that expires too soon, and clock drift. The most common Paramant login problems, with the fix for each. | the article: rejected code, "session expiry", "clock drift" |

All titles under 65 characters, all descriptions between 50 and 165, `og:*` and `twitter:*` identical to the title and the description on all 39 public pages, and the founder and the legal name in the Organization node of every one.

## Head re-check needed after these land

The head texts follow `docs/brand/messaging.md`, not the current body, so five open PRs rewrite bodies under a head that is already written for the new text. Each still deserves a look at the head after it merges, because a description that quotes a page has to keep quoting it:

| PR | pages | what to re-check |
|---|---|---|
| #339 | `/parasign`, `/parasend`, `/sign` | `/parasend` does not exist yet: a new page needs a title, a description and a sitemap entry, and the three gates apply to it the moment the file lands. `/parasign` and `/sign` descriptions quote the signing flow. |
| #335 | `/about`, `/security`, `/trust` | `/about` and `/trust` are pinned word for word here; `/security`'s description quotes the jurisdiction table, which #335 moves up the page. If the sentence changes on the page, the pin must change in the same commit. |
| #336 | `/pricing`, `/signup` | both pinned here, both quoting `pricing.html`. If a tier price or the Community wording moves, `PINNED` fails first, which is the intent. |
| #337 | auth pages | **Landed.** Its titles won the rebase on `/auth/backup`, `/auth/request-reset` and `/signup/verified`; those pages are `noindex` and have no description contract, so only the em-dash and caps sweep applies, and it is clean. |
| #333 | `/docs`, `/help` | **Landed.** Its `/docs` description won the rebase ("compliance docs for Paramant v3.0.0 ... The relay never holds a decryption key"); this branch keeps the title, because main's `og:title` there was still `PARAMANT · Documentation`. On the three `/help` pages main's head was still the untouched caps version, so this branch's head stands. |

Also still open and not closed by this PR, because they are body work: the first screen of `/pricing` at 390px carries no amount, the homepage H1 does not repeat the title, and and `/security`'s jurisdiction table still carries the unqualified "no US company" row that the guide's section 9 names as an open contradiction (#332 has since closed section 9's third point by putting the give-back sentence on /about). None of them is promoted by any head element in this branch.

## Green

`seo-contract` 14 pass, `ui-truthfulness`, `site-claims`, `links`, `frontend-loading-contract` (33 pass, 0 fail, 2 skipped for a missing live server), `scripts/check-csp-inline.sh`, `scripts/check-cache-bust.sh`, `npx eslint .` exit 0, `python3 bron-seo/apply_seo_head.py --check` = `would change: 0 pages`.

`tests/static-sanity.sh`: **PASS, all ten checks clear**, check 10 (commit-style guard) included. No trailer on the commit.
