### PR TITLE
Trust pages answer the buyer first: /about, /security, /trust

### DIFF
--- a/frontend/about.html
+++ b/frontend/about.html
@@ -48,7 +48,32 @@
 .person-card{border:1px solid var(--ink-hair);border-left:3px solid var(--cobalt);background:var(--bone);padding:var(--space-6);margin-top:var(--space-5);max-width:680px}
 .person-card p{margin-top:0}
 .person-card p + p{margin-top:var(--space-4)}
-@media(max-width:640px){.check-grid{grid-template-columns:1fr}}
+.person-name{font-size:var(--text-xl);font-weight:600;color:var(--navy);letter-spacing:-.02em}
+.person-title{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.08em;text-transform:uppercase;color:var(--cobalt);margin-top:var(--space-2);margin-bottom:var(--space-4)}
+.split-head{font-size:var(--text-md);font-weight:600;color:var(--navy);margin-top:var(--space-6)}
+.split-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1px;background:var(--ink-hair);border:1px solid var(--ink-hair);margin-top:var(--space-4)}
+.split-card{background:var(--bone);padding:var(--space-5)}
+.split-card .k{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.14em;text-transform:uppercase;color:var(--cobalt);font-weight:700}
+.split-card p{margin-top:var(--space-3);font-size:var(--text-sm);color:var(--ink);line-height:1.65;max-width:none}
+.split-note{font-size:var(--text-sm);color:var(--ink);line-height:1.7;max-width:680px;margin-top:var(--space-4)}
+.about-cta{margin-top:var(--space-5)}
+.about-byline{border-left:3px solid var(--cobalt);padding-left:var(--space-4);margin-top:var(--space-5);max-width:680px}
+.about-byline .n{font-size:var(--text-md);font-weight:600;color:var(--navy);letter-spacing:-.02em}
+.about-byline .t{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.08em;text-transform:uppercase;color:var(--cobalt);margin-top:4px}
+.about-for{font-size:var(--text-base);color:var(--ink);line-height:1.7;max-width:680px;margin-top:var(--space-4)}
+.hero-cta{display:flex;flex-wrap:wrap;gap:var(--space-3);margin-top:var(--space-5)}
+@media(max-width:640px){
+.check-grid{grid-template-columns:1fr}
+.split-grid{grid-template-columns:1fr}
+/* Mobile first: the page name comes before the section number, and the hero
+   starts near the top of the screen instead of a third of the way down. */
+#main-content{padding-top:var(--space-5) !important}
+#main-content .sec-head{grid-template-columns:1fr;column-gap:0;row-gap:var(--space-2);align-items:start;padding-bottom:var(--space-3);margin-bottom:var(--space-4)}
+#main-content .sec-head h1{order:1}
+#main-content .sec-head .num{display:none}
+#main-content .sec-head .mono-eyebrow{order:3}
+.about-lede{margin-top:var(--space-3)}
+}
 </style>
 <script type="application/ld+json" data-paramant-seo="1">
 {
@@ -147,7 +172,16 @@
       <h1 class="paramant-h2">About Paramant</h1>
       <span class="mono-eyebrow">Company, mission, and how to check us</span>
     </div>
-    <p class="about-lede">Paramant is privacy-first, post-quantum document signing and encrypted transfer, built to stay verifiable and to keep working under EU jurisdiction. You should not have to trust us. You should be able to check.</p>
+    <p class="about-lede">Sign and send documents so that only you and the person you send them to can read them, and so that anyone can check later that the document is genuine and unchanged. The servers stand in Germany, under EU law.</p>
+    <p class="about-for">For small offices that sign and send confidential papers, and for the person who has to check a supplier before it goes near client files.</p>
+    <div class="about-byline">
+      <div class="n">Mick Beer</div>
+      <div class="t">Privacy and security researcher, founder of Paramantis Solutions B.V.</div>
+    </div>
+    <div class="hero-cta">
+      <a href="/pricing" class="btn btn-primary">See pricing &rarr;</a>
+      <a href="/security" class="btn btn-secondary">See the evidence &rarr;</a>
+    </div>
   </div>
 </section>
 
@@ -161,10 +195,41 @@
   </div>
 </section>
 
+<!-- BEHIND PARAMANT -->
+<section class="about-band">
+  <div class="container-md">
+    <span class="mono-eyebrow">02 / Who is behind Paramant</span>
+    <h2 style="margin-top:var(--space-2)">Behind Paramant</h2>
+    <div class="person-card">
+      <div class="person-name">Mick Beer</div>
+      <div class="person-title">Privacy and security researcher, founder of Paramantis Solutions B.V.</div>
+      <p>Paramant is a product of <strong>Paramantis Solutions B.V.</strong> in Harderwijk, the Netherlands, founded by Mick Beer, privacy and security researcher. Paramantis Solutions B.V. is the contracting and responsible party; the founder is the origin of the work, not the service itself.</p>
+      <p>The Community plan is his way of giving something back to society; the business plans pay for it. That is the whole arrangement, and it is why the Community plan is not a trial and has no end date.</p>
+      <p>That background shapes the choices: post-quantum signatures (ML-DSA-65), a public transparency log, offline-verifiable documents, and source code you can inspect yourself. You do not have to take us at our word, you can verify it. The code is source-available and the transparency log is public: the product stands apart from the person and stays checkable.</p>
+    </div>
+
+    <div class="split-head">Free for everyone, paid for organisations</div>
+    <div class="split-grid">
+      <div class="split-card free">
+        <div class="k">Free for everyone</div>
+        <p><strong>ParaSign Community.</strong> &euro;0, forever. 2 signatures a month, unlimited receiving, full post-quantum crypto, public verification log. No card required.</p>
+        <p><strong>ParaSend Community.</strong> &euro;0, forever. AES-256-GCM with a browser-generated key, 1 hour link expiry, burn on first read. No card required.</p>
+      </div>
+      <div class="split-card paid">
+        <div class="k">For organisations</div>
+        <p><strong>ParaSign Pro</strong> adds volume and API access. <strong>ParaSign Business</strong> adds named support and an exportable audit log. <strong>ParaSign Enterprise</strong> adds a dedicated relay instance, an SLA and a self-hosting licence.</p>
+        <p><strong>ParaSend Pro.</strong> 24 hour link expiry, up to 10 reads per link, up to 50 registered devices, send history and webhooks. <strong>ParaSend Enterprise</strong> adds a dedicated relay and an SLA of 99.95%.</p>
+      </div>
+    </div>
+    <p class="split-note">Every plan gets the same encryption, the same post-quantum signatures and the same public proof log. Pay for volume, never for security. And pay per organisation, not per user.</p>
+    <p class="about-cta"><a href="/pricing" class="btn btn-primary">See pricing &rarr;</a></p>
+  </div>
+</section>
+
 <!-- HOW YOU CAN CHECK US -->
 <section class="about-band">
   <div class="container-md">
-    <span class="mono-eyebrow">02 / Technique &amp; transparency</span>
+    <span class="mono-eyebrow">03 / Technique &amp; transparency</span>
     <h2 style="margin-top:var(--space-2)">How you can check us</h2>
     <p>Every claim on this site is meant to be checkable, not taken on faith. Four things make that possible:</p>
     <div class="check-grid">
@@ -187,19 +252,6 @@
     </div>
     <div class="scope-note">
       <p><strong>Post-quantum, zero-knowledge. Not eIDAS-qualified.</strong> A ParaSign signature is a Simple Electronic Signature (SES): an ML-DSA-65 cryptographic attestation produced in your browser. It is not a notarised legal signature under eIDAS or any qualified-trust regime (QES). We state exactly what it is and what it is not.</p>
-    </div>
-  </div>
-</section>
-
-<!-- BEHIND PARAMANT -->
-<section class="about-band">
-  <div class="container-md">
-    <span class="mono-eyebrow">03 / Who is behind Paramant</span>
-    <h2 style="margin-top:var(--space-2)">Behind Paramant</h2>
-    <div class="person-card">
-      <p>Paramant is a product of <strong>Paramantis Solutions B.V.</strong> in Harderwijk, the Netherlands, founded by Mick Beer, privacy and security researcher. Paramantis Solutions B.V. is the contracting and responsible party; the founder is the origin of the work, not the service itself.</p>
-      <p>The Community plan is his way of giving something back to society; the business plans pay for it. That is the whole arrangement, and it is why the Community plan is not a trial and has no end date.</p>
-      <p>That background shapes the choices: post-quantum signatures (ML-DSA-65), a public transparency log, offline-verifiable documents, and source code you can inspect yourself. You do not have to take us at our word, you can verify it. The code is source-available and the transparency log is public: the product stands apart from the person and stays checkable.</p>
     </div>
   </div>
 </section>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -36,9 +36,14 @@ html{scroll-behavior:smooth}
 .page-hero--navy .eyebrow{background:var(--lime);color:var(--navy)}
 .page-hero--navy h1{color:var(--bone)}
 .page-hero--navy .lede{color:rgba(248,250,252,.8)}
+.hero-cta{display:flex;flex-wrap:wrap;gap:14px;margin-top:20px}
+.page-hero--navy .btn-secondary{color:var(--bone);border-color:rgba(248,250,252,.45)}
+.page-hero--navy .btn-secondary:hover{background:var(--bone);color:var(--navy);border-color:var(--bone)}
+.hero-by{color:rgba(248,250,252,.7);font-size:var(--text-sm);line-height:1.7;margin-top:16px;max-width:620px}
 main{max-width:780px;margin:0 auto;padding:48px 48px 120px}
 h1{font-size:36px;font-weight:600;letter-spacing:-.03em;margin-bottom:12px}
 .lead{font-size:var(--text-base);color:var(--ink-dim);line-height:1.7;margin-bottom:48px;max-width:580px}
+.page-hero-inner .lede + .lede{margin-top:18px;font-size:var(--text-base)}
 h2{font-size:18px;font-weight:600;letter-spacing:-.01em;margin-bottom:12px;margin-top:56px}
 h3{font-size:var(--text-xs);font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:16px;margin-top:40px}
 p{color:var(--ink-dim);line-height:1.8;margin-bottom:16px;font-size:var(--text-base)}
@@ -226,13 +231,73 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
 <section class="page-hero page-hero--navy">
 <div class="page-hero-inner">
-  <span class="eyebrow">DEFENSE IN DEPTH</span>
+  <span class="eyebrow">EVIDENCE</span>
   <h1>Security</h1>
-  <p class="lede">We treat security as infrastructure, not a feature. Every component is designed assuming the relay is compromised. This page documents how, what was audited, and how to report issues.</p>
+  <p class="lede">Break into our own server and you still cannot read the documents on it: they are encrypted on your device before they leave it, and the key never reaches us. That holds for the web app, ParaShare and the official SDKs. The Chromium and Outlook extensions still encrypt on our server, which means we can read what you upload through them until that is changed; the detail is further down this page.</p>
+  <p class="lede">This is the evidence under everything the rest of the site promises, and it covers every plan: the Community tier gets exactly the same protection as the paid ones.</p>
+  <p class="hero-by">Paramant is a product of Paramantis Solutions B.V. in Harderwijk, the Netherlands, KvK 42115132, founded by Mick Beer, privacy and security researcher.</p>
+  <div class="hero-cta">
+    <a href="/pricing" class="btn btn-primary">See pricing &rarr;</a>
+    <a href="/verify" class="btn btn-secondary">Verify a document &rarr;</a>
+  </div>
 </div>
 </section>
 
 <main id="main-content">
+
+  <h2 id="why-trust" style="margin-top:0">Why you can trust us</h2>
+  <p>Four things carry this product. Each one says what it means for you, and where you check it yourself. The technical detail that makes them true starts below.</p>
+
+  <div class="grid2" style="margin-top:20px">
+    <div class="card">
+      <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px">Your documents stay under EU law</div>
+      <p style="margin:0 0 10px">Server location: Hetzner Nuremberg, Germany. Legal jurisdiction: EU / Germany (GDPR). No US provider in the data path: your files and your keys stay in the EU and never reach a US company. Transactional email is the one exception in the chain and goes via Resend, a US provider, which receives the address, the message and the invite link but never the document. See the subprocessor list on <a href="/privacy">privacy</a>.</p>
+      <p style="margin:0;font-size:var(--text-sm)"><a href="#jurisdiction">Check the jurisdiction table &rarr;</a></p>
+    </div>
+    <div class="card">
+      <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px">The key stays on your device</div>
+      <p style="margin:0 0 10px">ML-DSA-65 (FIPS 204), generated in your browser. The private key never reaches the relay. The relay holds only ciphertext.</p>
+      <p style="margin:0;font-size:var(--text-sm)"><a href="/crypto-agility">Check the algorithm registry &rarr;</a></p>
+    </div>
+    <div class="card">
+      <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px">The proof outlives the supplier</div>
+      <p style="margin:0 0 10px">Every signature is entered into a public, append-only log. A signed document verifies without contacting us.</p>
+      <p style="margin:0;font-size:var(--text-sm)"><a href="/ct-log">Read the CT log &rarr;</a> &nbsp; <a href="/verify">Verify a document &rarr;</a></p>
+    </div>
+    <div class="card">
+      <div style="font-size:var(--text-sm);font-weight:600;margin-bottom:8px">You can read the code</div>
+      <p style="margin:0 0 10px">The relay is source-available under BUSL-1.1. You can read exactly what it does with your file and run it on your own server.</p>
+      <p style="margin:0;font-size:var(--text-sm)"><a href="https://github.com/Apolloccrypt/paramant-relay">Open the repository &rarr;</a> &nbsp; <a href="/trust">How to verify a deployment &rarr;</a></p>
+    </div>
+  </div>
+
+  <div class="card" style="margin-top:16px;border-left:3px solid var(--lime)">
+    <p style="margin:0;line-height:1.8">Every plan gets the same encryption, the same post-quantum signatures and the same public proof log. Pay for volume, never for security. And pay per organisation, not per user. The Community tier is not a weaker version of the product; it is the same product with lower limits. <a href="/pricing">See pricing &rarr;</a></p>
+  </div>
+
+  <h3>The limit, stated up front</h3>
+  <div class="card">
+    <p style="margin:0"><strong>Compliance documentation, not certification.</strong> The IEC 62443, NEN 7510 and NIS2 materials are architecture documents, security controls mappings and technical reference materials aligned to those frameworks. This is documentation you can use as input for your own compliance process. Paramant does not hold third-party certification for these frameworks.</p>
+  </div>
+
+  <hr class="divider">
+
+  <h2 id="jurisdiction">Jurisdiction &amp; privacy</h2>
+  <div class="card">
+    <table class="table">
+      <tbody>
+        <tr><td>Server location</td><td>Hetzner Nuremberg, Germany</td></tr>
+        <tr><td>Legal jurisdiction</td><td>EU / Germany (GDPR)</td></tr>
+        <tr><td>US CLOUD Act</td><td>No US provider in the data path: files and keys stay in the EU. Transactional email goes via Resend, a US provider, which never receives the document. See <a href="/privacy">privacy</a>.</td></tr>
+        <tr><td>Data retained</td><td>No plaintext, no keys. Only: transfer hash, creation timestamp, approximate encrypted size (up to 5 MB; exact 5 MB for ParaShare), view count. Deleted on burn.</td></tr>
+        <tr><td>IP logging</td><td>Nginx access logging is switched off in the deploy configuration (<code>access_log off</code> on every server block that serves the site and the relays in <code>deploy/nginx-paramant-live.conf</code>). Not linked to transfer content. No separate retention period is promised.</td></tr>
+        <tr><td>Analytics</td><td>None. No third-party scripts on the relay or API.</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <hr class="divider">
+
 
   <h3>Core principle</h3>
   <div class="card">
@@ -244,7 +309,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <p style="margin:0;line-height:1.75;font-size:var(--text-sm)">The guarantee above applies to transfers from the official SDKs (sdk-py 3.0.0, sdk-js 3.0.0) and the WebApp tools (ParaShare), each of which encrypts in the client before bytes leave the device. The Chromium and Outlook extensions currently take a server-side encryption path while their client-side crypto is being finished; until that migration lands, treat extension uploads as relay-side, not zero-knowledge. Per-client status: <a href="/crypto-agility#06">crypto-agility § 06</a>.</p>
   </div>
 
-  <p style="font-size:var(--text-sm);color:var(--ink-dim)">For the full audit history, patch timeline, and cryptographic architecture, see the <a href="/architecture">architecture page</a>.</p>
+  <h3 id="audits">What was audited</h3>
+  <div class="card">
+    <p style="margin:0 0 12px;line-height:1.8">Three external security audits in April 2026 reviewed the relay code: two by R. Zwarts, one by Ryan Williams of Smart Cyber Solutions. Together they produced 40 findings, 4 of them critical. Dates, finding counts and the commit that resolved each set are in the audit table on the <a href="/docs#audits">docs page</a>, and every finding is written up in <a href="https://github.com/Apolloccrypt/paramant-relay/blob/main/SECURITY.md">SECURITY.md</a> in the public repository.</p>
+    <p style="margin:0;line-height:1.8">The Smart Cyber Solutions review is published in full, finding by finding, as the <a href="/docs/security-audit-2026-04.md">April 2026 audit report</a>. What is not published is the raw pentest output behind it. A further external review of the v3.0.0 and open-core architecture is planned.</p>
+  </div>
+
+  <p style="font-size:var(--text-sm);color:var(--ink-dim)">For the cryptographic architecture in full, see the <a href="/architecture">architecture page</a>.</p>
 
   <hr class="divider">
 
@@ -378,24 +449,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     </tbody>
   </table>
 
-  <hr class="divider">
-
-  <h2>Jurisdiction &amp; privacy</h2>
-  <div class="card">
-    <table class="table">
-      <tbody>
-        <tr><td>Server location</td><td>Hetzner Nuremberg, Germany</td></tr>
-        <tr><td>Legal jurisdiction</td><td>EU / Germany (GDPR)</td></tr>
-        <tr><td>US CLOUD Act</td><td>Not applicable: no US infrastructure, no US company</td></tr>
-        <tr><td>Data retained</td><td>No plaintext, no keys. Only: transfer hash, creation timestamp, approximate encrypted size (up to 5 MB; exact 5 MB for ParaShare), view count. Deleted on burn.</td></tr>
-        <tr><td>IP logging</td><td>Nginx access logging is switched off in the deploy configuration (<code>access_log off</code> on every server block that serves the site and the relays in <code>deploy/nginx-paramant-live.conf</code>). Not linked to transfer content. No separate retention period is promised.</td></tr>
-        <tr><td>Analytics</td><td>None. No third-party scripts on the relay or API.</td></tr>
-      </tbody>
-    </table>
-  </div>
-
-  <hr class="divider">
-
   <h2 id="responsible-disclosure">Responsible disclosure</h2>
   <div class="card">
     <p style="margin-bottom:16px">Report to <a href="mailto:privacy@paramant.app">privacy@paramant.app</a>, encrypted with our <a href="/.well-known/openpgp-key.asc">PGP key</a> if the details are sensitive. Do not open a public GitHub issue before coordinating.</p>
@@ -423,8 +476,17 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
   <hr class="divider">
 
+  <h2 id="next">What to do next</h2>
+  <p>Every plan gets what this page describes. ParaSign Community and ParaSend Community cost &euro;0, forever, with no card required; the paid plans buy higher limits, API access, a dedicated relay and an SLA, never better cryptography.</p>
+  <div class="hero-cta">
+    <a href="/pricing" class="btn btn-primary">See pricing &rarr;</a>
+    <a href="/verify" class="btn btn-secondary">Verify a document &rarr;</a>
+  </div>
+
+  <hr class="divider">
+
   <h2 id="customer-transparency">Customer transparency</h2>
-  <p>Security is also about knowing what the vendor can and cannot do. The <a href="/trust">Trust &amp; Transparency page</a> documents, in plain terms, how license-check works, what Paramant can see of your relay (and what it never can), how to verify your deployment, and which remote actions are possible versus structurally impossible. Each claim there is tagged as live today or planned, with links to the public protocol specifications.</p>
+  <p>Security is also about knowing what the vendor can and cannot do. The <a href="/trust">Trust &amp; Verification page</a> documents, in plain terms, how license-check works, what Paramant can see of your relay (and what it never can), how to verify your deployment, and which remote actions are possible versus structurally impossible. Each claim there is tagged as live today or planned, with links to the public protocol specifications.</p>
 
 </main>
 

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -36,6 +36,10 @@ html{scroll-behavior:smooth}
 .page-hero--navy .eyebrow{background:var(--lime);color:var(--navy)}
 .page-hero--navy h1{color:var(--bone)}
 .page-hero--navy .lede{color:rgba(248,250,252,.8)}
+.page-hero--navy .lede a{color:var(--lime);text-decoration:underline}
+.hero-cta{display:flex;flex-wrap:wrap;gap:14px;margin-top:20px}
+.page-hero--navy .btn-secondary{color:var(--bone);border-color:rgba(248,250,252,.45)}
+.page-hero--navy .btn-secondary:hover{background:var(--bone);color:var(--navy);border-color:var(--bone)}
 main{max-width:780px;margin:0 auto;padding:48px 48px 120px}
 h1{font-size:36px;font-weight:600;letter-spacing:-.03em;margin-bottom:12px}
 .lead{font-size:var(--text-base);color:var(--ink-dim);line-height:1.7;margin-bottom:48px;max-width:580px}
@@ -242,16 +246,26 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
 <div class="page-hero-inner">
   <span class="eyebrow">TRANSPARENCY</span>
   <h1>Trust &amp; Verification</h1>
-  <p class="lede">How Paramant works with your relay. What we can see, what we can do, and how you verify both — without taking our word for it.</p>
+  <p class="lede">For organisations that run Paramant on their own server, and for anyone who has to check a supplier before it goes near client documents. What we can see, what we can do, and how you verify both, without taking our word for it. If you use the hosted service at paramant.app, the <a href="/security">security page</a> is the shorter answer.</p>
+  <div class="hero-cta">
+    <a href="/security" class="btn btn-primary">See the evidence &rarr;</a>
+    <a href="/pricing" class="btn btn-secondary">See pricing &rarr;</a>
+  </div>
 </div>
 </section>
 
 <main id="main-content">
 
+  <h3>Who this page is for</h3>
+  <div class="card">
+    <p style="margin:0 0 12px;line-height:1.8">Everything below is written for the two readers named above: the person who runs the server that passes the files on, and the reviewer who has to sign off on it. It answers what Paramant can and cannot do to a server it does not own.</p>
+    <p style="margin:0;line-height:1.8">Free for everyone, paid for organisations. ParaSign Community and ParaSend Community cost &euro;0, forever, with no card required. Organisations pay for the higher limits: ParaSign Pro, Business and Enterprise, ParaSend Pro and Enterprise. A dedicated relay, an SLA and a self-hosting licence are what ParaSign Enterprise and ParaSend Enterprise pay for. Every plan gets the same encryption, the same post-quantum signatures and the same public proof log. <a href="/pricing">See pricing &rarr;</a></p>
+  </div>
+
   <h3>How to read this page</h3>
   <div class="card">
     <p style="margin:0 0 12px;line-height:1.8">Paramant is moving from a single self-hosted binary to an open-core product: the relay stays open and runs entirely on your server, while Paramant operates a central licensing and management plane. That transition is partly live and partly still on paper.</p>
-    <p style="margin:0;line-height:1.8">So every claim below is tagged. <span class="badge badge-live">Live</span> means it works today on the public relay. <span class="badge badge-planned">Planned</span> means it is specified in a public design document (an ADR) but not yet implemented — we mark it so you are never told a capability exists before it does.</p>
+    <p style="margin:0;line-height:1.8">So every claim below is tagged. <span class="badge badge-live">Live</span> means it works today on the public relay. <span class="badge badge-planned">Planned</span> means it is specified in a public design document (an ADR) but not yet implemented. We mark it so you are never told a capability exists before it does.</p>
   </div>
 
   <!-- ───────────────────── License-check ───────────────────── -->
@@ -261,18 +275,18 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
 
   <p><strong>Planned <span class="badge badge-planned">Planned</span></strong> to sell tiers with capabilities beyond a user-count, the design adds an <em>online</em> license-check. Under that model your relay calls a Paramant licensing endpoint at startup and every 6 hours. The request carries your license-key, a relay-identity (the fingerprint of the ML-DSA-65 public key your relay generates on first boot), the relay version, and a telemetry block that is off by default.</p>
 
-  <p>The response is a <strong>signed capability-set</strong> — which features your tier unlocks — valid for a few hours. Your relay verifies the ML-DSA-65 signature against an embedded Paramant licensing key; an unsigned or invalid response is rejected. If the licensing endpoint is unreachable, the relay keeps using its last cached capability-set for up to 7 days, then degrades to Community mode. There are no surprise lockouts: an outage on our side cannot instantly disable your relay.</p>
+  <p>The response is a <strong>signed capability-set</strong> that says which features your tier unlocks, and it is valid for a few hours. Your relay verifies the ML-DSA-65 signature against an embedded Paramant licensing key; an unsigned or invalid response is rejected. If the licensing endpoint is unreachable, the relay keeps using its last cached capability-set for up to 7 days, then degrades to Community mode. There are no surprise lockouts: an outage on our side cannot instantly disable your relay.</p>
 
   <p class="see-also">Full wire-protocol specification: ADR R013 (Draft) in the public <a href="https://github.com/Apolloccrypt/paramant-relay/tree/main/docs/adrs">ADR directory</a>.</p>
 
   <!-- ───────────────────── What we see ───────────────────── -->
   <h2 id="what-we-see">What Paramant sees of your relay</h2>
 
-  <p>With today's offline license, the answer is simple: <strong>nothing at runtime</strong> — the relay makes no licensing call. The breakdown below describes the <span class="badge badge-planned">Planned</span> online model, so you can judge it before it ships.</p>
+  <p>With today's offline license, the answer is simple: <strong>nothing at runtime</strong>. The relay makes no licensing call. The breakdown below describes the <span class="badge badge-planned">Planned</span> online model, so you can judge it before it ships.</p>
 
   <h3>Always (each check-in)</h3>
   <ul>
-    <li>Your license-key — how we identify your subscription</li>
+    <li>Your license-key: how we identify your subscription</li>
     <li>Your relay's identity fingerprint (ML-DSA-65 public-key hash)</li>
     <li>Your relay's version number</li>
     <li>The timestamp of the check-in</li>
@@ -280,17 +294,17 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
 
   <h3>Only if you opt in (telemetry, off by default)</h3>
   <ul>
-    <li>Aggregate user count — a number, never identities</li>
-    <li>Aggregate transfer count per 24h — a number, never hashes</li>
+    <li>Aggregate user count: a number, never identities</li>
+    <li>Aggregate transfer count per 24h: a number, never hashes</li>
     <li>Error rates (5xx rate, auth-failure rate)</li>
     <li>Uptime</li>
   </ul>
 
-  <h3>Never — even with telemetry on</h3>
+  <h3>Never, even with telemetry on</h3>
   <ul>
-    <li>File content — we do not hold your decryption keys, anywhere</li>
+    <li>File content: we do not hold your decryption keys, anywhere</li>
     <li>Identities of your users (emails, names)</li>
-    <li>File hashes — they would link to specific transfers</li>
+    <li>File hashes: they would link to specific transfers</li>
     <li>Source or destination addresses of your transfers</li>
     <li>CT-log content beyond aggregate counts</li>
   </ul>
@@ -300,10 +314,10 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
   <!-- ───────────────────── Verify ───────────────────── -->
   <h2 id="verify-deployment">How to verify your deployment</h2>
 
-  <p>You do not have to trust these statements — the public surface lets you check them.</p>
+  <p>You do not have to trust these statements. The public surface lets you check them.</p>
 
   <h3>1. Source <span class="badge badge-live">Live</span></h3>
-  <p>Everything that runs on your server is in the public <a href="https://github.com/Apolloccrypt/paramant-relay">GitHub repository</a> under BUSL-1.1: the relay, the admin panel, the SDKs, and the license-<em>client</em> code that does the check-in. You can read exactly what your relay does — including every field it would send — and build it yourself:</p>
+  <p>Everything that runs on your server is in the public <a href="https://github.com/Apolloccrypt/paramant-relay">GitHub repository</a> under BUSL-1.1: the relay, the admin panel, the SDKs, and the license-<em>client</em> code that does the check-in. You can read exactly what your relay does, including every field it would send, and build it yourself:</p>
   <pre><code>git clone https://github.com/Apolloccrypt/paramant-relay
 cd paramant-relay
 git checkout v3.0.0
@@ -324,7 +338,7 @@ docker compose build   # build locally instead of pulling the published image</c
   <!-- ───────────────────── Remote actions ───────────────────── -->
   <h2 id="remote-actions">What Paramant can do remotely</h2>
 
-  <p>The remote-action model below is <span class="badge badge-planned">Planned</span> — specified, not yet implemented. The structural limits in "Not possible", however, hold <span class="badge badge-live">Live</span> today, because they follow from the architecture rather than from policy.</p>
+  <p>The remote-action model below is <span class="badge badge-planned">Planned</span>: specified, not yet implemented. The structural limits in "Not possible", however, hold <span class="badge badge-live">Live</span> today, because they follow from the architecture rather than from policy.</p>
 
   <p>In the design, every remote action is recorded to <strong>your relay's own CT log</strong>, where you can verify it independently: you see what was done, when, and by which Paramant role (Owner or Support). Our internal audit-trail additionally records which individual acted, but that record is private to us.</p>
 
@@ -334,22 +348,22 @@ docker compose build   # build locally instead of pulling the published image</c
     <dd>A time-boxed key for debugging an issue you reported. You can revoke it immediately from your admin panel.</dd>
 
     <dt>Offer an update</dt>
-    <dd>Make a new release available to your relay. How it applies follows your tier: a banner you act on, an opt-in update window, or explicit approval — never a silent push you did not agree to.</dd>
+    <dd>Make a new release available to your relay. How it applies follows your tier: a banner you act on, an opt-in update window, or explicit approval. Never a silent push you did not agree to.</dd>
 
     <dt>Set drain mode</dt>
-    <dd>Ask the relay to refuse new uploads, finish in-flight transfers, then idle — used ahead of maintenance.</dd>
+    <dd>Ask the relay to refuse new uploads, finish in-flight transfers, then idle. Used ahead of maintenance.</dd>
 
     <dt>Adjust your capability-set</dt>
     <dd>Apply a tier change (trial extension, upgrade after payment). It takes effect on the next check-in.</dd>
   </dl>
 
-  <h3>Not possible — structurally <span class="badge badge-live">Live</span></h3>
+  <h3>Not possible, structurally <span class="badge badge-live">Live</span></h3>
   <ul>
-    <li>Read your file content — we never hold decryption keys, anywhere</li>
-    <li>Rewrite your CT log after the fact — Merkle-tree integrity prevents it</li>
-    <li>Bypass your local TOTP or admin key — there is no backdoor in the source, and the source is public</li>
-    <li>Reach your users' data or another deployment — relays are isolated by design</li>
-    <li>Switch off your audit log — CT-log writes are not gated by any capability</li>
+    <li>Read your file content: we never hold decryption keys, anywhere</li>
+    <li>Rewrite your CT log after the fact: Merkle-tree integrity prevents it</li>
+    <li>Bypass your local TOTP or admin key: there is no backdoor in the source, and the source is public</li>
+    <li>Reach your users' data or another deployment: relays are isolated by design</li>
+    <li>Switch off your audit log: CT-log writes are not gated by any capability</li>
   </ul>
 
   <p class="see-also">Remote-action protocol: the management-plane ADR (R014, in progress) in the public <a href="https://github.com/Apolloccrypt/paramant-relay/tree/main/docs/adrs">ADR directory</a>.</p>
@@ -359,34 +373,34 @@ docker compose build   # build locally instead of pulling the published image</c
 
   <p>Paramant follows the open-core model used by HashiCorp, GitLab, Elastic and Sentry: the software you run is open; the service operating it is not.</p>
 
-  <h3>Open — BUSL-1.1, public on GitHub <span class="badge badge-live">Live</span></h3>
+  <h3>Open: BUSL-1.1, public on GitHub <span class="badge badge-live">Live</span></h3>
   <ul>
-    <li>The relay — everything that runs on your server</li>
+    <li>The relay: everything that runs on your server</li>
     <li>The SDKs and CLI tools</li>
-    <li>The frontend — admin panel, setup wizard, dashboard</li>
-    <li>The license-<em>client</em> — the check-in code on your relay</li>
+    <li>The frontend: admin panel, setup wizard, dashboard</li>
+    <li>The license-<em>client</em>: the check-in code on your relay</li>
     <li>All ADRs, including the licensing and management-plane protocols</li>
     <li>The cryptographic specification and test vectors</li>
   </ul>
   <p><a href="https://github.com/Apolloccrypt/paramant-relay">View the public repository &rarr;</a></p>
 
-  <h3>Closed — operated privately by Paramant</h3>
+  <h3>Closed: operated privately by Paramant</h3>
   <ul>
-    <li>The license-<em>server</em> — the service side of the check-in</li>
+    <li>The license-<em>server</em>: the service side of the check-in</li>
     <li>The internal fleet-management dashboard</li>
     <li>The customer and billing databases</li>
     <li>Support tooling and email templates</li>
   </ul>
-  <p>The <em>protocols</em> are public; only our implementation of the server side is private — the same way GitLab keeps its operations private while its core stays open. Because the protocol and the client are open, you can audit exactly what your relay says to us and what it accepts back.</p>
+  <p>The <em>protocols</em> are public; only our implementation of the server side is private, the same way GitLab keeps its operations private while its core stays open. Because the protocol and the client are open, you can audit exactly what your relay says to us and what it accepts back.</p>
 
   <p class="see-also">The open-core split is documented in the open-core ADR (R016) in the public <a href="https://github.com/Apolloccrypt/paramant-relay/tree/main/docs/adrs">ADR directory</a>.</p>
 
   <!-- ───────────────────── Independent verification ───────────────────── -->
   <h2 id="independent">Independent verification</h2>
 
-  <p>Three external security audits in April 2026 reviewed the relay code; the findings and patch timeline are on the <a href="/docs#audits">docs page</a>. A further external review of the v3.0.0 and open-core architecture is <span class="badge badge-planned">planned</span>; results will be published there when complete.</p>
+  <p>Three external security audits in April 2026 reviewed the relay code: two by R. Zwarts, one by Ryan Williams of Smart Cyber Solutions. Together they produced 40 findings, 4 of them critical. Dates, finding counts and the resolving commits are in the audit table on the <a href="/docs#audits">docs page</a>; every finding is written up in <a href="https://github.com/Apolloccrypt/paramant-relay/blob/main/SECURITY.md">SECURITY.md</a>. The Smart Cyber Solutions review is published in full as the <a href="/docs/security-audit-2026-04.md">April 2026 audit report</a>; the raw pentest output behind it is not published. A further external review of the v3.0.0 and open-core architecture is <span class="badge badge-planned">planned</span>; results will be published there when complete.</p>
 
-  <p>If you are running your own audit, the public surface — relay, SDKs, frontend and the protocol specifications — is enough to verify every claim on this page for yourself.</p>
+  <p>If you are running your own audit, the public surface (relay, SDKs, frontend and the protocol specifications) is enough to verify every claim on this page for yourself.</p>
 
   <!-- ───────────────────── Questions ───────────────────── -->
   <h2 id="questions">Questions</h2>

--- a/tests/site-claims.test.mjs
+++ b/tests/site-claims.test.mjs
@@ -602,3 +602,92 @@ test('the Community plan limits on the site are the ones tiers.js declares', () 
   }
   assert.deepEqual(problems, [], `\n  ${problems.join('\n  ')}\n`);
 });
+
+// 12 ── The free-versus-paid block on /about. It is the block a buyer reads to
+// decide, and it repeats numbers that live on /pricing: signature allowance,
+// link expiry, read count, device count, the Enterprise SLA. Nothing pinned it,
+// so /about could drift away from /pricing (or be edited outright) and every
+// test stayed green. This reads each number out of the /pricing tier card that
+// owns it and requires /about to say the same.
+test('the tier block on /about repeats the numbers /pricing charges for', () => {
+  const pricing = page('pricing');
+  const about = page('about');
+
+  // The two product blocks, split on their own headings, then the tier cards
+  // inside each one, keyed by the tier name /pricing prints. #336 renamed both
+  // headings and put ParaSign first, so the split finds the headings by their
+  // product prefix and orders them by position rather than assuming either.
+  const HEAD = /<h3[^>]*>(ParaSign|ParaSend)\s*(?:&middot;|\u00b7)[^<]*<\/h3>/g;
+  const marks = [...pricing.matchAll(HEAD)].map((m) => ({ product: m[1], at: m.index }));
+  assert.equal(marks.length, 2,
+    `pricing.html must carry one heading per product, found ${marks.length}`);
+  const section = (product) => {
+    const i = marks.findIndex((m) => m.product === product);
+    assert.notEqual(i, -1, `pricing.html no longer has a ${product} block`);
+    return pricing.slice(marks[i].at, i + 1 < marks.length ? marks[i + 1].at : undefined);
+  };
+  const tiers = (html) => {
+    const out = {};
+    for (const card of html.split('class="tier-card').slice(1)) {
+      const name = /<div class="tier-name">([^<]+)</.exec(card)?.[1];
+      if (name) out[name] = card;
+    }
+    return out;
+  };
+  const send = tiers(section('ParaSend'));
+  const sign = tiers(section('ParaSign'));
+  // The free tier is called Community on /pricing since #328, and the guide
+  // (docs/brand/messaging.md section 3) makes that name the rule rather than a
+  // preference. /about has to use the same word or a reader cannot find the
+  // card the sentence is about.
+  for (const [label, set, names] of [['ParaSend', send, ['Community', 'Pro', 'Enterprise']],
+                                     ['ParaSign', sign, ['Community', 'Pro', 'Business', 'Enterprise']]]) {
+    for (const n of names) assert.ok(set[n], `pricing.html no longer has a ${label} ${n} tier`);
+  }
+
+  // Each fact is a phrase lifted WHOLE out of the /pricing card that owns it,
+  // not a number plus a unit this file spells itself. #359 reworded "2
+  // signatures per month" to "2 signatures a month" and a hand-spelled unit
+  // went stale on a rewording that changed no number at all.
+  const phrase = (card, re, what) => {
+    const m = re.exec(card);
+    assert.ok(m, `pricing.html no longer states ${what}`);
+    return m[1].trim();
+  };
+  const facts = [
+    [phrase(sign.Community, /<li>(\d+ signatures? (?:a|per) month)<\/li>/, 'the ParaSign Community signature allowance'), 'ParaSign Community'],
+    [phrase(send.Community, /<li>(\d+ hour link expiry)<\/li>/, 'the ParaSend Community link expiry'), 'ParaSend Community'],
+    [phrase(send.Pro, /<li>(\d+ hour link expiry)<\/li>/, 'the ParaSend Pro link expiry'), 'ParaSend Pro'],
+    [phrase(send.Pro, /<li>(Up to \d+ reads per link)<\/li>/, 'the ParaSend Pro read limit'), 'ParaSend Pro'],
+    [phrase(send.Pro, /<li>(Up to \d+ registered devices)<\/li>/, 'the ParaSend Pro device limit'), 'ParaSend Pro'],
+    [phrase(send.Enterprise, /<li>SLA ([\d.]+%),/, 'the ParaSend Enterprise SLA'), 'ParaSend Enterprise'],
+  ];
+  for (const [expected, tier] of facts) {
+    assert.ok(about.toLowerCase().includes(expected.toLowerCase()),
+      `about: the ${tier} line must say "${expected}", because that is what pricing.html sells`);
+  }
+
+  // Free means free, in the same two words on both pages.
+  assert.match(sign.Community, /<div class="tier-price">&euro;0<\/div>/);
+  assert.match(send.Community, /<div class="tier-price">&euro;0<\/div>/);
+  assert.ok((about.match(/&euro;0, forever/g) || []).length >= 2,
+    'about: both free tiers must be named as costing &euro;0, forever');
+  assert.match(about, /No card required/,
+    'about: the free tier must say no card is required, as pricing.html does');
+
+  // And the paid tiers are named the way /pricing names them, so a reader can
+  // find the card the sentence is about.
+  for (const name of ['ParaSign Community', 'ParaSend Community',
+                      'ParaSign Pro', 'ParaSign Business', 'ParaSign Enterprise',
+                      'ParaSend Pro', 'ParaSend Enterprise']) {
+    assert.ok(about.includes(name), `about: the tier block must name ${name} the way /pricing does`);
+  }
+  // Scoped to /about in the first version of this check, which is exactly how
+  // security.html kept "ParaSign Free and ParaSend Free cost &euro;0" through a
+  // review. The three pages of this round are checked together; the sitewide
+  // sweep lives in tests/ui-truthfulness.test.mjs.
+  for (const slug of ['about', 'security', 'trust']) {
+    assert.doesNotMatch(page(slug), /Para(Sign|Send) Free/,
+      `${slug}: the free plan is called Community, which is what /pricing prints on the card`);
+  }
+});

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -423,6 +423,11 @@ const TIER_NAME_SHAPES = [
   /tier named <strong>Free<\/strong>/,
   /\bthe Free tier\b/,
   /<div class="tier-name">Free<\/div>/,
+  // "ParaSign Free" and "ParaSend Free" name a product tier and nothing else,
+  // so they cannot be a false positive. They were missing from this list, and
+  // security.html carried both through a full review because the only check
+  // that forbade them was scoped to /about.
+  /\bPara(Sign|Send) Free\b/,
 ];
 // vs.html describes COMPETITORS' pricing (WeTransfer has a tier it calls Free);
 // paramant-ot-brief.html prices its own tier, named Evaluation, at "Free".
@@ -839,7 +844,7 @@ for (const [name, text] of [['index', homeVisible], ['parasign', parasign], ['pa
 // not in it, and DNS is not a row. A page that names Bunny and then sends the
 // reader to that table has offered a checkpoint that fails when checked.
 const securityJurisdiction = (read('frontend/security.html')
-  .match(/<h2>Jurisdiction[\s\S]*?<\/table>/) || [''])[0];
+  .match(/<h2[^>]*>Jurisdiction[\s\S]*?<\/table>/) || [''])[0];
 assert.ok(securityJurisdiction, 'security.html must keep its Jurisdiction and privacy table');
 assert.ok(!/Bunny/i.test(securityJurisdiction),
   'the /security jurisdiction table now names Bunny; the product pages may point at it again');
@@ -853,8 +858,17 @@ for (const [name, text] of [['parasign', parasign], ['parasend', parasend]]) {
   assert.doesNotMatch(text, /no US (company|provider) in the chain|no US company\b/i,
     `${name}.html claims more than the data path, which /privacy does not support`);
 }
-assert.ok(security.includes('Not applicable: no US infrastructure, no US company'),
-  'security.html must keep the US CLOUD Act row that proof 1 is measured against');
+// The row used to read "Not applicable: no US infrastructure, no US company",
+// and this assertion pinned it, because /security was the one page where the
+// table qualified the broader claim. Section 9.2 of the guide names that row
+// as the one that has to move to the data-path wording in its own PR with its
+// own test. This is that PR. What proof 1 is measured against on /security is
+// now the same sentence / and /pararules carry, with its Resend exception; the
+// window check that keeps the two together lives further down this file.
+assert.ok(!/no US company/i.test(security),
+  'security.html must no longer claim "no US company", which is broader than /privacy supports');
+assert.ok(security.includes('No US provider in the data path'),
+  'security.html must carry proof 1 in the data-path wording the guide fixes');
 
 // Proof 2. The three /about sentences the signing claim rests on.
 for (const claim of [
@@ -1014,3 +1028,283 @@ for (const [name, text] of [['parasign', parasign], ['parasend', parasend]]) {
 }
 
 console.log('ui-truthfulness: the messaging guide claims are pinned to the pages that make them true');
+
+// Everything below runs inside its own scope. Four PRs merged into this file
+// in parallel on 2 September and two of them collided on a top-level const
+// (tiers, pricingVisible), which is a SyntaxError: not one assertion in the
+// file runs, on any branch. A block that declares nothing at module level
+// cannot do that to the next branch.
+{
+  // ── The pages that carry the promise: /about, /security, /trust ─────────────
+  // The messaging guide (docs/brand/messaging.md) allows a sentence on the site
+  // only if it already ships and a test fails when it stops shipping. These are
+  // the sentences the buyer-facing copy on /about and /security now rests on.
+  // Every one of them was already on a page before this file pinned it; nothing
+  // here was written for marketing.
+  const securityRaw = read('frontend/security.html');
+  const trustRaw = read('frontend/trust.html');
+
+  // The founder. Name and title are the only ones the site can support, so they
+  // are pinned as one string: no award, no year count, no prior employer.
+  assert.match(about, /Mick Beer/,
+    'about.html must name the founder');
+  assert.match(about, /Privacy and security researcher, founder of Paramantis Solutions B\.V\./i,
+    'about.html must carry the exact founder title, and no other qualification');
+  assert.match(about, /founded by Mick Beer, privacy and security researcher/,
+    'about.html must keep the founder sentence it has shipped with');
+  assert.match(about, /Paramantis Solutions B\.V\. is the contracting and responsible party/,
+    'about.html must keep saying the company, not the person, is the responsible party');
+
+  // Proof 2 of the guide: the key stays with the signer and the proof outlives
+  // us. These three sentences are what /security now points at as evidence.
+  assert.match(about, /ML-DSA-65 \(FIPS 204\), generated in your browser\. The private key never reaches the relay\./,
+    'about.html must keep the private-key sentence');
+  assert.match(about, /Every signature is entered into a public, append-only log\./,
+    'about.html must keep the transparency-log sentence');
+  assert.match(about, /A signed document verifies without contacting us\./,
+    'about.html must keep the offline-verification sentence');
+
+  // The eIDAS limit. It is the sentence a lawyer reads to decide whether the rest
+  // of the page is measured, so it may never be softened or moved to a footnote.
+  // It is pinned on /about only. /about calls a ParaSign signature a Simple
+  // Electronic Signature, the /pricing FAQ calls it advanced (AES), and those are
+  // different levels under eIDAS. Until that is settled in its own round, the
+  // wording stays on the one page that has always carried it and is not copied
+  // onto a second one.
+  assert.match(about, /Simple Electronic Signature \(SES\)/,
+    'about.html must state that a ParaSign signature is a Simple Electronic Signature');
+  assert.match(about, /not a notarised legal signature under eIDAS or any qualified-trust regime \(QES\)/,
+    'about.html must state what the signature is not');
+  assert.doesNotMatch(securityRaw, /Simple Electronic Signature|advanced \(AES\)/,
+    'security.html must not carry a second, competing eIDAS level while /about and /pricing disagree');
+  assert.doesNotMatch(about + securityRaw, /qualified electronic signature|legally binding|eIDAS-certified/i,
+    '/about and /security must not claim a qualified signature or legal effect');
+
+  // Proof 3: the same cryptography on every plan. This is the sentence the whole
+  // free-versus-paid split rests on. If cryptography is ever gated behind a tier,
+  // this is the assertion that must fail first.
+  const SAME_CRYPTO = /Every plan gets the same encryption, the same post-quantum signatures and the same public proof log\. Pay for volume, never for security\. And pay per organisation, not per user\./;
+  assert.match(pricing, SAME_CRYPTO, 'pricing.html must keep the same-crypto-every-plan sentence');
+  assert.match(securityRaw, SAME_CRYPTO, 'security.html must keep the same-crypto-every-plan sentence');
+
+  // Proof 1: EU jurisdiction. /security is where the buyer checks it, so the row
+  // and the claim above it have to agree.
+  assert.match(securityRaw, /Hetzner Nuremberg, Germany/,
+    'security.html must name the server location');
+  // The old row read "Not applicable: no US infrastructure, no US company",
+  // which is broader than /privacy allows: transactional email goes out through
+  // Resend, a US provider. The guide (section 9.2) says that row is the one that
+  // has to move to the data-path wording, and it may never be written without
+  // its one exception in the same breath.
+  assert.match(securityRaw, /No US provider in the data path/,
+    'security.html must state the jurisdiction claim about the data path, not about the whole chain');
+  assert.doesNotMatch(securityRaw, /no US company\b(?![^<]*Resend)/,
+    'security.html must not claim "no US company" without naming the Resend exception beside it');
+  // "In the same breath" is the whole point of the wording, so it is measured
+  // as a window and not as "somewhere on the page": an earlier version of this
+  // check let a card drop Resend entirely, because the jurisdiction table lower
+  // down still carried the word.
+  const WINDOW = 420;
+  for (const [label, html] of [['security.html', securityRaw]]) {
+    let at = -1, seen = 0;
+    while ((at = html.indexOf('No US provider in the data path', at + 1)) !== -1) {
+      seen += 1;
+      assert.match(html.slice(at, at + WINDOW), /Resend/,
+        `${label} states the data-path claim without naming the Resend exception within ${WINDOW} characters of it`);
+    }
+    assert.ok(seen >= 2,
+      `${label} must carry the data-path wording in both the card and the jurisdiction row, found ${seen}`);
+  }
+
+  // The certification limit, stated in the same voice as the proofs.
+  assert.match(securityRaw, /Paramant does not hold third-party certification for these frameworks\./,
+    'security.html must state that the compliance material is not a certification');
+  assert.match(pricing, /Paramant does not hold third-party certification for these frameworks\./,
+    'pricing.html must keep the certification limit it has shipped with');
+
+  // House style on the commercial pages, from the messaging guide: no marketing
+  // words we cannot back, no invented social proof, no em-dashes.
+  const commercial = about + securityRaw + trustRaw;
+  assert.doesNotMatch(commercial, /revolutionary|seamless|cutting-edge|military-grade|enterprise-grade|world-class|next-generation|effortless|trusted by \d/i,
+    'the commercial pages must not use the banned marketing vocabulary');
+  assert.doesNotMatch(commercial, /\u2014/,
+    'the commercial pages must not use em-dashes (U+2014)');
+
+  console.log('ui-truthfulness: /about, /security and /trust say only what the site can back');
+
+
+  // The first screen of each page. The complaint that sent this work back was
+  // that a buyer reaches the bottom of a phone screen without knowing what is
+  // sold, who sells it, or what to do next. These assert that the answers are in
+  // the markup before the first section heading, not a screen and a half down.
+  const aboveFold = (html) => html.slice(0, html.indexOf('<!-- WHAT PARAMANT IS -->') + 1 || html.length);
+  const aboutHero = aboveFold(about);
+  assert.match(aboutHero, /Sign and send documents so that only you and the person you send them to can read them/,
+    'about.html must open in plain language, before the word post-quantum');
+  assert.match(aboutHero, /For small offices that sign and send confidential papers/,
+    'about.html must say who it is for in the hero');
+  assert.match(aboutHero, /Mick Beer/, 'about.html must name the founder in the hero');
+  assert.match(aboutHero, /Privacy and security researcher, founder of Paramantis Solutions B\.V\./,
+    'about.html must carry the founder title in the hero');
+  assert.match(aboutHero, /href="\/pricing" class="btn btn-primary"/,
+    'about.html must offer a next step in the hero');
+  // Nobody can promise ten years. The lede used to end on "the cryptography is
+  // post-quantum, which is the proof that it still holds up in ten years", which
+  // is not a proof and not checkable, on the page whose whole argument is that
+  // everything on it is checkable.
+  assert.doesNotMatch(about, /holds up in ten years|proof that it still holds/i,
+    'about.html must not promise how long the cryptography holds; nothing on the site backs it');
+  // The give-back sentence, in the exact words the messaging guide fixes for it
+  // (section 5, sentence three of the founder paragraph). It is the split the
+  // whole site is built on, and it is quoted, not paraphrased.
+  assert.match(about, /The Community plan is his way of giving something back to society; the business plans pay for it\./,
+    'about.html must carry the give-back sentence in the words docs/brand/messaging.md fixes');
+  // The earlier draft explained the free plan with a jurisdiction claim ("should
+  // not depend on a US subscription"). The guide forbids that beside his name:
+  // the jurisdiction claim is proof 1 and needs its Resend exception with it.
+  assert.doesNotMatch(about, /US subscription/i,
+    'about.html must not hang the jurisdiction claim off the founder paragraph');
+
+  // The section number must not land under the H1 on a phone, where it reads as
+  // a stray "00".
+  assert.match(about, /#main-content \.sec-head \.num\{display:none\}/,
+    'about.html must hide the section number in the mobile hero override');
+
+  // /security: the first screen. The buttons used to sit at roughly y=11400 on a
+  // 390px phone, fourteen screens down, and the page never said who was behind
+  // it. Sliced at the first <main>, so a next step that drifts below the hero
+  // fails here.
+  const heroOf = (html) => html.slice(html.indexOf('<section class="page-hero'), html.indexOf('<main'));
+  const securityHero = heroOf(securityRaw);
+  assert.match(securityHero, /href="\/pricing" class="btn btn-primary"/,
+    'security.html must offer a next step in the first screen, not only at the foot of the page');
+  assert.match(securityHero, /href="\/verify" class="btn btn-secondary"/,
+    'security.html must offer the verify step in the first screen');
+  assert.match(securityHero, /Paramantis Solutions B\.V\. in Harderwijk, the Netherlands, KvK 42115132, founded by Mick Beer, privacy and security researcher/,
+    'security.html says "why you can trust us", so it must name who that is, under the lede');
+
+  // The hero promise is bounded where the code is bounded. It used to read "Even
+  // if our own server is broken into, nobody can read your documents" flat out,
+  // while ten screens lower the page says the Chromium and Outlook extensions
+  // take a server-side encryption path. For an extension user the flat version
+  // is untrue today, so the exception travels with the promise.
+  assert.match(securityHero, /That holds for the web app, ParaShare and the official SDKs\./,
+    'security.html must scope the zero-knowledge promise in the hero');
+  assert.match(securityHero, /The Chromium and Outlook extensions still encrypt on our server/,
+    'security.html must name the extension exception in the same breath as the promise');
+  // And say what that costs the reader. "Treat those uploads as relay-side" is
+  // the internal word for it, and it tells someone who does not already know
+  // what a relay is precisely nothing.
+  assert.match(securityHero, /which means we can read what you upload through them until that is changed/,
+    'security.html must say in plain words what the extension exception means: we can read those uploads');
+  // The claim this round makes about itself: relay does not appear above the
+  // fold undefined. Asserted rather than asserted-in-the-PR-text. The same word
+  // is fine lower down, where the page defines it.
+  assert.doesNotMatch(securityHero, /\brelay\b/i,
+    'security.html must not use "relay" in the first screen; it is undefined there');
+
+  assert.doesNotMatch(securityHero, /nobody can read your documents: they are encrypted on your device before they leave it, and the key never reaches us\. This page shows/,
+    'the unqualified version of the promise must not come back');
+
+  // /security promises "who audited it" in the hero and the meta description says
+  // "independent audit". Both have to resolve on the page itself: /architecture
+  // points back here for the audit material, so a pointer there is a loop.
+  assert.match(securityRaw, /Three external security audits in April 2026 reviewed the relay code/,
+    'security.html must state the audits its hero promises');
+  // The previous round asserted "The audit reports themselves are not
+  // published." That was false: docs/security-audit-2026-04.md is the full
+  // Smart Cyber Solutions writeup and it ships in the site tree as
+  // frontend/docs/security-audit-2026-04.md. Only the raw pentest output is
+  // missing, which is what that document itself calls the "Raw report". These
+  // pin what /docs#audits actually says: three audits, forty findings, four
+  // critical, all resolved.
+  assert.match(securityRaw, /Together they produced 40 findings, 4 of them critical\./,
+    'security.html must quote the finding counts the /docs#audits table adds up to');
+  assert.match(securityRaw, /the raw pentest output behind it is not published|What is not published is the raw pentest output/,
+    'security.html must name what is actually unpublished: the raw pentest output, not the reports');
+  assert.doesNotMatch(securityRaw + trustRaw, /The audit reports themselves are not published/,
+    'the April 2026 report IS published at /docs/security-audit-2026-04.md; that sentence was untrue');
+  assert.match(securityRaw, /href="\/docs\/security-audit-2026-04\.md"/,
+    'security.html must link the published audit report it points at');
+  // The auditor names were pinned on /trust only, so replacing them on
+  // /security with "an independent firm" left the suite green. Pinned on both.
+  assert.match(securityRaw, /two by R\. Zwarts, one by Ryan Williams of Smart Cyber Solutions/,
+    'security.html must name the auditors it credits');
+  assert.match(securityRaw, /href="\/docs#audits"/,
+    'security.html must link the audit table that carries the counts');
+  assert.doesNotMatch(securityRaw, /full audit history[^<]*<a href="\/architecture"/,
+    'security.html must not send the reader to /architecture for audit material it sends back');
+
+  // /trust: tab title and H1 say the same thing, and the audit claim names its
+  // auditors and where the outcome is.
+  // The literal head strings belong to #334 and tests/seo-contract.test.mjs
+  // pins them there. What this file guards is that the H1 and the head agree;
+  // see the structural check further down.
+  assert.match(trustRaw, /<h1>Trust &amp; Verification<\/h1>/, 'trust.html H1 names the page');
+  assert.match(trustRaw, /two by R\. Zwarts, one by Ryan Williams of Smart Cyber Solutions/,
+    'trust.html must name the auditors it credits');
+  assert.match(trustRaw, /Together they produced 40 findings, 4 of them critical\./,
+    'trust.html must quote the same finding counts /docs#audits adds up to');
+  assert.match(trustRaw, /href="\/docs\/security-audit-2026-04\.md"/,
+    'trust.html must link the published audit report');
+  const trustHero = heroOf(trustRaw);
+  assert.match(trustHero, /For organisations that run Paramant on their own server/,
+    'trust.html must name its audience in the hero, not a screen below it');
+  assert.doesNotMatch(trustHero, /\brelay\b/i,
+    'trust.html must not use "relay" in the first screen; it is undefined there');
+
+  // One name for one page. The H1 and the <title> said "Trust & Verification"
+  // while the social card and the structured data still said "Trust &
+  // Transparency", and no test in tests/ compares a title with its og:title.
+  // #334 owns the head wording and tests/seo-contract.test.mjs pins the literal
+  // strings, so this checks the RELATION instead: the four places that name the
+  // page must name it the same, and that name must be the one the H1 uses.
+  // Punctuation and case are not the point; "Transparency" versus
+  // "Verification" was.
+  const pageName = (re, label) => {
+    const m = re.exec(trustRaw);
+    assert.ok(m, `trust.html must carry ${label}`);
+    return m[1].replace(/&amp;|&/g, 'and').replace(/&middot;|\u00b7/g, '').replace(/[^a-z]+/gi, ' ').trim().toLowerCase();
+  };
+  const trustNames = {
+    title: pageName(/<title>([^<]*)<\/title>/, 'a title'),
+    og: pageName(/<meta property="og:title" content="([^"]*)"/, 'an og:title'),
+    twitter: pageName(/<meta name="twitter:title" content="([^"]*)"/, 'a twitter:title'),
+    jsonld: pageName(/"name": "([^"]*Paramant[^"]*)"/, 'a JSON-LD WebPage name'),
+  };
+  for (const [where, name] of Object.entries(trustNames)) {
+    assert.equal(name, trustNames.title,
+      `trust.html ${where} calls the page "${name}", the title calls it "${trustNames.title}"`);
+  }
+  const trustH1 = /<h1>([^<]*)<\/h1>/.exec(trustRaw)[1].replace(/&amp;|&/g, 'and').replace(/[^a-z]+/gi, ' ').trim().toLowerCase();
+  for (const word of trustH1.split(' ')) {
+    assert.ok(trustNames.title.includes(word),
+      `the /trust H1 says "${trustH1}" but the title says "${trustNames.title}"; the word "${word}" is missing`);
+  }
+  assert.doesNotMatch(trustRaw, /Trust &(amp;)? Transparency|Trust and transparency/i,
+    'trust.html must not keep the old page name anywhere');
+
+  // The hero addresses "anyone who has to check a supplier". That reader used to
+  // get one text link in the middle of a paragraph as the only way onward.
+  assert.match(trustHero, /href="\/security" class="btn btn-primary"/,
+    'trust.html must give the reviewer a real next step in the hero');
+  assert.match(trustHero, /href="\/pricing" class="btn btn-secondary"/,
+    'trust.html must offer pricing from the hero as well');
+
+  // "the operator who runs the relay" was the first sentence under the hero, and
+  // relay is not a word a supplier reviewer knows.
+  const trustFirstScreen = trustRaw.slice(0, trustRaw.indexOf('<h3>How to read this page</h3>'));
+  assert.doesNotMatch(trustFirstScreen, /the operator who runs the relay/,
+    'trust.html must not open on undefined jargon; say which server is meant');
+
+  // /pricing sells four ParaSign tiers. "Businesses pay for Pro or Enterprise"
+  // silently dropped Business, and the sentence sat on the page that exists to
+  // be checkable.
+  for (const name of ['ParaSign Community', 'ParaSend Community', 'ParaSign Pro, Business and Enterprise']) {
+    assert.ok(trustRaw.includes(name), `trust.html must name the plans as /pricing names them: "${name}"`);
+  }
+  assert.doesNotMatch(trustRaw, /Businesses pay for Pro or Enterprise/,
+    'trust.html must not name two of the three paid ParaSign tiers as if they were all of them');
+
+  console.log('ui-truthfulness: the trust pages answer who, what and what next above the fold');
+}


### PR DESCRIPTION
Rewrites the three pages a buyer reaches after the homepage, in the order
`docs/brand/messaging.md` fixes (merged as #331): what this is, who it is for,
who is behind it, a next step, then the proof including the honest limits.
Copy, hierarchy and order only. No restyle.

`frontend/index.html`, `frontend/apply-nav.py` and `frontend/js/nav-auth.js`
are untouched. Scope is five files: the three pages and the two test files
that pin them.

**Third round.** The second was rejected on a stale base plus twelve findings
across two reviews. Every one is answered below, with the pin that now fails
when it comes back.

## Rebased, and main's corrections kept

Base is current `main` (`56694a1`, #362). Since the previous head the branch
has picked up #327, #328, #331, #332, #333, #334, #336, #337, #339, #340,
#342, #352 to #359 and #362, plus the dependency bumps. What main fixed on these pages survives:

| What main fixed | State here |
|---|---|
| `ships 3 KEMs and 17 signature schemes` plus the core/extended caveat | kept |
| the account-lockout promise the code does not implement | stays removed |
| the IP-logging row citing `access_log off` in `deploy/nginx-paramant-live.conf` | kept, and carried into the moved-up jurisdiction table |
| the /trust audit link pointing at `/docs#audits` | kept |
| Cloudflare gone from the out-of-scope list (`Resend, Hetzner, Bunny, Mollie`) | kept, and the CLOUD Act card no longer names Cloudflare either |
| the free plan renamed Community | followed on all three pages, and now enforced sitewide |
| #332's give-back paragraph on /about (`about.html` r.169) | taken verbatim, moved with the section into the top half |

Two files conflicted. In `tests/ui-truthfulness.test.mjs` main's block is kept
whole; this branch's block is appended after it and reuses main's `about` and
`pricing` handles instead of redeclaring them. In `frontend/about.html` the
conflict is the section this branch moves out of position 03 and #332 edits in
place: main's three paragraphs win word for word, including both sentences
#332 added, and they travel with the section into the top half. The section
appears once, at 02, and the numbering below it is consecutive.

## The blocking findings

**1. "The audit reports themselves are not published" was untrue, and pinned.**
`docs/security-audit-2026-04.md` is the full Smart Cyber Solutions writeup and
it ships in the site tree as `frontend/docs/security-audit-2026-04.md`. Only
the raw pentest output is missing, which is what that document itself calls
the raw report. Both pages now say what `/docs#audits` adds up to: three
audits in April 2026, two by R. Zwarts and one by Ryan Williams of Smart Cyber
Solutions, forty findings, four of them critical, resolving commits in the
table. The published report is linked. The false sentence is now forbidden by
assertion on both pages.

**2. The absolute promise above the fold was contradicted lower down.** The
hero read "Even if our own server is broken into, nobody can read your
documents" flat out, while the page says ten screens lower that the Chromium
and Outlook extensions take a server-side encryption path. The exception now
travels with the promise: it holds for the web app, ParaShare and the official
SDKs, and the extensions are named in the same paragraph.

**3. /trust called itself two different things.** `<title>` and `<h1>` said
Trust & Verification; `og:title`, `twitter:title` and the JSON-LD `WebPage`
name still said Trust & Transparency. #334 has since rewritten every head on
the site, so the literal strings belong there and `tests/seo-contract.test.mjs`
pins them in its `PINNED` table. On rebase the head of all three pages was
resolved in main's favour, without exception, and
`python3 bron-seo/apply_seo_head.py --check` reports **would change: 0 pages**.

What this branch pins instead is the relation, which no test in `tests/`
covered and which #334 does not cover either: `<title>`, `og:title`,
`twitter:title` and the JSON-LD name must name the page the same, and that name
must contain the words the `<h1>` uses. Punctuation and case are normalised
away; Transparency versus Verification was the defect.

**4. The auditor names were pinned on /trust only.** Replacing them on
/security with "an independent firm" left the suite green. Pinned on both.

## /about

- The lede no longer ends on "the cryptography is post-quantum, which is the
  proof that it still holds up in ten years". That is not a proof and not
  checkable, on the page whose whole argument is that everything on it is
  checkable.
- The founder paragraph carries #332's give-back paragraph verbatim: "The
  Community plan is his way of giving something back to society; the business
  plans pay for it. That is the whole arrangement, and it is why the Community
  plan is not a trial and has no end date." It replaces a version that
  explained the free plan with a jurisdiction claim ("should not depend on a
  US subscription"), which the guide forbids beside his name because the
  jurisdiction claim needs its Resend exception with it. The pin is exact, so
  the copy here and the copy #332 landed cannot drift.
- The free plan is Community, as `/pricing` prints it on the card.
- Measured at 390x844: the founder name at y=463, the title at y=493, "See
  pricing" at y=549, "See the evidence" at y=608. The stray `00` under the H1
  is hidden by `#main-content .sec-head .num{display:none}`, confirmed in the
  browser as `display: none`, not merely reordered.

## /security

- The first screen now carries the bounded promise, who is behind the page
  (Paramantis Solutions B.V. in Harderwijk, KvK 42115132, and the founder
  line) and both next steps. The buttons used to sit at roughly y=11400, some
  fourteen phone screens down. Measured: "See pricing" y=629, "Verify a
  document" y=689.
- The CLOUD Act row and the EU-law card move to the data-path wording that
  section 9.2 of the guide requires: no US provider in the data path, with
  Resend named as the one exception in the same breath. The old row, "Not
  applicable: no US infrastructure, no US company", is broader than /privacy
  allows. The pin measures the exception as a window of 420 characters around
  the claim, not as "somewhere on the page", after a first version of that
  check let a card drop Resend while the table lower down still carried the
  word.
- The eyebrow stays EVIDENCE, not DEFENSE IN DEPTH, and the word relay does
  not appear above the fold undefined.

## /trust

- The hero addresses organisations that run their own server and anyone
  checking a supplier, and gives that reader two buttons instead of one text
  link mid-paragraph (y=416 and y=476).
- "the operator who runs the relay" is gone from the first screen. Relay is
  not a word a supplier reviewer knows.
- The plan sentence named two of the three paid ParaSign tiers. It names all
  three, and both free tiers as Community.

## The fourth-round finding

`security.html` r.448 still read "ParaSign Free and ParaSend Free cost
&euro;0" after three rounds. The reason is worth writing down: the check this
branch added forbidding the old plan name was scoped to `/about`, so the page
that repeated it was never looked at. Two changes, not one:

- the `site-claims` assertion now runs over `about`, `security` and `trust`;
- `TIER_NAME_SHAPES` in `ui-truthfulness` gains `/\bPara(Sign|Send) Free\b/`,
  so the sitewide sweep over every `frontend/**/*.html` catches it on any page,
  including pages no round of this work touches. Sabotage on `pricing.html`
  confirms that.

Two more in the same round:

- The hero said "treat those uploads as relay-side". Relay is the word this
  branch removed from the /trust hero, and it tells a reader who does not know
  what a relay is nothing at all. It now says what the exception costs them:
  the extensions encrypt on our server, which means we can read what you
  upload through them until that is changed. Neither hero uses the word relay
  now, and a test says so on both pages. The /security meta description, which
  sold "relay architecture" in the one line a search result shows, was rewritten
  with it.
- Three paid ParaSign tiers plus Community, not four paid ones. Corrected in
  the test message and the commit.

## Tests

`tests/ui-truthfulness.test.mjs` gains a block for the findings above.
`tests/site-claims.test.mjs` block 11 reads each number out of the `/pricing`
tier card that owns it and requires `/about` to repeat it; it follows the
Community rename and now also forbids `ParaSign Free` on `/about`.

Twenty-seven sabotages were applied in place and reverted, one per new pin: the
ten-year promise, the give-back sentence, the US-subscription framing, the
Community rename, the CLOUD Act row, the Resend exception dropped from the
card, the finding counts on each page, the "reports not published" sentence,
the auditor names on /security, the hero buttons on all three pages, the
who-is-behind line, the bounded promise, the /trust `og:title` and JSON-LD
name, the jargon in each hero, the plan name on each of the three pages plus
one page outside this PR, the "relay" word in both heroes, the /trust head naming the page differently from its own H1, and the paid tiers.
Twenty-seven red, no gaps.

## Following main through parallel merges

`main` moved nine times while this branch was in review. Three things came out
of that and are worth naming:

- **This branch's block in `tests/ui-truthfulness.test.mjs` now sits in a bare
  block scope and declares nothing at module level.** Four PRs merged into that
  file in parallel on 2 September and two of them collided on a top-level
  `const`, which is a SyntaxError: not one assertion in the file runs, on any
  branch. #359 fixed the collision and #362 added a gate for it; this makes the
  block unable to cause the next one. `scripts/check-test-declarations.sh`
  reports **110 suites parse and declare each top-level name once**.
- **`tests/site-claims.test.mjs` block 12 stopped spelling the units itself.**
  #336 renamed both /pricing section headings and put ParaSign first; #359
  reworded "2 signatures per month" to "2 signatures a month". The block now
  finds the headings by product prefix, orders them by position, and lifts each
  fact out of the card as a whole phrase, so /about repeats what /pricing says
  rather than what the test guesses it says. /about follows the new wording.
- **The head of all three pages was resolved in main's favour, without
  exception**, when #334 rewrote every head on the site.
  `python3 bron-seo/apply_seo_head.py --check` reports **would change: 0
  pages**.

Two assertions #339 added were adjusted rather than kept, and both are
deliberate:

- `security.html must keep its Jurisdiction and privacy table` matched
  `<h2>Jurisdiction`. This branch gives that heading an `id` so the EU-law card
  can link to `#jurisdiction`, so the selector became `<h2[^>]*>`. The check
  itself (Bunny is not in that table) is unchanged.
- `security.html must keep the US CLOUD Act row that proof 1 is measured
  against` pinned `Not applicable: no US infrastructure, no US company`.
  Section 9.2 of the guide names that row as the one that has to move to the
  data-path wording "in its own PR with its own test". This is that PR, so the
  assertion now requires the data-path wording and forbids `no US company`.

## Green locally

`node --test` over the CI glob (`.github/workflows/test.yml` r.200): **173
pass, 0 fail**, including `links`, `seo-contract`, `site-claims`,
`ui-truthfulness`, `frontend-loading-contract`, `navigation-shell`,
`code-manifest`, `version-consistency`, `env-documented`.
`scripts/check-csp-inline.sh` and `scripts/check-cache-bust.sh` exit 0.
`eslint@9` exits 0 over the whole repository, and `tests/static-sanity.sh` is
PASS on all eleven checks, check 10 (commit style) and #362's new check 11
(test scope) included. `scripts/check-commit-style.sh` is clean.

At 390x844, `scrollWidth === clientWidth === 390` on all three pages.

## Still open, deliberately

The eIDAS level (SES on `/about`, advanced (AES) in the `/pricing` FAQ) is a
real contradiction and needs a decision, not a copy edit. This branch stops it
spreading and pins that it stays on the one page that has always carried it.
