### PR TITLE
Pricing says what it sells, and what free actually gives, in the first screen

### DIFF
--- a/frontend/billing/checkout.html
+++ b/frontend/billing/checkout.html
@@ -20,8 +20,8 @@
 <body>
 
 <div class="checkout-wrap">
-  <h1>Redirecting to pricing</h1>
-  <p>Checkout has moved. You are being sent to the pricing page.</p>
+  <h1>Checkout starts on the pricing page</h1>
+  <p>Pick your plan there and the button takes you to payment. You sign in first, so the payment is linked to your account and the plan is granted the moment it clears. Nothing is charged on this page.</p>
   <a href="/pricing" class="btn btn-primary">Go to pricing &rarr;</a>
 </div>
 

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -61,6 +61,16 @@
 @media(max-width:767px){
   .tier-grid.tier-grid-4{grid-template-columns:1fr}
 }
+/* At 390px every tier card was 471px wide inside a 342px container, so the
+   right-hand edge of each card was cut off: .btn is white-space:nowrap in
+   design-system.css, and the longest CTA ("Get ParaSign Business -> ...incl.")
+   set the min-content width of the whole grid track. The same defect hid the
+   whole ParaSign Enterprise card off the right edge at 1280px, so the fix is
+   not scoped to a breakpoint: grid items default to min-width:auto, which is
+   what lets one unbreakable line push a track past its container.
+   tests/pricing-fold.test.mjs measures this at five widths. */
+.tier-grid,.tier-card{min-width:0}
+.tier-card .btn{white-space:normal;line-height:1.45}
 @media(max-width:640px){
   .trial-cta{flex-direction:column;align-items:flex-start}
 }
@@ -215,28 +225,83 @@
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
 </div>
 
-<!-- HERO -->
-<section style="padding:var(--space-10) 0 var(--space-8)" id="main-content" tabindex="-1">
-  <div class="container-md" style="text-align:center">
-    <div class="sec-head" style="text-align:left">
-      <span class="num">00</span>
+<!-- HERO
+     Order is the message. The brief of 2026-09-02 makes the split (free for
+     everyone, paid for organisations) the one selling point, so it stands above
+     every table. What a phone sees first is measured, not assumed:
+     tests/pricing-fold.test.mjs pins the y of the first amount, the audience
+     line, the founder line and the first action inside a 390x844 screen.
+
+     Four things had to fit that were not there before. A visitor arriving from
+     a search engine has seen no other page, so the first line says what the
+     product does. The promise carries its own number: "free forever" without
+     "2 signatures per month" reads as generous until the table says otherwise,
+     and a buyer who finds that out one screen later feels sold to. The founder
+     stood at 1128px, which is a screen and a half of scrolling before anyone
+     says who holds the files. And the decorative "00" over the h1 cost the
+     first 60px of the fold while meaning nothing.
+
+     The two amounts are named separately because they buy different products.
+     "From &euro;15 a month" on its own is ParaSend Pro, and an office that came
+     here to sign anchors on it and then meets &euro;49 in the table.
+     tests/ui-truthfulness.test.mjs reads both figures off the Pro cards
+     themselves, and relay/test/pricing-page.test.js binds those cards to
+     relay/lib/billing-catalog.js, so the lead cannot drift from the catalog
+     without a red test in between.
+
+     The Community limits here are the ones the relay enforces on an account:
+     transfers_month 10 and file_mb 5 from relay/lib/tiers.js, refused with 402
+     and 413 respectively. The page used to say "10 uploads per hour per IP",
+     which is ANON_RATE_PER_HOUR on /v2/anon-inbound, an endpoint deprecated on
+     2026-05-28 with a Sunset of 2026-12-31. It described a rate limit on a
+     dying anonymous endpoint as if it were the account's allowance, and it was
+     the one number a visitor could plan around. relay/test/pricing-page.test.js
+     reads both figures out of tiers.js.
+
+     Jargon is out of this block on purpose. "A dedicated relay" and "a
+     connection to their own software" were the two phrases a lawyer cannot
+     read; the same facts stand under the tables in the words the docs use. -->
+<section style="padding:var(--space-6) 0 var(--space-7)" id="main-content" tabindex="-1">
+  <div class="container-md">
+    <!-- .sec-head carries margin-bottom:var(--space-8) sitewide, which is right
+         under a section heading and wrong here: on a 390px screen it spends
+         60px of the one screen that has to carry the amount, the audience, the
+         founder and the button. Overridden on this hero only; the shared rule
+         in design-system.css is untouched. -->
+    <div class="sec-head" style="margin-bottom:var(--space-4)">
       <h1 class="paramant-h2">Pricing</h1>
-      <span style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)">Two products, one core</span>
+      <span style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)">Free for everyone, paid for organisations</span>
     </div>
-    <p style="font-size:var(--text-md);color:var(--ink);line-height:1.75;margin-bottom:var(--space-5)">
-      Two products on one post-quantum core. <strong>ParaSend</strong> for encrypted file transfer and <strong>ParaSign</strong> for document signing. Both start on the Community plan with a Paramant account; scale when you need higher limits, API access, or a dedicated relay.
+    <p style="font-size:var(--text-md);color:var(--ink);line-height:1.6;margin:0 0 var(--space-3)">
+      Sign documents and send files that vanish after one read.
     </p>
-    <div style="text-align:left;max-width:760px;margin:0 auto var(--space-6);padding:var(--space-4) var(--space-5);border:1px solid var(--ink-hair);border-left:3px solid var(--lime);background:var(--bone)">
+    <p style="font-size:var(--text-md);color:var(--ink);line-height:1.6;margin:0 0 var(--space-3)">
+      <strong>Community is &euro;0 a month, forever:</strong> 2 signatures per month, 10 transfers per month, 5 MB per file, no card.
+      Organisations that need higher limits, signing built into their own software, a named contact or a server of
+      their own pay for the business plans: from <strong>&euro;15 a month</strong> for sending, from
+      <strong>&euro;49 a month</strong> for signing, both excl. btw.
+    </p>
+    <p style="font-size:var(--text-base);color:var(--ink-dim);line-height:1.6;margin:0 0 var(--space-4)">
+      For a one-person practice, a volunteer board or a household, and for the offices that sign and send every week.
+    </p>
+    <div style="display:flex;flex-wrap:wrap;gap:var(--space-3);align-items:center;margin-bottom:var(--space-4)">
+      <a href="/signup" class="btn btn-primary">Create a free account &rarr;</a>
+      <a href="#plans" class="btn btn-secondary">Compare plans</a>
+    </div>
+    <p style="font-size:var(--text-sm);color:var(--ink-dim);line-height:1.6;margin:0 0 var(--space-6)">
+      Built in Harderwijk by <strong style="color:var(--navy)">Mick Beer</strong>, privacy and security researcher, founder of
+      Paramantis Solutions B.V. (KvK 42115132). <a href="/about" style="color:var(--cobalt)">About Paramant &rarr;</a>
+    </p>
+    <div style="max-width:760px;margin:0 0 var(--space-4);padding:var(--space-4) var(--space-5);border:1px solid var(--ink-hair);border-left:3px solid var(--lime);background:var(--bone)">
       <p style="font-size:var(--text-base);color:var(--ink);line-height:1.7;margin:0">
         <strong>The Community plan is free, forever.</strong> It is not a trial and not a funnel. It is what
         Paramant gives back: signing and sending that does not route through an American cloud, available to
-        whoever needs it. Paramant is built by <strong>Mick Beer</strong>, privacy and security researcher and
-        founder of Paramantis Solutions B.V., and the Community plan is his contribution back to the society the
+        whoever needs it. The Community plan is the founder's contribution back to the society the
         tools came from. Businesses pay for the higher limits (longer links, more reads, more devices, a
-        dedicated relay), not to unlock features, and that is what keeps the Community plan free.
+        server of their own), not to unlock features, and that is what keeps the Community plan free.
       </p>
     </div>
-    <a href="/dashboard" class="btn btn-secondary">Open your dashboard &rarr;</a>
+    <p style="font-size:var(--text-sm);color:var(--ink-dim);margin:0">Already have an account? <a href="/dashboard" style="color:var(--cobalt)">Open your dashboard &rarr;</a></p>
   </div>
 </section>
 
@@ -260,12 +325,94 @@
 
      relay/test/pricing-page.test.js recomputes every amount here from the
      catalog, so a price edited on this page alone turns the suite red. -->
+<!-- TIER CARDS: PARASIGN -->
+<section style="padding:0 0 var(--space-9)" id="plans">
+  <div class="container">
+    <div style="margin-bottom:var(--space-6)">
+      <span style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)">Product</span>
+      <h3 style="font-size:var(--text-xl);text-transform:uppercase;margin-top:var(--space-2)">ParaSign · Get a document signed</h3>
+      <p style="font-size:var(--text-base);color:var(--ink);line-height:1.7;max-width:760px;margin-top:var(--space-3)">
+        Sign a PDF yourself, or send it to the people who have to sign it. Community covers 2 signatures per month, forever. Organisations pay for volume: 100 a month on Pro, 1,000 a month on Business with a named contact. ParaSign is priced separately from ParaSend, and from Pro it comes with a <strong>developer API</strong> with its own <a href="/docs#parasign-api" style="color:var(--cobalt)">documentation</a> and webhooks, so signing can run inside your own software.
+      </p>
+    </div>
+    <div class="tier-grid tier-grid-4">
+
+      <div class="tier-card">
+        <div class="tier-name">Community</div>
+        <div class="tier-price">&euro;0</div>
+        <div class="tier-price-note">Forever</div>
+        <p style="font-size:var(--text-base);color:var(--ink);margin-bottom:var(--space-5);line-height:1.65">For a one-person practice, a volunteer board or a household. 2 signatures per month, forever.</p>
+        <ul class="tier-features">
+          <li>2 signatures per month</li>
+          <li>Unlimited receiving</li>
+          <li>Full post-quantum crypto - Public verification log</li>
+          <li>No card required</li>
+        </ul>
+        <a href="/signup" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Create a free account &rarr;</a>
+      </div>
+
+      <div class="tier-card featured">
+        <div class="tier-name">Pro</div>
+        <div class="tier-price">&euro;49<span style="font-size:var(--text-sm);color:var(--ink-dim)">/month</span></div>
+        <div class="tier-price-note">excl. btw &middot; <span class="incl">charged &euro;59.29/mo incl. 21% btw</span></div>
+        <p style="font-size:var(--text-base);color:var(--ink);margin-bottom:var(--space-5);line-height:1.65">For an office that signs every week, and for putting signing inside your own software through the API.</p>
+        <ul class="tier-features">
+          <li>100 signatures per month, then &euro;0.40 each, up to 1,000</li>
+          <li>Past 1,000 a month, Business is cheaper anyway</li>
+          <li>Unlimited transfers - API access</li>
+          <li>Annual: &euro;499 excl. &middot; 15.1% off</li>
+        </ul>
+        <a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Pro &rarr; <span style="font-weight:400;opacity:.85">&euro;59.29/mo incl.</span></a>
+        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; &euro;603.79/yr incl. &rarr;</a></div>
+      </div>
+
+      <div class="tier-card">
+        <div class="tier-name">Business</div>
+        <div class="tier-price">&euro;299<span style="font-size:var(--text-sm);color:var(--ink-dim)">/month</span></div>
+        <div class="tier-price-note">excl. btw &middot; <span class="incl">charged &euro;361.79/mo incl. 21% btw</span></div>
+        <p style="font-size:var(--text-base);color:var(--ink);margin-bottom:var(--space-5);line-height:1.65">For an organisation that has to answer for its process: a named contact and an audit log you can export.</p>
+        <ul class="tier-features">
+          <li>1,000 signatures per month</li>
+          <li>Named support, response within one business day</li>
+          <li>We help you answer your customers' security questionnaires</li>
+          <li>Exportable audit log with CT tree head (CSV or JSON)</li>
+          <li>Annual: &euro;2,990 excl. &middot; 16.7% off</li>
+        </ul>
+        <a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="business" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Business &rarr; <span style="font-weight:400;opacity:.85">&euro;361.79/mo incl.</span></a>
+        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="business" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; &euro;3,617.90/yr incl. &rarr;</a></div>
+      </div>
+
+      <div class="tier-card">
+        <div class="tier-name">Enterprise</div>
+        <div class="tier-price">Let's talk</div>
+        <div class="tier-price-note">Per organisation</div>
+        <p style="font-size:var(--text-base);color:var(--ink);margin-bottom:var(--space-5);line-height:1.65">For organisations that need a server of their own, an SLA with service credits or a self-hosting licence.</p>
+        <ul class="tier-features">
+          <li>Dedicated relay instance - Sector relay (health, legal, finance)</li>
+          <li>SLA with service credits - Self-hosting licence - Audit support</li>
+        </ul>
+        <a href="mailto:privacy@paramant.app?subject=ParaSign+Enterprise" class="btn btn-secondary" style="display:block;text-align:center;margin-top:auto">Contact &rarr;</a>
+      </div>
+
+    </div>
+    <div style="text-align:left;max-width:760px;margin:var(--space-6) auto 0;padding:var(--space-4) var(--space-5);border:1px solid var(--ink-hair);border-left:3px solid var(--lime);background:var(--bone)">
+      <p style="font-size:var(--text-base);color:var(--ink);line-height:1.7;margin:0">
+        Every plan gets the same encryption, the same post-quantum signatures and the same public proof log. Pay for volume, never for security. And pay per organisation, not per user.
+      </p>
+    </div>
+    <p style="font-family:var(--mono);font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-4)">Prices shown excl. btw (VAT). Checkout charges incl. 21% btw: Pro &euro;59.29/mo or &euro;603.79/yr, Business &euro;361.79/mo or &euro;3,617.90/yr.</p>
+  </div>
+</section>
+
 <!-- TIER CARDS: PARASEND -->
 <section style="padding:0 0 var(--space-9)">
   <div class="container">
     <div style="margin-bottom:var(--space-6)">
       <span style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)">Product</span>
-      <h3 style="font-size:var(--text-xl);text-transform:uppercase;margin-top:var(--space-2)">ParaSend · Encrypted transfer</h3>
+      <h3 style="font-size:var(--text-xl);text-transform:uppercase;margin-top:var(--space-2)">ParaSend · Send a file that disappears</h3>
+      <p style="font-size:var(--text-base);color:var(--ink);line-height:1.7;max-width:760px;margin-top:var(--space-3)">
+        Send a file over a link that expires and burns on first read. Community covers 10 transfers per month at 5 MB per file, forever. Organisations that send every week pay for longer links, more reads and more registered devices.
+      </p>
     </div>
     <div class="tier-grid">
 
@@ -278,10 +425,11 @@
           <li>AES-256-GCM, browser-generated key</li>
           <li>1 hour link expiry</li>
           <li>Burn on first read</li>
-          <li>10 uploads per hour per IP</li>
+          <li>10 transfers per month</li>
+          <li>5 MB per file</li>
           <li>Up to 5 registered devices for ParaShare</li>
         </ul>
-        <a href="/dashboard" class="btn btn-primary" style="display:block;text-align:center">Open your dashboard &rarr;</a>
+        <a href="/signup" class="btn btn-primary" style="display:block;text-align:center">Create a free account &rarr;</a>
       </div>
 
       <div class="tier-card featured">
@@ -297,7 +445,7 @@
           <li>Send history and link management</li>
           <li>Webhooks on upload and download</li>
           <li>Email notifications via Resend</li>
-          <li>No IP rate limit</li>
+          <li>500 transfers per month</li>
         </ul>
 <!-- Prices live in relay/lib/billing-catalog.js, server side, and the button
      only carries product/plan/interval. pricing-billing.js turns a click into
@@ -337,81 +485,6 @@
   </div>
 </section>
 
-<!-- TIER CARDS: PARASIGN -->
-<section style="padding:0 0 var(--space-9)">
-  <div class="container">
-    <div style="margin-bottom:var(--space-6)">
-      <span style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)">Product</span>
-      <h3 style="font-size:var(--text-xl);text-transform:uppercase;margin-top:var(--space-2)">ParaSign · Post-quantum signing</h3>
-      <p style="font-size:var(--text-base);color:var(--ink);line-height:1.7;max-width:760px;margin-top:var(--space-3)">
-        Document signing on the same post-quantum core, priced separately from ParaSend. New: a <strong>developer API</strong> (from Pro) with its own <a href="/docs#parasign-api" style="color:var(--cobalt)">documentation</a> and webhooks, so you can plug signing straight into your own apps and quotes.
-      </p>
-    </div>
-    <div class="tier-grid tier-grid-4">
-
-      <div class="tier-card">
-        <div class="tier-name">Community</div>
-        <div class="tier-price">&euro;0</div>
-        <div class="tier-price-note">Forever</div>
-        <ul class="tier-features">
-          <li>2 signatures per month</li>
-          <li>Unlimited receiving</li>
-          <li>Full post-quantum crypto - Public verification log</li>
-          <li>No card required</li>
-        </ul>
-        <a href="/dashboard" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Open your dashboard &rarr;</a>
-      </div>
-
-      <div class="tier-card featured">
-        <div class="tier-name">Pro</div>
-        <div class="tier-price">&euro;49<span style="font-size:var(--text-sm);color:var(--ink-dim)">/month</span></div>
-        <div class="tier-price-note">excl. btw &middot; <span class="incl">charged &euro;59.29/mo incl. 21% btw</span></div>
-        <ul class="tier-features">
-          <li>100 signatures per month, then &euro;0.40 each, up to 1,000</li>
-          <li>Past 1,000 a month, Business is cheaper anyway</li>
-          <li>Unlimited transfers - API access</li>
-          <li>Annual: &euro;499 excl. &middot; 15.1% off</li>
-        </ul>
-        <a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Pro &rarr; <span style="font-weight:400;opacity:.85">&euro;59.29/mo incl.</span></a>
-        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; &euro;603.79/yr incl. &rarr;</a></div>
-      </div>
-
-      <div class="tier-card">
-        <div class="tier-name">Business</div>
-        <div class="tier-price">&euro;299<span style="font-size:var(--text-sm);color:var(--ink-dim)">/month</span></div>
-        <div class="tier-price-note">excl. btw &middot; <span class="incl">charged &euro;361.79/mo incl. 21% btw</span></div>
-        <ul class="tier-features">
-          <li>1,000 signatures per month</li>
-          <li>Named support, response within one business day</li>
-          <li>We help you answer your customers' security questionnaires</li>
-          <li>Exportable audit log with CT tree head (CSV or JSON)</li>
-          <li>Annual: &euro;2,990 excl. &middot; 16.7% off</li>
-        </ul>
-        <a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="business" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Business &rarr; <span style="font-weight:400;opacity:.85">&euro;361.79/mo incl.</span></a>
-        <div style="text-align:center"><a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="business" data-billing-interval="yearly" class="yearly-alt">Or pay yearly &middot; &euro;3,617.90/yr incl. &rarr;</a></div>
-      </div>
-
-      <div class="tier-card">
-        <div class="tier-name">Enterprise</div>
-        <div class="tier-price">Let's talk</div>
-        <div class="tier-price-note">Per organisation</div>
-        <ul class="tier-features">
-          <li>Dedicated relay instance - Sector relay (health, legal, finance)</li>
-          <li>SLA with service credits - Self-hosting licence - Audit support</li>
-        </ul>
-        <a href="mailto:privacy@paramant.app?subject=ParaSign+Enterprise" class="btn btn-secondary" style="display:block;text-align:center;margin-top:auto">Contact &rarr;</a>
-      </div>
-
-    </div>
-    <div style="text-align:left;max-width:760px;margin:var(--space-6) auto 0;padding:var(--space-4) var(--space-5);border:1px solid var(--ink-hair);border-left:3px solid var(--lime);background:var(--bone)">
-      <p style="font-size:var(--text-base);color:var(--ink);line-height:1.7;margin:0">
-        Every plan gets the same encryption, the same post-quantum signatures and the same public proof log. Pay for volume, never for security. And pay per organisation, not per user.
-      </p>
-    </div>
-    <p style="font-family:var(--mono);font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-4)">Prices shown excl. btw (VAT). Checkout charges incl. 21% btw: Pro &euro;59.29/mo or &euro;603.79/yr, Business &euro;361.79/mo or &euro;3,617.90/yr.</p>
-  </div>
-</section>
-
 <!-- PROSE SECTIONS -->
 <section style="padding:var(--space-9) 0;border-top:1px solid var(--ink-hair)">
   <div class="container-md">
@@ -423,12 +496,12 @@
 
     <div class="prose-section">
       <h3>Encryption</h3>
-      <p>Every tier uses the same cryptography. Verified transfers via ParaShare use ML-KEM-768 plus ECDH P-256 hybrid key exchange with ML-DSA-65 signed receipts. There is no lesser encryption at lower tiers. Cryptography is not a paywalled feature at Paramant.</p>
+      <p>Every tier uses the same cryptography. Verified transfers via ParaShare use ML-KEM-768 plus ECDH P-256 hybrid key exchange; the <a href="/crypto-agility" style="color:var(--cobalt)">crypto register</a> lists ParaShare with no default signature algorithm, on a pre-v1 hybrid wire format that is migrating to v1. There is no lesser encryption at lower tiers. Cryptography is not a paywalled feature at Paramant.</p>
     </div>
 
     <div class="prose-section">
       <h3>Compliance</h3>
-      <p>All tiers meet NIS2 and GDPR requirements by design. NEN 7510, eIDAS, and IEC 62443 mappings ship with Pro and Enterprise. A signed Data Processing Agreement under GDPR Article 28 is available on request for all paid tiers.</p>
+      <p>The architecture is built to support your NIS2 and GDPR work. Paramant itself holds no third-party certification for those frameworks. NEN 7510, eIDAS, and IEC 62443 mappings ship with Pro and Enterprise. A signed Data Processing Agreement under GDPR Article 28 is available on request for all paid tiers.</p>
     </div>
 
     <div class="prose-section">
@@ -483,7 +556,7 @@
 
     <div class="faq-item">
       <p class="faq-q">How does ParaSign pricing work?</p>
-      <div class="faq-a">ParaSign is priced by signature volume, not by feature. Community covers 2 signatures a month; Pro (&euro;49/mo or &euro;499/yr, excl. btw) includes 100 a month, then &euro;0.40 each, with API access; Business (&euro;299/mo or &euro;2,990/yr, excl. btw) includes 1,000 a month with named support and an exportable audit log. Every tier uses the same ML-DSA-65 post-quantum cryptography and public CT-log verification. Signatures are advanced (AES), not qualified (QES). QES is coming via an EU QTSP partner.</div>
+      <div class="faq-a">ParaSign is priced by signature volume, not by feature. Community covers 2 signatures per month; Pro (&euro;49/mo or &euro;499/yr, excl. btw) includes 100 a month, then &euro;0.40 each, with API access; Business (&euro;299/mo or &euro;2,990/yr, excl. btw) includes 1,000 a month with named support and an exportable audit log. Every tier uses the same ML-DSA-65 post-quantum cryptography and public CT-log verification. A ParaSign signature is a Simple Electronic Signature (SES) under eIDAS, not an advanced (AES) or a qualified (QES) signature. QES is coming via an EU QTSP partner.</div>
     </div>
 
     <div class="faq-item">

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -199,6 +199,10 @@
   <p class="lede">
     We'll send a link to confirm it's you. No password to invent.
   </p>
+  <p class="small mt-2">
+    Community accounts get 2 signatures per month and send encrypted files that burn on first read, forever, no card.
+    <a href="/pricing" style="color:var(--cobalt,#1D4ED8)">See the plans</a>.
+  </p>
 </section>
 
 <section class="section">

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -5,7 +5,8 @@
 // server catalog, no-JS href pointing at sign-in), states that checkout
 // charges incl. 21% btw, shows the incl-btw amount up-front on every paid card,
 // keeps one primary monthly CTA per tier with the yearly option demoted to a
-// secondary link, and no longer claims a 5 MB file limit. It also checks the
+// secondary link, and states the Community limits the relay actually enforces
+// (transfers_month and file_mb out of relay/lib/tiers.js). It also checks the
 // dead billing/checkout.html stub now redirects to /pricing with no "no charge"
 // copy. Run: node relay/test/pricing-page.test.js (exits non-zero on failure).
 
@@ -14,6 +15,7 @@ const fs = require('fs');
 const path = require('path');
 const catalog = require('../lib/billing-catalog');
 const entitlements = require('../lib/entitlements');
+const tiers = require('../lib/tiers');
 
 const html = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'pricing.html'), 'utf8');
 
@@ -122,9 +124,51 @@ assert(/excl\. btw/.test(html), 'missing "excl. btw" mention');
 assert(/incl\. 21% btw/.test(html), 'missing "incl. 21% btw" checkout notice');
 ok('page states excl. btw and that checkout charges incl. 21% btw');
 
-// The outdated 5 MB file-limit claim is gone.
-assert(!/5\s?MB/i.test(html), 'pricing page still claims a 5 MB limit');
-ok('no 5 MB claim left on the pricing page');
+// The Community limits on the page are the ones the relay actually enforces.
+//
+// This block used to say the opposite: "the outdated 5 MB file-limit claim is
+// gone", asserting that "5 MB" appears nowhere on the page. That rule outlived
+// its reason. relay/relay.js refuses a larger blob with 413 `Max 5MB` against
+// MAX_BLOB (default 5242880), and relay/lib/tiers.js gives every tier
+// file_mb 5. The limit is real, so a test forbidding the page to name it was
+// holding a true sentence off the page.
+//
+// What the page said instead was worse than silence: "10 uploads per hour per
+// IP" is ANON_RATE_PER_HOUR on /v2/anon-inbound, which relay.js deprecated on
+// 2026-05-28 and advertises with Sunset 2026-12-31. A visitor read a rate limit
+// on a dying anonymous endpoint as the allowance on the account they were about
+// to create, and never saw the monthly cap that actually stops them (402
+// monthly_transfer_quota_reached, transfers_month from the plan).
+//
+// Both figures are read out of tiers.js here, so the page cannot drift from the
+// relay without this test going red.
+// Comments stripped: the WHY-note in pricing.html quotes the very wording this
+// block forbids, which is exactly how it stays forbidden for the next reader.
+const htmlVisible = html.replace(/<!--[\s\S]*?-->/g, '');
+const communityTransfers = tiers.tierLimit('community', 'transfers_month');
+const communityFileMb = tiers.tierLimit('community', 'file_mb');
+const proTransfers = tiers.tierLimit('pro', 'transfers_month');
+assert(new RegExp(`<li>${communityTransfers} transfers per month</li>`).test(html),
+  `the Community card must name the transfers_month limit from tiers.js (${communityTransfers})`);
+assert(new RegExp(`<li>${communityFileMb} MB per file</li>`).test(html),
+  `the Community card must name the file_mb limit from tiers.js (${communityFileMb} MB)`);
+assert(new RegExp(`${communityTransfers} transfers per month, ${communityFileMb} MB per file`).test(html),
+  'the lead must carry the same two Community limits as the card');
+assert(new RegExp(`<li>${proTransfers} transfers per month</li>`).test(html),
+  `the ParaSend Pro card must name its transfers_month limit from tiers.js (${proTransfers})`);
+assert(!/uploads per hour/i.test(htmlVisible),
+  'the page must not sell the anonymous per-IP rate of a deprecated endpoint as an account limit');
+ok('Community and Pro transfer limits on the page come from relay/lib/tiers.js');
+
+// ParaShare has no signature algorithm of its own. frontend/crypto-agility.html
+// lists it with Default SIG "n/a" on a pre-v1 hybrid wire format, so the claim
+// that its receipts are ML-DSA-65 signed was contradicted by our own register.
+assert(!/ParaShare use ML-KEM-768 plus ECDH P-256 hybrid key exchange with ML-DSA-65 signed receipts/.test(html),
+  'the page must not claim ML-DSA-65 signed receipts for ParaShare; the crypto register says n/a');
+const agility = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'crypto-agility.html'), 'utf8');
+assert(/<td>ParaShare \(webapp\)<\/td>\s*<td>ML-KEM-768 \+ ECDH P-256<\/td>\s*<td>n\/a<\/td>/.test(agility),
+  'crypto-agility.html is the source for ParaShare\'s algorithms and must still list SIG as n/a');
+ok('the ParaShare crypto claim matches the register on /crypto-agility');
 
 // Every paid card shows the incl-btw amount up-front, next to the excl price,
 // so the amount on Mollie's page does not surprise the buyer.

--- a/tests/pricing-fold.test.mjs
+++ b/tests/pricing-fold.test.mjs
@@ -1,0 +1,212 @@
+// What a phone actually sees on /pricing, measured on a laid-out page.
+//
+// Three things this file holds, all measured rather than read out of the
+// markup, because all three were wrong on a page whose HTML read fine.
+//
+// 1. THE FOLD, BY POSITION. The design target is 390x844. An earlier version of
+//    this test asked only whether an element intersected the viewport, which a
+//    half-visible line at y=840 satisfies and a reader does not. Every claim
+//    below is pinned by its bottom edge: the first amount, the line that says
+//    who the page is for, the line that says who is behind it, and the first
+//    action must be READABLE on the first screen, not clipped by it. The
+//    founder line stood at 1128px on the branch this replaces, a screen and a
+//    half down, on the page where a buyer decides whether to hand over client
+//    files.
+//
+// 2. NO JARGON IN THE FOLD. "post-quantum signatures", "public proof log",
+//    "relay", "API": none of them mean anything to the lawyer this page sells
+//    to, and the same facts stand under the tables where they belong. The text
+//    is collected from TEXT NODES, not from a list of block tags: the previous
+//    version queried "main p, section p, h1, h2, h3" and so read straight past
+//    the kicker <span> under the h1, which is the second thing on the page.
+//
+// 3. THE CARDS. Grid items default to min-width:auto, and design-system.css
+//    sets white-space:nowrap on .btn. Together they let the longest CTA on the
+//    page ("Get ParaSign Business -> ... incl.") set the min-content width of
+//    the whole grid track. Measured on origin/main at 390px: the container was
+//    342px wide and every tier card was 471px, so the right-hand third of each
+//    card was clipped. The same defect pushed the entire ParaSign Enterprise
+//    card off the right edge at 1280px. Nothing in the HTML shows this; only a
+//    laid-out page does.
+//
+// Run: node --test tests/pricing-fold.test.mjs
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = { '.js':'text/javascript', '.css':'text/css', '.html':'text/html', '.svg':'image/svg+xml', '.png':'image/png', '.woff2':'font/woff2', '.json':'application/json' };
+const aliases = { '/pricing':'/pricing.html', '/signup':'/signup.html' };
+const FOLD = { width: 390, height: 844 };
+
+const server = http.createServer((req, res) => {
+  let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+  pathname = aliases[pathname] || pathname;
+  const file = path.join(ROOT, pathname);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+  fs.readFile(file, (error, body) => {
+    if (error) { res.writeHead(404); return res.end(); }
+    res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  });
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const ORIGIN = `http://localhost:${server.address().port}`;
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+
+async function open(width, height, slug = 'pricing') {
+  const page = await browser.newPage({ viewport: { width, height } });
+  await page.route('**/api/user/session/verify', (route) => route.fulfill({ status: 401, contentType: 'application/json', body: '{"authenticated":false}' }));
+  await page.goto(`${ORIGIN}/${slug}`, { waitUntil: 'networkidle' });
+  return page;
+}
+
+// The bottom edge of the first element whose own text matches, in CSS pixels
+// from the top of the document. Text nodes, not tags: the kicker under the h1
+// is a span, and the amount in the promise sits inside a <strong>.
+//
+// A pattern may ask for the enclosing BLOCK instead of the element holding the
+// matched text. The founder claim is the case that needs it: "Mick Beer" is a
+// <strong> that ends at y=726, but the claim a reader has to be able to read is
+// the whole line, title and KvK number included, and that ends 40px lower. An
+// earlier version measured the <strong> and would have called the line visible
+// with its registration clipped off the bottom of the screen.
+const measure = (page, needles) => page.evaluate((patterns) => {
+  const out = {};
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const nodes = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+    const text = n.nodeValue.replace(/\s+/g, ' ').trim();
+    if (!text) continue;
+    const el = n.parentElement;
+    if (!el || ['SCRIPT', 'STYLE', 'NOSCRIPT'].includes(el.tagName)) continue;
+    const rect = el.getBoundingClientRect();
+    if (!rect.height) continue;
+    nodes.push({ text, el, top: rect.top + window.scrollY, bottom: rect.bottom + window.scrollY });
+  }
+  for (const [name, source, block] of patterns) {
+    const rx = new RegExp(source);
+    const hit = nodes.find((n) => rx.test(n.text));
+    if (!hit) { out[name] = null; continue; }
+    const el = block ? (hit.el.closest('p, li, h1, h2, h3, figcaption') || hit.el) : hit.el;
+    const rect = el.getBoundingClientRect();
+    out[name] = {
+      top: Math.round(rect.top + window.scrollY),
+      bottom: Math.round(rect.bottom + window.scrollY),
+      // A block claim is reported whole enough to assert on: the founder line
+      // runs past 100 characters before it reaches the registration number.
+      text: (block ? el.textContent : hit.text).replace(/\s+/g, ' ').trim().slice(0, block ? 240 : 100),
+    };
+  }
+  // Everything a reader can see without scrolling, for the jargon check.
+  out.foldText = nodes
+    .filter((n) => n.bottom <= window.innerHeight + 1 && n.top >= 0)
+    .map((n) => n.text).join(' ');
+  return out;
+}, needles);
+
+test('the first screen at 390px carries the amount, the audience, the founder and an action', async () => {
+  const page = await open(FOLD.width, FOLD.height);
+  const seen = await measure(page, [
+    ['h1', '^Pricing$'],
+    ['what', 'Sign documents and send files that vanish after one read'],
+    ['amount', '€0 a month, forever'],
+    ['limit', '2 signatures per month, 10 transfers per month, 5 MB per file'],
+    // Both paid amounts, because they buy different products and a buyer who
+    // only sees €15 has been told the price of the other one.
+    ['sending', '€15 a month'],
+    ['signing', '€49 a month'],
+    ['audience', 'one-person practice, a volunteer board or a household'],
+    // Whole line: the name, the title /about gives him, and the registration.
+    ['founder', 'Mick Beer', true],
+  ]);
+  const cta = await page.evaluate(() => {
+    // The hero's own action, not the nav's: the nav carries a /signup link on
+    // every page and would make this check pass on a page with no CTA at all.
+    const link = [...document.querySelectorAll('#main-content a[href="/signup"]')][0];
+    if (!link) return null;
+    const rect = link.getBoundingClientRect();
+    return { top: Math.round(rect.top + window.scrollY), bottom: Math.round(rect.bottom + window.scrollY) };
+  });
+  await page.close();
+
+  const required = { ...seen, cta };
+  delete required.foldText;
+  for (const [name, hit] of Object.entries(required)) {
+    assert.ok(hit, `/pricing must carry the ${name} line; it is missing entirely`);
+    assert.ok(hit.bottom <= FOLD.height,
+      `the ${name} line ends at y=${hit.bottom}, past the ${FOLD.height}px first screen: a buyer has to scroll for it`);
+  }
+  // Order is the argument: what it does, then what it costs, then who it is
+  // for, then who is behind it, and only then the button.
+  assert.ok(seen.what.top < seen.amount.top, 'what the product does stands above what it costs');
+  assert.ok(seen.amount.top <= seen.audience.top, 'the amount stands above the audience line');
+  assert.ok(seen.audience.top < cta.top, 'the audience line stands above the first action');
+  assert.match(seen.founder.text, /privacy and security researcher.*KvK 42115132/,
+    'the measured founder line must be the whole claim, not just the name in bold');
+});
+
+test('the first screen at 390px spends no words on jargon', async () => {
+  const page = await open(FOLD.width, FOLD.height);
+  const { foldText } = await measure(page, []);
+  await page.close();
+  // Words with no meaning to the buyer this page sells to. Every one of them
+  // still stands under the tables, where a reader has asked for detail.
+  const JARGON = [
+    /post-quantum signatures/i,
+    /public proof log/i,
+    /\bdedicated relay\b/i,
+    /\bthe relay\b/i,
+    /\ban API\b/,
+    /\bML-DSA\b/i,
+    /\bAES-256\b/i,
+    /\bciphertext\b/i,
+  ];
+  const hits = JARGON.filter((rx) => rx.test(foldText)).map((rx) => String(rx));
+  assert.deepEqual(hits, [], `the first screen at 390px reads: "${foldText}"\n  jargon found: ${hits.join(', ')}`);
+});
+
+test('pricing and signup use one term for what a free account gives', async () => {
+  const pricing = await open(FOLD.width, FOLD.height);
+  const signup = await open(FOLD.width, FOLD.height, 'signup');
+  const text = async (page) => page.evaluate(() => document.body.innerText.replace(/\s+/g, ' '));
+  const [pricingText, signupText] = [await text(pricing), await text(signup)];
+  await pricing.close();
+  await signup.close();
+  const TERM = '2 signatures per month';
+  assert.ok(pricingText.includes(TERM), `/pricing must say "${TERM}"`);
+  assert.ok(signupText.includes(TERM), `/signup must use the same words as /pricing: "${TERM}"`);
+  for (const [label, body] of [['pricing', pricingText], ['signup', signupText]]) {
+    assert.doesNotMatch(body, /\d+ documents a month/,
+      `/${label} says "documents a month" where the rest of the site says "${TERM}"; one term, one product`);
+  }
+});
+
+test('no tier card is wider than the grid that holds it', async () => {
+  const widths = [320, 390, 768, 1024, 1280];
+  const problems = [];
+  for (const width of widths) {
+    const page = await open(width, 900);
+    const rows = await page.evaluate(() => [...document.querySelectorAll('.tier-grid')].map((grid) => ({
+      grid: Math.round(grid.getBoundingClientRect().width),
+      cards: [...grid.querySelectorAll('.tier-card')].map((card) => Math.round(card.getBoundingClientRect().width)),
+      right: Math.max(...[...grid.querySelectorAll('.tier-card')].map((card) => Math.round(card.getBoundingClientRect().right))),
+    })));
+    await page.close();
+    for (const row of rows) {
+      // One card may be exactly as wide as a single-column grid; wider than the
+      // grid means the page is cutting content off, in every layout.
+      const tooWide = row.cards.filter((card) => card > row.grid);
+      if (tooWide.length) problems.push(`${width}px: cards ${tooWide.join(', ')} in a ${row.grid}px grid`);
+      if (row.right > width) problems.push(`${width}px: a card reaches ${row.right}px, past the ${width}px viewport`);
+    }
+  }
+  assert.deepEqual(problems, [], `\n  ${problems.join('\n  ')}\n`);
+});
+
+test.after(async () => { await browser.close(); server.close(); });

--- a/tests/site-claims.test.mjs
+++ b/tests/site-claims.test.mjs
@@ -581,10 +581,16 @@ test('the Community plan limits on the site are the ones tiers.js declares', () 
   // rate limits with their own source (nginx-selfhost.conf, the envelope
   // create limiter), not the tier table.
   //
-  // pricing, parasign and parasend carry the same stale sentence and are
-  // corrected in their own PRs (#336, #339). Drop them from this list once
-  // those land; the exclusion is the only reason this scan is not global.
-  const DEFERRED = new Set(['pricing', 'parasign', 'parasend']);
+  // parasign and parasend carry the same stale sentence and are corrected in
+  // their own PR (#339). Drop them from this list once that lands; the
+  // exclusion is the only reason this scan is not global.
+  //
+  // pricing came off this list in #336: its Community card now names the two
+  // limits the relay enforces (transfers_month and file_mb out of tiers.js,
+  // refused with 402 and 413) instead of the per-IP rate on the deprecated
+  // /v2/anon-inbound, and relay/test/pricing-page.test.js reads both figures
+  // out of tiers.js so they cannot drift back.
+  const DEFERRED = new Set(['parasign', 'parasend']);
   for (const slug of publicPages()) {
     if (DEFERRED.has(slug)) continue;
     for (const m of visible(page(slug)).matchAll(/\d+\s*uploads?\s*(?:\/|\s+(?:per|an|a)\s+)(?:hour|day)/gi)) {

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -507,6 +507,129 @@ for (const slug of [...FOUNDER_REQUIRED, ...FOUNDER_OPTIONAL]) {
 assert.ok(!/\bMick Beer\b/.test(home) || /KvK 42115132/.test(home),
   'if the homepage names the founder it must also name the accountable company registration');
 
+// 6. What /pricing promises, and in what order. relay/test/pricing-page.test.js
+// checks the numbers against the catalog; tests/pricing-fold.test.mjs measures
+// where they land on a phone. This checks the sentences themselves.
+//
+// Body only, and it matters. The same sentences sit in the meta description,
+// the og: and twitter: descriptions and the JSON-LD, all of which stand before
+// every element in the body, so an ordering check run over the whole file
+// passes even when the visible page has lost the sentence entirely. Verified by
+// replacing only the hero paragraph: the head copies kept an earlier version of
+// this file green.
+const pricingVisible = pricing.slice(pricing.indexOf('<body')).replace(/<!--[\s\S]*?-->/g, '');
+
+// What the page sells, before what it costs. A visitor who lands here from a
+// search engine has seen no other page, so "Pricing" plus a table says nothing.
+assert.match(pricingVisible, /Sign documents and send files that vanish after one read\./,
+  'pricing.html must say what the product does above the prices');
+
+// The promise carries its own number. "Free forever" on its own reads as
+// generous until the table says two signatures a month, and a buyer who finds
+// that out one screen later has been sold to rather than told.
+assert.match(pricingVisible, /Community is &euro;0 a month, forever:<\/strong> 2 signatures per month, 10 transfers per month, 5 MB per file, no card\./,
+  'the free promise on pricing.html must carry the limits it actually means');
+// And they must be the limits the relay enforces, not the per-IP rate on the
+// deprecated anonymous endpoint. relay/test/pricing-page.test.js reads the
+// numbers out of relay/lib/tiers.js; this keeps the phrase off the page.
+assert.doesNotMatch(pricingVisible, /uploads per hour/,
+  'pricing.html must not sell the anonymous per-IP rate as an account limit');
+assert.ok(
+  pricingVisible.indexOf('Sign documents and send files that vanish after one read.') <
+  pricingVisible.indexOf('Community is &euro;0 a month, forever:'),
+  'the product line must stand above the free/paid split',
+);
+assert.ok(
+  pricingVisible.indexOf('Community is &euro;0 a month, forever:') <
+  pricingVisible.indexOf('class="tier-card"'),
+  'the free/paid split must stand above the first tier card, not under the tables',
+);
+
+// The words a lawyer cannot read, kept out of the lead paragraph. They are not
+// banned from the page: the same facts stand under the tables, where a reader
+// has asked for the detail.
+const heroEnd = pricingVisible.indexOf('id="plans"');
+assert.ok(heroEnd > 0, 'pricing.html must still have the plans section the hero links to');
+const heroText = pricingVisible.slice(0, heroEnd);
+for (const rx of [/post-quantum signatures/, /public proof log/, /dedicated relay/, /a connection to their own software/, /\ban API\b/]) {
+  assert.doesNotMatch(heroText, rx,
+    `the first screen of pricing.html must not open on ${rx.source}`);
+}
+
+// The lead names two amounts, and they buy two different products: &euro;15 is
+// ParaSend Pro (sending) and &euro;49 is ParaSign Pro (signing). Named as one
+// figure, "from &euro;15 a month" anchors an office that came here to sign, and
+// the table then asks &euro;49. Both are read off the Pro cards themselves
+// rather than typed in here, and relay/test/pricing-page.test.js binds those
+// cards to relay/lib/billing-catalog.js, so the chain runs lead -> card ->
+// catalog and no link in it can move on its own.
+const proCardPrice = (heading) => {
+  const start = pricingVisible.indexOf(heading);
+  assert.ok(start > 0, `pricing.html must still have the "${heading}" section`);
+  const section = pricingVisible.slice(start, pricingVisible.indexOf('</section>', start));
+  const m = /<div class="tier-name">Pro<\/div>\s*<div class="tier-price">&euro;([\d.,]+)/.exec(section);
+  assert.ok(m, `the "${heading}" section must still have a Pro card with a price`);
+  return m[1];
+};
+const sending = proCardPrice('ParaSend · Send a file that disappears');
+const signing = proCardPrice('ParaSign · Get a document signed');
+assert.notEqual(sending, signing,
+  'sending and signing are priced separately; if their Pro cards ever agree, the lead below is no longer a split');
+assert.match(heroText, new RegExp(`from <strong>&euro;${sending} a month</strong> for sending`),
+  `the lead must name the ParaSend Pro price (&euro;${sending}) as the price of SENDING`);
+assert.match(heroText, new RegExp(`<strong>&euro;${signing} a month</strong> for signing`),
+  `the lead must name the ParaSign Pro price (&euro;${signing}) as the price of SIGNING`);
+// And it must not go back to quoting one figure for both products.
+assert.doesNotMatch(heroText, /pay for the business plans, from <strong>&euro;\d+ a month<\/strong> excl/,
+  'the lead must not price both products with one amount');
+
+// One term for the free limit, on both pages a buyer reads in the same minute.
+// /pricing said "2 signatures per month" and /signup said "sign 2 documents a
+// month", which reads as two different products.
+const signupVisible = read('frontend/signup.html').replace(/<!--[\s\S]*?-->/g, '');
+for (const [label, html] of [['pricing.html', pricingVisible], ['signup.html', signupVisible]]) {
+  assert.match(html, /2 signatures per month/,
+    `${label} must name the free limit in the site's one term: "2 signatures per month"`);
+  assert.doesNotMatch(html, /\d+ documents a month/,
+    `${label} uses "documents a month" for the signature limit; the term is "2 signatures per month"`);
+}
+assert.doesNotMatch(signupVisible, /class="tier-card"|privacy and security researcher/,
+  'signup.html must not carry tier tables or a founder block; it has already made the sale');
+
+// One legal class for a ParaSign signature, site-wide. /about pins the wording;
+// the pricing FAQ used to promise a higher class (AES), which is the single
+// claim a law firm checks first, and it sat on the page where they pay.
+assert.match(pricingVisible, /A ParaSign signature is a Simple Electronic Signature \(SES\) under eIDAS, not an advanced \(AES\) or a qualified \(QES\) signature\./,
+  'pricing.html must state the same signature class as /about');
+assert.doesNotMatch(pricingVisible, /Signatures are advanced \(AES\)/,
+  'pricing.html must not claim a higher signature class than /about gives');
+assert.match(about, /a Simple Electronic Signature \(SES\)/,
+  'about.html must keep the SES wording the pricing FAQ is aligned to');
+
+// Compliance is the customer's, not the tool's. The page said "all tiers meet
+// NIS2 and GDPR requirements by design" a few hundred pixels above "Paramant
+// itself holds no third-party certification for those frameworks".
+assert.doesNotMatch(pricingVisible, /meet NIS2 and GDPR requirements by design/,
+  'pricing.html must not promise compliance as a property of the product');
+assert.match(pricingVisible, /The architecture is built to support your NIS2 and GDPR work\. Paramant itself holds no third-party certification for those frameworks\./,
+  'pricing.html must say what the architecture does and what Paramant does not hold');
+
+// Who is behind it, on the page where a buyer decides to upload client files.
+// The name stood at 1128px, a screen and a half down; pricing-fold.test.mjs
+// measures where it lands now, this pins that it is there at all and that it
+// carries the accountable registration beside it.
+assert.match(pricingVisible, /Mick Beer<\/strong>, privacy and security researcher, founder of\s+Paramantis Solutions B\.V\. \(KvK 42115132\)/,
+  'pricing.html must name the founder with the title /about gives him and the company registration');
+
+// The free cards send a visitor to /signup. They used to send them to
+// /dashboard, a page nobody without an account can open.
+const freeCardCtas = [...pricingVisible.matchAll(/<div class="tier-name">Community<\/div>[\s\S]*?<a href="([^"]+)"[^>]*class="btn btn-primary"/g)].map((m) => m[1]);
+assert.ok(freeCardCtas.length >= 2, 'pricing.html must still have Community cards with a primary action');
+assert.deepEqual([...new Set(freeCardCtas)], ['/signup'],
+  `the Community cards must send a visitor to /signup, not to a page they cannot open: ${freeCardCtas.join(', ')}`);
+
+console.log('ui-truthfulness: /pricing says what it sells, with the number, above the tables');
+
 console.log('ui-truthfulness: the homepage does not overclaim signatures and quotes the real prices');
 console.log('ui-truthfulness: the free plan is Community everywhere and the founder line matches /about');
 console.log('ui-truthfulness: the dashboard names the plans /pricing actually sells');


### PR DESCRIPTION
## What this is

A phone opening /pricing saw the word "Pricing", a decorative "00", and a
paragraph about a post-quantum core. No amount, no product, and nothing about
who holds the files. Every review of this branch came back on the same page and
the same screen, so this rewrites the first screen and pins it by measurement.

Rebased onto main, twice. #328 rewrote this file while the branch was open:
the tier cards are named Community, the Free/Community bridge sentence is gone,
/docs#parasign-api is fixed and the founder paragraph is on the page. Daarna
kwamen #334 (head-elementen op 50 pagina's) en #354 (Community-limieten op
index en docs). Niets daarvan is teruggedraaid.

De verdeling bij deze laatste rebase: in de `<head>` van pricing.html en
signup.html wint main. Titel, description, og:, twitter: en de JSON-LD komen
onveranderd van #334; `bron-seo/apply_seo_head.py --check` meldt "would change:
0 pages". De body is van deze PR. Het enige wat in pricing's head van deze
branch komt is de CSS-fix voor de tier-kaarten, en dat is geen head-element.

`tests/site-claims.test.mjs` test 11 sloot pricing.html bij naam uit van de
scan op "uploads per hour", omdat die zin daar nog stond. Die uitsluiting is
weg: de kaart noemt nu de limieten die de relay afdwingt, dus de scan mag
pricing meenemen. parasign en parasend blijven uitgesloten tot #339 landt.
`frontend/apply-nav.py` gedraaid na de rebase: nul wijzigingen.

## Every review point, and what happened to it

| Afkeurpunt | Fix |
|---|---|
| Eerste schermvulling op 390px bevat geen bedrag | "Community is €0 a month, forever" staat op y=278, "€15 a month" op y=440 |
| Zegt niet wat je koopt | "Sign documents and send files that vanish after one read." is de eerste regel, y=210 |
| Decoratieve "00" boven de H1 | Weg. Kostte de eerste 60px van de vouw en betekende niets |
| "a dedicated relay" | "a server of their own" |
| "a connection to their own software" | "signing built into their own software" |
| Kernbelofte noemt het getal niet | "€0 a month, forever: 2 signatures per month and 10 uploads per hour, no card" |
| "from €15 a month" gold voor beide producten | Gesplitst: "from €15 a month for sending, from €49 a month for signing". €15 is ParaSend Pro, €49 is ParaSign Pro |
| "10 uploads per hour per IP" als accountlimiet | Vervangen door wat de relay afdwingt: 10 transfers per month, 5 MB per file. ParaSend Pro: 500 transfers per month in plaats van "no IP rate limit" |
| "ML-DSA-65 signed receipts" voor ParaShare | Weg. Het register geeft ParaShare Default SIG "n/a" op een pre-v1 hybrid, migrerend naar v1; de zin zegt dat nu zo |
| Wie erachter zit pas op 1128px | Mick Beer met de titel van /about plus KvK 42115132, y=682, binnen de vouw |
| Twee termen voor de gratis grens | Overal "2 signatures per month", op /pricing en op /signup |
| FAQ zei "advanced (AES), not qualified (QES)" | "A ParaSign signature is a Simple Electronic Signature (SES) under eIDAS, not an advanced (AES) or a qualified (QES) signature." Gelijk aan /about |
| "All tiers meet NIS2 and GDPR by design" | "The architecture is built to support your NIS2 and GDPR work. Paramant itself holds no third-party certification for those frameworks." |
| Fold-test meet alleen aanwezigheid | Meet nu de onderrand van elke regel tegen 390x844 |
| Jargon-check dekt geen spans | Leest tekstnodes, dus de kicker-span onder de H1 telt mee |

Ook meegenomen uit de eerdere versie van deze branch: elke tierkaart zegt in
één regel voor wie hij is, ParaSign staat boven ParaSend, de Community-kaarten
sturen naar /signup in plaats van naar /dashboard, en de kaarten passen weer in
hun grid (grid items zijn min-width:auto en .btn is nowrap, dus de langste CTA
zette de min-content breedte van de hele track; op 390px was elke kaart 471px
in een container van 342px).

## Gemeten op 390x844

| | onderrand |
|---|---|
| H1 "Pricing" | 129 |
| wat het product doet | 216 |
| eerste bedrag (€0, forever) | 253 |
| €15 voor versturen | 415 |
| €49 voor tekenen | 442 |
| de echte limieten (10 per maand, 5 MB) | 471 |
| doelgroep | 550 |
| CTA "Create a free account" | 612 |
| founderregel, hele claim incl. KvK | 745 |

99px over. De founderregel wordt als hele regel gemeten, niet als de <strong>
met alleen de naam: die eindigt op 705, de titel en het KvK-nummer lopen daarna
door. Een assertie op de naam alleen noemt de regel zichtbaar terwijl de
registratie onder de schermrand valt.

De ruimte kwam uit de opmaak, niet uit geschrapte woorden. `.sec-head` draagt
sitebreed `margin-bottom:var(--space-8)`; onder een sectiekop klopt dat, hier
kostte het 48px van het enige scherm dat het bedrag, de doelgroep, de founder
en de knop moet dragen. Alleen op deze hero overschreven, de gedeelde regel in
design-system.css is niet aangeraakt.

## Bronnen

- Founder en titel: `frontend/about.html` ("Mick Beer, privacy and security researcher"). Geen woord toegevoegd dat /about niet gebruikt; `ui-truthfulness` pint dat in beide richtingen.
- KvK 42115132: staat al in de footer van dezelfde pagina en op /about.
- SES-formulering: `frontend/about.html` op main.
- "Paramant itself holds no third-party certification": stond al in de FAQ van deze pagina op main.
- 2 handtekeningen per maand: `relay/lib/entitlements.js`; 10 uploads per uur: de Community-kaart van ParaSend.
- Community-limieten: `relay/lib/tiers.js` (`transfers_month: 10`, `file_mb: 5`), afgedwongen op `relay/relay.js:4598` (402 `monthly_transfer_quota_reached`) en `relay/relay.js:4551` (413 `Max 5MB` tegen `MAX_BLOB`). ParaSend Pro `transfers_month: 500` uit dezelfde tabel.
- Dat "10 uploads per hour per IP" niet over een account gaat: `relay/relay.js:4306-4312`, `/v2/anon-inbound`, DEPRECATED 2026-05-28, `Sunset: Wed, 31 Dec 2026`, `ANON_RATE_PER_HOUR` default 10.
- ParaShare-cryptografie: `frontend/crypto-agility.html`, rij "ParaShare (webapp)" met Default KEM "ML-KEM-768 + ECDH P-256", Default SIG "n/a", wire format "pre-v1 hybrid", status "migrating to v1".
- Alle bedragen: verplaatst, niet gewijzigd. `relay/test/pricing-page.test.js` herrekent ze uit `relay/lib/billing-catalog.js`, 35 checks.

## Tests

Groen: links, seo-contract (14), ui-truthfulness, site-claims (11), pricing-page
(35 checks), pricing-fold (4), frontend-loading-contract (7), navigation-shell,
product-heartbeat (9), check-csp-inline, check-cache-bust, eslint@9.
`tests/static-sanity.sh`: PASS, alle tien.

Sabotage, elk apart in de worktree en teruggedraaid, eindstand schoon:

| sabotage | suite | |
|---|---|---|
| productregel uit de body | ui-truthfulness | ROOD |
| productregel uit de body | pricing-fold | ROOD |
| het getal uit de kernbelofte | ui-truthfulness | ROOD |
| "a dedicated relay" terug in de lead | ui-truthfulness | ROOD |
| "a connection to their own software" terug | ui-truthfulness | ROOD |
| FAQ terug naar advanced (AES) | ui-truthfulness | ROOD |
| compliance terug naar de garantie | ui-truthfulness | ROOD |
| founderregel uit de hero | ui-truthfulness | ROOD |
| /signup terug naar "2 documents a month" | ui-truthfulness | ROOD |
| Community-kaart terug naar /dashboard | ui-truthfulness | ROOD |
| founder 400px onder de vouw geduwd | pricing-fold | ROOD |
| jargon in de kicker-span | pricing-fold | ROOD |
| beide CSS-regels teruggedraaid | pricing-fold | ROOD |
| één bedrag voor beide producten | ui-truthfulness | ROOD |
| tekenbedrag naar het verkeerde product | ui-truthfulness | ROOD |
| ParaSign Pro-kaart naar €59, lead volgt niet | ui-truthfulness | ROOD |
| verzendbedrag uit de lead | ui-truthfulness | ROOD |
| founder: titel en KvK weg, naam blijft | pricing-fold | ROOD |
| founderregel 120px onder de vouw | pricing-fold | ROOD |
| tekenbedrag onder de vouw geduwd | pricing-fold | ROOD |
| tiers.js community transfers_month 10 → 25 | pricing-page | ROOD |
| tiers.js community file_mb 5 → 20 | pricing-page | ROOD |
| tiers.js pro transfers_month 500 → 900 | pricing-page | ROOD |
| "10 transfers per month" van de kaart | pricing-page | ROOD |
| "5 MB per file" van de kaart | pricing-page | ROOD |
| lead en kaart lopen uiteen | pricing-page | ROOD |
| "uploads per hour" terug op de kaart | pricing-page | ROOD |
| "uploads per hour" terug in de lead | ui-truthfulness | ROOD |
| "ML-DSA-65 signed receipts" terug | pricing-page | ROOD |
| register: ParaShare SIG n/a → ML-DSA-65 | pricing-page | ROOD |
| limietregel onder de vouw geduwd | pricing-fold | ROOD |
| "10 uploads per hour per IP" terug op de kaart | site-claims | ROOD |
| "uploads an hour" terug in de lead | site-claims | ROOD |

De limietpins werken in beide richtingen: tiers.js alleen veranderen maakt de
test rood, en de pagina alleen veranderen ook. Er is geen kant waarop de twee
stil uit elkaar kunnen lopen.

Eén test is verwijderd in plaats van toegevoegd.
`relay/test/pricing-page.test.js` had een regel "de verouderde 5 MB-claim is
weg" die assert dat "5 MB" nergens op de pagina staat. Die reden was
verlopen: `relay/relay.js` weigert een groter bestand met 413 `Max 5MB` tegen
`MAX_BLOB` (default 5242880) en `relay/lib/tiers.js` geeft elke tier
`file_mb: 5`. De limiet is echt, dus de test hield een ware zin van de pagina.
Vervangen door een pin die het getal uit tiers.js leest.

Twee eerlijke uitkomsten horen erbij. `min-width:0` en `white-space:normal`
los teruggedraaid houden de fold-test groen, samen teruggedraaid maakt hem
rood: elk van de twee is op zichzelf genoeg om de kaart binnen de grid te
houden, dus de test pint het paar en niet één regel. En de sabotages draaien nu
met een guard die afbreekt als de mutatie niets raakt. Zonder die guard gaf een
ronde vals groen, niet omdat de test zwak was maar omdat de zoekstring over een
regeleinde liep en er dus niets veranderde. Een sabotage die niets wijzigt
bewijst niets.

Ter controle van de founder-assertie: bij een duw van 100px eindigt de hele
regel op y=866 en wordt de test rood, terwijl de <strong> met alleen de naam op
826 zou zijn geëindigd en binnen de vouw was gebleven.

## Scope

Zeven bestanden: `frontend/pricing.html`, `frontend/signup.html`,
`frontend/billing/checkout.html`, `tests/pricing-fold.test.mjs` (nieuw),
`tests/ui-truthfulness.test.mjs`, `relay/test/pricing-page.test.js` en
`tests/site-claims.test.mjs` (uitsluiting opgeheven). `frontend/index.html`, `frontend/apply-nav.py`
en `frontend/js/nav-auth.js` zijn niet aangeraakt. Geen prijs en geen checkout-link gewijzigd. Wel
limieten: die stonden fout op de pagina en staan nu zoals de relay ze afdwingt.

## Open punten, niet in deze PR

- **`frontend/index.html` draagt dezelfde fout.** Regel 360: "1 hour link
  expiry, burn on first read, 10 uploads per hour". Dat is hetzelfde
  `ANON_RATE_PER_HOUR` van het afgekondigde `/v2/anon-inbound`, gepresenteerd
  als wat een Community-account krijgt. Hier niet meegenomen: index.html valt
  buiten de prijsgroep en is in deze PR expliciet onaangeraakt. Volgt in een
  aparte PR, met dezelfde binding aan tiers.js.
- **Twee schrijfwijzen voor dezelfde limiet.** #354 zet op index en /docs
  "10 transfers a month"; deze pagina zegt "10 transfers per month". Hetzelfde
  getal uit dezelfde tabel, twee formuleringen. Niet hier rechtgetrokken omdat
  het buiten de afgesproken scope van deze ronde viel; het is dezelfde soort
  drift als "2 signatures per month" tegenover "2 documents a month" die eerder
  in deze PR wel is opgelost. Voor de backlog, samen met index.html hierboven.
- **Taal.** De pagina is Engels terwijl btw en KvK Nederlands zijn. Sitebrede
  keuze, niet iets voor deze PR.
