### PR TITLE
Give ParaSend a product page and put the buyer's questions first on ParaSign

### DIFF
--- a/bron-seo/apply_seo_head.py
+++ b/bron-seo/apply_seo_head.py
@@ -41,7 +41,7 @@ PRIVATE = {
 # SoftwareApplication; the rest stay WebPage. Claiming SoftwareApplication on a
 # policy page is the kind of over-tagging that gets structured data ignored.
 SOFTWARE = {
-    "index", "parashare", "parasign", "sign", "verify", "vault", "download",
+    "index", "parasend", "parasign", "parashare", "sign", "verify", "vault", "download",
     "co-sign"}
 
 # Where a page ships a SoftwareApplication node that is more specific than the

--- a/bron-seo/build_sitemap.py
+++ b/bron-seo/build_sitemap.py
@@ -33,7 +33,7 @@ PRIVATE = {
 # Crawl priority. Not a ranking factor, but it tells a crawler where to spend
 # its budget on a 60-page site: the product and the money pages first.
 PRIORITY = [
-    (0.9, {"index", "pricing", "parasign", "sign", "verify", "vault", "download"}),
+    (0.9, {"index", "pricing", "parasend", "parasign", "sign", "verify", "vault", "download"}),
     (0.8, {"security", "trust", "architecture", "docs", "vs", "about"}),
 ]
 DEFAULT_PRIORITY = 0.6

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -111,7 +111,7 @@
       "@type": "WebPage",
       "@id": "https://paramant.app/parasend#webpage",
       "url": "https://paramant.app/parasend",
-      "name": "ParaSend - Encrypted file transfer by Paramant",
+      "name": "ParaSend · Encrypted file transfer by Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -131,6 +131,35 @@
       "publisher": {
         "@id": "https://paramant.app/#organization"
       }
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://paramant.app/#organization",
+      "name": "Paramant",
+      "legalName": "Paramantis Solutions B.V.",
+      "url": "https://paramant.app/",
+      "description": "Document signing and encrypted file transfer for professional firms in the EU. Dutch company, servers in Germany.",
+      "founder": {
+        "@type": "Person",
+        "name": "Mick Beer",
+        "jobTitle": "Privacy and security researcher"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Harderwijk",
+        "addressCountry": "NL"
+      },
+      "identifier": {
+        "@type": "PropertyValue",
+        "name": "KvK",
+        "value": "42115132"
+      },
+      "email": "privacy@paramant.app",
+      "areaServed": "EU",
+      "knowsLanguage": [
+        "nl",
+        "en"
+      ]
     }
   ]
 }

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -1,0 +1,423 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>ParaSend &middot; Encrypted file transfer by Paramant</title>
+<meta property="og:site_name" content="Paramant">
+<meta name="description" content="Send a file that is scrambled on your device and gone once it has been downloaded. Never stored on disk, servers in Germany. Free for everyone, paid for volume.">
+<meta property="og:title" content="ParaSend &middot; Encrypted file transfer by Paramant">
+<meta property="og:description" content="Send a file that is scrambled on your device and gone once it has been downloaded. Never stored on disk, servers in Germany. Free for everyone, paid for volume.">
+<meta property="og:url" content="https://paramant.app/parasend">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://paramant.app/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="ParaSend &middot; Encrypted file transfer by Paramant">
+<meta name="twitter:description" content="Send a file that is scrambled on your device and gone once it has been downloaded. Never stored on disk, servers in Germany. Free for everyone, paid for volume.">
+<link rel="canonical" href="https://paramant.app/parasend">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="manifest" href="/manifest.json">
+<meta name="theme-color" content="#0B3A6A">
+
+<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<style>
+.ps-hero{padding:var(--space-10) 0 var(--space-6)}
+.ps-band{padding:var(--space-8) 0;border-top:1px solid var(--ink-hair)}
+.ps-band h2{font-size:var(--text-2xl);letter-spacing:-.02em;margin-bottom:var(--space-2)}
+.mono-eyebrow{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)}
+.ps-lede{font-size:var(--text-md);color:var(--ink);line-height:1.7;max-width:680px;margin-top:var(--space-4)}
+.ps-band p{font-size:var(--text-base);color:var(--ink);line-height:1.8;max-width:680px;margin-top:var(--space-4)}
+.ps-band p a,.ps-band li a{color:var(--cobalt)}
+.ps-band p strong{color:var(--navy)}
+.ps-actions{display:flex;gap:var(--space-3);flex-wrap:wrap;margin-top:var(--space-6)}
+.ps-actions .btn{flex:1 1 auto;text-align:center}
+.ps-sub{font-size:var(--text-sm);color:var(--ink-dim);line-height:1.7;max-width:680px;margin-top:var(--space-4)}
+.ps-sub a{color:var(--cobalt)}
+.ps-who{font-size:var(--text-base);color:var(--navy);font-weight:700;line-height:1.7;max-width:680px;margin-top:var(--space-3)}
+.ps-note{font-size:var(--text-sm);color:var(--ink);line-height:1.7;max-width:680px;margin-top:var(--space-4);border-left:3px solid var(--lime);background:var(--bone);padding:var(--space-3) var(--space-4)}
+.ps-note a{color:var(--cobalt)}
+.split-label{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.14em;text-transform:uppercase;color:var(--navy);font-weight:700;margin-top:var(--space-6);display:block}
+.split-label .who{color:var(--ink-dim);font-weight:400;letter-spacing:.06em;text-transform:none}
+.check-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1px;background:var(--ink-hair);border:1px solid var(--ink-hair);margin-top:var(--space-5)}
+.check-card{background:var(--bone);padding:var(--space-5) var(--space-5)}
+.check-card .k{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.14em;text-transform:uppercase;color:var(--cobalt);font-weight:700}
+.check-card p{margin-top:var(--space-2);font-size:var(--text-sm);color:var(--ink);line-height:1.65;max-width:none}
+.check-card a{color:var(--cobalt)}
+.tier-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--ink-hair);border:1px solid var(--ink-hair);margin-top:var(--space-3)}
+.tier-grid.one{grid-template-columns:1fr;max-width:420px}
+.tier-card{background:var(--bone);padding:var(--space-5);display:flex;flex-direction:column}
+.tier-card.featured{background:var(--lime)}
+.tier-name{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;font-weight:700;color:var(--cobalt)}
+.tier-price{font-family:var(--mono);font-size:var(--text-2xl);font-weight:700;color:var(--navy);margin-top:var(--space-2)}
+.tier-price span{font-size:var(--text-sm);color:var(--ink-dim);font-weight:400}
+.tier-note{font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-1);line-height:1.5}
+.tier-note .incl{color:var(--navy);font-weight:700}
+.tier-card ul{list-style:none;margin:var(--space-4) 0 0;padding:0}
+.tier-card li{font-family:var(--mono);font-size:var(--text-xs);color:var(--navy);padding:var(--space-2) 0;border-bottom:1px solid var(--ink-hair);line-height:1.5}
+.tier-card li:last-child{border-bottom:none}
+.tier-card li::before{content:'+ ';font-weight:700;color:var(--cobalt)}
+.ps-fine{font-family:var(--mono);font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-4);max-width:none}
+.ps-steps{list-style:none;counter-reset:step;margin-top:var(--space-5);padding:0;max-width:680px}
+.ps-steps li{counter-increment:step;position:relative;padding:var(--space-4) 0 var(--space-4) var(--space-8);border-top:1px solid var(--ink-hair);font-size:var(--text-base);color:var(--ink);line-height:1.7}
+.ps-steps li:last-child{border-bottom:1px solid var(--ink-hair)}
+.ps-steps li::before{content:counter(step,decimal-leading-zero);position:absolute;left:0;top:var(--space-4);font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.14em;font-weight:700;color:var(--cobalt)}
+.ps-steps strong{color:var(--navy)}
+.scope-note{background:var(--bone);border:1px solid var(--ink-hair);border-left:3px solid var(--lime);padding:var(--space-4) var(--space-5);margin-top:var(--space-5);max-width:680px}
+.scope-note p{margin-top:0}
+.scope-note p + p{margin-top:var(--space-4)}
+.person-card{border:1px solid var(--ink-hair);border-left:3px solid var(--cobalt);background:var(--bone);padding:var(--space-6);margin-top:var(--space-5);max-width:680px}
+.person-card p{margin-top:0}
+.person-card p + p{margin-top:var(--space-4)}
+.dev-line{font-size:var(--text-sm);color:var(--ink-dim);line-height:1.8;max-width:680px;margin-top:var(--space-4)}
+.dev-line a{color:var(--cobalt)}
+@media(max-width:860px){.tier-grid{grid-template-columns:1fr}}
+@media(max-width:640px){
+  .check-grid{grid-template-columns:1fr}
+  .ps-actions .btn{flex:1 1 100%}
+  /* The shared .sec-head is a three-column grid (number, heading, eyebrow). At
+     390px that leaves the h1 about half the screen and drops it below a very
+     large number, so the first thing a visitor reads is set in a column six
+     words wide. Stacked here, on this page only; the desktop layout and the
+     house style are untouched. */
+  .ps-hero{padding:var(--space-6) 0 var(--space-5)}
+  .ps-hero .sec-head{grid-template-columns:1fr;row-gap:var(--space-2);align-items:start;margin-bottom:var(--space-5);padding-bottom:var(--space-3)}
+  .ps-hero .sec-head .num{font-size:var(--text-lg);line-height:1}
+  .ps-hero .sec-head h1.paramant-h2{font-size:var(--text-2xl)}
+  .ps-lede{font-size:var(--text-base)}
+}
+/* Mobile is the design target and the house .sec-head is not, at this width:
+   it keeps the section number in its own grid column, which leaves the H1 about
+   160px to wrap in. On /parasign that cost six lines of headline and pushed the
+   buttons and the eIDAS note clean off the first screen. On a narrow screen the
+   number stacks above the headline instead of standing beside it. Page-local on
+   purpose: design-system.css is shared with pages this PR does not touch. */
+@media(max-width:640px){
+  .ps-hero{padding-top:var(--space-6)}
+  #main-content .sec-head{grid-template-columns:1fr;row-gap:var(--space-2)}
+  #main-content .sec-head .num{font-size:var(--text-xl);line-height:1}
+}
+</style>
+<script type="application/ld+json" data-paramant-seo="1">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": "https://paramant.app/parasend#webpage",
+      "url": "https://paramant.app/parasend",
+      "name": "ParaSend - Encrypted file transfer by Paramant",
+      "isPartOf": {
+        "@id": "https://paramant.app/#website"
+      },
+      "publisher": {
+        "@id": "https://paramant.app/#organization"
+      },
+      "inLanguage": "en",
+      "description": "Send a file that is scrambled on your device and gone once it has been downloaded. Never stored on disk, servers in Germany. Free for everyone, paid for volume."
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://paramant.app/parasend#software",
+      "name": "Paramant",
+      "applicationCategory": "SecurityApplication",
+      "operatingSystem": "Web browser",
+      "url": "https://paramant.app/parasend",
+      "publisher": {
+        "@id": "https://paramant.app/#organization"
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+
+<div class="meta-bar">
+  <span class="">build 3.0.0</span>
+  <span class="sep">·</span>
+  <span class="">aes-256-gcm / <a href="/crypto-agility" class="meta-link">post-quantum</a></span>
+  <span class="sep">·</span>
+  <span class="">eu/de · ram only</span>
+</div>
+<nav class="nav">
+  <a href="/" class="nav-logo"><span class="logo-para">Para</span><span class="logo-mant">MANT</span></a>
+
+  <ul class="nav-links">
+    <li><a href="/#products" class="nav-link">Product</a></li>
+    <li><a href="/security" class="nav-link">Security</a></li>
+    <li><a href="/pricing" class="nav-link">Pricing</a></li>
+    <li><a href="/docs" class="nav-link">Docs</a></li>
+  </ul>
+
+  <div class="nav-auth" id="nav-auth">
+    <a href="/help" class="nav-help">HELP</a>
+    <a href="/auth/login" class="nav-signin">Sign in</a>
+    <a href="/signup" class="nav-cta">Create account</a>
+  </div>
+
+  <button class="nav-hamburger" id="nav-hamburger" aria-label="Open menu" aria-expanded="false">
+    <span></span><span></span><span></span>
+  </button>
+</nav>
+<div class="nav-mobile" id="nav-mobile">
+  <a href="/#products" class="nav-mobile-standalone">Product</a>
+  <a href="/security" class="nav-mobile-standalone">Security</a>
+  <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
+  <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+
+
+
+<!-- HERO: what you can do here, who it is for, and one action. The buyer meets
+     a promise in plain words first; the algorithm names live in section 06. -->
+<section class="ps-hero" id="main-content" tabindex="-1">
+  <div class="container-md">
+    <div class="sec-head">
+      <span class="num">00</span>
+      <h1 class="paramant-h2">Send a file that burns after one read.</h1>
+      <span class="mono-eyebrow">ParaSend &middot; sending files without leaving a copy behind</span>
+    </div>
+    <p class="ps-lede">Your file is locked on your own device before it is sent, and it is gone the moment the person you sent it to has opened it. Servers in Germany, under EU law.</p>
+    <p class="ps-who">For offices that email client documents, contracts and personal data today, and would rather not leave them sitting in a mailbox.</p>
+    <div class="ps-actions">
+      <a href="/parashare" class="btn btn-primary">Send a file &rarr;</a>
+      <a href="/pricing" class="btn btn-secondary">See pricing &rarr;</a>
+    </div>
+    <p class="ps-sub">Free on the Community plan, forever, no card: links that last an hour, gone after one read, 10 uploads an hour. Organisations pay for volume, never for security.</p>
+    <p class="ps-note">Sending needs a free account. Receiving does not: the person you send to opens the link, gets the file once, and the copy is wiped. Keep your own copy, because a file that has been read cannot be fetched again.</p>
+  </div>
+</section>
+
+<!-- THE SPLIT: the one thing that has to be clear before anything else. Two
+     paragraphs here, both lifted from /pricing; the tier tables sit further
+     down, after the page has said what the product actually does. -->
+<section class="ps-band">
+  <div class="container-md">
+    <span class="mono-eyebrow">01 / Free for everyone</span>
+    <h2 style="margin-top:var(--space-2)">Free for everyone. Paid for organisations.</h2>
+    <p><strong>The Community plan is free, forever.</strong> It is not a trial and not a funnel. Businesses pay for the higher limits (longer links, more reads, more devices, a dedicated relay), not to unlock features, and that is what keeps the Community plan free.</p>
+    <p><strong>Every plan gets the same encryption, the same post-quantum signatures and the same public proof log. Pay for volume, never for security. And pay per organisation, not per user.</strong></p>
+    <p class="ps-sub">The plans and what each one costs are <a href="#plans">further down this page</a>. Checkout and the full comparison are on the <a href="/pricing">pricing page</a>.</p>
+  </div>
+</section>
+
+<!-- WHAT IT DOES -->
+<section class="ps-band">
+  <div class="container-md">
+    <span class="mono-eyebrow">02 / What it does</span>
+    <h2 style="margin-top:var(--space-2)">Scrambled here, unreadable in transit, gone after one read</h2>
+    <p>ParaSend is the transfer half of Paramant. It runs on the same post-quantum core as ParaSign. Your file is encrypted before it leaves your device, so our servers hold nothing they could hand over or lose.</p>
+    <div class="check-grid">
+      <div class="check-card">
+        <div class="k">Locked before it leaves you</div>
+        <p>Your browser locks the file on your own device. Our servers only ever hold the locked version, never the file itself and never the key that opens it.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Gone after one read</div>
+        <p>Nothing is written to disk. The file sits in server memory and is wiped the moment it is downloaded, or when the link runs out, whichever comes first.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">No account for receivers</div>
+        <p>The recipient opens the link, gets the file, and that is the whole flow. No account, nothing to install.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">A receipt the other side can check</div>
+        <p>The person you send to gets proof that the file came from you and was not changed on the way. ParaShare is the send screen you use; ParaSend is the product it belongs to.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Lock a file for yourself</div>
+        <p>No recipient, no account: <a href="/vault">lock a file</a> into a .prmnt container with a passphrase. The file and the passphrase never leave your browser.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Your own server, if you need one</div>
+        <p>A larger organisation can run its own instance, on our hardware or on its own, with its own limits. That is the Enterprise plan.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- HOW TO BEGIN -->
+<section class="ps-band">
+  <div class="container-md">
+    <span class="mono-eyebrow">03 / How to begin</span>
+    <h2 style="margin-top:var(--space-2)">Three steps to a file that disappears</h2>
+    <p>Sending needs a Paramant account. Receiving needs nothing at all.</p>
+    <ol class="ps-steps">
+      <li><strong><a href="/signup">Create a free account</a>.</strong> No card, no time limit. The free tier sends with a 1 hour link that burns on first read, forever.</li>
+      <li><strong><a href="/parashare">Open ParaShare</a>, the send screen of ParaSend, and pick your file.</strong> It is scrambled in your browser before anything is uploaded, so what our servers receive is unreadable, and they keep it in memory only.</li>
+      <li><strong>Share the link.</strong> The recipient opens it once and the file is wiped. On the free tier the link expires after an hour whether it is opened or not.</li>
+    </ol>
+  </div>
+</section>
+
+<!-- WHO IS BEHIND IT -->
+<section class="ps-band">
+  <div class="container-md">
+    <span class="mono-eyebrow">04 / Who is behind it</span>
+    <h2 style="margin-top:var(--space-2)">Built by a named person, in Harderwijk</h2>
+    <div class="person-card">
+      <p>Paramant is a product of <strong>Paramantis Solutions B.V.</strong> in Harderwijk, the Netherlands, founded by <strong>Mick Beer, privacy and security researcher</strong>. That background shapes the choices: post-quantum signatures, a public transparency log, offline-verifiable documents, and source code you can inspect yourself.</p>
+      <p>The Community plan is his way of giving something back to society; the business plans pay for it. Paramantis Solutions B.V. is the contracting and responsible party; the founder is the origin of the work, not the service itself.</p>
+      <p><a href="/about">More about Paramant &rarr;</a></p>
+    </div>
+  </div>
+</section>
+
+<!-- THE PLANS: the tier tables, after the product has been explained. -->
+<section class="ps-band" id="plans">
+  <div class="container-md">
+    <span class="mono-eyebrow">05 / The plans</span>
+    <h2 style="margin-top:var(--space-2)">What each plan gives you</h2>
+<span class="split-label">Free for everyone <span class="who">&middot; anyone with a browser</span></span>
+    <div class="tier-grid one">
+      <div class="tier-card featured">
+        <div class="tier-name">Community</div>
+        <div class="tier-price">&euro;0</div>
+        <div class="tier-note">Forever &middot; no card required</div>
+        <ul>
+          <li>Encrypted in your browser, key never sent</li>
+          <li>1 hour link expiry</li>
+          <li>Burn on first read</li>
+          <li>10 uploads per hour per IP</li>
+          <li>Up to 5 registered devices for ParaShare, the ParaSend send screen</li>
+        </ul>
+      </div>
+    </div>
+
+    <span class="split-label">For organisations <span class="who">&middot; the business plans</span></span>
+    <div class="tier-grid">
+      <div class="tier-card">
+        <div class="tier-name">Pro</div>
+        <div class="tier-price">&euro;15<span>/mo</span></div>
+        <div class="tier-note">excl. btw &middot; <span class="incl">charged &euro;18.15/mo incl. 21% btw</span><br>Annual &euro;150 excl. &middot; 16.7% off</div>
+        <ul>
+          <li>Everything in Community</li>
+          <li>24 hour link expiry</li>
+          <li>Up to 10 reads per link</li>
+          <li>Up to 50 registered devices</li>
+          <li>Send history and link management</li>
+          <li>Webhooks on upload and download</li>
+          <li>No IP rate limit</li>
+        </ul>
+      </div>
+      <div class="tier-card">
+        <div class="tier-name">Enterprise</div>
+        <div class="tier-price">Custom</div>
+        <div class="tier-note">Per organisation</div>
+        <ul>
+          <li>Everything in Pro</li>
+          <li>7 day link expiry</li>
+          <li>Up to 100 reads per link</li>
+          <li>Dedicated relay on our infra or yours</li>
+          <li>IEC 62443 / NIS2 / NEN 7510 documentation as input for your own compliance process, not third-party certification</li>
+          <li>Signed Data Processing Agreement (GDPR Art. 28)</li>
+          <li>SLA 99.95%, priority incident response</li>
+        </ul>
+      </div>
+    </div>
+    <p class="ps-fine">Every tier stores transfers in RAM and every tier uses the same cryptography. There is no lesser encryption at lower tiers. Cryptography is not a paywalled feature at Paramant.</p>
+    <p class="ps-fine">Prices shown excl. btw (VAT). Checkout charges incl. 21% btw: Pro &euro;18.15/mo or &euro;181.50/yr. Checkout and the full comparison are on the <a href="/pricing">pricing page</a>.</p>
+  </div>
+</section>
+
+<!-- THE PROOF, AND THE LIMITS -->
+<section class="ps-band">
+  <div class="container-md">
+    <span class="mono-eyebrow">06 / The proof</span>
+    <h2 style="margin-top:var(--space-2)">Every claim has a place to check it</h2>
+    <p>You should not have to trust us. You should be able to check. Each point below links to where you can.</p>
+    <div class="check-grid">
+      <div class="check-card">
+        <div class="k">We never had it</div>
+        <p>AES-256-GCM with a key your browser generates. The relay only ever holds fixed-size ciphertext, never the plaintext and never the key, and it holds it in RAM until the read burns it. The architecture is on the <a href="/security">security page</a>.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">The receipt, in full</div>
+        <p>Verified transfers via ParaShare use ML-KEM-768 plus ECDH P-256 hybrid key exchange with ML-DSA-65 signed receipts. The algorithm register is on the <a href="/crypto-agility">crypto agility page</a>.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">You own your keys</div>
+        <p>Generated on your device, never sent. We see only the public half. Read the <a href="/pararules">ParaRules</a>.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">EU soil, EU law</div>
+        <p>Hetzner Germany, Bunny DNS (Slovenia). No US provider in the data path. Email goes out via Resend, as <a href="/privacy">/privacy</a> sets out. The jurisdiction table is on the <a href="/security">security page</a>.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">No third-party requests</div>
+        <p>Your browser talks only to us. No fonts, CDNs, analytics or pixels. Open devtools and check.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Quantum-ready by default</div>
+        <p>FIPS 203/204 today, not &ldquo;soon&rdquo;. The algorithm register is on the <a href="/crypto-agility">crypto agility page</a>.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Dedicated relays, on the same rules</div>
+        <p>Enterprise customers run a dedicated relay on our infrastructure or their own, with limits configured per tenant within its RAM budget. The tiers are on the <a href="/pricing">pricing page</a>.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">Source-available code</div>
+        <p>The relay is source-available. Read it on <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a> and run it yourself.</p>
+      </div>
+    </div>
+    <div class="scope-note">
+      <p><strong>What the compliance documentation is.</strong> Architecture documents, security controls mappings and technical reference materials aligned to IEC 62443, NIS2 and NEN 7510. This is documentation you can use as input for your own compliance process. Paramant does not hold third-party certification for these frameworks.</p>
+      <p><strong>What burn-on-read costs you.</strong> A file is wiped immediately on download or on expiry, and there is no disk storage, so a file that has been read cannot be fetched again. Keep your own copy.</p>
+    </div>
+    <div class="ps-actions">
+      <a href="/parashare" class="btn btn-primary">Send a file &rarr;</a>
+      <a href="/pricing" class="btn btn-secondary">See pricing &rarr;</a>
+    </div>
+  </div>
+</section>
+
+<!-- DEVELOPERS, LAST -->
+<section class="ps-band">
+  <div class="container-md">
+    <span class="mono-eyebrow">07 / Developers</span>
+    <h2 style="margin-top:var(--space-2)">Send from your own code</h2>
+    <p class="dev-line">There is an open SDK in JavaScript and Python and a self-host installer. Read the <a href="/docs">documentation</a>, or run the relay yourself from <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>.</p>
+  </div>
+</section>
+
+<footer>
+  <div class="container-lg">
+    <div class="footer-grid footer-slim">
+      <div>
+        <div class="logo" style="margin-bottom:var(--space-3)"><span class="a">Para</span><span class="b">MANT</span></div>
+        <p style="font-size:var(--text-xs);color:var(--ink-dim);line-height:1.8;max-width:320px">Paramant is a product of <strong>Paramantis Solutions B.V.</strong><br>Harderwijk, the Netherlands<br>KvK 42115132<br><a href="mailto:privacy@paramant.app">privacy@paramant.app</a></p>
+        <p style="font-family:var(--mono);font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-4);line-height:1.8">BUSL-1.1 &middot; &copy; 2026 PARAMANTIS SOLUTIONS B.V.</p>
+      </div>
+      <div>
+        <div class="footer-col-label">Company</div>
+        <div class="footer-links">
+          <a href="/about">About</a>
+          <a href="/changelog">Changelog</a>
+        </div>
+      </div>
+      <div>
+        <div class="footer-col-label">Legal</div>
+        <div class="footer-links">
+          <a href="/privacy">Privacy Policy</a>
+          <a href="/dpa">Data Processing Agreement</a>
+          <a href="/terms">Terms of Service</a>
+          <a href="/sla">SLA</a>
+          <a href="/license">License</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+
+
+<script src="/nav.js?v=14" defer></script>
+<script src="/js/nav-auth.js?v=5" defer></script>
+</body>
+</html>

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -190,7 +190,7 @@
       <a href="/parashare" class="btn btn-primary">Send a file &rarr;</a>
       <a href="/pricing" class="btn btn-secondary">See pricing &rarr;</a>
     </div>
-    <p class="ps-sub">Free on the Community plan, forever, no card: links that last an hour, gone after one read, 10 uploads an hour. Organisations pay for volume, never for security.</p>
+    <p class="ps-sub">Free on the Community plan, forever, no card: 10 transfers a month, 5 MB a file, links that last an hour and are gone after one read. Organisations pay for volume, never for security.</p>
     <p class="ps-note">Sending needs a free account. Receiving does not: the person you send to opens the link, gets the file once, and the copy is wiped. Keep your own copy, because a file that has been read cannot be fetched again.</p>
   </div>
 </section>
@@ -228,8 +228,8 @@
         <p>The recipient opens the link, gets the file, and that is the whole flow. No account, nothing to install.</p>
       </div>
       <div class="check-card">
-        <div class="k">A receipt the other side can check</div>
-        <p>The person you send to gets proof that the file came from you and was not changed on the way. ParaShare is the send screen you use; ParaSend is the product it belongs to.</p>
+        <div class="k">It opens on their device, or nowhere</div>
+        <p>The file is locked to a key registered on the recipient's device, so it opens there and nowhere else, and a file altered on the way does not open at all. ParaShare is the send screen you use; ParaSend is the product it belongs to.</p>
       </div>
       <div class="check-card">
         <div class="k">Lock a file for yourself</div>
@@ -283,9 +283,10 @@
         <div class="tier-note">Forever &middot; no card required</div>
         <ul>
           <li>Encrypted in your browser, key never sent</li>
+          <li>10 transfers per month</li>
+          <li>5 MB per file, on every plan</li>
           <li>1 hour link expiry</li>
           <li>Burn on first read</li>
-          <li>10 uploads per hour per IP</li>
           <li>Up to 5 registered devices for ParaShare, the ParaSend send screen</li>
         </ul>
       </div>
@@ -299,12 +300,13 @@
         <div class="tier-note">excl. btw &middot; <span class="incl">charged &euro;18.15/mo incl. 21% btw</span><br>Annual &euro;150 excl. &middot; 16.7% off</div>
         <ul>
           <li>Everything in Community</li>
+          <li>500 transfers per month</li>
           <li>24 hour link expiry</li>
           <li>Up to 10 reads per link</li>
           <li>Up to 50 registered devices</li>
           <li>Send history and link management</li>
           <li>Webhooks on upload and download</li>
-          <li>No IP rate limit</li>
+          <li>Email notifications via Resend</li>
         </ul>
       </div>
       <div class="tier-card">
@@ -336,11 +338,11 @@
     <div class="check-grid">
       <div class="check-card">
         <div class="k">We never had it</div>
-        <p>AES-256-GCM with a key your browser generates. The relay only ever holds fixed-size ciphertext, never the plaintext and never the key, and it holds it in RAM until the read burns it. The architecture is on the <a href="/security">security page</a>.</p>
+        <p>AES-256-GCM with a key your browser generates. The relay only ever holds ciphertext, never the plaintext and never the key, and it holds it in RAM until the read burns it. A ParaShare transfer is stored at a fixed 5 MB, so its size says nothing about the file. The retention row is on the <a href="/security">security page</a>.</p>
       </div>
       <div class="check-card">
-        <div class="k">The receipt, in full</div>
-        <p>Verified transfers via ParaShare use ML-KEM-768 plus ECDH P-256 hybrid key exchange with ML-DSA-65 signed receipts. The algorithm register is on the <a href="/crypto-agility">crypto agility page</a>.</p>
+        <div class="k">The wire format, in full</div>
+        <p>ParaShare uses ML-KEM-768 plus ECDH P-256 hybrid key exchange. The register lists the webapp on the pre-v1 hybrid wire, signature n/a, migrating to v1; ML-DSA-65 signed receipts are live on the v1 wire in sdk-py 3.0.0 and sdk-js 3.0.0. Read the register on the <a href="/crypto-agility">crypto agility page</a>.</p>
       </div>
       <div class="check-card">
         <div class="k">You own your keys</div>
@@ -348,7 +350,7 @@
       </div>
       <div class="check-card">
         <div class="k">EU soil, EU law</div>
-        <p>Hetzner Germany, Bunny DNS (Slovenia). No US provider in the data path. Email goes out via Resend, as <a href="/privacy">/privacy</a> sets out. The jurisdiction table is on the <a href="/security">security page</a>.</p>
+        <p>Hetzner Germany, Bunny DNS (Slovenia). No US provider in the data path. Email goes out via Resend, as <a href="/privacy">/privacy</a> sets out. The subprocessors are listed there, and ParaRule 5 states the same claim in full on <a href="/pararules">ParaRules</a>.</p>
       </div>
       <div class="check-card">
         <div class="k">No third-party requests</div>

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -27,10 +27,12 @@
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
+.ps-hero{padding:var(--space-10) 0 var(--space-6)}
 .ps-band{padding:var(--space-8) 0;border-top:1px solid var(--ink-hair)}
 .ps-band h2{font-size:var(--text-2xl);letter-spacing:-.02em;margin-bottom:var(--space-2)}
 .mono-eyebrow{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)}
 .ps-lede{font-size:var(--text-md);color:var(--ink);line-height:1.7;max-width:680px;margin-top:var(--space-4)}
+.ps-who{font-size:var(--text-base);color:var(--navy);font-weight:700;line-height:1.7;max-width:680px;margin-top:var(--space-3)}
 .ps-band p{font-size:var(--text-base);color:var(--ink);line-height:1.8;max-width:680px;margin-top:var(--space-4)}
 .ps-band p a,.ps-band li a{color:var(--cobalt)}
 .ps-band p strong{color:var(--navy)}
@@ -68,6 +70,17 @@
 .scope-note p{margin-top:0}
 @media(max-width:1023px){.community{grid-template-columns:1fr;gap:var(--space-4)}}
 @media(max-width:640px){.check-grid,.tier-grid{grid-template-columns:1fr}}
+/* Mobile is the design target and the house .sec-head is not, at this width:
+   it keeps the section number in its own grid column, which leaves the H1 about
+   160px to wrap in. On /parasign that cost six lines of headline and pushed the
+   buttons and the eIDAS note clean off the first screen. On a narrow screen the
+   number stacks above the headline instead of standing beside it. Page-local on
+   purpose: design-system.css is shared with pages this PR does not touch. */
+@media(max-width:640px){
+  .ps-hero{padding-top:var(--space-6)}
+  #main-content .sec-head{grid-template-columns:1fr;row-gap:var(--space-2)}
+  #main-content .sec-head .num{font-size:var(--text-xl);line-height:1}
+}
 </style>
 <script type="application/ld+json" data-paramant-seo="1">
 {
@@ -168,19 +181,27 @@
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
 </div>
 
-<!-- HERO -->
-<section style="padding:var(--space-10) 0 var(--space-6)" id="main-content" tabindex="-1">
+<!-- HERO. Four things and no more, in the order docs/brand/messaging.md sets:
+     what you can do here, who it is for, the split with its real number, and
+     the one limit a lawyer asks about before anything else. The algorithm names
+     are the reason section 04 is true; section 6 of the guide keeps them out of
+     the H1 and out of the opening paragraph, so they live down there. -->
+<section class="ps-hero" id="main-content" tabindex="-1">
   <div class="container-md">
     <div class="sec-head">
       <span class="num">00</span>
-      <h1 class="paramant-h2">ParaSign</h1>
-      <span class="mono-eyebrow">Get documents signed, by Paramant</span>
+      <h1 class="paramant-h2">Sign documents in your browser, prove it years later.</h1>
+      <span class="mono-eyebrow">ParaSign &middot; document signing by Paramant</span>
     </div>
-    <p class="ps-lede">Send a contract, a quote or a consent form out for signature and get it back signed, without leaving your browser and without the document passing through anyone else's cloud. Everyone you send it to can check the result later, on their own, without an account and without us.</p>
-    <p class="ps-fine">Free on the <a href="#plans">Community plan</a> &middot; business plans from &euro;49 a month &middot; the person you invite needs no account, only the link in their email.</p>
+    <p class="ps-lede">Send a contract out for signature and get it back signed, without it passing through anyone else's cloud. Anyone can check the result later, without us.</p>
+    <p class="ps-who">For legal, finance and healthcare practices in the EU that sign contracts and client documents.</p>
     <div class="ps-actions">
       <a href="/sign" class="btn btn-primary">Sign a document &rarr;</a>
       <a href="/pricing" class="btn btn-secondary">See pricing &rarr;</a>
+    </div>
+    <p class="ps-fine">Free on the <a href="#plans">Community plan</a>: 2 signatures a month, no card, forever. Business plans from &euro;49 a month excl. btw. The person you invite needs no account, only the link in their email.</p>
+    <div class="scope-note">
+      <p><strong>What this is, before you read on.</strong> A ParaSign signature is a Simple Electronic Signature (SES): an ML-DSA-65 cryptographic attestation produced in your browser. It is not a notarised legal signature under eIDAS or any qualified-trust regime (QES). What the proof does show, and what it does not, is in <a href="#proof">section 04</a>.</p>
     </div>
   </div>
 </section>
@@ -218,6 +239,8 @@
     <span class="mono-eyebrow">02 / What it costs</span>
     <h2 style="margin-top:var(--space-2)">Community is free. Companies pay.</h2>
     <p>Two halves, and the split is the point. Individuals sign for nothing on the Community plan. Organisations that sign at volume buy a business plan, and those plans are what pay for the free one.</p>
+    <p><strong>The Community plan is free, forever.</strong> It is not a trial and not a funnel. Businesses pay for the higher limits (longer links, more reads, more devices, a dedicated relay), not to unlock features, and that is what keeps the Community plan free.</p>
+    <p><strong>Every plan gets the same encryption, the same post-quantum signatures and the same public proof log. Pay for volume, never for security. And pay per organisation, not per user.</strong></p>
 
     <div class="community">
       <div>
@@ -237,7 +260,7 @@
       </div>
       <div>
         <div class="k" style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.14em;text-transform:uppercase;font-weight:700;color:var(--navy)">Why it is free</div>
-        <p>Paramant is built by <strong>Mick Beer</strong>, privacy and security researcher and founder of Paramantis Solutions B.V. (see the <a href="/about">about page</a>). The Community plan is his way of giving something back: whoever needs to sign a document without handing it to an American cloud can do that here, at no cost, with the same cryptography a paying customer gets.</p>
+        <p>Paramant is built by <strong>Mick Beer, privacy and security researcher</strong>, founder of Paramantis Solutions B.V. (see the <a href="/about">about page</a>). The Community plan is his way of giving something back: whoever needs to sign a document without handing it to an American cloud can do that here, at no cost, with the same cryptography a paying customer gets.</p>
         <p>It is not a limited edition of the product. Community gets the same signatures, the same encryption and the same public proof log as Business. What a paid plan buys is volume, an API, support and accountability. Never security.</p>
       </div>
     </div>
@@ -296,7 +319,7 @@
 </section>
 
 <!-- THE PROOF, LAST -->
-<section class="ps-band">
+<section class="ps-band" id="proof">
   <div class="container-md">
     <span class="mono-eyebrow">04 / How it works, and how to check it</span>
     <h2 style="margin-top:var(--space-2)">The technique is the evidence, not the pitch</h2>
@@ -304,7 +327,7 @@
     <div class="check-grid">
       <div class="check-card">
         <div class="k">ML-DSA-65 (FIPS 204)</div>
-        <p>Signatures are post-quantum, generated in your browser. The algorithm register on the <a href="/crypto-agility">crypto agility page</a> lists ML-DSA-65 as the loaded default.</p>
+        <p>ML-DSA-65 (FIPS 204), generated in your browser. The private key never reaches the relay. The algorithm register on the <a href="/crypto-agility">crypto agility page</a> lists it as the loaded default.</p>
       </div>
       <div class="check-card">
         <div class="k">You own your keys</div>
@@ -320,15 +343,20 @@
       </div>
       <div class="check-card">
         <div class="k">Verification without us</div>
-        <p>A .psign envelope verifies offline, against the published key. Check one on the <a href="/verify">verify page</a>: no account, no API key, no call home.</p>
+        <p>A signed document verifies without contacting us. Check a .psign envelope on the <a href="/verify">verify page</a>: no account, no API key, no call home.</p>
       </div>
       <div class="check-card">
-        <div class="k">Source-available, EU jurisdiction</div>
-        <p>The relay is source-available on <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>, and runs under EU jurisdiction. Who is behind it is on the <a href="/about">about page</a>.</p>
+        <div class="k">Source-available code</div>
+        <p>The relay is source-available on <a href="https://github.com/Apolloccrypt/paramant-relay" target="_blank" rel="noopener">GitHub</a>. Who is behind it is on the <a href="/about">about page</a>.</p>
+      </div>
+      <div class="check-card">
+        <div class="k">EU soil, EU law</div>
+        <p>Hetzner Germany, Bunny DNS (Slovenia). No US provider in the data path. Email goes out via Resend, as <a href="/privacy">/privacy</a> sets out. The jurisdiction table is on the <a href="/security">security page</a>.</p>
       </div>
     </div>
     <div class="scope-note">
-      <p><strong>Post-quantum, zero-knowledge. Not eIDAS-qualified.</strong> A ParaSign signature is a Simple Electronic Signature (SES): an ML-DSA-65 cryptographic attestation produced in your browser. It is not a notarised legal signature under eIDAS or any qualified-trust regime (QES). We state exactly what it is and what it is not.</p>
+      <p><strong>What the proof covers.</strong> A completed signature shows that the key in the envelope signed this exact document, and that the entry sits in the public log. It does not show who holds that key. To bind a signature to a named email address, send the document as a signing request rather than signing in open mode.</p>
+      <p><strong>And what it is not.</strong> A ParaSign signature is a Simple Electronic Signature (SES), stated in full at the <a href="#main-content">top of this page</a>. We say exactly what it is and what it is not, in the same place a buyer decides.</p>
     </div>
     <div class="ps-actions">
       <a href="/sign" class="btn btn-primary">Sign a document &rarr;</a>

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -274,7 +274,7 @@
         <div class="tier-note">excl. btw &middot; <span class="incl">charged &euro;59.29/mo incl. 21% btw</span><br>Annual &euro;499 excl.</div>
         <ul>
           <li>100 signatures per month, then &euro;0.40 each, up to 1,000</li>
-          <li>Unlimited transfers</li>
+          <li>500 ParaSend transfers per month</li>
           <li>API access</li>
         </ul>
       </div>
@@ -351,7 +351,7 @@
       </div>
       <div class="check-card">
         <div class="k">EU soil, EU law</div>
-        <p>Hetzner Germany, Bunny DNS (Slovenia). No US provider in the data path. Email goes out via Resend, as <a href="/privacy">/privacy</a> sets out. The jurisdiction table is on the <a href="/security">security page</a>.</p>
+        <p>Hetzner Germany, Bunny DNS (Slovenia). No US provider in the data path. Email goes out via Resend, as <a href="/privacy">/privacy</a> sets out. The subprocessors are listed there, and ParaRule 5 states the same claim in full on <a href="/pararules">ParaRules</a>.</p>
       </div>
     </div>
     <div class="scope-note">

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -38,6 +38,12 @@
 .ds-kicker{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:8px}
 .ds-title{font-size:clamp(34px,5vw,52px);font-weight:700;letter-spacing:-.04em;line-height:1.05;margin-bottom:14px;color:var(--navy)}
 .ds-lede{font-size:16px;color:var(--ink-dim);line-height:1.65;max-width:690px}
+.ds-facts{list-style:none;display:flex;flex-wrap:wrap;gap:8px;margin:16px 0 0;padding:0;max-width:690px}
+.ds-facts li{font-family:var(--mono);font-size:11px;letter-spacing:.04em;color:var(--ink-dim);border:1px solid var(--ink-hair);background:var(--bone);padding:6px 10px;line-height:1.5}
+.ds-facts li b{color:var(--navy);font-weight:700;text-transform:uppercase;letter-spacing:.08em}
+.ds-headlink{margin:14px 0 0;font-size:13px}
+.ds-headlink a{color:var(--cobalt)}
+.ds-anon-actions{display:flex;flex-wrap:wrap;gap:10px;margin:20px 0 0}
 .ds-stepper{list-style:none;display:flex;gap:8px;padding:0;margin:0 0 32px;border-bottom:1px solid var(--ink-hair);counter-reset:dsstep}
 .ds-stepper li{flex:1;font-family:var(--mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-dim);padding:14px 0;border-bottom:2px solid transparent;counter-increment:dsstep;text-align:center}
 .ds-stepper li::before{content:counter(dsstep);display:inline-block;width:20px;height:20px;border:1px solid var(--ink-hair);border-radius:50%;line-height:18px;font-size:10px;margin-right:6px;font-weight:700}
@@ -224,7 +230,7 @@
 .ds-textarea{min-height:84px;resize:vertical;line-height:1.5}
 .ds-invite-status{font-family:var(--mono);font-size:10px;margin-top:5px;color:var(--ink-dim)}
 .ds-invite-status.ok{color:#087443}.ds-invite-status.err{color:#b42318}
-@media(max-width:640px){.ds-recipient-row,.ds-party-link-row{grid-template-columns:1fr}}
+@media(max-width:640px){.ds-recipient-row,.ds-party-link-row{grid-template-columns:1fr}.ds-anon-actions .btn{flex:1 1 100%;text-align:center}}
 @media(max-width:640px){.ds-party-link-row .ds-pl-url{white-space:normal;overflow:visible;text-overflow:clip;word-break:break-all}.ds-party-link-row .ds-pl-copy{width:100%;padding:12px 14px}.ds-recipient-row .ds-rm{padding:10px 12px}}
 @media(max-width:640px){.ds-proof-dl{grid-template-columns:1fr}}
 @media(max-width:640px){.ds-review-grid{grid-template-columns:1fr}}
@@ -366,6 +372,12 @@
     <p class="ds-kicker">ParaSign · secure document workflow</p>
     <h1 class="ds-title">Get an important document signed.</h1>
     <p class="ds-lede">Sign it yourself, work together or send it to others. Your document stays private and every completed signature comes with independently verifiable proof.</p>
+    <ul class="ds-facts">
+      <li><b>Free forever</b> &middot; 2 signatures a month, no card</li>
+      <li><b>Your signing key stays here</b> &middot; it is made on your device and never reaches our servers</li>
+      <li><b>EU jurisdiction</b> &middot; servers in Germany, under EU law</li>
+    </ul>
+    <p class="ds-headlink"><a href="/parasign">What ParaSign is, and what organisations pay &rarr;</a></p>
   </header>
 
   <ol class="ds-stepper" id="ds-stepper" aria-label="Sign progress" hidden>
@@ -398,9 +410,14 @@
       <a href="/verify">verify any signed document</a> against the public log. Neither needs
       an account.
     </p>
+    <!-- .ds-btn was never defined in any stylesheet, so the one CTA a
+         session-less visitor gets rendered as two lines of plain blue text.
+         These are the house button classes the rest of this page already
+         uses, and sign-flow.js selects neither class, so nothing behavioural
+         changes. -->
     <p class="ds-anon-actions">
-      <a class="ds-btn primary" href="/signup?next=/sign">Create an account</a>
-      <a class="ds-btn" href="/auth/login?next=/sign">Sign in</a>
+      <a class="btn btn-primary" href="/signup?next=/sign">Create an account</a>
+      <a class="btn btn-secondary" href="/auth/login?next=/sign">Sign in</a>
     </p>
     <p class="ds-sub ds-anon-foot">
       Community accounts sign 2 documents a month. <a href="/pricing">See what the paid tiers add</a>.
@@ -409,7 +426,7 @@
 
   <!-- Step 0: choose a signing setup -->
   <section class="ds-step" id="step-mode">
-    <div class="ds-mode-intro"><div><h2>How should it be signed?</h2><p class="ds-sub">Choose a workflow. You can change it before sending.</p></div><span class="ds-mode-safe">Private key stays on your device</span></div>
+    <div class="ds-mode-intro"><div><h2>How should it be signed?</h2><p class="ds-sub">Choose a workflow. You can change it before sending.</p></div><span class="ds-mode-safe">Your signing key stays on your device</span></div>
     <div class="ds-modes">
       <button type="button" class="ds-mode-card primary" data-mode="invite">
         <span class="ds-mode-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M4 6h16v12H4z"/><path d="m4 7 8 6 8-6"/></svg></span>

--- a/frontend/sitemap.xml
+++ b/frontend/sitemap.xml
@@ -117,6 +117,11 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://paramant.app/parasend</loc>
+    <lastmod>2026-09-02</lastmod>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://paramant.app/parasign</loc>
     <lastmod>2026-09-02</lastmod>
     <priority>0.9</priority>

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -437,16 +437,83 @@ for (const page of PRODUCT_PAGES) {
 }
 ok('both product pages carry the btw convention and the catalog amounts');
 
-// The quota lines are what a buyer picks a tier on, so they are pinned to the
-// words /pricing uses. A free tier that quietly loses "2 signatures per month"
-// is the same defect as a price that drifts.
+// ── The free number, pinned to the code that enforces it ─────────────────────
+//
+// /parasend said "10 uploads per hour per IP". That figure is real, but it is
+// ANON_RATE_PER_HOUR on POST /v2/anon-inbound (relay.js), an endpoint deprecated
+// on 2026-05-28 that answers with Deprecation and Sunset headers and retires on
+// 2026-12-31. It is not what a Community ACCOUNT gets. The account limits live
+// in relay/lib/tiers.js and are enforced in relay.js: transfers_month with a 402
+// (monthly_transfer_quota_reached), file_mb with a 413 (Max 5MB), view_ttl_ms
+// and max_views on the link itself.
+//
+// So the page is pinned to tiers.js rather than to the wording on /pricing.
+// Pinning one page to another only proves the two agree; it cannot catch both
+// being wrong together, which is exactly what happened here: /pricing and
+// index.html carry the same upload figure and are corrected in their own PRs.
+const tiers = require('../lib/tiers');
+const hours = (ms) => ms / 3_600_000;
+
+const COMMUNITY_LINES = [
+  [tiers.tierLimit('community', 'transfers_month') + ' transfers per month', 'transfers_month'],
+  [tiers.tierLimit('community', 'file_mb') + ' MB per file', 'file_mb'],
+  [hours(tiers.tierLimit('community', 'view_ttl_ms')) + ' hour link expiry', 'view_ttl_ms'],
+  [tiers.tierLimit('community', 'devices') + ' registered devices', 'devices'],
+];
+for (const [line, dim] of COMMUNITY_LINES) {
+  assert(productHtml.parasend.includes(line),
+    'parasend.html no longer states the Community ' + dim + ' that tiers.js enforces: "' + line + '"');
+}
+assert(tiers.tierLimit('community', 'max_views') === 1 && /Burn on first read/.test(productHtml.parasend),
+  'tiers.js gives Community one view, so parasend.html must say the link burns on first read');
+
+const PRO_LINES = [
+  [tiers.tierLimit('pro', 'transfers_month') + ' transfers per month', 'transfers_month'],
+  [hours(tiers.tierLimit('pro', 'view_ttl_ms')) + ' hour link expiry', 'view_ttl_ms'],
+  ['Up to ' + tiers.tierLimit('pro', 'max_views') + ' reads per link', 'max_views'],
+  ['Up to ' + tiers.tierLimit('pro', 'devices') + ' registered devices', 'devices'],
+];
+for (const [line, dim] of PRO_LINES) {
+  assert(productHtml.parasend.includes(line),
+    'parasend.html no longer states the ParaSend Pro ' + dim + ' that tiers.js enforces: "' + line + '"');
+}
+// The anon endpoint's figure may not come back on either product page under any
+// wording. It describes a keyless path that is being retired, not a plan.
+for (const [name, pageHtml] of [['parasign.html', productHtml.parasign], ['parasend.html', productHtml.parasend]]) {
+  assert(!/uploads per hour|uploads an hour/i.test(pageHtml),
+    name + ' states an uploads-per-hour figure; that is ANON_RATE_PER_HOUR on the deprecated /v2/anon-inbound, not a plan limit');
+}
+// No metered tier is unbounded: relay/lib/entitlements.js gives even enterprise
+// a finite ceiling. A page may not promise unlimited transfers to anyone.
+for (const [name, pageHtml] of [['parasign.html', productHtml.parasign], ['parasend.html', productHtml.parasend]]) {
+  assert(!/Unlimited transfers/i.test(pageHtml),
+    name + ' promises unlimited transfers, which entitlements.js forbids for every metered tier');
+}
+// A ParaSign plan derives its ParaSend tier (entitlements.js derivePlanParasend),
+// so where /parasign quotes a transfer number it must be that tier's number.
+assert(productHtml.parasign.includes(tiers.tierLimit('pro', 'transfers_month') + ' ParaSend transfers per month'),
+  'parasign.html must quote the ParaSend transfer ceiling a ParaSign Pro account actually derives');
+ok('the ParaSend limits on both product pages come from relay/lib/tiers.js (' +
+   tiers.tierLimit('community', 'transfers_month') + '/' + tiers.tierLimit('pro', 'transfers_month') + ' transfers, ' +
+   tiers.tierLimit('community', 'file_mb') + ' MB)');
+
+// A feature bullet quoted from /pricing has to stay a quote. This one names a
+// subprocessor, so dropping "via Resend" would quietly remove a disclosure the
+// EU claim depends on being made in the same breath.
+for (const line of ['Email notifications via Resend']) {
+  assert(html.includes(line), '/pricing lost the feature line: ' + line);
+  assert(productHtml.parasend.includes(line), 'parasend.html lost the feature line /pricing carries: ' + line);
+}
+ok('the ParaSend Pro feature bullets quoted from /pricing are still quotes');
+
+// The signature quota lines stay pinned to the words /pricing uses: those three
+// are billing copy (the overage rate and the hard cap), not a tiers.js row.
 for (const line of ['2 signatures per month', '100 signatures per month, then &euro;0.40 each, up to 1,000', '1,000 signatures per month']) {
   assert(productHtml.parasign.includes(line), 'parasign.html lost the quota line: ' + line);
 }
-for (const line of ['1 hour link expiry', 'Burn on first read', '24 hour link expiry', 'Up to 10 reads per link']) {
-  assert(productHtml.parasend.includes(line), 'parasend.html lost the limit line: ' + line);
-}
-ok('both product pages carry the same quota and limit lines as /pricing');
+assert(tiers.tierLimit('community', 'signs_month') === 2,
+  'tiers.js no longer gives the free plan 2 signatures a month, so the pages that say so are stale');
+ok('parasign.html carries the signature quota lines, and tiers.js still backs the free one');
 
 // ── The service promises in a tier bullet are pinned too ─────────────────────
 //

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -143,21 +143,31 @@ assert.strictEqual(yearlyAlts, 3, 'expected 3 yearly options demoted to secondar
 assert(!/data-billing-interval="yearly"\s+class="btn/.test(html), 'no yearly variant may still be an equal btn');
 ok('one primary monthly CTA per tier, yearly demoted to a secondary link');
 
+// An amount ends where it says it ends. A bare includes('&euro;49') is satisfied
+// by the annual "&euro;499 excl." on the same card, so the two Pro monthly
+// prices, the ones a buyer clicks, were pinned by nothing at all. Verified by
+// sabotage: &euro;49 -> &euro;59 and &euro;15 -> &euro;19 both stayed green
+// before this, and both go red after it.
+function esc(v) { return v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+function showsAmount(pageHtml, amount) {
+  return new RegExp(esc(amount) + '(?![\\d.,])').test(pageHtml);
+}
+// The excl-btw price has to sit on the card of the plan it belongs to. A page
+// may mention "from &euro;49 a month" in its opening line as well, and that
+// sentence must not be able to stand in for the tier itself.
+function showsAmountOnCard(pageHtml, amount, interval) {
+  const re = interval === 'monthly'
+    ? new RegExp('<div class="tier-price">' + esc(amount) + '(?![\\d.,])')
+    : new RegExp('Annual:?\\s*' + esc(amount) + '(?![\\d.,])');
+  return re.test(pageHtml);
+}
+
 // /parasign is the product page and quotes the ParaSign prices a second time.
 // relay/test/pricing-page.test.js is the only thing that ties a listed price to
 // the catalog, so the product page is held to the same numbers here: an edit
 // to one page without the other turns this suite red instead of leaving two
 // prices on the site.
 const parasignHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'parasign.html'), 'utf8');
-for (const v of VARIANTS.filter(x => x.product === 'parasign')) {
-  const order = catalog.resolveOrder({ product: v.product, plan: v.plan, interval: v.interval });
-  assert(!order.error, 'catalog rejects ' + v.plan + '/' + v.interval + ': ' + order.error);
-  const excl = '&euro;' + v.excl.toLocaleString('en-US');
-  assert(parasignHtml.includes(excl), 'parasign.html no longer shows ' + excl + ' for ' + v.plan + '/' + v.interval);
-  const incl = '&euro;' + Number(order.amount).toLocaleString('en-US', { minimumFractionDigits: 2 });
-  assert(parasignHtml.includes(incl), 'parasign.html no longer shows the catalog amount ' + incl + ' incl. btw for ' + v.plan + '/' + v.interval);
-  ok('parasign.html ' + v.plan + ' ' + v.interval + ': shows ' + excl + ' excl and ' + incl + ' incl');
-}
 for (const s of ['2 signatures per month', '100 signatures per month, then &euro;0.40 each, up to 1,000', '1,000 signatures per month']) {
   assert(parasignHtml.includes(s), 'parasign.html lost the quota line: ' + s);
 }
@@ -315,6 +325,7 @@ assert(VISIBLE.includes('There is no separate trial'), 'FAQ must keep saying the
 assert(VISIBLE.includes('Forever &middot; no card required'), 'Community card must keep the forever/no-card promise');
 ok('one starting-for-free promise: forever-free tier, no trial clock');
 
+
 // ── Every amount belongs to the card it stands in ────────────────────────────
 //
 // The catalog sweep above asks two questions: is every amount on the page a
@@ -394,5 +405,76 @@ for (const raw of cards) {
 }
 assert(bound >= 8, 'expected to bind at least 8 amounts to a card, bound ' + bound);
 ok('every amount and discount sits on the card of the plan it belongs to (' + bound + ' amounts bound)');
+
+// ── The product pages quote the same prices a second time ────────────────────
+//
+// /parasign and /parasend sell one product each and repeat its tiers. This file
+// is the only thing that ties a listed price to relay/lib/billing-catalog.js,
+// so both product pages are held to the same numbers here: an edit to one page
+// without the other turns this suite red instead of leaving two prices on the
+// site for the same plan. The pages carry no checkout button of their own; they
+// send the buyer to /pricing, which is where the data-billing-* buttons live.
+const PRODUCT_PAGES = [
+  { product: 'parasign', file: 'parasign.html' },
+  { product: 'parasend', file: 'parasend.html' },
+];
+const productHtml = {};
+for (const page of PRODUCT_PAGES) {
+  const pageHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', page.file), 'utf8');
+  productHtml[page.product] = pageHtml;
+  for (const v of VARIANTS.filter(x => x.product === page.product)) {
+    const order = catalog.resolveOrder({ product: v.product, plan: v.plan, interval: v.interval });
+    assert(!order.error, 'catalog rejects ' + v.plan + '/' + v.interval + ': ' + order.error);
+    const excl = '&euro;' + v.excl.toLocaleString('en-US');
+    assert(showsAmountOnCard(pageHtml, excl, v.interval),
+      page.file + ' no longer shows ' + excl + ' on the ' + v.plan + ' card for ' + v.interval);
+    const incl = '&euro;' + Number(order.amount).toLocaleString('en-US', { minimumFractionDigits: 2 });
+    assert(showsAmount(pageHtml, incl), page.file + ' no longer shows the catalog amount ' + incl + ' incl. btw for ' + v.plan + '/' + v.interval);
+    ok(page.file + ' ' + v.plan + ' ' + v.interval + ': shows ' + excl + ' excl and ' + incl + ' incl');
+  }
+  assert(/excl\. btw/.test(pageHtml) && /incl\. 21% btw/.test(pageHtml),
+    page.file + ' must state excl. btw and the incl. 21% btw checkout amount');
+}
+ok('both product pages carry the btw convention and the catalog amounts');
+
+// The quota lines are what a buyer picks a tier on, so they are pinned to the
+// words /pricing uses. A free tier that quietly loses "2 signatures per month"
+// is the same defect as a price that drifts.
+for (const line of ['2 signatures per month', '100 signatures per month, then &euro;0.40 each, up to 1,000', '1,000 signatures per month']) {
+  assert(productHtml.parasign.includes(line), 'parasign.html lost the quota line: ' + line);
+}
+for (const line of ['1 hour link expiry', 'Burn on first read', '24 hour link expiry', 'Up to 10 reads per link']) {
+  assert(productHtml.parasend.includes(line), 'parasend.html lost the limit line: ' + line);
+}
+ok('both product pages carry the same quota and limit lines as /pricing');
+
+// ── The service promises in a tier bullet are pinned too ─────────────────────
+//
+// The quota lines above were pinned, the service lines were not, and that is
+// exactly how "SLA 99.9%" reached parasend.html while /pricing and /sla both
+// published 99.95%. A number in a tier card is a promise whether it is priced
+// in euros or in uptime, so the uptime figure is now read from /sla, the page
+// that defines it, and every page that repeats it has to match.
+const slaHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'sla.html'), 'utf8');
+// /sla states two targets, one per tier, so read the Enterprise cell by name
+// rather than the first .uptime on the page: the Community figure (99.5%) is
+// a real number too and would silently become the thing under test.
+const slaTarget = /<div class="tier">Enterprise<\/div>\s*<div class="uptime">([\d.]+)%<\/div>/.exec(slaHtml);
+assert(slaTarget, 'sla.html no longer states an Enterprise uptime target');
+const SLA_TARGET = slaTarget[1];
+const SLA_LINE = 'SLA ' + SLA_TARGET + '%, priority incident response';
+const straySla = new RegExp('SLA (?!' + SLA_TARGET.replace('.', '\\.') + '%)\\d+\\.?\\d*%');
+for (const [name, pageHtml] of [['pricing.html', html], ['parasend.html', productHtml.parasend]]) {
+  assert(pageHtml.includes(SLA_LINE), name + ' must state "' + SLA_LINE + '", the target /sla publishes');
+  assert(!straySla.test(pageHtml), name + ' states an SLA figure that is not the one on /sla');
+}
+ok('the SLA figure on /pricing and /parasend is the one /sla publishes (' + SLA_TARGET + '%)');
+
+// A compliance framework named in a tier bullet carries its own limit in that
+// bullet. The nuance used to live thousands of pixels below the bullet, which
+// on a phone reads as a certification claim.
+assert(productHtml.parasend.includes('IEC 62443 / NIS2 / NEN 7510 documentation as input for your own compliance process, not third-party certification'),
+  'parasend.html must qualify the compliance bullet where the bullet stands');
+ok('the compliance bullet on /parasend carries its own limit');
 
 console.log('pricing-page: ' + passed + ' checks passed');

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -660,3 +660,146 @@ assert.doesNotMatch(docsHtml, /\u2014|&mdash;|\u2013|&ndash;/,
   'docs.html must carry no em-dash or en-dash');
 
 console.log('ui-truthfulness: /docs and /help answer a buyer with sentences that ship elsewhere');
+
+// ── The messaging guide, pinned ──────────────────────────────────────────────
+// docs/brand/messaging.md (PR #331) settles what the commercial pages promise
+// and in what order. Section 10 of that guide is the rule this block enforces:
+// a sentence may only go on the site if it is already true on the site or in
+// the code, and there is a test that fails when it stops being true. Every
+// string below is quoted from a page that ships, and the guide names each of
+// them as work to pin. Where the guide flagged a claim as disputed (ParaRule
+// 04's "no US provider in the chain", section 9) the claim is NOT asserted
+// here and does not appear on the product pages; only the /security row it
+// rests on is.
+// A claim is what a visitor reads, not how the markup happens to be wrapped.
+// The same sentence sits on one line in parasign.html and across three lines
+// with a <strong> in the middle in pricing.html, so comparing raw HTML would
+// pin the formatting instead of the promise. Comments, style and script are
+// dropped for the same reason ui-truthfulness already drops them on sign.html:
+// a comment routinely quotes the very wording it exists to forbid.
+function visible0(html) {
+  return html
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<(style|script)\b[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&middot;/g, '\u00b7').replace(/&euro;/g, '\u20ac')
+    .replace(/&amp;/g, '&').replace(/&nbsp;/g, ' ').replace(/&rarr;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+const visible = (file) => visible0(read(file));
+const parasign = visible('frontend/parasign.html');
+const parasend = visible('frontend/parasend.html');
+const aboutVisible = visible('frontend/about.html');
+const pricingVisible = visible('frontend/pricing.html');
+const security = visible('frontend/security.html');
+const signVisibleText = visible('frontend/sign.html');
+
+// Proof 1. The EU claim is about the data path, not the whole chain, and the
+// Resend exception travels with it. A page may shorten the long form on
+// /pararules to this one; it may never drop the second half.
+const EU_CLAIM = 'No US provider in the data path.';
+const EU_EXCEPTION = 'Email goes out via Resend';
+const homeVisible = visible('frontend/index.html');
+for (const [name, text] of [['index', homeVisible], ['parasign', parasign], ['parasend', parasend]]) {
+  assert.ok(text.includes(EU_CLAIM), `${name}.html lost the data-path wording of the EU claim`);
+  assert.ok(text.includes(EU_EXCEPTION), `${name}.html states the EU claim without naming the Resend exception`);
+}
+// The broader claim is the one section 9 of the guide holds open. It may stay
+// on /security, where the table qualifies it, and nowhere near a product hero.
+for (const [name, text] of [['parasign', parasign], ['parasend', parasend]]) {
+  assert.doesNotMatch(text, /no US (company|provider) in the chain|no US company\b/i,
+    `${name}.html claims more than the data path, which /privacy does not support`);
+}
+assert.ok(security.includes('Not applicable: no US infrastructure, no US company'),
+  'security.html must keep the US CLOUD Act row that proof 1 is measured against');
+
+// Proof 2. The three /about sentences the signing claim rests on.
+for (const claim of [
+  'ML-DSA-65 (FIPS 204), generated in your browser. The private key never reaches the relay.',
+  'Every signature is entered into a public, append-only log.',
+  'A signed document verifies without contacting us.',
+]) {
+  assert.ok(aboutVisible.includes(claim), `about.html lost the signing claim: ${claim}`);
+  assert.ok(parasign.includes(claim), `parasign.html lost the signing claim: ${claim}`);
+}
+
+// Proof 3. The sentence the whole free-versus-paid split rests on. If the
+// pricing model ever gates cryptography behind a tier, this is what fails first.
+const SPLIT = 'Every plan gets the same encryption, the same post-quantum signatures and the same public proof log. Pay for volume, never for security. And pay per organisation, not per user.';
+for (const [name, text] of [['pricing', pricingVisible], ['parasign', parasign], ['parasend', parasend]]) {
+  assert.ok(text.includes(SPLIT), `${name}.html lost the pay-for-volume sentence`);
+}
+// The other half of the split: the free plan is permanent, it is called
+// Community, and the reason it stays free is named in the same sentence.
+const FREE_FOREVER = 'not to unlock features, and that is what keeps the Community plan free';
+for (const [name, text] of [['pricing', pricingVisible], ['parasign', parasign], ['parasend', parasend]]) {
+  assert.ok(text.includes(FREE_FOREVER), `${name}.html lost the Community-plan promise`);
+}
+// /sign carries the same split in one line, next to the account requirement,
+// and it names the plan the way /pricing names it.
+assert.match(signVisibleText, /Community accounts sign 2 documents a month/,
+  'sign.html must keep the free-tier line, under the plan name /pricing uses');
+assert.doesNotMatch(signVisibleText, /\bFree accounts\b|tier named Free|the tier is called Free/,
+  'sign.html must not call the Community plan Free; one name across the site');
+
+// The founder, with the exact title and nothing added to it. No award, no year
+// count, no prior employer, no certification: none of that is on the site.
+const FOUNDER = 'Mick Beer, privacy and security researcher';
+for (const [name, text] of [['about', aboutVisible], ['parasign', parasign], ['parasend', parasend]]) {
+  assert.ok(text.includes(FOUNDER), `${name}.html must name the founder with his exact title`);
+}
+
+// Sentence three of the founder paragraph. It was the one claim on these pages
+// with no source on main; #332 put it on /about, so it is now quoted rather
+// than composed, and it is pinned to both ends of the quote.
+const GIVE_BACK = 'The Community plan is his way of giving something back to society; the business plans pay for it.';
+assert.ok(aboutVisible.includes(GIVE_BACK), 'about.html lost the give-back sentence the product pages quote');
+assert.ok(parasend.includes(GIVE_BACK), 'parasend.html must quote the give-back sentence as /about states it');
+
+// The limits, stated in the same voice as the promises. Both already shipped
+// before the product pages existed and neither may be softened or moved into
+// small print.
+const SES = 'A ParaSign signature is a Simple Electronic Signature (SES): an ML-DSA-65 cryptographic attestation produced in your browser. It is not a notarised legal signature under eIDAS or any qualified-trust regime (QES).';
+assert.ok(aboutVisible.includes(SES), 'about.html lost the SES scope note');
+assert.ok(parasign.includes(SES), 'parasign.html must carry the SES scope note, not a softer version');
+// Where it sits is part of the claim. The note has to land in the hero section,
+// before the first band of the page, or it is a footnote with a test on it.
+const parasignHero = read('frontend/parasign.html').split('<section class="ps-band"')[0];
+assert.ok(visible0(parasignHero).includes(SES),
+  'the SES scope note must sit in the first screen of /parasign, not below the tiers');
+assert.ok(visible0(parasignHero).includes('legal, finance and healthcare practices in the EU'),
+  '/parasign must name who it is for in the first screen');
+assert.ok(visible0(parasignHero).includes('2 signatures a month'),
+  'the free promise in the /parasign hero must carry its real number');
+const parasendHero = read('frontend/parasend.html').split('<section class="ps-band"')[0];
+for (const fact of ['links that last an hour', 'gone after one read', '10 uploads an hour']) {
+  assert.ok(visible0(parasendHero).includes(fact),
+    `the free promise in the /parasend hero must carry its real limit: ${fact}`);
+}
+assert.ok(visible0(parasendHero).includes('For offices that email client documents'),
+  '/parasend must name who it is for in the first screen');
+
+const NO_CERT = 'Paramant does not hold third-party certification for these frameworks.';
+assert.ok(pricing.includes(NO_CERT), 'pricing.html lost the certification limit');
+assert.ok(parasend.includes(NO_CERT), 'parasend.html quotes the compliance documentation, so it must carry its limit');
+
+// A product page must not claim the identity or legal effect that /sign is
+// already forbidden from claiming. Same overclaim, wider surface.
+for (const [name, text] of [['parasign', parasign], ['parasend', parasend]]) {
+  assert.doesNotMatch(text, /identity verified|verified signer|signer verified|legally binding/i,
+    `${name}.html must not claim a verified identity or legal effect it cannot deliver`);
+}
+
+// Tone, section 6 of the guide. We have no testimonials, no customer logos and
+// no user counts, so no page may imply them, and the marketing vocabulary the
+// guide bans stays banned by test rather than by good intentions. One word
+// from that list is absent here on purpose: "unlock" appears in the /pricing
+// sentence these pages quote ("not to unlock features"), so banning it would
+// fail on shipped copy the guide itself pins.
+const BANNED = /revolutionary|seamless|cutting-edge|enterprise-grade|military-grade|trusted by|world-class|effortless|next-generation|empower|journey/i;
+for (const [name, text] of [['parasign', parasign], ['parasend', parasend]]) {
+  assert.doesNotMatch(text, BANNED, `${name}.html uses vocabulary the messaging guide bans`);
+}
+
+console.log('ui-truthfulness: the messaging guide claims are pinned to the pages that make them true');

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -688,6 +688,10 @@ function visible0(html) {
     .trim();
 }
 const visible = (file) => visible0(read(file));
+// The plan limits are read from the code that enforces them, not from another
+// page. tiers.js is the single source; relay.js turns its rows into a 402 and a
+// 413. Comparing two pages only proves they agree, and both were wrong together.
+const { default: tiers } = await import('../relay/lib/tiers.js');
 const parasign = visible('frontend/parasign.html');
 const parasend = visible('frontend/parasend.html');
 const aboutVisible = visible('frontend/about.html');
@@ -698,12 +702,26 @@ const signVisibleText = visible('frontend/sign.html');
 // Proof 1. The EU claim is about the data path, not the whole chain, and the
 // Resend exception travels with it. A page may shorten the long form on
 // /pararules to this one; it may never drop the second half.
-const EU_CLAIM = 'No US provider in the data path.';
+const EU_CLAIM = 'Hetzner Germany, Bunny DNS (Slovenia). No US provider in the data path.';
 const EU_EXCEPTION = 'Email goes out via Resend';
 const homeVisible = visible('frontend/index.html');
 for (const [name, text] of [['index', homeVisible], ['parasign', parasign], ['parasend', parasend]]) {
   assert.ok(text.includes(EU_CLAIM), `${name}.html lost the data-path wording of the EU claim`);
   assert.ok(text.includes(EU_EXCEPTION), `${name}.html states the EU claim without naming the Resend exception`);
+}
+// And it may not be offered against a source that does not carry it. The
+// Jurisdiction and privacy table on /security lists Hetzner Nuremberg, the legal
+// jurisdiction, the CLOUD Act row, retention, IP logging and analytics. Bunny is
+// not in it, and DNS is not a row. A page that names Bunny and then sends the
+// reader to that table has offered a checkpoint that fails when checked.
+const securityJurisdiction = (read('frontend/security.html')
+  .match(/<h2>Jurisdiction[\s\S]*?<\/table>/) || [''])[0];
+assert.ok(securityJurisdiction, 'security.html must keep its Jurisdiction and privacy table');
+assert.ok(!/Bunny/i.test(securityJurisdiction),
+  'the /security jurisdiction table now names Bunny; the product pages may point at it again');
+for (const [name, text] of [['parasign', parasign], ['parasend', parasend]]) {
+  assert.doesNotMatch(text, /Bunny DNS[^.]*\.[^.]*\.[^.]*\.[^.]*jurisdiction table is on the/,
+    `${name}.html sends the reader to the /security jurisdiction table for a claim that table does not carry`);
 }
 // The broader claim is the one section 9 of the guide holds open. It may stay
 // on /security, where the table qualifies it, and nowhere near a product hero.
@@ -770,13 +788,23 @@ assert.ok(visible0(parasignHero).includes(SES),
   'the SES scope note must sit in the first screen of /parasign, not below the tiers');
 assert.ok(visible0(parasignHero).includes('legal, finance and healthcare practices in the EU'),
   '/parasign must name who it is for in the first screen');
-assert.ok(visible0(parasignHero).includes('2 signatures a month'),
-  'the free promise in the /parasign hero must carry its real number');
+assert.ok(visible0(parasignHero).includes(`${tiers.tierLimit('community', 'signs_month')} signatures a month`),
+  'the free promise in the /parasign hero must carry the number tiers.js enforces');
 const parasendHero = read('frontend/parasend.html').split('<section class="ps-band"')[0];
-for (const fact of ['links that last an hour', 'gone after one read', '10 uploads an hour']) {
+const communityHeroFacts = [
+  `${tiers.tierLimit('community', 'transfers_month')} transfers a month`,
+  `${tiers.tierLimit('community', 'file_mb')} MB a file`,
+  `links that last an hour`,
+  `gone after one read`,
+];
+for (const fact of communityHeroFacts) {
   assert.ok(visible0(parasendHero).includes(fact),
-    `the free promise in the /parasend hero must carry its real limit: ${fact}`);
+    `the free promise in the /parasend hero must carry the limit tiers.js enforces: ${fact}`);
 }
+assert.ok(tiers.tierLimit('community', 'view_ttl_ms') === 3_600_000 && tiers.tierLimit('community', 'max_views') === 1,
+  'the one-hour, one-read wording in the /parasend hero no longer matches tiers.js');
+assert.doesNotMatch(visible0(parasendHero), /uploads (per|an) hour/i,
+  'the /parasend hero states the deprecated anon-endpoint rate as if it were a plan limit');
 assert.ok(visible0(parasendHero).includes('For offices that email client documents'),
   '/parasend must name who it is for in the first screen');
 
@@ -790,6 +818,31 @@ for (const [name, text] of [['parasign', parasign], ['parasend', parasend]]) {
   assert.doesNotMatch(text, /identity verified|verified signer|signer verified|legally binding/i,
     `${name}.html must not claim a verified identity or legal effect it cannot deliver`);
 }
+
+// ── A claim may not be contradicted by the page it cites ─────────────────────
+//
+// /parasend promised "ML-DSA-65 signed receipts" for ParaShare and linked to the
+// algorithm register in the same sentence. That register lists ParaShare
+// (webapp) with SIG n/a on the pre-v1 hybrid wire, migrating to v1; ML-DSA-65 is
+// the SDK rows. The register is the source, so it is read here and the page is
+// held to what it says.
+const registerRow = (label) => {
+  const rows = read('frontend/crypto-agility.html').match(/<tr>[\s\S]*?<\/tr>/g) || [];
+  const row = rows.find((r) => r.includes(label));
+  return row ? [...row.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/g)].map((m) => m[1].replace(/<[^>]+>/g, '').trim()) : null;
+};
+const shareRow = registerRow('ParaShare (webapp)');
+assert.ok(shareRow && shareRow.length >= 4, 'crypto-agility.html no longer registers ParaShare (webapp)');
+const [, shareKem, shareSig, shareWire] = shareRow;
+assert.equal(shareKem, 'ML-KEM-768 + ECDH P-256', 'the ParaShare KEM in the register changed; /parasend quotes it');
+if (shareSig === 'n/a') {
+  assert.doesNotMatch(parasend, /ParaShare[^.]*ML-DSA-65 signed receipts/,
+    'the register gives ParaShare no signature, so /parasend may not sell it ML-DSA-65 signed receipts');
+  assert.ok(parasend.includes(`the webapp on the ${shareWire} wire`),
+    '/parasend must state the wire format the register gives the webapp, not a better one');
+}
+assert.doesNotMatch(parasend, /proof that the file came from you/,
+  '/parasend may not promise sender proof on a path the register gives no signature');
 
 // Tone, section 6 of the guide. We have no testimonials, no customer logos and
 // no user counts, so no page may imply them, and the marketing vocabulary the


### PR DESCRIPTION
## What this is

Three commercial pages, one shape, taken from `docs/brand/messaging.md` (#331):
what you can do here, who it is for, the split with its real number, who is
behind it, then the proof and the honest limits. `/parasend` is new; `/parasign`
has existed since #325 and is rebuilt around the buyer; `/sign` loses the last
piece of jargon in its first screenful.

Rebased on `main` at 6dded85. Conflicts resolved in favour of `main` for
everything outside these three pages, including the Community naming from #328
and the /about give-back sentence from #332.

## The review points, and what each one got

| Point | What changed |
| --- | --- |
| /parasign opens on technique, not a promise | First paragraph is two sentences and 160 characters about what the buyer gets. The guide's own tone rule keeps cryptography below the fold; the paragraph the guide specifies for this page broke that rule, so it now sits verbatim in the proof block at 04. |
| Jargon label under the H1 in the first screen | Eyebrow reads `ParaSign · document signing by Paramant`. |
| eIDAS status on screen 8 of 9 | Moved from 6,386px to **737px**. It is the first thing a lawyer asks, so the page answers it before the tiers. |
| Price table before the explanation | /parasign: 01 what it does, then 02 what it costs (first tier card at 2,518px). /parasend: tables at 4,220px, after what it does, how to begin, and who is behind it. |
| Nowhere does it say who it is for | Both pages name the buyer in the first screen. /parasign uses the audience index.html already states: legal, finance and healthcare practices in the EU. |
| "Free forever for everyone" hides the limits | /parasign: "2 signatures a month, no card, forever." /parasend: "10 transfers a month, 5 MB a file, links that last an hour and are gone after one read." Both at the promise, not four screens down, and both read from `relay/lib/tiers.js`. |
| "the tier named Free" bridge sentence | Gone, and the /parasend tier card is named Community. #328 renamed the tier on /pricing, so there is nothing left to explain away. |
| SLA is 99.95%, not 99.9% | Correct on the page, and now read off /sla by name (the Enterprise cell) so any page repeating it has to match. |
| The monthly prices are not pinned | Fixed, see below. |
| /sign: "private key" in the first screenful | "Your signing key stays here · it is made on your device and never reaches our servers." |
| /parasend "What it does" is technique | Section 02 says what the buyer gets. AES-256-GCM, ML-KEM-768, ECDH P-256, ML-DSA-65 and the RAM budget are in 06, each beside the page that checks it. |

Two things beyond the list, both from the same review:

- **"Post-quantum, zero-knowledge"** is gone from the scope note. It described
  nothing the page can point at, and it stood next to the most honest paragraph
  on the page.
- The /parasend founder block quoted a sentence about US subscriptions that had
  no source. #332 has since put the guide's sentence on /about, so the page now
  quotes it: "The Community plan is his way of giving something back to society;
  the business plans pay for it."

## The two gates that were not gates

Both found by sabotage, not by reading.

**The monthly price on both product pages was pinned by nothing.**
`relay/test/pricing-page.test.js` asserted with a bare substring, so
`includes('&euro;49')` was satisfied by the annual `&euro;499 excl.` on the same
card, and `includes('&euro;15')` by `&euro;150`. Verified: `&euro;49` to
`&euro;59` on /parasign and `&euro;15` to `&euro;19` on /parasend both stayed
green. Those are the two numbers a buyer clicks. An amount now has to end where
it says it ends and sit on the card of its own plan, so the opening line
"business plans from &euro;49 a month" cannot stand in for the tier.

**A claim that has to be read first was asserted against the whole file**, which
is satisfied by screen 8 of 9. The eIDAS scope note, the audience line and the
free promise with its number are now asserted against the hero section, not the
file.

Also pinned: the EU claim in the form #328 settled ("No US provider in the data
path", with the Resend exception in the same breath) on `/`, `/parasign` and
`/parasend`, with the broader "no US company" wording refused on the product
pages, since section 9 of the guide holds it open and it stays on /security
where the table qualifies it. And the stale string is gone: the suite pinned
"The community tier stays free", a sentence #328 removed from /pricing.


## Second round: four claims contradicted by their own source

Each of these was a claim with a checkpoint attached, where the checkpoint said
something else. That is worse than no checkpoint, so the pins moved with the
claims.

**1. The free number was the wrong number.** Both pages said "10 uploads an
hour". The figure is real, but it is `ANON_RATE_PER_HOUR` on
`POST /v2/anon-inbound` (`relay/relay.js`), deprecated on 2026-05-28, answering
with `Deprecation` and `Sunset` headers, retiring 2026-12-31. It is not what a
Community **account** gets. `relay/lib/tiers.js` gives the Community row 10
transfers a month, 5 MB a file, a one hour link and one read; `relay.js`
enforces them with a 402 (`monthly_transfer_quota_reached`) and a 413
(`Max 5MB`). Hero and Community card now state those. ParaSend Pro gains its
real ceiling, 500 a month, in place of "No IP rate limit", the same artefact.

On /parasign the ParaSign Pro card said "Unlimited transfers". A ParaSign Pro
account derives `plan_parasend: 'pro'` (`entitlements.js derivePlanParasend`),
which is 500 a month, and that file has a hard rule that no metered tier is
unbounded: even enterprise gets a finite ceiling, never `Infinity`. Now 500.

> `frontend/pricing.html:249` and `frontend/index.html:360` carry the same
> upload figure. They are **not** touched here; #336 and a separate PR correct
> them. Naming it so it is not lost.

**2. ParaShare has no signature, and the register the card cites says so.**
/parasend promised "ML-DSA-65 signed receipts" for ParaShare and linked to the
algorithm register in the same sentence. That register
(`crypto-agility.html:429-434`) lists ParaShare (webapp) with SIG **n/a** on the
**pre-v1 hybrid** wire, migrating to v1; ML-DSA-65 on the v1 wire is sdk-py
3.0.0 and sdk-js 3.0.0. The card now states what the register states. The
buyer-facing half went with it: section 02 promised the recipient "proof that
the file came from you", a signature claim on a path with no signature. It now
says what the path does deliver: the file opens on the recipient's registered
device and nowhere else, and a file altered on the way does not open at all.

**3. The jurisdiction table does not carry Bunny.** Both pages named Bunny DNS
(Slovenia) and then sent the reader to the Jurisdiction and privacy table on
/security. That table (`security.html:351-362`) lists Hetzner Nuremberg, the
legal jurisdiction, the CLOUD Act row, retention, IP logging and analytics. DNS
is not a row in it. The sentence stays exactly as `index.html:382` carries it;
the pointer now goes to /privacy and ParaRule 5, which do carry it.

**4. Two smaller ones.** "Fixed-size ciphertext" is a ParaShare property, not a
property of every transfer (`security.html:358`: "approximate encrypted size (up
to 5 MB; exact 5 MB for ParaShare)"), so it is bounded to that path. And the Pro
list was missing "Email notifications via Resend" (`pricing.html:267`), which
names a subprocessor, so its absence quietly dropped a disclosure.

### What the pins do now

The ParaSend limit lines are read from `relay/lib/tiers.js` instead of compared
against the wording on /pricing. Comparing two pages only proves they agree, and
that is exactly the failure here: /pricing and index.html are wrong in the same
way, so a page-to-page pin was green throughout. The uploads-per-hour figure and
"unlimited transfers" are refused on both product pages under any wording. The
algorithm register is parsed and the page held to the row it cites. The EU
sentence is pinned to index.html, where it ships, and an assertion fails if the
/security table ever starts naming Bunny, at which point the pointer may return.

## Sabotage log

Each string mutated on its own, suite run, reverted.

| Mutation | Result |
| --- | --- |
| /parasign Pro monthly `&euro;49` to `&euro;59` | RED |
| /parasign Pro annual `&euro;499` to `&euro;599` | RED |
| /parasend Pro monthly `&euro;15` to `&euro;19` | RED |
| /parasend `SLA 99.95%` to `SLA 99.9%` | RED |
| /parasign audience line removed from the hero | RED |
| /parasign "2 signatures a month" removed from the hero | RED |
| /parasend hero limits removed | RED |
| /parasign "No US provider in the data path" to "No US company in the chain" | RED |
| /parasend Resend sentence removed | RED |
| `tiers.js` community `transfers_month` 10 to 20 | RED |
| `tiers.js` pro `transfers_month` 500 to 900 | RED |
| `tiers.js` community `file_mb` 5 to 8 | RED |
| `tiers.js` community `signs_month` 2 to 3 | RED |
| /parasend Community transfers line removed | RED |
| /parasend 5 MB line removed | RED |
| /parasend Pro transfers line back to "No IP rate limit" | RED |
| /parasend hero back to the anon uploads figure | RED |
| /parasign back to "Unlimited transfers" | RED |
| /parasend "Email notifications via Resend" shortened | RED |
| /pricing "Email notifications via Resend" shortened | RED |
| /parasend re-claims ML-DSA-65 receipts for the webapp | RED |
| /parasend re-claims sender proof in section 02 | RED |
| register row: ParaShare KEM changed | RED |
| /security jurisdiction table gains Bunny | RED |
| index.html EU sentence changed | RED |

## Measured at 390px, Playwright, y from the top of the document

No horizontal overflow anywhere: `scrollWidth` is exactly 390 on all three.

| | /parasign | /parasend | /sign |
| --- | --- | --- | --- |
| H1 | 119 | 119 | 105 |
| audience line | 432 | 396 | n/a |
| first CTA | 511 | 500 | 763 |
| free promise with its number | 632 | 620 | 291 |
| eIDAS / SES status | **737** | n/a (signing only) | n/a |
| burn-on-read warning | n/a | 719 | n/a |
| first price table | 2,518 | 4,261 | n/a |
| page height | 7,744 (9.2 screens) | 8,963 (10.6) | 2,163 (2.6) |

On /parasign the H1, the audience, both buttons, the free promise and the eIDAS
note all land inside the first 844px.

## One layout fix, page-local

At 390px the house `.sec-head` keeps the section number in its own grid column,
which left the H1 about 160px to wrap in: six lines of headline on /parasign,
with the buttons and the eIDAS note pushed off the first screen. On a narrow
screen the number now stacks above the headline. The rule lives in each page's
own `<style>`; `design-system.css` is untouched, because it is shared with pages
this PR does not open.

## Checks run locally

`tests/links`, `tests/seo-contract`, `tests/ui-truthfulness`, `tests/site-claims`,
`tests/navigation-shell`, `tests/frontend-loading-contract`,
`relay/test/pricing-page.test.js`, `scripts/check-csp-inline.sh`,
`scripts/check-cache-bust.sh`, `eslint`, and `tests/static-sanity.sh`
(10/10, including the commit-style guard). All pass.

`frontend/apply-nav.py` was run and changed nothing: nav and footer were already
stamped correctly. `bron-seo/build_sitemap.py` regenerated the sitemap, which
adds the one `/parasend` entry.

## Not in scope

The pages are English while the audience named on them is a Dutch office. Every
reviewer raised it; it is a sitewide decision and belongs in its own round. The
SES versus AES contradiction between /about and the /pricing FAQ is section 9 of
the guide and is likewise left where it is.

