### PR TITLE
test(relay): real tests for the critical paths of relay.js

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,8 +110,9 @@ jobs:
       # parasign-sandbox-live-guard, the only guard on "a psk_live_ key must
       # never reach the sandbox auto-signer". They run here instead, against the
       # engine this job builds, and test/_requires.js now fails them outright if
-      # it is missing. This job has no redis service, so that one precondition is
-      # declared by name rather than silently swallowed.
+      # it is missing. These four need the engine but not redis, and the redis
+      # service now on this job is not exposed to them, so that one precondition
+      # stays declared by name rather than silently swallowed.
       - name: Relay ParaSign engine suites
         working-directory: relay
         env:
@@ -149,20 +150,30 @@ jobs:
       # the rate limiters including the redis-backed fleet-wide one. They live
       # here and not in the unit job below because relay.js requires `redis` and
       # @paramant/core at load, and this is the job that installs both.
-      - name: Relay route suites (a booted relay.js)
+      #
+      # parasign-signs-quota rides along here because it needs the same redis and
+      # nothing else. It was the LAST suite in the repo that asserted nothing in
+      # any CI job: it ran only in the no-install unit job, where it has no redis
+      # and therefore skipped every time, so its five checks on the monthly
+      # signs cap (the metering that was once stuck behind a dead `&& false`)
+      # have never actually run on a pull request. With a redis service they do.
+      - name: Relay route suites (a booted relay.js) and the redis-backed units
         working-directory: relay
         env:
           REDIS_URL: redis://127.0.0.1:6399
         run: |
           set -o pipefail
-          node --test test/route-*.test.js 2>&1 | tee /tmp/relay-routes.log
+          node --test test/route-*.test.js test/parasign-signs-quota.test.js 2>&1 | tee /tmp/relay-routes.log
           # The same gate as the unit job below: a suite that runs and asserts
           # NOTHING still reports green, and that is how four ParaSign suites
           # came to mean nothing for weeks. This job has redis AND the engine,
           # so nothing here has an excuse to be silent. The expected set is
           # empty, by name.
+          # `|| true`: GitHub runs this block under `bash -e`, and grep exits 1
+          # when it matches nothing. Finding no silent suite is the GOOD case, so
+          # without this the step fails exactly when the gate is satisfied.
           silent=$(grep -oE '^# [a-z0-9-]+: SKIPPED - 0 checks ran' /tmp/relay-routes.log \
-                   | sed 's/^# //; s/: SKIPPED.*//' | sort)
+                   | sed 's/^# //; s/: SKIPPED.*//' | sort || true)
           echo "--- route suites that asserted nothing in this job:"
           echo "${silent:-(none)}" | sed 's/^/      /'
           if [ -n "$silent" ]; then
@@ -197,7 +208,8 @@ jobs:
       # job, by name and on purpose, and that is fine as long as it stays two and
       # stays those two. What is not fine is a third joining them quietly, which
       # is exactly how four ParaSign suites came to report "ok" over nothing for
-      # weeks. So the skips are counted, named, and held to a list.
+      # weeks. So the skips are counted, named, and held to a list, and that
+      # list is now empty: every suite that runs here asserts something.
       - name: Relay unit suite
         working-directory: relay
         env:
@@ -209,17 +221,22 @@ jobs:
         run: |
           set -o pipefail
           node --test $(ls test/*.test.js | grep -vE \
-            'inbound-hash-verify|deep-health-gate|billing-stance-boot|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index|route-') \
+            'inbound-hash-verify|deep-health-gate|billing-stance-boot|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index|parasign-signs-quota|route-') \
             2>&1 | tee /tmp/relay-units.log
           # Which suites ran and asserted nothing. The line comes from
           # summary() in test/_requires.js.
+          # `|| true`: under `bash -e` a grep that matches nothing exits 1, and
+          # since the expected set below is now empty, no match is the good case.
           silent=$(grep -oE '^# [a-z0-9-]+: SKIPPED - 0 checks ran' /tmp/relay-units.log \
-                   | sed 's/^# //; s/: SKIPPED.*//' | sort)
-          # ONE suite, not two. parasign-store also lacks redis here, but it has a
-          # memory fallback and still runs three checks, so it is not silent.
-          # Measured, not assumed: the first version of this list said two and
-          # this gate caught it on the first run.
-          expected=$'parasign-signs-quota'
+                   | sed 's/^# //; s/: SKIPPED.*//' | sort || true)
+          # EMPTY, and it is meant to stay empty. parasign-signs-quota used to be
+          # the one name here: it needs redis, this job has none, so it skipped
+          # on every run and its five checks never ran anywhere. It now runs in
+          # the crypto job against a real redis service and is excluded from the
+          # glob above, which leaves nothing in this job that asserts nothing.
+          # parasign-store also lacks redis here but has a memory fallback and
+          # still runs three checks, so it is not silent either.
+          expected=''
           echo "--- suites that asserted nothing in this job:"
           echo "${silent:-(none)}" | sed 's/^/      /'
           if [ "$silent" != "$expected" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   # https://github.com/Apolloccrypt/paramant-sdk (with the cross-impl
   # conformance suite). This workflow now covers the relay only.
   shell-syntax:
-    name: shell — bash -n
+    name: shell, bash -n
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -30,7 +30,7 @@ jobs:
           echo "All shell scripts parse OK."
 
   undefined-names:
-    name: static — every name must exist
+    name: static, every name must exist
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -45,7 +45,7 @@ jobs:
         run: npx --yes eslint@9 .
 
   frontend-cache-bust:
-    name: frontend — cache-bust guard
+    name: frontend, cache-bust guard
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -55,6 +55,22 @@ jobs:
   relay-crypto-tests:
     name: relay - crypto suite (@paramant/core)
     runs-on: ubuntu-latest
+    # The route suites (test/route-*.test.js) boot a real relay.js, and the
+    # envelope store is redis-only (relay.js:5650), without a server every
+    # /v2/envelopes route answers 503 and the whole ParaSign lifecycle is
+    # untestable. This is also what makes the FLEET-WIDE half of the
+    # envelope-create limiter testable: two relay processes, one budget.
+    # Same image tag as docker-compose.yml runs in production.
+    services:
+      redis:
+        image: redis:7.4.8-alpine
+        ports:
+          - 6399:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -123,6 +139,39 @@ jobs:
         # one-off (BILLING_MODE empty, production) or opens subscriptions.
         run: node --test test/inbound-hash-verify.test.js test/deep-health-gate.test.js test/billing-stance-boot.test.js
 
+      # The route layer of relay.js. Until 2026-09-02 the 6488 lines and 68
+      # routes of relay.js were loaded by NO unit test at all, the coverage
+      # table simply did not list the file. These suites boot it (test/
+      # _relay-server.js) and drive it over HTTP: the auth gate, the ParaSign
+      # envelope lifecycle end to end with real ML-DSA-65 signatures and an
+      # offline verification of the receipt, ParaSend burn-on-read and the
+      # per-tier ceilings, entitlement persistence across a restart (#315), and
+      # the rate limiters including the redis-backed fleet-wide one. They live
+      # here and not in the unit job below because relay.js requires `redis` and
+      # @paramant/core at load, and this is the job that installs both.
+      - name: Relay route suites (a booted relay.js)
+        working-directory: relay
+        env:
+          REDIS_URL: redis://127.0.0.1:6399
+        run: |
+          set -o pipefail
+          node --test test/route-*.test.js 2>&1 | tee /tmp/relay-routes.log
+          # The same gate as the unit job below: a suite that runs and asserts
+          # NOTHING still reports green, and that is how four ParaSign suites
+          # came to mean nothing for weeks. This job has redis AND the engine,
+          # so nothing here has an excuse to be silent. The expected set is
+          # empty, by name.
+          silent=$(grep -oE '^# [a-z0-9-]+: SKIPPED - 0 checks ran' /tmp/relay-routes.log \
+                   | sed 's/^# //; s/: SKIPPED.*//' | sort)
+          echo "--- route suites that asserted nothing in this job:"
+          echo "${silent:-(none)}" | sed 's/^/      /'
+          if [ -n "$silent" ]; then
+            echo "::error::a route suite asserted nothing. It has redis and the"
+            echo "engine here, so a skip means a broken precondition, not a"
+            echo "missing dependency. Fix the suite; do not add it to a list."
+            exit 1
+          fi
+
   relay-unit-tests:
     name: relay - unit suite (no native deps)
     runs-on: ubuntu-latest
@@ -139,6 +188,10 @@ jobs:
       # parasign-* suites are excluded for the same reason: they need the
       # ML-DSA-65 engine, which this job deliberately does not build. They used
       # to run here and silently skip, which is what made "ok 24" mean nothing.
+      # The route-*.test.js suites are excluded for both reasons at once: they
+      # boot a real relay.js (which requires `redis` and @paramant/core at load)
+      # and the envelope ones need a reachable redis server. They run in the
+      # crypto job above, which installs the deps and has a redis service.
       # A declared skip is better than a silent one, but it still exits 0 and
       # still shows up as a green check. Two suites assert nothing at all in this
       # job, by name and on purpose, and that is fine as long as it stays two and
@@ -156,7 +209,7 @@ jobs:
         run: |
           set -o pipefail
           node --test $(ls test/*.test.js | grep -vE \
-            'inbound-hash-verify|deep-health-gate|billing-stance-boot|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index') \
+            'inbound-hash-verify|deep-health-gate|billing-stance-boot|parasign-sandbox|parasign-open-api-e2e|parasign-envelope-index|route-') \
             2>&1 | tee /tmp/relay-units.log
           # Which suites ran and asserted nothing. The line comes from
           # summary() in test/_requires.js.

--- a/relay/test/_relay-server.js
+++ b/relay/test/_relay-server.js
@@ -53,7 +53,13 @@ function stopChild(child) {
 function killAll() {
   const all = [..._children].map(stopChild);
   _children.clear();
-  return Promise.all(all);
+  return Promise.all(all).then(() => {
+    for (const d of _dirs) {
+      if (!d.startsWith(os.tmpdir())) continue;
+      try { fs.rmSync(d, { recursive: true, force: true }); } catch (_) {}
+    }
+    _dirs.clear();
+  });
 }
 
 // A port the OS just told us is free. Racy in theory (someone could take it in
@@ -69,8 +75,14 @@ function freePort() {
   });
 }
 
+// Scratch dirs handed out by boot(), removed by killAll() so a test run leaves
+// nothing behind. Only ever paths this module made under the OS temp dir.
+const _dirs = new Set();
+
 function scratchDir(tag) {
-  return fs.mkdtempSync(path.join(os.tmpdir(), `relay-${tag}-`));
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), `relay-${tag}-`));
+  _dirs.add(d);
+  return d;
 }
 
 // Env that keeps a booted relay entirely inside its own scratch dir. Every

--- a/relay/test/_relay-server.js
+++ b/relay/test/_relay-server.js
@@ -1,0 +1,245 @@
+'use strict';
+// One booted relay.js, for suites that test the ROUTE layer rather than a lib.
+//
+// WHY. relay.js is 6488 lines and 68 route comparisons, and until now no unit
+// test loaded it: it was only ever started as a black box by inbound-hash-verify,
+// deep-health-gate and billing-stance-boot, each of which rolled its own spawn.
+// The auth gate, the envelope lifecycle, the transfer burn and the per-tier
+// limits all live in that file, so testing them means booting it. This is the
+// shared version of the spawn those three suites already do by hand, plus:
+//   - a writable scratch dir for every path that otherwise defaults to /data
+//     (identity, STH log, peer STHs, code manifest, trial keys, users.json),
+//     so a test run neither needs root nor leaves anything behind;
+//   - an ephemeral port taken from the OS, so parallel suites never collide;
+//   - a small request helper that returns { status, headers, body } with the
+//     JSON already parsed.
+//
+// Nothing here reaches the network: the relay binds 127.0.0.1, redis and NATS
+// are switched off by empty URLs, and Mollie is never given a key.
+
+const { spawn } = require('child_process');
+const net = require('net');
+const http = require('http');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const RELAY_DIR = path.join(__dirname, '..');
+const RELAY_JS = path.join(RELAY_DIR, 'relay.js');
+
+// Every child this module started, so a suite's after() hook can kill the lot.
+const _children = new Set();
+
+// SIGTERM, not SIGKILL. relay.js handles SIGTERM (relay.js:6479) by zeroizing
+// its blobs, flushing the CT/STH queues and calling process.exit(0) - and a
+// clean exit is also what makes the child write its V8 coverage profile when
+// the run is wrapped in c8 or NODE_V8_COVERAGE. A SIGKILLed relay contributes
+// no coverage at all, which is exactly why relay.js showed up as "not in the
+// table" in the 2026-09-02 audit: the three suites that boot it all kill it
+// with SIGKILL. SIGKILL stays as the backstop for a child that ignores the ask.
+function stopChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolve) => {
+    const done = () => { clearTimeout(t); resolve(); };
+    const t = setTimeout(() => { try { child.kill('SIGKILL'); } catch (_) {} resolve(); }, 3000);
+    child.once('exit', done);
+    try { child.kill('SIGTERM'); } catch (_) { done(); }
+  });
+}
+
+// Await this in a suite's after() hook. Waiting is not politeness: a child that
+// has not finished exiting has not finished writing its coverage profile
+// either, and the parent exiting first loses it.
+function killAll() {
+  const all = [..._children].map(stopChild);
+  _children.clear();
+  return Promise.all(all);
+}
+
+// A port the OS just told us is free. Racy in theory (someone could take it in
+// the gap), which is why boot() retries on EADDRINUSE.
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const p = srv.address().port;
+      srv.close(() => resolve(p));
+    });
+  });
+}
+
+function scratchDir(tag) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `relay-${tag}-`));
+}
+
+// Env that keeps a booted relay entirely inside its own scratch dir. Every
+// entry here has a /data default in relay.js; without them the boot logs four
+// EACCES warnings and the identity is regenerated per restart, which quietly
+// breaks any test that restarts the relay on purpose.
+function scratchEnv(dir) {
+  return {
+    RELAY_IDENTITY_FILE: path.join(dir, 'relay-identity.json'),
+    TRIAL_KEYS_FILE: path.join(dir, 'trial-keys.jsonl'),
+    STH_FILE: path.join(dir, 'sth-log.jsonl'),
+    PEER_STH_DIR: path.join(dir, 'peer-sths'),
+    CODE_MANIFEST_FILE: path.join(dir, 'code-manifest.json'),
+    USERS_FILE: path.join(dir, 'users.json'),
+  };
+}
+
+// Boot relay.js and wait until /health answers.
+//
+// opts.users      – users.json content as an object; goes in USERS_JSON (read
+//                   only) unless opts.usersFile is true, in which case it is
+//                   written to <dir>/users.json so the relay can write it back.
+// opts.env        – extra environment, wins over everything above.
+// opts.dir        – reuse a scratch dir (this is how a restart test keeps the
+//                   users.json and the relay identity of the previous boot).
+// opts.captureLog – keep stdout, exposed as srv.log().
+async function boot(opts = {}) {
+  const dir = opts.dir || scratchDir(opts.tag || 'test');
+  const users = opts.users || { api_keys: [] };
+  const env = {
+    ...process.env,
+    ...scratchEnv(dir),
+    NODE_ENV: 'test',
+    // No redis, no NATS, no Mollie key: this relay talks to nothing.
+    REDIS_URL: '',
+    RELAY_REDIS_URL: '',
+    NATS_URL: '',
+    RELAY_SELF_URL: '',
+    RELAY_PRIMARY_URL: '',
+    HOST: '127.0.0.1',
+  };
+  for (const k of ['MOLLIE_API_KEY', 'MOLLIE_TEST_API_KEY', 'BILLING_MODE']) delete env[k];
+
+  if (opts.usersFile) {
+    // Only write when the caller supplied users, so a restart keeps whatever
+    // the previous boot persisted.
+    if (opts.users || !fs.existsSync(env.USERS_FILE)) {
+      fs.writeFileSync(env.USERS_FILE, JSON.stringify(users, null, 2));
+    }
+    delete env.USERS_JSON;
+  } else {
+    env.USERS_JSON = JSON.stringify(users);
+  }
+  Object.assign(env, opts.env || {});
+
+  let lastErr = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const port = await freePort();
+    const child = spawn(process.execPath, [RELAY_JS], {
+      cwd: RELAY_DIR,
+      env: { ...env, PORT: String(port) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    _children.add(child);
+
+    let out = '';
+    child.stdout.on('data', (d) => { out += d.toString(); });
+    child.stderr.on('data', (d) => { out += d.toString(); });
+
+    let exited = null;
+    child.on('exit', (code) => { exited = code; });
+
+    const deadline = Date.now() + 20000;
+    let healthy = false;
+    while (Date.now() < deadline && exited === null) {
+      try {
+        const r = await fetch(`http://127.0.0.1:${port}/health`);
+        if (r.ok) { healthy = true; break; }
+      } catch (_) { /* not up yet */ }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    if (healthy) {
+      return makeHandle(child, port, dir, env, () => out, opts);
+    }
+    _children.delete(child);
+    stopChild(child);
+    lastErr = new Error(
+      `relay.js did not become healthy on port ${port} (exit=${exited}).\n` +
+      `stdout/stderr tail:\n${out.slice(-2000)}`);
+    if (!/EADDRINUSE/.test(out)) break; // only a port clash is worth a retry
+  }
+  throw lastErr || new Error('relay.js did not boot');
+}
+
+function makeHandle(child, port, dir, env, log, bootOpts) {
+  const base = `http://127.0.0.1:${port}`;
+  const handle = {
+    port, dir, env, child, base, log,
+    // One request. `body` may be a string, a Buffer or a plain object (which is
+    // sent as JSON). Returns the parsed JSON when the answer is JSON, and the
+    // raw text either way.
+    req(method, p, { headers = {}, body } = {}) {
+      const hdr = { ...headers };
+      let payload = null;
+      if (body !== undefined && body !== null) {
+        if (Buffer.isBuffer(body) || typeof body === 'string') {
+          payload = Buffer.from(body);
+        } else {
+          payload = Buffer.from(JSON.stringify(body));
+          if (!Object.keys(hdr).some((h) => h.toLowerCase() === 'content-type')) {
+            hdr['Content-Type'] = 'application/json';
+          }
+        }
+      }
+      return new Promise((resolve, reject) => {
+        const r = http.request(base + p, {
+          method,
+          headers: hdr,
+          // GET /v2/outbound/:hash answers with an X-Paramant-Receipt header of
+          // about 18.5 KB (a base64 ML-DSA-65 signature over the delivery
+          // receipt, measured 2026-09-02). Node's own default maxHeaderSize is
+          // 16 KB and undici's fetch() caps earlier, so a plain fetch() of a
+          // download throws UND_ERR_HEADERS_OVERFLOW. Raised here so the test
+          // client is not the thing under test; the size itself is a finding,
+          // reported with this PR, not a fixture.
+          maxHeaderSize: 96 * 1024,
+        }, (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            const buf = Buffer.concat(chunks);
+            const text = buf.toString('utf8');
+            let json = null;
+            try { json = JSON.parse(text); } catch (_) { /* not JSON */ }
+            resolve({ status: res.statusCode, headers: res.headers, text, json, buf });
+          });
+        });
+        r.on('error', reject);
+        if (payload) r.write(payload);
+        r.end();
+      });
+    },
+    get(p, o) { return handle.req('GET', p, o); },
+    post(p, o) { return handle.req('POST', p, o); },
+    // Read what the relay persisted to its users.json (usersFile mode only).
+    readUsersFile() {
+      return JSON.parse(fs.readFileSync(env.USERS_FILE, 'utf8'));
+    },
+    stop() {
+      _children.delete(child);
+      stopChild(child);
+    },
+    // Stop and boot again on the SAME scratch dir: same users.json, same relay
+    // identity, new process. This is the shape of the #315 regression test.
+    async restart(extra = {}) {
+      handle.stop();
+      await new Promise((r) => setTimeout(r, 150));
+      // Same dir, same env, no fresh users payload: the relay must find on disk
+      // whatever the previous process wrote there.
+      return boot({
+        ...bootOpts,
+        users: null,
+        dir,
+        usersFile: true,
+        env: { ...(bootOpts.env || {}), ...extra },
+      });
+    },
+  };
+  return handle;
+}
+
+module.exports = { boot, killAll, freePort, RELAY_DIR };

--- a/relay/test/route-auth-gate.test.js
+++ b/relay/test/route-auth-gate.test.js
@@ -1,0 +1,265 @@
+'use strict';
+// The auth gate of relay.js, over HTTP, on a really booted relay.
+//
+// WHY THIS SUITE EXISTS. The gate is fifteen lines at relay.js:4194-4218 and it
+// is the only thing standing between the open internet and 68 routes. It had no
+// unit test at all: the 2026-09-02 audit measured relay.js at 0 % coverage,
+// loaded by no test in the suite. The ParaID bypass earlier this year was
+// exactly a route that answered before the gate had a say, so the rule this
+// suite pins is the ParaID rule: AUTH FIRST, VALIDATION SECOND. A 400 on a
+// keyless request is a leak, it tells an unauthenticated caller what the body
+// should have looked like.
+//
+// What is asserted here, and why each line earns its place:
+//   * a gated route answers 401 to no key, an unknown key and a de-activated
+//     key, with the same body every time (no oracle that separates them);
+//   * a garbage body plus a missing key is still a 401, never a 400;
+//   * the three envelope recipient routes are public BY DESIGN (an external
+//     signer has no key) and POST /v2/envelopes is NOT, which is the exact
+//     distinction isEnvelopePublic draws;
+//   * /v2/admin* is 401 without ADMIN_TOKEN and reachable with it, and the
+//     double-gated admin routes need X-Internal-Auth on top;
+//   * an admin route stays closed when ADMIN_TOKEN is not configured at all
+//     (fail closed, not open).
+//
+// Runs against a relay booted WITHOUT redis, so the envelope store is absent
+// and an authenticated envelope call answers 503. That is deliberate: this
+// suite is about who gets past the gate, not about what is behind it. The
+// lifecycle behind it is route-envelope-lifecycle.test.js.
+// Run: node --test relay/test/route-auth-gate.test.js
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const { boot, killAll } = require('./_relay-server');
+const { summary } = require('./_requires');
+
+const ADMIN = 'admin-token-for-the-auth-gate-suite';
+const INTERNAL = 'internal-token-for-the-auth-gate-suite';
+const LIVE_KEY = 'pgp_live_key_for_the_auth_gate_suite';
+const DEAD_KEY = 'pgp_dead_key_for_the_auth_gate_suite';
+
+let srv;      // relay with ADMIN_TOKEN + INTERNAL_AUTH_TOKEN configured
+let noAdmin;  // relay with neither configured
+let checks = 0;
+const did = () => { checks++; };
+
+before(async () => {
+  const users = {
+    api_keys: [
+      { key: LIVE_KEY, plan: 'pro', active: true, label: 'live', email: 'live@example.test', account_id: 'acct_live' },
+      // active:false is how a revoked key looks on disk. loadUsers skips it
+      // entirely (relay.js:1829), so it must be indistinguishable from a key
+      // that never existed.
+      { key: DEAD_KEY, plan: 'pro', active: false, label: 'dead', email: 'dead@example.test', account_id: 'acct_dead' },
+    ],
+  };
+  srv = await boot({ tag: 'authgate', users, env: { ADMIN_TOKEN: ADMIN, INTERNAL_AUTH_TOKEN: INTERNAL } });
+  noAdmin = await boot({ tag: 'authgate-noadmin', users });
+});
+
+after(async () => { await killAll(); summary('route-auth-gate', checks); });
+
+// ── 1. the gate itself ───────────────────────────────────────────────────────
+
+test('POST /v2/envelopes without a key is 401, and the body says only that', async () => {
+  const r = await srv.post('/v2/envelopes', { body: { doc_hash: 'a'.repeat(64), parties: [{ label: 'A' }] } });
+  assert.strictEqual(r.status, 401);
+  assert.deepStrictEqual(r.json, { error: 'Invalid API key', hint: 'X-Api-Key: pgp_...' });
+  did();
+});
+
+test('an unknown key and a de-activated key are the same 401 (no existence oracle)', async () => {
+  const body = { doc_hash: 'a'.repeat(64), parties: [{ label: 'A' }] };
+  const unknown = await srv.post('/v2/envelopes', { headers: { 'X-Api-Key': 'pgp_no_such_key' }, body });
+  const revoked = await srv.post('/v2/envelopes', { headers: { 'X-Api-Key': DEAD_KEY }, body });
+  assert.strictEqual(unknown.status, 401);
+  assert.strictEqual(revoked.status, 401);
+  assert.deepStrictEqual(revoked.json, unknown.json,
+    'a de-activated key must answer exactly like an unknown one, or the 401 is a key-existence oracle');
+  did();
+});
+
+test('THE ParaID RULE: auth runs before validation, so a bad body never turns a 401 into a 400', async () => {
+  // Four shapes that would each be a 400 from the handler if it ever saw them:
+  // no body at all, invalid JSON, valid JSON with nothing in it, and a doc_hash
+  // of the wrong length. All four must still be 401 without a key.
+  const cases = [
+    ['no body', undefined],
+    ['invalid json', '{ this is not json'],
+    ['empty object', {}],
+    ['short doc_hash', { doc_hash: 'abc', parties: [] }],
+  ];
+  for (const [name, body] of cases) {
+    const r = await srv.post('/v2/envelopes', {
+      headers: { 'Content-Type': 'application/json' },
+      body: body === undefined ? undefined : body,
+    });
+    assert.strictEqual(r.status, 401, `${name}: expected 401, got ${r.status} ${r.text}`);
+    assert.notStrictEqual(r.status, 400, `${name}: a keyless caller learned something about the body shape`);
+  }
+  did();
+});
+
+test('a WRONG key also cannot reach validation: still 401, not 400', async () => {
+  const r = await srv.post('/v2/envelopes', {
+    headers: { 'X-Api-Key': 'pgp_wrong', 'Content-Type': 'application/json' },
+    body: '{ broken',
+  });
+  assert.strictEqual(r.status, 401);
+  did();
+});
+
+test('a VALID key gets past the gate: the 503 behind it proves the gate opened', async () => {
+  // No redis in this boot, so the envelope store is null (relay.js:5669). The
+  // point of the assertion is the code, not the failure: 503 can only be
+  // reached after the gate let the request through.
+  const r = await srv.post('/v2/envelopes', {
+    headers: { 'X-Api-Key': LIVE_KEY },
+    body: { doc_hash: 'a'.repeat(64), parties: [{ label: 'A' }] },
+  });
+  assert.strictEqual(r.status, 503, `expected the store-unavailable 503, got ${r.status} ${r.text}`);
+  assert.match(String(r.json && r.json.error), /Envelope store unavailable/);
+  did();
+});
+
+// ── 2. the public recipient routes ───────────────────────────────────────────
+
+test('the three envelope recipient routes are reachable without any key', async () => {
+  // An external signer has no API key, so GET :id, POST :id/view and POST
+  // :id/sign are public by design (relay.js:4201-4204). Public means "not
+  // stopped by the gate": with no store behind them they answer 404/503, and
+  // what matters is that none of them answers 401.
+  const id = 'Zm9vYmFyZm9vYmFyZm9vYmFyZm9v';
+  const probes = [
+    ['GET', `/v2/envelopes/${id}`, undefined],
+    ['POST', `/v2/envelopes/${id}/view`, { party_index: 0 }],
+    ['POST', `/v2/envelopes/${id}/sign`, { party_index: 0, signer_public_key: 'AA==', signature: 'AA==' }],
+  ];
+  for (const [method, p, body] of probes) {
+    const r = await srv.req(method, p, { body });
+    assert.notStrictEqual(r.status, 401, `${method} ${p} must not be gated by X-Api-Key`);
+  }
+  did();
+});
+
+test('create is NOT in that public list: the trailing-slash prefix is what separates them', async () => {
+  // isEnvelopePublic only matches paths that start with '/v2/envelopes/'.
+  // '/v2/envelopes' (create) has no trailing slash, so it stays gated. This is
+  // the single character the whole distinction rests on.
+  const r = await srv.post('/v2/envelopes', { body: { doc_hash: 'a'.repeat(64), parties: [{ label: 'A' }] } });
+  assert.strictEqual(r.status, 401);
+  // And the neighbouring sub-routes that are NOT view/sign stay gated too.
+  const doc = await srv.post(`/v2/envelopes/someid/document`, { body: {} });
+  assert.strictEqual(doc.status, 401, 'POST :id/document is neither /view nor /sign, so it must stay gated');
+  did();
+});
+
+// ── 3. admin routes ──────────────────────────────────────────────────────────
+
+test('every admin route is 401 without a token', async () => {
+  for (const p of ['/v2/admin/keys', '/v2/admin/usage', '/v2/admin/entitlements/acct_live']) {
+    const r = await srv.get(p);
+    assert.strictEqual(r.status, 401, `${p} without a token`);
+    assert.deepStrictEqual(r.json, { error: 'ADMIN_TOKEN required for admin endpoints' });
+  }
+  const rev = await srv.post('/v2/admin/keys/revoke', { body: { key: LIVE_KEY } });
+  assert.strictEqual(rev.status, 401);
+  did();
+});
+
+test('a wrong admin token is 401, and the live API key is not an admin token', async () => {
+  const wrong = await srv.get('/v2/admin/keys', { headers: { 'X-Admin-Token': ADMIN + 'x' } });
+  assert.strictEqual(wrong.status, 401);
+  // A tenant key, even an enterprise one, must never open an admin route.
+  const asUser = await srv.get('/v2/admin/keys', { headers: { 'X-Admin-Token': LIVE_KEY } });
+  assert.strictEqual(asUser.status, 401);
+  const asApiKeyHeader = await srv.get('/v2/admin/keys', { headers: { 'X-Api-Key': LIVE_KEY } });
+  assert.strictEqual(asApiKeyHeader.status, 401, 'X-Api-Key must not be accepted on an admin path');
+  did();
+});
+
+test('with the admin token the route answers 200 and lists the keys masked', async () => {
+  const r = await srv.get('/v2/admin/keys', { headers: { 'X-Admin-Token': ADMIN } });
+  assert.strictEqual(r.status, 200, r.text);
+  assert.strictEqual(r.json.ok, true);
+  assert.strictEqual(r.json.masked, true);
+  const listed = r.json.keys.map((k) => k.account_id);
+  assert.ok(listed.includes('acct_live'), 'the active key is listed');
+  assert.ok(!listed.includes('acct_dead'), 'an active:false key is never loaded, so it cannot be listed');
+  // The masked listing must not hand back the secret.
+  assert.ok(!r.text.includes(LIVE_KEY), 'the raw key must not appear in a masked listing');
+  did();
+});
+
+test('the same token is accepted as a Bearer, and that is the only other form', async () => {
+  const bearer = await srv.get('/v2/admin/keys', { headers: { Authorization: `Bearer ${ADMIN}` } });
+  assert.strictEqual(bearer.status, 200);
+  const basic = await srv.get('/v2/admin/keys', { headers: { Authorization: `Basic ${ADMIN}` } });
+  assert.strictEqual(basic.status, 401, 'only the Bearer form is unwrapped');
+  did();
+});
+
+test('the double-gated admin routes need X-Internal-Auth on top of the admin token', async () => {
+  // update-plan / set-product-plan / entitlements are reachable only with BOTH
+  // headers (relay.js:5246, 5286, 5307). The admin token alone must not do.
+  const onlyAdmin = await srv.get('/v2/admin/entitlements/acct_live', { headers: { 'X-Admin-Token': ADMIN } });
+  assert.strictEqual(onlyAdmin.status, 401);
+  assert.deepStrictEqual(onlyAdmin.json, { error: 'unauthorized' });
+
+  const both = await srv.get('/v2/admin/entitlements/acct_live', {
+    headers: { 'X-Admin-Token': ADMIN, 'X-Internal-Auth': INTERNAL },
+  });
+  assert.strictEqual(both.status, 200, both.text);
+  assert.strictEqual(both.json.ok, true);
+  assert.strictEqual(both.json.account_id, 'acct_live');
+  assert.ok(both.json.entitlements.parasend && both.json.entitlements.parasign);
+
+  const wrongInternal = await srv.get('/v2/admin/entitlements/acct_live', {
+    headers: { 'X-Admin-Token': ADMIN, 'X-Internal-Auth': INTERNAL + 'x' },
+  });
+  assert.strictEqual(wrongInternal.status, 401);
+  did();
+});
+
+test('an unconfigured ADMIN_TOKEN fails CLOSED: no token in the env opens nothing', async () => {
+  // The dangerous shape of this bug is a gate that treats "no token configured"
+  // as "no token required". relay.js:4208 requires process.env.ADMIN_TOKEN to
+  // be truthy, so an unconfigured relay answers 401 to everything, including an
+  // empty header.
+  for (const headers of [{}, { 'X-Admin-Token': '' }, { 'X-Admin-Token': 'anything' }]) {
+    const r = await noAdmin.get('/v2/admin/keys', { headers });
+    assert.strictEqual(r.status, 401, `unconfigured relay answered ${r.status} to ${JSON.stringify(headers)}`);
+  }
+  // Same rule on the internal gate: no INTERNAL_AUTH_TOKEN configured means the
+  // user routes stay shut.
+  const user = await noAdmin.get('/v2/user/history', { headers: { 'X-Internal-Auth': 'anything' } });
+  assert.strictEqual(user.status, 401);
+  did();
+});
+
+// ── 4. the key must not travel in the URL ────────────────────────────────────
+
+test('an API key in the query string is refused before it is ever looked up', async () => {
+  // relay.js:2155-2158. A key in ?k= lands in access logs, referrers and
+  // browser history, so it is refused outright, with a 400, deliberately, and
+  // before any auth decision, so the refusal cannot leak whether it was valid.
+  const r = await srv.get(`/v2/audit?k=${LIVE_KEY}`);
+  assert.strictEqual(r.status, 400);
+  assert.match(String(r.json.error), /must be sent in the X-Api-Key header/);
+  assert.ok(!r.text.includes(LIVE_KEY), 'the refusal must not echo the key back');
+  did();
+});
+
+test('/health and /v2/capabilities stay public, and /health leaks nothing extra without the admin token', async () => {
+  const h = await srv.get('/health');
+  assert.strictEqual(h.status, 200);
+  assert.strictEqual(h.json.ok, true);
+  assert.strictEqual(h.json.uptime_s, undefined, 'the extended health fields are admin-only');
+  const withAdmin = await srv.get('/health', { headers: { 'X-Admin-Token': ADMIN } });
+  assert.strictEqual(withAdmin.status, 200);
+  assert.notStrictEqual(Object.keys(withAdmin.json).length, Object.keys(h.json).length,
+    'the admin view of /health must carry more than the public one');
+  const cap = await srv.get('/v2/capabilities');
+  assert.strictEqual(cap.status, 200);
+  did();
+});

--- a/relay/test/route-billing-entitlements.test.js
+++ b/relay/test/route-billing-entitlements.test.js
@@ -1,0 +1,355 @@
+'use strict';
+// What a paying account is entitled to, read out of a really booted relay, and
+// what survives a restart of it.
+//
+// WHY THIS SUITE EXISTS. Two bugs live in this corner and both were about a
+// restart, not about arithmetic:
+//   #315, the paid period was set in memory but never reached users.json, so
+//          the relay came back up and handed every paying account an UNBOUNDED
+//          grant. The fix (relay.js:1706-1722) passes paidUntil into the disk
+//          write; nothing tested that the value is still there afterwards.
+//   entitlements.js:137, a record with no paid_until must NEVER read as
+//          expired, or one missing field silently downgrades a paying customer.
+// lib/entitlements.js has its own unit tests for the date arithmetic. What had
+// no test at all is the layer above it: relay.js reading users.json at boot,
+// writing it back on an admin change, and reading the same answer out again
+// after a restart. That round trip is what #315 actually broke.
+//
+// So every test here does the same thing: put a record on disk, ask the relay
+// what the account is entitled to, restart the relay, and ask again. If the two
+// answers differ, the persistence is broken no matter what the unit tests say.
+//
+// No redis, no Mollie, no network. Note the gap this suite cannot close: the
+// only code path that WRITES paid_until is the Mollie webhook, and lib/mollie.js
+// hard-codes api.mollie.com (mollie.js:12) with no override, so the write half
+// cannot be driven offline. This suite therefore pins the read-back and the
+// admin write; the webhook's own call is covered by lib/billing's unit tests.
+// Run: node --test relay/test/route-billing-entitlements.test.js
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const { boot, killAll } = require('./_relay-server');
+const { summary } = require('./_requires');
+
+const ADMIN = 'admin-token-for-the-billing-suite';
+const INTERNAL = 'internal-token-for-the-billing-suite';
+const ADMIN_ENV = { ADMIN_TOKEN: ADMIN, INTERNAL_AUTH_TOKEN: INTERNAL };
+const BOTH = { 'X-Admin-Token': ADMIN, 'X-Internal-Auth': INTERNAL };
+
+const FUTURE = new Date(Date.now() + 20 * 86_400_000).toISOString();
+const PAST = new Date(Date.now() - 20 * 86_400_000).toISOString();
+
+let checks = 0;
+const did = () => { checks++; };
+after(async () => { await killAll(); summary('route-billing-entitlements', checks); });
+
+// One relay per test, on its own users.json, so a restart in one test cannot
+// leak state into another.
+function withUsers(tag, keys) {
+  return boot({ tag, usersFile: true, users: { api_keys: keys }, env: ADMIN_ENV });
+}
+const entitlementsOf = (srv, account) =>
+  srv.get(`/v2/admin/entitlements/${account}`, { headers: BOTH });
+
+// ── 1. the #315 shape: a paid period must survive the process ────────────────
+
+test('#315: a paid period on disk is still bounded after a restart', async () => {
+  let srv = await withUsers('paid-until-survives', [{
+    key: 'pgp_paid', plan: 'community', active: true, parasign: true,
+    account_id: 'acct_paid', email: 'paid@example.test',
+    plan_parasign: 'business', paid_until_parasign: FUTURE,
+  }]);
+
+  const before = await entitlementsOf(srv, 'acct_paid');
+  assert.strictEqual(before.status, 200, before.text);
+  assert.strictEqual(before.json.entitlements.parasign.tier, 'business',
+    'a period that has not passed still grants the tier it was paid for');
+
+  srv = await srv.restart();
+  const after = await entitlementsOf(srv, 'acct_paid');
+  assert.strictEqual(after.status, 200, after.text);
+  assert.deepStrictEqual(after.json.entitlements, before.json.entitlements,
+    'a restart must not change what an account is entitled to');
+  // And the bound itself is still on disk, not only the tier. This is the exact
+  // field #315 dropped: a bare tier with no date is an unbounded grant.
+  const onDisk = srv.readUsersFile().api_keys.find((k) => k.key === 'pgp_paid');
+  assert.strictEqual(onDisk.paid_until_parasign, FUTURE, 'the paid period must still be on disk after a restart');
+  srv.stop();
+  did();
+});
+
+// KNOWN FAILING, ON PURPOSE. This is the rule the paid_until field exists for,
+// and the account-level read path does not honour it today. Marked todo so the
+// run stays green while the finding stays visible; when the bug is fixed this
+// turns into "ok ... # TODO" and the flag can go.
+//
+// THE BUG: lib/entitlements.js:328-344 mergeAccountRecord() copies plan_parasign
+// and plan_parasend off the api-key records onto the merged account record, but
+// NOT their paid_until_* fields. Its own doc comment says why those fields can
+// only live on the key records ("the accounts summary never carries the
+// per-product plans"), so the merged record always arrives at getEntitlements
+// with a paid tier and no period, and entitlements.js:137 correctly reads "no
+// recorded period" as "never expired". The result is that an expired
+// subscription keeps granting on every account-level gate:
+//   relay.js:5316  GET /v2/admin/entitlements/:account_id
+//   relay.js:5990  the signs-quota gate on POST /v2/envelopes/:id/sign
+//   relay.js:1804  the plan a newly minted psk_ key inherits
+// Reading the SAME record directly (without the merge) does expire correctly,
+// which is how you can tell it is the merge and not the date logic:
+//   getEntitlements(keyRec).parasign.tier                      -> 'free'
+//   getEntitlements(mergeAccountRecord(acct,[keyRec])).parasign.tier -> 'business'
+test('#315: a period that HAS passed stops granting, and stops granting again after a restart',
+  { todo: 'mergeAccountRecord drops paid_until_* (lib/entitlements.js:328-344)' }, async () => {
+  let srv = await withUsers('paid-until-expired', [{
+    key: 'pgp_lapsed', plan: 'community', active: true, parasign: true,
+    account_id: 'acct_lapsed', email: 'lapsed@example.test',
+    plan_parasign: 'business', paid_until_parasign: PAST,
+  }]);
+
+  const before = await entitlementsOf(srv, 'acct_lapsed');
+  assert.strictEqual(before.json.entitlements.parasign.tier, 'free',
+    'a lapsed period falls back to the floor tier, which is the whole point of the date');
+
+  srv = await srv.restart();
+  const after = await entitlementsOf(srv, 'acct_lapsed');
+  assert.strictEqual(after.json.entitlements.parasign.tier, 'free',
+    'and a restart does not resurrect the grant');
+  // The stored tier is NOT erased: the grant is bounded by the date, so a
+  // renewal only has to move the date.
+  const onDisk = srv.readUsersFile().api_keys.find((k) => k.key === 'pgp_lapsed');
+  assert.strictEqual(onDisk.plan_parasign, 'business', 'expiry bounds the grant, it does not delete the record');
+  srv.stop();
+  did();
+});
+
+// The same fact, stated as something that is true TODAY, so the finding above is
+// not just a comment: the two read paths disagree about the same record. This
+// test is the evidence for the bug report, and it is expected to be deleted in
+// the same commit that fixes mergeAccountRecord.
+test('FINDING: the account-level read path loses the paid period the key record carries', () => {
+  const ent = require('../lib/entitlements');
+  const keyRec = { plan: 'community', parasign: true, plan_parasign: 'business', paid_until_parasign: PAST };
+  assert.strictEqual(ent.getEntitlements(keyRec).parasign.tier, 'free',
+    'read straight off the key record, an expired period does fall to the floor');
+  const merged = ent.mergeAccountRecord({ account_id: 'acct', plan: 'community' }, [keyRec]);
+  assert.ok(!('paid_until_parasign' in merged),
+    'the merge drops the period field entirely - this is the bug, in one line');
+  assert.strictEqual(ent.getEntitlements(merged).parasign.tier, 'business',
+    'so the account-level path still grants a tier that was paid for until ' + PAST);
+  did();
+});
+
+test('entitlements.js:137: a record with NO paid_until is never read as expired', async () => {
+  // The dangerous reading of "no date on file" is "the period ended". That would
+  // downgrade every account that predates the paid_until field, and every one
+  // whose webhook never wrote it. The rule is the opposite: absent means
+  // unbounded, and a floor tier can never expire at all.
+  let srv = await withUsers('paid-until-missing', [
+    { key: 'pgp_bare', plan: 'community', active: true, parasign: true, account_id: 'acct_bare',
+      email: 'bare@example.test', plan_parasign: 'pro' },                       // tier, no date
+    { key: 'pgp_junk', plan: 'community', active: true, parasign: true, account_id: 'acct_junk',
+      email: 'junk@example.test', plan_parasign: 'pro', paid_until_parasign: 'not-a-date' },
+    { key: 'pgp_floor', plan: 'community', active: true, account_id: 'acct_floor',
+      email: 'floor@example.test', plan_parasign: 'free', paid_until_parasign: PAST },
+  ]);
+
+  for (const [account, tier, why] of [
+    ['acct_bare', 'pro', 'a missing date must not downgrade anyone'],
+    ['acct_junk', 'pro', 'an unparseable date is treated as absent, not as expired'],
+    ['acct_floor', 'free', 'a floor tier has nothing to lose and cannot expire'],
+  ]) {
+    const r = await entitlementsOf(srv, account);
+    assert.strictEqual(r.status, 200, r.text);
+    assert.strictEqual(r.json.entitlements.parasign.tier, tier, `${account}: ${why}`);
+  }
+
+  srv = await srv.restart();
+  const again = await entitlementsOf(srv, 'acct_bare');
+  assert.strictEqual(again.json.entitlements.parasign.tier, 'pro', 'and the same holds after a restart');
+  srv.stop();
+  did();
+});
+
+// ── 2. an admin change must reach the disk ───────────────────────────────────
+
+test('an admin product-plan change is on disk before the relay is restarted, and holds afterwards', async () => {
+  // The mechanism #315 broke: an entitlement that lives only in the process
+  // memory. setProductPlan fans out over the account and queues a users.json
+  // write (relay.js:1710); this asserts the write really lands.
+  let srv = await withUsers('admin-write-through', [{
+    key: 'pgp_upgrade', plan: 'community', active: true, account_id: 'acct_upgrade', email: 'up@example.test',
+  }]);
+
+  const start = await entitlementsOf(srv, 'acct_upgrade');
+  assert.strictEqual(start.json.entitlements.parasend.tier, 'community');
+
+  const set = await srv.post('/v2/admin/keys/set-product-plan', {
+    headers: BOTH, body: { key: 'pgp_upgrade', product: 'parasend', tier: 'pro' },
+  });
+  assert.strictEqual(set.status, 200, set.text);
+  assert.deepStrictEqual(set.json, { ok: true, key: 'pgp_upgrade', product: 'parasend', tier: 'pro' });
+
+  // The write is queued, not awaited by the handler, so give the queue a tick.
+  await new Promise((r) => setTimeout(r, 300));
+  const onDisk = srv.readUsersFile().api_keys.find((k) => k.key === 'pgp_upgrade');
+  assert.strictEqual(onDisk.plan_parasend, 'pro', 'the change never reached users.json');
+  assert.strictEqual(onDisk.plan, 'community', 'a per-product change must not touch the unified plan');
+
+  srv = await srv.restart();
+  const after = await entitlementsOf(srv, 'acct_upgrade');
+  assert.strictEqual(after.json.entitlements.parasend.tier, 'pro', 'the upgrade did not survive the restart');
+  assert.strictEqual(after.json.entitlements.parasign.tier, 'free', 'and it did not leak into the other product');
+  srv.stop();
+  did();
+});
+
+test('an admin change on one product leaves the other product\'s paid period alone', async () => {
+  // applyProductTier is tri-state on paidUntil: undefined means "leave what is
+  // on record" (entitlements.js:193-195), and the admin route passes no date.
+  // So an admin touching ParaSend must not silently unbound a paid ParaSign.
+  let srv = await withUsers('cross-product', [{
+    key: 'pgp_mixed', plan: 'community', active: true, parasign: true, account_id: 'acct_mixed',
+    email: 'mixed@example.test', plan_parasign: 'business', paid_until_parasign: FUTURE,
+  }]);
+
+  const set = await srv.post('/v2/admin/keys/set-product-plan', {
+    headers: BOTH, body: { key: 'pgp_mixed', product: 'parasend', tier: 'pro' },
+  });
+  assert.strictEqual(set.status, 200, set.text);
+  await new Promise((r) => setTimeout(r, 300));
+
+  srv = await srv.restart();
+  const after = await entitlementsOf(srv, 'acct_mixed');
+  assert.strictEqual(after.json.entitlements.parasend.tier, 'pro');
+  assert.strictEqual(after.json.entitlements.parasign.tier, 'business');
+  const onDisk = srv.readUsersFile().api_keys.find((k) => k.key === 'pgp_mixed');
+  assert.strictEqual(onDisk.paid_until_parasign, FUTURE,
+    'the other product\'s paid period must be exactly as it was');
+  srv.stop();
+  did();
+});
+
+test('an admin change is refused for an unknown product or a tier off that product\'s ladder', async () => {
+  // Never silently floor a bad tier to the base one: that is how a typo becomes
+  // a downgrade nobody notices.
+  const srv = await withUsers('bad-product-plan', [{
+    key: 'pgp_v', plan: 'pro', active: true, account_id: 'acct_v', email: 'v@example.test',
+  }]);
+  const cases = [
+    [{ key: 'pgp_v', product: 'parasound', tier: 'pro' }, 400],
+    [{ key: 'pgp_v', product: 'parasend', tier: 'business' }, 400],  // business is not on the parasend ladder
+    [{ key: 'pgp_v', product: 'parasign', tier: 'gold' }, 400],
+    [{ key: 'pgp_missing', product: 'parasign', tier: 'pro' }, 404],
+  ];
+  for (const [body, status] of cases) {
+    const r = await srv.post('/v2/admin/keys/set-product-plan', { headers: BOTH, body });
+    assert.strictEqual(r.status, status, `${JSON.stringify(body)} -> ${r.status} ${r.text}`);
+  }
+  // Nothing changed on disk after four refusals.
+  const onDisk = srv.readUsersFile().api_keys.find((k) => k.key === 'pgp_v');
+  assert.ok(!onDisk.plan_parasend || onDisk.plan_parasend === 'pro');
+  srv.stop();
+  did();
+});
+
+// ── 3. plan id -> tier -> quota, as the relay itself reports it ──────────────
+
+test('the four plan ids map to the tiers and quotas the pricing rests on', async () => {
+  // One table, asserted through the relay rather than against lib/tiers.js, so a
+  // change to the mapping in relay.js or entitlements.js shows up here too.
+  // parasend has no business tier: a business plan maps UP to enterprise, on
+  // purpose (entitlements.js:205, no silent downgrade).
+  const srv = await withUsers('tier-map', [
+    { key: 'pgp_t_community', plan: 'community', active: true, account_id: 'acct_community', email: 'c@example.test' },
+    { key: 'pgp_t_pro', plan: 'pro', active: true, account_id: 'acct_pro', email: 'p@example.test' },
+    { key: 'pgp_t_business', plan: 'business', active: true, account_id: 'acct_business', email: 'b@example.test' },
+    { key: 'pgp_t_enterprise', plan: 'enterprise', active: true, account_id: 'acct_enterprise', email: 'e@example.test' },
+  ]);
+
+  const expected = {
+    acct_community: { parasend: 'community', parasign: 'free', transfers: 10, signs: 2 },
+    acct_pro: { parasend: 'pro', parasign: 'pro', transfers: 500, signs: 100 },
+    acct_business: { parasend: 'enterprise', parasign: 'business', transfers: 1_000_000, signs: 1000 },
+    acct_enterprise: { parasend: 'enterprise', parasign: 'enterprise', transfers: 1_000_000, signs: 1_000_000 },
+  };
+  for (const [account, want] of Object.entries(expected)) {
+    const r = await entitlementsOf(srv, account);
+    assert.strictEqual(r.status, 200, r.text);
+    const e = r.json.entitlements;
+    assert.strictEqual(e.parasend.tier, want.parasend, `${account} parasend tier`);
+    assert.strictEqual(e.parasign.tier, want.parasign, `${account} parasign tier`);
+    assert.strictEqual(e.parasend.quotas.transfers_month, want.transfers, `${account} transfers/month`);
+    assert.strictEqual(e.parasign.quotas.signs_month, want.signs, `${account} signs/month`);
+    // A metered quota is never Infinity: an unlimited tier still has a ceiling
+    // that a counter can be compared against (entitlements.js:41).
+    assert.ok(Number.isFinite(e.parasend.quotas.transfers_month), `${account} transfers quota must be finite`);
+    assert.ok(Number.isFinite(e.parasign.quotas.signs_month), `${account} signs quota must be finite`);
+  }
+  srv.stop();
+  did();
+});
+
+test('only ParaSign Pro meters overage, and only Business+ may export the audit trail', async () => {
+  const srv = await withUsers('perks', [
+    { key: 'pgp_o_pro', plan: 'pro', active: true, parasign: true, account_id: 'acct_o_pro', email: 'op@example.test' },
+    { key: 'pgp_o_bus', plan: 'business', active: true, parasign: true, account_id: 'acct_o_bus', email: 'ob@example.test' },
+    { key: 'pgp_o_com', plan: 'community', active: true, account_id: 'acct_o_com', email: 'oc@example.test' },
+  ]);
+  const pro = (await entitlementsOf(srv, 'acct_o_pro')).json.entitlements.parasign;
+  assert.strictEqual(pro.overage.rate_eur, 0.4, 'ParaSign Pro is the metering tier');
+  assert.strictEqual(pro.overage.hard_cap, 1000);
+
+  const bus = (await entitlementsOf(srv, 'acct_o_bus')).json.entitlements.parasign;
+  assert.strictEqual(bus.overage.rate_eur, null, 'Business buys its volume up front, it does not meter');
+  assert.strictEqual(bus.features.audit_export, true);
+  assert.strictEqual(pro.features.audit_export, false, 'audit export is a Business+ feature');
+
+  const com = (await entitlementsOf(srv, 'acct_o_com')).json.entitlements.parasign;
+  assert.strictEqual(com.overage.rate_eur, null);
+  assert.strictEqual(com.features.audit_export, false);
+  srv.stop();
+  did();
+});
+
+test('the admin usage view reports the same per-tier limits it enforces', async () => {
+  // /v2/admin/usage is what an operator looks at when a customer says "it says
+  // I am over my limit". It must not have a second opinion about the tier.
+  const srv = await withUsers('usage-view', [
+    { key: 'pgp_u_pro', plan: 'pro', active: true, account_id: 'acct_u_pro', email: 'u@example.test' },
+  ]);
+  const r = await srv.get('/v2/admin/usage/acct_u_pro', { headers: { 'X-Admin-Token': ADMIN } });
+  assert.strictEqual(r.status, 200, r.text);
+  assert.strictEqual(r.json.plan, 'pro');
+  assert.strictEqual(r.json.limits.transfers_month, 500);
+  assert.strictEqual(r.json.limits.signs_month, 100);
+  assert.strictEqual(r.json.limits.devices, 50);
+  assert.strictEqual(r.json.redis_available, false, 'this relay runs without redis, and the view says so');
+  srv.stop();
+  did();
+});
+
+// ── 4. the file itself ───────────────────────────────────────────────────────
+
+test('the users.json write is atomic: no temp file is left behind and the file always parses', async () => {
+  // _atomicWriteUsers writes a tmp file and renames it (relay.js:1629-1632),
+  // because an O_TRUNC window once let a concurrent reader see an empty file and
+  // wipe the key table. Two changes in a row, then check the directory.
+  const srv = await withUsers('atomic-write', [
+    { key: 'pgp_a1', plan: 'community', active: true, account_id: 'acct_a1', email: 'a1@example.test' },
+  ]);
+  for (const tier of ['pro', 'community', 'pro']) {
+    const r = await srv.post('/v2/admin/keys/set-product-plan', {
+      headers: BOTH, body: { key: 'pgp_a1', product: 'parasend', tier },
+    });
+    assert.strictEqual(r.status, 200, r.text);
+  }
+  await new Promise((r) => setTimeout(r, 400));
+  const leftovers = fs.readdirSync(srv.dir).filter((f) => f.includes('users.json.tmp'));
+  assert.deepStrictEqual(leftovers, [], `temp files were left behind: ${leftovers.join(', ')}`);
+  const parsed = srv.readUsersFile();
+  assert.ok(Array.isArray(parsed.api_keys) && parsed.api_keys.length === 1);
+  assert.strictEqual(parsed.api_keys[0].plan_parasend, 'pro', 'the last write wins and the queue kept the order');
+  srv.stop();
+  did();
+});

--- a/relay/test/route-envelope-lifecycle.test.js
+++ b/relay/test/route-envelope-lifecycle.test.js
@@ -1,0 +1,440 @@
+'use strict';
+// The whole ParaSign multi-party envelope, end to end, over HTTP, on a really
+// booted relay: create, view, sign with a real ML-DSA-65 signature, collect the
+// evidence bundle and verify it OFFLINE, then the three refusals that make the
+// evidence worth anything (double sign, a forged signature, an expired record).
+//
+// WHY THIS SUITE EXISTS. The lifecycle was covered at two levels and never in
+// the middle: unit tests call EnvelopeStore directly with a fake redis
+// (envelope-binding, parasign-envelope-index), and Playwright drives a browser
+// in sign-e2e. The HTTP layer between them, 400 lines of relay.js from 5665 to
+// 6093, the part that decides who may sign what and what the receipt says, was
+// loaded by no test. The 2026-09-02 audit measured relay.js at zero.
+//
+// The offline verification is the point of the whole product: a receipt is only
+// evidence if someone who does not trust the relay can check it. So the last
+// step here re-derives every signed message itself, verifies each party
+// signature and the notary signature with the raw engine, and never asks the
+// relay whether the receipt is good.
+//
+// NEEDS: a reachable redis (the envelope store is redis-only, relay.js:5650)
+// and the ML-DSA-65 engine from @paramant/core. Both are declared preconditions
+// via test/_requires.js, so a job without them fails loudly unless it says
+// RELAY_TEST_SKIP=redis,engine.
+// Run: REDIS_URL=redis://127.0.0.1:6399 node --test relay/test/route-envelope-lifecycle.test.js
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const { boot, killAll } = require('./_relay-server');
+const { requireEngine, requireRedis, summary } = require('./_requires');
+const envelopeMod = require('../envelope');
+const parasign = require('../parasign');
+
+// A fresh key per run. Envelope creation is capped at 50 per key per hour and
+// the counter lives in redis (relay.js:1426-1439), so a fixed key would make
+// the fourth run of this suite in one hour fail on the limiter instead of on
+// the code. The limiter is tested on purpose in route-env-rate-limits.test.js.
+const RUN = crypto.randomBytes(6).toString('hex');
+const OWNER = `pgp_owner_key_for_the_envelope_suite_${RUN}`;
+const STRANGER = `pgp_stranger_key_for_the_envelope_suite_${RUN}`;
+const DEFAULT_REDIS = 'redis://127.0.0.1:6399';
+
+let srv = null;
+let eng = null;
+let rc = null;
+let checks = 0;
+const did = () => { checks++; };
+
+// A run without redis or without the engine cannot assert anything here, so
+// every test returns early rather than pretending. _requires already made that
+// visible (declared SKIP, or a hard failure).
+const ready = () => srv !== null && eng !== null;
+
+const docHash = () => crypto.createHash('sha3-256').update(crypto.randomBytes(32)).digest('hex');
+
+// The view and sign routes are rate-limited per client IP (30/min and 10/min,
+// relay.js:1406-1411) and the buckets are process-global, so a suite that signs
+// two dozen times from one address would start measuring the limiter instead of
+// the lifecycle. Each test takes its own address, exactly as nginx presents it
+// (X-Real-IP, relay.js:1478-1484). The limiter itself is tested on purpose in
+// route-env-rate-limits.test.js.
+let _ipN = 0;
+let IP = '10.0.0.1';
+function nextIp() { _ipN++; return `10.0.${Math.floor(_ipN / 250)}.${(_ipN % 250) + 1}`; }
+const asParty = (extra = {}) => ({ 'X-Real-IP': IP, ...extra });
+
+before(async () => {
+  eng = requireEngine();
+  rc = await requireRedis(DEFAULT_REDIS);
+  if (!eng || !rc) return;
+  srv = await boot({
+    tag: 'envelope',
+    users: {
+      api_keys: [
+        { key: OWNER, plan: 'business', active: true, parasign: true, email: 'owner@example.test', account_id: 'acct_owner' },
+        { key: STRANGER, plan: 'business', active: true, parasign: true, email: 'stranger@example.test', account_id: 'acct_stranger' },
+      ],
+    },
+    env: { REDIS_URL: process.env.REDIS_URL || DEFAULT_REDIS },
+  });
+});
+
+after(async () => {
+  await killAll();
+  if (rc) { try { await rc.disconnect(); } catch (_) {} }
+  summary('route-envelope-lifecycle', checks);
+});
+
+// Create an open-mode envelope and return { id, docHash, parties, body }.
+async function createEnvelope(parties = [{ label: 'Alice' }, { label: 'Bob' }], extra = {}) {
+  const dh = docHash();
+  const r = await srv.post('/v2/envelopes', {
+    headers: asParty({ 'X-Api-Key': OWNER }),
+    body: { doc_hash: dh, parties, ...extra },
+  });
+  assert.strictEqual(r.status, 200, `create failed: ${r.status} ${r.text}`);
+  return { id: r.json.envelope.id, docHash: dh, envelope: r.json.envelope };
+}
+
+// A real ML-DSA-65 signature over the exact message the relay will re-derive.
+// Open envelopes are always verified at recipe 4 (envelope.js:806), which binds
+// the signer's own public key into the message.
+function signForParty(id, dh, partyIndex, keypair) {
+  const kp = keypair || eng.generateKeyPair();
+  const pubB64 = Buffer.from(kp.publicKey).toString('base64');
+  const msg = envelopeMod.signMessageBytes(id, dh, partyIndex, '', 4, pubB64);
+  const sigB64 = Buffer.from(eng.sign(msg, kp.secretKey)).toString('base64');
+  return { kp, pubB64, sigB64, msg };
+}
+
+const submit = (id, body) => srv.post(`/v2/envelopes/${id}/sign`, { headers: asParty(), body });
+const statusOf = (id) => srv.get(`/v2/envelopes/${id}`, { headers: asParty() });
+const view = (id, body) => srv.post(`/v2/envelopes/${id}/view`, { headers: asParty(), body });
+const receipt = (id, key) => srv.get(`/v2/envelopes/${id}/receipt`,
+  { headers: key ? asParty({ 'X-Api-Key': key }) : asParty() });
+
+// ── 1. create ────────────────────────────────────────────────────────────────
+
+test('create returns one signing link per party and an expiry derived from ttl_days', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  const before = Date.now();
+  const { envelope } = await createEnvelope([{ label: 'Alice' }, { label: 'Bob' }], { ttl_days: 3 });
+  assert.match(envelope.id, /^[A-Za-z0-9_-]{20,64}$/);
+  assert.strictEqual(envelope.party_count, 2);
+  assert.strictEqual(envelope.binding_mode, 'open');
+  assert.strictEqual(envelope.party_links.length, 2);
+  assert.strictEqual(envelope.party_links[0].party_index, 0);
+  assert.match(envelope.party_links[1].sign_path, /^\/co-sign\?env=/);
+  assert.strictEqual(envelope.party_links[0].invite_token, null, 'open mode issues no invite tokens');
+
+  const expires = Date.parse(envelope.expires_at);
+  const expected = before + 3 * 86_400_000;
+  assert.ok(Math.abs(expires - expected) < 60_000, `expires_at should be created_at + 3 days, got ${envelope.expires_at}`);
+  did();
+});
+
+test('create refuses a document hash that is not a sha3-256, and an empty party list', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  const bad = await srv.post('/v2/envelopes', {
+    headers: asParty({ 'X-Api-Key': OWNER }),
+    body: { doc_hash: 'not-a-hash', parties: [{ label: 'A' }] },
+  });
+  assert.strictEqual(bad.status, 400);
+  assert.match(String(bad.json.error), /doc_hash must be 64-char sha3-256 hex/);
+
+  const none = await srv.post('/v2/envelopes', {
+    headers: asParty({ 'X-Api-Key': OWNER }),
+    body: { doc_hash: docHash(), parties: [] },
+  });
+  assert.strictEqual(none.status, 400);
+  assert.match(String(none.json.error), /parties required/);
+  did();
+});
+
+test('the relay never receives the document, only its hash', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  // The whole zero-knowledge claim rests on this: what is stored under the
+  // envelope key is the hash the client computed and nothing that could
+  // reconstruct the file.
+  const { id, docHash: dh } = await createEnvelope();
+  const stored = await rc.hGetAll(`env:${id}`);
+  assert.strictEqual(stored.doc_hash, dh);
+  const blob = JSON.stringify(stored);
+  assert.ok(!/document|plaintext|content/i.test(String(stored.doc_hash)));
+  assert.ok(blob.length < 8000, 'an envelope record holds metadata, not a document');
+  did();
+});
+
+// ── 2. view ──────────────────────────────────────────────────────────────────
+
+test('a party marks itself viewed without any API key, and the status shows it', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  const { id } = await createEnvelope();
+  const before = await statusOf(id);
+  assert.strictEqual(before.status, 200);
+  assert.strictEqual(before.json.envelope.parties[0].status, 'pending');
+
+  const v = await view(id, { party_index: 0 });
+  assert.strictEqual(v.status, 200);
+  assert.deepStrictEqual(v.json, { ok: true });
+
+  const after = await statusOf(id);
+  assert.strictEqual(after.json.envelope.parties[0].status, 'viewed');
+  assert.strictEqual(after.json.envelope.parties[1].status, 'pending', 'only the party that opened it is marked');
+  did();
+});
+
+test('the public status is redacted: no signatures, no raw keys, no account id', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  const { id, docHash: dh } = await createEnvelope([{ label: 'Solo' }]);
+  const { pubB64, sigB64 } = signForParty(id, dh, 0);
+  assert.strictEqual((await submit(id, { party_index: 0, signer_public_key: pubB64, signature: sigB64 })).status, 200);
+
+  const r = await statusOf(id);
+  assert.strictEqual(r.status, 200);
+  const text = r.text;
+  assert.ok(!text.includes(sigB64), 'the raw signature must not be in the public status');
+  assert.ok(!text.includes(pubB64), 'the raw public key must not be in the public status');
+  assert.ok(!text.includes('acct_owner'), 'the owning account must not be in the public status');
+  assert.match(r.json.envelope.parties[0].signer_pk_hash, /^[0-9a-f]{64}$/, 'only a hash of the key is published');
+  assert.ok(r.json.sign_message_recipe, 'the recipe is published so a verifier can re-derive the message');
+  did();
+});
+
+// ── 3. sign ──────────────────────────────────────────────────────────────────
+
+test('a real ML-DSA-65 signature is accepted and completes the envelope when the last party signs', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  const { id, docHash: dh } = await createEnvelope();
+
+  const a = signForParty(id, dh, 0);
+  const first = await submit(id, { party_index: 0, signer_public_key: a.pubB64, signature: a.sigB64 });
+  assert.strictEqual(first.status, 200, first.text);
+  assert.strictEqual(first.json.ok, true);
+  assert.strictEqual(first.json.idempotent, false);
+  assert.strictEqual(first.json.signed_count, 1);
+  assert.strictEqual(first.json.status, 'sent', 'one of two parties is not a completed envelope');
+
+  const b = signForParty(id, dh, 1);
+  const second = await submit(id, { party_index: 1, signer_public_key: b.pubB64, signature: b.sigB64 });
+  assert.strictEqual(second.status, 200, second.text);
+  assert.strictEqual(second.json.signed_count, 2);
+  assert.strictEqual(second.json.status, 'complete');
+  did();
+});
+
+test('a signature over the WRONG message is refused, so the relay really verifies', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  // The failure mode that would make every test above worthless is a relay that
+  // stores whatever it is handed. Four forgeries, all rejected:
+  const { id, docHash: dh } = await createEnvelope([{ label: 'Solo' }]);
+  const good = signForParty(id, dh, 0);
+
+  // (a) a signature over a different document
+  const otherDoc = envelopeMod.signMessageBytes(id, docHash(), 0, '', 4, good.pubB64);
+  const wrongDoc = Buffer.from(eng.sign(otherDoc, good.kp.secretKey)).toString('base64');
+  // (b) a signature over a different party index
+  const otherIdx = envelopeMod.signMessageBytes(id, dh, 7, '', 4, good.pubB64);
+  const wrongIdx = Buffer.from(eng.sign(otherIdx, good.kp.secretKey)).toString('base64');
+  // (c) a valid signature from a key that is not the one presented
+  const impostor = eng.generateKeyPair();
+  const msgForImpostor = envelopeMod.signMessageBytes(id, dh, 0, '', 4, good.pubB64);
+  const wrongKey = Buffer.from(eng.sign(msgForImpostor, impostor.secretKey)).toString('base64');
+  // (d) noise
+  const noise = Buffer.from(crypto.randomBytes(3309)).toString('base64');
+
+  for (const [name, sig] of [['other document', wrongDoc], ['other party index', wrongIdx], ['other key', wrongKey], ['noise', noise]]) {
+    const r = await submit(id, { party_index: 0, signer_public_key: good.pubB64, signature: sig });
+    assert.strictEqual(r.status, 400, `${name}: expected 400, got ${r.status} ${r.text}`);
+    assert.deepStrictEqual(r.json, { error: 'bad_signature' }, name);
+  }
+
+  // The slot is still open after four refusals, and the good signature lands.
+  const ok = await submit(id, { party_index: 0, signer_public_key: good.pubB64, signature: good.sigB64 });
+  assert.strictEqual(ok.status, 200, ok.text);
+  did();
+});
+
+test('DOUBLE SIGN: the same submission is idempotent, a different one is a conflict', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  const { id, docHash: dh } = await createEnvelope([{ label: 'Alice' }, { label: 'Bob' }]);
+  const a = signForParty(id, dh, 0);
+  const first = await submit(id, { party_index: 0, signer_public_key: a.pubB64, signature: a.sigB64 });
+  assert.strictEqual(first.status, 200);
+  assert.strictEqual(first.json.idempotent, false);
+
+  // Replaying the exact same signature is a retry, not a second signature: it
+  // must not move the counter. (A network retry must be safe.)
+  const replay = await submit(id, { party_index: 0, signer_public_key: a.pubB64, signature: a.sigB64 });
+  assert.strictEqual(replay.status, 200);
+  assert.strictEqual(replay.json.idempotent, true, 'an identical resubmission is a replay');
+  assert.strictEqual(replay.json.signed_count, 1, 'a replay must never increase signed_count');
+
+  // A DIFFERENT signer trying to take an occupied slot is refused outright.
+  const other = signForParty(id, dh, 0);
+  const conflict = await submit(id, { party_index: 0, signer_public_key: other.pubB64, signature: other.sigB64 });
+  assert.strictEqual(conflict.status, 409);
+  assert.deepStrictEqual(conflict.json, { error: 'conflict' });
+
+  const status = await statusOf(id);
+  assert.strictEqual(status.json.envelope.signed_count, 1, 'the conflict changed nothing');
+  assert.strictEqual(status.json.envelope.parties[0].signer_pk_hash,
+    crypto.createHash('sha3-256').update(Buffer.from(a.pubB64, 'base64')).digest('hex'),
+    'the first signer still holds the slot');
+  did();
+});
+
+test('a completed envelope is closed: nobody signs it again', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  const { id, docHash: dh } = await createEnvelope([{ label: 'Solo' }]);
+  const a = signForParty(id, dh, 0);
+  assert.strictEqual((await submit(id, { party_index: 0, signer_public_key: a.pubB64, signature: a.sigB64 })).status, 200);
+
+  const b = signForParty(id, dh, 0);
+  const closed = await submit(id, { party_index: 0, signer_public_key: b.pubB64, signature: b.sigB64 });
+  assert.strictEqual(closed.status, 410);
+  assert.deepStrictEqual(closed.json, { error: 'closed' });
+  did();
+});
+
+test('a party index outside the envelope is a generic not_found, not an out-of-range hint', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  const { id, docHash: dh } = await createEnvelope([{ label: 'Solo' }]);
+  const a = signForParty(id, dh, 3);
+  const r = await submit(id, { party_index: 3, signer_public_key: a.pubB64, signature: a.sigB64 });
+  assert.strictEqual(r.status, 404);
+  assert.deepStrictEqual(r.json, { error: 'not_found' });
+
+  // And an envelope id that never existed answers exactly the same way.
+  const ghost = await submit('Zm9vYmFyZm9vYmFyZm9vYmFyZm9v', { party_index: 0, signer_public_key: a.pubB64, signature: a.sigB64 });
+  assert.strictEqual(ghost.status, 404);
+  assert.deepStrictEqual(ghost.json, { error: 'not_found' });
+  did();
+});
+
+// ── 4. expiry ────────────────────────────────────────────────────────────────
+
+test('EXPIRED: once the retention window closes the envelope is gone and cannot be signed', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  // ttl_days is enforced by the redis TTL on the record (envelope.js:373); the
+  // relay does not compare expires_at on every read. So the honest way to test
+  // expiry is to let the record actually expire. The suite shortens the TTL to
+  // 50 ms on the store rather than waiting a day.
+  const { id, docHash: dh } = await createEnvelope([{ label: 'Alice' }], { ttl_days: 1 });
+
+  const ttl = await rc.ttl(`env:${id}`);
+  assert.ok(ttl > 86_000 && ttl <= 86_400, `a 1-day envelope should carry a ~1 day redis TTL, got ${ttl}`);
+
+  await rc.pExpire(`env:${id}`, 50);
+  await new Promise((r) => setTimeout(r, 250));
+  assert.strictEqual(await rc.exists(`env:${id}`), 0, 'the record really expired');
+
+  const a = signForParty(id, dh, 0);
+  const signAfter = await submit(id, { party_index: 0, signer_public_key: a.pubB64, signature: a.sigB64 });
+  assert.strictEqual(signAfter.status, 404, 'an expired envelope must not accept a signature');
+  assert.deepStrictEqual(signAfter.json, { error: 'not_found' });
+
+  const viewAfter = await view(id, { party_index: 0 });
+  assert.strictEqual(viewAfter.status, 404, 'and it can no longer be viewed');
+  const status = await statusOf(id);
+  assert.strictEqual(status.status, 404, 'and it no longer has a public status');
+  did();
+});
+
+// ── 5. the evidence bundle, verified offline ────────────────────────────────
+
+test('the receipt is owner-only and only issued once the envelope is complete', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  const { id, docHash: dh } = await createEnvelope([{ label: 'Alice' }, { label: 'Bob' }]);
+
+  const early = await receipt(id, OWNER);
+  assert.strictEqual(early.status, 409, 'an unfinished envelope has no evidence to hand out');
+  assert.deepStrictEqual(early.json, { error: 'not_ready' });
+
+  for (const i of [0, 1]) {
+    const s = signForParty(id, dh, i);
+    assert.strictEqual((await submit(id, { party_index: i, signer_public_key: s.pubB64, signature: s.sigB64 })).status, 200);
+  }
+
+  const stranger = await receipt(id, STRANGER);
+  assert.strictEqual(stranger.status, 404, 'another tenant may not fetch the evidence, and learns nothing from trying');
+
+  const anon = await receipt(id);
+  assert.strictEqual(anon.status, 401, 'the receipt is not public');
+
+  const owner = await receipt(id, OWNER);
+  assert.strictEqual(owner.status, 200, owner.text);
+  assert.match(String(owner.headers['content-disposition'] || ''), /\.psign"?$/);
+  did();
+});
+
+test('OFFLINE VERIFICATION: the receipt checks out without asking the relay anything', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  const { id, docHash: dh } = await createEnvelope([{ label: 'Alice' }, { label: 'Bob' }]);
+  const signers = [];
+  for (const i of [0, 1]) {
+    const s = signForParty(id, dh, i);
+    assert.strictEqual((await submit(id, { party_index: i, signer_public_key: s.pubB64, signature: s.sigB64 })).status, 200);
+    signers.push(s);
+  }
+  const psign = (await receipt(id, OWNER)).json;
+
+  assert.strictEqual(psign.type, 'parasign-envelope-receipt');
+  assert.strictEqual(psign.algorithm, 'ML-DSA-65');
+  assert.strictEqual(psign.envelope_id, id);
+  assert.strictEqual(psign.document_hash, dh);
+  assert.strictEqual(psign.document_hash_algo, 'sha3-256');
+  assert.strictEqual(psign.parties.length, 2);
+
+  // From here on nothing from the relay is trusted: every byte is re-derived.
+  // (a) each party's signature, over the message this verifier builds itself
+  //     from the receipt's own fields.
+  for (const p of psign.parties) {
+    const msg = envelopeMod.signMessageBytes(
+      psign.envelope_id, psign.document_hash, p.index,
+      p.email_hash || '', psign.sign_recipe, p.public_key, p.appearance_hash || '');
+    const ok = eng.verify(
+      Buffer.from(p.signature, 'base64'), msg, Buffer.from(p.public_key, 'base64'));
+    assert.strictEqual(ok, true, `party ${p.index} signature does not verify offline`);
+    assert.strictEqual(p.public_key, signers[p.index].pubB64, 'the receipt names the key that actually signed');
+  }
+
+  // (b) the notary signature, over the canonical JSON of the receipt with the
+  //     signature field removed, the relay's own countersignature.
+  const { notary_signature, ...unsigned } = psign;
+  const notaryOk = eng.verify(
+    Buffer.from(notary_signature, 'base64'),
+    Buffer.from(parasign.canonicalJSON(unsigned), 'utf8'),
+    Buffer.from(psign.notary.relay_public_key, 'base64'));
+  assert.strictEqual(notaryOk, true, 'the notary signature does not verify offline');
+
+  // (c) the notary key really is the one the relay publishes at /v2/pubkey, so
+  //     a verifier can pin it without trusting the receipt it came in.
+  assert.strictEqual(
+    crypto.createHash('sha3-256').update(Buffer.from(psign.notary.relay_public_key, 'base64')).digest('hex'),
+    psign.notary.relay_pk_hash);
+
+  // (d) and the whole thing is tamper-evident: change one character of the
+  //     document hash and the notary signature no longer holds.
+  const tampered = { ...unsigned, document_hash: 'f' + unsigned.document_hash.slice(1) };
+  assert.strictEqual(eng.verify(
+    Buffer.from(notary_signature, 'base64'),
+    Buffer.from(parasign.canonicalJSON(tampered), 'utf8'),
+    Buffer.from(psign.notary.relay_public_key, 'base64')), false,
+    'a tampered receipt must not verify');
+  did();
+});

--- a/relay/test/route-rate-limits.test.js
+++ b/relay/test/route-rate-limits.test.js
@@ -1,0 +1,183 @@
+'use strict';
+// The rate limiters that guard the envelope routes, measured on a really booted
+// relay instead of on the Map underneath them.
+//
+// WHY THIS SUITE EXISTS. lib/rate-limit.js is well covered as a function, and
+// test/rate-limit.test.js even keeps a table of the live budgets. But nothing
+// checked that relay.js WIRES those budgets to the routes: a limiter with the
+// right numbers, applied to the wrong path or after the handler, is no limiter
+// at all. And the envelope-create limiter is not in lib/rate-limit.js at all -
+// it is the one redis-backed limiter in the codebase, defined inline at
+// relay.js:1426-1439, with a per-process fallback. That fallback is the part
+// that matters in an outage and it had no test.
+//
+// The two properties asserted:
+//   * per process, per KEY, creation is capped at 50/hour for one API key and
+//     the cap does not spill over to another key;
+//   * FLEET-WIDE with redis, two relay processes sharing one redis share one
+//     budget. That is the whole reason the redis variant exists: five relays
+//     behind nginx must not each grant 50.
+//
+// The per-IP limiters (view 30/min, sign 10/min) are checked on the routes they
+// actually guard, including that they answer BEFORE the handler does, a
+// limiter that runs after the work is done saves nothing.
+// Run: node --test relay/test/route-rate-limits.test.js
+//      (the fleet-wide test additionally needs REDIS_URL)
+
+const { test, after } = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const { boot, killAll } = require('./_relay-server');
+const { requireRedis, summary } = require('./_requires');
+
+const DEFAULT_REDIS = 'redis://127.0.0.1:6399';
+const ENV_CREATE_LIMIT = 50;   // relay.js:1404 and 1427
+const ENV_VIEW_LIMIT = 30;     // relay.js:1407, per minute per IP
+const ENV_SIGN_LIMIT = 10;     // relay.js:1410, per minute per IP
+
+let checks = 0;
+const did = () => { checks++; };
+after(async () => { await killAll(); summary('route-rate-limits', checks); });
+
+const docHash = () => crypto.createHash('sha3-256').update(crypto.randomBytes(32)).digest('hex');
+const runId = () => crypto.randomBytes(6).toString('hex');
+
+function createEnvelope(srv, key, ip) {
+  return srv.post('/v2/envelopes', {
+    headers: { 'X-Api-Key': key, 'X-Real-IP': ip || '10.9.0.1' },
+    body: { doc_hash: docHash(), parties: [{ label: 'A' }], ttl_days: 1 },
+  });
+}
+
+// The redis bucket is a wall-clock hour (relay.js:1432), so a test that spans a
+// boundary would count into two buckets. Wait it out rather than flake.
+async function awaitStableHour(seconds = 20) {
+  const msLeft = 3_600_000 - (Date.now() % 3_600_000);
+  if (msLeft < seconds * 1000) await new Promise((r) => setTimeout(r, msLeft + 250));
+}
+
+// ── 1. the per-process limiter (no redis) ────────────────────────────────────
+
+test('without redis, envelope creation is capped at 50 per hour for one key', async () => {
+  // No redis means no envelope store either, so every accepted create answers
+  // 503 (relay.js:5669). That is exactly what makes this a clean measurement of
+  // the LIMITER: the 503s are the requests it let through, and the switch to
+  // 429 is the moment it stopped.
+  const key = `pgp_rl_${runId()}`;
+  const spare = `pgp_rl_other_${runId()}`;
+  const srv = await boot({
+    tag: 'rl-process',
+    users: { api_keys: [
+      { key, plan: 'pro', active: true, account_id: 'acct_rl', email: 'rl@example.test' },
+      { key: spare, plan: 'pro', active: true, account_id: 'acct_rl_other', email: 'rl2@example.test' },
+    ] },
+  });
+
+  for (let i = 1; i <= ENV_CREATE_LIMIT; i++) {
+    const r = await createEnvelope(srv, key);
+    assert.strictEqual(r.status, 503, `create ${i} of ${ENV_CREATE_LIMIT} should have been let through, got ${r.status}`);
+  }
+  const over = await createEnvelope(srv, key);
+  assert.strictEqual(over.status, 429, 'the 51st create in an hour must be refused');
+  assert.strictEqual(over.headers['retry-after'], '3600', 'and must say when to come back');
+  assert.match(String(over.json.error), /50\/hour/);
+
+  // The budget is per KEY, not per process: a second tenant is untouched.
+  const other = await createEnvelope(srv, spare);
+  assert.strictEqual(other.status, 503, 'one key exhausting its budget must not lock out another');
+
+  // A refusal does not reset or extend the window either: still refused.
+  assert.strictEqual((await createEnvelope(srv, key)).status, 429);
+  srv.stop();
+  did();
+});
+
+// ── 2. the fleet-wide limiter (with redis) ───────────────────────────────────
+
+test('with redis the budget is FLEET-WIDE: two relays share one 50/hour cap', async () => {
+  // The reason the redis variant exists. Production runs five relay containers
+  // behind nginx; a per-process cap would grant 250 creations per hour per key
+  // while the docs and the 429 both say 50.
+  const rc = await requireRedis(DEFAULT_REDIS);
+  if (!rc) return;
+  await awaitStableHour();
+
+  const key = `pgp_rl_shared_${runId()}`;
+  const users = { api_keys: [{ key, plan: 'pro', active: true, account_id: 'acct_shared', email: 's@example.test' }] };
+  const env = { REDIS_URL: process.env.REDIS_URL || DEFAULT_REDIS };
+  const a = await boot({ tag: 'rl-shared-a', users, env });
+  const b = await boot({ tag: 'rl-shared-b', users, env });
+
+  try {
+    // Relay A spends the whole budget. With redis the store works, so these are
+    // real envelopes and every one of them is a 200.
+    for (let i = 1; i <= ENV_CREATE_LIMIT; i++) {
+      const r = await createEnvelope(a, key);
+      assert.strictEqual(r.status, 200, `relay A create ${i}: ${r.status} ${r.text}`);
+    }
+    // Relay B has created nothing at all, and is refused on its first attempt.
+    const onB = await createEnvelope(b, key);
+    assert.strictEqual(onB.status, 429,
+      'relay B must see relay A\'s spend; a per-process counter would have let this through');
+    assert.strictEqual(onB.headers['retry-after'], '3600');
+    // And A agrees.
+    assert.strictEqual((await createEnvelope(a, key)).status, 429);
+
+    // The counter is exactly where the code says it is, so an operator can read
+    // it, and it carries an expiry (no key left behind for an hour that passed).
+    const bucket = Math.floor(Date.now() / 3_600_000);
+    const rk = `paramant:rl:envcreate:${bucket}:${key}`;
+    assert.strictEqual(Number(await rc.get(rk)), ENV_CREATE_LIMIT + 2, 'refused attempts are counted too');
+    const ttl = await rc.ttl(rk);
+    assert.ok(ttl > 0 && ttl <= 3600, `the bucket must expire with its hour, got ttl ${ttl}`);
+    await rc.del(rk);
+  } finally {
+    a.stop(); b.stop();
+    try { await rc.disconnect(); } catch (_) {}
+  }
+  did();
+});
+
+// ── 3. the per-IP limiters on the recipient routes ───────────────────────────
+
+test('the public status route is capped at 30 requests a minute per client IP', async () => {
+  const srv = await boot({ tag: 'rl-view', users: { api_keys: [] } });
+  const ip = '10.9.1.1';
+  for (let i = 1; i <= ENV_VIEW_LIMIT; i++) {
+    const r = await srv.get('/v2/envelopes/Zm9vYmFyZm9vYmFyZm9vYmFyZm9v', { headers: { 'X-Real-IP': ip } });
+    assert.notStrictEqual(r.status, 429, `request ${i} of ${ENV_VIEW_LIMIT} should have been allowed`);
+  }
+  const over = await srv.get('/v2/envelopes/Zm9vYmFyZm9vYmFyZm9vYmFyZm9v', { headers: { 'X-Real-IP': ip } });
+  assert.strictEqual(over.status, 429);
+  assert.strictEqual(over.headers['retry-after'], '60');
+
+  // Another client is unaffected: the budget is per IP, not global.
+  const other = await srv.get('/v2/envelopes/Zm9vYmFyZm9vYmFyZm9vYmFyZm9v', { headers: { 'X-Real-IP': '10.9.1.2' } });
+  assert.notStrictEqual(other.status, 429);
+  srv.stop();
+  did();
+});
+
+test('the public sign route is capped at 10 a minute, and refuses BEFORE it does any work', async () => {
+  // Order matters: the limiter sits ahead of the store lookup and the signature
+  // verification (relay.js:5932-5934). If it ran after, a flood would still cost
+  // a redis read and an ML-DSA verification per request, which is the expensive
+  // half. The proof is that an over-limit request answers 429 while an
+  // under-limit one answers 503 from the store check behind it.
+  const srv = await boot({ tag: 'rl-sign', users: { api_keys: [] } });
+  const ip = '10.9.2.1';
+  const body = { party_index: 0, signer_public_key: 'AA==', signature: 'AA==' };
+  for (let i = 1; i <= ENV_SIGN_LIMIT; i++) {
+    const r = await srv.post('/v2/envelopes/Zm9vYmFyZm9vYmFyZm9vYmFyZm9v/sign', { headers: { 'X-Real-IP': ip }, body });
+    assert.strictEqual(r.status, 503, `sign attempt ${i} reached the store check, as it should`);
+  }
+  const over = await srv.post('/v2/envelopes/Zm9vYmFyZm9vYmFyZm9vYmFyZm9v/sign', { headers: { 'X-Real-IP': ip }, body });
+  assert.strictEqual(over.status, 429, 'the 11th signature attempt in a minute is refused');
+  assert.deepStrictEqual(over.json, { error: 'Too many requests' });
+
+  // The view budget is a different bucket: exhausting sign must not close view.
+  const view = await srv.get('/v2/envelopes/Zm9vYmFyZm9vYmFyZm9vYmFyZm9v', { headers: { 'X-Real-IP': ip } });
+  assert.notStrictEqual(view.status, 429, 'the two limiters must not share a bucket');
+  srv.stop();
+  did();
+});

--- a/relay/test/route-transfer-burn.test.js
+++ b/relay/test/route-transfer-burn.test.js
@@ -1,0 +1,277 @@
+'use strict';
+// ParaSend over HTTP on a really booted relay: upload, download, burn-on-read,
+// the download-link flow, and the per-tier ceilings.
+//
+// WHY THIS SUITE EXISTS. Burn-on-read is the product's central promise: the
+// blob is gone after the read, and a second read finds nothing. It was proved
+// only by the hourly transfer canary against LIVE production (tests/transfer-
+// canary.test.mjs), which measures the running server and not the commit being
+// merged. So a change to the burn could go green through CI and only be caught
+// by a canary an hour after deploy, on production, by a check that opens a
+// GitHub issue. That is the wrong order. Everything here runs against the
+// relay.js in the working tree, offline, in about a second.
+//
+// The relay boots WITHOUT redis, which is exactly what the blob path needs: the
+// blob store is an in-process Map (relay.js:blobStore) and the monthly quota
+// gate fails open without redis (lib/quota.js:170-197), so the transfer path is
+// fully exercisable with no service. The per-tier CEILINGS asserted here
+// (view_ttl_ms and max_views from lib/tiers.js) are the two that relay.js
+// really enforces on upload.
+// Run: node --test relay/test/route-transfer-burn.test.js
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const { boot, killAll } = require('./_relay-server');
+const { summary } = require('./_requires');
+
+const PRO = 'pgp_pro_key_for_the_transfer_suite';
+const COMMUNITY = 'pgp_community_key_for_the_transfer_suite';
+const OTHER = 'pgp_other_tenant_key_for_the_transfer_suite';
+
+let srv;
+let checks = 0;
+const did = () => { checks++; };
+
+// A fresh blob every time: the store is keyed on the sha256 and rejects a
+// repeat with 409, so tests must not share one.
+function blob(label) {
+  const payload = Buffer.from(`${label}-${crypto.randomBytes(8).toString('hex')}`);
+  return { payload, hash: crypto.createHash('sha256').update(payload).digest('hex') };
+}
+
+function upload(key, b, extra = {}) {
+  return srv.post('/v2/inbound', {
+    headers: { 'X-Api-Key': key },
+    body: { hash: b.hash, payload: b.payload.toString('base64'), ...extra },
+  });
+}
+
+const download = (key, hash) => srv.get(`/v2/outbound/${hash}`, { headers: { 'X-Api-Key': key } });
+
+before(async () => {
+  srv = await boot({
+    tag: 'transfer',
+    users: {
+      api_keys: [
+        { key: PRO, plan: 'pro', active: true, email: 'pro@example.test', account_id: 'acct_pro' },
+        { key: COMMUNITY, plan: 'community', active: true, email: 'com@example.test', account_id: 'acct_com' },
+        { key: OTHER, plan: 'pro', active: true, email: 'other@example.test', account_id: 'acct_other' },
+      ],
+    },
+  });
+});
+
+after(async () => { await killAll(); summary('route-transfer-burn', checks); });
+
+// ── 1. upload ────────────────────────────────────────────────────────────────
+
+test('an upload returns the hash, the size, a download token and a merkle proof', async () => {
+  const b = blob('happy');
+  const r = await upload(PRO, b, { ttl_ms: 60_000 });
+  assert.strictEqual(r.status, 200, r.text);
+  assert.strictEqual(r.json.ok, true);
+  assert.strictEqual(r.json.hash, b.hash);
+  assert.strictEqual(r.json.size, b.payload.length);
+  assert.match(r.json.download_token, /^[0-9a-f]{48}$/, 'the link credential is 24 random bytes in hex');
+  const p = r.json.merkle_proof;
+  assert.ok(p && typeof p.leaf_index === 'number' && p.tree_size >= 1, 'an inclusion proof travels with the upload');
+  assert.match(p.leaf_hash, /^[0-9a-f]{64}$/);
+  did();
+});
+
+test('the relay checks the hash it was given against the bytes it received', async () => {
+  // The hash is the blob's name in the store and the leaf in the CT log, so a
+  // caller must not be able to file bytes under someone else's name.
+  const b = blob('mismatch');
+  const other = blob('other');
+  const r = await srv.post('/v2/inbound', {
+    headers: { 'X-Api-Key': PRO },
+    body: { hash: other.hash, payload: b.payload.toString('base64') },
+  });
+  assert.strictEqual(r.status, 400);
+  assert.deepStrictEqual(r.json, { error: 'hash_mismatch' });
+  did();
+});
+
+test('a hash that is already stored is refused with 409, not silently overwritten', async () => {
+  const b = blob('dup');
+  assert.strictEqual((await upload(PRO, b)).status, 200);
+  const again = await upload(PRO, b);
+  assert.strictEqual(again.status, 409, 'a second upload under the same hash must not replace the first');
+  did();
+});
+
+test('a malformed hash is refused', async () => {
+  const b = blob('badhash');
+  const r = await srv.post('/v2/inbound', {
+    headers: { 'X-Api-Key': PRO },
+    body: { hash: 'not-a-sha256', payload: b.payload.toString('base64') },
+  });
+  assert.strictEqual(r.status, 400);
+  did();
+});
+
+// ── 2. burn-on-read ──────────────────────────────────────────────────────────
+
+test('BURN ON READ: the first download returns the bytes, the second finds nothing', async () => {
+  const b = blob('burn');
+  assert.strictEqual((await upload(PRO, b)).status, 200);
+
+  const first = await download(PRO, b.hash);
+  assert.strictEqual(first.status, 200);
+  assert.ok(first.buf.equals(b.payload), 'the bytes come back exactly as uploaded');
+  assert.strictEqual(first.headers['x-paramant-burned'], 'true', 'the response says the blob was burned');
+  assert.strictEqual(first.headers['x-paramant-hash'], b.hash);
+
+  const second = await download(PRO, b.hash);
+  assert.strictEqual(second.status, 404, 'a burned blob must be gone, not merely hidden');
+  assert.deepStrictEqual(second.json, { error: 'Not found. Expired, burned, or never stored.' });
+
+  // And a third read is the same 404: no state was left behind that a retry
+  // could revive.
+  assert.strictEqual((await download(PRO, b.hash)).status, 404);
+  did();
+});
+
+test('the 404 after a burn is the same 404 as for a hash that never existed', async () => {
+  // Otherwise the download route is an oracle for "this file existed once".
+  const burned = blob('oracle');
+  await upload(PRO, burned);
+  await download(PRO, burned.hash);
+  const afterBurn = await download(PRO, burned.hash);
+  const neverStored = await download(PRO, crypto.randomBytes(32).toString('hex'));
+  assert.strictEqual(afterBurn.status, neverStored.status);
+  assert.deepStrictEqual(afterBurn.json, neverStored.json);
+  did();
+});
+
+test('the download carries a signed delivery receipt with a burn confirmation', async () => {
+  const b = blob('receipt');
+  await upload(PRO, b);
+  const r = await download(PRO, b.hash);
+  assert.strictEqual(r.status, 200);
+  const raw = r.headers['x-paramant-receipt'];
+  assert.ok(raw, 'every delivery is receipted');
+  const receipt = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'));
+  assert.strictEqual(receipt.blob_hash, b.hash);
+  assert.strictEqual(receipt.burn_confirmed, true);
+  assert.ok(receipt.signature, 'the receipt is signed by the relay identity');
+  assert.ok(receipt.inclusion_proof, 'and carries the CT inclusion proof for the blob');
+  did();
+});
+
+test('one tenant cannot download another tenant\'s blob', async () => {
+  const b = blob('tenant');
+  await upload(PRO, b);
+  const thief = await download(OTHER, b.hash);
+  assert.strictEqual(thief.status, 403, 'the blob is bound to the uploading key');
+  // And the refused attempt must not have burned it for the rightful owner.
+  const owner = await download(PRO, b.hash);
+  assert.strictEqual(owner.status, 200, 'a refused read must not consume the view');
+  did();
+});
+
+// ── 3. per-tier ceilings ─────────────────────────────────────────────────────
+
+test('max_views is clamped to the tier ceiling: community gets one read, pro gets ten', async () => {
+  // lib/tiers.js: community.max_views = 1, pro.max_views = 10. The relay clamps
+  // whatever the client asks for (relay.js:4391), so a community key asking for
+  // 5 still burns on the first read.
+  const c = blob('views-community');
+  assert.strictEqual((await upload(COMMUNITY, c, { max_views: 5 })).status, 200);
+  assert.strictEqual((await download(COMMUNITY, c.hash)).status, 200);
+  assert.strictEqual((await download(COMMUNITY, c.hash)).status, 404,
+    'community asked for 5 views and must still be held to 1');
+
+  const p = blob('views-pro');
+  assert.strictEqual((await upload(PRO, p, { max_views: 5 })).status, 200);
+  for (let i = 1; i <= 5; i++) {
+    const r = await download(PRO, p.hash);
+    assert.strictEqual(r.status, 200, `pro read ${i} of 5`);
+    assert.strictEqual(r.headers['x-paramant-burned'], i === 5 ? 'true' : 'false',
+      'only the last permitted read reports the burn');
+  }
+  assert.strictEqual((await download(PRO, p.hash)).status, 404, 'the sixth read of a 5-view blob is gone');
+  did();
+});
+
+test('a pro key cannot exceed its own ceiling either: 99 requested, 10 granted', async () => {
+  const b = blob('views-cap');
+  assert.strictEqual((await upload(PRO, b, { max_views: 99 })).status, 200);
+  for (let i = 1; i <= 10; i++) {
+    assert.strictEqual((await download(PRO, b.hash)).status, 200, `read ${i}`);
+  }
+  assert.strictEqual((await download(PRO, b.hash)).status, 404, 'the eleventh read is past the pro ceiling of 10');
+  did();
+});
+
+test('the TTL is clamped to the tier ceiling: community 1 hour, pro 24 hours', async () => {
+  // lib/tiers.js: community.view_ttl_ms = 3_600_000, pro.view_ttl_ms =
+  // 86_400_000. A client asking for a week gets its tier's ceiling back in the
+  // upload response, so the clamp is visible to the caller and not silent.
+  const week = 7 * 86_400_000;
+  const c = await upload(COMMUNITY, blob('ttl-c'), { ttl_ms: week });
+  assert.strictEqual(c.json.ttl_ms, 3_600_000);
+  const p = await upload(PRO, blob('ttl-p'), { ttl_ms: week });
+  assert.strictEqual(p.json.ttl_ms, 86_400_000);
+  // A request below the ceiling is honoured as asked.
+  const small = await upload(PRO, blob('ttl-small'), { ttl_ms: 30_000 });
+  assert.strictEqual(small.json.ttl_ms, 30_000);
+  did();
+});
+
+// ── 4. the download-link flow ────────────────────────────────────────────────
+
+test('the /v2/dl link needs no API key, burns once, and is 410 afterwards', async () => {
+  // The 48-hex token IS the credential; a recipient has no key. This is the
+  // flow behind every "someone sent you a file" mail.
+  const b = blob('link');
+  const up = await upload(PRO, b);
+  const token = up.json.download_token;
+
+  const info = await srv.get(`/v2/dl/${token}/info`);
+  assert.strictEqual(info.status, 200);
+  assert.strictEqual(info.json.used, false);
+  assert.strictEqual(info.json.file_size, b.payload.length);
+
+  const got = await srv.get(`/v2/dl/${token}/get`);
+  assert.strictEqual(got.status, 200);
+  assert.ok(got.buf.equals(b.payload));
+  assert.strictEqual(got.headers['x-burned'], 'true');
+
+  const again = await srv.get(`/v2/dl/${token}/get`);
+  assert.strictEqual(again.status, 410, 'a used link is gone for good');
+
+  const infoAfter = await srv.get(`/v2/dl/${token}/info`);
+  assert.strictEqual(infoAfter.status, 404, 'and the probe no longer describes it');
+  did();
+});
+
+test('an unknown download token is refused, and the info probe never burns', async () => {
+  const b = blob('probe');
+  const token = (await upload(PRO, b)).json.download_token;
+  // Three probes in a row must all still say "not used".
+  for (let i = 0; i < 3; i++) {
+    const info = await srv.get(`/v2/dl/${token}/info`);
+    assert.strictEqual(info.json.used, false, 'probing must not consume the download');
+  }
+  assert.strictEqual((await srv.get(`/v2/dl/${token}/get`)).status, 200, 'the blob survived three probes');
+
+  const unknown = await srv.get(`/v2/dl/${'0'.repeat(48)}/get`);
+  assert.strictEqual(unknown.status, 410);
+  did();
+});
+
+// ── 5. the blob is opaque ────────────────────────────────────────────────────
+
+test('a caller may delete its own blob before anyone reads it, and only its own', async () => {
+  const b = blob('abort');
+  await upload(PRO, b);
+  const wrongTenant = await srv.req('DELETE', `/v2/inbound/${b.hash}`, { headers: { 'X-Api-Key': OTHER } });
+  assert.strictEqual(wrongTenant.status, 403);
+  const owner = await srv.req('DELETE', `/v2/inbound/${b.hash}`, { headers: { 'X-Api-Key': PRO } });
+  assert.strictEqual(owner.status, 200);
+  assert.strictEqual((await download(PRO, b.hash)).status, 404, 'the aborted blob is really gone');
+  did();
+});


### PR DESCRIPTION
relay.js is 6488 lines and 68 routes and, until this branch, no unit test loaded
it. The coverage table did not list the file: it was only ever started as a black
box by three suites that then killed it with SIGKILL, which is also why it could
never contribute a coverage profile. Five new suites boot the real relay.js and
drive it over HTTP.

Nothing here touches the network or production. The relay under test binds
127.0.0.1, gets no Mollie key, and every path that would default to /data is
redirected into a scratch dir.

## What is covered

| suite | tests | what it pins |
|---|---|---|
| `route-auth-gate` | 15 | auth before validation, the public envelope routes, admin and internal tokens |
| `route-envelope-lifecycle` | 13 | create, view, sign with real ML-DSA-65, receipt verified offline |
| `route-transfer-burn` | 14 | upload, download, burn-on-read, the link flow, per-tier ceilings |
| `route-billing-entitlements` | 11 (1 todo) | entitlements across a restart, paid_until, tier to quota |
| `route-rate-limits` | 4 | the 50/hour create budget per key and fleet-wide, the per-IP limiters |
| **total** | **57** | 56 pass, 1 todo (see finding 1), 6.3 s |

Highlights, rather than a list of asserts:

- **Auth before validation.** A missing or wrong key returns 401 for a body that
  is absent, malformed, empty, or wrong-shaped. It can never turn into a 400,
  which is the shape the ParaID bypass had. A de-activated key answers byte for
  byte like an unknown one, so the 401 is not a key-existence oracle. An
  unconfigured ADMIN_TOKEN fails closed.
- **The signature is really verified.** Four forgeries are refused with 400
  `bad_signature`: a signature over another document, over another party index,
  from a key other than the one presented, and pure noise. The slot stays open
  and the good signature still lands afterwards.
- **The receipt is verified offline.** The test re-derives every signed message
  from the receipt's own fields, verifies each party signature and the notary
  signature with the raw engine, checks the notary key hash, and shows that
  changing one character of the document hash breaks the notary signature. It
  never asks the relay whether the receipt is good.
- **Burn-on-read.** First read returns the bytes and says `X-Paramant-Burned:
  true`, the second is 404, and that 404 is identical to the 404 for a hash that
  never existed. A refused read by another tenant does not consume the view.
- **Restart.** The billing suite restarts the relay on the same users.json and
  asks the same question again. That round trip is what #315 actually broke.

## Coverage of relay.js

Measured with c8 over the suites exactly as CI runs them, `--all --include
relay.js`, so the file appears even when nothing loads it.

| | % lines | % branch | % funcs |
|---|---|---|---|
| before (CI suite as on main) | **0.00** (1-6493 uncovered) | 0.00 | 0.00 |
| after (the five new suites) | **41.42** | 58.21 | 43.88 |

The before figure is not an artefact of the tool: `inbound-hash-verify`,
`deep-health-gate` and `billing-stance-boot` do boot relay.js, but they SIGKILL
the child, and a killed process writes no V8 profile. The harness stops a relay
with SIGTERM (relay.js already handles it, zeroizes its blobs and exits 0), which
is what turned the profile on.

## Sabotage, per suite

One line changed, the suite run, the change reverted. Each is a real change to
production code, not to a fixture.

| # | sabotage | suite | result |
|---|---|---|---|
| S1 | `relay.js:4214` auth gate condition replaced by `false` (the gate lets everything through) | route-auth-gate | 2 red: "POST /v2/envelopes without a key is 401", "create is NOT in that public list". Only 2 because the create handler has a second `!keyData` check behind the gate, which is defence in depth working as intended. |
| S2 | `relay.js:4529` `views_remaining ... - 1` becomes `- 0` (nothing ever burns) | route-transfer-burn | 5 red, including "BURN ON READ", "the 404 after a burn is the same 404", both per-tier max_views tests |
| S3 | `relay.js:5657` `sigVerify` returns `true` unconditionally | route-envelope-lifecycle | 1 red: "a signature over the WRONG message is refused, so the relay really verifies" |
| S4 | `relay.js:1643` `_mutateUsersJson` becomes a no-op (this is the #315 mechanism: entitlements live only in memory) | route-billing-entitlements | 3 red: "an admin product-plan change is on disk", "leaves the other product's paid period alone", "the users.json write is atomic" |
| S5 | `relay.js:1404` and `1427` create budget 50 becomes 500 | route-rate-limits | 2 red: the per-process cap and the fleet-wide cap |

`git status` was clean after each revert.

## CI

- The route suites run in `relay-crypto-tests`, the job that installs the relay
  deps and builds @paramant/core. relay.js requires `redis` and the engine at
  load, so they cannot run in the no-install unit job, and they are excluded from
  its glob by name.
- That job gains a redis service (`redis:7.4.8-alpine`, the same tag
  docker-compose runs, on 6399). The envelope store is redis-only
  (relay.js:5650): without a server every `/v2/envelopes` route answers 503 and
  the ParaSign lifecycle cannot be tested. It is also what makes the fleet-wide
  half of the create limiter measurable, two relay processes against one budget.
- The step carries the same silent-suite gate as the unit job, with an **empty**
  expected set. Every suite prints its closing line through `summary()` in
  `test/_requires.js`, so a suite that runs and asserts nothing is caught here
  too. In this job it has redis and the engine, so a skip means broken, not
  under-equipped, and the gate fails rather than keeping a list.
- `parasign-signs-quota` moves into that step too. It needs redis and nothing
  else, and it ran in one place only: the no-install unit job, where it has no
  redis and skipped on every single run. Its five checks on the monthly signs cap
  (the metering that once sat behind a dead `&& false`) had therefore never run
  on a pull request. With a redis service they do, and the unit job's
  expected-silent list is now **empty**: every suite that runs there asserts
  something.
- Both silence gates gained `|| true` on the grep that collects the silent
  suites. GitHub runs a `run:` block under `bash -e` and grep exits 1 when it
  matches nothing, so an empty result, which is the good case, failed the step.
  That is what turned the first fully green route run into a red job; the suites
  themselves were 56 pass / 1 todo on that same run.

## Findings

Found while writing the tests. Not fixed here: this branch is tests only.

### 1. An expired paid tier keeps granting on every account-level read

`lib/entitlements.js:328-344` `mergeAccountRecord()` copies `plan_parasign` and
`plan_parasend` off the api-key records onto the merged account record, but not
their `paid_until_*` fields. Its own doc comment explains that those fields can
only live on the key records, because the accounts summary never carries the
per-product plans. So the merged record reaches `getEntitlements` with a paid
tier and no period, and `entitlements.js:137` then correctly reads "no recorded
period" as "never expired".

```
getEntitlements(keyRec).parasign.tier                             -> 'free'
getEntitlements(mergeAccountRecord(acct, [keyRec])).parasign.tier -> 'business'
```
(same record, `paid_until_parasign` 20 days in the past)

Reached through `entitlementRecordOf` at:
- `relay.js:5316` GET /v2/admin/entitlements/:account_id
- `relay.js:5990` the signs-quota gate on POST /v2/envelopes/:id/sign
- `relay.js:1804` the plan a newly minted `psk_` key inherits

This is the same class as #315, one step further along: the date is written and
persisted correctly, and then dropped on the way to the gate that reads it. The
fix is two lines in `mergeAccountRecord`, but it changes billing behaviour, so it
belongs in its own PR with a decision about accounts that are already lapsed.

Encoded in the branch as a `todo` test (`route-billing-entitlements`, "#315: a
period that HAS passed stops granting"), which states the correct rule and fails
today without failing the run, plus a passing test named `FINDING:` that pins the
divergence between the two read paths as evidence. Both go away with the fix.

### 2. A ParaSend download answers with a 19 KB response header

`GET /v2/outbound/:hash` returns `X-Paramant-Receipt`, a base64 delivery receipt
carrying a full ML-DSA-65 signature and the inclusion proof. Measured on this
branch: **18551 bytes for that one header, 19560 bytes of response headers in
total** (relay.js:4563-4590).

- Node's own default `maxHeaderSize` is 16384, so a Node client using `fetch()`
  or a default `http.request` cannot download a blob: it throws
  `UND_ERR_HEADERS_OVERFLOW`. This is how the finding surfaced, the test client
  hit it on the first download.
- No nginx config in this repo sets `proxy_buffer_size` (`nginx-selfhost.conf`,
  `deploy/nginx-paramant-live.conf`, `deploy/nginx-paramant-public.conf`,
  `deploy/nginx-selfhost.conf` all lack it). The nginx default is 4k/8k, which
  answers 502 on an upstream header this size. Whether production is configured
  differently was not checked, that is a production read.

The obvious shape of a fix is to move the receipt into the body or behind a
second endpoint, or return only a receipt id in the header. Not touched here.

### 3. Two smaller inconsistencies

- `relay.js:4386` takes the TTL ceiling with a `'community'` fallback for a key
  with no plan, `relay.js:4391` takes the max_views ceiling for the same key with
  a `'pro'` fallback. Two different defaults, one line apart, and the more
  permissive one is on the views.
- `relay.js:1607` `OUTBOUND_RATE = { free: 50, pro: 500, enterprise: Infinity }`
  has no `community` and no `business` key, so both fall to `?? free` = 50/hour.
  A Business account pays for the highest ParaSign volume and gets the free
  outbound rate.

### 4. A testability gap, not a bug

The only code path that writes `paid_until` is the Mollie webhook, and
`lib/mollie.js:12` hard-codes `api.mollie.com` with no override (deliberately, as
an anti-SSRF measure). So the write half cannot be driven offline and this branch
pins the read-back and the admin write instead. If that path is ever to be tested
end to end it needs an injection seam that does not widen the SSRF surface.

## How to run it

```
cd relay && npm install
docker run -d --rm -p 6399:6379 redis:7.4.8-alpine
REDIS_URL=redis://127.0.0.1:6399 node --test test/route-*.test.js
```
