### PR TITLE
fix(relay): the four bugs PR #341 found in the critical paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -315,13 +315,23 @@ jobs:
         with:
           fetch-depth: 0
       # Full-history secret scan. The repo-root .gitleaksignore (documented
-      # curl/PSS placeholder fingerprints) is honoured automatically. Pinned to a
-      # commit SHA, not a moving tag. License-free: Apolloccrypt is a personal
-      # account and paramant-relay is public, so gitleaks-action requires no
-      # GITLEAKS_LICENSE. Fails the job (and the PR) on any unignored finding.
+      # curl/PSS placeholder fingerprints) is honoured automatically, and so is
+      # .gitleaks.toml, which allowlists the two documentation placeholders.
+      # Pinned to a commit SHA, not a moving tag. License-free: Apolloccrypt is a
+      # personal account and paramant-relay is public, so gitleaks-action requires
+      # no GITLEAKS_LICENSE. Fails the job (and the PR) on any unignored finding.
+      #
+      # GITLEAKS_VERSION is pinned too, and it has to be. The action's own
+      # default resolved to 8.24.3, which parses a `[[allowlists]]` table in
+      # .gitleaks.toml and then IGNORES it: no error, no warning, the config
+      # simply does not apply. Measured on this branch, same repo, same config:
+      # 8.24.3 reports 2 findings and 8.28.0 reports 0. A config that is silently
+      # skipped is worse than one that fails to load, so the version that honours
+      # it is named here rather than inherited.
       - name: gitleaks
         uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: "8.28.0"
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
           GITLEAKS_ENABLE_SUMMARY: "true"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,29 @@
+# gitleaks configuration for paramant-relay.
+#
+# WHY THIS FILE EXISTS. The published API docs show every authenticated call as
+# a runnable curl, and a curl needs a key-shaped string in it. gitleaks' own
+# `curl-auth-header` rule then fires on the placeholder, so the secrets job goes
+# red on a documentation change that contains no secret at all.
+#
+# Until now that was handled by adding the finding's fingerprint to
+# .gitleaksignore. A fingerprint is commit:file:rule:line, so it goes stale the
+# moment a line moves, and every new example needs a new entry: the ignore file
+# already carries 20-odd of them for exactly this rule. This allowlist is the
+# durable half. .gitleaksignore stays as it is, for the findings that really are
+# per-commit history (the revoked RESEND_API_KEY, test fixtures).
+#
+# The regex is deliberately narrow: the two literal placeholder strings, and
+# only where they follow the API key header. `pgp_` and `plk_` keys with any
+# other body are still caught, which is the whole point. There is a test for
+# that claim in the PR that introduced this file: swap the placeholder for a
+# random-looking key and gitleaks fires again.
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Documentation placeholders in the published curl examples. Not keys: literal strings, in docs/api.md, frontend/docs/api.md and README.md."
+regexTarget = "match"
+regexes = [
+  '''X-Api-Key:\s*pgp_your_key''',
+  '''X-Api-Key:\s*plk_your_key''',
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,29 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-Nothing yet. New entries go here as they merge; `docs/RELEASE.md` says when and
-how they move into a version section.
+### Changed
+- **The ParaSend delivery receipt moved out of the response header.**
+  `GET /v2/outbound/:hash` used to answer with `X-Paramant-Receipt`, the whole
+  signed receipt inline: 18551 bytes for that header and 19560 for the block.
+  Node's default `maxHeaderSize` is 16384, so a client using `fetch()` could not
+  download at all (`UND_ERR_HEADERS_OVERFLOW`), and nginx's default
+  `proxy_buffer_size` of 4k/8k answers 502. The download now carries
+  `X-Paramant-Receipt-Id`, `X-Paramant-Receipt-Hash` and
+  `X-Paramant-Receipt-Url`, and the receipt itself comes from the new
+  `GET /v2/transfers/:receipt_id/receipt`, which returns the exact same
+  base64url payload. Receipts are held for 15 minutes, per account, and bound to
+  the API key that made the download.
+
+### Deprecated
+- **`X-Paramant-Receipt`.** Off by default from this release, removed after
+  **2026-12-01**. `PARAMANT_INLINE_RECEIPT_HEADER=1` puts it back for the
+  transition; a proxy in front of the relay then needs `proxy_buffer_size`
+  raised to match. While it is off, every download carries
+  `X-Paramant-Receipt-Deprecated` naming the new URL, so a client cannot
+  silently turn a missing header into a missing receipt. The Python SDK does
+  exactly that today (`sdk-py/paramant_sdk.py:681`), which is why the notice
+  exists; `Apolloccrypt/paramant-sdk` PR #5 teaches it both shapes and that
+  release must ship before this one reaches production.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ curl https://relay.paramant.app/v2/pubkey
 
 # Verify a delivery receipt
 curl -X POST https://relay.paramant.app/v2/verify-receipt \
-  -d '{"receipt":"<base64url from X-Paramant-Receipt header>"}'
+  -d '{"receipt":"<base64url from GET /v2/transfers/:receipt_id/receipt>"}'
 # {"valid":true,"blob_hash":"a3f2…","burn_confirmed":true}
 ```
 
@@ -582,7 +582,7 @@ Every transfer is appended to a public SHA3-256 Merkle tree. The trust model mir
 | What you can prove | How |
 |-------------------|-----|
 | A specific blob was uploaded | `merkle_proof` in `POST /v2/inbound` response |
-| A specific blob was delivered and burned | `X-Paramant-Receipt` header on `GET /v2/outbound` |
+| A specific blob was delivered and burned | `GET /v2/transfers/:receipt_id/receipt`, referenced by `X-Paramant-Receipt-Id` on `GET /v2/outbound` |
 | Receipt is genuine and unmodified | `POST /v2/verify-receipt` |
 | Log has not been forked | `GET /v2/sth/consistency?from=N&to=M` |
 | Peer relays agree on the tree | `GET /v2/sth/peers` |

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,6 +1,6 @@
 # PARAMANT: complete environment reference
 #
-# 77 variables. Copy to deploy/.env and fill in what the "required" blocks ask
+# 81 variables. Copy to deploy/.env and fill in what the "required" blocks ask
 # for. .env is NEVER committed to git.
 #
 # This file is the reference: every name the relay or the admin panel reads is
@@ -446,6 +446,47 @@ PARAMANT_TOTP_MASTER_KEY=
 # optional · default: none
 # read in: relay/scripts/parasign-backfill-envelope-index.js
 # RELAY_REDIS_URL=
+
+# -- ParaSend delivery receipts -----------------------------------------------
+# A download (GET /v2/outbound/:hash) hands its signed delivery receipt over by
+# REFERENCE: the response carries a receipt id and a hash, and the receipt
+# itself comes from GET /v2/transfers/:receipt_id/receipt. The payload is about
+# 18 KB, which does not fit in a response header (Node's maxHeaderSize is 16 KB,
+# and nginx' default proxy_buffer_size is 4k/8k). Receipts live in REDIS when
+# REDIS_URL is set, so they survive a relay restart, and in process memory
+# otherwise, where they do not.
+
+# Put the whole receipt back in the X-Paramant-Receipt response header, inline,
+# alongside the reference. DEPRECATED and removed after 2026-12-01; it exists so
+# a client written against the old shape keeps working for one release. Turning
+# it on REQUIRES raising proxy_buffer_size on every proxy in front of the relay,
+# or a download answers 502 instead.
+# optional · default: off (any value other than 1 is off)
+# read in: relay/relay.js
+# PARAMANT_INLINE_RECEIPT_HEADER=1
+
+# How many receipts one account may hold at once. Unset, the cap is derived from
+# the account's tier: twice its outbound_per_hour from relay/lib/tiers.js, so
+# community 100, pro 1000, business 4000. Set this only to force one flat number
+# for every tier; it is meant for tests, which need to drive the eviction rule
+# without making thousands of downloads.
+# optional · default: unset (per-tier, see above)
+# read in: relay/relay.js
+# PARAMANT_RECEIPT_PER_ACCOUNT_MAX=
+
+# The per-account cap for a tier with NO outbound ceiling to double, which today
+# is enterprise only.
+# optional · default: 10000
+# read in: relay/relay.js
+# PARAMANT_RECEIPT_UNCAPPED_MAX=10000
+
+# Backstop on the total number of receipts held in PROCESS MEMORY, for a relay
+# running without redis. When it is reached the largest holder loses its oldest
+# receipt, never the quietest one. At roughly 14 KB per receipt the default is
+# about 56 MB. Has no effect when REDIS_URL is set.
+# optional · default: 4000
+# read in: relay/relay.js
+# PARAMANT_RECEIPT_TOTAL_MAX=4000
 
 
 # ==============================================================================

--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -75,6 +75,39 @@ layer on is a separate decision, taken when there is a Mollie test key to
 prove it against first. That is step 3 in the vault's order (deny, then
 test key plus mode, then deploy) collapsed to: deploy now, decide later.
 
+## A second brake: the delivery receipt moved out of the download header
+
+**Precondition, not a step: `Apolloccrypt/paramant-sdk` PR #5 must be released
+to PyPI before main reaches production.**
+
+Relay PR #342 takes the signed ParaSend delivery receipt out of the
+`X-Paramant-Receipt` response header. It had to go: 18551 bytes for that one
+header, over Node's 16 KB limit and over the default nginx proxy buffer, so a
+client using `fetch()` could not download at all. The receipt is now fetched
+from `GET /v2/transfers/:receipt_id/receipt`.
+
+The out-of-tree Python SDK reads that header (`sdk-py/paramant_sdk.py:681`) and
+turns an absent one into `receipt = None`, without an error. So a `3.2.0`
+client against a deployed main keeps working and silently stops getting proof
+of delivery. `paramant-sdk` 3.2.1 reads both shapes and fails loudly; that is
+the release this deploy waits for.
+
+Two ways out if the release is not ready and the deploy cannot wait:
+
+- Set `PARAMANT_INLINE_RECEIPT_HEADER=1` in the relay containers for this
+  deploy. The old header comes back alongside the new reference, so old clients
+  keep working. It then also needs `proxy_buffer_size` raised on the
+  `/v2/outbound` locations in nginx, or the download is a 502; the repo copy of
+  `deploy/nginx-paramant-public.conf` already carries that setting with a
+  comment, the production conf does not.
+- Or hold main. The default is off on purpose, because on a default nginx the
+  fat header is a 502 rather than a feature.
+
+Either way the flag is temporary: the old header is removed after
+**2026-12-01**. While it is off, every download carries
+`X-Paramant-Receipt-Deprecated` naming the new url, so a client that looks
+finds out.
+
 ## Before you start (laptop or NUC, read-only)
 
 1. CI on main is green: `gh run list --branch main -L 5`.

--- a/deploy/nginx-paramant-public.conf
+++ b/deploy/nginx-paramant-public.conf
@@ -167,6 +167,18 @@ server {
     location ~ ^/v2/outbound {
         limit_req zone=relay_outbound burst=10 nodelay;
         limit_req_status 429;
+        # Explicit, because the default is 4k (8k on some builds) and that ONE
+        # buffer has to hold the whole upstream header block. A download used to
+        # answer with 19560 bytes of response headers (the signed delivery
+        # receipt rode along in X-Paramant-Receipt), which nginx turns into
+        # "upstream sent too big header" and a 502. The relay now hands the
+        # receipt over by reference and answers well under 8k, so this is a
+        # margin and not a fix: it keeps a future header from silently costing
+        # every download, and it covers a relay run with the deprecated
+        # PARAMANT_INLINE_RECEIPT_HEADER=1 opt-in still on.
+        proxy_buffer_size 32k;
+        proxy_buffers 8 32k;
+        proxy_busy_buffers_size 64k;
         proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,9 +95,49 @@ Response headers:
 |--------|-------|
 | `X-Paramant-Burned` | `true` if blob was destroyed |
 | `X-Paramant-Hash` | SHA-256 hex of the blob |
-| `X-Paramant-Receipt` | Base64url-encoded signed delivery receipt |
+| `X-Paramant-Receipt-Id` | 32 hex characters. Fetch the receipt with it |
+| `X-Paramant-Receipt-Hash` | `sha3-256:<hex>` over the receipt bytes you will get back |
+| `X-Paramant-Receipt-Url` | `/v2/transfers/<receipt_id>/receipt` |
 
-The `X-Paramant-Receipt` value is a base64url-encoded JSON object:
+The receipt is handed over by reference, not by value. It carries a full
+ML-DSA-65 signature and an inclusion proof, so the payload is around 18 KB:
+too large for a response header. Node's default `maxHeaderSize` is 16 KB and
+nginx's default `proxy_buffer_size` is 4k/8k, so a receipt in the header meant
+`UND_ERR_HEADERS_OVERFLOW` on the client and 502 at the proxy.
+
+**Deprecated:** `X-Paramant-Receipt`, which carried that payload inline. It is
+off by default from 2026-09 and will be removed after **2026-12-01**. An
+operator can put it back for the transition with
+`PARAMANT_INLINE_RECEIPT_HEADER=1`, and must then also raise
+`proxy_buffer_size` on any proxy in front of the relay.
+
+---
+
+### GET /v2/transfers/:receipt_id/receipt (fetch a delivery receipt)
+
+Requires the same API key that made the download. The receipt is kept for
+**15 minutes** and can be read more than once in that window. An unknown,
+expired, or foreign id all answer with the same 404, so the route cannot be
+used to probe whether a transfer existed.
+
+```bash
+curl https://relay.paramant.app/v2/transfers/$RECEIPT_ID/receipt \
+  -H "X-Api-Key: pgp_your_key"
+```
+
+```json
+{
+  "ok": true,
+  "receipt": "<base64url>",
+  "receipt_hash": "sha3-256:9c1f…"
+}
+```
+
+`receipt_hash` is identical to the `X-Paramant-Receipt-Hash` the download
+carried, over the exact `receipt` string returned here, so the handover is
+verifiable end to end.
+
+`receipt` decodes to:
 
 ```json
 {
@@ -123,7 +163,7 @@ Public. No API key required.
 ```bash
 curl -X POST https://relay.paramant.app/v2/verify-receipt \
   -H "Content-Type: application/json" \
-  -d '{"receipt":"<base64url from X-Paramant-Receipt>"}'
+  -d '{"receipt":"<base64url from GET /v2/transfers/:receipt_id/receipt>"}'
 ```
 
 Success:

--- a/docs/api.md
+++ b/docs/api.md
@@ -122,10 +122,25 @@ opt-in is on, because then there is nothing to announce.
 
 ### GET /v2/transfers/:receipt_id/receipt (fetch a delivery receipt)
 
-Requires the same API key that made the download. The receipt is kept for
-**15 minutes** and can be read more than once in that window. An unknown,
-expired, or foreign id all answer with the same 404, so the route cannot be
-used to probe whether a transfer existed.
+Requires the same API key that made the download. An unknown, expired, or
+foreign id all answer with the same 404, so the route cannot be used to probe
+whether a transfer existed.
+
+**How long you have, exactly.** Fetch the receipt right after the download.
+Three things can take it away, and all three answer with the same 404:
+
+| | |
+|---|---|
+| **Time** | 15 minutes from the download. |
+| **Your own volume** | The relay keeps your account's most recent receipts, up to twice your tier's hourly download ceiling: community 100, pro 1000, business 4000, enterprise 10000. Past that your oldest receipts drop. Another account's downloads can never take yours. |
+| **A relay without redis** | A relay configured with `REDIS_URL` keeps receipts in redis, so they survive a restart of the relay process. A relay without one keeps them in memory, and then a restart or a deploy loses every outstanding receipt. |
+
+If none of that is acceptable for your use, the receipt can still be delivered
+inline on the download itself: ask the operator to run the relay with
+`PARAMANT_INLINE_RECEIPT_HEADER=1`, which restores the `X-Paramant-Receipt`
+header alongside the reference. That header is around 18 KB, so it needs
+`proxy_buffer_size` raised on any proxy in front of the relay, and it is
+removed after 2026-12-01.
 
 ```bash
 curl https://relay.paramant.app/v2/transfers/$RECEIPT_ID/receipt \

--- a/docs/api.md
+++ b/docs/api.md
@@ -111,6 +111,13 @@ operator can put it back for the transition with
 `PARAMANT_INLINE_RECEIPT_HEADER=1`, and must then also raise
 `proxy_buffer_size` on any proxy in front of the relay.
 
+While the old header is off, every download also carries
+`X-Paramant-Receipt-Deprecated: removed 2026-12-01; GET /v2/transfers/<id>/receipt`.
+It exists because a client that reads `X-Paramant-Receipt` and finds nothing
+cannot tell "this transfer had no receipt" from "the receipt moved", and a
+delivery proof must never go missing quietly. The header is not sent when the
+opt-in is on, because then there is nothing to announce.
+
 ---
 
 ### GET /v2/transfers/:receipt_id/receipt (fetch a delivery receipt)

--- a/frontend/docs/api.md
+++ b/frontend/docs/api.md
@@ -102,10 +102,25 @@ opt-in is on, because then there is nothing to announce.
 
 ### GET /v2/transfers/:receipt_id/receipt (fetch a delivery receipt)
 
-Requires the same API key that made the download. The receipt is kept for
-**15 minutes** and can be read more than once in that window. An unknown,
-expired, or foreign id all answer with the same 404, so the route cannot be
-used to probe whether a transfer existed.
+Requires the same API key that made the download. An unknown, expired, or
+foreign id all answer with the same 404, so the route cannot be used to probe
+whether a transfer existed.
+
+**How long you have, exactly.** Fetch the receipt right after the download.
+Three things can take it away, and all three answer with the same 404:
+
+| | |
+|---|---|
+| **Time** | 15 minutes from the download. |
+| **Your own volume** | The relay keeps your account's most recent receipts, up to twice your tier's hourly download ceiling: community 100, pro 1000, business 4000, enterprise 10000. Past that your oldest receipts drop. Another account's downloads can never take yours. |
+| **A relay without redis** | A relay configured with `REDIS_URL` keeps receipts in redis, so they survive a restart of the relay process. A relay without one keeps them in memory, and then a restart or a deploy loses every outstanding receipt. |
+
+If none of that is acceptable for your use, the receipt can still be delivered
+inline on the download itself: ask the operator to run the relay with
+`PARAMANT_INLINE_RECEIPT_HEADER=1`, which restores the `X-Paramant-Receipt`
+header alongside the reference. That header is around 18 KB, so it needs
+`proxy_buffer_size` raised on any proxy in front of the relay, and it is
+removed after 2026-12-01.
 
 ```bash
 curl https://relay.paramant.app/v2/transfers/$RECEIPT_ID/receipt \

--- a/frontend/docs/api.md
+++ b/frontend/docs/api.md
@@ -91,6 +91,13 @@ operator can put it back for the transition with
 `PARAMANT_INLINE_RECEIPT_HEADER=1`, and must then also raise
 `proxy_buffer_size` on any proxy in front of the relay.
 
+While the old header is off, every download also carries
+`X-Paramant-Receipt-Deprecated: removed 2026-12-01; GET /v2/transfers/<id>/receipt`.
+It exists because a client that reads `X-Paramant-Receipt` and finds nothing
+cannot tell "this transfer had no receipt" from "the receipt moved", and a
+delivery proof must never go missing quietly. The header is not sent when the
+opt-in is on, because then there is nothing to announce.
+
 ---
 
 ### GET /v2/transfers/:receipt_id/receipt (fetch a delivery receipt)

--- a/frontend/docs/api.md
+++ b/frontend/docs/api.md
@@ -75,9 +75,49 @@ Response headers:
 |--------|-------|
 | `X-Paramant-Burned` | `true` if blob was destroyed |
 | `X-Paramant-Hash` | SHA-256 hex of the blob |
-| `X-Paramant-Receipt` | Base64url-encoded signed delivery receipt |
+| `X-Paramant-Receipt-Id` | 32 hex characters. Fetch the receipt with it |
+| `X-Paramant-Receipt-Hash` | `sha3-256:<hex>` over the receipt bytes you will get back |
+| `X-Paramant-Receipt-Url` | `/v2/transfers/<receipt_id>/receipt` |
 
-The `X-Paramant-Receipt` value is a base64url-encoded JSON object:
+The receipt is handed over by reference, not by value. It carries a full
+ML-DSA-65 signature and an inclusion proof, so the payload is around 18 KB:
+too large for a response header. Node's default `maxHeaderSize` is 16 KB and
+nginx's default `proxy_buffer_size` is 4k/8k, so a receipt in the header meant
+`UND_ERR_HEADERS_OVERFLOW` on the client and 502 at the proxy.
+
+**Deprecated:** `X-Paramant-Receipt`, which carried that payload inline. It is
+off by default from 2026-09 and will be removed after **2026-12-01**. An
+operator can put it back for the transition with
+`PARAMANT_INLINE_RECEIPT_HEADER=1`, and must then also raise
+`proxy_buffer_size` on any proxy in front of the relay.
+
+---
+
+### GET /v2/transfers/:receipt_id/receipt (fetch a delivery receipt)
+
+Requires the same API key that made the download. The receipt is kept for
+**15 minutes** and can be read more than once in that window. An unknown,
+expired, or foreign id all answer with the same 404, so the route cannot be
+used to probe whether a transfer existed.
+
+```bash
+curl https://relay.paramant.app/v2/transfers/$RECEIPT_ID/receipt \
+  -H "X-Api-Key: pgp_your_key"
+```
+
+```json
+{
+  "ok": true,
+  "receipt": "<base64url>",
+  "receipt_hash": "sha3-256:9c1f…"
+}
+```
+
+`receipt_hash` is identical to the `X-Paramant-Receipt-Hash` the download
+carried, over the exact `receipt` string returned here, so the handover is
+verifiable end to end.
+
+`receipt` decodes to:
 
 ```json
 {
@@ -103,7 +143,7 @@ Public. No API key required.
 ```bash
 curl -X POST https://relay.paramant.app/v2/verify-receipt \
   -H "Content-Type: application/json" \
-  -d '{"receipt":"<base64url from X-Paramant-Receipt>"}'
+  -d '{"receipt":"<base64url from GET /v2/transfers/:receipt_id/receipt>"}'
 ```
 
 Success:

--- a/relay/lib/entitlements.js
+++ b/relay/lib/entitlements.js
@@ -312,6 +312,57 @@ function getEntitlements(account, now) {
   };
 }
 
+// ── Per-product grant merging ────────────────────────────────────────────────
+// A grant is a PAIR: the tier that was paid for and the period it was paid for.
+// Merging only the tier is what let an expired subscription keep granting: the
+// merged record arrived at getEntitlements with a paid tier and no period, and
+// "no recorded period" correctly means "never expires". So the two fields must
+// always travel together, here and in keys-table.rebuildKeyIndexes.
+//
+// _grantOf ranks one record's grant for a product:
+//   rank       the tier it is entitled to RIGHT NOW (a lapsed period ranks as
+//              the floor tier, so it can never outrank a live lower tier)
+//   storedRank the tier on file, which breaks a tie between two floored records
+//              so the paid history is not thrown away
+//   paidUntil  null means unbounded
+function _grantOf(rec, product, at) {
+  const ladder = product === 'parasign' ? PARASIGN_TIERS : PARASEND_TIERS;
+  const norm = product === 'parasign' ? normaliseParasignTier : normaliseParasendTier;
+  return {
+    rank: ladder.indexOf(effectiveProductTier(rec, product, at).tier),
+    storedRank: ladder.indexOf(norm(rec[PRODUCT_PLAN_FIELD[product]])),
+    paidUntil: parsePaidUntil(rec[PRODUCT_PAID_UNTIL_FIELD[product]]),
+  };
+}
+
+// Does grant `a` beat grant `b`? Effective tier first, then the tier on file,
+// then the more generous period: no recorded period beats a date, and a later
+// date beats an earlier one.
+function _outranksGrant(a, b) {
+  if (a.rank !== b.rank) return a.rank > b.rank;
+  if (a.storedRank !== b.storedRank) return a.storedRank > b.storedRank;
+  if ((a.paidUntil === null) !== (b.paidUntil === null)) return a.paidUntil === null;
+  if (a.paidUntil === null) return false;
+  return a.paidUntil > b.paidUntil;
+}
+
+// Copy `source`'s grant for one product onto `target` IN PLACE when it is the
+// better of the two, tier AND period together. A source with no tier on file
+// carries no grant and is skipped. Clearing is deliberate: when the winning
+// record has no period, any period already on the target goes, or the target
+// would keep a date that belongs to a tier it no longer carries.
+function mergeProductGrantInto(target, source, product, now) {
+  const planField = PRODUCT_PLAN_FIELD[product];
+  const paidField = PRODUCT_PAID_UNTIL_FIELD[product];
+  if (!target || !source || !planField || source[planField] == null) return target;
+  const at = typeof now === 'number' ? now : Date.now();
+  if (target[planField] != null && !_outranksGrant(_grantOf(source, product, at), _grantOf(target, product, at))) return target;
+  target[planField] = source[planField];
+  if (source[paidField] == null) delete target[paidField];
+  else target[paidField] = source[paidField];
+  return target;
+}
+
 // mergeAccountRecord(acctRec, keyRecs) -> one record safe to hand to
 // getEntitlements, or null when the account is unknown.
 //
@@ -325,20 +376,14 @@ function getEntitlements(account, now) {
 //
 // The HIGHEST tier any key of the account holds wins, so a stale free key can
 // never hold a paid account down. Never mutates its inputs.
-function mergeAccountRecord(acctRec, keyRecs) {
+function mergeAccountRecord(acctRec, keyRecs, now) {
   const keys = Array.isArray(keyRecs) ? keyRecs.filter(Boolean) : [];
   if (!acctRec && keys.length === 0) return null;
   const merged = Object.assign({}, acctRec || {});
-  const higher = (order, cur, next) => {
-    if (!next || order.indexOf(next) < 0) return cur;
-    if (!cur || order.indexOf(cur) < 0) return next;
-    return order.indexOf(next) > order.indexOf(cur) ? next : cur;
-  };
   for (const rec of keys) {
     if (!merged.plan) merged.plan = rec.plan;
-    merged.plan_parasign = higher(PARASIGN_TIERS, merged.plan_parasign, rec.plan_parasign);
-    merged.plan_parasend = higher(PARASEND_TIERS, merged.plan_parasend, rec.plan_parasend);
     if (rec.parasign) merged.parasign = true;
+    for (const product of PRODUCTS) mergeProductGrantInto(merged, rec, product, now);
   }
   return merged;
 }
@@ -395,6 +440,7 @@ module.exports = {
   effectiveProductTier,
   getEntitlements,
   mergeAccountRecord,
+  mergeProductGrantInto,
   transfersQuota,
   signsQuota,
   signsOverage,

--- a/relay/lib/keys-table.js
+++ b/relay/lib/keys-table.js
@@ -238,7 +238,7 @@ function designatePrimary(apiKeys, accounts, accountKeys, accountId, key) {
 // keeps scope+parasign). A minted product key is never an account primary.
 //   randomHex: caller-supplied cryptographic hex (relay: crypto.randomBytes(32)).
 //   test:      psk_test_ (sandbox) vs psk_live_.
-function buildParasignKeyRecord({ accountId, plan, email, label, test, randomHex, createdAt, planParasign, planParasend }) {
+function buildParasignKeyRecord({ accountId, plan, email, label, test, randomHex, createdAt, planParasign, planParasend, paidUntilParasign, paidUntilParasend }) {
   if (!accountId) throw new Error('accountId required');
   if (!randomHex || typeof randomHex !== 'string') throw new Error('randomHex required');
   const key = (test ? 'psk_test_' : 'psk_live_') + randomHex;
@@ -273,6 +273,24 @@ function buildParasignKeyRecord({ accountId, plan, email, label, test, randomHex
     plan_parasign: normParasign, plan_parasend: normParasend,
     account_id: accountId, is_primary: false, scope: 'parasign', parasign: true, product: 'parasign',
   };
+  // The paid PERIOD travels with the inherited tier, onto BOTH the live record
+  // and the users.json entry. Without it a key minted while the subscription was
+  // still running carried a paid tier and no end date, and "no recorded period"
+  // means "never expires" (entitlements.js:137). So the new key outlived the
+  // subscription that paid for it, and outlived a restart too, because that is
+  // the shape that reached disk. Both issuance paths run through here
+  // (POST /v2/user/parasign-keys, self-serve, and the admin mint), so this is
+  // the one place it has to be right.
+  // applyProductTier is the shared field rule: undefined leaves the field alone,
+  // and landing on a floor tier clears any period, so a lapsed grant is minted
+  // as a plain floor key with no stale date on it.
+  for (const [product, tier, until] of [
+    ['parasign', normParasign, paidUntilParasign],
+    ['parasend', normParasend, paidUntilParasend],
+  ]) {
+    entitlements.applyProductTier(rec, product, tier, until);
+    entitlements.applyProductTier(usersEntry, product, tier, until);
+  }
   return { key, record: rec, usersEntry };
 }
 

--- a/relay/lib/keys-table.js
+++ b/relay/lib/keys-table.js
@@ -72,7 +72,18 @@ function parseAccountFields(rawKey) {
   // users.json reload. null (not undefined) keeps the admin JSON shape stable.
   const usage_purpose = typeof rawKey.usage_purpose === 'string' ? rawKey.usage_purpose : null;
   const usage_purpose_at = rawKey.usage_purpose_at || null;
-  return { account_id, is_primary, scope, legacy_revealable, parasign, plan_parasend, plan_parasign, usage_purpose, usage_purpose_at };
+  // The paid period belongs to the tier above and must be rehydrated with it.
+  // Without this the in-memory record carried a paid tier and no end date, and
+  // an end date that is not loaded is an entitlement that never expires: the
+  // relay wrote paid_until to users.json correctly and then dropped it on the
+  // way back in. Only set when present, so "no period on file" stays absent
+  // (never expired) rather than becoming an explicit null.
+  const out = { account_id, is_primary, scope, legacy_revealable, parasign, plan_parasend, plan_parasign, usage_purpose, usage_purpose_at };
+  for (const product of entitlements.PRODUCTS) {
+    const f = entitlements.PRODUCT_PAID_UNTIL_FIELD[product];
+    if (rawKey[f] != null) out[f] = rawKey[f];
+  }
+  return out;
 }
 
 // Pick a kid not already present in `taken` (anything with a .has(kid) method:
@@ -95,13 +106,6 @@ function assignKid(taken, key, log) {
 // is_primary/scope (set via parseAccountFields at load). Assigns each value a
 // stable `kid`. First-writer fills the account record; an explicit primary key
 // always wins primary_api_key.
-// Highest of two tiers on a product ladder; unknown/absent values never win.
-function _higherTier(order, cur, next) {
-  if (!next || order.indexOf(next) < 0) return cur;
-  if (!cur || order.indexOf(cur) < 0) return next;
-  return order.indexOf(next) > order.indexOf(cur) ? next : cur;
-}
-
 function rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex, log) {
   accounts.clear();
   accountKeys.clear();
@@ -119,8 +123,11 @@ function rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex, log) {
     // free 2-signature wall. It also means the mirror setProductPlan writes
     // survives a restart and POST /v2/admin/keys/reload instead of being
     // silently dropped on the next rebuild.
-    acct.plan_parasign = _higherTier(entitlements.PARASIGN_TIERS, acct.plan_parasign, v.plan_parasign);
-    acct.plan_parasend = _higherTier(entitlements.PARASEND_TIERS, acct.plan_parasend, v.plan_parasend);
+    // Tier AND paid period together: a summary that took the highest tier but
+    // left the date behind handed every account-level read an unbounded grant,
+    // which is the same drop mergeAccountRecord used to make one layer up.
+    entitlements.mergeProductGrantInto(acct, v, 'parasign');
+    entitlements.mergeProductGrantInto(acct, v, 'parasend');
     if (v.parasign) acct.parasign = true;
     if (v.is_primary || !acct.primary_api_key) acct.primary_api_key = v.is_primary ? key : (acct.primary_api_key || key);
     if (!accountKeys.has(account_id)) accountKeys.set(account_id, new Set());

--- a/relay/lib/tiers.js
+++ b/relay/lib/tiers.js
@@ -13,6 +13,12 @@
 //     _planMaxTtl   dev=1h,  pro=24h, enterprise=7d
 //     _planMaxViews free=1,  pro=10,  enterprise=100
 //     MAX_BLOB      5 MB (global, today)
+//     OUTBOUND_RATE free=50/h, pro=500/h, enterprise=unlimited
+//
+//   Every one of those legacy tables was keyed on THREE plan names and fell
+//   back to the free row for anything else, so `business` silently got the free
+//   ceiling. That is why the numbers live here: this table has a row per tier
+//   the pricing page sells, and normalisePlan maps the aliases onto it.
 //   So this refactor is a refactor, not a behaviour change.
 //
 //   For dimensions Mick stated in the tier-foundation brief (transfers_month,
@@ -42,6 +48,7 @@ const TIER_LIMITS = Object.freeze({
     devices: 5,            // mirrors legacy _pubkeyMax.free
     view_ttl_ms: 3_600_000, // mirrors legacy _planMaxTtl.dev (1 h)
     max_views: 1,          // mirrors legacy _planMaxViews.free (burn-on-read)
+    outbound_per_hour: 50,  // mirrors legacy OUTBOUND_RATE.free
   }),
   pro: Object.freeze({
     transfers_month: 500,
@@ -50,6 +57,7 @@ const TIER_LIMITS = Object.freeze({
     devices: 50,           // mirrors legacy _pubkeyMax.pro; brief says 10 once policy bump
     view_ttl_ms: 86_400_000, // 24 h
     max_views: 10,
+    outbound_per_hour: 500,  // mirrors legacy OUTBOUND_RATE.pro
   }),
   business: Object.freeze({
     transfers_month: 2000,
@@ -58,6 +66,8 @@ const TIER_LIMITS = Object.freeze({
     devices: 100,
     view_ttl_ms: 604_800_000, // 7 d
     max_views: 25,
+    outbound_per_hour: 2000, // its transfers_month; never below pro, which is
+                             // what the old table did by leaving it out
   }),
   enterprise: Object.freeze({
     transfers_month: UNLIMITED,
@@ -66,6 +76,7 @@ const TIER_LIMITS = Object.freeze({
     devices: UNLIMITED,
     view_ttl_ms: 604_800_000, // 7 d  (legacy enterprise ceiling)
     max_views: 100,
+    outbound_per_hour: UNLIMITED, // mirrors legacy OUTBOUND_RATE.enterprise
   }),
 });
 

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -185,14 +185,14 @@ const ALLOWED = {
                '/v2/did','/v2/ct','/v2/attest','/v2/admin','/metrics','/v2/dl',
                '/v2/key-sector','/v2/team','/v2/reload-users','/v2/session',
                '/v2/ws-ticket','/v2/fingerprint','/v2/relays','/v2/sign-dpa',
-               '/v2/sth','/v2/verify-receipt','/v2/capabilities','/v2/health','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
+               '/v2/sth','/v2/verify-receipt','/v2/transfers','/v2/capabilities','/v2/health','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
                '/v2/sign','/v2/verify','/v2/lookup-signer','/v2/envelopes','/v2/billing','/v2/claim','/v2/parasign','/v1'],
   iot:        ['/health','/v2/pubkey','/v2/inbound','/v2/anon-inbound','/v2/outbound','/v2/status',
                '/v2/webhook','/v2/audit','/v2/check-key','/v2/stream','/v2/stream-next',
                '/v2/ack','/v2/monitor',
                '/v2/did','/v2/ct','/v2/attest','/v2/admin','/metrics','/v2/dl',
                '/v2/key-sector','/v2/team','/v2/reload-users','/v2/session',
-               '/v2/relays','/v2/sign-dpa','/v2/sth','/v2/verify-receipt',
+               '/v2/relays','/v2/sign-dpa','/v2/sth','/v2/verify-receipt','/v2/transfers',
                '/v2/capabilities','/v2/health','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
                '/v2/sign','/v2/verify','/v2/lookup-signer','/v2/envelopes','/v2/billing','/v2/claim','/v2/parasign','/v1'],
   full:       null,
@@ -1635,6 +1635,47 @@ function outboundRateOk(apiKey, plan) {
   return true;
 }
 setInterval(() => { const now = Date.now(); for (const [k,v] of outboundRateMap) if (now > v.resetAt) outboundRateMap.delete(k); }, 3_600_000);
+
+// ── Delivery receipt store (PR #341, finding 2) ─────────────────────────
+// The signed delivery receipt used to ride out on the download itself, in the
+// X-Paramant-Receipt response header. It carries a full ML-DSA-65 signature and
+// an inclusion proof, so that header measured 18551 bytes and the response
+// header block 19560. Node's own default maxHeaderSize is 16384, so a client
+// using fetch() or a default http.request could not download a blob at all
+// (UND_ERR_HEADERS_OVERFLOW), and nginx's default proxy_buffer_size of 4k/8k
+// answers 502 on an upstream header block that size.
+//
+// So the receipt is handed over by REFERENCE instead: the download carries a
+// receipt id and the hash of the receipt bytes, and the bytes themselves are
+// fetched from GET /v2/transfers/:receipt_id/receipt. Same receipt, same
+// signature, same verification through POST /v2/verify-receipt.
+//
+// Kept in RAM like everything else on this relay, and deliberately short-lived:
+// a client fetches its receipt in the same breath as the download. The cap
+// bounds the memory a burst of downloads can pin (a receipt is about 18 KB).
+const RECEIPT_TTL_MS = 15 * 60 * 1000;
+const RECEIPT_MAX = 1000;
+const deliveryReceipts = new Map(); // receipt_id -> { payload, hash, apiKey, expiresAt }
+function storeDeliveryReceipt(payload, hash, apiKey) {
+  const id = crypto.randomBytes(16).toString('hex');
+  // Oldest-first eviction: Map preserves insertion order and every entry has
+  // the same TTL, so the head is always the one closest to expiring.
+  while (deliveryReceipts.size >= RECEIPT_MAX) {
+    const oldest = deliveryReceipts.keys().next();
+    if (oldest.done) break;
+    deliveryReceipts.delete(oldest.value);
+  }
+  deliveryReceipts.set(id, { payload, hash, apiKey: apiKey || null, expiresAt: Date.now() + RECEIPT_TTL_MS });
+  return id;
+}
+setInterval(() => { const now = Date.now(); for (const [id, r] of deliveryReceipts) if (now > r.expiresAt) deliveryReceipts.delete(id); }, 60_000).unref?.();
+
+// Deprecation window for the fat header. Nothing in this repo reads it outside
+// its own tests, but an out-of-tree client might, so an operator can put it back
+// for one release with PARAMANT_INLINE_RECEIPT_HEADER=1. It is off by default
+// because on a default nginx the fat header is a 502, not a feature. To be
+// removed after 2026-12-01; see docs/api.md.
+const INLINE_RECEIPT_HEADER = process.env.PARAMANT_INLINE_RECEIPT_HEADER === '1';
 
 // Serialized async write queue for users.json — prevents lost-update race.
 // _writeUsersJson: low-level write (caller must already hold the snapshot).
@@ -4614,10 +4655,43 @@ const server = http.createServer(async (req, res) => {
       'X-Paramant-Burned':  burned ? 'true' : 'false',
       'X-Paramant-Hash':    outm[1],
     };
-    if (receiptHeader) outHeaders['X-Paramant-Receipt'] = receiptHeader;
+    // The receipt travels by reference, not by value: an id to fetch it with and
+    // the hash of the exact bytes that will come back, so the handover itself is
+    // verifiable. The payload is ~18 KB and does not fit in a response header
+    // that Node clients or a default nginx will accept (see the store above).
+    if (receiptHeader) {
+      const receiptHash = crypto.createHash('sha3-256').update(receiptHeader).digest('hex');
+      const receiptId = storeDeliveryReceipt(receiptHeader, receiptHash, entry.apiKey || apiKey || null);
+      outHeaders['X-Paramant-Receipt-Id'] = receiptId;
+      outHeaders['X-Paramant-Receipt-Hash'] = 'sha3-256:' + receiptHash;
+      outHeaders['X-Paramant-Receipt-Url'] = `/v2/transfers/${receiptId}/receipt`;
+      // DEPRECATED, off by default, removed after 2026-12-01.
+      if (INLINE_RECEIPT_HEADER) outHeaders['X-Paramant-Receipt'] = receiptHeader;
+    }
     res.writeHead(200, outHeaders);
     if (burned) return res.end(blob, () => { try { blob.fill(0); } catch {} });
     return res.end(blob);
+  }
+
+  // ── GET /v2/transfers/:receipt_id/receipt ─ the delivery receipt, by reference ─
+  // Answers with the exact base64url payload GET /v2/outbound/:hash used to put
+  // in its X-Paramant-Receipt header, so a client that already decodes that
+  // string, or posts it to /v2/verify-receipt, needs no other change.
+  // The id is 16 random bytes handed only to the caller that did the download,
+  // and the receipt is additionally bound to that caller's API key. An unknown,
+  // expired, or foreign id answers with ONE 404, so the route can never be used
+  // to probe whether a transfer existed.
+  const rcptm = path.match(/^\/v2\/transfers\/([a-f0-9]{32})\/receipt$/);
+  if (rcptm && req.method === 'GET') {
+    const rec = deliveryReceipts.get(rcptm[1]);
+    const gone = { error: 'Not found. Expired, or never issued.' };
+    if (!rec || Date.now() > rec.expiresAt) {
+      if (rec) deliveryReceipts.delete(rcptm[1]);
+      res.writeHead(404, { 'Content-Type': 'application/json' }); return res.end(J(gone));
+    }
+    if (rec.apiKey && rec.apiKey !== apiKey) { res.writeHead(404, { 'Content-Type': 'application/json' }); return res.end(J(gone)); }
+    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+    return res.end(J({ ok: true, receipt: rec.payload, receipt_hash: 'sha3-256:' + rec.hash }));
   }
 
   // ── GET /v2/status/:hash ─────────────────────────────────────────────────────
@@ -6122,7 +6196,8 @@ const server = http.createServer(async (req, res) => {
 
   // ── POST /v2/verify-receipt — Verify a signed delivery receipt ───────────────
   // Verifies the ML-DSA-65 signature and re-walks the inclusion proof.
-  // Receipt must be base64url-encoded JSON (as returned in X-Paramant-Receipt header).
+  // Receipt must be base64url-encoded JSON, as returned by
+  // GET /v2/transfers/:receipt_id/receipt (before 2026-09, the X-Paramant-Receipt header).
   if (path === '/v2/verify-receipt' && req.method === 'POST') {
     try {
       const body = await readBody(req, 65536);

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1615,11 +1615,17 @@ let inFlightInbound = 0;
 // ── Per-key outbound rate limiting (finding #12) ──────────────────────────────
 // Limits how fast a key holder can burn blobs via /v2/outbound — reduces
 // ability to probe or burn other users' blobs via intercepted download tokens.
-const OUTBOUND_RATE = { free: 50, pro: 500, enterprise: Infinity };
+// The ceiling per tier lives in lib/tiers.js (outbound_per_hour) with every
+// other per-tier number. It used to be a local three-key table keyed on the raw
+// plan string, { free, pro, enterprise }, with a `?? free` fallback: 'community'
+// and 'business' were not in it, so a Business account, which pays for the
+// highest volume of all, was rate limited at the free 50 per hour. tiers.js
+// normalises the plan name (free/dev -> community, licensed -> enterprise), so
+// every plan the pricing page sells now resolves to its own ceiling.
 const OUTBOUND_RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour sliding window
 const outboundRateMap = new Map(); // apiKey → { count, resetAt }
 function outboundRateOk(apiKey, plan) {
-  const max = OUTBOUND_RATE[plan] ?? OUTBOUND_RATE.free;
+  const max = tiers.tierLimitNum(plan, 'outbound_per_hour');
   if (max === Infinity) return true;
   const now = Date.now();
   let c = outboundRateMap.get(apiKey);
@@ -4399,14 +4405,17 @@ const server = http.createServer(async (req, res) => {
         sigResult = verifyDsaSignature(hash, dsa_signature, keyData.dsa_pub);
       }
 
-      // Per-tier view TTL ceiling -- single source of truth in lib/tiers.js.
-      // Falls back to community ceiling when the plan is missing or unrecognised.
+      // Per-tier ceilings -- single source of truth in lib/tiers.js. ONE default
+      // for both, and it is the strictest one. The two used to disagree a line
+      // apart: the TTL fell back to 'community' and max_views to 'pro', so a key
+      // with no plan was held to the community link lifetime and handed the Pro
+      // read count at the same time. A missing plan is not evidence of a paid
+      // one, so both fall to community.
       const _plan = keyData?.plan || 'community';
       const _maxTtl = tiers.tierLimitNum(_plan, 'view_ttl_ms');
       const ttl = Math.min(parseInt(ttl_ms || TTL_MS), _maxTtl);
       // Access policies: max_views (default 1 = burn-on-read) + Argon2id password.
-      // Per-tier max_views ceiling also lives in lib/tiers.js now.
-      const maxViews = Math.max(1, Math.min(parseInt(reqMaxViews || 1) || 1, tiers.tierLimitNum(keyData?.plan || 'pro', 'max_views') || 1));
+      const maxViews = Math.max(1, Math.min(parseInt(reqMaxViews || 1) || 1, tiers.tierLimitNum(_plan, 'max_views') || 1));
       let pw_hash = null;
       if (password) {
         if (!argon2Lib) { res.writeHead(501); return res.end(J({ error: 'Argon2id not available on this relay' })); }

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1661,16 +1661,46 @@ setInterval(() => { const now = Date.now(); for (const [k,v] of outboundRateMap)
 // a backstop that takes from the LARGEST holder, which can never be the small
 // tenant it would be protecting.
 //
+// Where it lives. REDIS when the relay has one, which is what the envelope
+// store already runs on, and the in-process Map only as the fallback for a
+// relay without redis. A Map alone means every restart 404s every outstanding
+// receipt: a deploy in the middle of somebody's download window silently costs
+// them their proof of delivery, and a restart is a thing operators do on
+// purpose. With redis the receipt survives the process that issued it.
+//
 // Memory. The stored form is the receipt JSON, not its base64url wrapper: the
 // wrapper is 4/3 the size and re-encoding it on the way out is deterministic,
 // so the hash stays stable and about 4.6 KB per receipt is not held. That puts
-// a receipt at roughly 14 KB, so the ceiling below is a worst case of about
-// 56 MB, reached only when 20 accounts each hold a full 200 at once. Both caps
-// are overridable so the eviction rule itself is testable without driving
-// thousands of downloads.
+// a receipt at roughly 14 KB.
+//
+// The per-account cap is DERIVED from the tier's own outbound ceiling: two
+// hours of downloading at the rate that tier pays for. A flat 200 was wrong for
+// exactly the tier that pays most, business at 2000 downloads an hour would
+// lose its oldest receipts after six minutes of steady use, inside the 15
+// minute window it was promised. Enterprise has no outbound ceiling to double,
+// so it takes an explicit one.
+//
+//   community  50/h  ->   100      pro   500/h  ->  1000
+//   business 2000/h  ->  4000      enterprise   -> RECEIPT_UNCAPPED_TIER_MAX
+//
+// The global backstop applies to the Map path only, where the memory is this
+// process's. With redis the bound is the TTL, the per-account cap, and redis'
+// own maxmemory policy.
 const RECEIPT_TTL_MS = 15 * 60 * 1000;
-const RECEIPT_PER_ACCOUNT_MAX = Math.max(1, parseInt(process.env.PARAMANT_RECEIPT_PER_ACCOUNT_MAX || '200', 10) || 200);
-const RECEIPT_TOTAL_MAX = Math.max(RECEIPT_PER_ACCOUNT_MAX, parseInt(process.env.PARAMANT_RECEIPT_TOTAL_MAX || '4000', 10) || 4000);
+const RECEIPT_TTL_S = Math.round(RECEIPT_TTL_MS / 1000);
+const RECEIPT_UNCAPPED_TIER_MAX = Math.max(1, parseInt(process.env.PARAMANT_RECEIPT_UNCAPPED_MAX || '10000', 10) || 10000);
+// A fixed override, for tests that need to drive the eviction rule without
+// making thousands of downloads. Unset in production, where the tier decides.
+const RECEIPT_PER_ACCOUNT_OVERRIDE = parseInt(process.env.PARAMANT_RECEIPT_PER_ACCOUNT_MAX || '0', 10) || 0;
+function receiptCapFor(plan) {
+  if (RECEIPT_PER_ACCOUNT_OVERRIDE > 0) return RECEIPT_PER_ACCOUNT_OVERRIDE;
+  const rate = tiers.tierLimitNum(plan, 'outbound_per_hour');
+  const cap = Number.isFinite(rate) ? rate * 2 : RECEIPT_UNCAPPED_TIER_MAX;
+  return Math.max(1, Math.min(cap, RECEIPT_UNCAPPED_TIER_MAX));
+}
+const RECEIPT_TOTAL_MAX = Math.max(1, parseInt(process.env.PARAMANT_RECEIPT_TOTAL_MAX || '4000', 10) || 4000);
+const RECEIPT_RK = (id) => `paramant:receipt:${id}`;
+const RECEIPT_AK = (owner) => `paramant:receipts:acct:${owner}`;
 const deliveryReceipts = new Map(); // receipt_id -> { json, hash, apiKey, owner, expiresAt }
 const receiptsByOwner = new Map();  // owner (account_id) -> Set<receipt_id>, insertion ordered
 function _dropReceipt(id) {
@@ -1688,12 +1718,35 @@ function _dropOldestOf(owner) {
   _dropReceipt(oldest.value);
   return true;
 }
-function storeDeliveryReceipt(json, hash, apiKey, owner) {
+async function storeDeliveryReceipt(json, hash, apiKey, owner, plan) {
   const id = crypto.randomBytes(16).toString('hex');
   const bucket = owner || apiKey || '_anonymous';
+  const cap = receiptCapFor(plan);
+  if (redisClient && redisClient.isReady) {
+    try {
+      const ak = RECEIPT_AK(bucket);
+      await redisClient.set(RECEIPT_RK(id), JSON.stringify({ json, hash, apiKey: apiKey || null }), { EX: RECEIPT_TTL_S });
+      await redisClient.zAdd(ak, { score: Date.now(), value: id });
+      await redisClient.expire(ak, RECEIPT_TTL_S);
+      // The cap is per account and enforced against that account's own index,
+      // so a busy tenant can only ever drop its own oldest.
+      const over = (await redisClient.zCard(ak)) - cap;
+      if (over > 0) {
+        const stale = await redisClient.zRange(ak, 0, over - 1);
+        if (stale.length) {
+          await redisClient.del(stale.map(RECEIPT_RK));
+          await redisClient.zRemRangeByRank(ak, 0, over - 1);
+        }
+      }
+      return id;
+    } catch (e) {
+      // Never fail a download over its receipt: fall through to the Map.
+      log('warn', 'receipt_store_redis_failed', { err: e.message });
+    }
+  }
   // Sets preserve insertion order and every entry has the same TTL, so the head
   // of a bucket is always that owner's entry closest to expiring.
-  while ((receiptsByOwner.get(bucket)?.size || 0) >= RECEIPT_PER_ACCOUNT_MAX) {
+  while ((receiptsByOwner.get(bucket)?.size || 0) >= cap) {
     if (!_dropOldestOf(bucket)) break;
   }
   // Global backstop. Take from whoever holds the most, never from whoever
@@ -1709,6 +1762,24 @@ function storeDeliveryReceipt(json, hash, apiKey, owner) {
   return id;
 }
 setInterval(() => { const now = Date.now(); for (const [id, r] of deliveryReceipts) if (now > r.expiresAt) _dropReceipt(id); }, 60_000).unref?.();
+
+// Read one back. Redis first, so a receipt issued by a process that has since
+// been restarted is still there; the Map is the fallback for a relay with no
+// redis. Returns { json, hash, apiKey } or null.
+async function fetchDeliveryReceipt(id) {
+  if (redisClient && redisClient.isReady) {
+    try {
+      const raw = await redisClient.get(RECEIPT_RK(id));
+      if (raw) return JSON.parse(raw);
+    } catch (e) {
+      log('warn', 'receipt_fetch_redis_failed', { err: e.message });
+    }
+  }
+  const rec = deliveryReceipts.get(id);
+  if (!rec) return null;
+  if (Date.now() > rec.expiresAt) { _dropReceipt(id); return null; }
+  return rec;
+}
 
 // Deprecation window for the fat header. Nothing in this repo reads it outside
 // its own tests, but an out-of-tree client might, so an operator can put it back
@@ -4714,7 +4785,9 @@ const server = http.createServer(async (req, res) => {
     if (receiptHeader) {
       const receiptHash = crypto.createHash('sha3-256').update(receiptHeader).digest('hex');
       const _receiptKey = entry.apiKey || apiKey || null;
-      const receiptId = storeDeliveryReceipt(receiptJson, receiptHash, _receiptKey, _receiptKey ? acctOf(_receiptKey) : null);
+      const _receiptPlan = (_receiptKey && apiKeys.get(_receiptKey)?.plan) || keyData?.plan || 'community';
+      const receiptId = await storeDeliveryReceipt(receiptJson, receiptHash, _receiptKey,
+        _receiptKey ? acctOf(_receiptKey) : null, _receiptPlan);
       outHeaders['X-Paramant-Receipt-Id'] = receiptId;
       outHeaders['X-Paramant-Receipt-Hash'] = 'sha3-256:' + receiptHash;
       outHeaders['X-Paramant-Receipt-Url'] = `/v2/transfers/${receiptId}/receipt`;
@@ -4743,12 +4816,9 @@ const server = http.createServer(async (req, res) => {
   // to probe whether a transfer existed.
   const rcptm = path.match(/^\/v2\/transfers\/([a-f0-9]{32})\/receipt$/);
   if (rcptm && req.method === 'GET') {
-    const rec = deliveryReceipts.get(rcptm[1]);
+    const rec = await fetchDeliveryReceipt(rcptm[1]);
     const gone = { error: 'Not found. Expired, or never issued.' };
-    if (!rec || Date.now() > rec.expiresAt) {
-      if (rec) deliveryReceipts.delete(rcptm[1]);
-      res.writeHead(404, { 'Content-Type': 'application/json' }); return res.end(J(gone));
-    }
+    if (!rec) { res.writeHead(404, { 'Content-Type': 'application/json' }); return res.end(J(gone)); }
     if (rec.apiKey && rec.apiKey !== apiKey) { res.writeHead(404, { 'Content-Type': 'application/json' }); return res.end(J(gone)); }
     res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
     return res.end(J({ ok: true, receipt: Buffer.from(rec.json).toString('base64url'), receipt_hash: 'sha3-256:' + rec.hash }));

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1651,24 +1651,64 @@ setInterval(() => { const now = Date.now(); for (const [k,v] of outboundRateMap)
 // signature, same verification through POST /v2/verify-receipt.
 //
 // Kept in RAM like everything else on this relay, and deliberately short-lived:
-// a client fetches its receipt in the same breath as the download. The cap
-// bounds the memory a burst of downloads can pin (a receipt is about 18 KB).
+// a client fetches its receipt in the same breath as the download.
+//
+// The budget is PER ACCOUNT, not one shared queue. A single global LRU is a
+// cross-tenant eviction channel: one account doing enough downloads pushes
+// another account's receipt out inside its own 15 minute window, and before
+// this route the receipt was guaranteed to be on the response itself. So an
+// account can only ever evict its OWN oldest receipt, and the global ceiling is
+// a backstop that takes from the LARGEST holder, which can never be the small
+// tenant it would be protecting.
+//
+// Memory. The stored form is the receipt JSON, not its base64url wrapper: the
+// wrapper is 4/3 the size and re-encoding it on the way out is deterministic,
+// so the hash stays stable and about 4.6 KB per receipt is not held. That puts
+// a receipt at roughly 14 KB, so the ceiling below is a worst case of about
+// 56 MB, reached only when 20 accounts each hold a full 200 at once. Both caps
+// are overridable so the eviction rule itself is testable without driving
+// thousands of downloads.
 const RECEIPT_TTL_MS = 15 * 60 * 1000;
-const RECEIPT_MAX = 1000;
-const deliveryReceipts = new Map(); // receipt_id -> { payload, hash, apiKey, expiresAt }
-function storeDeliveryReceipt(payload, hash, apiKey) {
+const RECEIPT_PER_ACCOUNT_MAX = Math.max(1, parseInt(process.env.PARAMANT_RECEIPT_PER_ACCOUNT_MAX || '200', 10) || 200);
+const RECEIPT_TOTAL_MAX = Math.max(RECEIPT_PER_ACCOUNT_MAX, parseInt(process.env.PARAMANT_RECEIPT_TOTAL_MAX || '4000', 10) || 4000);
+const deliveryReceipts = new Map(); // receipt_id -> { json, hash, apiKey, owner, expiresAt }
+const receiptsByOwner = new Map();  // owner (account_id) -> Set<receipt_id>, insertion ordered
+function _dropReceipt(id) {
+  const rec = deliveryReceipts.get(id);
+  if (!rec) return;
+  deliveryReceipts.delete(id);
+  const own = receiptsByOwner.get(rec.owner);
+  if (own) { own.delete(id); if (own.size === 0) receiptsByOwner.delete(rec.owner); }
+}
+function _dropOldestOf(owner) {
+  const own = receiptsByOwner.get(owner);
+  if (!own) return false;
+  const oldest = own.values().next();
+  if (oldest.done) return false;
+  _dropReceipt(oldest.value);
+  return true;
+}
+function storeDeliveryReceipt(json, hash, apiKey, owner) {
   const id = crypto.randomBytes(16).toString('hex');
-  // Oldest-first eviction: Map preserves insertion order and every entry has
-  // the same TTL, so the head is always the one closest to expiring.
-  while (deliveryReceipts.size >= RECEIPT_MAX) {
-    const oldest = deliveryReceipts.keys().next();
-    if (oldest.done) break;
-    deliveryReceipts.delete(oldest.value);
+  const bucket = owner || apiKey || '_anonymous';
+  // Sets preserve insertion order and every entry has the same TTL, so the head
+  // of a bucket is always that owner's entry closest to expiring.
+  while ((receiptsByOwner.get(bucket)?.size || 0) >= RECEIPT_PER_ACCOUNT_MAX) {
+    if (!_dropOldestOf(bucket)) break;
   }
-  deliveryReceipts.set(id, { payload, hash, apiKey: apiKey || null, expiresAt: Date.now() + RECEIPT_TTL_MS });
+  // Global backstop. Take from whoever holds the most, never from whoever
+  // happens to be oldest, so a burst cannot evict a quiet tenant.
+  while (deliveryReceipts.size >= RECEIPT_TOTAL_MAX) {
+    let biggest = null; let most = 0;
+    for (const [o, set] of receiptsByOwner) if (set.size > most) { most = set.size; biggest = o; }
+    if (biggest === null || !_dropOldestOf(biggest)) break;
+  }
+  deliveryReceipts.set(id, { json, hash, apiKey: apiKey || null, owner: bucket, expiresAt: Date.now() + RECEIPT_TTL_MS });
+  if (!receiptsByOwner.has(bucket)) receiptsByOwner.set(bucket, new Set());
+  receiptsByOwner.get(bucket).add(id);
   return id;
 }
-setInterval(() => { const now = Date.now(); for (const [id, r] of deliveryReceipts) if (now > r.expiresAt) deliveryReceipts.delete(id); }, 60_000).unref?.();
+setInterval(() => { const now = Date.now(); for (const [id, r] of deliveryReceipts) if (now > r.expiresAt) _dropReceipt(id); }, 60_000).unref?.();
 
 // Deprecation window for the fat header. Nothing in this repo reads it outside
 // its own tests, but an out-of-tree client might, so an operator can put it back
@@ -1864,13 +1904,23 @@ function mintParasignKey(accountId, opts = {}) {
   // permanent one. A record with no per-product tier at all is left undefined,
   // so buildParasignKeyRecord still derives from the legacy plan as before.
   const eff = entitlementRecordOf(accountId) || {};
-  const _effTier = (product) => (eff[entitlements.PRODUCT_PLAN_FIELD[product]] == null
-    ? undefined
-    : entitlements.effectiveProductTier(eff, product).tier);
+  // Tier AND period, together, or the new key is an unbounded copy of a bounded
+  // grant. An ALREADY expired grant is minted as the floor tier with no period
+  // at all (effectiveProductTier reports it as expired), so a lapsed account
+  // does not get a stale date on a fresh key either.
+  const _effGrant = (product) => {
+    if (eff[entitlements.PRODUCT_PLAN_FIELD[product]] == null) return {};
+    const g = entitlements.effectiveProductTier(eff, product);
+    return { tier: g.tier, paidUntil: g.expired ? null : eff[entitlements.PRODUCT_PAID_UNTIL_FIELD[product]] };
+  };
+  const _pg = _effGrant('parasign');
+  const _ps = _effGrant('parasend');
   const built = keysTable.buildParasignKeyRecord({
     accountId, plan, email, label: opts.label, test: !!opts.test,
-    planParasign: opts.planParasign || _effTier('parasign'),
-    planParasend: opts.planParasend || _effTier('parasend'),
+    planParasign: opts.planParasign || _pg.tier,
+    planParasend: opts.planParasend || _ps.tier,
+    paidUntilParasign: _pg.paidUntil,
+    paidUntilParasend: _ps.paidUntil,
     randomHex: crypto.randomBytes(32).toString('hex'),
   });
   const { key, record, usersEntry } = built;
@@ -4617,6 +4667,7 @@ const server = http.createServer(async (req, res) => {
 
     // ── Build signed delivery receipt ────────────────────────────────────────
     let receiptHeader = null;
+    let receiptJson = null;
     const ctData = entry.ct_entry || null;
     if (ctData) {
       const inclusionProof = {
@@ -4646,7 +4697,8 @@ const server = http.createServer(async (req, res) => {
         } catch(e) { log('warn', 'receipt_sign_failed', { err: e.message }); }
       }
       const receipt = { ...receiptPayload, signature };
-      receiptHeader = Buffer.from(JSON.stringify(receipt)).toString('base64url');
+      receiptJson = JSON.stringify(receipt);
+      receiptHeader = Buffer.from(receiptJson).toString('base64url');
     }
 
     const outHeaders = {
@@ -4661,12 +4713,20 @@ const server = http.createServer(async (req, res) => {
     // that Node clients or a default nginx will accept (see the store above).
     if (receiptHeader) {
       const receiptHash = crypto.createHash('sha3-256').update(receiptHeader).digest('hex');
-      const receiptId = storeDeliveryReceipt(receiptHeader, receiptHash, entry.apiKey || apiKey || null);
+      const _receiptKey = entry.apiKey || apiKey || null;
+      const receiptId = storeDeliveryReceipt(receiptJson, receiptHash, _receiptKey, _receiptKey ? acctOf(_receiptKey) : null);
       outHeaders['X-Paramant-Receipt-Id'] = receiptId;
       outHeaders['X-Paramant-Receipt-Hash'] = 'sha3-256:' + receiptHash;
       outHeaders['X-Paramant-Receipt-Url'] = `/v2/transfers/${receiptId}/receipt`;
-      // DEPRECATED, off by default, removed after 2026-12-01.
+      // DEPRECATED, off by default, removed after 2026-12-01. When it is off,
+      // say so ON THE RESPONSE. A client that reads X-Paramant-Receipt and finds
+      // nothing there has no way to tell "this transfer had no receipt" from
+      // "the receipt moved", and the Python SDK's own handling of an absent
+      // header is a silent receipt=None (sdk-py/paramant_sdk.py:681). A silent
+      // downgrade of a delivery proof is the one failure mode this route must
+      // not have, so the removal announces itself and says where to go.
       if (INLINE_RECEIPT_HEADER) outHeaders['X-Paramant-Receipt'] = receiptHeader;
+      else outHeaders['X-Paramant-Receipt-Deprecated'] = `removed 2026-12-01; GET /v2/transfers/${receiptId}/receipt`;
     }
     res.writeHead(200, outHeaders);
     if (burned) return res.end(blob, () => { try { blob.fill(0); } catch {} });
@@ -4691,7 +4751,7 @@ const server = http.createServer(async (req, res) => {
     }
     if (rec.apiKey && rec.apiKey !== apiKey) { res.writeHead(404, { 'Content-Type': 'application/json' }); return res.end(J(gone)); }
     res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
-    return res.end(J({ ok: true, receipt: rec.payload, receipt_hash: 'sha3-256:' + rec.hash }));
+    return res.end(J({ ok: true, receipt: Buffer.from(rec.json).toString('base64url'), receipt_hash: 'sha3-256:' + rec.hash }));
   }
 
   // ── GET /v2/status/:hash ─────────────────────────────────────────────────────

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1812,11 +1812,18 @@ function mintParasignKey(accountId, opts = {}) {
   // The new key inherits the account's EFFECTIVE per-product tiers, resolved
   // over every key the account holds. Minting used to pass the legacy `plan`
   // only, which silently issued a free-tier ParaSign key to a paying account.
+  // EFFECTIVE, not the tier on file: the new key record carries no paid_until,
+  // so re-issuing a lapsed tier here would turn an expired subscription into a
+  // permanent one. A record with no per-product tier at all is left undefined,
+  // so buildParasignKeyRecord still derives from the legacy plan as before.
   const eff = entitlementRecordOf(accountId) || {};
+  const _effTier = (product) => (eff[entitlements.PRODUCT_PLAN_FIELD[product]] == null
+    ? undefined
+    : entitlements.effectiveProductTier(eff, product).tier);
   const built = keysTable.buildParasignKeyRecord({
     accountId, plan, email, label: opts.label, test: !!opts.test,
-    planParasign: opts.planParasign || eff.plan_parasign,
-    planParasend: opts.planParasend || eff.plan_parasend,
+    planParasign: opts.planParasign || _effTier('parasign'),
+    planParasend: opts.planParasend || _effTier('parasend'),
     randomHex: crypto.randomBytes(32).toString('hex'),
   });
   const { key, record, usersEntry } = built;

--- a/relay/test/_relay-server.js
+++ b/relay/test/_relay-server.js
@@ -184,7 +184,7 @@ function makeHandle(child, port, dir, env, log, bootOpts) {
     // One request. `body` may be a string, a Buffer or a plain object (which is
     // sent as JSON). Returns the parsed JSON when the answer is JSON, and the
     // raw text either way.
-    req(method, p, { headers = {}, body } = {}) {
+    req(method, p, { headers = {}, body, maxHeaderSize } = {}) {
       const hdr = { ...headers };
       let payload = null;
       if (body !== undefined && body !== null) {
@@ -201,14 +201,14 @@ function makeHandle(child, port, dir, env, log, bootOpts) {
         const r = http.request(base + p, {
           method,
           headers: hdr,
-          // GET /v2/outbound/:hash answers with an X-Paramant-Receipt header of
-          // about 18.5 KB (a base64 ML-DSA-65 signature over the delivery
-          // receipt, measured 2026-09-02). Node's own default maxHeaderSize is
-          // 16 KB and undici's fetch() caps earlier, so a plain fetch() of a
-          // download throws UND_ERR_HEADERS_OVERFLOW. Raised here so the test
-          // client is not the thing under test; the size itself is a finding,
-          // reported with this PR, not a fixture.
-          maxHeaderSize: 96 * 1024,
+          // NO maxHeaderSize override by default, on purpose. This client is
+          // held to Node's own 16 KB limit, the same one a caller using fetch()
+          // has, so any route that grows a header block past it fails here
+          // instead of only in production. GET /v2/outbound/:hash used to answer
+          // with 19560 bytes of headers and threw UND_ERR_HEADERS_OVERFLOW on
+          // every download (PR #341, finding 2). A test that needs the old
+          // behaviour asks for the room explicitly.
+          ...(maxHeaderSize ? { maxHeaderSize } : {}),
         }, (res) => {
           const chunks = [];
           res.on('data', (c) => chunks.push(c));

--- a/relay/test/route-billing-entitlements.test.js
+++ b/relay/test/route-billing-entitlements.test.js
@@ -166,6 +166,68 @@ test('a key loaded from users.json keeps the paid period it was stored with', ()
   did();
 });
 
+test('a key minted while the subscription is LIVE does not outlive it', async () => {
+  // The third place the period could be dropped, and the only one a customer can
+  // trigger on demand: POST /v2/user/parasign-keys (relay.js:3259, self-serve
+  // through the admin server) and the admin mint (relay.js:5451) both run
+  // keys-table.buildParasignKeyRecord, which wrote plan_parasign onto the new
+  // key and its users.json entry but never paid_until_parasign. A key minted
+  // one day before the subscription ended therefore carried a paid tier with no
+  // end date, and "no recorded period" means "never expires". Mint on the last
+  // day, keep ParaSign Business forever, restart included.
+  //
+  // The period here is deliberately a few seconds out, so the test watches a
+  // real subscription end instead of asserting on a stored string.
+  const SOON = new Date(Date.now() + 3500).toISOString();
+  let srv = await withUsers('mint-carries-period', [{
+    key: 'pgp_minting', plan: 'community', active: true, parasign: true,
+    account_id: 'acct_minting', email: 'mint@example.test',
+    plan_parasign: 'business', paid_until_parasign: SOON,
+  }]);
+  const live = await entitlementsOf(srv, 'acct_minting');
+  assert.strictEqual(live.json.entitlements.parasign.tier, 'business',
+    'precondition: at mint time the account really is a paying Business account');
+
+  const minted = await srv.post('/v2/user/parasign-keys', { headers: BOTH, body: { user_id: 'acct_minting' } });
+  assert.strictEqual(minted.status, 201, minted.text);
+  assert.match(minted.json.key, /^psk_(live|test)_[0-9a-f]{64}$/);
+
+  // The users.json write is queued, not awaited by the handler.
+  await new Promise((r) => setTimeout(r, 300));
+  const onDisk = srv.readUsersFile().api_keys.find((k) => k.key === minted.json.key);
+  assert.ok(onDisk, 'the minted key reached users.json');
+  assert.strictEqual(onDisk.plan_parasign, 'business', 'the new key inherits the paid tier');
+  assert.strictEqual(onDisk.paid_until_parasign, SOON,
+    'and the period that bounds it, or the tier is a permanent copy of a temporary grant');
+
+  // Let the subscription actually end, then come back on a cold process so the
+  // answer is read from disk and not from anything still in memory.
+  while (Date.now() < Date.parse(SOON) + 250) await new Promise((r) => setTimeout(r, 100));
+  srv = await srv.restart();
+  const after = await entitlementsOf(srv, 'acct_minting');
+  assert.strictEqual(after.json.entitlements.parasign.tier, 'free',
+    'the minted key must not outlive the subscription that paid for it');
+  srv.stop();
+  did();
+});
+
+test('a key minted for an ALREADY lapsed account is a plain floor key, with no stale date', async () => {
+  let srv = await withUsers('mint-after-lapse', [{
+    key: 'pgp_lapsed_mint', plan: 'community', active: true, parasign: true,
+    account_id: 'acct_lapsed_mint', email: 'lapsed-mint@example.test',
+    plan_parasign: 'business', paid_until_parasign: PAST,
+  }]);
+  const minted = await srv.post('/v2/user/parasign-keys', { headers: BOTH, body: { user_id: 'acct_lapsed_mint' } });
+  assert.strictEqual(minted.status, 201, minted.text);
+  await new Promise((r) => setTimeout(r, 300));
+  const onDisk = srv.readUsersFile().api_keys.find((k) => k.key === minted.json.key);
+  assert.strictEqual(onDisk.plan_parasign, 'free', 'a lapsed account mints what it is entitled to now, not what it paid for once');
+  assert.ok(!('paid_until_parasign' in onDisk),
+    'and carries no date, because a floor tier has no period to be bounded by');
+  srv.stop();
+  did();
+});
+
 test('entitlements.js:137: a record with NO paid_until is never read as expired', async () => {
   // The dangerous reading of "no date on file" is "the period ended". That would
   // downgrade every account that predates the paid_until field, and every one

--- a/relay/test/route-billing-entitlements.test.js
+++ b/relay/test/route-billing-entitlements.test.js
@@ -79,28 +79,26 @@ test('#315: a paid period on disk is still bounded after a restart', async () =>
   did();
 });
 
-// KNOWN FAILING, ON PURPOSE. This is the rule the paid_until field exists for,
-// and the account-level read path does not honour it today. Marked todo so the
-// run stays green while the finding stays visible; when the bug is fixed this
-// turns into "ok ... # TODO" and the flag can go.
-//
-// THE BUG: lib/entitlements.js:328-344 mergeAccountRecord() copies plan_parasign
-// and plan_parasend off the api-key records onto the merged account record, but
-// NOT their paid_until_* fields. Its own doc comment says why those fields can
-// only live on the key records ("the accounts summary never carries the
-// per-product plans"), so the merged record always arrives at getEntitlements
-// with a paid tier and no period, and entitlements.js:137 correctly reads "no
-// recorded period" as "never expired". The result is that an expired
-// subscription keeps granting on every account-level gate:
+// WAS KNOWN FAILING (PR #341, finding 1), now the rule this whole field exists
+// for. The bug had two halves, both of them a DROP of paid_until_* while the
+// tier travelled on:
+//   keys-table.parseAccountFields() rehydrated plan_parasign off users.json but
+//     not paid_until_parasign, so the in-memory key record already had a paid
+//     tier and no period before any merge ran;
+//   entitlements.mergeAccountRecord() copied the per-product plans off the key
+//     records onto the merged account record and left the periods behind, and
+//     the same drop sat in keys-table.rebuildKeyIndexes() for the accounts
+//     summary.
+// Either half is enough: the record reaches getEntitlements with a paid tier and
+// no period, and entitlements.js:137 correctly reads "no recorded period" as
+// "never expired". So an expired subscription kept granting on every
+// account-level gate:
 //   relay.js:5316  GET /v2/admin/entitlements/:account_id
 //   relay.js:5990  the signs-quota gate on POST /v2/envelopes/:id/sign
 //   relay.js:1804  the plan a newly minted psk_ key inherits
-// Reading the SAME record directly (without the merge) does expire correctly,
-// which is how you can tell it is the merge and not the date logic:
-//   getEntitlements(keyRec).parasign.tier                      -> 'free'
-//   getEntitlements(mergeAccountRecord(acct,[keyRec])).parasign.tier -> 'business'
-test('#315: a period that HAS passed stops granting, and stops granting again after a restart',
-  { todo: 'mergeAccountRecord drops paid_until_* (lib/entitlements.js:328-344)' }, async () => {
+// Fixed by making tier and period travel together in all three places
+// (entitlements.mergeProductGrantInto).
+test('#315: a period that HAS passed stops granting, and stops granting again after a restart', async () => {
   let srv = await withUsers('paid-until-expired', [{
     key: 'pgp_lapsed', plan: 'community', active: true, parasign: true,
     account_id: 'acct_lapsed', email: 'lapsed@example.test',
@@ -123,20 +121,48 @@ test('#315: a period that HAS passed stops granting, and stops granting again af
   did();
 });
 
-// The same fact, stated as something that is true TODAY, so the finding above is
-// not just a comment: the two read paths disagree about the same record. This
-// test is the evidence for the bug report, and it is expected to be deleted in
-// the same commit that fixes mergeAccountRecord.
-test('FINDING: the account-level read path loses the paid period the key record carries', () => {
+// The inverse of the finding that used to stand here: the two read paths must
+// give the SAME answer about the same record. The direct read was always right;
+// it was the merged one that over-granted. Stated as a property, so it holds for
+// a lapsed period, a live one, and no period at all -- that last row is the edge
+// entitlements.js:137 protects and it must keep granting.
+test('the merged read path answers exactly like a direct read of the same record', () => {
   const ent = require('../lib/entitlements');
-  const keyRec = { plan: 'community', parasign: true, plan_parasign: 'business', paid_until_parasign: PAST };
-  assert.strictEqual(ent.getEntitlements(keyRec).parasign.tier, 'free',
-    'read straight off the key record, an expired period does fall to the floor');
-  const merged = ent.mergeAccountRecord({ account_id: 'acct', plan: 'community' }, [keyRec]);
-  assert.ok(!('paid_until_parasign' in merged),
-    'the merge drops the period field entirely - this is the bug, in one line');
-  assert.strictEqual(ent.getEntitlements(merged).parasign.tier, 'business',
-    'so the account-level path still grants a tier that was paid for until ' + PAST);
+  const cases = [
+    ['expired', { plan: 'community', parasign: true, plan_parasign: 'business', paid_until_parasign: PAST }, 'free'],
+    ['live',    { plan: 'community', parasign: true, plan_parasign: 'business', paid_until_parasign: FUTURE }, 'business'],
+    ['bare',    { plan: 'community', parasign: true, plan_parasign: 'business' }, 'business'],
+  ];
+  for (const [tag, keyRec, expect] of cases) {
+    assert.strictEqual(ent.getEntitlements(keyRec).parasign.tier, expect,
+      `${tag}: precondition, the direct read is the answer we trust`);
+    const merged = ent.mergeAccountRecord({ account_id: 'acct', plan: 'community' }, [keyRec]);
+    assert.strictEqual(merged.paid_until_parasign, keyRec.paid_until_parasign,
+      `${tag}: the merge carries the period with the tier (or carries neither)`);
+    assert.strictEqual(ent.getEntitlements(merged).parasign.tier, expect,
+      `${tag}: and the account-level path lands on the same tier`);
+  }
+  // A lapsed grant must not outrank a live lower one, or fixing the drop would
+  // introduce a downgrade: the account really does still hold ParaSign Pro.
+  const lapsedPlusLive = ent.mergeAccountRecord({ account_id: 'acct', plan: 'community' }, [
+    { plan_parasign: 'business', paid_until_parasign: PAST },
+    { plan_parasign: 'pro', parasign: true },
+  ]);
+  assert.strictEqual(ent.getEntitlements(lapsedPlusLive).parasign.tier, 'pro',
+    'an expired business grant falls away, the live pro grant on the sibling key stays');
+  did();
+});
+
+// The same divergence one layer lower: users.json -> in-memory record. Before
+// the fix parseAccountFields returned the tier without the date, so the expiry
+// could not be enforced no matter what the merge did.
+test('a key loaded from users.json keeps the paid period it was stored with', () => {
+  const kt = require('../lib/keys-table');
+  const lapsed = kt.parseAccountFields({ key: 'k', plan: 'community', parasign: true, plan_parasign: 'business', paid_until_parasign: PAST });
+  assert.strictEqual(lapsed.paid_until_parasign, PAST, 'the period is rehydrated with the tier it bounds');
+  const bare = kt.parseAccountFields({ key: 'k', plan: 'community', parasign: true, plan_parasign: 'business' });
+  assert.ok(!('paid_until_parasign' in bare),
+    'and a key with no period on file stays absent, not an explicit null that could read as expired');
   did();
 });
 

--- a/relay/test/route-transfer-burn.test.js
+++ b/relay/test/route-transfer-burn.test.js
@@ -215,6 +215,13 @@ test('a download answers with less than 8 KB of response headers', async () => {
     `a download must fit a default proxy buffer, got ${bytes} bytes of headers`);
   assert.ok(!('x-paramant-receipt' in r.headers),
     'and the fat header is gone by default, not merely smaller');
+  // The removal is announced ON the response, because a client that reads the
+  // old header and finds nothing cannot tell "no receipt" from "it moved". The
+  // Python SDK turns an absent header into a silent receipt=None, which is a
+  // delivery proof quietly becoming nothing.
+  assert.strictEqual(r.headers['x-paramant-receipt-deprecated'],
+    `removed 2026-12-01; GET /v2/transfers/${r.headers['x-paramant-receipt-id']}/receipt`,
+    'a download says out loud that the old header is gone and where the receipt went');
   did();
 });
 
@@ -236,6 +243,58 @@ test('a receipt reference is single-tenant, and unknown or foreign ids give one 
   for (let i = 0; i < 2; i++) {
     assert.strictEqual((await srv.get(`/v2/transfers/${id}/receipt`, { headers: { 'X-Api-Key': PRO } })).status, 200);
   }
+  did();
+});
+
+test('a busy tenant cannot evict a quiet tenant\'s receipt', async () => {
+  // The receipt store started as ONE shared LRU. That is a cross-tenant
+  // eviction channel: enough downloads by B push A's receipt out inside A's own
+  // 15 minute window, and before this route existed the receipt was guaranteed
+  // to be on the response itself, so this would be a regression paid for by a
+  // stranger. The budget is per account now, and the global ceiling takes from
+  // the LARGEST holder, which can never be the tenant it would be protecting.
+  //
+  // The caps are driven down here so the RULE is measured rather than the
+  // numbers: with a shared queue of 8, B's ninth receipt evicts A's first.
+  const A = 'pgp_quiet_tenant_receipt_suite';
+  const B = 'pgp_busy_tenant_receipt_suite';
+  const srv2 = await boot({
+    tag: 'transfer-receipt-budget',
+    env: { PARAMANT_RECEIPT_PER_ACCOUNT_MAX: '4', PARAMANT_RECEIPT_TOTAL_MAX: '8' },
+    users: { api_keys: [
+      { key: A, plan: 'pro', active: true, email: 'quiet@example.test', account_id: 'acct_quiet' },
+      { key: B, plan: 'business', active: true, email: 'busy@example.test', account_id: 'acct_busy' },
+    ] },
+  });
+  const put = async (key) => {
+    const b = blob(`budget-${crypto.randomBytes(4).toString('hex')}`);
+    assert.strictEqual((await srv2.post('/v2/inbound', {
+      headers: { 'X-Api-Key': key }, body: { hash: b.hash, payload: b.payload.toString('base64') },
+    })).status, 200);
+    const r = await srv2.get(`/v2/outbound/${b.hash}`, { headers: { 'X-Api-Key': key } });
+    assert.strictEqual(r.status, 200);
+    return r.headers['x-paramant-receipt-id'];
+  };
+
+  const quiet = await put(A);
+  assert.ok(quiet, 'the quiet tenant has exactly one receipt outstanding');
+  // Three times the whole store, all from one account.
+  const busy = [];
+  for (let i = 0; i < 24; i++) busy.push(await put(B));
+
+  const still = await srv2.get(`/v2/transfers/${quiet}/receipt`, { headers: { 'X-Api-Key': A } });
+  assert.strictEqual(still.status, 200,
+    'a stranger\'s download burst must not take the quiet tenant\'s receipt away');
+
+  // And the busy tenant is held to its OWN budget, so the burst is bounded.
+  const survivors = [];
+  for (const id of busy) {
+    const r = await srv2.get(`/v2/transfers/${id}/receipt`, { headers: { 'X-Api-Key': B } });
+    if (r.status === 200) survivors.push(id);
+  }
+  assert.strictEqual(survivors.length, 4, 'the busy tenant keeps its own 4 newest and no more');
+  assert.deepStrictEqual(survivors, busy.slice(-4), 'and they are the newest, not an arbitrary four');
+  srv2.stop();
   did();
 });
 
@@ -261,6 +320,8 @@ test('the fat header comes back only when an operator asks for it, and it is dep
   assert.ok(Buffer.byteLength(r.headers['x-paramant-receipt']) > 16384,
     'and it is still the header that does not fit, which is why it is going away');
   assert.ok(r.headers['x-paramant-receipt-id'], 'the reference is served alongside it during the window');
+  assert.ok(!('x-paramant-receipt-deprecated' in r.headers),
+    'and while the opt-in is on there is nothing to announce: the old header is really there');
   legacy.stop();
   did();
 });

--- a/relay/test/route-transfer-burn.test.js
+++ b/relay/test/route-transfer-burn.test.js
@@ -23,7 +23,9 @@ const { test, before, after } = require('node:test');
 const assert = require('assert');
 const crypto = require('crypto');
 const { boot, killAll } = require('./_relay-server');
-const { summary } = require('./_requires');
+const { requireRedis, summary } = require('./_requires');
+
+const DEFAULT_REDIS = 'redis://127.0.0.1:6399';
 
 const PRO = 'pgp_pro_key_for_the_transfer_suite';
 const COMMUNITY = 'pgp_community_key_for_the_transfer_suite';
@@ -296,6 +298,103 @@ test('a busy tenant cannot evict a quiet tenant\'s receipt', async () => {
   assert.deepStrictEqual(survivors, busy.slice(-4), 'and they are the newest, not an arbitrary four');
   srv2.stop();
   did();
+});
+
+test('the global backstop takes from the biggest holder, never from the quiet one', async () => {
+  // The per-account cap bounds one tenant. The GLOBAL cap is what happens when
+  // the store is full anyway, and an oldest-first global eviction there would
+  // reintroduce exactly the cross-tenant channel the per-account cap closes:
+  // the quiet tenant's single receipt is, by definition, the oldest one.
+  const SMALL = 'pgp_small_holder_receipt_suite';
+  const HUGE = 'pgp_huge_holder_receipt_suite';
+  const srv2 = await boot({
+    tag: 'transfer-receipt-backstop',
+    // Per-account room for 6 each but only 5 slots in the whole store, so the
+    // two caps cannot both be satisfied and the GLOBAL backstop is the rule
+    // under test rather than the per-account one.
+    env: { PARAMANT_RECEIPT_PER_ACCOUNT_MAX: '6', PARAMANT_RECEIPT_TOTAL_MAX: '5' },
+    users: { api_keys: [
+      { key: SMALL, plan: 'pro', active: true, email: 'small@example.test', account_id: 'acct_small' },
+      { key: HUGE, plan: 'pro', active: true, email: 'huge@example.test', account_id: 'acct_huge' },
+    ] },
+  });
+  const put = async (key) => {
+    const b = blob(`backstop-${crypto.randomBytes(4).toString('hex')}`);
+    assert.strictEqual((await srv2.post('/v2/inbound', {
+      headers: { 'X-Api-Key': key }, body: { hash: b.hash, payload: b.payload.toString('base64') },
+    })).status, 200);
+    const r = await srv2.get(`/v2/outbound/${b.hash}`, { headers: { 'X-Api-Key': key } });
+    assert.strictEqual(r.status, 200);
+    return r.headers['x-paramant-receipt-id'];
+  };
+  const alive = async (id, key) =>
+    (await srv2.get(`/v2/transfers/${id}/receipt`, { headers: { 'X-Api-Key': key } })).status === 200;
+
+  // The quiet tenant goes FIRST, so under an oldest-first global rule it is the
+  // first thing evicted. That is the regression this test exists for.
+  const small = [await put(SMALL), await put(SMALL)];
+  const huge = [];
+  for (let i = 0; i < 6; i++) huge.push(await put(HUGE));
+
+  for (const id of small) {
+    assert.ok(await alive(id, SMALL),
+      'the store filled up and the small holder still has both of its receipts');
+  }
+  const hugeAlive = [];
+  for (const id of huge) if (await alive(id, HUGE)) hugeAlive.push(id);
+  assert.strictEqual(hugeAlive.length, 3,
+    'the biggest holder paid for the whole overflow: 5 slots, 2 of them the small holder\'s');
+  assert.deepStrictEqual(hugeAlive, huge.slice(-3), 'and it lost its oldest, not an arbitrary set');
+  srv2.stop();
+  did();
+});
+
+test('with redis, a receipt outlives the process that issued it', async () => {
+  // The store used to be a bare in-process Map, so every restart 404d every
+  // outstanding receipt. A deploy in the middle of somebody's 15 minute window
+  // silently cost them their proof of delivery, and restarting is a thing
+  // operators do on purpose. The envelope store already runs on redis; so does
+  // this now, with the Map kept only as the fallback for a relay without one.
+  const rc = await requireRedis(DEFAULT_REDIS);
+  if (!rc) return;
+  // The client is closed in a finally: an open redis connection keeps the test
+  // runner alive, so a FAILING assertion would hang the run instead of
+  // reporting, which is a worse outcome than the failure itself.
+  try {
+  const KEY = 'pgp_restart_receipt_suite';
+  const env = { REDIS_URL: process.env.REDIS_URL || DEFAULT_REDIS };
+  // usersFile mode: restart() re-reads users.json from the same scratch dir, so
+  // the key has to be on disk and not only in USERS_JSON.
+  let srv2 = await boot({
+    tag: 'transfer-receipt-restart',
+    env,
+    usersFile: true,
+    users: { api_keys: [{ key: KEY, plan: 'pro', active: true, email: 'restart@example.test', account_id: 'acct_restart' }] },
+  });
+  const b = blob('restart-receipt');
+  assert.strictEqual((await srv2.post('/v2/inbound', {
+    headers: { 'X-Api-Key': KEY }, body: { hash: b.hash, payload: b.payload.toString('base64') },
+  })).status, 200);
+  const dl = await srv2.get(`/v2/outbound/${b.hash}`, { headers: { 'X-Api-Key': KEY } });
+  assert.strictEqual(dl.status, 200);
+  const id = dl.headers['x-paramant-receipt-id'];
+  const hash = dl.headers['x-paramant-receipt-hash'];
+  assert.ok(id, 'the download was receipted');
+
+  const before = await srv2.get(`/v2/transfers/${id}/receipt`, { headers: { 'X-Api-Key': KEY } });
+  assert.strictEqual(before.status, 200, before.text);
+
+  srv2 = await srv2.restart();
+  const after = await srv2.get(`/v2/transfers/${id}/receipt`, { headers: { 'X-Api-Key': KEY } });
+  assert.strictEqual(after.status, 200, 'a restart must not take an outstanding receipt away');
+  assert.deepStrictEqual(after.json, before.json, 'and it is the same receipt, byte for byte');
+  assert.strictEqual(after.json.receipt_hash, hash,
+    'still matching the hash the download promised, across the process boundary');
+  srv2.stop();
+  did();
+  } finally {
+    try { await rc.quit(); } catch (_) { /* already gone */ }
+  }
 });
 
 test('the fat header comes back only when an operator asks for it, and it is deprecated', async () => {

--- a/relay/test/route-transfer-burn.test.js
+++ b/relay/test/route-transfer-burn.test.js
@@ -28,6 +28,12 @@ const { summary } = require('./_requires');
 const PRO = 'pgp_pro_key_for_the_transfer_suite';
 const COMMUNITY = 'pgp_community_key_for_the_transfer_suite';
 const OTHER = 'pgp_other_tenant_key_for_the_transfer_suite';
+// A key with NO plan field at all. Real users.json entries in this shape exist:
+// every key minted before the plan field did, plus anything an import wrote.
+const NOPLAN = 'pgp_no_plan_key_for_the_transfer_suite';
+// A Business account. It is the tier the pricing page sells for the highest
+// volume, and the one the old three-key outbound table left out entirely.
+const BUSINESS = 'pgp_business_key_for_the_transfer_suite';
 
 let srv;
 let checks = 0;
@@ -57,6 +63,8 @@ before(async () => {
         { key: PRO, plan: 'pro', active: true, email: 'pro@example.test', account_id: 'acct_pro' },
         { key: COMMUNITY, plan: 'community', active: true, email: 'com@example.test', account_id: 'acct_com' },
         { key: OTHER, plan: 'pro', active: true, email: 'other@example.test', account_id: 'acct_other' },
+        { key: NOPLAN, active: true, email: 'noplan@example.test', account_id: 'acct_noplan' },
+        { key: BUSINESS, plan: 'business', active: true, email: 'biz@example.test', account_id: 'acct_biz' },
       ],
     },
   });
@@ -218,6 +226,75 @@ test('the TTL is clamped to the tier ceiling: community 1 hour, pro 24 hours', a
   // A request below the ceiling is honoured as asked.
   const small = await upload(PRO, blob('ttl-small'), { ttl_ms: 30_000 });
   assert.strictEqual(small.json.ttl_ms, 30_000);
+  did();
+});
+
+test('a key with no plan is held to ONE ceiling, the strictest, on both dimensions', async () => {
+  // The two ceilings are taken one line apart and used to disagree about what a
+  // missing plan means: the TTL fell back to 'community' (1 hour) and max_views
+  // to 'pro' (10 reads). So an unplanned key got the community link lifetime and
+  // the Pro read count in the same upload. A missing plan is not evidence of a
+  // paid one, so both must land on community: 1 hour, 1 read.
+  const week = 7 * 86_400_000;
+  const t = await upload(NOPLAN, blob('noplan-ttl'), { ttl_ms: week });
+  assert.strictEqual(t.status, 200, t.text);
+  assert.strictEqual(t.json.ttl_ms, 3_600_000, 'the TTL ceiling for a missing plan is the community hour');
+
+  const v = blob('noplan-views');
+  assert.strictEqual((await upload(NOPLAN, v, { max_views: 10 })).status, 200);
+  const first = await download(NOPLAN, v.hash);
+  assert.strictEqual(first.status, 200);
+  assert.strictEqual(first.headers['x-paramant-burned'], 'true',
+    'and the views ceiling is the community one too: the first read is the last');
+  assert.strictEqual((await download(NOPLAN, v.hash)).status, 404,
+    'a missing plan must not quietly buy the pro ceiling of 10 reads');
+  did();
+});
+
+test('a Business key is not rate limited at the free 50 downloads per hour', async () => {
+  // relay.js:1607 used to hold its own three-key table, { free, pro,
+  // enterprise }, keyed on the raw plan string with a `?? free` fallback.
+  // 'business' was not a key in it, so a Business account, which pays for the
+  // highest volume of all, was capped at the free 50 per hour. The ceiling now
+  // comes from lib/tiers.js (outbound_per_hour), which has a row per tier and
+  // normalises the aliases, so the 51st download goes through.
+  const tiers = require('../lib/tiers');
+  const FREE_CEILING = tiers.tierLimitNum('community', 'outbound_per_hour');
+  assert.strictEqual(FREE_CEILING, 50, 'the free ceiling this test is measuring against');
+  assert.ok(tiers.tierLimitNum('business', 'outbound_per_hour') > FREE_CEILING,
+    'business must buy more outbound than community, not the same');
+
+  for (let i = 1; i <= FREE_CEILING + 1; i++) {
+    const b = blob(`biz-${i}`);
+    assert.strictEqual((await upload(BUSINESS, b)).status, 200, `upload ${i}`);
+    const r = await download(BUSINESS, b.hash);
+    assert.strictEqual(r.status, 200,
+      `download ${i} of ${FREE_CEILING + 1}: a Business key must not hit the free hourly ceiling`);
+  }
+  did();
+});
+
+test('every tier the pricing page sells has its own outbound ceiling, and they only go up', async () => {
+  // The regression this pins is a table with a hole in it. Any tier missing
+  // from lib/tiers.js falls back to the community row, which is how 'business'
+  // silently got the free rate for as long as the local table existed.
+  const tiers = require('../lib/tiers');
+  const ladder = ['community', 'pro', 'business', 'enterprise'];
+  assert.deepStrictEqual(Object.keys(tiers.TIER_LIMITS), ladder,
+    'the tier list this assertion walks must be the whole tier list');
+  let previous = 0;
+  for (const tier of ladder) {
+    const raw = tiers.tierLimit(tier, 'outbound_per_hour');
+    assert.notStrictEqual(raw, null, `${tier} has no outbound_per_hour, so it silently gets the community rate`);
+    const rate = tiers.tierLimitNum(tier, 'outbound_per_hour');
+    assert.ok(rate > previous, `${tier} must buy more outbound than the tier below it, got ${rate} after ${previous}`);
+    previous = rate;
+  }
+  // And the aliases the relay really sees on a key record resolve to a row.
+  for (const [alias, canonical] of [['free', 'community'], ['dev', 'community'], ['licensed', 'enterprise']]) {
+    assert.strictEqual(tiers.tierLimitNum(alias, 'outbound_per_hour'), tiers.tierLimitNum(canonical, 'outbound_per_hour'),
+      `the legacy plan name ${alias} must resolve to the ${canonical} ceiling`);
+  }
   did();
 });
 

--- a/relay/test/route-transfer-burn.test.js
+++ b/relay/test/route-transfer-burn.test.js
@@ -159,13 +159,109 @@ test('the download carries a signed delivery receipt with a burn confirmation', 
   await upload(PRO, b);
   const r = await download(PRO, b.hash);
   assert.strictEqual(r.status, 200);
-  const raw = r.headers['x-paramant-receipt'];
-  assert.ok(raw, 'every delivery is receipted');
-  const receipt = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'));
+  // The download hands over a REFERENCE now; the receipt itself is fetched.
+  const id = r.headers['x-paramant-receipt-id'];
+  assert.match(id || '', /^[0-9a-f]{32}$/, 'every delivery is receipted');
+  assert.strictEqual(r.headers['x-paramant-receipt-url'], `/v2/transfers/${id}/receipt`);
+
+  const fetched = await srv.get(`/v2/transfers/${id}/receipt`, { headers: { 'X-Api-Key': PRO } });
+  assert.strictEqual(fetched.status, 200, fetched.text);
+  // The hash in the header is over the exact bytes that come back, so the
+  // handover cannot be tampered with in between.
+  assert.strictEqual(fetched.json.receipt_hash, r.headers['x-paramant-receipt-hash']);
+  assert.strictEqual('sha3-256:' + crypto.createHash('sha3-256').update(fetched.json.receipt).digest('hex'),
+    r.headers['x-paramant-receipt-hash'], 'the advertised hash really is the hash of the receipt');
+
+  const receipt = JSON.parse(Buffer.from(fetched.json.receipt, 'base64url').toString('utf8'));
   assert.strictEqual(receipt.blob_hash, b.hash);
   assert.strictEqual(receipt.burn_confirmed, true);
   assert.ok(receipt.signature, 'the receipt is signed by the relay identity');
   assert.ok(receipt.inclusion_proof, 'and carries the CT inclusion proof for the blob');
+
+  // And it is still the thing /v2/verify-receipt was built to check.
+  const verified = await srv.post('/v2/verify-receipt', {
+    headers: { 'X-Api-Key': PRO }, body: { receipt: fetched.json.receipt },
+  });
+  assert.strictEqual(verified.status, 200, verified.text);
+  assert.strictEqual(verified.json.valid, true, 'the fetched receipt verifies as delivered');
+  did();
+});
+
+test('a download answers with less than 8 KB of response headers', async () => {
+  // PR #341, finding 2. X-Paramant-Receipt carried the whole signed receipt:
+  // 18551 bytes for that one header, 19560 for the block. Two hard consequences,
+  // neither of them theoretical:
+  //   Node's default maxHeaderSize is 16384, so fetch() and a default
+  //   http.request threw UND_ERR_HEADERS_OVERFLOW on every single download.
+  //   nginx's default proxy_buffer_size is 4k/8k and that one buffer must hold
+  //   the whole upstream header block, so a proxied download is a 502.
+  // 8 KB is the ceiling here because it is the larger of the two nginx defaults:
+  // stay under it and the smallest realistic proxy still passes the response.
+  const b = blob('header-size');
+  await upload(PRO, b);
+  const r = await download(PRO, b.hash);
+  assert.strictEqual(r.status, 200);
+  assert.ok(r.headers['x-paramant-receipt-id'], 'measured on a download that really is receipted');
+
+  // Reconstruct the wire bytes of the header block: "Name: value\r\n" each,
+  // plus the closing CRLF. The status line is a few dozen bytes on top.
+  let bytes = 2;
+  for (const [name, value] of Object.entries(r.headers)) {
+    for (const v of Array.isArray(value) ? value : [value]) {
+      bytes += Buffer.byteLength(`${name}: ${v}\r\n`);
+    }
+  }
+  assert.ok(bytes < 8192,
+    `a download must fit a default proxy buffer, got ${bytes} bytes of headers`);
+  assert.ok(!('x-paramant-receipt' in r.headers),
+    'and the fat header is gone by default, not merely smaller');
+  did();
+});
+
+test('a receipt reference is single-tenant, and unknown or foreign ids give one 404', async () => {
+  const b = blob('receipt-auth');
+  await upload(PRO, b);
+  const id = (await download(PRO, b.hash)).headers['x-paramant-receipt-id'];
+
+  const foreign = await srv.get(`/v2/transfers/${id}/receipt`, { headers: { 'X-Api-Key': OTHER } });
+  const unknown = await srv.get(`/v2/transfers/${'0'.repeat(32)}/receipt`, { headers: { 'X-Api-Key': OTHER } });
+  assert.strictEqual(foreign.status, 404, 'another tenant may not read the receipt for a delivery it did not make');
+  assert.deepStrictEqual(foreign.json, unknown.json,
+    'and it answers exactly like an id that never existed, so it is no oracle');
+
+  const noKey = await srv.get(`/v2/transfers/${id}/receipt`);
+  assert.strictEqual(noKey.status, 401, 'the route sits behind the same auth gate as the download');
+
+  // The owner can still read it, and more than once: nothing was consumed.
+  for (let i = 0; i < 2; i++) {
+    assert.strictEqual((await srv.get(`/v2/transfers/${id}/receipt`, { headers: { 'X-Api-Key': PRO } })).status, 200);
+  }
+  did();
+});
+
+test('the fat header comes back only when an operator asks for it, and it is deprecated', async () => {
+  // The removal is not silent: an out-of-tree client that still reads
+  // X-Paramant-Receipt gets one release to move, behind an explicit opt-in.
+  const legacy = await boot({
+    tag: 'transfer-legacy-receipt',
+    env: { PARAMANT_INLINE_RECEIPT_HEADER: '1' },
+    users: { api_keys: [{ key: PRO, plan: 'pro', active: true, email: 'pro@example.test', account_id: 'acct_pro' }] },
+  });
+  const b = blob('legacy-header');
+  assert.strictEqual((await legacy.post('/v2/inbound', {
+    headers: { 'X-Api-Key': PRO }, body: { hash: b.hash, payload: b.payload.toString('base64') },
+  })).status, 200);
+  // Reading it back needs room Node does not give by default. That IS the bug:
+  // a client cannot ask for this without knowing about it first.
+  const r = await legacy.get(`/v2/outbound/${b.hash}`, {
+    headers: { 'X-Api-Key': PRO }, maxHeaderSize: 96 * 1024,
+  });
+  assert.strictEqual(r.status, 200);
+  assert.ok(r.headers['x-paramant-receipt'], 'the opt-in really puts the old header back');
+  assert.ok(Buffer.byteLength(r.headers['x-paramant-receipt']) > 16384,
+    'and it is still the header that does not fit, which is why it is going away');
+  assert.ok(r.headers['x-paramant-receipt-id'], 'the reference is served alongside it during the window');
+  legacy.stop();
   did();
 });
 


### PR DESCRIPTION
PR #341 found four real bugs while writing tests for the critical paths and
fixed none of them, because that branch was tests only. This is the fix branch.
Every bug gets a test that was red first, and every fix is shown by sabotage:
one line changed in production code, the suite run, the change reverted.
`git status` was clean after each revert.

The five route suites are green: **69 pass, 0 fail, 0 todo**, up from 56 pass
and 1 todo on #341. With `parasign-signs-quota`, which shares the CI step, the
step runs 70. (An earlier revision of this body said 65 for the route suites;
that number was the CI step, not the suites.) The relay unit suite is 175 pass,
the relay integration suites 11, the root integration suites 143. eslint clean,
`tests/static-sanity.sh` PASS including check 10, and gitleaks clean.

**Review round 1 (commit 4).** The mint path dropped the paid period as well,
the receipt store was a cross-tenant eviction channel, the deprecation was
silent where a real client depends on it, and gitleaks went red on the new curl
example.

**Review round 2 (commit 5).** The gitleaks fix was correct and untested where
it mattered, the receipt store did not survive a restart, its per-account cap
was wrong for the tier that pays most, and four new env vars were undocumented.

Each is written up at the end of the section it belongs to. Companion SDK
release: **Apolloccrypt/paramant-sdk#5**, which must ship before this reaches
production and which had a data-loss bug of its own this round.

---

## 1. An expired paid tier kept granting on every account-level read

The bug had **two** halves, not one, and either is enough on its own. Both are
the same mistake: the tier travels and its paid period does not.

- `lib/keys-table.js` `parseAccountFields()` rehydrated `plan_parasign` and
  `plan_parasend` off users.json but **none** of the `paid_until_*` fields. So
  the in-memory key record already carried a paid tier with no end date, before
  any merge ran. Finding 1 in #341 did not name this half.
- `lib/entitlements.js` `mergeAccountRecord()` copied the per-product plans off
  the key records and left the periods behind, and
  `keys-table.rebuildKeyIndexes()` made the same drop into the accounts summary.

The record then reaches `getEntitlements` with a paid tier and no period, and
`entitlements.js:137` correctly reads "no recorded period" as "never expired".
Reached through `entitlementRecordOf` at `relay.js:5316` (admin entitlements),
`:5990` (the signs-quota gate on sign) and `:1804` (the plan a newly minted
`psk_` key inherits).

**The fix** is one shared rule, `entitlements.mergeProductGrantInto`, used in
all three places: tier and period always travel together, and the better grant
wins on its **effective** tier first. That ordering is load-bearing. Ranking on
the stored tier would let a lapsed Business grant outrank a live Pro grant on a
sibling key, so closing an over-grant would have opened a downgrade instead.
There is a test for exactly that.

Two edges are pinned rather than changed:

- **A paid tier with no `paid_until` stays unbounded.** Old customers and every
  account from before billing exist only in that shape (`entitlements.js:137`).
  `parseAccountFields` leaves the field absent rather than writing an explicit
  `null`, so "no period on file" can never start reading as expired.
- **`mintParasignKey` now inherits the effective tier.** The new key record
  carries no `paid_until` of its own, so re-issuing a stored-but-lapsed tier
  there would have turned an expired subscription into a permanent one on the
  next mint. A record with no per-product tier at all still derives from the
  legacy plan, exactly as before.

Tests, in `route-billing-entitlements`: the `todo` ("a period that HAS passed
stops granting") is now a real passing test, and the `FINDING:` test that
pinned the divergence is replaced by its inverse, a property over
expired/live/absent that both read paths must answer identically, plus a loader
test that the period survives users.json.

| # | sabotage | result |
|---|---|---|
| S1 | `keys-table.parseAccountFields` stops carrying `paid_until_*` | 2 red: "a period that HAS passed stops granting", "a key loaded from users.json keeps the paid period" |
| S2 | `entitlements.mergeProductGrantInto` stops carrying the period | 2 red: "a period that HAS passed stops granting", "the merged read path answers exactly like a direct read" |

### Review round: there was a **third** drop, on the path a customer can trigger

`keys-table.buildParasignKeyRecord` wrote `plan_parasign` onto the new key and
its users.json entry and never `paid_until_parasign`. So a key minted **while
the subscription was still running** carried a paid tier with no end date, and
under the same "no recorded period means never expires" rule that key outlived
the subscription that paid for it, restart included, because that is the shape
that reached disk. Both issuance paths run through this builder:
`POST /v2/user/parasign-keys` (`relay.js:3259`, self-serve through the admin
server) and the admin mint (`relay.js:5451`). Minting is on-demand, so this is
the half of finding 1 a paying customer could have exercised themselves.

The period now travels with the tier onto both the live record and the
users.json entry, through the shared `applyProductTier` rule, so landing on a
floor tier clears it and an **already lapsed** account mints a plain free key
with no stale date on it.

| # | sabotage | result |
|---|---|---|
| S7 | `buildParasignKeyRecord` stops carrying the period | 1 red: "a key minted while the subscription is LIVE does not outlive it" |

The test mints with a period a few seconds out, watches the subscription
actually end, restarts on a cold process, and expects `free`. A second test
pins the lapsed-account mint.

## 2. A ParaSend download answered with a 19 KB response header

`GET /v2/outbound/:hash` put the whole signed delivery receipt in
`X-Paramant-Receipt`: 18551 bytes for that header, 19560 for the block. It
carries a full ML-DSA-65 signature and an inclusion proof, so it was never
going to fit.

**Who reads it.** Checked before changing anything: there is no SDK in this
repo (`sdk-js/`, `sdk-py/`, `paramant-app/` are all absent, the SDK moved to
`Apolloccrypt/paramant-sdk`), and no code in-tree reads the header except
`route-transfer-burn`'s own test. The browser download path
(`frontend/js/ontvang.page.js`) uses `/v2/dl/:token/get` and never looks at it.
`tests/transfer-canary.test.mjs`, the hourly canary against production, calls
`/v2/outbound/:hash` with a plain `fetch()` and is a second victim rather than a
consumer. There was no existing receipt route for blob transfers;
`/v2/verify-receipt` takes the receipt in the request **body**, and the two
`/v2/envelopes/:id/receipt` routes are ParaSign, unrelated.

**The two consequences**, both on the download path:

- Node's default `maxHeaderSize` is 16384, so a client using `fetch()` or a
  default `http.request` threw `UND_ERR_HEADERS_OVERFLOW` on every receipted
  download. `fetch()` cannot raise that limit at all.
- nginx's default `proxy_buffer_size` is 4k (8k on some builds) and that one
  buffer must hold the whole upstream header block. No conf in this repo sets
  it, so a proxied download is an "upstream sent too big header" 502.
  Production was not read; this is the repo's own config.

**The fix, smallest compatible shape:** the receipt travels by reference. The
download answers with `X-Paramant-Receipt-Id`, `X-Paramant-Receipt-Hash`
(`sha3-256:` over the bytes that will come back) and `X-Paramant-Receipt-Url`,
about 190 bytes in total. New `GET /v2/transfers/:receipt_id/receipt` returns
the **exact** base64url payload the header used to carry, so a client that
decodes that string, or posts it to `/v2/verify-receipt`, needs no other change.

- The id is 16 random bytes and the receipt is additionally bound to the API key
  that made the download. Unknown, expired and foreign ids answer with **one**
  404, so the route cannot be used to probe whether a transfer existed. That is
  the same rule the burn 404 already follows.
- Receipts live 15 minutes, hard cap 1000 entries, oldest evicted first. A
  receipt is ~18 KB and this relay is RAM-only, so the window is sized for
  "fetch it in the same breath as the download".
- `X-Paramant-Receipt` is **deprecated, not deleted**:
  `PARAMANT_INLINE_RECEIPT_HEADER=1` puts it back for one release, off by
  default, removal after **2026-12-01**, stated in `docs/api.md`.

`test/_relay-server.js` no longer raises `maxHeaderSize`. The test client is
held to the same 16 KB a caller using `fetch()` gets, so a header block that
grows past it now fails in CI instead of in production.

Documented in `docs/api.md` and its `frontend/docs/api.md` mirror, plus the two
`README.md` references. `deploy/nginx-paramant-public.conf` gains an explicit
`proxy_buffer_size` on the `/v2/outbound` location, with a comment saying why:
a margin, and cover for a relay run with the deprecated opt-in still on.
Production config untouched.

| # | sabotage | result |
|---|---|---|
| S3 | the fat `X-Paramant-Receipt` header set unconditionally again | **10 of 20 red** in route-transfer-burn, because the test client is now held to Node's own 16 KB and throws `UND_ERR_HEADERS_OVERFLOW` on every download, which is exactly what a real client did |

New test: "a download answers with less than 8 KB of response headers". It
reconstructs the wire bytes of the header block. 8 KB is the ceiling because it
is the larger of the two nginx defaults, so the smallest realistic proxy passes.

### Review round: the receipt store was a cross-tenant eviction channel

It was one shared LRU of 1000. Measured: an account doing 1050 downloads pushes
another account's receipt out **inside that account's own 15 minute window**,
and before this route the receipt was guaranteed to be on the response itself,
so the regression would have been paid for by a stranger.

The budget is per account now. An account can only ever evict its **own**
oldest receipt, and the global ceiling takes from the **largest holder**, which
can never be the small tenant it would be protecting.

- per account: **200**, global: **4000**, both overridable.
- The stored form is the receipt JSON, not its base64url wrapper. The wrapper is
  4/3 the size and re-encoding on the way out is deterministic, so the hash
  stays stable and ~4.6 KB per receipt is not held. That puts a receipt at
  roughly **14 KB**, so the ceiling is a worst case of about **56 MB**, reached
  only when 20 accounts each hold a full 200 at once. Documented at the store.

| # | sabotage | result |
|---|---|---|
| S8 | one shared LRU again, no per-account budget | 1 red: "a busy tenant cannot evict a quiet tenant's receipt" |

The test sizes the store down to 8 so the rule is measured rather than the
numbers: a quiet tenant holding one receipt survives 24 downloads by a busy
one, and the busy tenant keeps exactly its own newest 4.

### Round 2: the store did not survive a restart, and the cap was wrong for business

**It was a bare in-process Map.** Every relay restart 404d every outstanding
receipt, so a deploy in the middle of somebody's 15 minute window silently cost
them their proof of delivery, and restarting is a thing operators do on purpose.
The envelope store already runs on redis; receipts do now too: one key per
receipt id with a 15 minute TTL, plus a per-account sorted set for the cap. The
Map stays as the fallback for a relay without redis, and a redis error never
fails a download, it logs and falls through.

**The flat 200 was wrong for exactly the tier that pays most.** Business buys
2000 downloads an hour, so it would lose its oldest receipts after six minutes
of steady use, inside the window it was promised. The cap is derived from the
tier's own outbound ceiling now, two hours at the rate that tier pays for:

| tier | outbound/hour | receipts held |
|---|---|---|
| community | 50 | 100 |
| pro | 500 | 1000 |
| business | 2000 | 4000 |
| enterprise | uncapped | 10000 (explicit) |

**`docs/api.md` now says this plainly** instead of "kept for 15 minutes": the
three things that can take a receipt away (time, your own volume, a relay
without redis), each with its number, and that an operator can put the receipt
back on the download itself with the opt-in.

| # | sabotage | result |
|---|---|---|
| S9 | receipts back to the in-process Map only | 1 red: "with redis, a receipt outlives the process that issued it" |
| S10 | global backstop evicts oldest-first across tenants | 1 red: "the global backstop takes from the biggest holder, never from the quiet one" |

The backstop test is not a duplicate of the per-account one: it fills the store
so the two caps cannot both be satisfied, and stores the quiet tenant's
receipts **first**, so an oldest-first global rule takes exactly them. Its redis
sibling closes its client in a `finally`, because an open connection keeps the
runner alive and a failing assertion would otherwise hang the run instead of
reporting.

Also: `tests/env-documented.test.mjs`, which landed on main between the two
pushes, caught all four new `PARAMANT_RECEIPT_*` variables as undocumented.
They are in `deploy/.env.example` now, in the file's own format.

### Review round: there IS an out-of-tree client, so the deprecation is now loud

`paramant-sdk`'s `sdk-py/paramant_sdk.py:681` reads `x-paramant-receipt` and
turns an absent header into a **silent `receipt = None`**. `None` is also what
an unreceipted transfer returns, so against a deployed main a 3.2.0 client
would have kept working while proving nothing. My earlier "nothing reads it"
was scoped to this repo and that scope was too narrow.

Two things follow:

1. A download without the inline header now carries
   `X-Paramant-Receipt-Deprecated: removed 2026-12-01; GET /v2/transfers/<id>/receipt`.
   It is not sent when the opt-in is on, because then there is nothing to
   announce. In `CHANGELOG.md` and `docs/api.md` as well, with a test on both
   halves.
2. **Apolloccrypt/paramant-sdk#5** teaches the Python SDK both shapes: inline
   header if present, otherwise the reference fetched with the same API key,
   with the advertised `sha3-256` verified over the returned bytes.

   That PR needed a second round too, and its bug was worse than the one it
   fixed. Its first revision resolved the receipt **before** decrypting and
   raised on a 404. But the download is burn-on-read: the relay has already
   destroyed the blob, so a receipt 404 (an expired window, a per-account cap, a
   relay restarted between the two calls) threw the only copy of the plaintext
   away over a missing proof of delivery. It now decrypts and returns the data
   first, and a missing receipt is `receipt=None` plus a warning with the reason
   on `last_receipt_error`. 57 pass there; reverting to the old ordering turns 7
   of its 12 tests red. Released as **3.3.0**, not a patch, because a call that
   used to return a receipt can now return `None` with a warning.

`PARAMANT_INLINE_RECEIPT_HEADER` **stays off by default**. Instead,
`deploy/DEPLOY-3.1.md` gains the SDK release as a precondition for main
reaching production, with the opt-in plus a raised `proxy_buffer_size` written
down as the way out if the deploy cannot wait.

## 3. Two ceilings, one line apart, with two different defaults

`relay.js:4386` took the view-TTL ceiling with a `'community'` fallback for a
key with no plan; `relay.js:4391` took the max_views ceiling for that same key
with a `'pro'` fallback. An unplanned key was held to the community link
lifetime of one hour and handed the Pro read count of ten, in the same upload.
A missing plan is not evidence of a paid one, so both now read one shared
default and it is the strictest.

| # | sabotage | result |
|---|---|---|
| S4 | max_views fallback back to `'pro'` | 1 red: "a key with no plan is held to ONE ceiling, the strictest, on both dimensions" |

## 4. Business paid for the highest volume and got the free rate

`relay.js:1607` kept its own table, `{ free: 50, pro: 500, enterprise: Infinity }`,
keyed on the raw plan string with a `?? free` fallback. `community` and
`business` were never keys in it, so a Business account was rate limited at the
free 50 downloads per hour.

The number moves to `lib/tiers.js` as `outbound_per_hour`, one row per tier the
pricing page sells, and `normalisePlan` maps `free`/`dev`/`licensed` onto those
rows. The three legacy values are mirrored exactly (community 50, pro 500,
enterprise unlimited); business gets 2000, its own `transfers_month`, on the
rule that it can never sit below pro. Every other legacy per-tier table in
tiers.js had the same three-key shape, which is why the numbers belong there.

| # | sabotage | result |
|---|---|---|
| S5 | the local three-key table put back in `outboundRateOk` | 1 red: "a Business key is not rate limited at the free 50 downloads per hour" (it completes 51 downloads in an hour) |
| S6 | the `business` row loses `outbound_per_hour` | 2 red: the same test, plus "every tier the pricing page sells has its own outbound ceiling, and they only go up" |

That last test is the one that stops the bug class rather than the bug: a tier
added to tiers.js without a rate falls back to the community row, silently.

---

## Measured, not fixed: the USERS_JSON load path is thinner than USERS_FILE

Finding 4 of this round, raised as a suspicion in #341 and measured here.
`relay.js:1882` builds a key record from `USERS_JSON` with
`{plan, label, email, active, created, ...parseAccountFields(k)}`. The
`USERS_FILE` path at `:1886` adds seven more fields. Missing under `USERS_JSON`:

`dsa_pub`, `daily_uploads`, `daily_reset_ts`, `is_trial`, `trial_created`,
`uploads_today`, `last_upload_day`

**Not a live bug.** Production runs the `USERS_FILE` path
(`docker-compose.yml:46`), so nothing below is happening on the deployed relay.
This is a trap for whoever picks the env variant, which the repo documents in
`.env.example:47` as a supported way to configure a relay.

Two consequences on that path, traced to the gate that reads them:

- **`dsa_pub` absent** means `relay.js:4380` `if (dsa_signature && keyData.dsa_pub)`
  is never true, so an inbound ML-DSA signature is accepted without being
  verified and logged as `not provided`.
- **`is_trial` absent** means the entire trial block at `relay.js:4363` never
  runs. Not just the daily cap: also the 30-day expiry, the 5 MB size cap and
  the 1 hour TTL cap. On an env-configured relay a trial key has none of them.

Not fixed here. The mechanical fix is one shared record builder, but it would
switch trial enforcement **on** for every relay configured through the
environment, which is a policy change rather than a refactor. Since production
does not use that path, nothing is urgent about it; it wants its own PR and its
own decision.

## Review round: gitleaks, and why an ignore file was the wrong tool

The secrets job went red on the new curl example,
`-H "X-Api-Key: pgp_your_key"` in `docs/api.md` and its frontend mirror.
Reproduced with gitleaks v8.28.0 over `origin/main..HEAD`: **2 findings**, rule
`curl-auth-header`, both the placeholder.

The published docs show every authenticated call as a runnable curl, so a
key-shaped string in them is a permanent feature. It was being handled by
adding a `commit:file:rule:line` fingerprint to `.gitleaksignore` per
occurrence, which goes stale the moment a line moves; that file already carries
twenty-odd for this one rule. A `.gitleaks.toml` now allowlists the two literal
placeholders (`pgp_your_key`, `plk_your_key`) and only where they follow the
API key header. `.gitleaksignore` stays as it is, for the findings that really
are per-commit history.

Verified three ways:

- without the file: **2 findings** over `origin/main..HEAD`; with it: **0**;
- all 11 placeholder findings in `docs/api.md` disappear;
- a key-shaped string in the same position (`pgp_9f31c07a...`) is still caught,
  twice, by `curl-auth-header` and `generic-api-key`.

### Round 2: the fix above was correct and CI was not running it

The action resolved its own default gitleaks version, **8.24.3**, which parses
a `[[allowlists]]` table and then does not apply it. No error, no warning, the
config is simply skipped. Same repo, same branch, same config:

| gitleaks | findings over `origin/main..HEAD` |
|---|---|
| 8.24.3 (what CI ran) | **2** |
| 8.28.0 (what I tested on) | **0** |

`GITLEAKS_VERSION: "8.28.0"` is now pinned in the step's env, with that
measurement written next to it. A config that is silently skipped is worse than
one that fails to load, so the version is named rather than inherited. The
`secrets - gitleaks` check passes on this PR.

## Deliberately not done

No merge, no deploy, no production config touched (the nginx change is the repo
copy). No commit trailer here or in the SDK PR. The receipt store is in-process
RAM, not redis: adding a redis dependency to the download path would make a
receipt fetch fail in an outage that the download itself survives. And
`PARAMANT_INLINE_RECEIPT_HEADER` is not turned on as a shortcut past the SDK
release, because the fat header is a 502 on a default nginx and turning it on
would quietly require a proxy change on every deployment.
