### PR TITLE
chore(deps): keep the Node major out of Dependabot's hands

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,25 @@ updates:
       - "dependencies"
       - "docker"
       - "relay"
+    # The Node line is a paired decision, not a dependency bump. `engines`
+    # (">=22 <25"), `.nvmrc`, the `node-version` steps in every CI job and both
+    # Dockerfiles have to move together, and only to a line that is in Active
+    # LTS. #340 set that grid deliberately: "it makes adopting Node 26 a
+    # deliberate bump rather than an accident". Dependabot opened #343 and #346
+    # (24 -> 26) anyway. Node 26 is the next even line but does not enter Active
+    # LTS until late October 2026, and all three package manifests say
+    # ">=22 <25". Nothing in CI enforces `engines` (no engine-strict), so that
+    # image would have built green and only disagreed with its own manifest at
+    # runtime.
+    #
+    # Scoped to "node" on purpose: the rust builder still gets its majors (#313
+    # was a real break that had to be seen), and node minor/patch bumps, Alpine
+    # rebuilds and digest updates all still come through. When a new even line
+    # reaches Active LTS, bump it by hand together with `engines`, `.nvmrc` and
+    # the CI node-version steps; docs/RELEASE.md carries that checklist.
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
 
   # Docker – admin image base
   - package-ecosystem: "docker"
@@ -42,6 +61,12 @@ updates:
       - "dependencies"
       - "docker"
       - "admin"
+    # Same Node-line rule as the relay entry above, and for the same reason:
+    # admin/Dockerfile is kept in lockstep with relay/Dockerfile, so a major
+    # here that does not land there splits the two images apart.
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Follow-up to #340, and the reason #343 and #346 are being closed.

## What happened

#340 pinned one Node line across four places at once:

| place | value |
|---|---|
| `package.json`, `relay/package.json`, `admin/package.json` | `engines: ">=22 <25"` |
| `.nvmrc` | `24` |
| `node-version` in all 7 CI job steps | `24` |
| `relay/Dockerfile`, `admin/Dockerfile` | `node:24-alpine3.24` (by digest) |

Its own wording: `>=22 <25` "makes adopting Node 26 a deliberate bump rather
than an accident".

Dependabot opened #343 (admin) and #346 (relay) within the hour, both
`node:24-alpine3.24 -> 26-alpine3.24`. Two things made that quiet rather than
loud:

- **Node 26 is not in Active LTS.** It is the next even line, but it does not
  enter LTS until late October 2026. Node 24 is the current LTS line.
- **Nothing checks `engines`.** There is no `.npmrc` anywhere in the repo, so
  `engine-strict` is off and the `npm ci` inside both Dockerfiles never looks at
  it. The image would have built green on a runtime all three manifests forbid,
  and disagreed with itself only at runtime.

`Build prod image (drift gate)` did go green on #346, because that job proves
the Dockerfile *builds*, not that the manifest agrees with the runtime it built
for. #343 had no image build at all: build-image.yml is path-gated on
`relay/**`, so the admin Dockerfile has no CI that ever builds it.

## What this changes

The docker updater for `/relay` and `/admin` ignores `version-update:semver-major`
for `node`, and for `node` only:

- the **rust builder keeps its majors**, deliberately. #313 (rust 1.95 -> 1.98)
  was a real break in the liboqs bindings and had to be seen.
- **node minor/patch, Alpine rebuilds and digest updates still arrive weekly**,
  which is where the CVE traffic is.

Adopting a new LTS line stays what #340 wanted it to be: a hand bump of the
whole grid, with `docs/RELEASE.md` as the checklist.

No workflow, image or manifest changes here, so nothing to run beyond the
existing checks.