### PR TITLE
Voer DEPLOY-3.1.md uit als een script, met bewijs per stap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ deploy/token
 # Stijl-denylist met te-beschermen namen (lokaal, NOOIT committen; .example wel)
 .style-denylist
 heartbeat-evidence/
+
+# Deploy logs (deploy/deploy-3.1.sh writes one per run)
+deploy/logs/

--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -86,8 +86,14 @@ test key plus mode, then deploy) collapsed to: deploy now, decide later.
 
 ## A second brake: the delivery receipt moved out of the download header
 
-**Precondition, not a step: `Apolloccrypt/paramant-sdk` PR #5 must be released
-to PyPI before main reaches production.**
+**This precondition is dropped, and the version in it was wrong. It used to
+read: `Apolloccrypt/paramant-sdk` PR #5 must be released to PyPI before main
+reaches production. The release in question is **3.3.0**, not 3.2.1, and it
+cannot reach PyPI: the project has no trusted publisher configured, which is a
+setting in PyPI and not something this repository can fix. Reported
+2026-09-02; not measured here. Waiting on it would hold the deploy for an
+unknown time, so the deploy is decoupled from it and takes the first of the
+two ways out below. `deploy/deploy-3.1.sh` does that automatically.**
 
 Relay PR #342 takes the signed ParaSend delivery receipt out of the
 `X-Paramant-Receipt` response header. It had to go: 18551 bytes for that one
@@ -98,8 +104,8 @@ from `GET /v2/transfers/:receipt_id/receipt`.
 The out-of-tree Python SDK reads that header (`sdk-py/paramant_sdk.py:681`) and
 turns an absent one into `receipt = None`, without an error. So a `3.2.0`
 client against a deployed main keeps working and silently stops getting proof
-of delivery. `paramant-sdk` 3.2.1 reads both shapes and fails loudly; that is
-the release this deploy waits for.
+of delivery. `paramant-sdk` 3.3.0 reads both shapes and fails loudly; that is
+the release this deploy no longer waits for.
 
 Two ways out if the release is not ready and the deploy cannot wait:
 
@@ -111,6 +117,12 @@ Two ways out if the release is not ready and the deploy cannot wait:
   comment, the production conf does not.
 - Or hold main. The default is off on purpose, because on a default nginx the
   fat header is a 502 rather than a feature.
+
+This deploy takes the first way out, so the follow-up is a real step and not a
+footnote: **once 3.3.0 is on PyPI, take `PARAMANT_INLINE_RECEIPT_HEADER` back
+out of `/opt/paramant-relay/.env` and recreate the relays.** That is one line
+and a `docker compose up -d --no-deps`, no deploy. The raised
+`proxy_buffer_size` may stay; #342 calls it a margin rather than a fix.
 
 Either way the flag is temporary: the old header is removed after
 **2026-12-01**. While it is off, every download carries

--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -1,5 +1,14 @@
 # Deploy runbook: main (3.1.0) to production
 
+> `deploy/deploy-3.1.sh` executes this runbook. One command from the NUC
+> (`bash deploy/deploy-3.1.sh`) runs every step below, prints the command and
+> the measurement for each one, and stops at the first result the runbook did
+> not predict. `--preflight-only` does the checks and nothing else,
+> `--dry-run` prints every remote command instead of running it, and
+> `--rollback <TS>` is step 8. This file stays the readable source: the script
+> follows it, it does not replace it, and a step that is argued out here is
+> argued out here only.
+
 Target: `116.203.86.81` (Hetzner). Mick runs this by hand over SSH, from the
 NUC, where the production key lives (`~/.ssh/paramant_prod_claude`, see
 `scripts/check-prod-drift.sh`). Nothing in this file runs on its own. Every
@@ -374,6 +383,17 @@ this brake exists to prevent.
 Trigger: any of the stop conditions in step 6, or clear breakage in the first
 thirty minutes.
 
+From the NUC, with the `TS` that step 2 printed:
+
+```bash
+bash deploy/deploy-3.1.sh --rollback 20260902-1830
+```
+
+That reads the manifest of step 2, retags the saved images, recreates the
+containers without rebuilding, restores `.env`, the nginx confs and the
+docroot, and re-runs the smoke tests. By hand, on the server, the equivalent
+is the 3.0.0 script, which asks before it restores `.env`:
+
 ```bash
 cd /opt/paramant-relay
 COMPOSE_DIR=/opt/paramant-relay BACKUP_DIR=/home/paramant/backups bash scripts/rollback-3.0.0.sh
@@ -413,7 +433,12 @@ fast path.
 
 ## What this runbook does not do
 
-- It does not deploy. Every command above is for Mick to run.
+- It does not deploy by itself. Every command above is one Mick runs, by hand
+  or through `deploy/deploy-3.1.sh`, which runs exactly these steps and
+  nothing more.
+- It does not automate step 7. Watching the logs, minting the canary key,
+  tagging the release and writing the deploy down stay hand work, because each
+  needs a judgement the script cannot make.
 - It does not set `BILLING_MODE`. The recurring layer stays off until there is
   a test key and a deliberate second change.
 - It does not remove the ParaID nginx deny. Harmless while it stays, and its

--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -48,10 +48,28 @@ What main brings that touches the deploy, with the PR that did it:
 - **#323** seventeen norms and sector pages removed (nginx: the `/compliance/*` locations go).
 - this PR: the recurring layer needs an explicit `BILLING_MODE`.
 
-`docker-compose.yml` is byte-identical between `41501bb` and main
-(`git diff 41501bb origin/main -- docker-compose.yml` is empty). Every
-environment variable this runbook mentions already has its line in the
-`x-relay-env` block; nothing has to be added to the compose file, only to `.env`.
+`docker-compose.yml` is **no longer** byte-identical between `41501bb` and
+main, and that matters for this deploy. Two changes:
+
+- #340 rewrote the version header comment.
+- This PR adds `PARAMANT_INLINE_RECEIPT_HEADER` and the three
+  `PARAMANT_RECEIPT_*` variables from #342 to the `x-relay-env` block.
+
+That second one is not cosmetic. There is **no `env_file`** in
+`docker-compose.yml`: `.env` only fills in `${VAR}` references inside the
+compose file itself, so a variable without its own line in `x-relay-env`
+never reaches a container, however carefully it is written into `.env`. The
+four receipt variables had no line, so setting the inline-receipt opt-in in
+`.env` alone would have done nothing at all.
+
+Nothing has to be done by hand for this: step 3 pulls the new compose file
+with the rest of main, and the step 4 recreate is what makes the containers
+read it. `deploy/deploy-3.1.sh` proves it before recreating anything, with
+`docker compose config` on the server: the flag has to render as
+`PARAMANT_INLINE_RECEIPT_HEADER: "1"` on all five relays, or the deploy stops
+there rather than at the smoke test with 3.1.0 already live.
+
+Every other environment variable this runbook mentions already had its line.
 
 ## The brake, and why the deploy is now allowed
 

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -9,7 +9,7 @@
 #
 # Usage:
 #   bash deploy/deploy-3.1.sh                  full deploy, phases 0 to 7
-#   bash deploy/deploy-3.1.sh --preflight-only phases 0 and 1, then stop
+#   bash deploy/deploy-3.1.sh --preflight-only phases 0 and 1, read-only
 #   bash deploy/deploy-3.1.sh --rollback <TS>  phase 8, back to the <TS> backup
 #   bash deploy/deploy-3.1.sh --dry-run        print every remote and gated
 #                                              command instead of running it
@@ -18,7 +18,8 @@
 #
 # Secrets: this script never prints a key value. Environment variables are
 # reported as "empty" or "set, prefix <first 5 chars>", which is the shape the
-# runbook's own step 1 uses. No remote block runs under set -x.
+# runbook's own step 1 uses. No remote block runs under set -x, and no read of
+# .env is ever written to stdout.
 #
 # Everything the script prints also lands in deploy/logs/deploy-3.1-<TS>.log.
 
@@ -34,6 +35,15 @@ BACKUP_DIR="${PARAMANT_BACKUP_DIR:-/home/paramant/backups}"
 NGINX_BACKUP_DIR=/etc/nginx/backups
 NGINX_SITES=/etc/nginx/sites-enabled
 
+# The two server confs the runbook names. Phase 5 edits these and nothing else:
+# a wildcard loop over sites-enabled would silently rewrite a conf nobody
+# reviewed. Override only if the server names them differently.
+NGINX_CONFS="${PARAMANT_NGINX_CONFS:-paramant-public.conf paramant-live.conf}"
+
+# Present on the server by design, absent from the repo. Same list as
+# scripts/check-prod-drift.sh: these are never pruned from the docroot.
+DOCROOT_IGNORE="dist paramant-mark.svg developer.js docs/paramant-investor-brief.html"
+
 DEPLOY_REF="${DEPLOY_REF:-origin/main}"
 EXPECT_PROD_COMMIT="${EXPECT_PROD_COMMIT:-41501bb}"   # runbook: where we start
 EXPECT_VERSION="3.1.0"
@@ -45,12 +55,14 @@ cd "$ROOT"
 
 SSH_OPTS=(-i "$PROD_KEY" -o BatchMode=yes -o IdentitiesOnly=yes
           -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15)
-SSH_SHOWN="ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes $PROD_HOST 'bash -s'"
+SSH_SHOWN="ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes $PROD_HOST"
 
 DRY_RUN=0
 PREFLIGHT_ONLY=0
 ROLLBACK_TS=""
 REMOTE_OUT=""
+REMOTE_RC=0
+PREV_HEAD=""
 WARNINGS=0
 SUMMARY=""
 
@@ -76,10 +88,6 @@ die()   { printf '\n  STOP  %s\n' "$*" >&2
           printf '\nThe deploy stopped. Nothing further ran. Log: %s\n' "${LOG:-<none>}" >&2
           exit 1; }
 
-# Evidence around a step that changes the server. Both lines always print, so
-# the log shows the state the change was applied to and the state it produced.
-evidence() { printf '  %-7s %s\n' "$1" "$2"; }
-
 # --------------------------------------------------------------- executables --
 
 # run_gated: a local command that reaches the network or the server, or that is
@@ -98,23 +106,52 @@ run_gated() {
   return $rc
 }
 
+# q_args: shell-quote each argument into one string.
+#
+# This is load bearing. ssh does NOT preserve argv: it joins everything after
+# the host into a single command string and the remote shell splits it again on
+# whitespace. So `ssh host 'bash -s' -- "$COMPOSE_DIR" "$SERVICES"` arrives as
+# `bash -s -- /opt/paramant-relay relay-main relay-health ...` and the remote
+# $2 is "relay-main", not the six names. Every loop over "$2" then ran once.
+# printf %q makes each argument survive that second split intact.
+q_args() {
+  local a out=""
+  for a in "$@"; do out="$out $(printf '%q' "$a")"; done
+  printf '%s' "$out"
+}
+
 # remote: run a heredoc on the server over one ssh call. Arguments after the
-# label are passed to the remote bash as $1, $2, ... so nothing has to be
-# interpolated into the heredoc body locally.
-remote() {
+# label reach the remote bash as $1, $2, ... with their spaces intact.
+# A non-zero exit stops the deploy and prints the output as the diagnosis.
+_remote_run() {
   local label="$1"; shift
-  local body rc=0
+  local body qargs
   body="$(cat)"
-  printf '\n  $ %s -- %s   # %s\n' "$SSH_SHOWN" "$*" "$label"
+  qargs="$(q_args "$@")"
+  printf '\n  $ %s "bash -s --%s"   # %s\n' "$SSH_SHOWN" "$qargs" "$label"
   if [ "$DRY_RUN" -eq 1 ]; then
     printf '%s\n' "$body" | sed 's/^/  [dry-run] > /'
     REMOTE_OUT=""
+    REMOTE_RC=0
     return 0
   fi
-  REMOTE_OUT="$(printf '%s\n' "$body" | ssh "${SSH_OPTS[@]}" "$PROD_HOST" 'bash -s' -- "$@" 2>&1)" || rc=$?
+  REMOTE_RC=0
+  REMOTE_OUT="$(printf '%s\n' "$body" | ssh "${SSH_OPTS[@]}" "$PROD_HOST" "bash -s --$qargs" 2>&1)" \
+    || REMOTE_RC=$?
   printf '%s\n' "$REMOTE_OUT" | sed 's/^/  | /'
-  return $rc
+  return 0
 }
+
+remote() {
+  local label="$1"
+  _remote_run "$@"
+  if [ "$REMOTE_RC" -ne 0 ]; then
+    die "remote step '$label' exited $REMOTE_RC; the server output above is the diagnosis"
+  fi
+}
+
+# remote_soft: same, but the caller judges the exit code itself.
+remote_soft() { _remote_run "$@"; }
 
 # expect: assert against the output of the last remote call. Skipped, loudly,
 # under --dry-run, because there was no measurement to judge.
@@ -141,6 +178,36 @@ expect_not() {
     die "$what -- server output matched /$pattern/, which the runbook forbids"
   fi
   ok "$what"
+}
+
+# remote_field: read one "name = value" line out of the last remote output.
+remote_field() { printf '%s\n' "$REMOTE_OUT" | sed -n "s/^$1 = //p" | head -1; }
+
+# expect_count: assert a printed measurement equals an exact number.
+expect_count() {
+  local field="$1" want="$2" what="$3" got
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  SKIP  assert (dry-run): %s   [%s = %s]\n' "$what" "$field" "$want"
+    return 0
+  fi
+  got="$(remote_field "$field")"
+  [ -n "$got" ] || die "$what -- the server never printed '$field'"
+  [ "$got" = "$want" ] || die "$what -- $field is $got, expected $want"
+  ok "$what ($field = $got)"
+}
+
+# expect_min: assert a printed measurement is at least N.
+expect_min() {
+  local field="$1" min="$2" what="$3" got
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  SKIP  assert (dry-run): %s   [%s >= %s]\n' "$what" "$field" "$min"
+    return 0
+  fi
+  got="$(remote_field "$field")"
+  [ -n "$got" ] || die "$what -- the server never printed '$field'"
+  printf '%s' "$got" | grep -qE '^[0-9]+$' || die "$what -- $field is '$got', not a number"
+  [ "$got" -ge "$min" ] || die "$what -- $field is $got, expected at least $min"
+  ok "$what ($field = $got)"
 }
 
 # ------------------------------------------------- the static sanity reading --
@@ -213,7 +280,7 @@ fi
 exec > >(tee -a "$LOG") 2>&1
 
 MODE="full deploy"
-[ "$PREFLIGHT_ONLY" -eq 1 ] && MODE="preflight only (phases 0 and 1)"
+[ "$PREFLIGHT_ONLY" -eq 1 ] && MODE="preflight only (phases 0 and 1, read-only)"
 [ -n "$ROLLBACK_TS" ] && MODE="rollback to $ROLLBACK_TS (phase 8)"
 [ "$DRY_RUN" -eq 1 ] && MODE="$MODE, DRY RUN (nothing is executed on the server)"
 
@@ -226,6 +293,7 @@ printf '  run TS        %s\n' "$TS"
 printf '  target        %s\n' "$PROD_HOST"
 printf '  compose dir   %s\n' "$COMPOSE_DIR"
 printf '  docroot       %s\n' "$DOCROOT"
+printf '  nginx confs   %s\n' "$NGINX_CONFS"
 printf '  deploy ref    %s\n' "$DEPLOY_REF"
 printf '  log           %s\n' "$LOG"
 
@@ -288,7 +356,7 @@ phase_0() {
     [ "$DRY_RUN" -eq 0 ] && ok "prod drift guard: docroot matches $DEPLOY_REF"
   else
     if [ "$DRY_RUN" -eq 0 ]; then
-      warn "prod drift guard reported drift or could not check; read the list above before phase 5 overwrites the docroot"
+      warn "prod drift guard reported drift or could not check; read the list above before phase 5 touches the docroot"
     fi
   fi
 
@@ -300,44 +368,50 @@ phase_0() {
 # =============================================================== PHASE 1 =====
 
 phase_1() {
-  phase 1 "Layout and environment (server, read-only, one write)" "Step 1"
+  if [ "$PREFLIGHT_ONLY" -eq 1 ]; then
+    phase 1 "Layout and environment (server, read-only)" "Step 1, without the writes"
+    note "--preflight-only: steps 1c and 1d only report. Nothing is written."
+  else
+    phase 1 "Layout and environment (server, read-only plus two env writes)" "Step 1"
+  fi
 
   step "1a. checkout, compose project and container health"
   remote "layout and health" "$COMPOSE_DIR" "$SERVICES" <<'EOF'
-set -uo pipefail
-cd "$1" || { echo "FATAL cannot cd to $1"; exit 1; }
-echo "checkout_head=$(git rev-parse --short HEAD)"
-echo "checkout_dir=$PWD"
-echo "compose_file_present=$([ -f docker-compose.yml ] && echo yes || echo no)"
-docker compose ls 2>&1 | sed 's/^/compose_ls /'
+set -euo pipefail
+cd "$1"
+echo "checkout_head = $(git rev-parse --short HEAD)"
+echo "checkout_dir = $PWD"
+docker compose ls 2>&1 | sed 's/^/compose_ls /' || true
+found=0
 for svc in $2; do
-  cid=$(docker compose ps -q "$svc" 2>/dev/null)
+  cid="$(docker compose ps -q "$svc" 2>/dev/null || true)"
   if [ -z "$cid" ]; then
     echo "container $svc MISSING"
     continue
   fi
-  st=$(docker inspect -f '{{.State.Status}}/{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealthcheck{{end}}' "$cid")
+  st="$(docker inspect -f '{{.State.Status}}/{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealthcheck{{end}}' "$cid")"
   echo "container $svc $st"
+  found=$((found + 1))
 done
+echo "services seen = $found"
 EOF
 
-  expect "checkout_head=$EXPECT_PROD_COMMIT" \
+  expect "checkout_head = $EXPECT_PROD_COMMIT" \
     "production checkout is on $EXPECT_PROD_COMMIT, the commit the runbook measured"
-  expect_not 'container [a-z-]+ MISSING' "all six services have a container"
+  expect_count "services seen" 6 "all six services have a container"
+  expect_not 'container [a-z-]+ MISSING' "no service is missing a container"
   expect_not 'unhealthy' "no container reports unhealthy"
 
   step "1b. environment presence (never values)"
   remote "env presence" "$COMPOSE_DIR" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
-for v in BILLING_MODE MOLLIE_API_KEY MOLLIE_TEST_API_KEY INTERNAL_AUTH_TOKEN ADMIN_TOKEN PARAMANT_TOTP_MASTER_KEY RELAY_REDIS_URL; do
+set -euo pipefail
+cd "$1"
+for v in BILLING_MODE MOLLIE_API_KEY MOLLIE_TEST_API_KEY INTERNAL_AUTH_TOKEN ADMIN_TOKEN PARAMANT_TOTP_MASTER_KEY RELAY_REDIS_URL PARAMANT_INLINE_RECEIPT_HEADER; do
   printf 'env %-26s ' "$v"
   docker compose exec -T relay-main sh -c \
     "v=\$(printenv $v); if [ -z \"\$v\" ]; then echo empty; else echo \"set, prefix \$(printf %s \"\$v\" | cut -c1-5)\"; fi" \
     2>/dev/null || echo "unreadable"
 done
-echo "envfile INTERNAL_AUTH_TOKEN lines=$(grep -c '^INTERNAL_AUTH_TOKEN=' .env || true)"
-echo "envfile BILLING_MODE lines=$(grep -c '^BILLING_MODE=.\+' .env || true)"
 EOF
 
   expect 'env BILLING_MODE +empty' \
@@ -345,33 +419,86 @@ EOF
   expect 'env MOLLIE_API_KEY +set, prefix live_' \
     "MOLLIE_API_KEY is set with a live_ prefix, unchanged since 08-08"
 
-  step "1c. INTERNAL_AUTH_TOKEN (WRITE if absent: step 5 cannot read /v2/health/deep without it)"
-  remote "internal auth token" "$COMPOSE_DIR" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
-before=$(grep -c '^INTERNAL_AUTH_TOKEN=.\+' .env || true)
-echo "before INTERNAL_AUTH_TOKEN non-empty lines in .env = $before"
+  local envmode="write"
+  [ "$PREFLIGHT_ONLY" -eq 1 ] && envmode="report"
+
+  step "1c. INTERNAL_AUTH_TOKEN (${envmode}: step 6 cannot read /v2/health/deep without it)"
+  remote "internal auth token" "$COMPOSE_DIR" "$envmode" <<'EOF'
+set -euo pipefail
+cd "$1"
+MODE="$2"
+# Counts only. The value is never read into a variable that reaches stdout.
+before="$(grep -c '^INTERNAL_AUTH_TOKEN=.\+' .env || true)"
+echo "before INTERNAL_AUTH_TOKEN lines = $before"
 if [ "$before" -eq 0 ]; then
-  cp -a .env ".env.bak-before-iat-$(date +%Y%m%d-%H%M%S)"
-  sed -i '/^INTERNAL_AUTH_TOKEN=$/d' .env
-  tok=$(openssl rand -hex 32)
-  printf 'INTERNAL_AUTH_TOKEN=%s\n' "$tok" >> .env
-  chmod 600 .env
-  echo "action GENERATED a new INTERNAL_AUTH_TOKEN and appended it to .env"
-  echo "action new token prefix $(printf %s "$tok" | cut -c1-5), length ${#tok}"
-  echo "action the containers pick it up when phase 4 recreates them, nothing restarted now"
-  unset tok
+  if [ "$MODE" = report ]; then
+    echo "action REPORT ONLY: INTERNAL_AUTH_TOKEN is missing and a full run would generate one"
+  else
+    cp -a .env ".env.bak-before-iat-$(date +%Y%m%d-%H%M%S)"
+    sed -i '/^INTERNAL_AUTH_TOKEN=$/d' .env
+    tok="$(openssl rand -hex 32)"
+    printf 'INTERNAL_AUTH_TOKEN=%s\n' "$tok" >> .env
+    chmod 600 .env
+    echo "action GENERATED a new INTERNAL_AUTH_TOKEN and appended it to .env"
+    echo "action new token prefix $(printf %s "$tok" | cut -c1-5), length ${#tok}"
+    unset tok
+  fi
 else
   echo "action none, INTERNAL_AUTH_TOKEN was already set"
 fi
-after=$(grep -c '^INTERNAL_AUTH_TOKEN=.\+' .env || true)
-echo "after INTERNAL_AUTH_TOKEN non-empty lines in .env = $after"
+echo "after INTERNAL_AUTH_TOKEN lines = $(grep -c '^INTERNAL_AUTH_TOKEN=.\+' .env || true)"
 EOF
 
-  expect 'after INTERNAL_AUTH_TOKEN non-empty lines in \.env = 1' \
-    "INTERNAL_AUTH_TOKEN present exactly once in .env"
-  if [ "$DRY_RUN" -eq 0 ] && printf '%s\n' "$REMOTE_OUT" | grep -q 'action GENERATED'; then
-    warn "a new INTERNAL_AUTH_TOKEN was generated on the server; note it in the deploy record"
+  if [ "$PREFLIGHT_ONLY" -eq 1 ]; then
+    if [ "$DRY_RUN" -eq 0 ] && printf '%s\n' "$REMOTE_OUT" | grep -q 'action REPORT ONLY'; then
+      warn "INTERNAL_AUTH_TOKEN is missing; a full run will generate one. Preflight wrote nothing."
+    else
+      ok "INTERNAL_AUTH_TOKEN state reported, nothing written"
+    fi
+  else
+    expect_count "after INTERNAL_AUTH_TOKEN lines" 1 "INTERNAL_AUTH_TOKEN present exactly once in .env"
+    if [ "$DRY_RUN" -eq 0 ] && printf '%s\n' "$REMOTE_OUT" | grep -q 'action GENERATED'; then
+      warn "a new INTERNAL_AUTH_TOKEN was generated on the server; note it in the deploy record"
+    fi
+  fi
+
+  step "1d. PARAMANT_INLINE_RECEIPT_HEADER (${envmode}: keeps old SDK clients receipted)"
+  note "the SDK release that reads the new receipt-by-reference shape (3.3.0) cannot"
+  note "reach PyPI: the project has no trusted publisher. Reported 2026-09-02, not"
+  note "measured here. So this deploy takes the runbook's first way out and turns the"
+  note "deprecated inline header back on. Phase 5 raises the nginx proxy buffers that"
+  note "the fat header needs, or every download would answer 502 instead."
+  remote "inline receipt opt-in" "$COMPOSE_DIR" "$envmode" <<'EOF'
+set -euo pipefail
+cd "$1"
+MODE="$2"
+before="$(grep -c '^PARAMANT_INLINE_RECEIPT_HEADER=1$' .env || true)"
+echo "before PARAMANT_INLINE_RECEIPT_HEADER lines = $before"
+if [ "$before" -eq 0 ]; then
+  if [ "$MODE" = report ]; then
+    echo "action REPORT ONLY: PARAMANT_INLINE_RECEIPT_HEADER is not set and a full run would set it to 1"
+  else
+    cp -a .env ".env.bak-before-inline-receipt-$(date +%Y%m%d-%H%M%S)"
+    sed -i '/^PARAMANT_INLINE_RECEIPT_HEADER=/d' .env
+    echo 'PARAMANT_INLINE_RECEIPT_HEADER=1' >> .env
+    chmod 600 .env
+    echo "action SET PARAMANT_INLINE_RECEIPT_HEADER=1"
+    echo "action deprecated, removed after 2026-12-01; take it out once 3.3.0 is on PyPI"
+  fi
+else
+  echo "action none, PARAMANT_INLINE_RECEIPT_HEADER=1 was already set"
+fi
+echo "after PARAMANT_INLINE_RECEIPT_HEADER lines = $(grep -c '^PARAMANT_INLINE_RECEIPT_HEADER=1$' .env || true)"
+EOF
+
+  if [ "$PREFLIGHT_ONLY" -eq 1 ]; then
+    ok "inline receipt flag state reported, nothing written"
+  else
+    expect_count "after PARAMANT_INLINE_RECEIPT_HEADER lines" 1 \
+      "PARAMANT_INLINE_RECEIPT_HEADER=1 present exactly once in .env"
+    if [ "$DRY_RUN" -eq 0 ] && printf '%s\n' "$REMOTE_OUT" | grep -q 'action SET PARAMANT_INLINE'; then
+      warn "the deprecated inline receipt header was switched on; remove it once paramant-sdk 3.3.0 reaches PyPI (one line in .env plus a recreate)"
+    fi
   fi
 }
 
@@ -382,17 +509,20 @@ phase_2() {
 
   step "2a. tag the running images and write the manifest"
   remote "rollback tags" "$COMPOSE_DIR" "$TS" "$BACKUP_DIR" "$SERVICES" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
+set -euo pipefail
+cd "$1"
 TS="$2"; BK="$3"; SVCS="$4"
 mkdir -p "$BK"
 MANIFEST="$BK/rollback-images-$TS.txt"
-echo "before existing rollback tags = $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -c '^paramant-rollback/' || true)"
+echo "before tags for this TS = $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -c ":$TS\$" || true)"
 : > "$MANIFEST"
 for svc in $SVCS; do
-  cid=$(docker compose ps -q "$svc" 2>/dev/null)
-  [ -z "$cid" ] && { echo "skip $svc (not running)"; continue; }
-  img=$(docker inspect --format '{{.Config.Image}}' "$cid")
+  cid="$(docker compose ps -q "$svc" 2>/dev/null || true)"
+  if [ -z "$cid" ]; then
+    echo "skip $svc (not running)"
+    continue
+  fi
+  img="$(docker inspect --format '{{.Config.Image}}' "$cid")"
   docker tag "$img" "paramant-rollback/$svc:$TS"
   echo "$svc|$img|paramant-rollback/$svc:$TS" >> "$MANIFEST"
 done
@@ -401,53 +531,68 @@ echo "--- manifest $MANIFEST ---"
 cat "$MANIFEST"
 echo "--- end manifest ---"
 echo "after manifest lines = $(wc -l < "$MANIFEST")"
-echo "after existing rollback tags = $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -c '^paramant-rollback/' || true)"
+# The tags are what phase 8 actually restores, so count the tags, not the text.
+echo "after tags for this TS = $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -c "^paramant-rollback/.*:$TS\$" || true)"
 EOF
 
-  expect 'after manifest lines = 6' \
-    "rollback manifest has six lines, one per service, so phase 8 can undo this deploy"
+  expect_count "after manifest lines" 6 "the rollback manifest has six lines, one per service"
+  expect_count "after tags for this TS" 6 "six rollback images really exist on the host, not just six lines of text"
 
   step "2b. back up .env, compose state, docroot and the nginx confs"
-  remote "backups" "$COMPOSE_DIR" "$TS" "$BACKUP_DIR" "$DOCROOT" "$NGINX_BACKUP_DIR" "$NGINX_SITES" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
-TS="$2"; BK="$3"; DOCROOT="$4"; NGBK="$5"; NGSITES="$6"
+  remote "backups" "$COMPOSE_DIR" "$TS" "$BACKUP_DIR" "$DOCROOT" "$NGINX_BACKUP_DIR" "$NGINX_SITES" "$NGINX_CONFS" <<'EOF'
+set -euo pipefail
+cd "$1"
+TS="$2"; BK="$3"; DOCROOT="$4"; NGBK="$5"; NGSITES="$6"; CONFS="$7"
 mkdir -p "$BK" "$NGBK"
 
-echo "before .env bytes = $(stat -c%s .env 2>/dev/null || echo missing)"
-cp .env "$BK/.env-pre-3.1-$TS" && chmod 600 "$BK/.env-pre-3.1-$TS"
-echo "after  .env backup = $BK/.env-pre-3.1-$TS ($(stat -c%s "$BK/.env-pre-3.1-$TS") bytes, mode $(stat -c%a "$BK/.env-pre-3.1-$TS"))"
+echo "before .env bytes = $(stat -c%s .env)"
+cp .env "$BK/.env-pre-3.1-$TS"
+chmod 600 "$BK/.env-pre-3.1-$TS"
+echo "after .env backup bytes = $(stat -c%s "$BK/.env-pre-3.1-$TS")"
 
 docker compose ps > "$BK/state-pre-3.1-$TS.txt"
-echo "after  compose state = $BK/state-pre-3.1-$TS.txt ($(wc -l < "$BK/state-pre-3.1-$TS.txt") lines)"
+echo "after compose state lines = $(wc -l < "$BK/state-pre-3.1-$TS.txt")"
 
 echo "before docroot files = $(find "$DOCROOT" -type f | wc -l)"
 tar czf "$BK/docroot-pre-3.1-$TS.tgz" -C "$(dirname "$DOCROOT")" "$(basename "$DOCROOT")"
-echo "after  docroot tar = $BK/docroot-pre-3.1-$TS.tgz ($(stat -c%s "$BK/docroot-pre-3.1-$TS.tgz") bytes, $(tar tzf "$BK/docroot-pre-3.1-$TS.tgz" | wc -l) entries)"
+echo "after docroot tar bytes = $(stat -c%s "$BK/docroot-pre-3.1-$TS.tgz")"
+echo "after docroot tar entries = $(tar tzf "$BK/docroot-pre-3.1-$TS.tgz" | wc -l)"
 
-# Back up every enabled site conf, not only the public one: phase 5 edits
-# whichever files actually carry the lines the runbook names.
+# sites-enabled entries are usually symlinks into sites-available. cp -a of a
+# symlink copies the link, not the file, which is not a backup: resolve first.
 n=0
-for f in "$NGSITES"/*; do
-  [ -f "$f" ] || continue
-  cp -a "$f" "$NGBK/$(basename "$f").pre-3.1-$TS"
-  n=$((n+1))
+for name in $CONFS; do
+  link="$NGSITES/$name"
+  if [ ! -e "$link" ]; then
+    echo "nginxconf $name ABSENT"
+    continue
+  fi
+  target="$(readlink -f "$link")"
+  echo "nginxconf $name -> $target ($(stat -c%s "$target") bytes)"
+  cp -a "$target" "$NGBK/$name.pre-3.1-$TS"
+  echo "nginxbackup $name.pre-3.1-$TS $(stat -c%s "$NGBK/$name.pre-3.1-$TS") bytes"
+  n=$((n + 1))
 done
-echo "after  nginx conf backups = $n file(s) in $NGBK with suffix .pre-3.1-$TS"
-ls -1 "$NGBK" | grep -F "pre-3.1-$TS" | sed 's/^/nginxbackup /'
+echo "after nginx conf backups = $n"
 
 if [ -x deploy/ops/backup-full-state.sh ]; then
   echo "--- deploy/ops/backup-full-state.sh ---"
-  bash deploy/ops/backup-full-state.sh 2>&1 | tail -25
-  echo "fullstate exit=${PIPESTATUS[0]}"
+  rc=0
+  bash deploy/ops/backup-full-state.sh > /tmp/paramant-fullstate.$$ 2>&1 || rc=$?
+  tail -25 /tmp/paramant-fullstate.$$
+  rm -f /tmp/paramant-fullstate.$$
+  echo "fullstate exit = $rc"
 else
   echo "fullstate deploy/ops/backup-full-state.sh not present or not executable, skipped"
 fi
 EOF
 
-  expect "after  \\.env backup = $BACKUP_DIR/\\.env-pre-3\\.1-$TS" ".env backed up"
-  expect "after  docroot tar = $BACKUP_DIR/docroot-pre-3\\.1-$TS\\.tgz" "docroot tarred"
-  expect 'after  nginx conf backups = [1-9]' "at least one nginx conf backed up"
+  expect_min "after .env backup bytes" 1 ".env backup is a real file with content"
+  expect_min "after docroot tar bytes" 1 "docroot tar is a real file with content"
+  expect_min "after docroot tar entries" 1 "docroot tar holds entries"
+  expect_count "after nginx conf backups" 2 "both named nginx confs were resolved and backed up"
+  expect_not 'nginxconf [a-z.-]+ ABSENT' \
+    "both named nginx confs exist on the server (set PARAMANT_NGINX_CONFS if they are named differently)"
 }
 
 # =============================================================== PHASE 3 =====
@@ -457,16 +602,16 @@ phase_3() {
 
   step "3a. pull $DEPLOY_REF fast-forward only"
   remote "git pull" "$COMPOSE_DIR" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
+set -euo pipefail
+cd "$1"
 echo "before HEAD = $(git rev-parse --short HEAD)"
-echo "before status:"
-git status --porcelain | sed 's/^/  dirty /'
+echo "before HEAD long = $(git rev-parse HEAD)"
 if [ -n "$(git status --porcelain)" ]; then
+  git status --porcelain | sed 's/^/  dirty /'
   echo "FATAL working tree not clean; stash and note what it was before deploying"
   exit 1
 fi
-git fetch origin 2>&1 | sed 's/^/  fetch /'
+git fetch origin 2>&1 | sed 's/^/  fetch /' || true
 git pull --ff-only origin main 2>&1 | sed 's/^/  pull /'
 echo "after HEAD = $(git rev-parse --short HEAD)"
 echo "after HEAD long = $(git rev-parse HEAD)"
@@ -474,38 +619,51 @@ EOF
 
   expect_not 'FATAL working tree not clean' "server working tree was clean before the pull"
   if [ "$DRY_RUN" -eq 0 ]; then
-    local after_head; after_head="$(printf '%s\n' "$REMOTE_OUT" | sed -n 's/^after HEAD long = //p')"
-    local want; want="$(git rev-parse "$DEPLOY_REF")"
+    local after_head want
+    PREV_HEAD="$(remote_field 'before HEAD long')"
+    after_head="$(remote_field 'after HEAD long')"
+    want="$(git rev-parse "$DEPLOY_REF")"
     [ -n "$after_head" ] || die "could not read the server HEAD after the pull"
     [ "$after_head" = "$want" ] \
       || die "server is on $after_head after the pull, expected $want ($DEPLOY_REF, the commit phase 0 tested)"
     ok "server checkout is on ${after_head:0:7}, the commit phase 0 tested"
-    printf '%s\n' "$REMOTE_OUT" | grep -q "before HEAD = $EXPECT_PROD_COMMIT" \
-      || warn "server was not on $EXPECT_PROD_COMMIT before the pull; the rollback images are still correct, but the runbook's starting point was different"
+    if ! printf '%s\n' "$REMOTE_OUT" | grep -q "before HEAD = $EXPECT_PROD_COMMIT"; then
+      warn "server was not on $EXPECT_PROD_COMMIT before the pull; the rollback images are still correct, but the runbook's starting point was different"
+    fi
   fi
 
   step "3b. static sanity on the server, same reading rule as phase 0"
-  remote "static sanity" "$COMPOSE_DIR" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
-bash tests/static-sanity.sh 2>&1
-echo "sanity exit=$?"
+  remote_soft "static sanity" "$COMPOSE_DIR" <<'EOF'
+set -euo pipefail
+cd "$1"
+rc=0
+bash tests/static-sanity.sh > /tmp/paramant-sanity.$$ 2>&1 || rc=$?
+cat /tmp/paramant-sanity.$$
+rm -f /tmp/paramant-sanity.$$
+echo "sanity exit = $rc"
 EOF
-  [ "$DRY_RUN" -eq 1 ] && printf '  SKIP  assert (dry-run): static sanity on the server\n' \
-    || sanity_verdict "$REMOTE_OUT" "server"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  SKIP  assert (dry-run): static sanity on the server\n'
+  else
+    sanity_verdict "$REMOTE_OUT" "server"
+  fi
 
   step "3c. build the relays and admin from source (containers untouched)"
   remote "docker compose build" "$COMPOSE_DIR" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
+set -euo pipefail
+cd "$1"
 echo "before images:"
-docker compose images 2>/dev/null | sed 's/^/  img /'
-docker compose build 2>&1 | tail -40
-echo "build exit=${PIPESTATUS[0]}"
+docker compose images 2>/dev/null | sed 's/^/  img /' || true
+rc=0
+docker compose build > /tmp/paramant-build.$$ 2>&1 || rc=$?
+tail -40 /tmp/paramant-build.$$
+rm -f /tmp/paramant-build.$$
+echo "build exit = $rc"
+[ "$rc" -eq 0 ] || exit 1
 echo "after images:"
-docker compose images 2>/dev/null | sed 's/^/  img /'
+docker compose images 2>/dev/null | sed 's/^/  img /' || true
 EOF
-  expect 'build exit=0' "docker compose build succeeded"
+  expect_count "build exit" 0 "docker compose build succeeded"
 }
 
 # =============================================================== PHASE 4 =====
@@ -515,36 +673,42 @@ phase_4() {
 
   step "4a. relay-iot alone, then read its two boot lines"
   remote "recreate relay-iot" "$COMPOSE_DIR" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
+set -euo pipefail
+cd "$1"
 
 wait_healthy() {  # container id, max seconds
-  local w=0
+  local w=0 s
   while [ "$w" -lt "${2:-60}" ]; do
-    s=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealthcheck{{end}}' "$1" 2>/dev/null || echo unknown)
-    [ "$s" = healthy ] && { echo "healthy $1 after ${w}s"; return 0; }
-    [ "$s" = nohealthcheck ] && { echo "healthy $1 (no healthcheck defined, running)"; return 0; }
-    [ "$s" = unhealthy ] && { echo "UNHEALTHY $1"; docker logs "$1" 2>&1 | tail -20; return 1; }
-    sleep 5; w=$((w+5))
+    s="$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealthcheck{{end}}' "$1" 2>/dev/null || echo unknown)"
+    if [ "$s" = healthy ]; then
+      echo "healthy $1 after ${w}s"; return 0
+    elif [ "$s" = nohealthcheck ]; then
+      echo "healthy $1 (no healthcheck defined, running)"; return 0
+    elif [ "$s" = unhealthy ]; then
+      echo "UNHEALTHY $1"; docker logs "$1" 2>&1 | tail -20 || true; return 1
+    fi
+    sleep 5; w=$((w + 5))
   done
   echo "NOTHEALTHY $1 after ${2:-60}s"
   return 1
 }
 
-old=$(docker compose ps -q relay-iot 2>/dev/null)
-echo "before relay-iot container = ${old:-none}"
-[ -n "$old" ] && echo "before relay-iot image = $(docker inspect -f '{{.Image}}' "$old")"
+old="$(docker compose ps -q relay-iot 2>/dev/null || true)"
+if [ -n "$old" ]; then
+  echo "before relay-iot image = $(docker inspect -f '{{.Image}}' "$old")"
+else
+  echo "before relay-iot image = none"
+fi
 
 docker compose up -d --no-deps relay-iot 2>&1 | sed 's/^/  up /'
-cid=$(docker compose ps -q relay-iot)
+cid="$(docker compose ps -q relay-iot)"
 [ -n "$cid" ] || { echo "FATAL relay-iot has no container after up"; exit 1; }
-echo "after  relay-iot container = $cid"
-echo "after  relay-iot image = $(docker inspect -f '{{.Image}}' "$cid")"
+echo "after relay-iot image = $(docker inspect -f '{{.Image}}' "$cid")"
 
-wait_healthy "$cid" 120 || exit 1
+wait_healthy "$cid" 120
 
 echo "--- relay-iot boot lines ---"
-docker logs "$cid" 2>&1 | grep -E '"relay_started"|"billing_config"' | tail -4 | sed 's/^/bootline /'
+docker logs "$cid" 2>&1 | grep -E '"relay_started"|"billing_config"' | tail -4 | sed 's/^/bootline /' || true
 echo "--- end boot lines ---"
 EOF
 
@@ -554,55 +718,62 @@ EOF
     "billing_config says recurring:false, the brake is on"
   expect 'bootline .*"billing_config".*"mode_source":"inferred"' \
     "billing_config says mode_source:inferred, so BILLING_MODE is not set anywhere"
-  expect_not '"billing_config".*"recurring":true' \
-    "no relay reports recurring:true"
+  expect_not '"billing_config".*"recurring":true' "no relay reports recurring:true"
   expect "bootline .*\"relay_started\".*\"version\":\"$EXPECT_VERSION\"" \
     "relay_started reports version $EXPECT_VERSION"
 
   step "4b. relay-main, then the rest"
   remote "recreate the fleet" "$COMPOSE_DIR" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
+set -euo pipefail
+cd "$1"
 
 wait_healthy() {
-  local w=0
+  local w=0 s
   while [ "$w" -lt "${2:-60}" ]; do
-    s=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealthcheck{{end}}' "$1" 2>/dev/null || echo unknown)
-    [ "$s" = healthy ] && { echo "healthy $1 after ${w}s"; return 0; }
-    [ "$s" = nohealthcheck ] && { echo "healthy $1 (no healthcheck defined, running)"; return 0; }
-    [ "$s" = unhealthy ] && { echo "UNHEALTHY $1"; docker logs "$1" 2>&1 | tail -20; return 1; }
-    sleep 5; w=$((w+5))
+    s="$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealthcheck{{end}}' "$1" 2>/dev/null || echo unknown)"
+    if [ "$s" = healthy ]; then
+      echo "healthy $1 after ${w}s"; return 0
+    elif [ "$s" = nohealthcheck ]; then
+      echo "healthy $1 (no healthcheck defined, running)"; return 0
+    elif [ "$s" = unhealthy ]; then
+      echo "UNHEALTHY $1"; docker logs "$1" 2>&1 | tail -20 || true; return 1
+    fi
+    sleep 5; w=$((w + 5))
   done
   echo "NOTHEALTHY $1 after ${2:-60}s"
   return 1
 }
 
 recreate() {
-  local svc="$1"
-  local old; old=$(docker compose ps -q "$svc" 2>/dev/null)
-  echo "before $svc image = $([ -n "$old" ] && docker inspect -f '{{.Image}}' "$old" || echo none)"
-  docker compose up -d --no-deps "$svc" 2>&1 | sed "s/^/  up /"
-  local cid; cid=$(docker compose ps -q "$svc")
+  local svc="$1" old cid
+  old="$(docker compose ps -q "$svc" 2>/dev/null || true)"
+  if [ -n "$old" ]; then
+    echo "before $svc image = $(docker inspect -f '{{.Image}}' "$old")"
+  else
+    echo "before $svc image = none"
+  fi
+  docker compose up -d --no-deps "$svc" 2>&1 | sed 's/^/  up /'
+  cid="$(docker compose ps -q "$svc")"
   [ -n "$cid" ] || { echo "FATAL $svc has no container after up"; return 1; }
-  echo "after  $svc image = $(docker inspect -f '{{.Image}}' "$cid")"
-  wait_healthy "$cid" 120 || return 1
+  echo "after $svc image = $(docker inspect -f '{{.Image}}' "$cid")"
+  wait_healthy "$cid" 120
   echo "recreated $svc"
 }
 
-recreate relay-main || exit 1
+recreate relay-main
 for svc in relay-health relay-finance relay-legal admin; do
-  recreate "$svc" || exit 1
+  recreate "$svc"
 done
 
 echo "--- billing stance on every relay ---"
 for svc in relay-main relay-health relay-finance relay-legal relay-iot; do
-  cid=$(docker compose ps -q "$svc")
+  cid="$(docker compose ps -q "$svc")"
   printf 'stance %-14s ' "$svc"
   docker logs "$cid" 2>&1 | grep '"billing_config"' | tail -1 | grep -o '"recurring":[a-z]*' || echo "no billing_config line"
 done
 echo "--- versions ---"
 for svc in relay-main relay-health relay-finance relay-legal relay-iot; do
-  cid=$(docker compose ps -q "$svc")
+  cid="$(docker compose ps -q "$svc")"
   printf 'version %-14s ' "$svc"
   docker logs "$cid" 2>&1 | grep '"relay_started"' | tail -1 | grep -o '"version":"[^"]*"' || echo "no relay_started line"
 done
@@ -620,94 +791,221 @@ EOF
 phase_5() {
   phase 5 "Frontend and nginx (server, WRITE)" "Step 5"
 
+  local base="${PREV_HEAD:-$EXPECT_PROD_COMMIT}"
+
   step "5a. rsync the docroot, never with --delete"
   remote "rsync docroot" "$COMPOSE_DIR" "$DOCROOT" <<'EOF'
-set -uo pipefail
+set -euo pipefail
 SRC="$1/frontend/"; DST="$2/"
 echo "before docroot files = $(find "$2" -type f | wc -l)"
-echo "before would change:"
-rsync -rinc --no-times "$SRC" "$DST" | sed 's/^/  wouldchange /' | head -60
-echo "before would change count = $(rsync -rinc --no-times "$SRC" "$DST" | grep -c . || true)"
-rsync -rc --no-times "$SRC" "$DST" 2>&1 | tail -5 | sed 's/^/  rsync /'
-echo "rsync exit=${PIPESTATUS[0]}"
-echo "after  docroot files = $(find "$2" -type f | wc -l)"
-echo "after  would change count = $(rsync -rinc --no-times "$SRC" "$DST" | grep -c . || true)"
+echo "before would change = $(rsync -rinc --no-times "$SRC" "$DST" | grep -c . || true)"
+rsync -rinc --no-times "$SRC" "$DST" | sed 's/^/  wouldchange /' | head -60 || true
+rc=0
+rsync -rc --no-times "$SRC" "$DST" > /tmp/paramant-rsync.$$ 2>&1 || rc=$?
+tail -5 /tmp/paramant-rsync.$$ | sed 's/^/  rsync /'
+rm -f /tmp/paramant-rsync.$$
+echo "rsync exit = $rc"
+[ "$rc" -eq 0 ] || exit 1
+echo "after docroot files = $(find "$2" -type f | wc -l)"
+echo "after would change = $(rsync -rinc --no-times "$SRC" "$DST" | grep -c . || true)"
 EOF
-  expect 'rsync exit=0' "docroot rsync succeeded"
-  expect 'after  would change count = 0' "docroot now matches the checkout frontend"
+  expect_count "rsync exit" 0 "docroot rsync succeeded"
+  expect_count "after would change" 0 "docroot now matches the checkout frontend"
 
-  step "5b. the three nginx changes, by hand, keeping the ParaID deny"
-  remote "nginx edits" "$TS" "$NGINX_SITES" "$NGINX_BACKUP_DIR" <<'EOF'
-set -uo pipefail
-TS="$1"; SITES="$2"; NGBK="$3"
+  step "5b. prune the frontend files main deleted (rsync without --delete leaves them)"
+  note "a page removed from git keeps being served by try_files until the file"
+  note "goes; the list comes from git, never from a wildcard on the server"
+  remote "prune deleted frontend files" "$COMPOSE_DIR" "$DOCROOT" "$base" "$DOCROOT_IGNORE" <<'EOF'
+set -euo pipefail
+cd "$1"
+DOCROOT="$2"; BASE="$3"; IGNORE="$4"
 
-echo "--- before ---"
-grep -rn 'paraid/issue' "$SITES" 2>/dev/null | sed 's/^/  paraid /' | head -20
-echo "before paraid deny lines = $(grep -rc 'paraid/issue' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
-echo "before sign gated lines = $(grep -rc 'location = /sign.*auth_request' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
-echo "before compliance lines = $(grep -rcE '^[[:space:]]*location = /compliance(/(nis2|iec62443|nen7510))?[[:space:]]*\{' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
-echo "before dicom try_files lines = $(grep -rc 'location = /dicom.*try_files /dicom.html' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
+DEL="$(git diff --diff-filter=D --name-only "$BASE"..HEAD -- frontend/ || true)"
+echo "before deleted-in-git count = $(printf '%s\n' "$DEL" | grep -c . || true)"
 
-PARAID_BEFORE=$(grep -rc 'paraid/issue' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+removed=0
+kept=0
+absent=0
+for f in $DEL; do
+  rel="${f#frontend/}"
+  # Never step outside the docroot, and never touch what the drift guard
+  # legitimately expects to exist only on the server.
+  case "$rel" in
+    ''|*..*) echo "  skip suspicious path $f"; continue ;;
+  esac
+  skip=no
+  for ig in $IGNORE; do
+    case "$rel" in
+      "$ig"|"$ig"/*) skip=yes ;;
+    esac
+  done
+  if [ "$skip" = yes ]; then
+    echo "  keep $rel (on the drift guard IGNORE list)"
+    kept=$((kept + 1))
+    continue
+  fi
+  if [ -f "$DOCROOT/$rel" ]; then
+    rm -f "$DOCROOT/$rel"
+    echo "  removed $rel"
+    removed=$((removed + 1))
+  else
+    absent=$((absent + 1))
+  fi
+done
+echo "after removed = $removed"
+echo "after kept on ignore list = $kept"
+echo "after already absent = $absent"
+echo "after docroot files = $(find "$DOCROOT" -type f | wc -l)"
+EOF
+  expect_min "before deleted-in-git count" 1 \
+    "git names at least one frontend file deleted since the deployed commit"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    local rm_n ab_n
+    rm_n="$(remote_field 'after removed')"
+    ab_n="$(remote_field 'after already absent')"
+    ok "pruned $rm_n stale docroot file(s), $ab_n were already gone"
+  fi
+
+  step "5c. the three nginx changes, by hand, keeping the ParaID deny"
+  remote "nginx edits" "$TS" "$NGINX_SITES" "$NGINX_BACKUP_DIR" "$NGINX_CONFS" <<'EOF'
+set -euo pipefail
+TS="$1"; SITES="$2"; NGBK="$3"; CONFS="$4"
+
+# Resolve the two named confs to real files. A symlink is not the file.
+TARGETS=""
+for name in $CONFS; do
+  link="$SITES/$name"
+  if [ ! -e "$link" ]; then
+    echo "FATAL named nginx conf $name does not exist in $SITES"
+    exit 1
+  fi
+  t="$(readlink -f "$link")"
+  echo "target $name -> $t"
+  TARGETS="$TARGETS $t"
+done
+
+count() { grep -hcE -- "$1" $TARGETS 2>/dev/null | awk '{s+=$1} END{print s+0}'; }
+
+SIGN_RE='location = /sign[[:space:]]*\{[^}]*auth_request'
+COMP_RE='^[[:space:]]*location = /compliance(/(nis2|iec62443|nen7510))?[[:space:]]*\{'
+DICOM_RE='location = /dicom[[:space:]]*\{[[:space:]]*try_files /dicom\.html'
+PARAID_RE='paraid/issue'
+OUT_RE='^[[:space:]]*location[[:space:]]*~[[:space:]]*\^/v2/outbound[[:space:]]*\{'
+BUF_RE='proxy_buffer_size 32k'
+
+echo "before sign gated = $(count "$SIGN_RE")"
+echo "before compliance = $(count "$COMP_RE")"
+echo "before dicom try_files = $(count "$DICOM_RE")"
+echo "before paraid deny = $(count "$PARAID_RE")"
+echo "before outbound locations = $(count "$OUT_RE")"
+echo "before outbound buffers = $(count "$BUF_RE")"
+
+# Each edit must have something to do. A zero here means the server conf is not
+# the shape the runbook describes, and guessing further would be editing blind.
+for pair in "sign:$(count "$SIGN_RE")" "compliance:$(count "$COMP_RE")" "dicom:$(count "$DICOM_RE")"; do
+  n="${pair#*:}"
+  if [ "$n" -eq 0 ]; then
+    echo "FATAL nothing to change for '${pair%%:*}': the server conf does not match the pattern the runbook names"
+    exit 1
+  fi
+done
+if [ "$(count "$PARAID_RE")" -eq 0 ]; then
+  echo "FATAL the ParaID deny is not present; the 01-09 server edit this runbook relies on is gone"
+  exit 1
+fi
+if [ "$(count "$OUT_RE")" -eq 0 ]; then
+  echo "FATAL no location ~ ^/v2/outbound block found; the inline receipt header would 502"
+  exit 1
+fi
 
 edited=0
-for f in "$SITES"/*; do
-  [ -f "$f" ] || continue
+for f in $TARGETS; do
   cp -a "$f" "/tmp/nginx-pre-3.1-$(basename "$f").$TS"
   # 1. /sign leaves the auth_request gate (#317).
   sed -i -E 's|(location = /sign[[:space:]]*\{)[[:space:]]*auth_request /api/user/check; error_page 401 = @login_redirect;|\1|' "$f"
-  # 2. the /compliance locations go (#323), redirect included.
+  # 2. the /compliance locations go (#323), the redirect included.
   sed -i -E '/^[[:space:]]*location = \/compliance(\/(nis2|iec62443|nen7510))?[[:space:]]*\{/d' "$f"
-  # 3. /dicom answers 404 instead of serving the page, exact match kept so
-  #    nginx cannot auto-redirect it into the /dicom/ proxy.
+  # 3. /dicom answers 404 instead of serving the page. The exact match stays so
+  #    nginx cannot auto-redirect it into the /dicom/ proxy below.
   sed -i -E 's|(location = /dicom[[:space:]]*\{)[[:space:]]*try_files /dicom\.html[[:space:]]*=404;[[:space:]]*\}|\1 return 404; }|' "$f"
+  # 4. #342: raise the proxy buffers on /v2/outbound. Nginx has to hold the
+  #    whole upstream header block in ONE buffer, and the default 4k/8k is far
+  #    under the ~19 KB the deprecated inline X-Paramant-Receipt costs, which
+  #    is a 502 on every download. Inserted once, right after the location
+  #    opens; running this twice must not stack a second copy.
+  if ! grep -qF "proxy_buffer_size 32k" "$f"; then
+    awk '{ print }
+         /^[[:space:]]*location[[:space:]]*~[[:space:]]*\^\/v2\/outbound[[:space:]]*\{/ {
+           print "        proxy_buffer_size 32k;"
+           print "        proxy_buffers 8 32k;"
+           print "        proxy_busy_buffers_size 64k;"
+         }' "$f" > "/tmp/nginx-buf.$$"
+    cat "/tmp/nginx-buf.$$" > "$f"
+    rm -f "/tmp/nginx-buf.$$"
+  fi
   if ! cmp -s "$f" "/tmp/nginx-pre-3.1-$(basename "$f").$TS"; then
     echo "edited $(basename "$f")"
-    edited=$((edited+1))
+    edited=$((edited + 1))
   fi
 done
-echo "after  edited files = $edited"
+echo "after edited files = $edited"
+echo "after sign gated = $(count "$SIGN_RE")"
+echo "after compliance = $(count "$COMP_RE")"
+echo "after dicom try_files = $(count "$DICOM_RE")"
+echo "after dicom 404 = $(count 'location = /dicom[[:space:]]*\{[[:space:]]*return 404')"
+echo "after paraid deny = $(count "$PARAID_RE")"
+echo "after outbound locations = $(count "$OUT_RE")"
+echo "after outbound buffers = $(count "$BUF_RE")"
 
-echo "--- after ---"
-echo "after  paraid deny lines = $(grep -rc 'paraid/issue' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
-echo "after  sign gated lines = $(grep -rc 'location = /sign.*auth_request' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
-echo "after  compliance lines = $(grep -rcE '^[[:space:]]*location = /compliance(/(nis2|iec62443|nen7510))?[[:space:]]*\{' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
-echo "after  dicom try_files lines = $(grep -rc 'location = /dicom.*try_files /dicom.html' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
-echo "after  dicom 404 lines = $(grep -rc 'location = /dicom.*return 404' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
-
-PARAID_AFTER=$(grep -rc 'paraid/issue' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
-if [ "$PARAID_AFTER" -lt "$PARAID_BEFORE" ]; then
-  echo "FATAL the ParaID deny lost $((PARAID_BEFORE - PARAID_AFTER)) line(s); restoring"
+restore() {
   for b in "$NGBK"/*.pre-3.1-"$TS"; do
     [ -f "$b" ] || continue
-    cp -a "$b" "$SITES/$(basename "$b" ".pre-3.1-$TS")"
+    name="$(basename "$b" ".pre-3.1-$TS")"
+    cp -a "$b" "$(readlink -f "$SITES/$name")"
   done
+}
+
+if [ "$(count "$PARAID_RE")" -eq 0 ]; then
+  echo "FATAL the ParaID deny disappeared; restoring"
+  restore
   exit 1
 fi
 
-if nginx -t 2>&1 | sed 's/^/  nginxt /'; then
-  systemctl reload nginx && echo "reloaded nginx"
-else
+rc=0
+nginx -t > /tmp/paramant-nginxt.$$ 2>&1 || rc=$?
+sed 's/^/  nginxt /' /tmp/paramant-nginxt.$$
+rm -f /tmp/paramant-nginxt.$$
+if [ "$rc" -ne 0 ]; then
   echo "FATAL nginx -t failed, restoring the backed up confs"
-  for b in "$NGBK"/*.pre-3.1-"$TS"; do
-    [ -f "$b" ] || continue
-    cp -a "$b" "$SITES/$(basename "$b" ".pre-3.1-$TS")"
-  done
-  nginx -t 2>&1 | sed 's/^/  restoredtest /'
+  restore
+  nginx -t 2>&1 | sed 's/^/  restoredtest /' || true
   systemctl reload nginx && echo "restored and reloaded the previous nginx conf"
   exit 1
 fi
+systemctl reload nginx
+echo "reloaded nginx"
 EOF
 
   expect_not 'FATAL' "nginx edits applied and the config tests clean"
-  expect 'after  sign gated lines = 0' "/sign is no longer behind auth_request"
-  expect 'after  compliance lines = 0' "the /compliance locations are gone"
-  expect 'after  dicom try_files lines = 0' "/dicom no longer serves the page"
+  expect_count "after edited files" 2 "both named confs were really rewritten"
+  expect_count "after sign gated" 0 "/sign is no longer behind auth_request"
+  expect_count "after compliance" 0 "the /compliance locations are gone"
+  expect_count "after dicom try_files" 0 "/dicom no longer serves the page"
+  expect_min "after dicom 404" 1 "/dicom now returns 404"
+  expect_min "before outbound locations" 1 "the /v2/outbound location the buffers go on exists"
   expect 'reloaded nginx' "nginx reloaded"
   if [ "$DRY_RUN" -eq 0 ]; then
+    local ol bf
+    ol="$(remote_field 'after outbound locations')"
+    bf="$(remote_field 'after outbound buffers')"
+    [ "$bf" = "$ol" ] \
+      || die "proxy_buffer_size is on $bf of $ol /v2/outbound locations; the inline receipt header would 502 on the rest"
+    ok "every /v2/outbound location carries proxy_buffer_size 32k ($bf of $ol)"
+  fi
+  if [ "$DRY_RUN" -eq 0 ]; then
     local pb pa
-    pb="$(printf '%s\n' "$REMOTE_OUT" | sed -n 's/^before paraid deny lines = //p')"
-    pa="$(printf '%s\n' "$REMOTE_OUT" | sed -n 's/^after  paraid deny lines = //p')"
+    pb="$(remote_field 'before paraid deny')"
+    pa="$(remote_field 'after paraid deny')"
     if [ -n "$pb" ] && [ -n "$pa" ] && [ "$pa" -ge "$pb" ] && [ "$pa" -gt 0 ]; then
       ok "the ParaID deny survived the edit ($pa line(s), was $pb)"
     else
@@ -717,6 +1015,9 @@ EOF
 }
 
 # =============================================================== PHASE 6 =====
+
+# http_code <url> [extra curl args...]
+http_code() { curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$@" || echo 000; }
 
 phase_6() {
   phase 6 "Smoke tests" "Step 6"
@@ -734,14 +1035,13 @@ phase_6() {
     printf '  [dry-run] not executed\n'
     printf '  SKIP  assert (dry-run): /health is 200 on six hosts, version %s\n' "$EXPECT_VERSION"
   else
-    local h code
+    local h code ver
     for h in $HOSTS; do
-      code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "https://$h/health" || echo 000)"
+      code="$(http_code "https://$h/health")"
       printf '  health %-26s %s\n' "$h" "$code"
       [ "$code" = "200" ] || die "/health on $h answered $code, expected 200"
     done
     ok "/health is 200 on all six hosts"
-    local ver
     ver="$(curl -s --max-time 15 https://paramant.app/health \
            | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version",""))' 2>/dev/null || echo "")"
     printf '  version reported by paramant.app/health = %s\n' "$ver"
@@ -751,22 +1051,22 @@ phase_6() {
 
   step "6c. /v2/health/deep, 401 without the token and 200 with it (server-local)"
   remote "deep health" "$COMPOSE_DIR" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
-# The token is read into a variable and never echoed; only the status codes
-# and the parsed overall field are printed.
-T=$(grep '^INTERNAL_AUTH_TOKEN=' .env | head -1 | cut -d= -f2-)
+set -euo pipefail
+cd "$1"
+# The token goes straight into a curl header. It is never echoed, and the only
+# things printed are status codes and the parsed overall field.
+T="$(grep '^INTERNAL_AUTH_TOKEN=' .env | head -1 | cut -d= -f2-)"
 if [ -z "$T" ]; then echo "FATAL INTERNAL_AUTH_TOKEN empty in .env"; exit 1; fi
-echo "deep token present, length ${#T}, prefix $(printf %s "$T" | cut -c1-5)"
+echo "deep token length = ${#T}"
 echo "deep noauth code = $(curl -s -o /dev/null -w '%{http_code}' --max-time 15 http://127.0.0.1:3000/v2/health/deep)"
-echo "deep auth   code = $(curl -s -o /dev/null -w '%{http_code}' --max-time 15 -H "X-Internal-Auth: $T" http://127.0.0.1:3000/v2/health/deep)"
+echo "deep auth code = $(curl -s -o /dev/null -w '%{http_code}' --max-time 15 -H "X-Internal-Auth: $T" http://127.0.0.1:3000/v2/health/deep)"
 curl -s --max-time 15 -H "X-Internal-Auth: $T" http://127.0.0.1:3000/v2/health/deep \
   | python3 -c 'import json,sys; d=json.load(sys.stdin); print("deep overall =", d.get("overall") or d.get("status") or "unknown")' 2>/dev/null \
   || echo "deep overall = unparseable"
 unset T
 EOF
-  expect 'deep noauth code = 401' "/v2/health/deep is 401 without X-Internal-Auth"
-  expect 'deep auth   code = 200' "/v2/health/deep is 200 with X-Internal-Auth"
+  expect_count "deep noauth code" 401 "/v2/health/deep is 401 without X-Internal-Auth"
+  expect_count "deep auth code" 200 "/v2/health/deep is 200 with X-Internal-Auth"
 
   step "6d. /v1/paraid/issue-document is 404 on all six hosts (#319)"
   if [ "$DRY_RUN" -eq 1 ]; then
@@ -776,50 +1076,146 @@ EOF
   else
     local h code
     for h in $HOSTS; do
-      code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 -X POST "https://$h/v1/paraid/issue-document" || echo 000)"
+      code="$(http_code -X POST "https://$h/v1/paraid/issue-document")"
       printf '  paraid %-26s %s\n' "$h" "$code"
       [ "$code" = "404" ] || die "/v1/paraid/issue-document on $h answered $code, expected 404"
     done
     ok "/v1/paraid/issue-document is 404 on all six hosts"
   fi
 
-  step "6e. /sign answers itself, 200 and no redirect to /auth/login (#317)"
+  step "6e. the pages main deleted are really gone, not just unlinked (#319, #323)"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '\n  $ curl -s -o /dev/null -w %%{http_code} https://paramant.app/compliance/nis2   # and /paraid\n'
+    printf '  [dry-run] not executed\n'
+    printf '  SKIP  assert (dry-run): /compliance/nis2 and /paraid are 404\n'
+  else
+    local p code
+    for p in /compliance/nis2 /compliance/iec62443 /compliance/nen7510 /paraid /paraid-app /dicom; do
+      code="$(http_code "https://paramant.app$p")"
+      printf '  gone %-24s %s\n' "$p" "$code"
+      [ "$code" = "404" ] || die "https://paramant.app$p answered $code, expected 404 after phase 5b removed the file"
+    done
+    ok "every page main deleted answers 404 on the public host"
+  fi
+
+  step "6f. /sign answers itself, 200 and no redirect to /auth/login (#317)"
   if [ "$DRY_RUN" -eq 1 ]; then
     printf '\n  $ curl -s -o /dev/null -w %%{http_code} https://paramant.app/sign\n'
     printf '  [dry-run] not executed\n'
     printf '  SKIP  assert (dry-run): /sign is 200 without a session\n'
   else
     local code
-    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 https://paramant.app/sign || echo 000)"
+    code="$(http_code https://paramant.app/sign)"
     printf '  sign code = %s\n' "$code"
     [ "$code" = "200" ] || die "/sign answered $code, expected 200 without a login"
     ok "/sign is 200 without a login"
   fi
 
-  step "6f. the 3.0.0 verify suite, on the server (informational, exit 2 blocks)"
-  remote "post-deploy-verify" "$COMPOSE_DIR" <<'EOF'
-set -uo pipefail
+  step "6g. the 3.0.0 verify suite, on the server (informational, exit 2 blocks)"
+  remote_soft "post-deploy-verify" "$COMPOSE_DIR" <<'EOF'
+set -euo pipefail
 cd "$1" || exit 1
-bash scripts/post-deploy-verify.sh https://paramant.app http://127.0.0.1:3000 2>&1 | tail -40
-echo "verify exit=${PIPESTATUS[0]}"
+rc=0
+bash scripts/post-deploy-verify.sh https://paramant.app http://127.0.0.1:3000 > /tmp/paramant-pdv.$$ 2>&1 || rc=$?
+tail -40 /tmp/paramant-pdv.$$
+rm -f /tmp/paramant-pdv.$$
+echo "verify exit = $rc"
 EOF
   if [ "$DRY_RUN" -eq 0 ]; then
-    if printf '%s\n' "$REMOTE_OUT" | grep -q 'verify exit=2'; then
+    local vrc; vrc="$(remote_field 'verify exit')"
+    if [ "$vrc" = "2" ]; then
       die "post-deploy-verify.sh exited 2 (critical); the runbook rolls back on this (phase 8)"
-    fi
-    if printf '%s\n' "$REMOTE_OUT" | grep -q 'verify exit=0'; then
+    elif [ "$vrc" = "0" ]; then
       ok "post-deploy-verify.sh passed"
     else
-      warn "post-deploy-verify.sh exited non-zero but not 2; its /health/deep probe is known red (the route is /v2/health/deep), read the list above"
+      warn "post-deploy-verify.sh exited ${vrc:-unknown} but not 2; its /health/deep probe is known red (the route is /v2/health/deep), read the list above"
     fi
   fi
 
-  step "6g. billing stance once more, from every relay log"
+  step "6h. the inline receipt opt-in really works end to end (#342)"
+  remote "inline receipt config" "$COMPOSE_DIR" <<'EOF'
+set -euo pipefail
+cd "$1"
+for svc in relay-main relay-iot; do
+  printf 'inline %-12s ' "$svc"
+  docker compose exec -T "$svc" sh -c 'v=$(printenv PARAMANT_INLINE_RECEIPT_HEADER); [ -n "$v" ] && echo "$v" || echo empty' 2>/dev/null || echo unreadable
+done
+# The effective config, not the file: nginx -T is what is actually loaded.
+echo "effective outbound buffers = $(nginx -T 2>/dev/null | grep -c 'proxy_buffer_size 32k' || true)"
+EOF
+  expect 'inline relay-main +1' "relay-main runs with PARAMANT_INLINE_RECEIPT_HEADER=1"
+  expect 'inline relay-iot +1'  "relay-iot runs with PARAMANT_INLINE_RECEIPT_HEADER=1"
+  expect_min "effective outbound buffers" 1 "the loaded nginx config carries the raised proxy buffers"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '\n  $ curl -sI https://relay.paramant.app/v2/outbound/<64 hex that never existed>\n'
+    printf '  [dry-run] not executed\n'
+    printf '  SKIP  assert (dry-run): /v2/outbound proxies without a 502\n'
+    printf '  SKIP  assert (dry-run): a real download carries the inline receipt (needs PARAMANT_SMOKE_API_KEY)\n'
+  else
+    # Keyless: the location proxies at all, and does not answer 502.
+    local miss code
+    miss="$(openssl rand -hex 32)"
+    code="$(http_code "https://relay.paramant.app/v2/outbound/$miss")"
+    printf '  outbound miss code = %s\n' "$code"
+    case "$code" in
+      5*) die "/v2/outbound answered $code for a hash that never existed; the location is not proxying cleanly" ;;
+    esac
+    ok "/v2/outbound proxies without a 5xx (answered $code for an unknown hash)"
+
+    # The real proof needs an account, so it is opt-in. Without a key the
+    # script says exactly what it could not check rather than implying it did.
+    if [ -n "${PARAMANT_SMOKE_API_KEY:-}" ]; then
+      local tmp payload hash body hdr up dn size
+      tmp="$(mktemp)"; hdr="$(mktemp)"; body="$(mktemp)"
+      head -c 4096 /dev/urandom > "$tmp"
+      hash="$(sha256sum "$tmp" | cut -d" " -f1)"
+      payload="$(base64 -w0 "$tmp")"
+      printf '{"hash":"%s","payload":"%s"}' "$hash" "$payload" > "$body"
+      up="$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 \
+            -X POST https://relay.paramant.app/v2/inbound \
+            -H "X-Api-Key: $PARAMANT_SMOKE_API_KEY" \
+            -H 'Content-Type: application/json' --data-binary "@$body")"
+      printf '  smoke upload code = %s\n' "$up"
+      case "$up" in
+        20*) : ;;
+        *) rm -f "$tmp" "$hdr" "$body"; die "smoke upload answered $up; cannot test the receipt header" ;;
+      esac
+      dn="$(curl -s -o /dev/null -D "$hdr" -w '%{http_code}' --max-time 30 \
+            -H "X-Api-Key: $PARAMANT_SMOKE_API_KEY" \
+            "https://relay.paramant.app/v2/outbound/$hash")"
+      size="$(stat -c%s "$hdr")"
+      printf '  smoke download code = %s, response header block = %s bytes\n' "$dn" "$size"
+      # Header names only. The receipt itself is never printed.
+      grep -io '^x-paramant-receipt[a-z-]*:' "$hdr" | sort -u | sed 's/^/  header /' || true
+      [ "$dn" = "200" ] || { rm -f "$tmp" "$hdr" "$body"; die "smoke download answered $dn, expected 200 (502 means the proxy buffers are still too small)"; }
+      grep -qi '^x-paramant-receipt:' "$hdr" \
+        || { rm -f "$tmp" "$hdr" "$body"; die "no inline X-Paramant-Receipt header; the opt-in did not take"; }
+      local f
+      for f in id hash url; do
+        grep -qi "^x-paramant-receipt-$f:" "$hdr" \
+          || { rm -f "$tmp" "$hdr" "$body"; die "the download is missing X-Paramant-Receipt-$f, the reference shape #342 added"; }
+      done
+      grep -qi '^x-paramant-receipt-deprecated:' "$hdr" \
+        && warn "the deprecation header is present alongside the inline one; the relay thinks the opt-in is off"
+      if [ "$size" -gt 16000 ]; then
+        ok "a real download returned 200 with a ${size}-byte header block, so nginx carried the fat inline receipt"
+      else
+        warn "the header block was only ${size} bytes; the inline receipt may not have been attached, so the >16 KB path is unproven"
+      fi
+      ok "the download carries both the inline receipt and the id/hash/url reference"
+      rm -f "$tmp" "$hdr" "$body"
+    else
+      warn "PARAMANT_SMOKE_API_KEY is not set: NOT proven that a real download returns the inline receipt through nginx without a 502. Only the config was checked. Set the variable to a ParaSend key to run the full test."
+    fi
+  fi
+
+  step "6i. billing stance once more, from every relay log"
   remote "billing stance" "$COMPOSE_DIR" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
+set -euo pipefail
+cd "$1"
 for svc in relay-main relay-health relay-finance relay-legal relay-iot; do
-  cid=$(docker compose ps -q "$svc")
+  cid="$(docker compose ps -q "$svc")"
   printf 'stance %-14s ' "$svc"
   docker logs "$cid" 2>&1 | grep '"billing_config"' | tail -1 | grep -o '"recurring":[a-z]*' || echo "no billing_config line"
 done
@@ -859,99 +1255,169 @@ phase_7() {
 phase_8() {
   phase 8 "Rollback to $ROLLBACK_TS (server, WRITE)" "Step 8"
 
-  step "8a. the manifest and the saved images"
-  remote "rollback manifest" "$COMPOSE_DIR" "$ROLLBACK_TS" "$BACKUP_DIR" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
-TS="$2"; BK="$3"
+  step "8a. the manifest, the saved images and the backups this rollback needs"
+  remote "rollback preconditions" "$COMPOSE_DIR" "$ROLLBACK_TS" "$BACKUP_DIR" "$NGINX_BACKUP_DIR" "$NGINX_CONFS" <<'EOF'
+set -euo pipefail
+cd "$1"
+TS="$2"; BK="$3"; NGBK="$4"; CONFS="$5"
 M="$BK/rollback-images-$TS.txt"
 [ -f "$M" ] || { echo "FATAL no manifest $M"; exit 1; }
 echo "manifest lines = $(wc -l < "$M")"
-cat "$M" | sed 's/^/  manifest /'
+sed 's/^/  manifest /' "$M"
+
 missing=0
 while IFS='|' read -r svc image rbtag; do
-  [ -z "${svc:-}" ] && continue
+  [ -n "${svc:-}" ] || continue
   if docker image inspect "$rbtag" >/dev/null 2>&1; then
     echo "  present $rbtag"
   else
     echo "  MISSING $rbtag"
-    missing=$((missing+1))
+    missing=$((missing + 1))
   fi
 done < "$M"
 echo "missing rollback images = $missing"
+
+# Everything 8c will restore has to be here BEFORE 8b starts recreating, so a
+# half rollback is impossible.
+absent=0
+for f in "$BK/.env-pre-3.1-$TS" "$BK/docroot-pre-3.1-$TS.tgz"; do
+  if [ -f "$f" ]; then
+    echo "  backup present $f ($(stat -c%s "$f") bytes)"
+  else
+    echo "  backup MISSING $f"
+    absent=$((absent + 1))
+  fi
+done
+for name in $CONFS; do
+  f="$NGBK/$name.pre-3.1-$TS"
+  if [ -f "$f" ]; then
+    echo "  backup present $f ($(stat -c%s "$f") bytes)"
+  else
+    echo "  backup MISSING $f"
+    absent=$((absent + 1))
+  fi
+done
+echo "missing backups = $absent"
 EOF
   expect_not 'FATAL no manifest' "the manifest for $ROLLBACK_TS exists"
-  expect 'missing rollback images = 0' "every rollback image from $ROLLBACK_TS is still on the host"
+  expect_count "manifest lines" 6 "the manifest still has its six lines"
+  expect_count "missing rollback images" 0 "every rollback image from $ROLLBACK_TS is still on the host"
+  expect_count "missing backups" 0 "every .env, docroot and nginx backup this rollback needs is present"
 
-  step "8b. retag the saved images and recreate without rebuilding"
-  remote "rollback images" "$COMPOSE_DIR" "$ROLLBACK_TS" "$BACKUP_DIR" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
+  step "8b. restore .env first, then retag the saved images and recreate all six"
+  note ".env goes back before the containers, so the recreate reads the old file"
+  remote "rollback images and env" "$COMPOSE_DIR" "$ROLLBACK_TS" "$BACKUP_DIR" <<'EOF'
+set -euo pipefail
+cd "$1"
 TS="$2"; BK="$3"
 M="$BK/rollback-images-$TS.txt"
+
+echo "before .env bytes = $(stat -c%s .env)"
+cp -a .env ".env.bak-rollback-$TS"
+cp "$BK/.env-pre-3.1-$TS" .env
+chmod 600 .env
+echo "after .env bytes = $(stat -c%s .env)"
+
 SVCS=""
 while IFS='|' read -r svc image rbtag; do
-  [ -z "${svc:-}" ] && continue
-  cid=$(docker compose ps -q "$svc" 2>/dev/null)
-  echo "before $svc image = $([ -n "$cid" ] && docker inspect -f '{{.Image}}' "$cid" || echo none)"
+  [ -n "${svc:-}" ] || continue
+  cid="$(docker compose ps -q "$svc" 2>/dev/null || true)"
+  if [ -n "$cid" ]; then
+    echo "before $svc image = $(docker inspect -f '{{.Image}}' "$cid")"
+  else
+    echo "before $svc image = none"
+  fi
   docker tag "$rbtag" "$image"
   SVCS="$SVCS $svc"
 done < "$M"
+
+# shellcheck disable=SC2086
 docker compose up -d --no-deps --force-recreate $SVCS 2>&1 | sed 's/^/  up /'
-for svc in $SVCS; do
-  cid=$(docker compose ps -q "$svc" 2>/dev/null)
-  echo "after  $svc image = $([ -n "$cid" ] && docker inspect -f '{{.Image}}' "$cid" || echo none)"
-done
-echo "recreated:$SVCS"
-EOF
-  expect 'recreated: ' "the saved images were retagged and the containers recreated"
-
-  step "8c. restore .env, the nginx confs and the docroot"
-  remote "restore state" "$COMPOSE_DIR" "$ROLLBACK_TS" "$BACKUP_DIR" "$DOCROOT" "$NGINX_BACKUP_DIR" "$NGINX_SITES" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
-TS="$2"; BK="$3"; DOCROOT="$4"; NGBK="$5"; SITES="$6"
-
-if [ -f "$BK/.env-pre-3.1-$TS" ]; then
-  echo "before .env bytes = $(stat -c%s .env)"
-  cp -a .env ".env.bak-rollback-$TS"
-  cp "$BK/.env-pre-3.1-$TS" .env && chmod 600 .env
-  echo "after  .env bytes = $(stat -c%s .env) (restored from $BK/.env-pre-3.1-$TS)"
-else
-  echo "WARN no .env backup for $TS, .env left as it is"
-fi
 
 n=0
-for b in "$NGBK"/*.pre-3.1-"$TS"; do
-  [ -f "$b" ] || continue
-  target="$SITES/$(basename "$b" ".pre-3.1-$TS")"
-  echo "before nginx $(basename "$target") bytes = $(stat -c%s "$target" 2>/dev/null || echo missing)"
+for svc in $SVCS; do
+  cid="$(docker compose ps -q "$svc" 2>/dev/null || true)"
+  if [ -n "$cid" ]; then
+    echo "after $svc image = $(docker inspect -f '{{.Image}}' "$cid")"
+    n=$((n + 1))
+  else
+    echo "after $svc image = none"
+  fi
+done
+echo "after recreated services = $n"
+EOF
+  expect_count "after recreated services" 6 "all six services came back on their saved images"
+
+  step "8c. restore the nginx confs and the docroot"
+  remote "rollback nginx and docroot" "$ROLLBACK_TS" "$BACKUP_DIR" "$DOCROOT" "$NGINX_BACKUP_DIR" "$NGINX_SITES" "$NGINX_CONFS" "$DOCROOT_IGNORE" <<'EOF'
+set -euo pipefail
+TS="$1"; BK="$2"; DOCROOT="$3"; NGBK="$4"; SITES="$5"; CONFS="$6"; IGNORE="$7"
+
+n=0
+for name in $CONFS; do
+  b="$NGBK/$name.pre-3.1-$TS"
+  [ -f "$b" ] || { echo "FATAL missing nginx backup $b"; exit 1; }
+  target="$(readlink -f "$SITES/$name")"
+  echo "before nginx $name bytes = $(stat -c%s "$target")"
   cp -a "$b" "$target"
-  echo "after  nginx $(basename "$target") bytes = $(stat -c%s "$target")"
-  n=$((n+1))
+  echo "after nginx $name bytes = $(stat -c%s "$target")"
+  n=$((n + 1))
 done
 echo "restored nginx confs = $n"
-if [ "$n" -gt 0 ]; then
-  nginx -t 2>&1 | sed 's/^/  nginxt /'
-  systemctl reload nginx && echo "reloaded nginx"
-fi
 
-if [ -f "$BK/docroot-pre-3.1-$TS.tgz" ]; then
-  echo "before docroot files = $(find "$DOCROOT" -type f | wc -l)"
-  tar xzf "$BK/docroot-pre-3.1-$TS.tgz" -C "$(dirname "$DOCROOT")"
-  echo "after  docroot files = $(find "$DOCROOT" -type f | wc -l) (restored from the pre-3.1 tar)"
-else
-  echo "WARN no docroot tar for $TS, docroot left as it is"
-fi
+# Test before reload. A reload on a broken conf keeps the old workers alive and
+# hides the breakage until the next restart.
+rc=0
+nginx -t > /tmp/paramant-nginxt.$$ 2>&1 || rc=$?
+sed 's/^/  nginxt /' /tmp/paramant-nginxt.$$
+rm -f /tmp/paramant-nginxt.$$
+[ "$rc" -eq 0 ] || { echo "FATAL nginx -t failed on the restored conf; not reloading"; exit 1; }
+systemctl reload nginx
+echo "reloaded nginx"
 
-# .env changed, so the relays have to come back on the restored file.
-docker compose up -d --no-deps --force-recreate relay-main 2>&1 | sed 's/^/  up /'
+TAR="$BK/docroot-pre-3.1-$TS.tgz"
+[ -f "$TAR" ] || { echo "FATAL missing docroot tar $TAR"; exit 1; }
+echo "before docroot files = $(find "$DOCROOT" -type f | wc -l)"
+
+# tar x overlays: it puts back what phase 5 changed or removed, but it does NOT
+# remove what phase 5 ADDED. Delete those first, so the docroot really is the
+# pre-deploy one. Anything on the drift guard IGNORE list is left alone.
+base="$(basename "$DOCROOT")"
+tar tzf "$TAR" | sed -e "s|^\./||" -e "s|^$base/||" -e '/\/$/d' | sort -u > /tmp/paramant-intar.$$
+( cd "$DOCROOT" && find . -type f | sed 's|^\./||' | sort -u ) > /tmp/paramant-onserver.$$
+added=0
+kept=0
+while IFS= read -r rel; do
+  [ -n "$rel" ] || continue
+  skip=no
+  for ig in $IGNORE; do
+    case "$rel" in
+      "$ig"|"$ig"/*) skip=yes ;;
+    esac
+  done
+  if [ "$skip" = yes ]; then
+    kept=$((kept + 1))
+    continue
+  fi
+  rm -f "$DOCROOT/$rel"
+  echo "  removed added-by-deploy $rel"
+  added=$((added + 1))
+done < <(comm -13 /tmp/paramant-intar.$$ /tmp/paramant-onserver.$$)
+rm -f /tmp/paramant-intar.$$ /tmp/paramant-onserver.$$
+echo "removed files the deploy added = $added"
+echo "kept on ignore list = $kept"
+
+tar xzf "$TAR" -C "$(dirname "$DOCROOT")"
+echo "after docroot files = $(find "$DOCROOT" -type f | wc -l)"
 EOF
+  expect_not 'FATAL' "nginx confs and docroot restored, nginx tested clean before the reload"
+  expect_count "restored nginx confs" 2 "both named nginx confs came back"
+  expect 'reloaded nginx' "nginx reloaded on the restored conf"
 
   step "8d. health after the rollback"
   remote "rollback health" "$COMPOSE_DIR" <<'EOF'
-set -uo pipefail
-cd "$1" || exit 1
+set -euo pipefail
+cd "$1"
 ok=no
 for _ in $(seq 1 30); do
   if curl -fs --max-time 3 http://127.0.0.1:3000/health >/dev/null 2>&1; then ok=yes; break; fi
@@ -959,8 +1425,8 @@ for _ in $(seq 1 30); do
 done
 echo "rollback relay health = $ok"
 echo "rollback version = $(curl -s --max-time 5 http://127.0.0.1:3000/health | grep -o '"version":"[^"]*"' || echo unknown)"
-cid=$(docker compose ps -q relay-main)
-echo "rollback paraidAuth occurrences in relay.js = $(docker exec "$cid" grep -c _paraidAuth /app/relay.js 2>/dev/null || echo 0)"
+cid="$(docker compose ps -q relay-main)"
+echo "rollback paraidAuth occurrences = $(docker exec "$cid" grep -c _paraidAuth /app/relay.js 2>/dev/null || echo 0)"
 EOF
   expect 'rollback relay health = yes' "the relay answers /health after the rollback"
 
@@ -973,7 +1439,7 @@ EOF
   if [ "$DRY_RUN" -eq 0 ]; then
     local h code
     for h in $HOSTS; do
-      code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "https://$h/health" || echo 000)"
+      code="$(http_code "https://$h/health")"
       printf '  health %-26s %s\n' "$h" "$code"
       [ "$code" = "200" ] || warn "/health on $h answered $code after the rollback"
     done
@@ -1009,7 +1475,7 @@ phase_1
 if [ "$PREFLIGHT_ONLY" -eq 1 ]; then
   echo
   hr
-  echo "PREFLIGHT ONLY: phases 0 and 1 done, stopping before any deploy write."
+  echo "PREFLIGHT ONLY: phases 0 and 1 done, read-only. Nothing was written."
   printf 'Warnings: %s. Log: %s\n' "$WARNINGS" "$LOG"
   hr
   exit 0

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -671,6 +671,23 @@ EOF
 phase_4() {
   phase 4 "Recreate, the canary relay first (server, WRITE)" "Step 4"
 
+  step "4pre. the rendered compose really carries the receipt flag"
+  note 'there is no env_file in docker-compose.yml: .env only substitutes'
+  note '${VAR} into it, so a variable without a line in x-relay-env never'
+  note 'reaches a container. This proves the flag lands BEFORE the recreate,'
+  note 'instead of learning it from a failed smoke test at the very end.'
+  remote "compose config" "$COMPOSE_DIR" <<'EOF'
+set -euo pipefail
+cd "$1"
+rendered="$(docker compose config 2>/dev/null)"
+echo "compose inline flag on = $(printf '%s\n' "$rendered" | grep -c 'PARAMANT_INLINE_RECEIPT_HEADER: "1"' || true)"
+echo "compose inline flag declared = $(printf '%s\n' "$rendered" | grep -c 'PARAMANT_INLINE_RECEIPT_HEADER:' || true)"
+printf '%s\n' "$rendered" | grep -nE 'PARAMANT_(RECEIPT_|INLINE_RECEIPT)' | head -8 | sed 's/^/  cfg /' || true
+EOF
+  # Five relays share x-relay-env; the anchor itself renders once more.
+  expect_min "compose inline flag on" 5 \
+    "the rendered compose sets PARAMANT_INLINE_RECEIPT_HEADER=1 on all five relays"
+
   step "4a. relay-iot alone, then read its two boot lines"
   remote "recreate relay-iot" "$COMPOSE_DIR" <<'EOF'
 set -euo pipefail
@@ -826,6 +843,7 @@ echo "before deleted-in-git count = $(printf '%s\n' "$DEL" | grep -c . || true)"
 removed=0
 kept=0
 absent=0
+outside=0
 for f in $DEL; do
   rel="${f#frontend/}"
   # Never step outside the docroot, and never touch what the drift guard
@@ -844,21 +862,34 @@ for f in $DEL; do
     kept=$((kept + 1))
     continue
   fi
-  if [ -f "$DOCROOT/$rel" ]; then
-    rm -f "$DOCROOT/$rel"
-    echo "  removed $rel"
-    removed=$((removed + 1))
-  else
+  if [ ! -f "$DOCROOT/$rel" ]; then
     absent=$((absent + 1))
+    continue
   fi
+  # A symlinked subdirectory inside the docroot would let this rm land outside
+  # it. Resolve the path and refuse anything that is not really under DOCROOT.
+  real="$(readlink -f "$DOCROOT/$rel")"
+  realroot="$(readlink -f "$DOCROOT")"
+  case "$real" in
+    "$realroot"/*) : ;;
+    *) echo "  REFUSED $rel resolves to $real, outside $realroot"
+       outside=$((outside + 1))
+       continue ;;
+  esac
+  rm -f "$real"
+  echo "  removed $rel"
+  removed=$((removed + 1))
 done
 echo "after removed = $removed"
 echo "after kept on ignore list = $kept"
 echo "after already absent = $absent"
+echo "after refused outside docroot = $outside"
 echo "after docroot files = $(find "$DOCROOT" -type f | wc -l)"
 EOF
   expect_min "before deleted-in-git count" 1 \
     "git names at least one frontend file deleted since the deployed commit"
+  expect_count "after refused outside docroot" 0 \
+    "no deletion resolved to a path outside the docroot"
   if [ "$DRY_RUN" -eq 0 ]; then
     local rm_n ab_n
     rm_n="$(remote_field 'after removed')"
@@ -893,12 +924,50 @@ PARAID_RE='paraid/issue'
 OUT_RE='^[[:space:]]*location[[:space:]]*~[[:space:]]*\^/v2/outbound[[:space:]]*\{'
 BUF_RE='proxy_buffer_size 32k'
 
+# Two-pass insert: learn which /v2/outbound blocks already carry the buffer,
+# then insert only into the ones that do not.
+BUF_AWK='
+FNR==NR {
+  if ($0 ~ /^[[:space:]]*location[[:space:]]*~[[:space:]]*\^\/v2\/outbound[[:space:]]*\{/) { b++; inb=1; depth=1; next }
+  if (inb) {
+    if ($0 ~ /proxy_buffer_size 32k/) has[b]=1
+    depth += gsub(/\{/,"{") - gsub(/\}/,"}")
+    if (depth <= 0) inb=0
+  }
+  next
+}
+{
+  print
+  if ($0 ~ /^[[:space:]]*location[[:space:]]*~[[:space:]]*\^\/v2\/outbound[[:space:]]*\{/) {
+    j++
+    if (!has[j]) {
+      print "        proxy_buffer_size 32k;"
+      print "        proxy_buffers 8 32k;"
+      print "        proxy_busy_buffers_size 64k;"
+    }
+  }
+}'
+
+# Count /v2/outbound blocks, and how many of them carry the buffer INSIDE the
+# block. Counting matches per file cannot tell those apart.
+BLOCK_AWK='
+/^[[:space:]]*location[[:space:]]*~[[:space:]]*\^\/v2\/outbound[[:space:]]*\{/ { total++; inb=1; has=0; depth=1; next }
+inb {
+  if ($0 ~ /proxy_buffer_size 32k/) has=1
+  depth += gsub(/\{/,"{") - gsub(/\}/,"}")
+  if (depth <= 0) { if (has) withbuf++; inb=0 }
+}
+END { printf "%d %d\n", total+0, withbuf+0 }'
+
+count_blocks() { awk "$BLOCK_AWK" $TARGETS | awk '{t+=$1; w+=$2} END{printf "%d %d\n", t, w}'; }
+
 echo "before sign gated = $(count "$SIGN_RE")"
 echo "before compliance = $(count "$COMP_RE")"
 echo "before dicom try_files = $(count "$DICOM_RE")"
 echo "before paraid deny = $(count "$PARAID_RE")"
-echo "before outbound locations = $(count "$OUT_RE")"
-echo "before outbound buffers = $(count "$BUF_RE")"
+read -r _obt _obw <<< "$(count_blocks)"
+echo "before outbound locations = $_obt"
+echo "before outbound blocks with buffer = $_obw"
 
 # Each edit must have something to do. A zero here means the server conf is not
 # the shape the runbook describes, and guessing further would be editing blind.
@@ -931,18 +1000,16 @@ for f in $TARGETS; do
   # 4. #342: raise the proxy buffers on /v2/outbound. Nginx has to hold the
   #    whole upstream header block in ONE buffer, and the default 4k/8k is far
   #    under the ~19 KB the deprecated inline X-Paramant-Receipt costs, which
-  #    is a 502 on every download. Inserted once, right after the location
-  #    opens; running this twice must not stack a second copy.
-  if ! grep -qF "proxy_buffer_size 32k" "$f"; then
-    awk '{ print }
-         /^[[:space:]]*location[[:space:]]*~[[:space:]]*\^\/v2\/outbound[[:space:]]*\{/ {
-           print "        proxy_buffer_size 32k;"
-           print "        proxy_buffers 8 32k;"
-           print "        proxy_busy_buffers_size 64k;"
-         }' "$f" > "/tmp/nginx-buf.$$"
-    cat "/tmp/nginx-buf.$$" > "$f"
-    rm -f "/tmp/nginx-buf.$$"
-  fi
+  #    is a 502 on every download.
+  #
+  #    The guard is per BLOCK, not per file. A file-wide grep passes as soon as
+  #    proxy_buffer_size appears anywhere, so a conf that already sets it on
+  #    /v2/inbound would leave the outbound block bare and every download would
+  #    502. Pass one reads which outbound blocks already have it, pass two
+  #    inserts only into the ones that do not, which also makes it idempotent.
+  awk "$BUF_AWK" "$f" "$f" > "/tmp/nginx-buf.$$"
+  cat "/tmp/nginx-buf.$$" > "$f"
+  rm -f "/tmp/nginx-buf.$$"
   if ! cmp -s "$f" "/tmp/nginx-pre-3.1-$(basename "$f").$TS"; then
     echo "edited $(basename "$f")"
     edited=$((edited + 1))
@@ -954,8 +1021,9 @@ echo "after compliance = $(count "$COMP_RE")"
 echo "after dicom try_files = $(count "$DICOM_RE")"
 echo "after dicom 404 = $(count 'location = /dicom[[:space:]]*\{[[:space:]]*return 404')"
 echo "after paraid deny = $(count "$PARAID_RE")"
-echo "after outbound locations = $(count "$OUT_RE")"
-echo "after outbound buffers = $(count "$BUF_RE")"
+read -r _oat _oaw <<< "$(count_blocks)"
+echo "after outbound locations = $_oat"
+echo "after outbound blocks with buffer = $_oaw"
 
 restore() {
   for b in "$NGBK"/*.pre-3.1-"$TS"; do
@@ -997,10 +1065,11 @@ EOF
   if [ "$DRY_RUN" -eq 0 ]; then
     local ol bf
     ol="$(remote_field 'after outbound locations')"
-    bf="$(remote_field 'after outbound buffers')"
+    bf="$(remote_field 'after outbound blocks with buffer')"
+    [ -n "$ol" ] && [ -n "$bf" ] || die "could not read the /v2/outbound block counts from the server"
     [ "$bf" = "$ol" ] \
-      || die "proxy_buffer_size is on $bf of $ol /v2/outbound locations; the inline receipt header would 502 on the rest"
-    ok "every /v2/outbound location carries proxy_buffer_size 32k ($bf of $ol)"
+      || die "proxy_buffer_size sits inside $bf of $ol /v2/outbound blocks; the inline receipt header would 502 on the rest"
+    ok "every /v2/outbound block carries proxy_buffer_size 32k ($bf of $ol blocks)"
   fi
   if [ "$DRY_RUN" -eq 0 ]; then
     local pb pa
@@ -1198,12 +1267,14 @@ EOF
       done
       grep -qi '^x-paramant-receipt-deprecated:' "$hdr" \
         && warn "the deprecation header is present alongside the inline one; the relay thinks the opt-in is off"
-      if [ "$size" -gt 16000 ]; then
-        ok "a real download returned 200 with a ${size}-byte header block, so nginx carried the fat inline receipt"
-      else
-        warn "the header block was only ${size} bytes; the inline receipt may not have been attached, so the >16 KB path is unproven"
-      fi
       ok "the download carries both the inline receipt and the id/hash/url reference"
+      if [ "$size" -gt 16000 ]; then
+        ok "a real download returned 200 with a ${size}-byte header block, so nginx carried the fat inline receipt through the raised buffers"
+      else
+        # No ok line here on purpose: the summary must not read as if the
+        # oversized-header path was proven when it was not.
+        warn "NOT PROVEN: the header block was only ${size} bytes, under the 16 KB that makes this test meaningful. The download worked, but the oversized-header path through nginx is untested."
+      fi
       rm -f "$tmp" "$hdr" "$body"
     else
       warn "PARAMANT_SMOKE_API_KEY is not set: NOT proven that a real download returns the inline receipt through nginx without a 502. Only the config was checked. Set the variable to a ParaSend key to run the full test."

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -1,0 +1,1028 @@
+#!/usr/bin/env bash
+#
+# deploy-3.1.sh - execute deploy/DEPLOY-3.1.md end to end, from the NUC.
+#
+# The runbook stays the readable source: every phase below names the runbook
+# step it performs, and every assertion is a sentence the runbook already
+# writes down. This script adds nothing to the plan, it only refuses to
+# continue when a measurement disagrees with it.
+#
+# Usage:
+#   bash deploy/deploy-3.1.sh                  full deploy, phases 0 to 7
+#   bash deploy/deploy-3.1.sh --preflight-only phases 0 and 1, then stop
+#   bash deploy/deploy-3.1.sh --rollback <TS>  phase 8, back to the <TS> backup
+#   bash deploy/deploy-3.1.sh --dry-run        print every remote and gated
+#                                              command instead of running it
+#
+# Flags combine: --dry-run --preflight-only, --dry-run --rollback <TS>.
+#
+# Secrets: this script never prints a key value. Environment variables are
+# reported as "empty" or "set, prefix <first 5 chars>", which is the shape the
+# runbook's own step 1 uses. No remote block runs under set -x.
+#
+# Everything the script prints also lands in deploy/logs/deploy-3.1-<TS>.log.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------- constants --
+
+PROD_HOST="${PARAMANT_PROD_HOST:-root@116.203.86.81}"
+PROD_KEY="${PARAMANT_PROD_KEY:-$HOME/.ssh/paramant_prod_claude}"
+COMPOSE_DIR="${PARAMANT_COMPOSE_DIR:-/opt/paramant-relay}"
+DOCROOT="${PARAMANT_DOCROOT:-/home/paramant/app}"
+BACKUP_DIR="${PARAMANT_BACKUP_DIR:-/home/paramant/backups}"
+NGINX_BACKUP_DIR=/etc/nginx/backups
+NGINX_SITES=/etc/nginx/sites-enabled
+
+DEPLOY_REF="${DEPLOY_REF:-origin/main}"
+EXPECT_PROD_COMMIT="${EXPECT_PROD_COMMIT:-41501bb}"   # runbook: where we start
+EXPECT_VERSION="3.1.0"
+SERVICES="relay-main relay-health relay-finance relay-legal relay-iot admin"
+HOSTS="paramant.app health.paramant.app legal.paramant.app finance.paramant.app iot.paramant.app relay.paramant.app"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+SSH_OPTS=(-i "$PROD_KEY" -o BatchMode=yes -o IdentitiesOnly=yes
+          -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15)
+SSH_SHOWN="ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes $PROD_HOST 'bash -s'"
+
+DRY_RUN=0
+PREFLIGHT_ONLY=0
+ROLLBACK_TS=""
+REMOTE_OUT=""
+WARNINGS=0
+SUMMARY=""
+
+# ------------------------------------------------------------------- output --
+
+hr() { printf '%s\n' "------------------------------------------------------------------------"; }
+
+phase() {
+  echo
+  hr
+  printf 'PHASE %s: %s\n' "$1" "$2"
+  printf '  runbook: %s\n' "$3"
+  hr
+}
+
+step()  { printf '\n[step] %s\n' "$*"; }
+ok()    { printf '  OK    %s\n' "$*"; SUMMARY="$SUMMARY
+  OK    $*"; }
+note()  { printf '  note  %s\n' "$*"; }
+warn()  { printf '  WARN  %s\n' "$*"; WARNINGS=$((WARNINGS + 1)); SUMMARY="$SUMMARY
+  WARN  $*"; }
+die()   { printf '\n  STOP  %s\n' "$*" >&2
+          printf '\nThe deploy stopped. Nothing further ran. Log: %s\n' "${LOG:-<none>}" >&2
+          exit 1; }
+
+# Evidence around a step that changes the server. Both lines always print, so
+# the log shows the state the change was applied to and the state it produced.
+evidence() { printf '  %-7s %s\n' "$1" "$2"; }
+
+# --------------------------------------------------------------- executables --
+
+# run_gated: a local command that reaches the network or the server, or that is
+# slow. Printed, not run, under --dry-run.
+GATED_OUT=""
+run_gated() {
+  printf '\n  $ %s\n' "$*"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  [dry-run] not executed\n'
+    GATED_OUT=""
+    return 0
+  fi
+  local rc=0
+  GATED_OUT="$("$@" 2>&1)" || rc=$?
+  printf '%s\n' "$GATED_OUT" | sed 's/^/  | /'
+  return $rc
+}
+
+# remote: run a heredoc on the server over one ssh call. Arguments after the
+# label are passed to the remote bash as $1, $2, ... so nothing has to be
+# interpolated into the heredoc body locally.
+remote() {
+  local label="$1"; shift
+  local body rc=0
+  body="$(cat)"
+  printf '\n  $ %s -- %s   # %s\n' "$SSH_SHOWN" "$*" "$label"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '%s\n' "$body" | sed 's/^/  [dry-run] > /'
+    REMOTE_OUT=""
+    return 0
+  fi
+  REMOTE_OUT="$(printf '%s\n' "$body" | ssh "${SSH_OPTS[@]}" "$PROD_HOST" 'bash -s' -- "$@" 2>&1)" || rc=$?
+  printf '%s\n' "$REMOTE_OUT" | sed 's/^/  | /'
+  return $rc
+}
+
+# expect: assert against the output of the last remote call. Skipped, loudly,
+# under --dry-run, because there was no measurement to judge.
+expect() {
+  local pattern="$1" what="$2"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  SKIP  assert (dry-run): %s   [would match /%s/]\n' "$what" "$pattern"
+    return 0
+  fi
+  if printf '%s\n' "$REMOTE_OUT" | grep -qE -- "$pattern"; then
+    ok "$what"
+  else
+    die "$what -- expected to match /$pattern/ in the server output above"
+  fi
+}
+
+expect_not() {
+  local pattern="$1" what="$2"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  SKIP  assert (dry-run, must NOT match): %s   [/%s/]\n' "$what" "$pattern"
+    return 0
+  fi
+  if printf '%s\n' "$REMOTE_OUT" | grep -qE -- "$pattern"; then
+    die "$what -- server output matched /$pattern/, which the runbook forbids"
+  fi
+  ok "$what"
+}
+
+# ------------------------------------------------- the static sanity reading --
+
+# One implementation, used on the local checkout in phase 0 and on the server
+# checkout in phase 3. The runbook's rule, verbatim: checks 1 to 9 are the
+# gate, check 10 (the commit style guard on the last commit) is known red on
+# main and does not block, anything else red blocks.
+STYLE_GUARD_FAIL='FAIL  style guard flagged the last commit'
+
+sanity_verdict() {
+  local out="$1" where="$2"
+  local fails other reached
+
+  reached="$(printf '%s\n' "$out" | grep -c '10\. Commit/GitHub style guard' || true)"
+  [ "$reached" -ge 1 ] || die "static sanity ($where) never reached check 10; the run did not complete"
+
+  fails="$(printf '%s\n' "$out" | grep -E '^[[:space:]]*FAIL' || true)"
+  other="$(printf '%s\n' "$fails" | grep -v "$STYLE_GUARD_FAIL" | grep -c . || true)"
+
+  if [ "$other" -ne 0 ]; then
+    printf '\n  blocking FAIL lines:\n'
+    printf '%s\n' "$fails" | grep -v "$STYLE_GUARD_FAIL" | sed 's/^/    /'
+    die "static sanity ($where): $other FAIL line(s) outside check 10; the runbook blocks on any of these"
+  fi
+
+  if printf '%s\n' "$fails" | grep -q "$STYLE_GUARD_FAIL"; then
+    ok "static sanity ($where): checks 1 to 9 clear, only check 10 red, as the runbook expects"
+  else
+    ok "static sanity ($where): checks 1 to 10 clear"
+  fi
+}
+
+# --------------------------------------------------------- argument handling --
+
+usage() {
+  sed -n '2,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --preflight-only) PREFLIGHT_ONLY=1; shift ;;
+    --dry-run)        DRY_RUN=1; shift ;;
+    --rollback)       [ $# -ge 2 ] || { echo "--rollback needs a <TS>" >&2; exit 2; }
+                      ROLLBACK_TS="$2"; shift 2 ;;
+    -h|--help)        usage 0 ;;
+    *)                echo "unknown argument: $1" >&2; usage 2 ;;
+  esac
+done
+
+if [ -n "$ROLLBACK_TS" ] && [ "$PREFLIGHT_ONLY" -eq 1 ]; then
+  echo "--rollback and --preflight-only are different runs; pick one" >&2
+  exit 2
+fi
+if [ -n "$ROLLBACK_TS" ] && ! printf '%s' "$ROLLBACK_TS" | grep -qE '^[0-9]{8}-[0-9]{4}$'; then
+  echo "--rollback <TS> must look like 20260902-1830" >&2
+  exit 2
+fi
+
+# ------------------------------------------------------------------ logging --
+
+TS="$(date +%Y%m%d-%H%M)"
+mkdir -p "$ROOT/deploy/logs"
+if [ -n "$ROLLBACK_TS" ]; then
+  LOG="$ROOT/deploy/logs/deploy-3.1-rollback-$ROLLBACK_TS.log"
+else
+  LOG="$ROOT/deploy/logs/deploy-3.1-$TS.log"
+fi
+exec > >(tee -a "$LOG") 2>&1
+
+MODE="full deploy"
+[ "$PREFLIGHT_ONLY" -eq 1 ] && MODE="preflight only (phases 0 and 1)"
+[ -n "$ROLLBACK_TS" ] && MODE="rollback to $ROLLBACK_TS (phase 8)"
+[ "$DRY_RUN" -eq 1 ] && MODE="$MODE, DRY RUN (nothing is executed on the server)"
+
+hr
+echo "PARAMANT deploy 3.1.0 - deploy/DEPLOY-3.1.md as one command"
+hr
+printf '  run started   %s\n' "$(date -Is)"
+printf '  mode          %s\n' "$MODE"
+printf '  run TS        %s\n' "$TS"
+printf '  target        %s\n' "$PROD_HOST"
+printf '  compose dir   %s\n' "$COMPOSE_DIR"
+printf '  docroot       %s\n' "$DOCROOT"
+printf '  deploy ref    %s\n' "$DEPLOY_REF"
+printf '  log           %s\n' "$LOG"
+
+if [ "$DRY_RUN" -eq 0 ]; then
+  [ -r "$PROD_KEY" ] || die "production key not readable: $PROD_KEY (run this from the NUC)"
+  printf '  prod key      present, %s bytes, mode %s\n' \
+    "$(stat -c%s "$PROD_KEY")" "$(stat -c%a "$PROD_KEY")"
+else
+  if [ -r "$PROD_KEY" ]; then
+    printf '  prod key      present (not used in a dry run)\n'
+  else
+    printf '  prod key      absent (fine for a dry run)\n'
+  fi
+fi
+
+# =============================================================== PHASE 0 =====
+
+phase_0() {
+  phase 0 "Before you start (read-only)" "Before you start, points 1 to 4"
+
+  step "0a. CI on main"
+  run_gated gh run list --branch main -L 5 || warn "gh run list did not succeed; check CI on main by hand"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    local concl
+    concl="$(gh run list --branch main -L 5 --json conclusion --jq '.[].conclusion' 2>/dev/null || echo UNKNOWN)"
+    printf '  conclusions: %s\n' "$(printf '%s' "$concl" | tr '\n' ' ')"
+    if printf '%s\n' "$concl" | grep -qx 'failure'; then
+      die "CI on main has a failing run in the last 5; the runbook wants main green"
+    fi
+    if printf '%s\n' "$concl" | grep -qx 'UNKNOWN'; then
+      warn "could not read CI conclusions from gh; check main by hand before continuing"
+    else
+      ok "CI on main: no failing run in the last 5"
+    fi
+  fi
+
+  step "0b. static sanity on the commit that will be deployed ($DEPLOY_REF)"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '\n  $ git worktree add --detach <tmp> %s && tests/static-sanity.sh\n' "$DEPLOY_REF"
+    printf '  [dry-run] not executed\n'
+    printf '  SKIP  assert (dry-run): static sanity, checks 1 to 9 clear\n'
+  else
+    git fetch -q origin || warn "git fetch origin failed; $DEPLOY_REF may be stale"
+    DEPLOY_SHA="$(git rev-parse --short "$DEPLOY_REF")"
+    printf '\n  deploying commit %s (%s)\n' "$DEPLOY_SHA" "$DEPLOY_REF"
+    local wt; wt="$(mktemp -d /tmp/paramant-deploy31.XXXXXX)"
+    rmdir "$wt"
+    git worktree add -q --detach "$wt" "$DEPLOY_REF" \
+      || die "cannot create a worktree at $DEPLOY_REF to test the deploy commit"
+    local out rc=0
+    out="$(cd "$wt" && bash tests/static-sanity.sh 2>&1)" || rc=$?
+    printf '%s\n' "$out" | sed 's/^/  | /'
+    printf '  exit %s\n' "$rc"
+    git worktree remove --force "$wt" >/dev/null 2>&1 || rm -rf "$wt"
+    sanity_verdict "$out" "local, $DEPLOY_SHA"
+  fi
+
+  step "0c. frontend drift against $DEPLOY_REF"
+  if run_gated bash scripts/check-prod-drift.sh "$DEPLOY_REF"; then
+    [ "$DRY_RUN" -eq 0 ] && ok "prod drift guard: docroot matches $DEPLOY_REF"
+  else
+    if [ "$DRY_RUN" -eq 0 ]; then
+      warn "prod drift guard reported drift or could not check; read the list above before phase 5 overwrites the docroot"
+    fi
+  fi
+
+  step "0d. the timestamp this run is named by"
+  printf '  TS = %s (rollback tags, backups and the manifest all carry it)\n' "$TS"
+  ok "run timestamp fixed at $TS"
+}
+
+# =============================================================== PHASE 1 =====
+
+phase_1() {
+  phase 1 "Layout and environment (server, read-only, one write)" "Step 1"
+
+  step "1a. checkout, compose project and container health"
+  remote "layout and health" "$COMPOSE_DIR" "$SERVICES" <<'EOF'
+set -uo pipefail
+cd "$1" || { echo "FATAL cannot cd to $1"; exit 1; }
+echo "checkout_head=$(git rev-parse --short HEAD)"
+echo "checkout_dir=$PWD"
+echo "compose_file_present=$([ -f docker-compose.yml ] && echo yes || echo no)"
+docker compose ls 2>&1 | sed 's/^/compose_ls /'
+for svc in $2; do
+  cid=$(docker compose ps -q "$svc" 2>/dev/null)
+  if [ -z "$cid" ]; then
+    echo "container $svc MISSING"
+    continue
+  fi
+  st=$(docker inspect -f '{{.State.Status}}/{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealthcheck{{end}}' "$cid")
+  echo "container $svc $st"
+done
+EOF
+
+  expect "checkout_head=$EXPECT_PROD_COMMIT" \
+    "production checkout is on $EXPECT_PROD_COMMIT, the commit the runbook measured"
+  expect_not 'container [a-z-]+ MISSING' "all six services have a container"
+  expect_not 'unhealthy' "no container reports unhealthy"
+
+  step "1b. environment presence (never values)"
+  remote "env presence" "$COMPOSE_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+for v in BILLING_MODE MOLLIE_API_KEY MOLLIE_TEST_API_KEY INTERNAL_AUTH_TOKEN ADMIN_TOKEN PARAMANT_TOTP_MASTER_KEY RELAY_REDIS_URL; do
+  printf 'env %-26s ' "$v"
+  docker compose exec -T relay-main sh -c \
+    "v=\$(printenv $v); if [ -z \"\$v\" ]; then echo empty; else echo \"set, prefix \$(printf %s \"\$v\" | cut -c1-5)\"; fi" \
+    2>/dev/null || echo "unreadable"
+done
+echo "envfile INTERNAL_AUTH_TOKEN lines=$(grep -c '^INTERNAL_AUTH_TOKEN=' .env || true)"
+echo "envfile BILLING_MODE lines=$(grep -c '^BILLING_MODE=.\+' .env || true)"
+EOF
+
+  expect 'env BILLING_MODE +empty' \
+    "BILLING_MODE is empty in the running relay, so the recurring layer stays off"
+  expect 'env MOLLIE_API_KEY +set, prefix live_' \
+    "MOLLIE_API_KEY is set with a live_ prefix, unchanged since 08-08"
+
+  step "1c. INTERNAL_AUTH_TOKEN (WRITE if absent: step 5 cannot read /v2/health/deep without it)"
+  remote "internal auth token" "$COMPOSE_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+before=$(grep -c '^INTERNAL_AUTH_TOKEN=.\+' .env || true)
+echo "before INTERNAL_AUTH_TOKEN non-empty lines in .env = $before"
+if [ "$before" -eq 0 ]; then
+  cp -a .env ".env.bak-before-iat-$(date +%Y%m%d-%H%M%S)"
+  sed -i '/^INTERNAL_AUTH_TOKEN=$/d' .env
+  tok=$(openssl rand -hex 32)
+  printf 'INTERNAL_AUTH_TOKEN=%s\n' "$tok" >> .env
+  chmod 600 .env
+  echo "action GENERATED a new INTERNAL_AUTH_TOKEN and appended it to .env"
+  echo "action new token prefix $(printf %s "$tok" | cut -c1-5), length ${#tok}"
+  echo "action the containers pick it up when phase 4 recreates them, nothing restarted now"
+  unset tok
+else
+  echo "action none, INTERNAL_AUTH_TOKEN was already set"
+fi
+after=$(grep -c '^INTERNAL_AUTH_TOKEN=.\+' .env || true)
+echo "after INTERNAL_AUTH_TOKEN non-empty lines in .env = $after"
+EOF
+
+  expect 'after INTERNAL_AUTH_TOKEN non-empty lines in \.env = 1' \
+    "INTERNAL_AUTH_TOKEN present exactly once in .env"
+  if [ "$DRY_RUN" -eq 0 ] && printf '%s\n' "$REMOTE_OUT" | grep -q 'action GENERATED'; then
+    warn "a new INTERNAL_AUTH_TOKEN was generated on the server; note it in the deploy record"
+  fi
+}
+
+# =============================================================== PHASE 2 =====
+
+phase_2() {
+  phase 2 "Rollback tags and backups (server, WRITE)" "Step 2"
+
+  step "2a. tag the running images and write the manifest"
+  remote "rollback tags" "$COMPOSE_DIR" "$TS" "$BACKUP_DIR" "$SERVICES" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+TS="$2"; BK="$3"; SVCS="$4"
+mkdir -p "$BK"
+MANIFEST="$BK/rollback-images-$TS.txt"
+echo "before existing rollback tags = $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -c '^paramant-rollback/' || true)"
+: > "$MANIFEST"
+for svc in $SVCS; do
+  cid=$(docker compose ps -q "$svc" 2>/dev/null)
+  [ -z "$cid" ] && { echo "skip $svc (not running)"; continue; }
+  img=$(docker inspect --format '{{.Config.Image}}' "$cid")
+  docker tag "$img" "paramant-rollback/$svc:$TS"
+  echo "$svc|$img|paramant-rollback/$svc:$TS" >> "$MANIFEST"
+done
+ln -sfn "$MANIFEST" "$BK/rollback-images-latest.txt"
+echo "--- manifest $MANIFEST ---"
+cat "$MANIFEST"
+echo "--- end manifest ---"
+echo "after manifest lines = $(wc -l < "$MANIFEST")"
+echo "after existing rollback tags = $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -c '^paramant-rollback/' || true)"
+EOF
+
+  expect 'after manifest lines = 6' \
+    "rollback manifest has six lines, one per service, so phase 8 can undo this deploy"
+
+  step "2b. back up .env, compose state, docroot and the nginx confs"
+  remote "backups" "$COMPOSE_DIR" "$TS" "$BACKUP_DIR" "$DOCROOT" "$NGINX_BACKUP_DIR" "$NGINX_SITES" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+TS="$2"; BK="$3"; DOCROOT="$4"; NGBK="$5"; NGSITES="$6"
+mkdir -p "$BK" "$NGBK"
+
+echo "before .env bytes = $(stat -c%s .env 2>/dev/null || echo missing)"
+cp .env "$BK/.env-pre-3.1-$TS" && chmod 600 "$BK/.env-pre-3.1-$TS"
+echo "after  .env backup = $BK/.env-pre-3.1-$TS ($(stat -c%s "$BK/.env-pre-3.1-$TS") bytes, mode $(stat -c%a "$BK/.env-pre-3.1-$TS"))"
+
+docker compose ps > "$BK/state-pre-3.1-$TS.txt"
+echo "after  compose state = $BK/state-pre-3.1-$TS.txt ($(wc -l < "$BK/state-pre-3.1-$TS.txt") lines)"
+
+echo "before docroot files = $(find "$DOCROOT" -type f | wc -l)"
+tar czf "$BK/docroot-pre-3.1-$TS.tgz" -C "$(dirname "$DOCROOT")" "$(basename "$DOCROOT")"
+echo "after  docroot tar = $BK/docroot-pre-3.1-$TS.tgz ($(stat -c%s "$BK/docroot-pre-3.1-$TS.tgz") bytes, $(tar tzf "$BK/docroot-pre-3.1-$TS.tgz" | wc -l) entries)"
+
+# Back up every enabled site conf, not only the public one: phase 5 edits
+# whichever files actually carry the lines the runbook names.
+n=0
+for f in "$NGSITES"/*; do
+  [ -f "$f" ] || continue
+  cp -a "$f" "$NGBK/$(basename "$f").pre-3.1-$TS"
+  n=$((n+1))
+done
+echo "after  nginx conf backups = $n file(s) in $NGBK with suffix .pre-3.1-$TS"
+ls -1 "$NGBK" | grep -F "pre-3.1-$TS" | sed 's/^/nginxbackup /'
+
+if [ -x deploy/ops/backup-full-state.sh ]; then
+  echo "--- deploy/ops/backup-full-state.sh ---"
+  bash deploy/ops/backup-full-state.sh 2>&1 | tail -25
+  echo "fullstate exit=${PIPESTATUS[0]}"
+else
+  echo "fullstate deploy/ops/backup-full-state.sh not present or not executable, skipped"
+fi
+EOF
+
+  expect "after  \\.env backup = $BACKUP_DIR/\\.env-pre-3\\.1-$TS" ".env backed up"
+  expect "after  docroot tar = $BACKUP_DIR/docroot-pre-3\\.1-$TS\\.tgz" "docroot tarred"
+  expect 'after  nginx conf backups = [1-9]' "at least one nginx conf backed up"
+}
+
+# =============================================================== PHASE 3 =====
+
+phase_3() {
+  phase 3 "Pull main, run the sanity gate, build (server, WRITE)" "Step 3"
+
+  step "3a. pull $DEPLOY_REF fast-forward only"
+  remote "git pull" "$COMPOSE_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+echo "before HEAD = $(git rev-parse --short HEAD)"
+echo "before status:"
+git status --porcelain | sed 's/^/  dirty /'
+if [ -n "$(git status --porcelain)" ]; then
+  echo "FATAL working tree not clean; stash and note what it was before deploying"
+  exit 1
+fi
+git fetch origin 2>&1 | sed 's/^/  fetch /'
+git pull --ff-only origin main 2>&1 | sed 's/^/  pull /'
+echo "after HEAD = $(git rev-parse --short HEAD)"
+echo "after HEAD long = $(git rev-parse HEAD)"
+EOF
+
+  expect_not 'FATAL working tree not clean' "server working tree was clean before the pull"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    local after_head; after_head="$(printf '%s\n' "$REMOTE_OUT" | sed -n 's/^after HEAD long = //p')"
+    local want; want="$(git rev-parse "$DEPLOY_REF")"
+    [ -n "$after_head" ] || die "could not read the server HEAD after the pull"
+    [ "$after_head" = "$want" ] \
+      || die "server is on $after_head after the pull, expected $want ($DEPLOY_REF, the commit phase 0 tested)"
+    ok "server checkout is on ${after_head:0:7}, the commit phase 0 tested"
+    printf '%s\n' "$REMOTE_OUT" | grep -q "before HEAD = $EXPECT_PROD_COMMIT" \
+      || warn "server was not on $EXPECT_PROD_COMMIT before the pull; the rollback images are still correct, but the runbook's starting point was different"
+  fi
+
+  step "3b. static sanity on the server, same reading rule as phase 0"
+  remote "static sanity" "$COMPOSE_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+bash tests/static-sanity.sh 2>&1
+echo "sanity exit=$?"
+EOF
+  [ "$DRY_RUN" -eq 1 ] && printf '  SKIP  assert (dry-run): static sanity on the server\n' \
+    || sanity_verdict "$REMOTE_OUT" "server"
+
+  step "3c. build the relays and admin from source (containers untouched)"
+  remote "docker compose build" "$COMPOSE_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+echo "before images:"
+docker compose images 2>/dev/null | sed 's/^/  img /'
+docker compose build 2>&1 | tail -40
+echo "build exit=${PIPESTATUS[0]}"
+echo "after images:"
+docker compose images 2>/dev/null | sed 's/^/  img /'
+EOF
+  expect 'build exit=0' "docker compose build succeeded"
+}
+
+# =============================================================== PHASE 4 =====
+
+phase_4() {
+  phase 4 "Recreate, the canary relay first (server, WRITE)" "Step 4"
+
+  step "4a. relay-iot alone, then read its two boot lines"
+  remote "recreate relay-iot" "$COMPOSE_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+
+wait_healthy() {  # container id, max seconds
+  local w=0
+  while [ "$w" -lt "${2:-60}" ]; do
+    s=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealthcheck{{end}}' "$1" 2>/dev/null || echo unknown)
+    [ "$s" = healthy ] && { echo "healthy $1 after ${w}s"; return 0; }
+    [ "$s" = nohealthcheck ] && { echo "healthy $1 (no healthcheck defined, running)"; return 0; }
+    [ "$s" = unhealthy ] && { echo "UNHEALTHY $1"; docker logs "$1" 2>&1 | tail -20; return 1; }
+    sleep 5; w=$((w+5))
+  done
+  echo "NOTHEALTHY $1 after ${2:-60}s"
+  return 1
+}
+
+old=$(docker compose ps -q relay-iot 2>/dev/null)
+echo "before relay-iot container = ${old:-none}"
+[ -n "$old" ] && echo "before relay-iot image = $(docker inspect -f '{{.Image}}' "$old")"
+
+docker compose up -d --no-deps relay-iot 2>&1 | sed 's/^/  up /'
+cid=$(docker compose ps -q relay-iot)
+[ -n "$cid" ] || { echo "FATAL relay-iot has no container after up"; exit 1; }
+echo "after  relay-iot container = $cid"
+echo "after  relay-iot image = $(docker inspect -f '{{.Image}}' "$cid")"
+
+wait_healthy "$cid" 120 || exit 1
+
+echo "--- relay-iot boot lines ---"
+docker logs "$cid" 2>&1 | grep -E '"relay_started"|"billing_config"' | tail -4 | sed 's/^/bootline /'
+echo "--- end boot lines ---"
+EOF
+
+  expect 'healthy [0-9a-f]+ after' "relay-iot reached healthy"
+  expect 'bootline .*"billing_config"' "relay-iot logged a billing_config line"
+  expect 'bootline .*"billing_config".*"recurring":false' \
+    "billing_config says recurring:false, the brake is on"
+  expect 'bootline .*"billing_config".*"mode_source":"inferred"' \
+    "billing_config says mode_source:inferred, so BILLING_MODE is not set anywhere"
+  expect_not '"billing_config".*"recurring":true' \
+    "no relay reports recurring:true"
+  expect "bootline .*\"relay_started\".*\"version\":\"$EXPECT_VERSION\"" \
+    "relay_started reports version $EXPECT_VERSION"
+
+  step "4b. relay-main, then the rest"
+  remote "recreate the fleet" "$COMPOSE_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+
+wait_healthy() {
+  local w=0
+  while [ "$w" -lt "${2:-60}" ]; do
+    s=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealthcheck{{end}}' "$1" 2>/dev/null || echo unknown)
+    [ "$s" = healthy ] && { echo "healthy $1 after ${w}s"; return 0; }
+    [ "$s" = nohealthcheck ] && { echo "healthy $1 (no healthcheck defined, running)"; return 0; }
+    [ "$s" = unhealthy ] && { echo "UNHEALTHY $1"; docker logs "$1" 2>&1 | tail -20; return 1; }
+    sleep 5; w=$((w+5))
+  done
+  echo "NOTHEALTHY $1 after ${2:-60}s"
+  return 1
+}
+
+recreate() {
+  local svc="$1"
+  local old; old=$(docker compose ps -q "$svc" 2>/dev/null)
+  echo "before $svc image = $([ -n "$old" ] && docker inspect -f '{{.Image}}' "$old" || echo none)"
+  docker compose up -d --no-deps "$svc" 2>&1 | sed "s/^/  up /"
+  local cid; cid=$(docker compose ps -q "$svc")
+  [ -n "$cid" ] || { echo "FATAL $svc has no container after up"; return 1; }
+  echo "after  $svc image = $(docker inspect -f '{{.Image}}' "$cid")"
+  wait_healthy "$cid" 120 || return 1
+  echo "recreated $svc"
+}
+
+recreate relay-main || exit 1
+for svc in relay-health relay-finance relay-legal admin; do
+  recreate "$svc" || exit 1
+done
+
+echo "--- billing stance on every relay ---"
+for svc in relay-main relay-health relay-finance relay-legal relay-iot; do
+  cid=$(docker compose ps -q "$svc")
+  printf 'stance %-14s ' "$svc"
+  docker logs "$cid" 2>&1 | grep '"billing_config"' | tail -1 | grep -o '"recurring":[a-z]*' || echo "no billing_config line"
+done
+echo "--- versions ---"
+for svc in relay-main relay-health relay-finance relay-legal relay-iot; do
+  cid=$(docker compose ps -q "$svc")
+  printf 'version %-14s ' "$svc"
+  docker logs "$cid" 2>&1 | grep '"relay_started"' | tail -1 | grep -o '"version":"[^"]*"' || echo "no relay_started line"
+done
+EOF
+
+  expect 'recreated relay-main' "relay-main recreated and healthy"
+  expect 'recreated admin' "admin recreated and healthy"
+  expect_not 'NOTHEALTHY|UNHEALTHY|FATAL' "every recreated container reached healthy"
+  expect_not 'stance .*"recurring":true' "no relay reports recurring:true after the recreate"
+  expect_not 'version .*no relay_started line' "every relay logged relay_started"
+}
+
+# =============================================================== PHASE 5 =====
+
+phase_5() {
+  phase 5 "Frontend and nginx (server, WRITE)" "Step 5"
+
+  step "5a. rsync the docroot, never with --delete"
+  remote "rsync docroot" "$COMPOSE_DIR" "$DOCROOT" <<'EOF'
+set -uo pipefail
+SRC="$1/frontend/"; DST="$2/"
+echo "before docroot files = $(find "$2" -type f | wc -l)"
+echo "before would change:"
+rsync -rinc --no-times "$SRC" "$DST" | sed 's/^/  wouldchange /' | head -60
+echo "before would change count = $(rsync -rinc --no-times "$SRC" "$DST" | grep -c . || true)"
+rsync -rc --no-times "$SRC" "$DST" 2>&1 | tail -5 | sed 's/^/  rsync /'
+echo "rsync exit=${PIPESTATUS[0]}"
+echo "after  docroot files = $(find "$2" -type f | wc -l)"
+echo "after  would change count = $(rsync -rinc --no-times "$SRC" "$DST" | grep -c . || true)"
+EOF
+  expect 'rsync exit=0' "docroot rsync succeeded"
+  expect 'after  would change count = 0' "docroot now matches the checkout frontend"
+
+  step "5b. the three nginx changes, by hand, keeping the ParaID deny"
+  remote "nginx edits" "$TS" "$NGINX_SITES" "$NGINX_BACKUP_DIR" <<'EOF'
+set -uo pipefail
+TS="$1"; SITES="$2"; NGBK="$3"
+
+echo "--- before ---"
+grep -rn 'paraid/issue' "$SITES" 2>/dev/null | sed 's/^/  paraid /' | head -20
+echo "before paraid deny lines = $(grep -rc 'paraid/issue' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
+echo "before sign gated lines = $(grep -rc 'location = /sign.*auth_request' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
+echo "before compliance lines = $(grep -rcE '^[[:space:]]*location = /compliance(/(nis2|iec62443|nen7510))?[[:space:]]*\{' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
+echo "before dicom try_files lines = $(grep -rc 'location = /dicom.*try_files /dicom.html' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
+
+PARAID_BEFORE=$(grep -rc 'paraid/issue' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+
+edited=0
+for f in "$SITES"/*; do
+  [ -f "$f" ] || continue
+  cp -a "$f" "/tmp/nginx-pre-3.1-$(basename "$f").$TS"
+  # 1. /sign leaves the auth_request gate (#317).
+  sed -i -E 's|(location = /sign[[:space:]]*\{)[[:space:]]*auth_request /api/user/check; error_page 401 = @login_redirect;|\1|' "$f"
+  # 2. the /compliance locations go (#323), redirect included.
+  sed -i -E '/^[[:space:]]*location = \/compliance(\/(nis2|iec62443|nen7510))?[[:space:]]*\{/d' "$f"
+  # 3. /dicom answers 404 instead of serving the page, exact match kept so
+  #    nginx cannot auto-redirect it into the /dicom/ proxy.
+  sed -i -E 's|(location = /dicom[[:space:]]*\{)[[:space:]]*try_files /dicom\.html[[:space:]]*=404;[[:space:]]*\}|\1 return 404; }|' "$f"
+  if ! cmp -s "$f" "/tmp/nginx-pre-3.1-$(basename "$f").$TS"; then
+    echo "edited $(basename "$f")"
+    edited=$((edited+1))
+  fi
+done
+echo "after  edited files = $edited"
+
+echo "--- after ---"
+echo "after  paraid deny lines = $(grep -rc 'paraid/issue' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
+echo "after  sign gated lines = $(grep -rc 'location = /sign.*auth_request' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
+echo "after  compliance lines = $(grep -rcE '^[[:space:]]*location = /compliance(/(nis2|iec62443|nen7510))?[[:space:]]*\{' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
+echo "after  dicom try_files lines = $(grep -rc 'location = /dicom.*try_files /dicom.html' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
+echo "after  dicom 404 lines = $(grep -rc 'location = /dicom.*return 404' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')"
+
+PARAID_AFTER=$(grep -rc 'paraid/issue' "$SITES" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+if [ "$PARAID_AFTER" -lt "$PARAID_BEFORE" ]; then
+  echo "FATAL the ParaID deny lost $((PARAID_BEFORE - PARAID_AFTER)) line(s); restoring"
+  for b in "$NGBK"/*.pre-3.1-"$TS"; do
+    [ -f "$b" ] || continue
+    cp -a "$b" "$SITES/$(basename "$b" ".pre-3.1-$TS")"
+  done
+  exit 1
+fi
+
+if nginx -t 2>&1 | sed 's/^/  nginxt /'; then
+  systemctl reload nginx && echo "reloaded nginx"
+else
+  echo "FATAL nginx -t failed, restoring the backed up confs"
+  for b in "$NGBK"/*.pre-3.1-"$TS"; do
+    [ -f "$b" ] || continue
+    cp -a "$b" "$SITES/$(basename "$b" ".pre-3.1-$TS")"
+  done
+  nginx -t 2>&1 | sed 's/^/  restoredtest /'
+  systemctl reload nginx && echo "restored and reloaded the previous nginx conf"
+  exit 1
+fi
+EOF
+
+  expect_not 'FATAL' "nginx edits applied and the config tests clean"
+  expect 'after  sign gated lines = 0' "/sign is no longer behind auth_request"
+  expect 'after  compliance lines = 0' "the /compliance locations are gone"
+  expect 'after  dicom try_files lines = 0' "/dicom no longer serves the page"
+  expect 'reloaded nginx' "nginx reloaded"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    local pb pa
+    pb="$(printf '%s\n' "$REMOTE_OUT" | sed -n 's/^before paraid deny lines = //p')"
+    pa="$(printf '%s\n' "$REMOTE_OUT" | sed -n 's/^after  paraid deny lines = //p')"
+    if [ -n "$pb" ] && [ -n "$pa" ] && [ "$pa" -ge "$pb" ] && [ "$pa" -gt 0 ]; then
+      ok "the ParaID deny survived the edit ($pa line(s), was $pb)"
+    else
+      die "the ParaID deny changed from ${pb:-?} to ${pa:-?} lines; the runbook keeps it in this round"
+    fi
+  fi
+}
+
+# =============================================================== PHASE 6 =====
+
+phase_6() {
+  phase 6 "Smoke tests" "Step 6"
+
+  step "6a. public auth surface (tests/auth-smoke.sh)"
+  if run_gated bash tests/auth-smoke.sh https://paramant.app; then
+    [ "$DRY_RUN" -eq 0 ] && ok "auth-smoke.sh passed against https://paramant.app"
+  else
+    [ "$DRY_RUN" -eq 0 ] && die "auth-smoke.sh failed; the runbook rolls back on this (phase 8)"
+  fi
+
+  step "6b. /health on each of the six hosts, and the version it reports"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '\n  $ curl -s -o /dev/null -w %%{http_code} https://<host>/health   # six hosts\n'
+    printf '  [dry-run] not executed\n'
+    printf '  SKIP  assert (dry-run): /health is 200 on six hosts, version %s\n' "$EXPECT_VERSION"
+  else
+    local h code
+    for h in $HOSTS; do
+      code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "https://$h/health" || echo 000)"
+      printf '  health %-26s %s\n' "$h" "$code"
+      [ "$code" = "200" ] || die "/health on $h answered $code, expected 200"
+    done
+    ok "/health is 200 on all six hosts"
+    local ver
+    ver="$(curl -s --max-time 15 https://paramant.app/health \
+           | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version",""))' 2>/dev/null || echo "")"
+    printf '  version reported by paramant.app/health = %s\n' "$ver"
+    [ "$ver" = "$EXPECT_VERSION" ] || die "/health reports version '$ver', expected $EXPECT_VERSION"
+    ok "/health reports version $EXPECT_VERSION"
+  fi
+
+  step "6c. /v2/health/deep, 401 without the token and 200 with it (server-local)"
+  remote "deep health" "$COMPOSE_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+# The token is read into a variable and never echoed; only the status codes
+# and the parsed overall field are printed.
+T=$(grep '^INTERNAL_AUTH_TOKEN=' .env | head -1 | cut -d= -f2-)
+if [ -z "$T" ]; then echo "FATAL INTERNAL_AUTH_TOKEN empty in .env"; exit 1; fi
+echo "deep token present, length ${#T}, prefix $(printf %s "$T" | cut -c1-5)"
+echo "deep noauth code = $(curl -s -o /dev/null -w '%{http_code}' --max-time 15 http://127.0.0.1:3000/v2/health/deep)"
+echo "deep auth   code = $(curl -s -o /dev/null -w '%{http_code}' --max-time 15 -H "X-Internal-Auth: $T" http://127.0.0.1:3000/v2/health/deep)"
+curl -s --max-time 15 -H "X-Internal-Auth: $T" http://127.0.0.1:3000/v2/health/deep \
+  | python3 -c 'import json,sys; d=json.load(sys.stdin); print("deep overall =", d.get("overall") or d.get("status") or "unknown")' 2>/dev/null \
+  || echo "deep overall = unparseable"
+unset T
+EOF
+  expect 'deep noauth code = 401' "/v2/health/deep is 401 without X-Internal-Auth"
+  expect 'deep auth   code = 200' "/v2/health/deep is 200 with X-Internal-Auth"
+
+  step "6d. /v1/paraid/issue-document is 404 on all six hosts (#319)"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '\n  $ curl -s -o /dev/null -w %%{http_code} -X POST https://<host>/v1/paraid/issue-document   # six hosts\n'
+    printf '  [dry-run] not executed\n'
+    printf '  SKIP  assert (dry-run): issue-document is 404 on six hosts\n'
+  else
+    local h code
+    for h in $HOSTS; do
+      code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 -X POST "https://$h/v1/paraid/issue-document" || echo 000)"
+      printf '  paraid %-26s %s\n' "$h" "$code"
+      [ "$code" = "404" ] || die "/v1/paraid/issue-document on $h answered $code, expected 404"
+    done
+    ok "/v1/paraid/issue-document is 404 on all six hosts"
+  fi
+
+  step "6e. /sign answers itself, 200 and no redirect to /auth/login (#317)"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '\n  $ curl -s -o /dev/null -w %%{http_code} https://paramant.app/sign\n'
+    printf '  [dry-run] not executed\n'
+    printf '  SKIP  assert (dry-run): /sign is 200 without a session\n'
+  else
+    local code
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 https://paramant.app/sign || echo 000)"
+    printf '  sign code = %s\n' "$code"
+    [ "$code" = "200" ] || die "/sign answered $code, expected 200 without a login"
+    ok "/sign is 200 without a login"
+  fi
+
+  step "6f. the 3.0.0 verify suite, on the server (informational, exit 2 blocks)"
+  remote "post-deploy-verify" "$COMPOSE_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+bash scripts/post-deploy-verify.sh https://paramant.app http://127.0.0.1:3000 2>&1 | tail -40
+echo "verify exit=${PIPESTATUS[0]}"
+EOF
+  if [ "$DRY_RUN" -eq 0 ]; then
+    if printf '%s\n' "$REMOTE_OUT" | grep -q 'verify exit=2'; then
+      die "post-deploy-verify.sh exited 2 (critical); the runbook rolls back on this (phase 8)"
+    fi
+    if printf '%s\n' "$REMOTE_OUT" | grep -q 'verify exit=0'; then
+      ok "post-deploy-verify.sh passed"
+    else
+      warn "post-deploy-verify.sh exited non-zero but not 2; its /health/deep probe is known red (the route is /v2/health/deep), read the list above"
+    fi
+  fi
+
+  step "6g. billing stance once more, from every relay log"
+  remote "billing stance" "$COMPOSE_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+for svc in relay-main relay-health relay-finance relay-legal relay-iot; do
+  cid=$(docker compose ps -q "$svc")
+  printf 'stance %-14s ' "$svc"
+  docker logs "$cid" 2>&1 | grep '"billing_config"' | tail -1 | grep -o '"recurring":[a-z]*' || echo "no billing_config line"
+done
+EOF
+  expect_not '"recurring":true' "every relay still reports recurring:false"
+}
+
+# =============================================================== PHASE 7 =====
+
+phase_7() {
+  phase 7 "Summary" "Step 7, what to do after the deploy"
+
+  echo
+  echo "Result lines, in order:"
+  printf '%s\n' "$SUMMARY"
+  echo
+  printf '  warnings      %s\n' "$WARNINGS"
+  printf '  run TS        %s\n' "$TS"
+  printf '  rollback with bash deploy/deploy-3.1.sh --rollback %s\n' "$TS"
+  printf '  log           %s\n' "$LOG"
+  echo
+  echo "Still by hand, on purpose (runbook step 7):"
+  echo "  1. watch thirty minutes: docker compose logs -f --tail=200 relay-main"
+  echo "  2. mint the ParaSign canary key and set PARASIGN_CANARY_KEY as an"
+  echo "     Actions secret, then dispatch product-heartbeat.yml once"
+  echo "  3. scripts/check-prod-drift.sh origin/main must print OK"
+  echo "  4. git tag v$EXPECT_VERSION <commit> and push it, put the live date in CHANGELOG.md"
+  echo "  5. write the deploy down in the vault, with the billing_config line as logged"
+  echo
+  echo "BILLING_MODE stays empty. Turning the recurring layer on is a separate"
+  echo "change that needs a Mollie test key first (runbook, 'Deciding on the"
+  echo "recurring layer, later, not today')."
+}
+
+# =============================================================== PHASE 8 =====
+
+phase_8() {
+  phase 8 "Rollback to $ROLLBACK_TS (server, WRITE)" "Step 8"
+
+  step "8a. the manifest and the saved images"
+  remote "rollback manifest" "$COMPOSE_DIR" "$ROLLBACK_TS" "$BACKUP_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+TS="$2"; BK="$3"
+M="$BK/rollback-images-$TS.txt"
+[ -f "$M" ] || { echo "FATAL no manifest $M"; exit 1; }
+echo "manifest lines = $(wc -l < "$M")"
+cat "$M" | sed 's/^/  manifest /'
+missing=0
+while IFS='|' read -r svc image rbtag; do
+  [ -z "${svc:-}" ] && continue
+  if docker image inspect "$rbtag" >/dev/null 2>&1; then
+    echo "  present $rbtag"
+  else
+    echo "  MISSING $rbtag"
+    missing=$((missing+1))
+  fi
+done < "$M"
+echo "missing rollback images = $missing"
+EOF
+  expect_not 'FATAL no manifest' "the manifest for $ROLLBACK_TS exists"
+  expect 'missing rollback images = 0' "every rollback image from $ROLLBACK_TS is still on the host"
+
+  step "8b. retag the saved images and recreate without rebuilding"
+  remote "rollback images" "$COMPOSE_DIR" "$ROLLBACK_TS" "$BACKUP_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+TS="$2"; BK="$3"
+M="$BK/rollback-images-$TS.txt"
+SVCS=""
+while IFS='|' read -r svc image rbtag; do
+  [ -z "${svc:-}" ] && continue
+  cid=$(docker compose ps -q "$svc" 2>/dev/null)
+  echo "before $svc image = $([ -n "$cid" ] && docker inspect -f '{{.Image}}' "$cid" || echo none)"
+  docker tag "$rbtag" "$image"
+  SVCS="$SVCS $svc"
+done < "$M"
+docker compose up -d --no-deps --force-recreate $SVCS 2>&1 | sed 's/^/  up /'
+for svc in $SVCS; do
+  cid=$(docker compose ps -q "$svc" 2>/dev/null)
+  echo "after  $svc image = $([ -n "$cid" ] && docker inspect -f '{{.Image}}' "$cid" || echo none)"
+done
+echo "recreated:$SVCS"
+EOF
+  expect 'recreated: ' "the saved images were retagged and the containers recreated"
+
+  step "8c. restore .env, the nginx confs and the docroot"
+  remote "restore state" "$COMPOSE_DIR" "$ROLLBACK_TS" "$BACKUP_DIR" "$DOCROOT" "$NGINX_BACKUP_DIR" "$NGINX_SITES" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+TS="$2"; BK="$3"; DOCROOT="$4"; NGBK="$5"; SITES="$6"
+
+if [ -f "$BK/.env-pre-3.1-$TS" ]; then
+  echo "before .env bytes = $(stat -c%s .env)"
+  cp -a .env ".env.bak-rollback-$TS"
+  cp "$BK/.env-pre-3.1-$TS" .env && chmod 600 .env
+  echo "after  .env bytes = $(stat -c%s .env) (restored from $BK/.env-pre-3.1-$TS)"
+else
+  echo "WARN no .env backup for $TS, .env left as it is"
+fi
+
+n=0
+for b in "$NGBK"/*.pre-3.1-"$TS"; do
+  [ -f "$b" ] || continue
+  target="$SITES/$(basename "$b" ".pre-3.1-$TS")"
+  echo "before nginx $(basename "$target") bytes = $(stat -c%s "$target" 2>/dev/null || echo missing)"
+  cp -a "$b" "$target"
+  echo "after  nginx $(basename "$target") bytes = $(stat -c%s "$target")"
+  n=$((n+1))
+done
+echo "restored nginx confs = $n"
+if [ "$n" -gt 0 ]; then
+  nginx -t 2>&1 | sed 's/^/  nginxt /'
+  systemctl reload nginx && echo "reloaded nginx"
+fi
+
+if [ -f "$BK/docroot-pre-3.1-$TS.tgz" ]; then
+  echo "before docroot files = $(find "$DOCROOT" -type f | wc -l)"
+  tar xzf "$BK/docroot-pre-3.1-$TS.tgz" -C "$(dirname "$DOCROOT")"
+  echo "after  docroot files = $(find "$DOCROOT" -type f | wc -l) (restored from the pre-3.1 tar)"
+else
+  echo "WARN no docroot tar for $TS, docroot left as it is"
+fi
+
+# .env changed, so the relays have to come back on the restored file.
+docker compose up -d --no-deps --force-recreate relay-main 2>&1 | sed 's/^/  up /'
+EOF
+
+  step "8d. health after the rollback"
+  remote "rollback health" "$COMPOSE_DIR" <<'EOF'
+set -uo pipefail
+cd "$1" || exit 1
+ok=no
+for _ in $(seq 1 30); do
+  if curl -fs --max-time 3 http://127.0.0.1:3000/health >/dev/null 2>&1; then ok=yes; break; fi
+  sleep 2
+done
+echo "rollback relay health = $ok"
+echo "rollback version = $(curl -s --max-time 5 http://127.0.0.1:3000/health | grep -o '"version":"[^"]*"' || echo unknown)"
+cid=$(docker compose ps -q relay-main)
+echo "rollback paraidAuth occurrences in relay.js = $(docker exec "$cid" grep -c _paraidAuth /app/relay.js 2>/dev/null || echo 0)"
+EOF
+  expect 'rollback relay health = yes' "the relay answers /health after the rollback"
+
+  step "8e. smoke tests after the rollback"
+  if run_gated bash tests/auth-smoke.sh https://paramant.app; then
+    [ "$DRY_RUN" -eq 0 ] && ok "auth-smoke.sh passed after the rollback"
+  else
+    [ "$DRY_RUN" -eq 0 ] && warn "auth-smoke.sh failed after the rollback; the site needs hands, not another script"
+  fi
+  if [ "$DRY_RUN" -eq 0 ]; then
+    local h code
+    for h in $HOSTS; do
+      code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "https://$h/health" || echo 000)"
+      printf '  health %-26s %s\n' "$h" "$code"
+      [ "$code" = "200" ] || warn "/health on $h answered $code after the rollback"
+    done
+  else
+    printf '\n  $ curl -s -o /dev/null -w %%{http_code} https://<host>/health   # six hosts\n'
+    printf '  [dry-run] not executed\n'
+  fi
+
+  echo
+  echo "Rollback summary:"
+  printf '%s\n' "$SUMMARY"
+  printf '\n  warnings      %s\n' "$WARNINGS"
+  printf '  log           %s\n' "$LOG"
+  echo
+  echo "The checkout stays on main; the images are what run. Decide separately"
+  echo "whether to move the checkout back."
+}
+
+# ------------------------------------------------------------------- driver --
+
+if [ -n "$ROLLBACK_TS" ]; then
+  phase_8
+  echo
+  hr
+  echo "ROLLBACK FINISHED, warnings: $WARNINGS"
+  hr
+  exit 0
+fi
+
+phase_0
+phase_1
+
+if [ "$PREFLIGHT_ONLY" -eq 1 ]; then
+  echo
+  hr
+  echo "PREFLIGHT ONLY: phases 0 and 1 done, stopping before any deploy write."
+  printf 'Warnings: %s. Log: %s\n' "$WARNINGS" "$LOG"
+  hr
+  exit 0
+fi
+
+phase_2
+phase_3
+phase_4
+phase_5
+phase_6
+phase_7
+
+echo
+hr
+echo "DEPLOY FINISHED, warnings: $WARNINGS"
+hr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,16 @@ x-relay-env: &relay-env
   REDIS_URL: "${RELAY_REDIS_URL}"
   ENABLE_USER_TOTP: "${ENABLE_USER_TOTP:-false}"
   INTERNAL_AUTH_TOKEN: "${INTERNAL_AUTH_TOKEN:-}"
+  # ParaSend delivery receipts (#342). The relay reads these by name, so they
+  # need a line here: .env only substitutes ${VAR} into this file, there is no
+  # env_file, and a variable that is not listed never reaches a container.
+  # Empty is the documented default for all four: the inline header is off
+  # unless the value is exactly 1, and the caps fall back to their built-in
+  # numbers when the variable is empty.
+  PARAMANT_INLINE_RECEIPT_HEADER: "${PARAMANT_INLINE_RECEIPT_HEADER:-}"
+  PARAMANT_RECEIPT_PER_ACCOUNT_MAX: "${PARAMANT_RECEIPT_PER_ACCOUNT_MAX:-}"
+  PARAMANT_RECEIPT_UNCAPPED_MAX: "${PARAMANT_RECEIPT_UNCAPPED_MAX:-}"
+  PARAMANT_RECEIPT_TOTAL_MAX: "${PARAMANT_RECEIPT_TOTAL_MAX:-}"
   PARAMANT_WIRE_VERSION: "${PARAMANT_WIRE_VERSION:-1}"
   # Opt-in static frontend serving (plug-and-play self-host). Default false:
   # production serves frontend/ via nginx and ignores this + the ro mount below.

--- a/tests/deploy-3.1-dryrun.test.sh
+++ b/tests/deploy-3.1-dryrun.test.sh
@@ -3,11 +3,15 @@
 #
 # The deploy script is the only thing in this repo that recreates production
 # containers and rewrites the nginx config, and it cannot be exercised against
-# the server from CI. So this test asserts the two properties that can be
-# checked without a server:
+# the server from CI. So this test asserts the properties that can be checked
+# without a server:
 #
 #   1. every phase of deploy/DEPLOY-3.1.md is reached, in every mode
-#   2. no line the script would print can carry a key value
+#   2. ssh argument passing survives the join-and-resplit that ssh performs
+#   3. every remote block runs under set -euo pipefail
+#   4. --preflight-only writes nothing
+#   5. no line the script would print, and no line in its source, can carry a
+#      key value
 #
 # It runs the script with --dry-run, which executes nothing: every remote block
 # and every gated local command is printed instead. Exit 0 = all pass.
@@ -26,10 +30,10 @@ pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS + 1)); }
 fail() { printf '  FAIL  %s\n' "$1"; FAIL=$((FAIL + 1)); FAILURES="$FAILURES
   - $1"; }
 
-check_has() {   # haystack-file, pattern, name
+check_has() {   # file, pattern, name
   if grep -qE -- "$2" "$1"; then pass "$3"; else fail "$3 (no line matching /$2/)"; fi
 }
-check_lacks() { # haystack-file, pattern, name
+check_lacks() { # file, pattern, name
   if grep -qE -- "$2" "$1"; then
     fail "$3"
     grep -nE -- "$2" "$1" | head -5 | sed 's/^/        /'
@@ -61,34 +65,103 @@ else
   printf '  SKIP  shellcheck not installed\n'
 fi
 
+# ------------------------------------------------ 2. the ssh argv join bug ---
+echo ""
+echo "2. ssh joins argv into one string; a multi-word argument must survive it"
+# This is a regression test for a real bug. ssh does not preserve argv: it
+# joins everything after the host into a single command string, which the
+# remote shell splits again on whitespace. So passing the six service names as
+# one argument used to arrive as six separate parameters, and every remote
+# `for svc in $2` ran exactly once. Phase 1 then checked 1 of 6 containers and
+# phase 2 wrote a 1-line rollback manifest.
+#
+# There is no sshd to talk to here, so the join is reproduced exactly: "$*"
+# concatenates with spaces, and bash -c re-splits, which is what sshd does.
+if eval "$(sed -n '/^q_args()/,/^}/p' "$SCRIPT")" 2>/dev/null && declare -F q_args >/dev/null; then
+  pass "q_args() could be extracted from the script"
+
+  SVCS="relay-main relay-health relay-finance relay-legal relay-iot admin"
+  BODY='echo "argc=$#"; for s in $2; do echo "svc $s"; done'
+
+  # ssh: the client joins, the server re-splits.
+  fake_ssh() { local joined="$*"; bash -c "$joined"; }
+
+  quoted="$(printf '%s\n' "$BODY" | fake_ssh "bash -s --$(q_args /opt/paramant-relay "$SVCS")")"
+  n_svc="$(printf '%s\n' "$quoted" | grep -c '^svc ' || true)"
+  argc="$(printf '%s\n' "$quoted" | sed -n 's/^argc=//p')"
+
+  if [ "$argc" = "2" ]; then pass "the remote shell sees 2 arguments, not 7"; else
+    fail "the remote shell sees argc=$argc, expected 2 (arguments are being re-split)"
+  fi
+  if [ "$n_svc" = "6" ]; then pass "all six service names survive the ssh join"; else
+    fail "only $n_svc of 6 service names survived the ssh join"
+    printf '%s\n' "$quoted" | sed 's/^/        /'
+  fi
+
+  # Negative control: without the quoting the bug comes back. If this ever
+  # passes, the simulation stopped reproducing ssh and the test above is empty.
+  unquoted="$(printf '%s\n' "$BODY" | fake_ssh "bash -s --" /opt/paramant-relay "$SVCS")"
+  n_bad="$(printf '%s\n' "$unquoted" | grep -c '^svc ' || true)"
+  if [ "$n_bad" = "1" ]; then
+    pass "negative control: unquoted arguments really do collapse to 1 of 6"
+  else
+    fail "negative control saw $n_bad of 6; the simulation no longer reproduces ssh"
+  fi
+else
+  fail "could not extract q_args() from the script to test it"
+fi
+
+# The script must never hand raw arguments to ssh again.
+if grep -vE '^[[:space:]]*#' "$SCRIPT" | grep -qE "ssh .*'bash -s' --"; then
+  fail "no unquoted 'bash -s' -- argument list is left in the script"
+  grep -nvE '^[[:space:]]*#' "$SCRIPT" | grep -E "ssh .*'bash -s' --" | head -3 | sed 's/^/        /'
+else
+  pass "no unquoted 'bash -s' -- argument list is left in the script"
+fi
+check_has "$SCRIPT" 'bash -s --\$qargs' \
+  "the remote command is built from the quoted argument string"
+
+# --------------------------------------------- 3. every heredoc is strict ----
+echo ""
+echo "3. Every remote block runs under set -euo pipefail"
+HD_TOTAL="$(grep -c "<<'EOF'" "$SCRIPT" || true)"
+HD_STRICT="$(grep -c '^set -euo pipefail$' "$SCRIPT" || true)"
+# One of the strict lines is the script's own; the rest are the heredocs.
+if [ "$HD_STRICT" -eq $((HD_TOTAL + 1)) ]; then
+  pass "all $HD_TOTAL remote blocks plus the script itself are strict"
+else
+  fail "found $HD_TOTAL heredocs but $HD_STRICT strict-mode lines (expected $((HD_TOTAL + 1)))"
+fi
+check_lacks "$SCRIPT" '^set -uo pipefail$' "no remote block runs without -e"
+# `cp x && chmod y` hides a failing cp from -e, because the AND-list as a whole
+# is what -e judges.
+check_lacks "$SCRIPT" '^cp .* && chmod ' "no cp-and-chmod pair hides a failure from -e"
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 FULL="$WORK/full.txt"
 PRE="$WORK/preflight.txt"
 RB="$WORK/rollback.txt"
 
-# The script writes its log under deploy/logs/, which is gitignored. Point it
-# at the real place anyway: the test asserts the log is written and readable.
 ( cd "$ROOT" && bash "$SCRIPT" --dry-run                          >"$FULL" 2>&1 ); FULL_RC=$?
 ( cd "$ROOT" && bash "$SCRIPT" --dry-run --preflight-only         >"$PRE"  2>&1 ); PRE_RC=$?
 ( cd "$ROOT" && bash "$SCRIPT" --dry-run --rollback 20260101-0000 >"$RB"   2>&1 ); RB_RC=$?
 
-# ------------------------------------------------------------------ 2. modes --
+# ------------------------------------------------------------------ 4. modes --
 echo ""
-echo "2. Every mode runs to the end and exits 0"
-[ "$FULL_RC" -eq 0 ] && pass "--dry-run exits 0"                 || fail "--dry-run exits $FULL_RC"
+echo "4. Every mode runs to the end and exits 0"
+[ "$FULL_RC" -eq 0 ] && pass "--dry-run exits 0"                  || fail "--dry-run exits $FULL_RC"
 [ "$PRE_RC"  -eq 0 ] && pass "--dry-run --preflight-only exits 0" || fail "--dry-run --preflight-only exits $PRE_RC"
 [ "$RB_RC"   -eq 0 ] && pass "--dry-run --rollback exits 0"       || fail "--dry-run --rollback exits $RB_RC"
 
-# Bad arguments are refused, not guessed at.
 ( cd "$ROOT" && bash "$SCRIPT" --rollback nonsense >/dev/null 2>&1 )
 [ $? -eq 2 ] && pass "--rollback with a malformed TS exits 2" || fail "--rollback with a malformed TS was accepted"
 ( cd "$ROOT" && bash "$SCRIPT" --nope >/dev/null 2>&1 )
 [ $? -eq 2 ] && pass "an unknown flag exits 2" || fail "an unknown flag was accepted"
 
-# ----------------------------------------------------------------- 3. phases --
+# ----------------------------------------------------------------- 5. phases --
 echo ""
-echo "3. Every phase of the runbook is reached"
+echo "5. Every phase of the runbook is reached"
 check_has "$FULL" '^PHASE 0: Before you start'                  "phase 0, before you start"
 check_has "$FULL" '^PHASE 1: Layout and environment'            "phase 1, layout and environment"
 check_has "$FULL" '^PHASE 2: Rollback tags and backups'         "phase 2, rollback tags and backups"
@@ -100,35 +173,73 @@ check_has "$FULL" '^PHASE 7: Summary'                           "phase 7, summar
 check_has "$RB"   '^PHASE 8: Rollback to 20260101-0000'         "phase 8, rollback, under --rollback"
 
 echo ""
-echo "3b. Each mode stops where it should"
+echo "5b. Each mode stops where it should"
 check_has   "$PRE" '^PHASE 1: '                 "preflight reaches phase 1"
-check_lacks "$PRE" '^PHASE [2-8]: '             "preflight stops before phase 2, no deploy write"
+check_lacks "$PRE" '^PHASE [2-8]: '             "preflight stops before phase 2"
 check_has   "$PRE" 'PREFLIGHT ONLY'             "preflight says so on the last line"
 check_lacks "$RB"  '^PHASE [0-7]: '             "rollback runs phase 8 only"
 check_has   "$FULL" '^DEPLOY FINISHED'          "full run reaches the end marker"
 
-# ---------------------------------------------------- 4. the runbook's checks --
 echo ""
-echo "4. The assertions the runbook demands are in the script"
-check_has "$FULL" 'checkout_head=41501bb'                        "asserts the checkout is on 41501bb"
+echo "5c. --preflight-only writes nothing"
+check_has   "$PRE" 'read-only'                          "preflight announces itself as read-only"
+check_has   "$PRE" 'Nothing was written'                "preflight ends by saying nothing was written"
+check_lacks "$PRE" 'WRITE'                              "no phase header in preflight is marked WRITE"
+check_has   "$PRE"  'bash -s --.* report'               "the token step is invoked in report mode"
+check_lacks "$PRE"  'bash -s --.* write'                "no step in preflight is invoked in write mode"
+check_has   "$FULL" 'bash -s --.* write'                "a full run invokes the token step in write mode"
+check_has   "$PRE" 'REPORT ONLY'                        "the token step reports instead of generating"
+
+# ---------------------------------------------------- 6. the runbook's checks --
+echo ""
+echo "6. The assertions the runbook demands are in the script"
+check_has "$FULL" 'checkout_head = 41501bb'                      "asserts the checkout is on 41501bb"
+check_has "$FULL" 'services seen = 6'                            "asserts all six services were seen"
 check_has "$FULL" '"recurring":false'                            "asserts billing_config recurring:false"
 check_has "$FULL" '"mode_source":"inferred"'                     "asserts billing_config mode_source:inferred"
 check_has "$FULL" '"version":"3\.1\.0"'                          "asserts relay_started version 3.1.0"
-check_has "$FULL" 'manifest lines = 6|after manifest lines'      "asserts the rollback manifest has six lines"
+check_has "$FULL" 'after manifest lines = 6'                     "asserts the manifest has six lines"
+check_has "$FULL" 'after tags for this TS = 6'                   "asserts six rollback IMAGES exist, not six lines of text"
+check_has "$FULL" 'after \.env backup bytes >= 1'                "asserts the .env backup has real bytes"
+check_has "$FULL" 'after docroot tar entries >= 1'               "asserts the docroot tar has real entries"
 check_has "$FULL" 'rsync -rc --no-times'                         "rsyncs the docroot"
 check_lacks "$FULL" 'rsync -rc[^|]*--delete'                     "never rsyncs the docroot with --delete"
-check_has "$FULL" 'paraid deny lines'                            "measures the ParaID deny before and after"
+check_has "$FULL" 'diff-filter=D'                                "derives the stale docroot files from git, not a wildcard"
+check_has "$FULL" 'after paraid deny'                            "measures the ParaID deny before and after"
+check_has "$FULL" 'after edited files = 2'                       "asserts both named nginx confs were rewritten"
+check_has "$FULL" 'readlink -f'                                  "resolves sites-enabled symlinks before backing up or editing"
 check_has "$FULL" 'nginx -t'                                     "runs nginx -t before reloading"
 check_has "$FULL" 'auth-smoke\.sh'                               "runs tests/auth-smoke.sh"
 check_has "$FULL" 'v1/paraid/issue-document'                     "probes the removed ParaID route"
+check_has "$FULL" 'compliance/nis2'                              "probes a page main deleted"
 check_has "$FULL" 'X-Internal-Auth'                              "probes /v2/health/deep behind the internal header"
 
 echo ""
-echo "4b. Every destructive phase carries evidence before and after"
+echo "6aa. The inline receipt opt-in (#342) is set, buffered and proven"
+check_has "$FULL" 'PARAMANT_INLINE_RECEIPT_HEADER'      "phase 1 handles the inline receipt flag"
+check_has "$FULL" 'proxy_buffer_size 32k'               "phase 5 raises the proxy buffers the fat header needs"
+check_has "$FULL" 'before outbound locations'           "phase 5 refuses to add buffers to a location that is not there"
+check_has "$FULL" 'effective outbound buffers'          "phase 6 reads the LOADED nginx config, not the file"
+check_has "$SCRIPT" 'x-paramant-receipt:'               "phase 6 checks the inline receipt header on a real download"
+check_has "$SCRIPT" 'x-paramant-receipt-\$f:'            "phase 6 checks the id/hash/url reference shape too"
+check_has "$SCRIPT" '\-gt 16000'                         "phase 6 asserts the header block really exceeded 16 KB"
+check_has "$SCRIPT" 'PARAMANT_SMOKE_API_KEY is not set'  "phase 6 says plainly what it could NOT prove without a key"
+check_has "$FULL"   'needs PARAMANT_SMOKE_API_KEY'      "the dry run names the key the full proof needs"
+
+echo ""
+echo "6b. Rollback restores in an order that cannot half-fail"
+check_has "$RB" 'missing backups = 0'    "rollback refuses to start when a backup it needs is absent"
+check_has "$RB" 'restore \.env first'    "rollback restores .env before recreating the containers"
+check_has "$RB" 'after recreated services = 6' "rollback asserts all six services came back"
+check_has "$RB" 'removed added-by-deploy' "rollback removes the files the deploy added, which tar x cannot"
+check_has "$RB" 'not reloading'          "rollback tests nginx before reloading it"
+
+echo ""
+echo "6c. Every destructive phase carries evidence before and after"
 for phase in 2 3 4 5; do
   body="$(awk -v p="^PHASE $phase:" '$0 ~ p {f=1} /^PHASE [0-9]+:/ && $0 !~ p && f {exit} f' "$FULL")"
-  b=$(printf '%s\n' "$body" | grep -cE '(^|> )(echo ")?before ' || true)
-  a=$(printf '%s\n' "$body" | grep -cE '(^|> )(echo ")?after ' || true)
+  b=$(printf '%s\n' "$body" | grep -cE '(^|> )[[:space:]]*(echo ")?before ' || true)
+  a=$(printf '%s\n' "$body" | grep -cE '(^|> )[[:space:]]*(echo ")?after ' || true)
   if [ "$b" -gt 0 ] && [ "$a" -gt 0 ]; then
     pass "phase $phase prints evidence before ($b) and after ($a)"
   else
@@ -136,10 +247,9 @@ for phase in 2 3 4 5; do
   fi
 done
 
-# ---------------------------------------------------------------- 5. secrets --
+# ---------------------------------------------------------------- 7. secrets --
 echo ""
-echo "5. No line the script would print can carry a key value"
-# A real Mollie, ParaSign or GitHub key, or a hex token, in any printed line.
+echo "7. No line the script would print can carry a key value"
 check_lacks "$FULL" '(live|test|psk_test|psk_live|sk|gho|ghp|ghs)_[A-Za-z0-9_-]{12,}' \
   "no key-shaped literal in the output"
 check_lacks "$FULL" '[0-9a-f]{32,}' \
@@ -148,51 +258,103 @@ check_lacks "$FULL" 'BEGIN [A-Z ]*(PRIVATE KEY|OPENSSH)' \
   "no private key material in the output"
 check_lacks "$FULL" 'paramant_prod_claude' \
   "the ssh key path is masked, never printed"
-
-# The script must never turn tracing on remotely: set -x would expand $T and
-# $tok into the log.
 check_lacks "$FULL" '(^|> )[[:space:]]*set -x|set -euxo|set -uxo' \
   "no remote block enables tracing"
 
-# Any line that reads a secret out of .env must consume it, never echo it. The
-# three shapes the runbook does allow are a length, a five-character prefix, and
-# handing the value straight to curl as a header whose only output is a status
-# code. A write whose stdout is redirected into .env is a fourth: it reaches the
-# file, never the log. Strip those four, then flag any bare expansion that is
-# left.
+# Any line that reads a secret must consume it, never echo it. The three shapes
+# the runbook does allow are a length, a five-character prefix, and handing the
+# value straight to curl as a header whose only output is a status code. A write
+# whose stdout is redirected into .env is a fourth: it reaches the file, never
+# the log. Strip those four, then flag any bare expansion that is left.
 STRIPPED="$WORK/stripped.txt"
 sed -E 's/\$\{#[A-Za-z_]+\}//g
         s/\$\(printf %s "\$[A-Za-z_]+" \| cut -c1-5\)//g
-        s/-H "X-(Internal-Auth|Admin-Token): \$[A-Za-z_]+"//g
+        s/-H "X-(Internal-Auth|Admin-Token|Api-Key): \$[A-Za-z_]+"//g
         /(>|>>)[[:space:]]*"?\.env"?[[:space:]]*$/d' "$FULL" > "$STRIPPED"
-check_lacks "$STRIPPED" '(echo|printf)[^|]*\$\{?(T|A|tok|TOKEN)\}?([^A-Za-z_0-9]|$)' \
-  "no bare echo or printf of a secret variable"
+check_lacks "$STRIPPED" '(echo|printf)[^|]*\$\{?(T|A|K|tok|TOKEN|KEY|SECRET)\}?([^A-Za-z_0-9]|$)' \
+  "no bare echo or printf of a known secret variable"
 
-# The only shapes allowed near a secret are presence, length and a 5-char
-# prefix. Assert those are what the script actually does.
+# A name list only catches the names on it. Learn instead which variables hold
+# a value read out of .env (or minted by openssl), then flag any echo or printf
+# of one of those, whatever it ended up being called. This is what catches a
+# rename that a fixed list would wave through.
+SRCSTRIP="$WORK/srcstrip.txt"
+sed -E 's/\$\{#[A-Za-z_]+\}//g
+        s/\$\(printf %s "\$[A-Za-z_]+" \| cut -c1-5\)//g
+        s/-H "X-(Internal-Auth|Admin-Token|Api-Key): \$[A-Za-z_]+"//g
+        /(>|>>)[[:space:]]*"?\.env"?[[:space:]]*$/d' "$SCRIPT" > "$SRCSTRIP"
+# A counting read (grep -c, wc -l) yields a number, not content, so the
+# variable it fills is not tainted.
+TAINT="$(grep -E '(\.env|openssl rand)' "$SCRIPT" \
+         | grep -vE 'grep -c|grep -qc|wc -l' \
+         | grep -oE '(^|[[:space:]])[A-Za-z_][A-Za-z_0-9]*=' \
+         | tr -d ' =' | sort -u)"
+if [ -z "$TAINT" ]; then
+  fail "the taint scan found no variable reading .env; the scan is not looking at anything"
+else
+  TLEAK="$WORK/taintleak.txt"
+  : > "$TLEAK"
+  for v in $TAINT; do
+    grep -nE "(echo|printf)[^|]*\\\$\\{?$v\\}?([^A-Za-z_0-9]|\$)" "$SRCSTRIP" >> "$TLEAK" || true
+  done
+  if [ ! -s "$TLEAK" ]; then
+    pass "no .env-derived variable is ever echoed (tainted: $(printf '%s' "$TAINT" | tr '\n' ' '))"
+  else
+    fail "a variable holding a value read from .env would be printed"
+    sort -u "$TLEAK" | head -5 | sed 's/^/        /'
+  fi
+fi
+
 check_has "$FULL" 'cut -c1-5' "secrets are reported by prefix only"
 check_has "$FULL" 'echo empty' "secrets are reported as present or empty"
 
-# Same scan over the source, so a future edit that prints a value fails here
-# even if the printing line sits in a branch the dry run does not walk.
 echo ""
-echo "5b. The same scan over the source of deploy/deploy-3.1.sh"
+echo "7b. The same scan over the source, including branches the dry run misses"
 check_lacks "$SCRIPT" '(live|test|psk_test|psk_live|sk|gho|ghp|ghs)_[A-Za-z0-9_-]{12,}' \
   "no key-shaped literal in the source"
 check_lacks "$SCRIPT" '[0-9a-f]{32,}' "no long hex run in the source"
 check_lacks "$SCRIPT" '(^|; |&& )[[:space:]]*set -x' "the source never enables tracing"
 
-# ------------------------------------------------------------------- 6. safe --
+# Every read of .env in the source has to go somewhere that is not stdout: into
+# a variable, into a redirect, or into a counter. A read whose output falls
+# through to the log is a leak whatever the variable ends up being called, so
+# this scans the shape of the read and not the name of the variable.
+ENVREADS="$WORK/envreads.txt"
+# The tool name has to sit at a command position and be a whole word, or
+# "header" matches "head" and every sentence mentioning .env is a finding.
+grep -nE '(^|[;&|(]|[[:space:]])(cat|grep|awk|sed|head|tail|cut|printenv)[[:space:]][^|]*\.env' "$SCRIPT" > "$ENVREADS" || true
+LEAKY="$WORK/leaky.txt"
+: > "$LEAKY"
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  code="${line#*:}"
+  # Comments describe, they do not execute.
+  case "$(printf '%s' "$code" | sed 's/^[[:space:]]*//')" in '#'*) continue;; esac
+  # Allowed: captured into a substitution, assigned, redirected, or counted.
+  case "$code" in
+    *'$('*|*'`'*|*'>'*|*'grep -c'*|*'grep -qc'*|*'sed -i'*|*'grep -q '*) continue;; esac
+  printf '%s\n' "$line" >> "$LEAKY"
+done < "$ENVREADS"
+if [ ! -s "$LEAKY" ]; then
+  pass "every read of .env is captured, redirected or counted, never printed ($(wc -l < "$ENVREADS") read(s) checked)"
+else
+  fail "a read of .env would reach stdout"
+  sed 's/^/        /' "$LEAKY"
+fi
+check_lacks "$SCRIPT" '(^|[^-])cat[[:space:]]+[^|;]*\.env([^.a-zA-Z]|$)' \
+  "the source never cats .env"
+
+# ------------------------------------------------------------------- 8. safe --
 echo ""
-echo "6. A dry run reaches nothing"
+echo "8. A dry run reaches nothing"
 check_has "$FULL" '\[dry-run\] not executed' "gated local commands are printed, not run"
 check_has "$FULL" '\[dry-run\] >'            "remote blocks are printed, not run"
 check_lacks "$FULL" '^  \| '                 "no line of real remote output, so no ssh was made"
 check_has "$FULL" 'DRY RUN \(nothing is executed on the server\)' "the run announces itself as a dry run"
 
-# ---------------------------------------------------------------- 7. logging --
+# ---------------------------------------------------------------- 9. logging --
 echo ""
-echo "7. The run is written to deploy/logs/"
+echo "9. The run is written to deploy/logs/"
 LOGLINE="$(grep -m1 '^  log ' "$FULL" | awk '{print $2}')"
 if [ -n "$LOGLINE" ] && [ -f "$LOGLINE" ]; then
   pass "the log file named in the header exists ($(basename "$LOGLINE"))"

--- a/tests/deploy-3.1-dryrun.test.sh
+++ b/tests/deploy-3.1-dryrun.test.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Dry-run test for deploy/deploy-3.1.sh.
+#
+# The deploy script is the only thing in this repo that recreates production
+# containers and rewrites the nginx config, and it cannot be exercised against
+# the server from CI. So this test asserts the two properties that can be
+# checked without a server:
+#
+#   1. every phase of deploy/DEPLOY-3.1.md is reached, in every mode
+#   2. no line the script would print can carry a key value
+#
+# It runs the script with --dry-run, which executes nothing: every remote block
+# and every gated local command is printed instead. Exit 0 = all pass.
+#
+# Usage: bash tests/deploy-3.1-dryrun.test.sh
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/deploy/deploy-3.1.sh"
+PASS=0
+FAIL=0
+FAILURES=""
+
+pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL  %s\n' "$1"; FAIL=$((FAIL + 1)); FAILURES="$FAILURES
+  - $1"; }
+
+check_has() {   # haystack-file, pattern, name
+  if grep -qE -- "$2" "$1"; then pass "$3"; else fail "$3 (no line matching /$2/)"; fi
+}
+check_lacks() { # haystack-file, pattern, name
+  if grep -qE -- "$2" "$1"; then
+    fail "$3"
+    grep -nE -- "$2" "$1" | head -5 | sed 's/^/        /'
+  else
+    pass "$3"
+  fi
+}
+
+echo "======== deploy-3.1.sh dry run ========"
+
+# ---------------------------------------------------------------- 1. syntax --
+echo ""
+echo "1. The script parses"
+if [ -f "$SCRIPT" ]; then pass "deploy/deploy-3.1.sh exists"; else
+  fail "deploy/deploy-3.1.sh is missing"
+  echo ""; echo "RESULT: $PASS passed, $FAIL failed"; exit 1
+fi
+if [ -x "$SCRIPT" ]; then pass "deploy/deploy-3.1.sh is executable"; else fail "deploy/deploy-3.1.sh is not executable"; fi
+if bash -n "$SCRIPT" 2>/dev/null; then pass "bash -n clean"; else
+  fail "bash -n reported a syntax error"
+  bash -n "$SCRIPT" 2>&1 | sed 's/^/        /'
+fi
+if command -v shellcheck >/dev/null 2>&1; then
+  if shellcheck -S error "$SCRIPT" >/dev/null 2>&1; then pass "shellcheck (severity error) clean"; else
+    fail "shellcheck reported an error-level finding"
+    shellcheck -S error "$SCRIPT" 2>&1 | head -20 | sed 's/^/        /'
+  fi
+else
+  printf '  SKIP  shellcheck not installed\n'
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+FULL="$WORK/full.txt"
+PRE="$WORK/preflight.txt"
+RB="$WORK/rollback.txt"
+
+# The script writes its log under deploy/logs/, which is gitignored. Point it
+# at the real place anyway: the test asserts the log is written and readable.
+( cd "$ROOT" && bash "$SCRIPT" --dry-run                          >"$FULL" 2>&1 ); FULL_RC=$?
+( cd "$ROOT" && bash "$SCRIPT" --dry-run --preflight-only         >"$PRE"  2>&1 ); PRE_RC=$?
+( cd "$ROOT" && bash "$SCRIPT" --dry-run --rollback 20260101-0000 >"$RB"   2>&1 ); RB_RC=$?
+
+# ------------------------------------------------------------------ 2. modes --
+echo ""
+echo "2. Every mode runs to the end and exits 0"
+[ "$FULL_RC" -eq 0 ] && pass "--dry-run exits 0"                 || fail "--dry-run exits $FULL_RC"
+[ "$PRE_RC"  -eq 0 ] && pass "--dry-run --preflight-only exits 0" || fail "--dry-run --preflight-only exits $PRE_RC"
+[ "$RB_RC"   -eq 0 ] && pass "--dry-run --rollback exits 0"       || fail "--dry-run --rollback exits $RB_RC"
+
+# Bad arguments are refused, not guessed at.
+( cd "$ROOT" && bash "$SCRIPT" --rollback nonsense >/dev/null 2>&1 )
+[ $? -eq 2 ] && pass "--rollback with a malformed TS exits 2" || fail "--rollback with a malformed TS was accepted"
+( cd "$ROOT" && bash "$SCRIPT" --nope >/dev/null 2>&1 )
+[ $? -eq 2 ] && pass "an unknown flag exits 2" || fail "an unknown flag was accepted"
+
+# ----------------------------------------------------------------- 3. phases --
+echo ""
+echo "3. Every phase of the runbook is reached"
+check_has "$FULL" '^PHASE 0: Before you start'                  "phase 0, before you start"
+check_has "$FULL" '^PHASE 1: Layout and environment'            "phase 1, layout and environment"
+check_has "$FULL" '^PHASE 2: Rollback tags and backups'         "phase 2, rollback tags and backups"
+check_has "$FULL" '^PHASE 3: Pull main, run the sanity gate'    "phase 3, pull and build"
+check_has "$FULL" '^PHASE 4: Recreate, the canary relay first'  "phase 4, recreate"
+check_has "$FULL" '^PHASE 5: Frontend and nginx'                "phase 5, frontend and nginx"
+check_has "$FULL" '^PHASE 6: Smoke tests'                       "phase 6, smoke tests"
+check_has "$FULL" '^PHASE 7: Summary'                           "phase 7, summary"
+check_has "$RB"   '^PHASE 8: Rollback to 20260101-0000'         "phase 8, rollback, under --rollback"
+
+echo ""
+echo "3b. Each mode stops where it should"
+check_has   "$PRE" '^PHASE 1: '                 "preflight reaches phase 1"
+check_lacks "$PRE" '^PHASE [2-8]: '             "preflight stops before phase 2, no deploy write"
+check_has   "$PRE" 'PREFLIGHT ONLY'             "preflight says so on the last line"
+check_lacks "$RB"  '^PHASE [0-7]: '             "rollback runs phase 8 only"
+check_has   "$FULL" '^DEPLOY FINISHED'          "full run reaches the end marker"
+
+# ---------------------------------------------------- 4. the runbook's checks --
+echo ""
+echo "4. The assertions the runbook demands are in the script"
+check_has "$FULL" 'checkout_head=41501bb'                        "asserts the checkout is on 41501bb"
+check_has "$FULL" '"recurring":false'                            "asserts billing_config recurring:false"
+check_has "$FULL" '"mode_source":"inferred"'                     "asserts billing_config mode_source:inferred"
+check_has "$FULL" '"version":"3\.1\.0"'                          "asserts relay_started version 3.1.0"
+check_has "$FULL" 'manifest lines = 6|after manifest lines'      "asserts the rollback manifest has six lines"
+check_has "$FULL" 'rsync -rc --no-times'                         "rsyncs the docroot"
+check_lacks "$FULL" 'rsync -rc[^|]*--delete'                     "never rsyncs the docroot with --delete"
+check_has "$FULL" 'paraid deny lines'                            "measures the ParaID deny before and after"
+check_has "$FULL" 'nginx -t'                                     "runs nginx -t before reloading"
+check_has "$FULL" 'auth-smoke\.sh'                               "runs tests/auth-smoke.sh"
+check_has "$FULL" 'v1/paraid/issue-document'                     "probes the removed ParaID route"
+check_has "$FULL" 'X-Internal-Auth'                              "probes /v2/health/deep behind the internal header"
+
+echo ""
+echo "4b. Every destructive phase carries evidence before and after"
+for phase in 2 3 4 5; do
+  body="$(awk -v p="^PHASE $phase:" '$0 ~ p {f=1} /^PHASE [0-9]+:/ && $0 !~ p && f {exit} f' "$FULL")"
+  b=$(printf '%s\n' "$body" | grep -cE '(^|> )(echo ")?before ' || true)
+  a=$(printf '%s\n' "$body" | grep -cE '(^|> )(echo ")?after ' || true)
+  if [ "$b" -gt 0 ] && [ "$a" -gt 0 ]; then
+    pass "phase $phase prints evidence before ($b) and after ($a)"
+  else
+    fail "phase $phase is missing evidence lines (before=$b after=$a)"
+  fi
+done
+
+# ---------------------------------------------------------------- 5. secrets --
+echo ""
+echo "5. No line the script would print can carry a key value"
+# A real Mollie, ParaSign or GitHub key, or a hex token, in any printed line.
+check_lacks "$FULL" '(live|test|psk_test|psk_live|sk|gho|ghp|ghs)_[A-Za-z0-9_-]{12,}' \
+  "no key-shaped literal in the output"
+check_lacks "$FULL" '[0-9a-f]{32,}' \
+  "no long hex run (an INTERNAL_AUTH_TOKEN or ADMIN_TOKEN value) in the output"
+check_lacks "$FULL" 'BEGIN [A-Z ]*(PRIVATE KEY|OPENSSH)' \
+  "no private key material in the output"
+check_lacks "$FULL" 'paramant_prod_claude' \
+  "the ssh key path is masked, never printed"
+
+# The script must never turn tracing on remotely: set -x would expand $T and
+# $tok into the log.
+check_lacks "$FULL" '(^|> )[[:space:]]*set -x|set -euxo|set -uxo' \
+  "no remote block enables tracing"
+
+# Any line that reads a secret out of .env must consume it, never echo it. The
+# three shapes the runbook does allow are a length, a five-character prefix, and
+# handing the value straight to curl as a header whose only output is a status
+# code. A write whose stdout is redirected into .env is a fourth: it reaches the
+# file, never the log. Strip those four, then flag any bare expansion that is
+# left.
+STRIPPED="$WORK/stripped.txt"
+sed -E 's/\$\{#[A-Za-z_]+\}//g
+        s/\$\(printf %s "\$[A-Za-z_]+" \| cut -c1-5\)//g
+        s/-H "X-(Internal-Auth|Admin-Token): \$[A-Za-z_]+"//g
+        /(>|>>)[[:space:]]*"?\.env"?[[:space:]]*$/d' "$FULL" > "$STRIPPED"
+check_lacks "$STRIPPED" '(echo|printf)[^|]*\$\{?(T|A|tok|TOKEN)\}?([^A-Za-z_0-9]|$)' \
+  "no bare echo or printf of a secret variable"
+
+# The only shapes allowed near a secret are presence, length and a 5-char
+# prefix. Assert those are what the script actually does.
+check_has "$FULL" 'cut -c1-5' "secrets are reported by prefix only"
+check_has "$FULL" 'echo empty' "secrets are reported as present or empty"
+
+# Same scan over the source, so a future edit that prints a value fails here
+# even if the printing line sits in a branch the dry run does not walk.
+echo ""
+echo "5b. The same scan over the source of deploy/deploy-3.1.sh"
+check_lacks "$SCRIPT" '(live|test|psk_test|psk_live|sk|gho|ghp|ghs)_[A-Za-z0-9_-]{12,}' \
+  "no key-shaped literal in the source"
+check_lacks "$SCRIPT" '[0-9a-f]{32,}' "no long hex run in the source"
+check_lacks "$SCRIPT" '(^|; |&& )[[:space:]]*set -x' "the source never enables tracing"
+
+# ------------------------------------------------------------------- 6. safe --
+echo ""
+echo "6. A dry run reaches nothing"
+check_has "$FULL" '\[dry-run\] not executed' "gated local commands are printed, not run"
+check_has "$FULL" '\[dry-run\] >'            "remote blocks are printed, not run"
+check_lacks "$FULL" '^  \| '                 "no line of real remote output, so no ssh was made"
+check_has "$FULL" 'DRY RUN \(nothing is executed on the server\)' "the run announces itself as a dry run"
+
+# ---------------------------------------------------------------- 7. logging --
+echo ""
+echo "7. The run is written to deploy/logs/"
+LOGLINE="$(grep -m1 '^  log ' "$FULL" | awk '{print $2}')"
+if [ -n "$LOGLINE" ] && [ -f "$LOGLINE" ]; then
+  pass "the log file named in the header exists ($(basename "$LOGLINE"))"
+else
+  fail "no readable log file at '${LOGLINE:-<unnamed>}'"
+fi
+if git -C "$ROOT" check-ignore -q deploy/logs/ 2>/dev/null; then
+  pass "deploy/logs/ is gitignored"
+else
+  fail "deploy/logs/ is not gitignored; a deploy log would be committable"
+fi
+
+# ------------------------------------------------------------------- result --
+echo ""
+echo "======== RESULT ========"
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failures:%s\n' "$FAILURES"
+  exit 1
+fi
+echo "All checks passed."
+exit 0

--- a/tests/deploy-3.1-dryrun.test.sh
+++ b/tests/deploy-3.1-dryrun.test.sh
@@ -227,6 +227,29 @@ check_has "$SCRIPT" 'PARAMANT_SMOKE_API_KEY is not set'  "phase 6 says plainly w
 check_has "$FULL"   'needs PARAMANT_SMOKE_API_KEY'      "the dry run names the key the full proof needs"
 
 echo ""
+echo "6ab. The compose file really passes the receipt variables through"
+# There is no env_file in docker-compose.yml: .env only substitutes ${VAR}
+# inside the compose file, so a variable without a line in x-relay-env never
+# reaches a container no matter what .env says.
+COMPOSE="$ROOT/docker-compose.yml"
+check_lacks "$COMPOSE" '^[[:space:]]*env_file' \
+  "docker-compose.yml still has no env_file, so x-relay-env is the only route in"
+for v in PARAMANT_INLINE_RECEIPT_HEADER PARAMANT_RECEIPT_PER_ACCOUNT_MAX \
+         PARAMANT_RECEIPT_UNCAPPED_MAX PARAMANT_RECEIPT_TOTAL_MAX; do
+  check_has "$COMPOSE" "^  $v: " "x-relay-env declares $v"
+done
+check_has "$FULL" 'compose inline flag on'  "phase 4 proves the flag renders BEFORE the recreate"
+check_has "$FULL" 'docker compose config'   "that proof uses docker compose config, not a guess"
+
+echo ""
+echo "6ac. The round-2 guards"
+check_has "$SCRIPT" 'BLOCK_AWK'                          "the buffer guard counts inside each /v2/outbound block"
+check_has "$FULL"   'after outbound blocks with buffer'  "phase 5 reports blocks, not file-wide grep hits"
+check_has "$SCRIPT" 'REFUSED'                            "phase 5b refuses a deletion that resolves outside the docroot"
+check_has "$FULL"   'after refused outside docroot'      "phase 5b reports how many deletions it refused"
+check_has "$SCRIPT" 'NOT PROVEN'                         "phase 6h says NOT PROVEN when the header block is under 16 KB"
+
+echo ""
 echo "6b. Rollback restores in an order that cannot half-fail"
 check_has "$RB" 'missing backups = 0'    "rollback refuses to start when a backup it needs is absent"
 check_has "$RB" 'restore \.env first'    "rollback restores .env before recreating the containers"
@@ -289,6 +312,16 @@ TAINT="$(grep -E '(\.env|openssl rand)' "$SCRIPT" \
          | grep -vE 'grep -c|grep -qc|wc -l' \
          | grep -oE '(^|[[:space:]])[A-Za-z_][A-Za-z_0-9]*=' \
          | tr -d ' =' | sort -u)"
+# Let the taint inherit over one assignment, so `s3cr="$tok"` is tainted too.
+# One hop only: a full dataflow analysis is not what a shell test should be,
+# and two hops have never appeared in this script. If that changes, this is
+# the line to extend, and the limit is written down here on purpose.
+for _v in $TAINT; do
+  _heirs="$(grep -oE "(^|[[:space:]])[A-Za-z_][A-Za-z_0-9]*=\"?\\\$\{?$_v\}?\"?[[:space:]]*\$" "$SCRIPT" \
+            | grep -oE '[A-Za-z_][A-Za-z_0-9]*=' | tr -d ' =' || true)"
+  [ -n "$_heirs" ] && TAINT="$TAINT $_heirs"
+done
+TAINT="$(printf '%s\n' $TAINT | sort -u)"
 if [ -z "$TAINT" ]; then
   fail "the taint scan found no variable reading .env; the scan is not looking at anything"
 else


### PR DESCRIPTION
`deploy/deploy-3.1.sh` voert `deploy/DEPLOY-3.1.md` uit. Een deploy is een
commando vanaf de NUC:

```
bash deploy/deploy-3.1.sh [--preflight-only] [--rollback <TS>] [--dry-run]
```

Het runbook blijft de leesbare bron. Het script voegt niets aan het plan toe,
het weigert alleen door te gaan als een meting het tegenspreekt.

## Reviewronde: negen punten, met bewijs

**1. De ssh-argumenten. Dit was een echte bug en de reviewer had gelijk.**
ssh bewaart argv niet: het plakt alles na de host aan elkaar tot een string, en
de remote shell splitst opnieuw op witruimte. De zes servicenamen als een
argument kwamen aan als zes losse parameters, dus elke remote lus over `$2`
draaide precies een keer. Reproductie, met `bash -c` als sshd:

```
--- current: unquoted ---     --- fixed: printf %q per argument ---
container relay-main          container relay-main
argc=7                        container relay-health
                              container relay-finance
                              container relay-legal
                              container relay-iot
                              container admin
                              argc=2
```

`q_args()` quote nu elk argument met `printf %q`. De test bootst de
samenvoeging na en heeft een tegenproef die faalt als de simulatie ooit stopt
met ssh na te doen. Er draait geen sshd waar ik een sleutel voor heb, dus de
simulatie is `"$*"` plus `bash -c`, wat exact is wat de client en de server
samen doen.

**2. Strict mode.** Alle twintig heredocs draaien `set -euo pipefail`; de test
telt heredocs tegen strict-regels, dus een nieuwe heredoc zonder `-e` faalt.
`cp ... && chmod ...` is uit elkaar getrokken (een AND-lijst verbergt een
falende `cp` voor `-e`), en de test verbiedt dat patroon. `remote()` vangt de
exitcode, print de serveruitvoer met `|`-prefix en stopt daarna met de
STOP-regel, dus de diagnose staat er nog.

**3. Backupasserties meten nu iets.** `after .env backup bytes`,
`after docroot tar bytes`, `after docroot tar entries`, en
`after tags for this TS = 6` telt de echte `docker images`-tags in plaats van
de zes regels tekst in het manifest. `expect_count` en `expect_min` lezen een
veld en vergelijken een getal; ze matchen niet meer op een geechode padstring.

**4. Fase 5c.** Alleen de twee benoemde confs (`PARAMANT_NGINX_CONFS`),
`readlink -f` eerst want `cp -a` van een symlink is geen backup, en per
sed-edit de eis dat `before > 0`. Is er niets te doen, dan stopt hij met
`FATAL nothing to change for 'sign': de server conf heeft niet de vorm die het
runbook noemt` in plaats van OK te melden. `after edited files = 2` is een
harde assertie.

**5. `--preflight-only` schrijft niets.** 1c en 1d krijgen `report` in plaats
van `write` mee en melden alleen. De slotregel is `Nothing was written`, de
faseheader zegt `read-only`, en het runbook zegt het ook. De test controleert
dat preflight `bash -s -- ... report` aanroept en nergens `write`.

**6. Rollback.** `.env` gaat terug voor de recreate, zodat de containers de
oude file lezen. `nginx -t` voor de reload, en bij een fout geen reload.
`tar x` legt over maar verwijdert niet wat de deploy toevoegde, dus 8c
vergelijkt de tar-inhoud met de docroot en ruimt het verschil op (met de
IGNORE-lijst ontzien). 8a stopt als het manifest, `.env`, de tar of een
nginx-backup ontbreekt: `missing backups = 0` is een assertie, geen mededeling.

**7. De 26 verwijderde frontendbestanden.** `rsync` zonder `--delete` liet ze
staan en `try_files` bleef ze serveren, dus `/compliance/nis2` en `/paraid`
gaven nog 200. Fase 5b leidt de lijst af uit
`git diff --diff-filter=D --name-only <vorige HEAD>..HEAD -- frontend/` (26
bestanden, `frontend/paraid.html` erbij) en verwijdert die uit de docroot, met
de IGNORE-lijst van `check-prod-drift.sh` ontzien en een pad-guard. Fase 6e
controleert dat `/compliance/nis2`, `/compliance/iec62443`,
`/compliance/nen7510`, `/paraid`, `/paraid-app` en `/dicom` 404 geven.

**8. De SDK-precondition.** Het runbook zei 3.2.1; dat is 3.3.0, en die release
komt niet op PyPI omdat er geen trusted publisher staat (gerapporteerd
2026-09-02, niet hier gemeten; zo staat het er ook). De deploy wacht er niet
meer op en neemt de eerste uitweg uit het runbook:
`PARAMANT_INLINE_RECEIPT_HEADER=1` in `.env` als de regel ontbreekt (fase 1d),
de drie `proxy_buffer`-regels op elke `location ~ ^/v2/outbound` (fase 5c,
idempotent, met `before outbound locations > 0` als eis), en fase 6h. Die leest
de env-var uit de draaiende containers, leest `nginx -T` in plaats van het
bestand, controleert dat `/v2/outbound` geen 5xx geeft, en doet met
`PARAMANT_SMOKE_API_KEY` een echte upload plus download tegen
`relay.paramant.app`: 200 en geen 502, `X-Paramant-Receipt` aanwezig, de drie
referentievelden aanwezig, en het headerblok boven 16 KB. Zonder die sleutel
zegt de stap met zoveel woorden wat hij **niet** heeft bewezen. Het runbook
noemt nu ook de vervolgstap: zodra 3.3.0 op PyPI staat, de regel eruit en
recreaten.

**9. De secretscan is een taintscan geworden.** Een namenlijst vangt alleen de
namen die erop staan. De test leidt nu uit de bron af welke variabelen een
`.env`-waarde of een `openssl rand` dragen (nu: `miss T tok`) en meldt elke
`echo` of `printf` daarvan. Tellende lezen (`grep -c`, `wc -l`) leveren een
getal en tellen niet mee. Drie tegenproeven:

| injectie | gevangen |
|---|---|
| `cat .env` | ja, 2 checks |
| `echo "deep token IS $T"` | ja |
| `SEKRIT="$(grep '^ADMIN_TOKEN=' .env \| cut -d= -f2-)"; echo "leaked $SEKRIT"` | ja, via de taintscan (de oude namenlijst liet dit door) |


## Reviewronde 2: de blocker en vier guards

**1. Blocker: de vlag bereikte de containers nooit.** `docker-compose.yml`
heeft **geen `env_file`**. `.env` vult alleen `${VAR}` in het compose-bestand
zelf in, dus een variabele zonder eigen regel in `x-relay-env` komt nooit in
een container, hoe netjes je hem ook in `.env` zet. De vier receipt-variabelen
uit #342 hadden die regel niet. Fase 1d schreef dus een vlag die nergens
aankwam, en fase 6h zou pas aan het eind falen met 3.1.0 al live.

Toegevoegd aan `x-relay-env`, alle vier met lege default (de vlag telt alleen
bij exact `1`; de caps vallen leeg terug op hun ingebouwde getallen):

```
PARAMANT_INLINE_RECEIPT_HEADER:    "${PARAMANT_INLINE_RECEIPT_HEADER:-}"
PARAMANT_RECEIPT_PER_ACCOUNT_MAX:  "${PARAMANT_RECEIPT_PER_ACCOUNT_MAX:-}"
PARAMANT_RECEIPT_UNCAPPED_MAX:     "${PARAMANT_RECEIPT_UNCAPPED_MAX:-}"
PARAMANT_RECEIPT_TOTAL_MAX:        "${PARAMANT_RECEIPT_TOTAL_MAX:-}"
```

Bewijs, lokaal met `docker compose config`:

```
$ docker compose --env-file probe.env config | grep -n 'PARAMANT_INLINE_RECEIPT_HEADER\|PARAMANT_RECEIPT_'
152:      PARAMANT_INLINE_RECEIPT_HEADER: "1"
153:      PARAMANT_RECEIPT_PER_ACCOUNT_MAX: ""
154:      PARAMANT_RECEIPT_TOTAL_MAX: ""
155:      PARAMANT_RECEIPT_UNCAPPED_MAX: ""
241, 330, 419, 508:  idem voor de vier andere relays
596:      (het x-relay-env anker zelf)

met de vlag in .env : 6 treffers op PARAMANT_INLINE_RECEIPT_HEADER: "1"
zonder de vlag      : 0 treffers
```

Vijf relays plus het anker. Nieuwe stap **4pre** doet exact deze meting op de
server voordat er iets herstart wordt en eist `>= 5`, dus een ontbrekende
doorgifte blokkeert op een leesbare assertie in plaats van op een smoketest
achteraf. Runbookregel 52-54 herschreven: de claim dat compose byte-identiek
is aan `41501bb` klopte trouwens al niet meer sinds #340 (`git diff` geeft
2 insertions, 1 deletion), en er staat nu bij dat fase 3 het compose-bestand
meetrekt en fase 4 het oppakt.

**2. Bufferguard per blok in plaats van per bestand.** Het gat nagespeeld:

```
    location /v2/inbound {
        proxy_buffer_size 32k;      <-- staat er, maar op het verkeerde blok
    }
    location ~ ^/v2/outbound {
        limit_req ...;              <-- leeg, en elke download geeft 502
    }

file-scoped grep -c 'proxy_buffer_size 32k'  ->  1   (dus insert overgeslagen)
```

Vervangen door een tweetraps-awk: pass 1 leest per outbound-blok of de buffer
er al staat, pass 2 voegt alleen toe waar hij ontbreekt. Op de conf hierboven
belandt hij nu wel in het outbound-blok, en tweemaal draaien verandert niets
(2 bufferregels blijven 2, `cmp` gelijk). De eindcheck telt ook per blok:
`after outbound blocks with buffer` moet gelijk zijn aan
`after outbound locations`.

**3. Fase 5b resolvet het doelpad.** `readlink -f` op het te verwijderen
bestand en op de docroot, en alles wat niet echt onder de docroot uitkomt
wordt geweigerd en geteld. `after refused outside docroot = 0` is een harde
assertie, dus een symlinked submap kan `rm` niet meer buiten de docroot laten
komen.

**4. De 16 KB-claim alleen als hij waar is.** De `ok` over het oversized
headerblok staat nu in de `> 16000`-tak. Onder die grens volgt een WARN met
`NOT PROVEN` en geen enkele `ok`, dus de samenvatting kan niet lezen alsof het
pad door nginx bewezen is terwijl het dat niet is.

**5. Taint erft over een toewijzing.** `s3cr="$tok"` telt nu ook als besmet.
Tegenproef: `s3cr="$T"; echo "inherited $s3cr"` wordt gevangen. Een hop, en
die grens staat als commentaar in de test, met de reden erbij.

## Lokaal groen, ronde 2

- `bash -n` schoon op beide bestanden.
- `tests/static-sanity.sh`: **PASS, alle tien checks OK**, check 10 groen.
- `tests/deploy-3.1-dryrun.test.sh`: **108 pass, 0 fail**.
- `docker compose config` met en zonder de vlag: 6 tegen 0 (hierboven).
- Alle drie de modi exit 0 onder `--dry-run`.

## Lokaal groen

- `bash -n` schoon op beide bestanden; `shellcheck` staat niet op deze machine
  en wordt overgeslagen als hij ontbreekt.
- `tests/static-sanity.sh`: **PASS, alle tien checks OK**, check 10 groen.
- `tests/deploy-3.1-dryrun.test.sh`: **96 pass, 0 fail**.
- Alle drie de modi exit 0 onder `--dry-run`, geen enkele ssh gelegd.

## Dry-run uitvoer, ingekort

```
  mode          full deploy, DRY RUN (nothing is executed on the server)
  nginx confs   paramant-public.conf paramant-live.conf
PHASE 0: Before you start (read-only)
[step] 0a. CI on main
  $ gh run list --branch main -L 5
[step] 0b. static sanity on the commit that will be deployed (origin/main)
  $ git worktree add --detach <tmp> origin/main && tests/static-sanity.sh
  SKIP  assert (dry-run): static sanity, checks 1 to 9 clear
[step] 0c. frontend drift against origin/main
  $ bash scripts/check-prod-drift.sh origin/main
[step] 0d. the timestamp this run is named by
  OK    run timestamp fixed at 20260902-1915
PHASE 1: Layout and environment (server, read-only plus two env writes)
[step] 1a. checkout, compose project and container health
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay relay-main\ relay-health\ relay-finance\ relay-legal\ relay-iot\ admin"   # layout and health
  SKIP  assert (dry-run): production checkout is on 41501bb, the commit the runbook measured   [would match /checkout_head = 41501bb/]
  SKIP  assert (dry-run): all six services have a container   [services seen = 6]
  SKIP  assert (dry-run, must NOT match): no service is missing a container   [/container [a-z-]+ MISSING/]
  SKIP  assert (dry-run, must NOT match): no container reports unhealthy   [/unhealthy/]
[step] 1b. environment presence (never values)
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay"   # env presence
  SKIP  assert (dry-run): BILLING_MODE is empty in the running relay, so the recurring layer stays off   [would match /env BILLING_MODE +empty/]
  SKIP  assert (dry-run): MOLLIE_API_KEY is set with a live_ prefix, unchanged since 08-08   [would match /env MOLLIE_API_KEY +set, prefix live_/]
[step] 1c. INTERNAL_AUTH_TOKEN (write: step 6 cannot read /v2/health/deep without it)
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay write"   # internal auth token
  SKIP  assert (dry-run): INTERNAL_AUTH_TOKEN present exactly once in .env   [after INTERNAL_AUTH_TOKEN lines = 1]
[step] 1d. PARAMANT_INLINE_RECEIPT_HEADER (write: keeps old SDK clients receipted)
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay write"   # inline receipt opt-in
  SKIP  assert (dry-run): PARAMANT_INLINE_RECEIPT_HEADER=1 present exactly once in .env   [after PARAMANT_INLINE_RECEIPT_HEADER lines = 1]
PHASE 2: Rollback tags and backups (server, WRITE)
[step] 2a. tag the running images and write the manifest
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay 20260902-1915 /home/paramant/backups relay-main\ relay-health\ relay-finance\ relay-legal\ relay-iot\ admin"   # rollback tags
  SKIP  assert (dry-run): the rollback manifest has six lines, one per service   [after manifest lines = 6]
  SKIP  assert (dry-run): six rollback images really exist on the host, not just six lines of text   [after tags for this TS = 6]
[step] 2b. back up .env, compose state, docroot and the nginx confs
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay 20260902-1915 /home/paramant/backups /home/paramant/app /etc/nginx/backups /etc/nginx/sites-enabled paramant-public.conf\ paramant-live.conf"   # backups
  SKIP  assert (dry-run): .env backup is a real file with content   [after .env backup bytes >= 1]
  SKIP  assert (dry-run): docroot tar is a real file with content   [after docroot tar bytes >= 1]
  SKIP  assert (dry-run): docroot tar holds entries   [after docroot tar entries >= 1]
  SKIP  assert (dry-run): both named nginx confs were resolved and backed up   [after nginx conf backups = 2]
  SKIP  assert (dry-run, must NOT match): both named nginx confs exist on the server (set PARAMANT_NGINX_CONFS if they are named differently)   [/nginxconf [a-z.-]+ ABSENT/]
PHASE 3: Pull main, run the sanity gate, build (server, WRITE)
[step] 3a. pull origin/main fast-forward only
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay"   # git pull
  SKIP  assert (dry-run, must NOT match): server working tree was clean before the pull   [/FATAL working tree not clean/]
[step] 3b. static sanity on the server, same reading rule as phase 0
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay"   # static sanity
  SKIP  assert (dry-run): static sanity on the server
[step] 3c. build the relays and admin from source (containers untouched)
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay"   # docker compose build
  SKIP  assert (dry-run): docker compose build succeeded   [build exit = 0]
PHASE 4: Recreate, the canary relay first (server, WRITE)
[step] 4a. relay-iot alone, then read its two boot lines
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay"   # recreate relay-iot
  SKIP  assert (dry-run): relay-iot reached healthy   [would match /healthy [0-9a-f]+ after/]
  SKIP  assert (dry-run): relay-iot logged a billing_config line   [would match /bootline .*"billing_config"/]
  SKIP  assert (dry-run): billing_config says recurring:false, the brake is on   [would match /bootline .*"billing_config".*"recurring":false/]
  SKIP  assert (dry-run): billing_config says mode_source:inferred, so BILLING_MODE is not set anywhere   [would match /bootline .*"billing_config".*"mode_source":"inferred"/]
  SKIP  assert (dry-run, must NOT match): no relay reports recurring:true   [/"billing_config".*"recurring":true/]
  SKIP  assert (dry-run): relay_started reports version 3.1.0   [would match /bootline .*"relay_started".*"version":"3.1.0"/]
[step] 4b. relay-main, then the rest
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay"   # recreate the fleet
  SKIP  assert (dry-run): relay-main recreated and healthy   [would match /recreated relay-main/]
  SKIP  assert (dry-run): admin recreated and healthy   [would match /recreated admin/]
  SKIP  assert (dry-run, must NOT match): every recreated container reached healthy   [/NOTHEALTHY|UNHEALTHY|FATAL/]
  SKIP  assert (dry-run, must NOT match): no relay reports recurring:true after the recreate   [/stance .*"recurring":true/]
  SKIP  assert (dry-run, must NOT match): every relay logged relay_started   [/version .*no relay_started line/]
PHASE 5: Frontend and nginx (server, WRITE)
[step] 5a. rsync the docroot, never with --delete
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay /home/paramant/app"   # rsync docroot
  SKIP  assert (dry-run): docroot rsync succeeded   [rsync exit = 0]
  SKIP  assert (dry-run): docroot now matches the checkout frontend   [after would change = 0]
[step] 5b. prune the frontend files main deleted (rsync without --delete leaves them)
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay /home/paramant/app 41501bb dist\ paramant-mark.svg\ developer.js\ docs/paramant-investor-brief.html"   # prune deleted frontend files
  SKIP  assert (dry-run): git names at least one frontend file deleted since the deployed commit   [before deleted-in-git count >= 1]
[step] 5c. the three nginx changes, by hand, keeping the ParaID deny
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- 20260902-1915 /etc/nginx/sites-enabled /etc/nginx/backups paramant-public.conf\ paramant-live.conf"   # nginx edits
  SKIP  assert (dry-run, must NOT match): nginx edits applied and the config tests clean   [/FATAL/]
  SKIP  assert (dry-run): both named confs were really rewritten   [after edited files = 2]
  SKIP  assert (dry-run): /sign is no longer behind auth_request   [after sign gated = 0]
  SKIP  assert (dry-run): the /compliance locations are gone   [after compliance = 0]
  SKIP  assert (dry-run): /dicom no longer serves the page   [after dicom try_files = 0]
  SKIP  assert (dry-run): /dicom now returns 404   [after dicom 404 >= 1]
  SKIP  assert (dry-run): the /v2/outbound location the buffers go on exists   [before outbound locations >= 1]
  SKIP  assert (dry-run): nginx reloaded   [would match /reloaded nginx/]
PHASE 6: Smoke tests
[step] 6a. public auth surface (tests/auth-smoke.sh)
  $ bash tests/auth-smoke.sh https://paramant.app
[step] 6b. /health on each of the six hosts, and the version it reports
  $ curl -s -o /dev/null -w %{http_code} https://<host>/health   # six hosts
  SKIP  assert (dry-run): /health is 200 on six hosts, version 3.1.0
[step] 6c. /v2/health/deep, 401 without the token and 200 with it (server-local)
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay"   # deep health
  SKIP  assert (dry-run): /v2/health/deep is 401 without X-Internal-Auth   [deep noauth code = 401]
  SKIP  assert (dry-run): /v2/health/deep is 200 with X-Internal-Auth   [deep auth code = 200]
[step] 6d. /v1/paraid/issue-document is 404 on all six hosts (#319)
  $ curl -s -o /dev/null -w %{http_code} -X POST https://<host>/v1/paraid/issue-document   # six hosts
  SKIP  assert (dry-run): issue-document is 404 on six hosts
[step] 6e. the pages main deleted are really gone, not just unlinked (#319, #323)
  $ curl -s -o /dev/null -w %{http_code} https://paramant.app/compliance/nis2   # and /paraid
  SKIP  assert (dry-run): /compliance/nis2 and /paraid are 404
[step] 6f. /sign answers itself, 200 and no redirect to /auth/login (#317)
  $ curl -s -o /dev/null -w %{http_code} https://paramant.app/sign
  SKIP  assert (dry-run): /sign is 200 without a session
[step] 6g. the 3.0.0 verify suite, on the server (informational, exit 2 blocks)
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay"   # post-deploy-verify
[step] 6h. the inline receipt opt-in really works end to end (#342)
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay"   # inline receipt config
  SKIP  assert (dry-run): relay-main runs with PARAMANT_INLINE_RECEIPT_HEADER=1   [would match /inline relay-main +1/]
  SKIP  assert (dry-run): relay-iot runs with PARAMANT_INLINE_RECEIPT_HEADER=1   [would match /inline relay-iot +1/]
  SKIP  assert (dry-run): the loaded nginx config carries the raised proxy buffers   [effective outbound buffers >= 1]
  $ curl -sI https://relay.paramant.app/v2/outbound/<64 hex that never existed>
  SKIP  assert (dry-run): /v2/outbound proxies without a 502
  SKIP  assert (dry-run): a real download carries the inline receipt (needs PARAMANT_SMOKE_API_KEY)
[step] 6i. billing stance once more, from every relay log
  $ ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes root@116.203.86.81 "bash -s -- /opt/paramant-relay"   # billing stance
  SKIP  assert (dry-run, must NOT match): every relay still reports recurring:false   [/"recurring":true/]
PHASE 7: Summary
  OK    run timestamp fixed at 20260902-1915
DEPLOY FINISHED, warnings: 0
```

## Bewust niet geautomatiseerd

- **Stap 7 na de deploy.** Meekijken, de canary-key minten, taggen, CHANGELOG,
  vaultnotitie. Elk vraagt een oordeel of een geheim dat het script niet maakt.
- **`BILLING_MODE` zetten.** Precies de deploy waar de rem voor bestaat. Het
  script controleert dat hij leeg is en zet hem nooit.
- **De ParaID-deny verwijderen.** Het runbook houdt hem deze ronde; het script
  telt hem voor en na en breekt af als hij verdwijnt.
- **Drift bij fase 0 blokkeert niet.** Handmatige edits op de docroot zijn een
  WARN met de lijst erbij; alleen Mick weet of zo'n bestand mag sneuvelen.
- **De volledige receipt-smoketest zonder sleutel.** Een upload vraagt een
  account, en een deploy hoort geen productiesleutel te bevatten. Met
  `PARAMANT_SMOKE_API_KEY` draait hij, zonder zegt hij dat hij het niet weet.
- **`scripts/rollback-3.0.0.sh` wordt niet aangeroepen.** Die vraagt
  interactief om bevestiging, wat niet gaat door `ssh 'bash -s'`. Fase 8 doet
  dezelfde stappen plus de nginx- en docroot-restore die dat script niet doet.
