### PR TITLE
Gate the deploy on each required workflow, not on the last 5 runs on main

### DIFF
--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -149,7 +149,42 @@ finds out.
 
 ## Before you start (laptop or NUC, read-only)
 
-1. CI on main is green: `gh run list --branch main -L 5`.
+1. CI on main is green, judged per workflow. `gh run list --branch main -L 5`
+   is not the check: that window mixes workflows, so one red run of something
+   that is red on purpose reads as "main is broken". On 2026-09-02 it stopped
+   `--preflight-only` on a red `heartbeat` run, which is the hourly alarm
+   reporting that its own two canary secrets are absent, and it waved through
+   two runs that were still `in_progress`, because "in progress" is not the
+   string "failure".
+
+   ```bash
+   for wf in test.yml csp-inline-check.yml sign-e2e.yml product-heartbeat.yml; do
+     printf '%-24s ' "$wf"
+     gh run list --workflow "$wf" --branch main --status completed -L 1 \
+       --json conclusion --jq '.[0].conclusion // "NONE"'
+   done
+   ```
+
+   Every one must print `success`. `NONE` (no completed run on main) blocks too.
+   That list is every workflow in `.github/workflows` that runs on a push to
+   `main` without a `paths:` filter. Not on it, on purpose:
+
+   * `heartbeat.yml` does not run on push at all (schedule and
+     `workflow_dispatch`, gated on `vars.HEARTBEAT_ENABLED`) and is red by its
+     own design while the two canary secrets are missing: it has no skip, a
+     missing secret fails and names the secret. Gating the deploy on it would
+     mean no deploy until the alarm has its secrets.
+   * `docker-publish.yml` and `build-image.yml` are path-gated on `relay/**`, so
+     a commit that touches only the frontend produces no run at all and a hard
+     "must be success" would block every such deploy. Neither is what this
+     runbook deploys: step 4 recreates from the server's own checkout.
+
+   A run of a required workflow that is still `in_progress` or `queued` on the
+   sha you would deploy is not a pass, it is an answer that has not arrived.
+   Wait for it with `gh run watch <id>`, at most 15 minutes, then judge what it
+   became. `deploy/deploy-3.1.sh` phase 0a does exactly this and stops when a
+   required workflow is still running after the wait.
+
 2. Local suites on the commit you will deploy, from the repo root:
    ```bash
    tests/static-sanity.sh                                   # the gate deploy.sh runs first

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -50,6 +50,43 @@ EXPECT_VERSION="3.1.0"
 SERVICES="relay-main relay-health relay-finance relay-legal relay-iot admin"
 HOSTS="paramant.app health.paramant.app legal.paramant.app finance.paramant.app iot.paramant.app relay.paramant.app"
 
+# The CI gate on main (runbook: "Before you start", point 1).
+#
+# One verdict per required workflow, not "the last 5 runs on main". That older
+# gate mixed workflows in one window and read a red run of ANY of them as a
+# stop: on 2026-09-02 --preflight-only stopped on a red `heartbeat` run, which
+# is the hourly alarm saying its two canary secrets are absent. That is a
+# statement about the alarm, not about whether main deploys.
+#
+# The list below is every workflow in .github/workflows that runs on a push to
+# main WITHOUT a paths: filter. tests/deploy-3.1-dryrun.test.sh derives the same
+# list from the workflow files and fails when the two disagree, so a new
+# push-gated workflow cannot quietly stay outside the gate.
+#
+# Deliberately NOT in the list:
+#   heartbeat.yml       does not run on push at all (schedule + workflow_dispatch)
+#                       and is gated on vars.HEARTBEAT_ENABLED. It is red on
+#                       purpose while the two canary secrets are missing, by its
+#                       own design: "there is no skip, a missing secret fails and
+#                       names the secret". Gating a deploy on it would mean no
+#                       deploy can happen until the alarm has its secrets.
+#   docker-publish.yml  path-gated on relay/**, so a main commit that touches
+#                       only the frontend produces no run at all, and a hard
+#                       "must be success" would block every such deploy. This
+#                       runbook also does not deploy that published image:
+#                       phase 4 recreates from the server's own checkout.
+#   build-image.yml     path-gated on relay/** for the same reason. It is a
+#                       toolchain-drift gate for pull requests, not a
+#                       main-is-deployable gate.
+REQUIRED_WORKFLOWS="${PARAMANT_REQUIRED_WORKFLOWS:-test.yml csp-inline-check.yml sign-e2e.yml product-heartbeat.yml}"
+
+# A required workflow still in_progress or queued on the sha we would deploy is
+# neither a pass nor a failure: it is an answer that has not arrived. The old
+# gate only looked for the literal string "failure", so two in_progress runs on
+# 2026-09-02 counted as "not failing" and the gate waved them through. Wait for
+# them instead, then judge what they became.
+CI_WAIT_SECONDS="${PARAMANT_CI_WAIT_SECONDS:-900}"   # 15 minutes
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
@@ -104,6 +141,56 @@ run_gated() {
   GATED_OUT="$("$@" 2>&1)" || rc=$?
   printf '%s\n' "$GATED_OUT" | sed 's/^/  | /'
   return $rc
+}
+
+# ci_running_ids: the run ids of <workflow> on main that have not finished on
+# <sha>. queued counts as running: it has not even started, so it certainly has
+# no conclusion.
+ci_running_ids() {   # workflow file, sha
+  local st
+  for st in in_progress queued; do
+    gh run list --workflow "$1" --branch main --status "$st" -L 20 \
+      --json databaseId,headSha \
+      --jq ".[] | select(.headSha == \"$2\") | .databaseId" 2>/dev/null || true
+  done
+}
+
+# ci_gate_workflow: the verdict for one required workflow. Returns 0 only when
+# nothing of it is still in flight on the sha we would deploy AND its last
+# completed run on main concluded success. Everything else, including a
+# workflow that has never completed a run on main, returns non-zero.
+ci_gate_workflow() {   # workflow file, sha
+  local wf="$1" sha="$2" id ids concl
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '\n  $ gh run list --workflow %s --branch main --status in_progress -L 20 --json databaseId,headSha\n' "$wf"
+    printf '  [dry-run] not executed; a run of %s still in flight on the main sha is waited on with gh run watch, up to %ss, and judged afterwards\n' \
+      "$wf" "$CI_WAIT_SECONDS"
+  else
+    ids="$(ci_running_ids "$wf" "$sha" | tr '\n' ' ')"
+    for id in $ids; do
+      printf '  %-22s run %s is still in flight on %s; waiting up to %ss\n' \
+        "$wf" "$id" "$(printf '%s' "$sha" | cut -c1-7)" "$CI_WAIT_SECONDS"
+      timeout "$CI_WAIT_SECONDS" gh run watch "$id" >/dev/null 2>&1 || true
+    done
+    if [ -n "${ids// /}" ]; then
+      ids="$(ci_running_ids "$wf" "$sha" | tr '\n' ' ')"
+      if [ -n "${ids// /}" ]; then
+        printf '  %-22s STILL RUNNING after %ss (run %s)\n' "$wf" "$CI_WAIT_SECONDS" "$ids"
+        return 1
+      fi
+    fi
+  fi
+
+  run_gated gh run list --workflow "$wf" --branch main --status completed -L 1 \
+    --json conclusion,headSha,displayTitle,url || true
+  [ "$DRY_RUN" -eq 1 ] && return 0
+
+  concl="$(gh run list --workflow "$wf" --branch main --status completed -L 1 \
+           --json conclusion --jq '.[0].conclusion // "NONE"' 2>/dev/null || echo UNKNOWN)"
+  [ -n "$concl" ] || concl=UNKNOWN
+  printf '  %-22s last completed run on main: %s\n' "$wf" "$concl"
+  [ "$concl" = "success" ]
 }
 
 # q_args: shell-quote each argument into one string.
@@ -314,20 +401,30 @@ fi
 phase_0() {
   phase 0 "Before you start (read-only)" "Before you start, points 1 to 4"
 
-  step "0a. CI on main"
-  run_gated gh run list --branch main -L 5 || warn "gh run list did not succeed; check CI on main by hand"
+  step "0a. CI on main, one verdict per required workflow"
+  printf '  required: %s\n' "$REQUIRED_WORKFLOWS"
+  printf '  excluded: heartbeat.yml (schedule only, red by design while its canary secrets are absent),\n'
+  printf '            docker-publish.yml and build-image.yml (path-gated on relay/**, so they need not have run)\n'
+
+  local main_sha wf ci_bad=0 ci_n=0
+  if [ "$DRY_RUN" -eq 1 ]; then
+    main_sha="<main sha>"
+  else
+    main_sha="$(gh api "repos/{owner}/{repo}/commits/main" --jq .sha 2>/dev/null || echo unknown)"
+    printf '  main sha: %s\n' "$(printf '%s' "$main_sha" | cut -c1-7)"
+    [ "$main_sha" = "unknown" ] && warn "could not read the main sha from gh; in-flight runs cannot be matched to it"
+  fi
+
+  for wf in $REQUIRED_WORKFLOWS; do
+    ci_n=$((ci_n + 1))
+    ci_gate_workflow "$wf" "$main_sha" || ci_bad=$((ci_bad + 1))
+  done
+
   if [ "$DRY_RUN" -eq 0 ]; then
-    local concl
-    concl="$(gh run list --branch main -L 5 --json conclusion --jq '.[].conclusion' 2>/dev/null || echo UNKNOWN)"
-    printf '  conclusions: %s\n' "$(printf '%s' "$concl" | tr '\n' ' ')"
-    if printf '%s\n' "$concl" | grep -qx 'failure'; then
-      die "CI on main has a failing run in the last 5; the runbook wants main green"
+    if [ "$ci_bad" -gt 0 ]; then
+      die "$ci_bad of $ci_n required workflows on main did not conclude success (or is still running); the runbook wants main green"
     fi
-    if printf '%s\n' "$concl" | grep -qx 'UNKNOWN'; then
-      warn "could not read CI conclusions from gh; check main by hand before continuing"
-    else
-      ok "CI on main: no failing run in the last 5"
-    fi
+    ok "CI on main: all $ci_n required workflows concluded success ($REQUIRED_WORKFLOWS)"
   fi
 
   step "0b. static sanity on the commit that will be deployed ($DEPLOY_REF)"

--- a/tests/deploy-3.1-dryrun.test.sh
+++ b/tests/deploy-3.1-dryrun.test.sh
@@ -250,6 +250,74 @@ check_has "$FULL"   'after refused outside docroot'      "phase 5b reports how m
 check_has "$SCRIPT" 'NOT PROVEN'                         "phase 6h says NOT PROVEN when the header block is under 16 KB"
 
 echo ""
+echo "6d. The CI gate on main is one verdict per required workflow"
+# The old gate was `gh run list --branch main -L 5`: five runs of whichever
+# workflows happened to run last, with a stop on any `failure` among them. On
+# 2026-09-02 that stopped --preflight-only on a red `heartbeat` run, which is
+# the hourly alarm reporting that its own two canary secrets are missing, and it
+# waved through two runs that were still in_progress because "in progress" is
+# not the string "failure".
+check_lacks "$SCRIPT" 'gh run list --branch main -L 5' \
+  "the mixed-workflow 'last 5 runs on main' gate is gone from the script"
+
+# The gated list must be exactly the workflows that run on a push to main
+# without a paths: filter. It is derived here from .github/workflows rather than
+# copied, so a new push-gated workflow that nobody adds to the gate fails this
+# test instead of quietly deploying ungated.
+DERIVED=""
+for _f in "$ROOT"/.github/workflows/*.yml; do
+  [ -f "$_f" ] || continue
+  _blk="$(awk '/^on:/                              {inon=1; next}
+               inon && /^[^[:space:]#]/            {inon=0}
+               inon && /^  push:/                  {inpush=1; next}
+               inon && inpush && /^  [^[:space:]]/ {inpush=0}
+               inpush' "$_f")"
+  [ -n "$_blk" ] || continue                                    # no push trigger
+  printf '%s\n' "$_blk" | grep -qE 'branches:.*[][ ,]main([][ ,]|$)|^[[:space:]]*-[[:space:]]*main[[:space:]]*$' || continue
+  printf '%s\n' "$_blk" | grep -qE '^[[:space:]]*paths:' && continue   # path-gated: may not run at all
+  DERIVED="$DERIVED $(basename "$_f")"
+done
+DERIVED="$(printf '%s\n' $DERIVED | sort | tr '\n' ' ' | sed 's/^ *//; s/ *$//')"
+GATED="$(sed -n 's/^REQUIRED_WORKFLOWS="\${PARAMANT_REQUIRED_WORKFLOWS:-\(.*\)}"$/\1/p' "$SCRIPT" \
+         | tr ' ' '\n' | sort | tr '\n' ' ' | sed 's/^ *//; s/ *$//')"
+if [ -z "$DERIVED" ]; then
+  fail "no push-to-main workflow was derived from .github/workflows; the derivation is not looking at anything"
+elif [ "$DERIVED" = "$GATED" ]; then
+  pass "the gated list is exactly the push-to-main workflows without a paths: filter ($GATED)"
+else
+  fail "the gated list does not match .github/workflows"
+  printf '        gated:   %s\n' "$GATED"
+  printf '        derived: %s\n' "$DERIVED"
+fi
+
+# Every required workflow really is asked about, by name, in the dry run.
+for _wf in test.yml csp-inline-check.yml sign-e2e.yml product-heartbeat.yml; do
+  check_has "$FULL" "gh run list --workflow $_wf --branch main --status completed -L 1" \
+    "the dry run reads the last completed run of $_wf on main"
+done
+
+# And the three excluded ones are not. The space after --workflow anchors these:
+# "--workflow product-heartbeat.yml" does not match "--workflow heartbeat.yml".
+check_lacks "$FULL" 'gh run list --workflow heartbeat\.yml' \
+  "heartbeat.yml is not gated on (schedule only, red by design without its canary secrets)"
+check_lacks "$FULL" 'gh run list --workflow docker-publish\.yml' \
+  "docker-publish.yml is not gated on (path-gated on relay/**)"
+check_lacks "$FULL" 'gh run list --workflow build-image\.yml' \
+  "build-image.yml is not gated on (path-gated on relay/**)"
+check_has "$SCRIPT" 'Deliberately NOT in the list' \
+  "the script writes down why each excluded workflow is excluded"
+
+echo ""
+echo "6e. A required run still in flight is waited on, not read as not-failing"
+check_has "$FULL"   'status in_progress'       "the gate asks GitHub which runs have not finished"
+check_has "$SCRIPT" 'in_progress queued'       "queued counts as unfinished too"
+check_has "$FULL"   'gh run watch'             "an unfinished run of a required workflow is waited on"
+check_has "$SCRIPT" 'CI_WAIT_SECONDS:-900'     "that wait is capped at 15 minutes"
+check_has "$SCRIPT" 'STILL RUNNING after'      "a run still going after the wait blocks instead of passing"
+check_has "$SCRIPT" 'conclusion // "NONE"'     "a workflow with no completed run on main is NONE, not a pass"
+check_has "$SCRIPT" 'headSha'                  "in-flight runs are matched against the sha that would be deployed"
+
+echo ""
 echo "6b. Rollback restores in an order that cannot half-fail"
 check_has "$RB" 'missing backups = 0'    "rollback refuses to start when a backup it needs is absent"
 check_has "$RB" 'restore \.env first'    "rollback restores .env before recreating the containers"


### PR DESCRIPTION
## Wat er stuk was

Fase 0a van `deploy/deploy-3.1.sh` deed `gh run list --branch main -L 5` en stopte op elke `failure` in dat venster. Dat venster mengt workflows, dus het beantwoordt een vraag die niemand stelt.

Gemeten op 2026-09-02 met `bash deploy/deploy-3.1.sh --preflight-only`: de poort stopte op een rode `heartbeat`-run. `heartbeat.yml` draait alleen op `schedule` en `workflow_dispatch`, is gated op `vars.HEARTBEAT_ENABLED`, en is met opzet rood zolang de twee kanarie-secrets ontbreken (het heeft geen skip: een ontbrekend secret faalt en noemt het secret). Dat rood zegt dat het alarm geen secrets heeft, niet dat main stuk is.

In diezelfde run stonden twee runs nog `in_progress`. Die liep de poort voorbij, want "in progress" is niet de string "failure". Een antwoord dat nog niet binnen is, is geen groen.

## Wat fase 0a nu doet

Eén oordeel per verplichte workflow.

- De verplichte lijst is elke workflow in `.github/workflows` die op een push naar `main` draait **zonder** `paths:`-filter: `test.yml`, `csp-inline-check.yml`, `sign-e2e.yml`, `product-heartbeat.yml`. Te overschrijven met `PARAMANT_REQUIRED_WORKFLOWS`.
- Bewust erbuiten, met de reden in een comment naast de lijst:
  - `heartbeat.yml`: niet push-getriggerd en met opzet rood zonder zijn secrets. Erop gaten zou betekenen: geen deploy tot het alarm zijn secrets heeft.
  - `docker-publish.yml` en `build-image.yml`: path-gated op `relay/**`, dus een frontend-only commit levert helemaal geen run op. Een harde "moet success zijn" zou elke zulke deploy blokkeren. Deze runbook deployt die image ook niet: fase 4 recreate't uit de checkout op de server zelf.
- Per workflow: elke run die `in_progress` of `queued` is op de huidige main-sha wordt afgewacht met `gh run watch`, gecapt op `PARAMANT_CI_WAIT_SECONDS` (900, dus 15 minuten). Draait hij daarna nog steeds, dan blokkeert dat. Daarna wordt de laatste afgeronde run op main gelezen met `gh run list --workflow <file> --branch main --status completed -L 1 --json conclusion`. Elke conclusie moet `success` zijn. Geen afgeronde run leest als `NONE` en blokkeert ook.
- De conclusie van elke workflow wordt op een eigen regel geprint.

## Nieuwe 0a-uitvoer (dry run)

```
[step] 0a. CI on main, one verdict per required workflow
  required: test.yml csp-inline-check.yml sign-e2e.yml product-heartbeat.yml
  excluded: heartbeat.yml (schedule only, red by design while its canary secrets are absent),
            docker-publish.yml and build-image.yml (path-gated on relay/**, so they need not have run)

  $ gh run list --workflow test.yml --branch main --status in_progress -L 20 --json databaseId,headSha
  [dry-run] not executed; a run of test.yml still in flight on the main sha is waited on with gh run watch, up to 900s, and judged afterwards

  $ gh run list --workflow test.yml --branch main --status completed -L 1 --json conclusion,headSha,displayTitle,url
  [dry-run] not executed
```

En zo voor `csp-inline-check.yml`, `sign-e2e.yml` en `product-heartbeat.yml`. In een echte run komt daar per workflow een regel bij:

```
  test.yml               last completed run on main: success
```

## Test

`tests/deploy-3.1-dryrun.test.sh` krijgt twee secties.

**6d** leidt de verplichte lijst zelf af uit `.github/workflows` (push-blok bevat `main`, geen `paths:`) en faalt als die niet gelijk is aan `REQUIRED_WORKFLOWS` in het script. Een nieuwe push-gated workflow kan dus niet stilletjes buiten de poort blijven. Verder: de oude `-L 5`-query is weg, elke verplichte workflow wordt in de dry run bij naam bevraagd, en `heartbeat.yml`, `docker-publish.yml` en `build-image.yml` juist niet.

**6e** dekt de in-flight-afhandeling: de poort vraagt naar `in_progress`, `queued` telt mee, er wordt gewacht met `gh run watch`, de wachttijd is gecapt, nog draaien na de cap blokkeert, en `NONE` is geen pass.

## Runbook

"Before you start" punt 1 in `deploy/DEPLOY-3.1.md` zegt nu hetzelfde met de hand, inclusief de uitsluitingen en hun reden.

## Bewijs

- `bash -n deploy/deploy-3.1.sh`: schoon
- `bash tests/deploy-3.1-dryrun.test.sh`: 125 passed, 0 failed
- `bash tests/static-sanity.sh`: PASS, checks 1 tot en met 10 `OK`

Niets op productie aangeraakt. Alles gemeten met `--dry-run`.
