### PR TITLE
Community limits on index and docs come from tiers.js

### DIFF
--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -987,7 +987,7 @@ python3 scripts/paramant-admin.py sync</pre>
 
     <div class="faq-item">
       <div class="faq-q">How do I get a pgp_ API key?</div>
-      <div class="faq-a"><a href="/signup" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">paramant.app/signup</a>: create a free account to receive your API key with TOTP protection. Community plan: 10 uploads/hour per IP, 1-hour TTL, burn-on-first-read. See <a href="/pricing">/pricing</a> for tier details.</div>
+      <div class="faq-a"><a href="/signup" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">paramant.app/signup</a>: create a free account to receive your API key with TOTP protection. Community plan: 10 transfers a month, 5 MB per file, 1-hour TTL, burn-on-first-read. See <a href="/pricing">/pricing</a> for tier details.</div>
     </div>
 
   </div>

--- a/frontend/docs/api.md
+++ b/frontend/docs/api.md
@@ -14,7 +14,7 @@
 
 All data-plane endpoints require: `X-Api-Key: your_key`
 
-- `pgp_` prefix — end user key (10 uploads/day free, no account needed)
+- `pgp_` prefix, end user key. Community plan: 10 transfers a month, 5 MB per file.
 - `plk_` prefix — operator license key (unlimited, from `.env`)
 
 CT log and STH endpoints are **public** — no API key required.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -357,7 +357,7 @@
       <h3>ParaSend</h3>
       <p class="price-sub">Sending files that burn on read.</p>
       <ul class="tiers">
-        <li><span class="tier-price">&euro;0</span><span class="tier-what"><b>Community</b> &middot; 1 hour link expiry, burn on first read, 10 uploads per hour</span></li>
+        <li><span class="tier-price">&euro;0</span><span class="tier-what"><b>Community</b> &middot; 10 transfers a month, 5 MB per file, 1 hour link expiry, burn on first read</span></li>
         <li><span class="tier-price">&euro;15</span><span class="tier-what"><b>Pro</b> &middot; 24 hour expiry, up to 10 reads per link, send history, webhooks</span></li>
         <li><span class="tier-price">Custom</span><span class="tier-what"><b>Enterprise</b> &middot; dedicated relay, signed DPA, SLA 99.95%, per-tenant limits</span></li>
       </ul>

--- a/tests/site-claims.test.mjs
+++ b/tests/site-claims.test.mjs
@@ -538,3 +538,61 @@ test('any CLI tool count the site states is the size of the developer catalogue'
   }
   assert.deepEqual(wrong, [], `\n  ${wrong.join('\n  ')}\n`);
 });
+
+// 11 ── What the free Community plan actually gives you.
+//
+// The homepage, the docs FAQ and the API reference all sold Community as "10
+// uploads per hour". That number is ANON_RATE_PER_HOUR, the per-IP ceiling on
+// POST /v2/anon-inbound (relay.js), an endpoint deprecated 2026-05-28 with a
+// sunset of 31 December 2026. It was never the limit of a logged-in Community
+// account. The real caps live in relay/lib/tiers.js and are enforced in
+// relay.js: transfers_month via the 402 monthly_transfer_quota_reached gate,
+// file_mb via the 413 "Max 5MB" check. So the pages read the tier row.
+test('the Community plan limits on the site are the ones tiers.js declares', () => {
+  const tiers = read('relay/lib/tiers.js');
+  const block = tiers.slice(tiers.indexOf('community:'), tiers.indexOf('pro:'));
+  const num = (dim) => {
+    const m = new RegExp(`${dim}:\\s*([\\d_]+)`).exec(block);
+    assert.ok(m, `tiers.js community.${dim} must be a literal number`);
+    return Number(m[1].replace(/_/g, ''));
+  };
+  const transfers = num('transfers_month');
+  const mb = num('file_mb');
+
+  // The quota gate and the size check must still be the things that enforce
+  // them, or the pages would be pinned to a constant nobody reads.
+  const relay = read('relay/relay.js');
+  assert.match(relay, /monthly_transfer_quota_reached/, 'relay.js must enforce transfers_month');
+  assert.match(relay, /dimension:\s*'transfers_month'/, 'relay.js must decline on the transfers_month dimension');
+  assert.match(relay, /Max \$\{Math\.round\(planMaxSize\/1048576\)\}MB/, 'relay.js must enforce the per-file size cap');
+
+  const problems = [];
+  const says = (where, text, phrase) => { if (!text.includes(phrase)) problems.push(`${where}: must state "${phrase}"`); };
+  says('index', visible(page('index')), `${transfers} transfers a month`);
+  says('index', visible(page('index')), `${mb} MB per file`);
+  says('docs', visible(page('docs')), `${transfers} transfers a month`);
+  says('docs', visible(page('docs')), `${mb} MB per file`);
+  const apiMd = read('frontend/docs/api.md');
+  says('docs/api.md', apiMd, `${transfers} transfers a month`);
+  says('docs/api.md', apiMd, `${mb} MB per file`);
+
+  // And no page may go back to selling the retired anonymous rate as a plan
+  // limit. Per-MINUTE claims are out of scope here: those are nginx and API
+  // rate limits with their own source (nginx-selfhost.conf, the envelope
+  // create limiter), not the tier table.
+  //
+  // pricing, parasign and parasend carry the same stale sentence and are
+  // corrected in their own PRs (#336, #339). Drop them from this list once
+  // those land; the exclusion is the only reason this scan is not global.
+  const DEFERRED = new Set(['pricing', 'parasign', 'parasend']);
+  for (const slug of publicPages()) {
+    if (DEFERRED.has(slug)) continue;
+    for (const m of visible(page(slug)).matchAll(/\d+\s*uploads?\s*(?:\/|\s+(?:per|an|a)\s+)(?:hour|day)/gi)) {
+      problems.push(`${slug}: claims "${m[0]}", which is the retired /v2/anon-inbound rate, not a tier limit`);
+    }
+  }
+  for (const m of apiMd.matchAll(/\d+\s*uploads?\s*(?:\/|\s+(?:per|an|a)\s+)(?:hour|day)/gi)) {
+    problems.push(`docs/api.md: claims "${m[0]}", which is the retired /v2/anon-inbound rate, not a tier limit`);
+  }
+  assert.deepEqual(problems, [], `\n  ${problems.join('\n  ')}\n`);
+});


### PR DESCRIPTION
The free Community plan was sold on three pages with a number that belongs to a different, retired thing.

`10 uploads per hour` is `ANON_RATE_PER_HOUR`, the per-IP ceiling on `POST /v2/anon-inbound` (`relay/relay.js:4300-4312`). That endpoint was deprecated on 2026-05-28 and carries `Sunset: Wed, 31 Dec 2026`. It has never been the limit of a logged-in Community account.

## The source of truth

`relay/lib/tiers.js`, the `community` row:

| dimension | value | enforced at |
|---|---|---|
| `transfers_month` | 10 | `relay/relay.js:4594-4602`, `402 monthly_transfer_quota_reached` |
| `file_mb` | 5 | `relay/relay.js:4550`, `413 Max 5MB` |
| `signs_month` | 2 | already stated correctly on index.html and sign.html |
| `view_ttl_ms` | 1 h | already stated as "1 hour link expiry" |
| `max_views` | 1 | already stated as "burn on first read" |

## Per page

**frontend/index.html** (ParaSend tier list)

- old: `Community · 1 hour link expiry, burn on first read, 10 uploads per hour`
- new: `Community · 10 transfers a month, 5 MB per file, 1 hour link expiry, burn on first read`

**frontend/docs.html** (FAQ, "How do I get a pgp_ API key?")

- old: `Community plan: 10 uploads/hour per IP, 1-hour TTL, burn-on-first-read.`
- new: `Community plan: 10 transfers a month, 5 MB per file, 1-hour TTL, burn-on-first-read.`

**frontend/docs/api.md** (Authentication)

- old: ``- `pgp_` prefix — end user key (10 uploads/day free, no account needed)``
- new: ``- `pgp_` prefix, end user key. Community plan: 10 transfers a month, 5 MB per file.``

`10 uploads/day` matched nothing in the code at all, and "no account needed" was wrong too: a `pgp_` key comes from `/signup`.

## The pin

`tests/site-claims.test.mjs`, test 11. It reads `transfers_month` and `file_mb` straight out of the `community` block in `tiers.js`, asserts the three pages state those numbers, and asserts the relay still enforces them (`monthly_transfer_quota_reached`, the `Max ${...}MB` check), so the pages are pinned to a constant that is actually load-bearing. It then scans every public page for any `N uploads per hour/day` phrasing and fails on it.

Sabotage check, `10` to `20` in index.html:

```
not ok 11 - the Community plan limits on the site are the ones tiers.js declares
      index: must state "10 transfers a month"
```

And with the old sentence restored on both pages:

```
      docs: claims "10 uploads/hour", which is the retired /v2/anon-inbound rate, not a tier limit
      index: claims "10 uploads per hour", which is the retired /v2/anon-inbound rate, not a tier limit
```

Per-minute claims are deliberately out of scope: `frontend/help/iot-integration.html` (60/min, API) and `frontend/docs/self-hosting.md` (10/min, nginx) have their own sources.

`pricing.html:249` still says `10 uploads per hour per IP` and is excluded from the scan by name, with a comment saying to drop the exclusion once #336 and #339 land. `parasign.html` and `parasend.html` were left alone as asked; neither carries the phrase today.

## Not touched

pricing.html, parasign.html, parasend.html, the nav generator, every head element.

## Tests

links, seo-contract, ui-truthfulness, site-claims (11/11), frontend-loading-contract, csp-inline, cache-bust, eslint, static-sanity (10 green) all pass.
