### PR TITLE
The deploy can run a second time, and resume one that died halfway

### DIFF
--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -213,7 +213,7 @@ finds out.
 ```bash
 ssh -i ~/.ssh/paramant_prod_claude root@116.203.86.81
 
-cd /opt/paramant-relay && git rev-parse --short HEAD        # expect 41501bb
+cd /opt/paramant-relay && git rev-parse --short HEAD        # see "Which commit do we expect here" below
 docker compose ls                                            # which compose project, which file
 docker compose ps                                            # six containers plus redis, all healthy
 
@@ -224,6 +224,44 @@ for v in BILLING_MODE MOLLIE_API_KEY MOLLIE_TEST_API_KEY INTERNAL_AUTH_TOKEN ADM
 done
 grep -c '^INTERNAL_AUTH_TOKEN=' .env
 ```
+
+### Which commit do we expect here
+
+`41501bb` is where **this runbook** starts: the stand of 8 August, before any
+3.1 deploy ran. It is not where the checkout stands after a deploy. After step
+3 the checkout is on main, so a gate that only ever accepts `41501bb` makes the
+whole procedure single-use: the second deploy stops on this line, and so does
+every resume of a run that died halfway through step 5.
+
+So `deploy/deploy-3.1.sh` treats the expected commit as a parameter with three
+sources, most specific first.
+
+| source | when it applies | what it demands |
+|---|---|---|
+| `PARAMANT_EXPECTED_HEAD=<commit>` | you set it | the checkout equals it, and nothing else is consulted |
+| `/home/paramant/backups/deployed-head` | the file exists on the server | the checkout equals what that file names, **and** that commit is an ancestor of the deploy ref (`git merge-base --is-ancestor`, after a `git fetch`) |
+| `41501bb` | no marker, so no deploy has ever finished here | the checkout equals `41501bb`, the runbook's own starting point |
+
+The marker is written by step 7, by the script, with the commit the checkout is
+actually on. The ancestor test is what keeps the second and later runs honest:
+equal to the marker says nothing moved the checkout outside a deploy, and
+ancestor of the ref says the fast-forward pull in step 3 can reach the ref from
+here. Both have to hold; either alone lets a deploy start from a commit the ref
+does not contain.
+
+A short sha and a full sha of the same commit count as equal. Anything shorter
+than seven characters is not an identification and never matches.
+
+If the checkout has moved and you know why, say so:
+`PARAMANT_EXPECTED_HEAD=<commit> bash deploy/deploy-3.1.sh`. That is the escape
+hatch, and it is deliberately explicit: it accepts equality and skips the
+ancestor test, so it is the one place where a human overrules the measurement.
+
+The rollback (step 8) does **not** rewrite the marker. It restores images,
+`.env`, nginx and the docroot and leaves the checkout where it stands, and the
+marker names the checkout. If you move the checkout back by hand afterwards,
+either write that commit into the marker or run the next deploy with
+`PARAMANT_EXPECTED_HEAD`.
 
 What has to be true before step 2:
 
@@ -358,6 +396,30 @@ The ParaID deny may stay: the route is gone from the relay (#319), so the
 deny answers 404 for a path that would answer 404 anyway. Remove it in a later
 round, not in this one.
 
+### Running step 5 twice
+
+All four nginx changes are idempotent, and the script reads each one as being
+in one of three states before it edits anything:
+
+| state | what the conf carries | what happens |
+|---|---|---|
+| `todo` | the old shape (`auth_request` on `/sign`, a `/compliance` location, `try_files /dicom.html`) | the edit runs |
+| `done` | the old shape is gone and the wanted shape is there (`location = /sign` without `auth_request`, no `/compliance` locations, `location = /dicom { return 404; }`) | reported as **already applied**, no error |
+| `unknown` | neither shape | `FATAL`, because this is not the conf the runbook describes and editing it further would be editing blind |
+
+Only `unknown` stops the deploy. The older script read "nothing to do" as
+`FATAL` outright, which meant the second deploy died on an edit that had simply
+already succeeded. The removal of the docroot files main deleted (step 5b)
+already worked this way: a file that is already gone is counted as *already
+absent*, not as a failure.
+
+What is asserted after the edits does not change, and that is where the weight
+sits: no `auth_request` on `/sign`, zero `/compliance` locations, `/dicom`
+answering `return 404`, the ParaID deny still present, `proxy_buffer_size 32k`
+inside **every** `location ~ ^/v2/outbound` block, and `nginx -t` clean before
+the reload. A run that changed nothing still tests and reloads nginx, so a hand
+edit made between deploys cannot hide behind "already applied".
+
 ## Step 6: smoke tests
 
 In the order `deploy.sh` runs them, plus the two the 3.0.0 runbook used.
@@ -426,6 +488,18 @@ Stop and roll back (step 8) on: a relay that does not reach `healthy`,
    date in `CHANGELOG.md`.
 5. Write the deploy down in the vault (`Sessies/2026-09/`), with the
    `billing_config` line as it was logged.
+
+`deploy/deploy-3.1.sh` does one write of its own here, before the summary: it
+records the commit the checkout ended on in
+`/home/paramant/backups/deployed-head`. That file is the whole reason a second
+deploy can start (see "Which commit do we expect here" under step 1). Doing it
+by hand comes down to:
+
+```bash
+cd /opt/paramant-relay && git rev-parse HEAD > /home/paramant/backups/deployed-head
+```
+
+Without it the next run has no marker, falls back to `41501bb`, and stops.
 
 ## Deciding on the recurring layer, later, not today
 

--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -407,6 +407,25 @@ in one of three states before it edits anything:
 | `done` | the old shape is gone and the wanted shape is there (`location = /sign` without `auth_request`, no `/compliance` locations, `location = /dicom { return 404; }`) | reported as **already applied**, no error |
 | `unknown` | neither shape | `FATAL`, because this is not the conf the runbook describes and editing it further would be editing blind |
 
+The `/sign` state is read per **block**, not per line. The sed edit removes the
+one-line spelling the repo conf uses, and a grep for that line is blind to a
+hand edit that put the gate back across several lines:
+
+```nginx
+location = /sign {
+    auth_request /api/user/check;
+    error_page 401 = @login_redirect;
+    try_files /sign.html =404;
+}
+```
+
+A line-based read calls that `done` and reports **already applied** while
+`/sign` is behind the login again. An awk walk over the `location = /sign`
+block, brace depth and all, sees the `auth_request` wherever it sits, so this
+reads as `todo`. The one-line sed still cannot remove it, and that is the
+point: the phase then stops with a `FATAL` that names the multi-line spelling
+and asks for a hand edit, instead of shipping a gated `/sign` as a success.
+
 Only `unknown` stops the deploy. The older script read "nothing to do" as
 `FATAL` outright, which meant the second deploy died on an edit that had simply
 already succeeded. The removal of the docroot files main deleted (step 5b)
@@ -569,6 +588,42 @@ docker compose up -d --no-deps --force-recreate relay-main
 `deploy.sh` itself prints `git revert HEAD && ./deploy.sh <container>` as its
 rollback. That rebuilds from source and is slower; the tagged images are the
 fast path.
+
+### Deploying again after a rollback
+
+A rollback leaves the server in a state that reads like a finished deploy but
+is not one, and step 5b is where that bites.
+
+The tar restore puts the **whole** pre-3.1 docroot back, including all 26 pages
+main deleted. The checkout is untouched, so it stays on main, and so does the
+deployed-head marker. A step 5b that diffed `marker..HEAD` would find that main
+deleted nothing since the commit the marker names, prune nothing, and leave the
+26 pages served. Step 6e then dies on `/compliance/nis2` answering `200`, with
+the containers, `.env` and nginx already live. That is the worst place to find
+out.
+
+So 5b never diffs against the marker alone. It takes the **older** of the
+deployed commit and `41501bb`, which in practice means it diffs `41501bb..HEAD`
+on every run. The server decides which is older, with
+`git merge-base --is-ancestor`, because only the server has both commits. The
+choice is printed as `before base choice` and the answer as `before prune base`.
+
+Pruning something that is already gone costs nothing, so the normal answer on a
+healthy second deploy is:
+
+```
+after removed = 0
+after already absent = 26
+```
+
+and after a rollback it is `after removed = 26` instead. Both are fine. What is
+not fine is a delete list of zero on a docroot that still serves the pages, and
+that is the case the floor removes.
+
+The same applies if you move the checkout back by hand during a rollback: put
+that commit in the marker, or run the next deploy with
+`PARAMANT_EXPECTED_HEAD`. The prune base is unaffected either way, because the
+floor is older than both.
 
 ## What this runbook does not do
 

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -16,6 +16,12 @@
 #
 # Flags combine: --dry-run --preflight-only, --dry-run --rollback <TS>.
 #
+# The commit the production checkout must be on before phase 3 moves it is a
+# parameter, not a constant. PARAMANT_EXPECTED_HEAD=<commit> wins; without it
+# the script reads the deployed-head marker phase 7 wrote on the server; with
+# no marker either it falls back to the runbook's starting commit. So a second
+# deploy, and a resume of a failed one, no longer stop on the first gate.
+#
 # Secrets: this script never prints a key value. Environment variables are
 # reported as "empty" or "set, prefix <first 5 chars>", which is the shape the
 # runbook's own step 1 uses. No remote block runs under set -x, and no read of
@@ -45,7 +51,35 @@ NGINX_CONFS="${PARAMANT_NGINX_CONFS:-paramant-public.conf paramant-live.conf}"
 DOCROOT_IGNORE="dist paramant-mark.svg developer.js docs/paramant-investor-brief.html"
 
 DEPLOY_REF="${DEPLOY_REF:-origin/main}"
+
+# Where the production checkout has to stand before phase 3 moves it.
+#
+# 41501bb is where the RUNBOOK starts: the stand of 08-08, before any 3.1
+# deploy ran. Hard-coding it as the only acceptable answer made the script
+# single-use: after the first successful deploy the checkout is on main, phase
+# 1a stops on "expected 41501bb", and the same script can never be run again,
+# not even to resume a deploy that failed halfway through phase 5.
+#
+# So the expected commit is a parameter with three sources, most specific first:
+#
+#   1. PARAMANT_EXPECTED_HEAD, if set. An explicit answer from whoever is
+#      running the deploy, for the case where they know what the checkout is
+#      on and why. Hard equality, no ancestor test.
+#   2. the deployed-head marker, if the server has one. Phase 7 writes the
+#      commit it left the checkout on into $BACKUP_DIR/deployed-head. Phase 1a
+#      of the NEXT run reads it back and demands two things: the checkout is
+#      still on that commit (nothing moved it outside a deploy), AND that
+#      commit is an ancestor of the deploy ref (so phase 3a's --ff-only pull
+#      can actually reach the ref from here).
+#   3. EXPECT_PROD_COMMIT. No marker means no deploy has ever recorded one, so
+#      this is the first run and the runbook's own starting point applies.
+#
+# A rollback (phase 8) deliberately does NOT rewrite the marker: it restores
+# images, .env, nginx and the docroot, and leaves the checkout where it is. The
+# marker names the checkout, so it stays true.
 EXPECT_PROD_COMMIT="${EXPECT_PROD_COMMIT:-41501bb}"   # runbook: where we start
+EXPECTED_HEAD="${PARAMANT_EXPECTED_HEAD:-}"           # explicit override, wins
+DEPLOYED_HEAD_FILE="${PARAMANT_DEPLOYED_HEAD_FILE:-$BACKUP_DIR/deployed-head}"
 EXPECT_VERSION="3.1.0"
 SERVICES="relay-main relay-health relay-finance relay-legal relay-iot admin"
 HOSTS="paramant.app health.paramant.app legal.paramant.app finance.paramant.app iot.paramant.app relay.paramant.app"
@@ -100,6 +134,7 @@ ROLLBACK_TS=""
 REMOTE_OUT=""
 REMOTE_RC=0
 PREV_HEAD=""
+DEPLOYED_HEAD=""
 WARNINGS=0
 SUMMARY=""
 
@@ -297,6 +332,83 @@ expect_min() {
   ok "$what ($field = $got)"
 }
 
+# ------------------------------------------------ the starting commit gate --
+
+# sha_eq: two git object names are the same commit when one is a prefix of the
+# other. The server prints both a short and a full sha, the marker holds a full
+# one, and PARAMANT_EXPECTED_HEAD may be either, so a plain [ a = b ] would
+# reject a correct answer for being spelled shorter. Fewer than 7 characters is
+# not an answer at all and never matches.
+sha_eq() {
+  local a="$1" b="$2" n
+  [ -n "$a" ] && [ -n "$b" ] || return 1
+  n=${#a}
+  [ ${#b} -lt "$n" ] && n=${#b}
+  [ "$n" -ge 7 ] || return 1
+  [ "${a:0:$n}" = "${b:0:$n}" ]
+}
+
+# head_gate_verdict: is the commit the production checkout stands on an
+# acceptable starting point? Pure: it reads no file, opens no connection and
+# touches no global, so tests/deploy-3.1-dryrun.test.sh can extract it and put
+# every case through it without a server.
+#
+#   $1 override   PARAMANT_EXPECTED_HEAD, empty when unset
+#   $2 marker     what $DEPLOYED_HEAD_FILE holds, "none" when the file is absent
+#   $3 head       the sha the production checkout is on (full)
+#   $4 fallback   EXPECT_PROD_COMMIT, the runbook's first-deploy commit
+#   $5 ancestor   yes | no | unknown: is head an ancestor of the deploy ref
+#
+# Prints "OK <sentence>" and returns 0, or "STOP <sentence>" and returns 1.
+head_gate_verdict() {
+  local override="$1" marker="$2" head="$3" fallback="$4" ancestor="$5"
+  local short="${head:0:7}"
+
+  if [ -z "$head" ]; then
+    printf 'STOP the server never printed the commit its checkout is on\n'
+    return 1
+  fi
+
+  # 1. An explicit answer wins, and is judged on equality alone. Someone who
+  #    sets this has looked at the server; the script does not second-guess it.
+  if [ -n "$override" ]; then
+    if sha_eq "$head" "$override"; then
+      printf 'OK checkout is on %s, which PARAMANT_EXPECTED_HEAD names\n' "$short"
+      return 0
+    fi
+    printf 'STOP checkout is on %s, but PARAMANT_EXPECTED_HEAD names %s\n' "$short" "$override"
+    return 1
+  fi
+
+  # 2. A marker means a previous run finished phase 7 and wrote down what it
+  #    left the checkout on. Both halves have to hold.
+  if [ -n "$marker" ] && [ "$marker" != none ]; then
+    if ! sha_eq "$head" "$marker"; then
+      printf 'STOP checkout is on %s, but the last deploy recorded %s; something moved the checkout outside a deploy, so the rollback images no longer match the source\n' \
+        "$short" "${marker:0:7}"
+      return 1
+    fi
+    case "$ancestor" in
+      yes) printf 'OK checkout is on %s, the commit the last deploy recorded, and that commit is an ancestor of the deploy ref\n' "$short"
+           return 0 ;;
+      no)  printf 'STOP checkout %s is not an ancestor of the deploy ref; the ref does not contain what is deployed, so the fast-forward pull in phase 3a cannot succeed\n' "$short"
+           return 1 ;;
+      *)   printf 'STOP could not decide whether %s is an ancestor of the deploy ref; the server could not resolve the ref\n' "$short"
+           return 1 ;;
+    esac
+  fi
+
+  # 3. No marker: nothing has ever deployed from here, so the runbook's own
+  #    starting point is the only acceptable answer.
+  if sha_eq "$head" "$fallback"; then
+    printf 'OK no deployed-head marker yet, so this is the first deploy, and the checkout is on %s as the runbook says\n' "$fallback"
+    return 0
+  fi
+  printf 'STOP no deployed-head marker, so this is a first deploy and the checkout must be on %s; it is on %s. Set PARAMANT_EXPECTED_HEAD if you know why it moved\n' \
+    "$fallback" "$short"
+  return 1
+}
+
 # ------------------------------------------------- the static sanity reading --
 
 # One implementation, used on the local checkout in phase 0 and on the server
@@ -382,6 +494,12 @@ printf '  compose dir   %s\n' "$COMPOSE_DIR"
 printf '  docroot       %s\n' "$DOCROOT"
 printf '  nginx confs   %s\n' "$NGINX_CONFS"
 printf '  deploy ref    %s\n' "$DEPLOY_REF"
+if [ -n "$EXPECTED_HEAD" ]; then
+  printf '  expected head %s (PARAMANT_EXPECTED_HEAD)\n' "$EXPECTED_HEAD"
+else
+  printf '  expected head %s if the server has one, else %s (first deploy)\n' \
+    "$DEPLOYED_HEAD_FILE" "$EXPECT_PROD_COMMIT"
+fi
 printf '  log           %s\n' "$LOG"
 
 if [ "$DRY_RUN" -eq 0 ]; then
@@ -473,11 +591,42 @@ phase_1() {
   fi
 
   step "1a. checkout, compose project and container health"
-  remote "layout and health" "$COMPOSE_DIR" "$SERVICES" <<'EOF'
+  note "the expected starting commit is a parameter: PARAMANT_EXPECTED_HEAD wins,"
+  note "else the deployed-head marker a previous run wrote, else $EXPECT_PROD_COMMIT"
+  remote "layout and health" "$COMPOSE_DIR" "$SERVICES" "$DEPLOYED_HEAD_FILE" "$DEPLOY_REF" <<'EOF'
 set -euo pipefail
 cd "$1"
+MARKER="$3"; REF="$4"
 echo "checkout_head = $(git rev-parse --short HEAD)"
+echo "checkout_head_long = $(git rev-parse HEAD)"
 echo "checkout_dir = $PWD"
+
+# What the last finished deploy recorded, if any. An empty or whitespace-only
+# file is not an answer, so it reads as absent.
+m=none
+if [ -f "$MARKER" ]; then
+  m="$(tr -d '[:space:]' < "$MARKER")"
+  [ -n "$m" ] || m=none
+fi
+echo "deployed_marker = $m"
+
+# Refs only. fetch updates remote-tracking refs; it does not move HEAD, does
+# not touch the working tree and does not check anything out. Phase 3a is still
+# the only place that moves the checkout. Without this the ancestor test below
+# would judge against a stale origin/main.
+git fetch origin >/dev/null 2>&1 || echo "fetch = failed"
+if ref_sha="$(git rev-parse --verify --quiet "$REF^{commit}")"; then
+  echo "deploy_ref_sha = $ref_sha"
+  if git merge-base --is-ancestor HEAD "$ref_sha" 2>/dev/null; then
+    echo "head_is_ancestor_of_ref = yes"
+  else
+    echo "head_is_ancestor_of_ref = no"
+  fi
+else
+  echo "deploy_ref_sha = unknown"
+  echo "head_is_ancestor_of_ref = unknown"
+fi
+
 docker compose ls 2>&1 | sed 's/^/compose_ls /' || true
 found=0
 for svc in $2; do
@@ -493,8 +642,32 @@ done
 echo "services seen = $found"
 EOF
 
-  expect "checkout_head = $EXPECT_PROD_COMMIT" \
-    "production checkout is on $EXPECT_PROD_COMMIT, the commit the runbook measured"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  SKIP  assert (dry-run): the starting commit gate\n'
+    if [ -n "$EXPECTED_HEAD" ]; then
+      printf '        PARAMANT_EXPECTED_HEAD is set, so the checkout must equal it and nothing else is consulted\n'
+    else
+      printf '        no marker in %s (first deploy): [would match /checkout_head = %s/]\n' \
+        "$DEPLOYED_HEAD_FILE" "$EXPECT_PROD_COMMIT"
+      printf '        with a marker (second deploy and after): the checkout must equal the marker AND be an ancestor of %s\n' \
+        "$DEPLOY_REF"
+    fi
+  else
+    local gate_head gate_marker gate_anc gate_out gate_rc=0
+    gate_head="$(remote_field 'checkout_head_long')"
+    gate_marker="$(remote_field 'deployed_marker')"
+    gate_anc="$(remote_field 'head_is_ancestor_of_ref')"
+    gate_out="$(head_gate_verdict "$EXPECTED_HEAD" "$gate_marker" "$gate_head" \
+                "$EXPECT_PROD_COMMIT" "$gate_anc")" || gate_rc=$?
+    if [ "$gate_rc" -eq 0 ]; then
+      ok "${gate_out#OK }"
+      # Phase 5b diffs the docroot against the commit that was deployed. That
+      # is this one, read from the server, not a constant from August.
+      PREV_HEAD="$gate_head"
+    else
+      die "${gate_out#STOP }"
+    fi
+  fi
   expect_count "services seen" 6 "all six services have a container"
   expect_not 'container [a-z-]+ MISSING' "no service is missing a container"
   expect_not 'unhealthy' "no container reports unhealthy"
@@ -716,17 +889,24 @@ EOF
 
   expect_not 'FATAL working tree not clean' "server working tree was clean before the pull"
   if [ "$DRY_RUN" -eq 0 ]; then
-    local after_head want
-    PREV_HEAD="$(remote_field 'before HEAD long')"
+    local after_head before_head want
+    before_head="$(remote_field 'before HEAD long')"
     after_head="$(remote_field 'after HEAD long')"
     want="$(git rev-parse "$DEPLOY_REF")"
     [ -n "$after_head" ] || die "could not read the server HEAD after the pull"
     [ "$after_head" = "$want" ] \
       || die "server is on $after_head after the pull, expected $want ($DEPLOY_REF, the commit phase 0 tested)"
     ok "server checkout is on ${after_head:0:7}, the commit phase 0 tested"
-    if ! printf '%s\n' "$REMOTE_OUT" | grep -q "before HEAD = $EXPECT_PROD_COMMIT"; then
-      warn "server was not on $EXPECT_PROD_COMMIT before the pull; the rollback images are still correct, but the runbook's starting point was different"
+    # Phase 7 writes this into the deployed-head marker, which is what the NEXT
+    # run's phase 1a gate reads back.
+    DEPLOYED_HEAD="$after_head"
+    # Phase 1a already judged the starting commit against the marker, the
+    # override or the runbook constant. All that is left is that nothing moved
+    # the checkout between phase 1 and here.
+    if [ -n "$PREV_HEAD" ] && [ -n "$before_head" ] && [ "$before_head" != "$PREV_HEAD" ]; then
+      die "the checkout was on ${PREV_HEAD:0:7} in phase 1a and on ${before_head:0:7} at the pull; something moved it mid-deploy"
     fi
+    PREV_HEAD="$before_head"
   fi
 
   step "3b. static sanity on the server, same reading rule as phase 0"
@@ -983,15 +1163,24 @@ echo "after already absent = $absent"
 echo "after refused outside docroot = $outside"
 echo "after docroot files = $(find "$DOCROOT" -type f | wc -l)"
 EOF
-  expect_min "before deleted-in-git count" 1 \
-    "git names at least one frontend file deleted since the deployed commit"
   expect_count "after refused outside docroot" 0 \
     "no deletion resolved to a path outside the docroot"
   if [ "$DRY_RUN" -eq 0 ]; then
-    local rm_n ab_n
+    local rm_n ab_n del_n
+    del_n="$(remote_field 'before deleted-in-git count')"
     rm_n="$(remote_field 'after removed')"
     ab_n="$(remote_field 'after already absent')"
-    ok "pruned $rm_n stale docroot file(s), $ab_n were already gone"
+    [ -n "$del_n" ] || die "the server never printed 'before deleted-in-git count'"
+    # An empty list is an answer: between the deployed commit and the ref, main
+    # deleted no frontend file. Demanding at least one only held for the first
+    # deploy, where the runbook had already counted them. On a resume, or on a
+    # deploy of a ref that deleted nothing, a hard minimum stops a run that has
+    # nothing wrong with it. Already absent is likewise OK and always was.
+    if [ "$del_n" -eq 0 ]; then
+      ok "git names no frontend file deleted since the deployed commit, so there is nothing to prune"
+    else
+      ok "pruned $rm_n of $del_n stale docroot file(s), $ab_n were already gone"
+    fi
   fi
 
   step "5c. the three nginx changes, by hand, keeping the ParaID deny"
@@ -1012,11 +1201,19 @@ for name in $CONFS; do
   TARGETS="$TARGETS $t"
 done
 
-count() { grep -hcE -- "$1" $TARGETS 2>/dev/null | awk '{s+=$1} END{print s+0}'; }
+# grep exits 1 when it matches nothing, and pipefail turns that into a failed
+# pipeline. The count IS the answer here, and zero is a perfectly good answer,
+# so grep's verdict is swallowed: without this, reading a count into a variable
+# ends the block under set -e the moment a pattern is already gone.
+count() { grep -hcE -- "$1" $TARGETS 2>/dev/null | awk '{s+=$1} END{print s+0}' || true; }
 
 SIGN_RE='location = /sign[[:space:]]*\{[^}]*auth_request'
 COMP_RE='^[[:space:]]*location = /compliance(/(nis2|iec62443|nen7510))?[[:space:]]*\{'
 DICOM_RE='location = /dicom[[:space:]]*\{[[:space:]]*try_files /dicom\.html'
+# The wanted END state of each edit, so an edit with nothing left to do can be
+# told apart from a conf that was never the shape the runbook describes.
+SIGN_LOC_RE='location = /sign[[:space:]]*\{'
+DICOM404_RE='location = /dicom[[:space:]]*\{[[:space:]]*return 404'
 PARAID_RE='paraid/issue'
 OUT_RE='^[[:space:]]*location[[:space:]]*~[[:space:]]*\^/v2/outbound[[:space:]]*\{'
 BUF_RE='proxy_buffer_size 32k'
@@ -1066,15 +1263,64 @@ read -r _obt _obw <<< "$(count_blocks)"
 echo "before outbound locations = $_obt"
 echo "before outbound blocks with buffer = $_obw"
 
-# Each edit must have something to do. A zero here means the server conf is not
-# the shape the runbook describes, and guessing further would be editing blind.
-for pair in "sign:$(count "$SIGN_RE")" "compliance:$(count "$COMP_RE")" "dicom:$(count "$DICOM_RE")"; do
-  n="${pair#*:}"
-  if [ "$n" -eq 0 ]; then
-    echo "FATAL nothing to change for '${pair%%:*}': the server conf does not match the pattern the runbook names"
-    exit 1
+# Each edit is in one of three states, and only one of them is a stop:
+#
+#   todo     the old shape is present, so there is work to do
+#   done     the old shape is gone AND the wanted end shape is there, so a
+#            previous run already applied this edit. Not an error: it is what
+#            every deploy after the first one looks like.
+#   unknown  neither shape is present. The conf is not what the runbook
+#            describes, and editing further would be editing blind.
+#
+# The old gate read "todo" as the only acceptable state, which made a second
+# deploy FATAL on an edit that had simply already succeeded.
+#
+# Removal-only edits (compliance) have no wanted end shape other than absence,
+# so for those "gone" is "done", the same rule 5b already uses for a file that
+# is already absent.
+state() {   # old-count, wanted-count, has-wanted-shape(yes|no)
+  if [ "$1" -gt 0 ]; then echo todo
+  elif [ "$3" = no ]; then echo done
+  elif [ "$2" -gt 0 ]; then echo done
+  else echo unknown
+  fi
+}
+
+_b_sign="$(count "$SIGN_RE")";     _b_signloc="$(count "$SIGN_LOC_RE")"
+_b_comp="$(count "$COMP_RE")"
+_b_dicom="$(count "$DICOM_RE")";   _b_dicom404="$(count "$DICOM404_RE")"
+
+SIGN_STATE="$(state "$_b_sign" "$_b_signloc" yes)"
+COMP_STATE="$(state "$_b_comp" 0 no)"
+DICOM_STATE="$(state "$_b_dicom" "$_b_dicom404" yes)"
+echo "before sign location = $_b_signloc"
+echo "before dicom 404 = $_b_dicom404"
+echo "before sign state = $SIGN_STATE"
+echo "before compliance state = $COMP_STATE"
+echo "before dicom state = $DICOM_STATE"
+
+unknown=0
+for pair in "sign:$SIGN_STATE" "compliance:$COMP_STATE" "dicom:$DICOM_STATE"; do
+  if [ "${pair#*:}" = unknown ]; then
+    echo "FATAL '${pair%%:*}': the conf carries neither the shape the runbook edits nor the shape the edit leaves behind, so this conf is not the one the runbook describes"
+    unknown=$((unknown + 1))
   fi
 done
+[ "$unknown" -eq 0 ] || exit 1
+
+pending=0
+for st in "$SIGN_STATE" "$COMP_STATE" "$DICOM_STATE"; do
+  [ "$st" = todo ] && pending=$((pending + 1))
+done
+# A /v2/outbound block without the buffer is a fourth thing still to do.
+pending=$((pending + _obt - _obw))
+echo "before edits pending = $pending"
+if [ "$pending" -eq 0 ]; then
+  echo "before everything already applied = yes"
+else
+  echo "before everything already applied = no"
+fi
+
 if [ "$(count "$PARAID_RE")" -eq 0 ]; then
   echo "FATAL the ParaID deny is not present; the 01-09 server edit this runbook relies on is gone"
   exit 1
@@ -1152,7 +1398,27 @@ echo "reloaded nginx"
 EOF
 
   expect_not 'FATAL' "nginx edits applied and the config tests clean"
-  expect_count "after edited files" 2 "both named confs were really rewritten"
+  # How many files were rewritten depends on what was left to do, so the exact
+  # count of 2 only holds on a run that found work in both confs. What always
+  # holds is the END state, and that is asserted hard just below: no
+  # auth_request on /sign, no /compliance locations, /dicom answering 404, and
+  # a buffer inside every /v2/outbound block. Those four are the deploy.
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  SKIP  assert (dry-run): both named confs were rewritten, unless every edit was already applied\n'
+  else
+    local pend edited
+    pend="$(remote_field 'before everything already applied')"
+    edited="$(remote_field 'after edited files')"
+    [ -n "$pend" ] && [ -n "$edited" ] \
+      || die "could not read the nginx edit state from the server"
+    if [ "$pend" = yes ]; then
+      ok "nginx: already applied. All three edits and the outbound buffers were in place before this run, so nothing was rewritten (edited files = $edited)"
+    else
+      [ "$edited" -ge 1 ] \
+        || die "$(remote_field 'before edits pending') nginx edit(s) were still pending but no conf was rewritten"
+      ok "nginx: $(remote_field 'before edits pending') pending edit(s), $edited conf(s) rewritten"
+    fi
+  fi
   expect_count "after sign gated" 0 "/sign is no longer behind auth_request"
   expect_count "after compliance" 0 "the /compliance locations are gone"
   expect_count "after dicom try_files" 0 "/dicom no longer serves the page"
@@ -1396,6 +1662,42 @@ EOF
 phase_7() {
   phase 7 "Summary" "Step 7, what to do after the deploy"
 
+  step "7a. record the deployed commit, so the next run's phase 1a has a gate"
+  note "without this marker the next run falls back to $EXPECT_PROD_COMMIT and stops:"
+  note "that is exactly the poort that made this script single-use"
+  remote "record deployed head" "$COMPOSE_DIR" "$BACKUP_DIR" "$DEPLOYED_HEAD_FILE" <<'EOF'
+set -euo pipefail
+cd "$1"
+BK="$2"; MARKER="$3"
+mkdir -p "$BK"
+if [ -f "$MARKER" ]; then
+  echo "before deployed marker = $(tr -d '[:space:]' < "$MARKER")"
+else
+  echo "before deployed marker = none"
+fi
+# The checkout is the source the containers were built from, so the checkout is
+# what the marker names. Read it here rather than being told, so the file can
+# never claim something the server is not on.
+head="$(git rev-parse HEAD)"
+tmp="$MARKER.tmp.$$"
+printf '%s\n' "$head" > "$tmp"
+chmod 644 "$tmp"
+mv -f "$tmp" "$MARKER"
+echo "after deployed marker = $(tr -d '[:space:]' < "$MARKER")"
+echo "after deployed marker short = $(git rev-parse --short HEAD)"
+EOF
+
+  if [ "$DRY_RUN" -eq 0 ]; then
+    local wrote
+    wrote="$(remote_field 'after deployed marker')"
+    [ -n "$wrote" ] \
+      || die "could not write $DEPLOYED_HEAD_FILE; the next deploy would fall back to $EXPECT_PROD_COMMIT and stop on phase 1a"
+    if [ -n "$DEPLOYED_HEAD" ] && [ "$wrote" != "$DEPLOYED_HEAD" ]; then
+      die "the marker says $wrote but phase 3 left the checkout on $DEPLOYED_HEAD"
+    fi
+    ok "deployed-head marker written: ${wrote:0:7} in $DEPLOYED_HEAD_FILE (the next run gates on this, not on $EXPECT_PROD_COMMIT)"
+  fi
+
   echo
   echo "Result lines, in order:"
   printf '%s\n' "$SUMMARY"
@@ -1624,6 +1926,12 @@ EOF
   echo
   echo "The checkout stays on main; the images are what run. Decide separately"
   echo "whether to move the checkout back."
+  echo
+  echo "The deployed-head marker is left as it is on purpose: it names the"
+  echo "COMMIT THE CHECKOUT IS ON, and this rollback did not move the checkout."
+  echo "If you do move it back by hand, either update"
+  printf '%s\n' "  $DEPLOYED_HEAD_FILE to match, or run the next deploy with"
+  echo "  PARAMANT_EXPECTED_HEAD=<the commit you moved to>."
 }
 
 # ------------------------------------------------------------------- driver --

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -1085,7 +1085,22 @@ EOF
 phase_5() {
   phase 5 "Frontend and nginx (server, WRITE)" "Step 5"
 
+  # The base 5b diffs against, to learn which frontend files main deleted.
+  #
+  # The obvious base is the commit that was deployed. It is wrong after a
+  # rollback. Phase 8 restores the docroot from the pre-3.1 tar, which puts all
+  # 26 pruned pages BACK, and it leaves the checkout, and therefore the marker,
+  # on main. The next deploy then diffs marker..HEAD, finds nothing deleted,
+  # prunes nothing, and phase 6e dies on /compliance/nis2 answering 200 with
+  # everything else already live. That is the worst place to find out.
+  #
+  # So the base is the OLDER of the deployed commit and the runbook's own
+  # starting commit, which in practice means 41501bb on every run. The server
+  # decides which is older, because only the server has both commits. Pruning
+  # something that is already gone costs nothing: "pruned 0 of 26, 26 were
+  # already gone" is the normal answer on a healthy second deploy.
   local base="${PREV_HEAD:-$EXPECT_PROD_COMMIT}"
+  local base_floor="$EXPECT_PROD_COMMIT"
 
   step "5a. rsync the docroot, never with --delete"
   remote "rsync docroot" "$COMPOSE_DIR" "$DOCROOT" <<'EOF'
@@ -1109,10 +1124,31 @@ EOF
   step "5b. prune the frontend files main deleted (rsync without --delete leaves them)"
   note "a page removed from git keeps being served by try_files until the file"
   note "goes; the list comes from git, never from a wildcard on the server"
-  remote "prune deleted frontend files" "$COMPOSE_DIR" "$DOCROOT" "$base" "$DOCROOT_IGNORE" <<'EOF'
+  note "the base is the older of the deployed commit and $base_floor, so a deploy"
+  note "after a rollback still prunes the pages the restored docroot brought back"
+  remote "prune deleted frontend files" "$COMPOSE_DIR" "$DOCROOT" "$base" "$DOCROOT_IGNORE" "$base_floor" <<'EOF'
 set -euo pipefail
 cd "$1"
-DOCROOT="$2"; BASE="$3"; IGNORE="$4"
+DOCROOT="$2"; BASE="$3"; IGNORE="$4"; FLOOR="$5"
+
+echo "before base candidate = $BASE"
+echo "before base floor = $FLOOR"
+# Older wins. "Older" here is git's own answer: FLOOR is older than BASE exactly
+# when FLOOR is an ancestor of it. A rollback leaves BASE on main and the
+# docroot back at the pre-3.1 tar, and only the floor still names every page
+# that has to go.
+if ! git rev-parse --verify --quiet "$FLOOR^{commit}" >/dev/null; then
+  echo "before base choice = kept $BASE, the floor $FLOOR does not resolve in this checkout"
+elif [ -z "$BASE" ]; then
+  echo "before base choice = took the floor $FLOOR, no deployed commit was measured"
+  BASE="$FLOOR"
+elif git merge-base --is-ancestor "$FLOOR" "$BASE" 2>/dev/null; then
+  echo "before base choice = took the floor $FLOOR, it is older than $BASE"
+  BASE="$FLOOR"
+else
+  echo "before base choice = kept $BASE, the floor $FLOOR is not an ancestor of it"
+fi
+echo "before prune base = $BASE"
 
 DEL="$(git diff --diff-filter=D --name-only "$BASE"..HEAD -- frontend/ || true)"
 echo "before deleted-in-git count = $(printf '%s\n' "$DEL" | grep -c . || true)"
@@ -1179,7 +1215,7 @@ EOF
     if [ "$del_n" -eq 0 ]; then
       ok "git names no frontend file deleted since the deployed commit, so there is nothing to prune"
     else
-      ok "pruned $rm_n of $del_n stale docroot file(s), $ab_n were already gone"
+      ok "pruned $rm_n of $del_n stale docroot file(s) against base $(remote_field 'before prune base'), $ab_n were already gone"
     fi
   fi
 
@@ -1242,6 +1278,32 @@ FNR==NR {
   }
 }'
 
+# Count /sign blocks, and how many of them carry an auth_request ANYWHERE
+# inside the block, whatever the line layout is.
+#
+# SIGN_RE only sees the one-line spelling the repo conf uses. A hand edit
+# between two deploys that put the gate back across several lines,
+#
+#     location = /sign {
+#         auth_request /api/user/check;
+#         ...
+#     }
+#
+# leaves SIGN_RE at zero, which the state read below would call "done" and
+# report as already applied while /sign is in fact behind the login again.
+# Reading the block instead of the line closes that. The header line is NOT
+# skipped, because the one-line spelling opens and closes on it.
+SIGN_AWK='
+/^[[:space:]]*location[[:space:]]*=[[:space:]]*\/sign[[:space:]]*\{/ { total++; inb=1; has=0; depth=0 }
+inb {
+  if ($0 ~ /auth_request/) has=1
+  depth += gsub(/\{/,"{") - gsub(/\}/,"}")
+  if (depth <= 0) { if (has) withauth++; inb=0 }
+}
+END { printf "%d %d\n", total+0, withauth+0 }'
+
+count_sign() { awk "$SIGN_AWK" $TARGETS | awk '{t+=$1; w+=$2} END{printf "%d %d\n", t, w}'; }
+
 # Count /v2/outbound blocks, and how many of them carry the buffer INSIDE the
 # block. Counting matches per file cannot tell those apart.
 BLOCK_AWK='
@@ -1256,6 +1318,9 @@ END { printf "%d %d\n", total+0, withbuf+0 }'
 count_blocks() { awk "$BLOCK_AWK" $TARGETS | awk '{t+=$1; w+=$2} END{printf "%d %d\n", t, w}'; }
 
 echo "before sign gated = $(count "$SIGN_RE")"
+read -r _sbt _sbw <<< "$(count_sign)"
+echo "before sign blocks = $_sbt"
+echo "before sign blocks with auth_request = $_sbw"
 echo "before compliance = $(count "$COMP_RE")"
 echo "before dicom try_files = $(count "$DICOM_RE")"
 echo "before paraid deny = $(count "$PARAID_RE")"
@@ -1286,14 +1351,16 @@ state() {   # old-count, wanted-count, has-wanted-shape(yes|no)
   fi
 }
 
-_b_sign="$(count "$SIGN_RE")";     _b_signloc="$(count "$SIGN_LOC_RE")"
+# /sign is judged on the BLOCK counts, so a multi-line auth_request reads as
+# todo and never as done. The other two edits are single lines by construction:
+# a /compliance location and the /dicom try_files both live on one line.
 _b_comp="$(count "$COMP_RE")"
 _b_dicom="$(count "$DICOM_RE")";   _b_dicom404="$(count "$DICOM404_RE")"
 
-SIGN_STATE="$(state "$_b_sign" "$_b_signloc" yes)"
+SIGN_STATE="$(state "$_sbw" "$_sbt" yes)"
 COMP_STATE="$(state "$_b_comp" 0 no)"
 DICOM_STATE="$(state "$_b_dicom" "$_b_dicom404" yes)"
-echo "before sign location = $_b_signloc"
+echo "before sign location = $_sbt"
 echo "before dicom 404 = $_b_dicom404"
 echo "before sign state = $SIGN_STATE"
 echo "before compliance state = $COMP_STATE"
@@ -1360,6 +1427,9 @@ for f in $TARGETS; do
 done
 echo "after edited files = $edited"
 echo "after sign gated = $(count "$SIGN_RE")"
+read -r _sat _saw <<< "$(count_sign)"
+echo "after sign blocks = $_sat"
+echo "after sign blocks with auth_request = $_saw"
 echo "after compliance = $(count "$COMP_RE")"
 echo "after dicom try_files = $(count "$DICOM_RE")"
 echo "after dicom 404 = $(count 'location = /dicom[[:space:]]*\{[[:space:]]*return 404')"
@@ -1378,6 +1448,18 @@ restore() {
 
 if [ "$(count "$PARAID_RE")" -eq 0 ]; then
   echo "FATAL the ParaID deny disappeared; restoring"
+  restore
+  exit 1
+fi
+
+# The sed above only removes the one-line spelling of the gate. If a block
+# still carries an auth_request, the edit did not take, and saying "OK" here
+# would ship /sign behind the login. Restore and say what to do by hand.
+if [ "$_saw" -gt 0 ]; then
+  echo "FATAL $_saw of $_sat 'location = /sign' block(s) still carry an auth_request after the edit."
+  echo "FATAL the runbook removes the ONE-LINE spelling; this conf spreads the gate over several lines,"
+  echo "FATAL so someone edited it by hand between deploys. Take the auth_request and the error_page 401"
+  echo "FATAL line out of the /sign block yourself, then run this phase again. Restoring the backed up confs."
   restore
   exit 1
 fi
@@ -1664,7 +1746,7 @@ phase_7() {
 
   step "7a. record the deployed commit, so the next run's phase 1a has a gate"
   note "without this marker the next run falls back to $EXPECT_PROD_COMMIT and stops:"
-  note "that is exactly the poort that made this script single-use"
+  note "that is exactly the gate that made this script single-use"
   remote "record deployed head" "$COMPOSE_DIR" "$BACKUP_DIR" "$DEPLOYED_HEAD_FILE" <<'EOF'
 set -euo pipefail
 cd "$1"
@@ -1951,7 +2033,11 @@ phase_1
 if [ "$PREFLIGHT_ONLY" -eq 1 ]; then
   echo
   hr
-  echo "PREFLIGHT ONLY: phases 0 and 1 done, read-only. Nothing was written."
+  echo "PREFLIGHT ONLY: phases 0 and 1 done. Read-only for the working tree and"
+  echo "the containers: no file was written, no container touched, no nginx conf"
+  echo "changed. The one thing that did run is git fetch in phase 1a, which"
+  echo "updates remote-tracking refs so the ancestor test judges against the real"
+  echo "origin/main. It does not move HEAD and does not check anything out."
   printf 'Warnings: %s. Log: %s\n' "$WARNINGS" "$LOG"
   hr
   exit 0

--- a/tests/deploy-3.1-dryrun.test.sh
+++ b/tests/deploy-3.1-dryrun.test.sh
@@ -183,7 +183,10 @@ check_has   "$FULL" '^DEPLOY FINISHED'          "full run reaches the end marker
 echo ""
 echo "5c. --preflight-only writes nothing"
 check_has   "$PRE" 'read-only'                          "preflight announces itself as read-only"
-check_has   "$PRE" 'Nothing was written'                "preflight ends by saying nothing was written"
+check_has   "$PRE" 'no file was written, no container touched' \
+  "preflight ends by saying what it did not write"
+check_has   "$PRE" 'git fetch in phase 1a'   "preflight names the one thing it does run: git fetch"
+check_has   "$PRE" 'does not move HEAD'      "preflight says what that fetch does not do"
 check_lacks "$PRE" 'WRITE'                              "no phase header in preflight is marked WRITE"
 check_has   "$PRE"  'bash -s --.* report'               "the token step is invoked in report mode"
 check_lacks "$PRE"  'bash -s --.* write'                "no step in preflight is invoked in write mode"
@@ -507,6 +510,144 @@ check_has "$SCRIPT" 'already applied' \
   "the script has an already-applied verdict instead of a FATAL"
 check_has "$FULL"   'before edits pending'  "the dry run shows the pending-edit count"
 check_has "$FULL"   'before sign state'     "the dry run shows the per-edit state read"
+
+echo ""
+echo "6g-4. A multi-line auth_request on /sign is todo, never already applied"
+# SIGN_RE only matches the one-line spelling the repo conf uses. A hand edit
+# between two deploys that puts the gate back across several lines leaves that
+# count at zero, and a line-based state read would call it done and report
+# "already applied" while /sign sits behind the login again. The state is read
+# per BLOCK for exactly this.
+cat > "$NG/available/paramant-public.conf" <<'CONF'
+server {
+    server_name paramant.app;
+    location = /sign {
+        auth_request /api/user/check;
+        error_page 401 = @login_redirect;
+        try_files /sign.html =404;
+    }
+    location = /dicom { return 404; }
+    location = /v1/paraid/issue-document { deny all; }
+    location ~ ^/v2/outbound {
+        proxy_buffer_size 32k;
+        proxy_buffers 8 32k;
+        proxy_busy_buffers_size 64k;
+        proxy_pass http://relay;
+    }
+}
+CONF
+cp "$NG/available/paramant-public.conf" "$NG/available/paramant-live.conf"
+OUT4="$(cd "$NG" && PATH="$NG/bin:$PATH" bash "$NG/5c.sh" 20260101-0003 "$NG/sites" "$NG/bk" \
+        "paramant-public.conf paramant-live.conf" 2>&1)"; RC4=$?
+
+if [ "$(field_5c "$OUT4" 'before sign gated')" = "0" ]; then
+  pass "the one-line pattern really does miss a multi-line auth_request (the trap)"
+else
+  fail "the fixture does not reproduce the trap: before sign gated = $(field_5c "$OUT4" 'before sign gated')"
+fi
+if [ "$(field_5c "$OUT4" 'before sign blocks with auth_request')" = "2" ]; then
+  pass "the block read finds the auth_request the line read missed"
+else
+  fail "the block read found $(field_5c "$OUT4" 'before sign blocks with auth_request') of 2 gated /sign blocks"
+fi
+if [ "$(field_5c "$OUT4" 'before sign state')" = "todo" ]; then
+  pass "a multi-line auth_request reads as todo, not as done"
+else
+  fail "a multi-line auth_request reads as '$(field_5c "$OUT4" 'before sign state')', expected todo"
+fi
+if [ "$(field_5c "$OUT4" 'before everything already applied')" = "no" ]; then
+  pass "the run does NOT report already applied while /sign is gated"
+else
+  fail "the run reported already applied with /sign still behind auth_request"
+fi
+if [ "$RC4" -ne 0 ] && printf '%s\n' "$OUT4" | grep -q 'still carry an auth_request'; then
+  pass "the edit could not remove it, so 5c stops and says so instead of shipping it"
+else
+  fail "5c exited $RC4 with /sign still gated"
+  printf '%s\n' "$OUT4" | sed 's/^/        /' | head -20
+fi
+
+echo ""
+echo "6h. A deploy AFTER a rollback still prunes the pages the rollback restored"
+# Phase 8 restores the docroot from the pre-3.1 tar, which puts every pruned
+# page back, and leaves the checkout, and so the marker, on main. Diffing
+# marker..HEAD then names nothing deleted, 5b prunes nothing, and phase 6e dies
+# on /compliance/nis2 answering 200 with everything else already live. 5b takes
+# the OLDER of the deployed commit and the runbook floor for this reason.
+RB5B="$WORK/rb5b"
+mkdir -p "$RB5B/repo" "$RB5B/docroot"
+sed -n '/^  remote "prune deleted frontend files"/,/^EOF$/p' "$SCRIPT" | sed '1d;$d' > "$RB5B/5b.sh"
+if [ -s "$RB5B/5b.sh" ]; then
+  pass "the 5b remote block could be extracted from the script"
+else
+  fail "could not extract the 5b remote block from the script"
+fi
+(
+  cd "$RB5B/repo"
+  git init -q . && git config user.email t@example.com && git config user.name t
+  mkdir -p frontend/compliance
+  for f in nis2 iec62443 nen7510; do echo "page $f" > "frontend/compliance/$f.html"; done
+  echo index > frontend/index.html
+  git add -A && git commit -qm floor
+  git rev-parse HEAD > "$RB5B/floor"
+  git rm -q frontend/compliance/nis2.html frontend/compliance/iec62443.html frontend/compliance/nen7510.html
+  git commit -qm "remove the compliance pages"
+  git rev-parse HEAD > "$RB5B/head"
+) >/dev/null 2>&1
+FLOOR="$(cat "$RB5B/floor")"
+HEADC="$(cat "$RB5B/head")"
+
+# The docroot as phase 8 leaves it: the deleted pages are back.
+mkdir -p "$RB5B/docroot/compliance"
+for f in nis2 iec62443 nen7510; do echo "page $f" > "$RB5B/docroot/compliance/$f.html"; done
+echo index > "$RB5B/docroot/index.html"
+
+# The marker is on main, because the rollback did not move the checkout.
+OUT5="$(bash "$RB5B/5b.sh" "$RB5B/repo" "$RB5B/docroot" "$HEADC" "dist" "$FLOOR" 2>&1)"; RC5=$?
+if [ "$RC5" -eq 0 ]; then pass "5b exits 0 in the deploy-after-rollback situation"; else
+  fail "5b exits $RC5 in the deploy-after-rollback situation"
+  printf '%s\n' "$OUT5" | sed 's/^/        /' | head -20
+fi
+if printf '%s\n' "$OUT5" | grep -q "took the floor"; then
+  pass "5b takes the older floor as its base, not the commit the marker names"
+else
+  fail "5b kept the marker commit as its base, so it prunes nothing after a rollback"
+  printf '%s\n' "$OUT5" | sed 's/^/        /' | head -20
+fi
+if [ "$(field_5c "$OUT5" 'before prune base')" = "$FLOOR" ]; then
+  pass "the base it actually diffs against is the floor"
+else
+  fail "the prune base is '$(field_5c "$OUT5" 'before prune base')', expected the floor"
+fi
+if [ "$(field_5c "$OUT5" 'before deleted-in-git count')" = "3" ]; then
+  pass "git names the three restored pages as deleted, where marker..HEAD named none"
+else
+  fail "the delete list has $(field_5c "$OUT5" 'before deleted-in-git count') entries, expected 3"
+fi
+if [ "$(field_5c "$OUT5" 'after removed')" = "3" ]; then
+  pass "all three pages the rollback restored are pruned again"
+else
+  fail "5b removed $(field_5c "$OUT5" 'after removed') of 3 restored pages"
+fi
+if [ ! -f "$RB5B/docroot/compliance/nis2.html" ] && [ -f "$RB5B/docroot/index.html" ]; then
+  pass "the docroot lost the pruned page and kept the one main still ships"
+else
+  fail "the docroot is wrong after the prune"
+fi
+
+# The healthy second deploy: nothing was restored, so everything is already
+# gone. That is an OK answer and must not be a failure.
+OUT6="$(bash "$RB5B/5b.sh" "$RB5B/repo" "$RB5B/docroot" "$HEADC" "dist" "$FLOOR" 2>&1)"; RC6=$?
+if [ "$RC6" -eq 0 ] && [ "$(field_5c "$OUT6" 'after already absent')" = "3" ] \
+   && [ "$(field_5c "$OUT6" 'after removed')" = "0" ]; then
+  pass "running 5b again prunes nothing and reports all three as already absent"
+else
+  fail "the second 5b run exits $RC6, removed=$(field_5c "$OUT6" 'after removed') absent=$(field_5c "$OUT6" 'after already absent')"
+fi
+
+check_has "$SCRIPT" 'merge-base --is-ancestor "\$FLOOR" "\$BASE"' \
+  "the older-of-the-two choice is git's answer, not a guess"
+check_has "$FULL"   'before prune base'   "the dry run shows which base 5b will diff against"
 
 echo ""
 echo "6d. The CI gate on main is one verdict per required workflow"

--- a/tests/deploy-3.1-dryrun.test.sh
+++ b/tests/deploy-3.1-dryrun.test.sh
@@ -193,7 +193,7 @@ check_has   "$PRE" 'REPORT ONLY'                        "the token step reports 
 # ---------------------------------------------------- 6. the runbook's checks --
 echo ""
 echo "6. The assertions the runbook demands are in the script"
-check_has "$FULL" 'checkout_head = 41501bb'                      "asserts the checkout is on 41501bb"
+check_has "$FULL" 'checkout_head = 41501bb'                      "falls back to 41501bb when the server has no deployed-head marker"
 check_has "$FULL" 'services seen = 6'                            "asserts all six services were seen"
 check_has "$FULL" '"recurring":false'                            "asserts billing_config recurring:false"
 check_has "$FULL" '"mode_source":"inferred"'                     "asserts billing_config mode_source:inferred"
@@ -206,7 +206,7 @@ check_has "$FULL" 'rsync -rc --no-times'                         "rsyncs the doc
 check_lacks "$FULL" 'rsync -rc[^|]*--delete'                     "never rsyncs the docroot with --delete"
 check_has "$FULL" 'diff-filter=D'                                "derives the stale docroot files from git, not a wildcard"
 check_has "$FULL" 'after paraid deny'                            "measures the ParaID deny before and after"
-check_has "$FULL" 'after edited files = 2'                       "asserts both named nginx confs were rewritten"
+check_has "$FULL" 'after edited files'                           "measures how many nginx confs were rewritten"
 check_has "$FULL" 'readlink -f'                                  "resolves sites-enabled symlinks before backing up or editing"
 check_has "$FULL" 'nginx -t'                                     "runs nginx -t before reloading"
 check_has "$FULL" 'auth-smoke\.sh'                               "runs tests/auth-smoke.sh"
@@ -248,6 +248,265 @@ check_has "$FULL"   'after outbound blocks with buffer'  "phase 5 reports blocks
 check_has "$SCRIPT" 'REFUSED'                            "phase 5b refuses a deletion that resolves outside the docroot"
 check_has "$FULL"   'after refused outside docroot'      "phase 5b reports how many deletions it refused"
 check_has "$SCRIPT" 'NOT PROVEN'                         "phase 6h says NOT PROVEN when the header block is under 16 KB"
+
+echo ""
+echo "6f. The expected starting commit is a parameter, so a second deploy runs"
+# The old phase 1a asserted `checkout_head = 41501bb` and nothing else. After
+# the first successful deploy the checkout is on main, so every later run, and
+# every resume of a run that died in phase 5, stopped on that one line. These
+# checks are the four situations the parameter has to cover.
+check_has "$SCRIPT" 'PARAMANT_EXPECTED_HEAD'   "the expected commit can be given explicitly"
+check_has "$SCRIPT" 'DEPLOYED_HEAD_FILE'       "the script knows where the deployed-head marker lives"
+check_has "$FULL"   'deployed_marker'          "phase 1a reads the marker off the server"
+check_has "$FULL"   'merge-base --is-ancestor' "phase 1a asks whether the checkout is an ancestor of the deploy ref"
+check_has "$FULL"   'git fetch origin'         "that ancestor question is asked after a fetch, not against stale refs"
+check_has "$FULL"   'after deployed marker'    "phase 7 writes the marker the next run reads"
+check_lacks "$SCRIPT" 'expect "checkout_head = \$EXPECT_PROD_COMMIT"' \
+  "the hard-coded one-commit gate is gone from phase 1a"
+
+# The decision itself is a pure function, so every case can be put through it
+# here without a server. Same trick as q_args above.
+if eval "$(sed -n '/^sha_eq()/,/^}/p' "$SCRIPT")" 2>/dev/null \
+   && eval "$(sed -n '/^head_gate_verdict()/,/^}/p' "$SCRIPT")" 2>/dev/null \
+   && declare -F head_gate_verdict >/dev/null; then
+  pass "head_gate_verdict() and sha_eq() could be extracted from the script"
+
+  # Synthetic commits. Never a real sha, so nothing here can be mistaken for
+  # a value read off the server.
+  A=aaaaaaa1111222233334444555566667777888899
+  B=bbbbbbb1111222233334444555566667777888899
+  OLD=41501bb
+
+  gate() {   # override marker head fallback ancestor -> prints "<rc> <text>"
+    local out rc=0
+    out="$(head_gate_verdict "$1" "$2" "$3" "$4" "$5")" || rc=$?
+    printf '%s %s\n' "$rc" "$out"
+  }
+  gate_is() {   # name, want-rc, want-word, args...
+    local name="$1" wrc="$2" word="$3"; shift 3
+    local got; got="$(gate "$@")"
+    if [ "${got%% *}" = "$wrc" ] && printf '%s' "$got" | grep -q "$word"; then
+      pass "$name"
+    else
+      fail "$name (got: $got)"
+    fi
+  }
+
+  echo ""
+  echo "6f-1. First deploy: no marker, so the runbook's own starting commit applies"
+  gate_is "no marker and the checkout is on $OLD: OK" 0 'first deploy' \
+          "" none "$OLD" "$OLD" unknown
+  gate_is "no marker and the checkout is somewhere else: STOP" 1 'must be on' \
+          "" none "$A" "$OLD" yes
+  gate_is "an empty marker file reads as no marker at all" 0 'first deploy' \
+          "" "" "$OLD" "$OLD" unknown
+
+  echo ""
+  echo "6f-2. Second deploy: the marker is the expectation, plus an ancestor test"
+  gate_is "the checkout matches the marker and is an ancestor of the ref: OK" 0 'last deploy recorded' \
+          "" "$A" "$A" "$OLD" yes
+  gate_is "the checkout matches the marker but is NOT an ancestor: STOP" 1 'not an ancestor' \
+          "" "$A" "$A" "$OLD" no
+  gate_is "the ref could not be resolved on the server: STOP, not a pass" 1 'could not decide' \
+          "" "$A" "$A" "$OLD" unknown
+  gate_is "the checkout drifted away from the marker: STOP" 1 'outside a deploy' \
+          "" "$A" "$B" "$OLD" yes
+  gate_is "a marker never makes $OLD acceptable again by itself" 1 'outside a deploy' \
+          "" "$A" "$OLD" "$OLD" yes
+  gate_is "the marker may be written short and still match a full sha" 0 'last deploy recorded' \
+          "" "${A:0:7}" "$A" "$OLD" yes
+
+  echo ""
+  echo "6f-3. PARAMANT_EXPECTED_HEAD overrides both, on equality alone"
+  gate_is "the override matches: OK, no marker consulted" 0 'PARAMANT_EXPECTED_HEAD names' \
+          "$A" none "$A" "$OLD" no
+  gate_is "the override matches while the marker says otherwise: OK" 0 'PARAMANT_EXPECTED_HEAD names' \
+          "$A" "$B" "$A" "$OLD" unknown
+  gate_is "the override does not match: STOP, even on the runbook commit" 1 'PARAMANT_EXPECTED_HEAD names' \
+          "$A" none "$OLD" "$OLD" yes
+  gate_is "a short override matches a full checkout sha" 0 'PARAMANT_EXPECTED_HEAD names' \
+          "${A:0:7}" none "$A" "$OLD" yes
+
+  echo ""
+  echo "6f-4. Nonsense answers are stops, never passes"
+  gate_is "an empty checkout sha: STOP" 1 'never printed' \
+          "" none "" "$OLD" yes
+  if sha_eq abc abc; then
+    fail "sha_eq accepts a 3-character prefix; that is not an identification"
+  else
+    pass "sha_eq refuses anything shorter than 7 characters"
+  fi
+  if sha_eq "$A" "$B"; then fail "sha_eq matched two different commits"
+  else pass "sha_eq refuses two different commits"; fi
+else
+  fail "could not extract head_gate_verdict() from the script to test it"
+fi
+
+echo ""
+echo "6f-5. The whole script, run with the override set"
+OVR="$WORK/override.txt"
+( cd "$ROOT" && PARAMANT_EXPECTED_HEAD=deadbee1234567 bash "$SCRIPT" --dry-run --preflight-only >"$OVR" 2>&1 )
+OVR_RC=$?
+[ "$OVR_RC" -eq 0 ] && pass "--dry-run with PARAMANT_EXPECTED_HEAD set exits 0" \
+                    || fail "--dry-run with PARAMANT_EXPECTED_HEAD set exits $OVR_RC"
+check_has   "$OVR" 'expected head deadbee1234567' "the header names the override it will gate on"
+check_lacks "$OVR" 'no marker in'                 "with the override set, the marker fallback is not announced"
+check_has   "$PRE" 'deployed-head'                "without the override, the header names the marker file"
+
+echo ""
+echo "6g. Phase 5c is idempotent: an edit that is already applied is not FATAL"
+# The old 5c stopped with FATAL as soon as an edit had nothing to do, so the
+# second deploy died on the nginx step even though the conf was exactly right.
+# This runs the REAL 5c remote block, extracted from the script, against
+# synthetic confs, with nginx and systemctl stubbed. Three passes:
+#
+#   1. the conf in its pre-3.1 shape        -> edits applied, files rewritten
+#   2. the same conf, run again             -> already applied, nothing rewritten
+#   3. a conf with neither shape            -> FATAL, which is still correct
+NG="$WORK/ng"
+mkdir -p "$NG/bin" "$NG/sites" "$NG/bk"
+cat > "$NG/bin/nginx" <<'STUB'
+#!/bin/sh
+exit 0
+STUB
+cat > "$NG/bin/systemctl" <<'STUB'
+#!/bin/sh
+exit 0
+STUB
+chmod +x "$NG/bin/nginx" "$NG/bin/systemctl"
+
+# The 5c body, verbatim from the script.
+sed -n '/^  remote "nginx edits"/,/^EOF$/p' "$SCRIPT" | sed '1d;$d' > "$NG/5c.sh"
+if [ -s "$NG/5c.sh" ]; then
+  pass "the 5c remote block could be extracted from the script"
+else
+  fail "could not extract the 5c remote block from the script"
+fi
+
+make_conf() {   # file, sign-shape(old|new|absent), dicom-shape, compliance(yes|no), buffers(yes|no)
+  local f="$1" sign="$2" dicom="$3" comp="$4" buf="$5"
+  {
+    echo 'server {'
+    echo '    server_name paramant.app;'
+    case "$sign" in
+      old)    echo '    location = /sign { auth_request /api/user/check; error_page 401 = @login_redirect; try_files /sign.html =404; }' ;;
+      new)    echo '    location = /sign { try_files /sign.html =404; }' ;;
+      absent) : ;;
+    esac
+    if [ "$comp" = yes ]; then
+      echo '    location = /compliance { try_files /compliance/index.html =404; }'
+      echo '    location = /compliance/nis2 { try_files /compliance/nis2.html =404; }'
+      echo '    location = /compliance/iec62443 { try_files /compliance/iec62443.html =404; }'
+      echo '    location = /compliance/nen7510 { try_files /compliance/nen7510.html =404; }'
+    fi
+    case "$dicom" in
+      old)    echo '    location = /dicom { try_files /dicom.html =404; }' ;;
+      new)    echo '    location = /dicom { return 404; }' ;;
+      absent) : ;;
+    esac
+    echo '    location = /v1/paraid/issue-document { deny all; }'
+    echo '    location ~ ^/v2/outbound {'
+    if [ "$buf" = yes ]; then
+      echo '        proxy_buffer_size 32k;'
+      echo '        proxy_buffers 8 32k;'
+      echo '        proxy_busy_buffers_size 64k;'
+    fi
+    echo '        proxy_pass http://relay;'
+    echo '    }'
+    echo '}'
+  } > "$f"
+}
+
+field_5c() { printf '%s\n' "$1" | sed -n "s/^$2 = //p" | head -1; }
+
+# sites-enabled is symlinks into sites-available on the real server, so the
+# fixture is too: that is also what exercises the readlink -f resolution.
+mkdir -p "$NG/available"
+make_conf "$NG/available/paramant-public.conf" old old yes no
+make_conf "$NG/available/paramant-live.conf"   old old yes no
+ln -sfn "$NG/available/paramant-public.conf" "$NG/sites/paramant-public.conf"
+ln -sfn "$NG/available/paramant-live.conf"   "$NG/sites/paramant-live.conf"
+
+echo ""
+echo "6g-1. First run: the conf is in its pre-3.1 shape, so there is work to do"
+OUT1="$(cd "$NG" && PATH="$NG/bin:$PATH" bash "$NG/5c.sh" 20260101-0000 "$NG/sites" "$NG/bk" \
+        "paramant-public.conf paramant-live.conf" 2>&1)"; RC1=$?
+if [ "$RC1" -eq 0 ]; then pass "5c exits 0 on a conf that still needs the edits"; else
+  fail "5c exits $RC1 on a conf that still needs the edits"
+  printf '%s\n' "$OUT1" | sed 's/^/        /' | head -20
+fi
+# Everything after this run is the END state the deploy is actually for.
+for want in "after sign gated:0" "after compliance:0" "after dicom try_files:0"; do
+  f="${want%%:*}"; v="${want##*:}"
+  if [ "$(field_5c "$OUT1" "$f")" = "$v" ]; then pass "5c leaves $f at $v"; else
+    fail "5c left $f at '$(field_5c "$OUT1" "$f")', expected $v"; fi
+done
+if [ "$(field_5c "$OUT1" 'after edited files')" = "2" ]; then
+  pass "5c rewrote both confs on the first run"
+else
+  fail "5c rewrote $(field_5c "$OUT1" 'after edited files') conf(s) on the first run, expected 2"
+fi
+if [ "$(field_5c "$OUT1" 'after outbound blocks with buffer')" \
+   = "$(field_5c "$OUT1" 'after outbound locations')" ]; then
+  pass "every /v2/outbound block came out with the buffer"
+else
+  fail "the buffer landed in $(field_5c "$OUT1" 'after outbound blocks with buffer') of $(field_5c "$OUT1" 'after outbound locations') blocks"
+fi
+
+echo ""
+echo "6g-2. Second run on the same confs: already applied, not FATAL"
+OUT2="$(cd "$NG" && PATH="$NG/bin:$PATH" bash "$NG/5c.sh" 20260101-0001 "$NG/sites" "$NG/bk" \
+        "paramant-public.conf paramant-live.conf" 2>&1)"; RC2=$?
+if [ "$RC2" -eq 0 ]; then pass "a second 5c on an already-edited conf exits 0"; else
+  fail "a second 5c on an already-edited conf exits $RC2 (this is the bug)"
+  printf '%s\n' "$OUT2" | sed 's/^/        /' | head -20
+fi
+if printf '%s\n' "$OUT2" | grep -q FATAL; then
+  fail "a second 5c still prints FATAL"
+  printf '%s\n' "$OUT2" | grep FATAL | sed 's/^/        /'
+else
+  pass "a second 5c prints no FATAL"
+fi
+for want in "before sign state:done" "before compliance state:done" "before dicom state:done" \
+            "before edits pending:0" "before everything already applied:yes" \
+            "after edited files:0"; do
+  f="${want%%:*}"; v="${want##*:}"
+  if [ "$(field_5c "$OUT2" "$f")" = "$v" ]; then pass "second run reports $f = $v"; else
+    fail "second run reports $f = '$(field_5c "$OUT2" "$f")', expected $v"; fi
+done
+if printf '%s\n' "$OUT2" | grep -q 'reloaded nginx'; then
+  pass "a second 5c still tests and reloads nginx, so a hand edit cannot hide"
+else
+  fail "a second 5c never reloaded nginx"
+fi
+
+echo ""
+echo "6g-3. A conf with neither the old nor the wanted shape is still FATAL"
+make_conf "$NG/available/paramant-public.conf" absent absent no yes
+make_conf "$NG/available/paramant-live.conf"   absent absent no yes
+OUT3="$(cd "$NG" && PATH="$NG/bin:$PATH" bash "$NG/5c.sh" 20260101-0002 "$NG/sites" "$NG/bk" \
+        "paramant-public.conf paramant-live.conf" 2>&1)"; RC3=$?
+if [ "$RC3" -ne 0 ]; then pass "5c stops on a conf that is not the one the runbook describes"; else
+  fail "5c accepted a conf carrying neither shape"; fi
+if printf '%s\n' "$OUT3" | grep -q "FATAL 'sign'"; then
+  pass "it names which edit it could not place"
+else
+  fail "the FATAL does not name the edit"
+  printf '%s\n' "$OUT3" | sed 's/^/        /' | head -20
+fi
+if [ "$(field_5c "$OUT3" 'before sign state')" = unknown ]; then
+  pass "the unrecognisable conf reads as state unknown, not as done"
+else
+  fail "state for an absent /sign location is '$(field_5c "$OUT3" 'before sign state')', expected unknown"
+fi
+
+# And the script must read the already-applied answer, not just print it.
+check_has "$SCRIPT" 'before everything already applied' \
+  "phase 5c reports whether every edit was already applied"
+check_has "$SCRIPT" 'already applied' \
+  "the script has an already-applied verdict instead of a FATAL"
+check_has "$FULL"   'before edits pending'  "the dry run shows the pending-edit count"
+check_has "$FULL"   'before sign state'     "the dry run shows the per-edit state read"
 
 echo ""
 echo "6d. The CI gate on main is one verdict per required workflow"


### PR DESCRIPTION
Phase 1a of `deploy/deploy-3.1.sh` demanded that the production checkout stood
on `41501bb`. That is where the runbook starts, not where the checkout stands
after a deploy: phase 3 moves it to main. So every later run, and every resume
of a run that died in phase 5, stopped on the first gate.

## The expected commit is a parameter

Three sources, most specific first:

| source | when | what it demands |
|---|---|---|
| `PARAMANT_EXPECTED_HEAD=<commit>` | you set it | equality, nothing else consulted |
| `/home/paramant/backups/deployed-head` | the file exists | the checkout equals the marker **and** that commit is an ancestor of the deploy ref (`git merge-base --is-ancestor`, after a fetch on the server) |
| `41501bb` | no marker | the runbook's own starting point, so the first deploy is gated exactly as before |

Phase 7 writes the marker with the commit the checkout actually ended on. Both
halves of the marker test have to hold: equality says nothing moved the
checkout outside a deploy, the ancestor test says the ff-only pull in 3a can
reach the ref from here. Either alone would let a deploy start from a commit
the ref does not contain.

The rollback (phase 8) deliberately does not rewrite the marker: it leaves the
checkout where it stands, and the marker names the checkout. The phase says so
in its own output.

The decision is a pure function, `head_gate_verdict()`, so the test drives every
case through it without a server.

## Phase 5c: already applied is not FATAL

Same bug one level down. 5c stopped with `FATAL nothing to change` as soon as an
edit had nothing left to do, so the second deploy died on an edit that had
already succeeded. Each of the three edits is now read as:

- `todo` the old shape is present, the edit runs
- `done` the old shape is gone and the wanted end shape is there (`location = /sign` without `auth_request`, no `/compliance` locations, `location = /dicom { return 404; }`), reported as already applied
- `unknown` neither shape, still `FATAL`, because that conf is not the one the runbook describes

Removal-only edits treat absence as `done`, which is the rule 5b already used
for a docroot file that was already gone.

What is asserted AFTER the edits is unchanged, and that is where the weight
sits: no `auth_request` on `/sign`, zero `/compliance` locations, `/dicom`
returning 404, the ParaID deny intact, `proxy_buffer_size 32k` inside every
`location ~ ^/v2/outbound` block, `nginx -t` clean before the reload. A run that
changed nothing still tests and reloads nginx, so a hand edit between deploys
cannot hide behind "already applied". The `after edited files = 2` assertion is
replaced by "at least one conf rewritten when something was pending, zero when
nothing was".

## Two smaller things found on the way

- `count()` piped `grep` into `awk` under `pipefail`, so reading a count into a
  variable ended the remote block under `set -e` the moment a pattern was
  already gone. Zero is an answer, so grep's verdict is swallowed.
- 5b demanded at least one frontend file deleted since the deployed commit.
  True for the first deploy, where the runbook had counted them. A deploy of a
  ref that deleted no frontend file is not a failure.

## Tests

`tests/deploy-3.1-dryrun.test.sh` grows the four cases asked for plus the stops:

- **6f-1** first deploy, no marker: on `41501bb` passes, anywhere else stops, an empty marker file reads as no marker
- **6f-2** second deploy, marker present: equal plus ancestor passes; equal but not an ancestor stops; an unresolvable ref stops rather than passing; a checkout that drifted from the marker stops; a marker never makes `41501bb` acceptable again by itself
- **6f-3** `PARAMANT_EXPECTED_HEAD` overrides both, on equality alone, in both directions
- **6f-5** the whole script under `--dry-run` with the override set
- **6g** 5c already applied, by extracting the real 5c remote block and running it against synthetic nginx confs with `nginx` and `systemctl` stubbed: first run edits both confs and reaches the end state, second run reports `already applied` and rewrites nothing, a conf with neither shape still stops and names the edit it could not place

`bash -n` clean, `tests/deploy-3.1-dryrun.test.sh` 176 pass 0 fail,
`tests/static-sanity.sh` PASS with all ten checks green.

Nothing ran against production.
