### PR TITLE
Link the product pages, state the hourly ceiling, and write one monthly form

### DIFF
--- a/docs/brand/messaging.md
+++ b/docs/brand/messaging.md
@@ -82,13 +82,18 @@ It ships on /pricing in these words, and this is the sourced version:
 > devices, a dedicated relay), not to unlock features, and that is what keeps
 > the Community plan free.
 
+**A monthly allowance is written "a month", never "per month".** One limit, one
+spelling, on every page that repeats it. `relay/test/pricing-page.test.js` fails
+a page that drifts back, and the number checks around it accept both spellings
+on purpose so a real limit change fails on the number instead.
+
 **The free plan is called Community.** Not Free, not Starter, not Basic. It is
 Community on both products and `tests/ui-truthfulness.test.mjs` fails when a
 page calls it anything else.
 
 **Free for everyone** (name the tiers as /pricing names them):
 
-- ParaSign Community. EUR 0, forever. 2 signatures per month, unlimited
+- ParaSign Community. EUR 0, forever. 2 signatures a month, no limit on
   receiving, full post-quantum crypto, public verification log, no card
   required.
 - ParaSend Community. EUR 0, forever, no card required. AES-256-GCM with a
@@ -97,10 +102,10 @@ page calls it anything else.
 **For organisations** (same names, same prices, always excl. btw with the incl.
 figure beside it, exactly as /pricing does it):
 
-- ParaSign Pro. EUR 49/month excl. btw (EUR 59.29 incl.). 100 signatures per
+- ParaSign Pro. EUR 49/month excl. btw (EUR 59.29 incl.). 100 signatures a
   month, then EUR 0.40 each up to 1,000. API access. Annual EUR 499 excl.
 - ParaSign Business. EUR 299/month excl. btw (EUR 361.79 incl.). 1,000
-  signatures per month, named support with a response within one business day,
+  signatures a month, named support with a response within one business day,
   exportable audit log with CT tree head (CSV or JSON). Annual EUR 2,990 excl.
 - ParaSign Enterprise. "Let's talk", per organisation. Dedicated relay instance,
   sector relay, SLA with service credits, self-hosting licence, audit support.

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -236,7 +236,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
     <div class="buyer-qa-item">
       <div class="buyer-qa-q">What does it cost?</div>
-      <p class="buyer-qa-a">ParaSign Community is free, forever, and no card is required. It covers 2 signatures per month. The first paid plan is ParaSign Pro at &euro;49 a month excl. btw (&euro;59.29 incl.), which includes 100 signatures a month. Every plan gets the same encryption, the same post-quantum signatures and the same public proof log.</p>
+      <p class="buyer-qa-a">ParaSign Community is free, forever, and no card is required. It covers 2 signatures a month. The first paid plan is ParaSign Pro at &euro;49 a month excl. btw (&euro;59.29 incl.), which includes 100 signatures a month. Every plan gets the same encryption, the same post-quantum signatures and the same public proof log.</p>
       <a class="buyer-qa-link" href="/pricing">See pricing &rarr;</a>
     </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -87,7 +87,7 @@
 .prod-lines { list-style: none; margin: 0 0 var(--space-4); padding: 0; }
 .prod-lines li { display: block; background: none; border: 0; padding: 0 0 0 18px; position: relative; font-size: 14px; line-height: 1.55; color: var(--ink-dim); margin-bottom: 6px; }
 .prod-lines li::before { content: ""; position: absolute; left: 0; top: 9px; width: 7px; height: 2px; background: var(--lime); }
-.prod-cta { margin-top: auto; }
+.prod-cta { margin-top: auto; display: flex; flex-wrap: wrap; gap: var(--space-2); }
 @media (max-width: 760px) { .prod-grid { grid-template-columns: 1fr; } }
 
 /* ── Three steps ── */
@@ -312,7 +312,7 @@
         <li>They sign with the link from that email. Signing an invitation needs no account.</li>
         <li>You keep a receipt anyone can check offline, plus an entry in the public log.</li>
       </ul>
-      <div class="prod-cta"><a class="btn btn-lime" href="/sign">Sign a document</a></div>
+      <div class="prod-cta"><a class="btn btn-lime" href="/parasign">What ParaSign is</a><a class="btn home-act-ghost" href="/sign">Sign a document</a></div>
     </li>
     <li>
       <span class="prod-name">ParaSend</span>
@@ -322,7 +322,7 @@
         <li>The relay only ever holds the encrypted blob in RAM, never on a disk.</li>
         <li>It is burned on the first read, so there is nothing left to leak later.</li>
       </ul>
-      <div class="prod-cta"><a class="btn home-act-ghost" href="/parashare">Send a file</a></div>
+      <div class="prod-cta"><a class="btn btn-lime" href="/parasend">What ParaSend is</a><a class="btn home-act-ghost" href="/parashare">Send a file</a></div>
     </li>
   </ul>
 </section>
@@ -363,9 +363,9 @@
       <h3>ParaSign</h3>
       <p class="price-sub">Getting documents signed.</p>
       <ul class="tiers">
-        <li><span class="tier-price">&euro;0</span><span class="tier-what"><b>Community</b> &middot; 2 signatures per month, unlimited receiving</span></li>
-        <li><span class="tier-price">&euro;49</span><span class="tier-what"><b>Pro</b> &middot; 100 signatures per month, then &euro;0.40 each up to 1,000</span></li>
-        <li><span class="tier-price">&euro;299</span><span class="tier-what"><b>Business</b> &middot; 1,000 signatures per month, named support, exportable audit log</span></li>
+        <li><span class="tier-price">&euro;0</span><span class="tier-what"><b>Community</b> &middot; 2 signatures a month, no limit on receiving</span></li>
+        <li><span class="tier-price">&euro;49</span><span class="tier-what"><b>Pro</b> &middot; 100 signatures a month, then &euro;0.40 each up to 1,000</span></li>
+        <li><span class="tier-price">&euro;299</span><span class="tier-what"><b>Business</b> &middot; 1,000 signatures a month, named support, exportable audit log</span></li>
         <li><span class="tier-price">Talk</span><span class="tier-what"><b>Enterprise</b> &middot; dedicated relay, SLA with service credits, self-hosting licence</span></li>
       </ul>
       <p class="price-foot">&euro;59.29 and &euro;361.79 per month incl. 21% btw &middot; yearly is cheaper</p>

--- a/frontend/js/quota-upgrade.js
+++ b/frontend/js/quota-upgrade.js
@@ -51,8 +51,8 @@
   function freeSignHtml(data) {
     return '<div class="pa-quota-upsell pa-quota-card" role="status">' +
       '<strong>You\'ve used both signatures this month.</strong>' +
-      '<span>Community gives you 2 per month, with the same encryption, the same post-quantum signatures and the same public proof log as every paid plan. You never pay for security here. You pay for volume.</span>' +
-      '<span><strong>Pro - EUR 49/month</strong><br>100 signatures per month, then EUR 0.40 each, up to 1,000. Unlimited transfers. API access.</span>' +
+      '<span>Community gives you 2 a month, with the same encryption, the same post-quantum signatures and the same public proof log as every paid plan. You never pay for security here. You pay for volume.</span>' +
+      '<span><strong>Pro - EUR 49/month</strong><br>100 signatures a month, then EUR 0.40 each, up to 1,000. Unlimited transfers. API access.</span>' +
       '<span class="pa-quota-actions">' +
         '<a class="btn btn-primary" href="/pricing">Upgrade to Pro</a>' +
         '<button type="button" class="btn btn-secondary" data-pa-quota-dismiss>Maybe later</button>' +
@@ -110,7 +110,7 @@
     var over = Number(quota.overage_count);
     if (included === 100 && isFinite(over) && over >= 1) {
       return '<div class="pa-sign-note" role="status">' +
-        '<span>You\'ve passed 100 signatures this month. Everything keeps working. Additional signatures are EUR 0.40 each and appear on your next invoice, up to 1,000 per month.</span>' +
+        '<span>You\'ve passed 100 signatures this month. Everything keeps working. Additional signatures are EUR 0.40 each and appear on your next invoice, up to 1,000 a month.</span>' +
         '<span>Signing more than 600 a month? Business (EUR 299) works out cheaper. <a href="/pricing">Compare plans</a></span>' +
         '</div>';
     }

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -312,10 +312,11 @@
         <div class="tier-note">Forever &middot; no card required</div>
         <ul>
           <li>Encrypted in your browser, key never sent</li>
-          <li>10 transfers per month</li>
+          <li>10 transfers a month</li>
           <li>5 MB per file, on every plan</li>
           <li>1 hour link expiry</li>
           <li>Burn on first read</li>
+          <li>Up to 50 retrievals an hour through the API</li>
           <li>Up to 5 registered devices for ParaShare, the ParaSend send screen</li>
         </ul>
       </div>
@@ -329,9 +330,10 @@
         <div class="tier-note">excl. btw &middot; <span class="incl">charged &euro;18.15/mo incl. 21% btw</span><br>Annual &euro;150 excl. &middot; 16.7% off</div>
         <ul>
           <li>Everything in Community</li>
-          <li>500 transfers per month</li>
+          <li>500 transfers a month</li>
           <li>24 hour link expiry</li>
           <li>Up to 10 reads per link</li>
+          <li>Up to 500 retrievals an hour through the API</li>
           <li>Up to 50 registered devices</li>
           <li>Send history and link management</li>
           <li>Webhooks on upload and download</li>
@@ -346,6 +348,7 @@
           <li>Everything in Pro</li>
           <li>7 day link expiry</li>
           <li>Up to 100 reads per link</li>
+          <li>No hourly cap on API retrievals</li>
           <li>Dedicated relay on our infra or yours</li>
           <li>IEC 62443 / NIS2 / NEN 7510 documentation as input for your own compliance process, not third-party certification</li>
           <li>Signed Data Processing Agreement (GDPR Art. 28)</li>
@@ -353,6 +356,7 @@
         </ul>
       </div>
     </div>
+    <p class="ps-fine">What the hourly figure counts: fetching a transfer back yourself with your own API key, the route the SDKs and scripts use. A recipient who opens the link you sent goes through the download token instead, and that path is not counted against your hour. Past the ceiling the relay answers 429 until the hour rolls over. The number is outbound_per_hour in relay/lib/tiers.js, the same table the transfer, file size and link limits above come from.</p>
     <p class="ps-fine">Every tier stores transfers in RAM and every tier uses the same cryptography. There is no lesser encryption at lower tiers. Cryptography is not a paywalled feature at Paramant.</p>
     <p class="ps-fine">Prices shown excl. btw (VAT). Checkout charges incl. 21% btw: Pro &euro;18.15/mo or &euro;181.50/yr. Checkout and the full comparison are on the <a href="/pricing">pricing page</a>.</p>
   </div>

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -248,8 +248,8 @@
         <h3>&euro;0, forever</h3>
         <p>No card, no clock, no trial that quietly ends. It is called <strong>Community</strong> on the <a href="/pricing">pricing page</a> too.</p>
         <ul>
-          <li>2 signatures per month</li>
-          <li>Unlimited receiving</li>
+          <li>2 signatures a month</li>
+          <li>No limit on receiving</li>
           <li>Full post-quantum crypto</li>
           <li>Public verification log</li>
           <li>No card required</li>
@@ -257,6 +257,7 @@
         <div class="ps-actions">
           <a href="/signup" class="btn btn-primary">Start free &rarr;</a>
         </div>
+        <p class="ps-fine">Receiving is not metered. The tier table in relay/lib/tiers.js has no inbound or receiving dimension at all, so being invited, opening an invitation and fetching the document back are not counted against anything, on any plan. Putting your own signature on one is: that counts against the 2 a month above, whoever sent it to you.</p>
       </div>
       <div>
         <div class="k" style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.14em;text-transform:uppercase;font-weight:700;color:var(--navy)">Why it is free</div>
@@ -273,8 +274,9 @@
         <div class="tier-price">&euro;49<span>/month</span></div>
         <div class="tier-note">excl. btw &middot; <span class="incl">charged &euro;59.29/mo incl. 21% btw</span><br>Annual &euro;499 excl.</div>
         <ul>
-          <li>100 signatures per month, then &euro;0.40 each, up to 1,000</li>
-          <li>500 ParaSend transfers per month</li>
+          <li>100 signatures a month, then &euro;0.40 each, up to 1,000</li>
+          <li>500 ParaSend transfers a month</li>
+          <li>Up to 500 ParaSend retrievals an hour through the API</li>
           <li>API access</li>
         </ul>
       </div>
@@ -283,7 +285,7 @@
         <div class="tier-price">&euro;299<span>/month</span></div>
         <div class="tier-note">excl. btw &middot; <span class="incl">charged &euro;361.79/mo incl. 21% btw</span><br>Annual &euro;2,990 excl.</div>
         <ul>
-          <li>1,000 signatures per month</li>
+          <li>1,000 signatures a month</li>
           <li>Named support, response within one business day</li>
           <li>Exportable audit log with CT tree head</li>
         </ul>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -235,7 +235,7 @@
      Four things had to fit that were not there before. A visitor arriving from
      a search engine has seen no other page, so the first line says what the
      product does. The promise carries its own number: "free forever" without
-     "2 signatures per month" reads as generous until the table says otherwise,
+     "2 signatures a month" reads as generous until the table says otherwise,
      and a buyer who finds that out one screen later feels sold to. The founder
      stood at 1128px, which is a screen and a half of scrolling before anyone
      says who holds the files. And the decorative "00" over the h1 cost the
@@ -276,7 +276,7 @@
       Sign documents and send files that vanish after one read.
     </p>
     <p style="font-size:var(--text-md);color:var(--ink);line-height:1.6;margin:0 0 var(--space-3)">
-      <strong>Community is &euro;0 a month, forever:</strong> 2 signatures per month, 10 transfers per month, 5 MB per file, no card.
+      <strong>Community is &euro;0 a month, forever:</strong> 2 signatures a month, 10 transfers a month, 5 MB per file, no card.
       Organisations that need higher limits, signing built into their own software, a named contact or a server of
       their own pay for the business plans: from <strong>&euro;15 a month</strong> for sending, from
       <strong>&euro;49 a month</strong> for signing, both excl. btw.
@@ -332,7 +332,7 @@
       <span style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)">Product</span>
       <h3 style="font-size:var(--text-xl);text-transform:uppercase;margin-top:var(--space-2)">ParaSign · Get a document signed</h3>
       <p style="font-size:var(--text-base);color:var(--ink);line-height:1.7;max-width:760px;margin-top:var(--space-3)">
-        Sign a PDF yourself, or send it to the people who have to sign it. Community covers 2 signatures per month, forever. Organisations pay for volume: 100 a month on Pro, 1,000 a month on Business with a named contact. ParaSign is priced separately from ParaSend, and from Pro it comes with a <strong>developer API</strong> with its own <a href="/docs#parasign-api" style="color:var(--cobalt)">documentation</a> and webhooks, so signing can run inside your own software.
+        Sign a PDF yourself, or send it to the people who have to sign it. Community covers 2 signatures a month, forever. Organisations pay for volume: 100 a month on Pro, 1,000 a month on Business with a named contact. ParaSign is priced separately from ParaSend, and from Pro it comes with a <strong>developer API</strong> with its own <a href="/docs#parasign-api" style="color:var(--cobalt)">documentation</a> and webhooks, so signing can run inside your own software.
       </p>
     </div>
     <div class="tier-grid tier-grid-4">
@@ -341,10 +341,10 @@
         <div class="tier-name">Community</div>
         <div class="tier-price">&euro;0</div>
         <div class="tier-price-note">Forever</div>
-        <p style="font-size:var(--text-base);color:var(--ink);margin-bottom:var(--space-5);line-height:1.65">For a one-person practice, a volunteer board or a household. 2 signatures per month, forever.</p>
+        <p style="font-size:var(--text-base);color:var(--ink);margin-bottom:var(--space-5);line-height:1.65">For a one-person practice, a volunteer board or a household. 2 signatures a month, forever.</p>
         <ul class="tier-features">
-          <li>2 signatures per month</li>
-          <li>Unlimited receiving</li>
+          <li>2 signatures a month</li>
+          <li>No limit on receiving</li>
           <li>Full post-quantum crypto - Public verification log</li>
           <li>No card required</li>
         </ul>
@@ -357,7 +357,7 @@
         <div class="tier-price-note">excl. btw &middot; <span class="incl">charged &euro;59.29/mo incl. 21% btw</span></div>
         <p style="font-size:var(--text-base);color:var(--ink);margin-bottom:var(--space-5);line-height:1.65">For an office that signs every week, and for putting signing inside your own software through the API.</p>
         <ul class="tier-features">
-          <li>100 signatures per month, then &euro;0.40 each, up to 1,000</li>
+          <li>100 signatures a month, then &euro;0.40 each, up to 1,000</li>
           <li>Past 1,000 a month, Business is cheaper anyway</li>
           <li>Unlimited transfers - API access</li>
           <li>Annual: &euro;499 excl. &middot; 15.1% off</li>
@@ -372,7 +372,7 @@
         <div class="tier-price-note">excl. btw &middot; <span class="incl">charged &euro;361.79/mo incl. 21% btw</span></div>
         <p style="font-size:var(--text-base);color:var(--ink);margin-bottom:var(--space-5);line-height:1.65">For an organisation that has to answer for its process: a named contact and an audit log you can export.</p>
         <ul class="tier-features">
-          <li>1,000 signatures per month</li>
+          <li>1,000 signatures a month</li>
           <li>Named support, response within one business day</li>
           <li>We help you answer your customers' security questionnaires</li>
           <li>Exportable audit log with CT tree head (CSV or JSON)</li>
@@ -411,7 +411,7 @@
       <span style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)">Product</span>
       <h3 style="font-size:var(--text-xl);text-transform:uppercase;margin-top:var(--space-2)">ParaSend · Send a file that disappears</h3>
       <p style="font-size:var(--text-base);color:var(--ink);line-height:1.7;max-width:760px;margin-top:var(--space-3)">
-        Send a file over a link that expires and burns on first read. Community covers 10 transfers per month at 5 MB per file, forever. Organisations that send every week pay for longer links, more reads and more registered devices.
+        Send a file over a link that expires and burns on first read. Community covers 10 transfers a month at 5 MB per file, forever. Organisations that send every week pay for longer links, more reads and more registered devices.
       </p>
     </div>
     <div class="tier-grid">
@@ -425,7 +425,7 @@
           <li>AES-256-GCM, browser-generated key</li>
           <li>1 hour link expiry</li>
           <li>Burn on first read</li>
-          <li>10 transfers per month</li>
+          <li>10 transfers a month</li>
           <li>5 MB per file</li>
           <li>Up to 5 registered devices for ParaShare</li>
         </ul>
@@ -445,7 +445,7 @@
           <li>Send history and link management</li>
           <li>Webhooks on upload and download</li>
           <li>Email notifications via Resend</li>
-          <li>500 transfers per month</li>
+          <li>500 transfers a month</li>
         </ul>
 <!-- Prices live in relay/lib/billing-catalog.js, server side, and the button
      only carries product/plan/interval. pricing-billing.js turns a click into
@@ -556,7 +556,7 @@
 
     <div class="faq-item">
       <p class="faq-q">How does ParaSign pricing work?</p>
-      <div class="faq-a">ParaSign is priced by signature volume, not by feature. Community covers 2 signatures per month; Pro (&euro;49/mo or &euro;499/yr, excl. btw) includes 100 a month, then &euro;0.40 each, with API access; Business (&euro;299/mo or &euro;2,990/yr, excl. btw) includes 1,000 a month with named support and an exportable audit log. Every tier uses the same ML-DSA-65 post-quantum cryptography and public CT-log verification. A ParaSign signature is a Simple Electronic Signature (SES) under eIDAS, not an advanced (AES) or a qualified (QES) signature. QES is coming via an EU QTSP partner.</div>
+      <div class="faq-a">ParaSign is priced by signature volume, not by feature. Community covers 2 signatures a month; Pro (&euro;49/mo or &euro;499/yr, excl. btw) includes 100 a month, then &euro;0.40 each, with API access; Business (&euro;299/mo or &euro;2,990/yr, excl. btw) includes 1,000 a month with named support and an exportable audit log. Every tier uses the same ML-DSA-65 post-quantum cryptography and public CT-log verification. A ParaSign signature is a Simple Electronic Signature (SES) under eIDAS, not an advanced (AES) or a qualified (QES) signature. QES is coming via an EU QTSP partner.</div>
     </div>
 
     <div class="faq-item">

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -200,7 +200,7 @@
     We'll send a link to confirm it's you. No password to invent.
   </p>
   <p class="small mt-2">
-    Community accounts get 2 signatures per month and send encrypted files that burn on first read, forever, no card.
+    Community accounts get 2 signatures a month and send encrypted files that burn on first read, forever, no card.
     <a href="/pricing" style="color:var(--cobalt,#1D4ED8)">See the plans</a>.
   </p>
 </section>

--- a/relay/lib/tiers.js
+++ b/relay/lib/tiers.js
@@ -61,7 +61,7 @@ const TIER_LIMITS = Object.freeze({
   }),
   business: Object.freeze({
     transfers_month: 2000,
-    signs_month: 1000,     // matches the pricing page: ~1,000 signatures per month
+    signs_month: 1000,     // matches the pricing page: ~1,000 signatures a month
     file_mb: 5,            // mirrors current MAX_BLOB global 5 MB
     devices: 100,
     view_ttl_ms: 604_800_000, // 7 d

--- a/relay/test/parasign-pro-perks.test.js
+++ b/relay/test/parasign-pro-perks.test.js
@@ -1,7 +1,7 @@
 'use strict';
 // ParaSign Pro perk delivery. The pricing page (frontend/pricing.html, ParaSign
 // Pro card) promises, per perk:
-//   1. "100 signatures per month, then EUR 0.40 each, up to 1,000"
+//   1. "100 signatures a month, then EUR 0.40 each, up to 1,000"
 //   2. "Unlimited transfers - API access"
 //
 // These prove, per perk, what a per-product grant of parasign=pro (the exact

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -72,19 +72,19 @@ for (const v of VARIANTS) {
 const PARASIGN_COPY = [
   // FREE - EUR 0
   '>&euro;0<',
-  '2 signatures per month',
-  'Unlimited receiving',
+  '2 signatures a month',
+  'No limit on receiving',
   'Full post-quantum crypto - Public verification log',
   'No card required',
   // PRO - EUR 49/month
   '&euro;49<',
-  '100 signatures per month, then &euro;0.40 each, up to 1,000',
+  '100 signatures a month, then &euro;0.40 each, up to 1,000',
   'Past 1,000 a month, Business is cheaper anyway',
   'Unlimited transfers - API access',
   'Annual: &euro;499 excl. &middot; 15.1% off',
   // BUSINESS - EUR 299/month
   '&euro;299<',
-  '1,000 signatures per month',
+  '1,000 signatures a month',
   'Named support, response within one business day',
   "We help you answer your customers' security questionnaires",
   'Exportable audit log with CT tree head (CSV or JSON)',
@@ -148,13 +148,31 @@ const htmlVisible = html.replace(/<!--[\s\S]*?-->/g, '');
 const communityTransfers = tiers.tierLimit('community', 'transfers_month');
 const communityFileMb = tiers.tierLimit('community', 'file_mb');
 const proTransfers = tiers.tierLimit('pro', 'transfers_month');
-assert(new RegExp(`<li>${communityTransfers} transfers per month</li>`).test(html),
+
+// Two different failures, kept apart on purpose.
+//
+// The site used to say "10 transfers a month" on / and /docs and "10 transfers
+// per month" on /pricing, /parasend and /parasign: one limit, two spellings,
+// and a reader who compares two pages cannot tell whether that is one number or
+// two. The site's form is now "a month" everywhere.
+//
+// So the NUMBER checks accept either spelling. If tiers.js moves from 10 to 20
+// they go red on the number, whatever the wording is that day. The WORDING is
+// pinned once, further down (MONTHLY_FORM), so a page that drifts back to "per
+// month" fails on wording and not on a limit that is still perfectly correct.
+// Declared as functions, not consts: two parallel PRs each adding a top-level
+// `const` under one name is exactly what stopped this file parsing on main, and
+// a function declaration tolerates being declared twice where a const throws.
+function aMonth(n, noun) { return new RegExp(`${n} ${noun} (?:a|per) month`); }
+function statesLine(pageHtml, line) { return line instanceof RegExp ? line.test(pageHtml) : pageHtml.includes(line); }
+
+assert(new RegExp(`<li>${communityTransfers} transfers (?:a|per) month</li>`).test(html),
   `the Community card must name the transfers_month limit from tiers.js (${communityTransfers})`);
 assert(new RegExp(`<li>${communityFileMb} MB per file</li>`).test(html),
   `the Community card must name the file_mb limit from tiers.js (${communityFileMb} MB)`);
-assert(new RegExp(`${communityTransfers} transfers per month, ${communityFileMb} MB per file`).test(html),
+assert(new RegExp(`${communityTransfers} transfers (?:a|per) month, ${communityFileMb} MB per file`).test(html),
   'the lead must carry the same two Community limits as the card');
-assert(new RegExp(`<li>${proTransfers} transfers per month</li>`).test(html),
+assert(new RegExp(`<li>${proTransfers} transfers (?:a|per) month</li>`).test(html),
   `the ParaSend Pro card must name its transfers_month limit from tiers.js (${proTransfers})`);
 assert(!/uploads per hour/i.test(htmlVisible),
   'the page must not sell the anonymous per-IP rate of a deprecated endpoint as an account limit');
@@ -212,7 +230,7 @@ function showsAmountOnCard(pageHtml, amount, interval) {
 // to one page without the other turns this suite red instead of leaving two
 // prices on the site.
 const parasignHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'parasign.html'), 'utf8');
-for (const s of ['2 signatures per month', '100 signatures per month, then &euro;0.40 each, up to 1,000', '1,000 signatures per month']) {
+for (const s of ['2 signatures a month', '100 signatures a month, then &euro;0.40 each, up to 1,000', '1,000 signatures a month']) {
   assert(parasignHtml.includes(s), 'parasign.html lost the quota line: ' + s);
 }
 assert(/excl\. btw/.test(parasignHtml) && /incl\. 21% btw/.test(parasignHtml), 'parasign.html must state excl. btw and the incl. 21% btw checkout amount');
@@ -495,30 +513,34 @@ ok('both product pages carry the btw convention and the catalog amounts');
 // Pinning one page to another only proves the two agree; it cannot catch both
 // being wrong together, which is exactly what happened here: /pricing and
 // index.html carry the same upload figure and are corrected in their own PRs.
-const tiers = require('../lib/tiers');
 const hours = (ms) => ms / 3_600_000;
 
+// The transfer lines are matched on the number and accept either spelling of
+// the period, so tiers.js drift fails here and wording drift fails in the
+// MONTHLY_FORM block instead. Same split as the /pricing checks above.
 const COMMUNITY_LINES = [
-  [tiers.tierLimit('community', 'transfers_month') + ' transfers per month', 'transfers_month'],
+  [aMonth(tiers.tierLimit('community', 'transfers_month'), 'transfers'), 'transfers_month'],
   [tiers.tierLimit('community', 'file_mb') + ' MB per file', 'file_mb'],
   [hours(tiers.tierLimit('community', 'view_ttl_ms')) + ' hour link expiry', 'view_ttl_ms'],
+  ['Up to ' + tiers.tierLimit('community', 'outbound_per_hour') + ' retrievals an hour', 'outbound_per_hour'],
   [tiers.tierLimit('community', 'devices') + ' registered devices', 'devices'],
 ];
 for (const [line, dim] of COMMUNITY_LINES) {
-  assert(productHtml.parasend.includes(line),
+  assert(statesLine(productHtml.parasend, line),
     'parasend.html no longer states the Community ' + dim + ' that tiers.js enforces: "' + line + '"');
 }
 assert(tiers.tierLimit('community', 'max_views') === 1 && /Burn on first read/.test(productHtml.parasend),
   'tiers.js gives Community one view, so parasend.html must say the link burns on first read');
 
 const PRO_LINES = [
-  [tiers.tierLimit('pro', 'transfers_month') + ' transfers per month', 'transfers_month'],
+  [aMonth(tiers.tierLimit('pro', 'transfers_month'), 'transfers'), 'transfers_month'],
   [hours(tiers.tierLimit('pro', 'view_ttl_ms')) + ' hour link expiry', 'view_ttl_ms'],
   ['Up to ' + tiers.tierLimit('pro', 'max_views') + ' reads per link', 'max_views'],
+  ['Up to ' + tiers.tierLimit('pro', 'outbound_per_hour') + ' retrievals an hour', 'outbound_per_hour'],
   ['Up to ' + tiers.tierLimit('pro', 'devices') + ' registered devices', 'devices'],
 ];
 for (const [line, dim] of PRO_LINES) {
-  assert(productHtml.parasend.includes(line),
+  assert(statesLine(productHtml.parasend, line),
     'parasend.html no longer states the ParaSend Pro ' + dim + ' that tiers.js enforces: "' + line + '"');
 }
 // The anon endpoint's figure may not come back on either product page under any
@@ -533,9 +555,69 @@ for (const [name, pageHtml] of [['parasign.html', productHtml.parasign], ['paras
   assert(!/Unlimited transfers/i.test(pageHtml),
     name + ' promises unlimited transfers, which entitlements.js forbids for every metered tier');
 }
+// ── The hourly ceiling the relay enforces and no page stated ─────────────────
+//
+// outbound_per_hour has been enforced since the rate-limit finding (relay.js,
+// outboundRateOk, applied on GET /v2/outbound/:hash) and appeared on no page at
+// all: a Community account that scripts its own downloads hit a 429 it had
+// never been told about. It is now on /parasend per tier and on the /parasign
+// Pro card, and it is pinned here like every other tiers.js number.
+//
+// What the page may NOT do is call it a send limit or a recipient limit. It
+// counts the account's own retrievals through GET /v2/outbound with its own key;
+// the browser recipient path is GET /v2/dl/:token/get, which has no rate limit,
+// so a recipient opening a link never spends the sender's hour.
+//
+// In its own scope, like every block added below it: nothing this PR introduces
+// reaches the top level, so a parallel PR cannot collide with it.
+(function hourlyCeiling() {
+  assert(tiers.isUnlimited(tiers.tierLimit('enterprise', 'outbound_per_hour')),
+    'tiers.js now caps enterprise outbound_per_hour, so parasend.html may not say there is no hourly cap');
+  assert(/No hourly cap on API retrievals/.test(productHtml.parasend),
+    'parasend.html must state the Enterprise hourly position tiers.js gives it (unlimited)');
+  for (const [name, pageHtml] of [['parasign.html', productHtml.parasign], ['parasend.html', productHtml.parasend]]) {
+    assert(!/(sends|uploads) an hour/i.test(pageHtml),
+      name + ' calls the hourly figure a send rate; outbound_per_hour counts retrievals through GET /v2/outbound, not sends');
+  }
+  assert(new RegExp('Up to ' + tiers.tierLimit('pro', 'outbound_per_hour') + ' ParaSend retrievals an hour').test(productHtml.parasign),
+    'parasign.html must quote the hourly retrieval ceiling a ParaSign Pro account derives (' +
+    tiers.tierLimit('pro', 'outbound_per_hour') + ')');
+  ok('the hourly retrieval ceiling on /parasend and /parasign comes from tiers.js (' +
+     tiers.tierLimit('community', 'outbound_per_hour') + '/' + tiers.tierLimit('pro', 'outbound_per_hour') + ' an hour)');
+})();
+
+// ── "No limit on receiving", pinned negatively ───────────────────────────────
+//
+// Every other limit on these pages points at a field. This one points at the
+// absence of one: /parasign, /pricing and the homepage say receiving is not
+// metered, and that is only true as long as no receiving dimension exists to
+// meter it with. Nothing in tiers.js or in the entitlement quotas may name one,
+// and the day something does, this fails and the pages have to state the real
+// ceiling instead of a promise the code stopped keeping.
+(function receivingIsNotMetered() {
+  const receivingDim = (obj) => Object.keys(obj).find((k) => /receiv|inbound/i.test(k));
+  for (const [tier, row] of Object.entries(tiers.TIER_LIMITS)) {
+    const dim = receivingDim(row);
+    assert(!dim, 'tiers.js gives ' + tier + ' a receiving dimension (' + dim + '), so "No limit on receiving" is no longer true');
+  }
+  const account = { key: 'k_demo', account_id: 'acct_demo', plan: 'community' };
+  for (const [product, block] of Object.entries(entitlements.getEntitlements(account))) {
+    if (!block || !block.quotas) continue;
+    const dim = receivingDim(block.quotas);
+    assert(!dim, 'entitlements.js meters receiving for ' + product + ' (' + dim + '), so "No limit on receiving" is no longer true');
+  }
+  for (const [name, pageHtml] of [['pricing.html', html], ['parasign.html', productHtml.parasign]]) {
+    assert(pageHtml.includes('No limit on receiving'),
+      name + ' dropped the receiving line; it is the one claim on these pages backed by a field that does not exist');
+  }
+  assert(/Receiving is not metered\./.test(productHtml.parasign),
+    '/parasign must say what "no limit on receiving" rests on, and that signing what you receive is still counted');
+  ok('"No limit on receiving" holds: no receiving dimension in tiers.js or in the entitlement quotas');
+})();
+
 // A ParaSign plan derives its ParaSend tier (entitlements.js derivePlanParasend),
 // so where /parasign quotes a transfer number it must be that tier's number.
-assert(productHtml.parasign.includes(tiers.tierLimit('pro', 'transfers_month') + ' ParaSend transfers per month'),
+assert(aMonth(tiers.tierLimit('pro', 'transfers_month'), 'ParaSend transfers').test(productHtml.parasign),
   'parasign.html must quote the ParaSend transfer ceiling a ParaSign Pro account actually derives');
 ok('the ParaSend limits on both product pages come from relay/lib/tiers.js (' +
    tiers.tierLimit('community', 'transfers_month') + '/' + tiers.tierLimit('pro', 'transfers_month') + ' transfers, ' +
@@ -552,7 +634,7 @@ ok('the ParaSend Pro feature bullets quoted from /pricing are still quotes');
 
 // The signature quota lines stay pinned to the words /pricing uses: those three
 // are billing copy (the overage rate and the hard cap), not a tiers.js row.
-for (const line of ['2 signatures per month', '100 signatures per month, then &euro;0.40 each, up to 1,000', '1,000 signatures per month']) {
+for (const line of ['2 signatures a month', '100 signatures a month, then &euro;0.40 each, up to 1,000', '1,000 signatures a month']) {
   assert(productHtml.parasign.includes(line), 'parasign.html lost the quota line: ' + line);
 }
 assert(tiers.tierLimit('community', 'signs_month') === 2,
@@ -587,5 +669,30 @@ ok('the SLA figure on /pricing and /parasend is the one /sla publishes (' + SLA_
 assert(productHtml.parasend.includes('IEC 62443 / NIS2 / NEN 7510 documentation as input for your own compliance process, not third-party certification'),
   'parasend.html must qualify the compliance bullet where the bullet stands');
 ok('the compliance bullet on /parasend carries its own limit');
+
+// ── One spelling for the monthly period ──────────────────────────────────────
+//
+// The same Community limit shipped as "10 transfers a month" on / and /docs and
+// as "10 transfers per month" on /pricing, /parasend and /parasign. Both are
+// true, which is what makes it a problem: a buyer comparing two pages has to
+// work out whether that is one allowance or two, and every page that repeats a
+// limit multiplies the chance of a real drift hiding inside a wording drift.
+//
+// The site's form is "a month". The number checks above accept both spellings
+// on purpose, so a tiers.js change fails on the number; this is the only place
+// the wording is pinned, so a page that reverts fails here and says so plainly.
+(function oneMonthlyForm() {
+  const MONTHLY_FORM = /([\d,]+) (signatures|transfers|ParaSend transfers) per month/;
+  const PAGES = ['pricing.html', 'parasend.html', 'parasign.html', 'index.html', 'signup.html', 'help/index.html'];
+  for (const rel of PAGES) {
+    const pageHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', ...rel.split('/')), 'utf8');
+    const stray = MONTHLY_FORM.exec(pageHtml);
+    assert(!stray, rel + ' says "' + (stray ? stray[0] : '') + '"; the site says "' +
+      (stray ? stray[1] + ' ' + stray[2] : 'N noun') + ' a month" and one limit gets one spelling');
+    assert(/(signatures|transfers) a month/.test(pageHtml),
+      rel + ' no longer states a monthly allowance at all, so this gate is guarding nothing');
+  }
+  ok('every page that repeats a monthly limit uses one spelling ("a month")');
+})();
 
 console.log('pricing-page: ' + passed + ' checks passed');

--- a/relay/test/quota-upgrade-render.test.js
+++ b/relay/test/quota-upgrade-render.test.js
@@ -42,9 +42,9 @@ ok('isQuota402 accepts the three quota errors and nothing else');
 const free = q.html({ error: 'monthly_sign_quota_reached', plan: 'free', limit: 2, used: 2, reset_date: '2026-08-01' });
 for (const s of [
   "You've used both signatures this month.",
-  'Community gives you 2 per month, with the same encryption, the same post-quantum signatures and the same public proof log as every paid plan. You never pay for security here. You pay for volume.',
+  'Community gives you 2 a month, with the same encryption, the same post-quantum signatures and the same public proof log as every paid plan. You never pay for security here. You pay for volume.',
   'Pro - EUR 49/month',
-  '100 signatures per month, then EUR 0.40 each, up to 1,000. Unlimited transfers. API access.',
+  '100 signatures a month, then EUR 0.40 each, up to 1,000. Unlimited transfers. API access.',
   'Upgrade to Pro',
   'Maybe later',
   'Your limit resets on 2026-08-01.',
@@ -88,7 +88,7 @@ ok('free second signature renders the inline notice verbatim');
 
 const over = q.signNotice({ used: 101, included: 100, overage_count: 1, overage_rate_eur: 0.4, hard_cap: 1000, reset_date: '2026-08-01' });
 for (const s of [
-  "You've passed 100 signatures this month. Everything keeps working. Additional signatures are EUR 0.40 each and appear on your next invoice, up to 1,000 per month.",
+  "You've passed 100 signatures this month. Everything keeps working. Additional signatures are EUR 0.40 each and appear on your next invoice, up to 1,000 a month.",
   'Signing more than 600 a month? Business (EUR 299) works out cheaper.',
   'Compare plans',
 ]) {

--- a/tests/links.test.mjs
+++ b/tests/links.test.mjs
@@ -98,6 +98,30 @@ test('every internal link resolves to a page that exists', () => {
     `\n\n  Add the page, fix the path, or add the route to SERVER_ROUTES if the relay serves it.\n`);
 });
 
+// A page nothing links to is a page nobody reaches. /parasend shipped exactly
+// like that: the product page existed and was in the sitemap, and not one link
+// on the whole site pointed at it. /parasign had one, from /sign. The check
+// above proves a link leads somewhere; this proves a page is arrived at, which
+// is the other half of the same question.
+test('the two product pages are reachable, and from the homepage', () => {
+  const home = new Set(destinations(path.join(ROOT, 'index.html')).map((d) => d.split('?')[0].split('#')[0]));
+  const overal = new Map();
+  for (const { d, f } of alle) {
+    const clean = d.split('?')[0].split('#')[0];
+    if (!overal.has(clean)) overal.set(clean, new Set());
+    overal.get(clean).add(path.relative(ROOT, f));
+  }
+  for (const route of ['/parasign', '/parasend']) {
+    const bronnen = [...(overal.get(route) || [])].filter((f) => f !== route.slice(1) + '.html');
+    assert.ok(bronnen.length,
+      `Nothing on the site links to ${route}. The page exists and is in the sitemap, so it is` +
+      ` indexed and unreachable at the same time.`);
+    assert.ok(home.has(route),
+      `The homepage does not link to ${route}. It is where a visitor starts, and both products` +
+      ` are introduced there, so both product pages are reached from there.`);
+  }
+});
+
 const BASE = process.env.PARAMANT_BASE_URL || 'https://paramant.app';
 
 test('every file served from the docroot is really there', { skip: !process.env.CHECK_EXTERNAL_LINKS && 'set CHECK_EXTERNAL_LINKS=1 (runs hourly against production, not in pull requests)' }, async () => {

--- a/tests/navigation-shell.test.mjs
+++ b/tests/navigation-shell.test.mjs
@@ -36,7 +36,17 @@ ok('public navigation has four clear destinations', JSON.stringify(publicDesktop
 // the product is; ParaSend keeps its own call to action further down the page,
 // where it is next to the three lines that explain it.
 ok('public homepage leads with one primary action and one secondary', JSON.stringify(await publicPage.locator('[data-home="out"] .home-actions a').evaluateAll((nodes) => nodes.map((node) => node.getAttribute('href')))) === JSON.stringify(['/sign','/pricing']), await publicPage.locator('[data-home="out"] .home-actions').innerText());
-ok('the homepage still routes to ParaSend from its own section', JSON.stringify(await publicPage.locator('#products .prod-cta a').evaluateAll((nodes) => nodes.map((node) => node.getAttribute('href')))) === JSON.stringify(['/sign','/parashare']), await publicPage.locator('#products').innerText());
+// Both product PAGES have to be reachable from the homepage, not just the two
+// apps. /parasend shipped with no inbound link anywhere on the site and
+// /parasign had exactly one, from /sign: a product page nothing links to is a
+// page a buyer never sees. So the two-products section now leads with the page
+// that explains the product and keeps the app as the second action, and this
+// pins the order: explain first, app second, per card.
+await (async () => {
+  const ctas = await publicPage.locator('#products .prod-cta a').evaluateAll((nodes) => nodes.map((node) => node.getAttribute('href')));
+  ok('the homepage leads to both product pages, with the apps as the second action', JSON.stringify(ctas) === JSON.stringify(['/parasign','/sign','/parasend','/parashare']), await publicPage.locator('#products').innerText());
+  ok('the homepage still routes to ParaSend from its own section', ctas.includes('/parashare'), await publicPage.locator('#products').innerText());
+})();
 const publicMobilePaint = await publicPage.locator('nav.nav').evaluate((node) => ({
   background: getComputedStyle(node).backgroundColor,
   backdropFilter: getComputedStyle(node).backdropFilter,

--- a/tests/pricing-fold.test.mjs
+++ b/tests/pricing-fold.test.mjs
@@ -116,7 +116,7 @@ test('the first screen at 390px carries the amount, the audience, the founder an
     ['h1', '^Pricing$'],
     ['what', 'Sign documents and send files that vanish after one read'],
     ['amount', '€0 a month, forever'],
-    ['limit', '2 signatures per month, 10 transfers per month, 5 MB per file'],
+    ['limit', '2 signatures a month, 10 transfers a month, 5 MB per file'],
     // Both paid amounts, because they buy different products and a buyer who
     // only sees €15 has been told the price of the other one.
     ['sending', '€15 a month'],
@@ -178,7 +178,7 @@ test('pricing and signup use one term for what a free account gives', async () =
   const [pricingText, signupText] = [await text(pricing), await text(signup)];
   await pricing.close();
   await signup.close();
-  const TERM = '2 signatures per month';
+  const TERM = '2 signatures a month';
   assert.ok(pricingText.includes(TERM), `/pricing must say "${TERM}"`);
   assert.ok(signupText.includes(TERM), `/signup must use the same words as /pricing: "${TERM}"`);
   for (const [label, body] of [['pricing', pricingText], ['signup', signupText]]) {

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -527,7 +527,7 @@ assert.match(pricingVisible, /Sign documents and send files that vanish after on
 // The promise carries its own number. "Free forever" on its own reads as
 // generous until the table says two signatures a month, and a buyer who finds
 // that out one screen later has been sold to rather than told.
-assert.match(pricingVisible, /Community is &euro;0 a month, forever:<\/strong> 2 signatures per month, 10 transfers per month, 5 MB per file, no card\./,
+assert.match(pricingVisible, /Community is &euro;0 a month, forever:<\/strong> 2 signatures a month, 10 transfers a month, 5 MB per file, no card\./,
   'the free promise on pricing.html must carry the limits it actually means');
 // And they must be the limits the relay enforces, not the per-IP rate on the
 // deprecated anonymous endpoint. relay/test/pricing-page.test.js reads the
@@ -584,14 +584,14 @@ assert.doesNotMatch(heroText, /pay for the business plans, from <strong>&euro;\d
   'the lead must not price both products with one amount');
 
 // One term for the free limit, on both pages a buyer reads in the same minute.
-// /pricing said "2 signatures per month" and /signup said "sign 2 documents a
+// /pricing said "2 signatures a month" and /signup said "sign 2 documents a
 // month", which reads as two different products.
 const signupVisible = read('frontend/signup.html').replace(/<!--[\s\S]*?-->/g, '');
 for (const [label, html] of [['pricing.html', pricingVisible], ['signup.html', signupVisible]]) {
-  assert.match(html, /2 signatures per month/,
-    `${label} must name the free limit in the site's one term: "2 signatures per month"`);
+  assert.match(html, /2 signatures a month/,
+    `${label} must name the free limit in the site's one term: "2 signatures a month"`);
   assert.doesNotMatch(html, /\d+ documents a month/,
-    `${label} uses "documents a month" for the signature limit; the term is "2 signatures per month"`);
+    `${label} uses "documents a month" for the signature limit; the term is "2 signatures a month"`);
 }
 assert.doesNotMatch(signupVisible, /class="tier-card"|privacy and security researcher/,
   'signup.html must not carry tier tables or a founder block; it has already made the sale');
@@ -700,13 +700,13 @@ assert.match(helpAnswers, /open a signing request someone sent you/i,
 const parasignGrid = pricing.slice(pricing.indexOf('<!-- TIER CARDS: PARASIGN -->'));
 assert.ok(parasignGrid.length > 0 && parasignGrid.length < pricing.length,
   'pricing.html must keep the ParaSign tier grid this block reads from');
-assert.match(parasignGrid, /<div class="tier-name">Community<\/div>[\s\S]{0,400}?<li>2 signatures per month<\/li>/,
+assert.match(parasignGrid, /<div class="tier-name">Community<\/div>[\s\S]{0,400}?<li>2 signatures a month<\/li>/,
   'pricing.html is the source of the ParaSign Community allowance quoted on /help');
 assert.match(pricing, /&euro;49<span/,
   'pricing.html is the source of the ParaSign Pro price quoted on /help');
 assert.match(pricing, /charged &euro;59\.29\/mo incl\. 21% btw/,
   'pricing.html is the source of the incl. btw figure quoted on /help');
-assert.match(helpAnswers, /ParaSign Community is free, forever, and no card is required\. It covers 2 signatures per month\./,
+assert.match(helpAnswers, /ParaSign Community is free, forever, and no card is required\. It covers 2 signatures a month\./,
   'help/index.html must name the free allowance, not just promise that free exists');
 assert.match(helpAnswers, /ParaSign Pro at &euro;49 a month excl\. btw \(&euro;59\.29 incl\.\)/,
   'help/index.html must name the first paid price the way /pricing prints it');
@@ -818,7 +818,8 @@ const { default: tiers } = await import('../relay/lib/tiers.js');
 const parasign = visible('frontend/parasign.html');
 const parasend = visible('frontend/parasend.html');
 const aboutVisible = visible('frontend/about.html');
-const pricingVisible = visible('frontend/pricing.html');
+// pricingVisible above is the same page as markup; this is its plain text.
+const pricingText = visible('frontend/pricing.html');
 const security = visible('frontend/security.html');
 const signVisibleText = visible('frontend/sign.html');
 
@@ -868,13 +869,13 @@ for (const claim of [
 // Proof 3. The sentence the whole free-versus-paid split rests on. If the
 // pricing model ever gates cryptography behind a tier, this is what fails first.
 const SPLIT = 'Every plan gets the same encryption, the same post-quantum signatures and the same public proof log. Pay for volume, never for security. And pay per organisation, not per user.';
-for (const [name, text] of [['pricing', pricingVisible], ['parasign', parasign], ['parasend', parasend]]) {
+for (const [name, text] of [['pricing', pricingText], ['parasign', parasign], ['parasend', parasend]]) {
   assert.ok(text.includes(SPLIT), `${name}.html lost the pay-for-volume sentence`);
 }
 // The other half of the split: the free plan is permanent, it is called
 // Community, and the reason it stays free is named in the same sentence.
 const FREE_FOREVER = 'not to unlock features, and that is what keeps the Community plan free';
-for (const [name, text] of [['pricing', pricingVisible], ['parasign', parasign], ['parasend', parasend]]) {
+for (const [name, text] of [['pricing', pricingText], ['parasign', parasign], ['parasend', parasend]]) {
   assert.ok(text.includes(FREE_FOREVER), `${name}.html lost the Community-plan promise`);
 }
 // /sign carries the same split in one line, next to the account requirement,
@@ -958,11 +959,45 @@ const shareRow = registerRow('ParaShare (webapp)');
 assert.ok(shareRow && shareRow.length >= 4, 'crypto-agility.html no longer registers ParaShare (webapp)');
 const [, shareKem, shareSig, shareWire] = shareRow;
 assert.equal(shareKem, 'ML-KEM-768 + ECDH P-256', 'the ParaShare KEM in the register changed; /parasend quotes it');
-if (shareSig === 'n/a') {
+
+// These used to sit inside `if (shareSig === 'n/a')`, which made the register
+// the only thing under test: move the webapp to ML-DSA-65 in the register and
+// the guard simply stopped running, so /parasend and /pricing could go on
+// saying "signature n/a" and "no default signature algorithm" with nothing red.
+// The check now runs on whatever the SIG column holds and works in both
+// directions: the register's value has to be what the pages say, and a value
+// this test has no wording for fails loudly instead of passing quietly.
+// In its own scope: two parallel PRs each adding a top-level const under one
+// name is what stopped this file parsing on main, so nothing here reaches it.
+(function registerSignatureWording() {
+  const SIG_ON_PAGE = {
+    'n/a': { parasend: 'signature n/a', pricing: 'no default signature algorithm' },
+    'ML-DSA-65': { parasend: 'signature ML-DSA-65', pricing: 'ML-DSA-65 as its default signature algorithm' },
+  };
+  const wanted = SIG_ON_PAGE[shareSig];
+  assert.ok(wanted,
+    `crypto-agility.html now gives ParaShare (webapp) SIG "${shareSig}". /parasend and /pricing both ` +
+    `describe that column in words, and this test has no wording for the new value, so update both ` +
+    `pages and SIG_ON_PAGE together.`);
+  assert.ok(parasend.includes(wanted.parasend),
+    `the register gives ParaShare (webapp) SIG "${shareSig}", so /parasend must say "${wanted.parasend}"`);
+  assert.ok(pricing.includes(wanted.pricing),
+    `the register gives ParaShare (webapp) SIG "${shareSig}", so /pricing must say "${wanted.pricing}"`);
+  // The other direction: no page may carry the wording for a SIG the register
+  // does not give the webapp.
+  for (const [sig, wording] of Object.entries(SIG_ON_PAGE)) {
+    if (sig === shareSig) continue;
+    assert.ok(!parasend.includes(wording.parasend),
+      `/parasend describes ParaShare as "${wording.parasend}" while the register says "${shareSig}"`);
+    assert.ok(!pricing.includes(wording.pricing),
+      `/pricing describes ParaShare as "${wording.pricing}" while the register says "${shareSig}"`);
+  }
+})();
+assert.ok(parasend.includes(`the webapp on the ${shareWire} wire`),
+  '/parasend must state the wire format the register gives the webapp, not a better one');
+if (shareSig !== 'ML-DSA-65') {
   assert.doesNotMatch(parasend, /ParaShare[^.]*ML-DSA-65 signed receipts/,
     'the register gives ParaShare no signature, so /parasend may not sell it ML-DSA-65 signed receipts');
-  assert.ok(parasend.includes(`the webapp on the ${shareWire} wire`),
-    '/parasend must state the wire format the register gives the webapp, not a better one');
 }
 assert.doesNotMatch(parasend, /proof that the file came from you/,
   '/parasend may not promise sender proof on a path the register gives no signature');


### PR DESCRIPTION
Four truthfulness items after #339 and #336 merged, plus two files that stopped parsing when they did.

## 1. /parasend was unreachable, /parasign nearly

`/parasend` had zero inbound links anywhere on the site. `/parasign` had one, from `/sign`. Both are in the sitemap, so they were indexed and unreachable at the same time.

Both homepage product cards now lead with the page that explains the product and keep the app as the second action:

| card | was | now |
| --- | --- | --- |
| ParaSign | `/sign` | `/parasign`, then `/sign` |
| ParaSend | `/parashare` | `/parasend`, then `/parashare` |

Pinned twice. `tests/links.test.mjs` gains a reachability test: the existing check proves a link leads somewhere, this proves a page is arrived at. `tests/navigation-shell.test.mjs` pins the CTA order per card in the rendered page.

## 2. outbound_per_hour was enforced and stated nowhere

`relay/lib/tiers.js` carries `outbound_per_hour` (Community 50, Pro 500, Business 2000, Enterprise unlimited) and `relay/relay.js` enforces it in `outboundRateOk`, applied on `GET /v2/outbound/:hash` (relay.js:1627-1636, 4692). No page said so, so a Community account scripting its own downloads met a 429 it had never been told about.

It is now on `/parasend` per tier and on the `/parasign` Pro card, pinned to tiers.js like transfers, file size, expiry and devices.

It is stated as **retrievals**, not sends. `outboundRateOk` counts the account's own fetches with its own key: `entry.apiKey !== apiKey` returns 403, so the caller must be the uploader. The browser recipient path is `GET /v2/dl/:token/get` (relay.js:4004-4062), which has no rate limit at all, at the application layer or in `deploy/nginx-paramant-public.conf`. A recipient opening a link never spends the sender's hour. `pricing-page.test.js` bans `sends an hour` and `uploads an hour` on both product pages for that reason.

## 3. "Unlimited receiving" pointed at no field

It pointed at nothing in `tiers.js` or `entitlements.js`, and it is true: no per-account quota meters receiving. Being invited, opening an invitation and fetching the document capsule back are gated only by a 30/min per-IP window (`envViewRateOk`), and there is no index of envelopes an account was invited to, so there is nothing to cap. Putting your own signature on one does count, against `signs_month`.

The line now reads **No limit on receiving** on `/parasign`, `/pricing` and the homepage, and `/parasign` says what it rests on and names the one thing that is still counted.

Pinned negatively: `pricing-page.test.js` fails if any row in `tiers.TIER_LIMITS` or any entitlement quota block gains a key matching `/receiv|inbound/i`. The day receiving gets metered, the pages have to name the real ceiling.

`frontend/signup.html`'s meta descriptions and JSON-LD still say "unlimited receiving". Head elements are left alone here; #335 is open.

## 4. One spelling for the monthly period

The same Community limit shipped as `10 transfers a month` on `/` and `/docs` (#354) and `10 transfers per month` on `/pricing`, `/parasend` and `/parasign`. Both true, which is what makes it a problem: a buyer comparing two pages has to work out whether that is one allowance or two.

The site's form is `a month`, on pages, in `frontend/js/quota-upgrade.js`, and in `docs/brand/messaging.md`. `frontend/vs.html` is untouched: that figure is WeTransfer's own plan, not ours.

The two failures are kept apart on purpose. The number checks accept either spelling, so a `tiers.js` change fails on the number whatever the wording is that day. The wording is pinned once, in `MONTHLY_FORM`, so a page that drifts back fails on wording and not on a limit that is still correct.

## 5. Two test files could not parse on main

`#336` and `#339` each added a declaration under the same name in the same scope, and both merged:

- `relay/test/pricing-page.test.js`: two `const tiers = require('../lib/tiers')`
- `tests/ui-truthfulness.test.mjs`: two `const pricingVisible`

Both threw `SyntaxError: Identifier ... has already been declared` on `origin/main` and neither suite ran. Deduplicated; the second `pricingVisible` is a different value (tags stripped) and is renamed `pricingText` rather than merged.

## 6. ui-truthfulness: the register guard switched itself off

From the #339 end review. The ParaShare register assertions sat inside `if (shareSig === 'n/a')`, so moving the webapp to ML-DSA-65 in `crypto-agility.html` would stop the guard running and leave `/parasend` saying "signature n/a" with nothing red.

They now run on whatever the SIG column holds, in both directions: the register's value has to be what `/parasend` and `/pricing` say, no page may carry the wording for a value the register does not give, and a SIG the test has no wording for fails loudly instead of passing quietly.

## Tests

All green, and every new pin verified by sabotage:

`links`, `seo-contract`, `ui-truthfulness`, `site-claims`, `pricing-page` (46 checks), `pricing-fold`, `frontend-loading-contract`, `navigation-shell` (26 checks), `csp-inline`, `cache-bust`, `eslint`, `static-sanity` (10 green).

| sabotage | result |
| --- | --- |
| `tiers.js` community `outbound_per_hour` 50 to 60 | red on the number |
| `tiers.js` gains `inbound_per_hour` | red on "No limit on receiving" |
| `/parasend` back to "per month" | red on wording |
| `/parasend` says "sends an hour" | red on the send/retrieve distinction |
| `/parasign` drops the receiving line | red |
| `/parasign` drops the hourly line | red |
| homepage drops the `/parasend` link | red in `links` and in `navigation-shell` |
| register gives ParaShare ML-DSA-65 | red on `/parasend` and `/pricing` |
| register gives ParaShare an unmapped SIG | red, with what to update |

`pricing.html`, `about.html`, `security.html` and `trust.html`: #336 has merged so `pricing.html` is edited here; `about`, `security` and `trust` are untouched for #335. No head element changed.