### PR TITLE
Every ParaSend limit reads the product tier, not the plan billing leaves behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,77 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Every ParaSend limit now reads the product tier, not the unified `plan`.**
+  Billing writes a purchase with `setProductPlan` ->
+  `entitlements.applyProductTier`, which sets `plan_parasend` (or
+  `plan_parasign`) and deliberately leaves the unified `plan` alone. Three
+  enforcement points still resolved their ceiling off `plan` and so could not
+  see a paid ParaSend upgrade at all: the link TTL and the read count on
+  `POST /v2/inbound`, and the device cap on `POST /v2/pubkey`. The moment
+  self-serve billing goes live that would hold a ParaSend Pro customer to a
+  1 hour link, 1 read and 5 devices while `/pricing` sells him 24 hours, 10
+  reads and 50 devices. It is not visible today only because billing still runs
+  through the admin route, which sets `plan` as well. All six ParaSend ceilings
+  (TTL, max views, devices, transfers per month, blob size, downloads per hour)
+  now come from `getEntitlements(record).parasend`, and the ParaSign quotas from
+  `.parasign`. `outbound_per_hour` was the one dimension the entitlement layer
+  did not carry and has been added, mirroring `lib/tiers.js` like the rest.
+- **A key with no plan no longer gets the Pro ceiling.** The device cap
+  defaulted to `pro` (50 devices) and the DID-registration pubkey TTL to `pro`
+  (30 days) for a record with no plan on file, the mirror image of the default
+  already fixed on the inbound ceilings. A missing plan is not evidence of a
+  paid one; both now fall to Community, 5 devices and 7 days.
+- **The device cap counted nothing.** Registered pubkeys are stored under
+  `<device_id>:<account_id>`, but the cap counted entries ending in
+  `:<api_key>`, which equals the account id only for a key that has none. For
+  every real account the tally stayed 0 and the cap never fired at any tier.
+  It now counts the suffix the route writes, so the ceiling is enforced.
+
+  Because the cap never fired, accounts can be over it today, and a tier change
+  can put an account over it at any time. The cap governs how many devices an
+  account may HAVE, so it applies only to a registration that would ADD one:
+  `POST /v2/pubkey` for a device the account already holds skips the cap
+  entirely and answers on the device itself (`409` while the entry is live,
+  `200` renewing an entry whose TTL has passed but which the hourly sweep has
+  not reached). Without that skip an account over its cap got `429` on every
+  re-registration, which is the normal path rather than an edge: a Community
+  device pubkey lives 7 days, so devices come back to this route routinely, and
+  such an account would have lost them one at a time. **The change an operator
+  will see: an account over its tier's device count keeps every device it has
+  and is refused its next NEW one.**
+- **The device-pubkey TTL table had the same hole as `outbound_per_hour`.** It
+  held three rows (`free`, `pro`, `enterprise`) behind a `?? free` fallback, so
+  `community` and `business` were not in it and reached the free row by
+  accident. Every tier name a caller can produce now has its own row.
+- **A 402 over quota now names the tier that decided.** The transfer and sign
+  quota declines reported the unified `plan`, telling a paying customer he was
+  on a tier he was not being held to. Same for `GET /v2/admin/usage`, which
+  reported limits derived from `plan` while the gates enforced the product
+  tier; it now reports the enforced numbers and carries `parasend_tier` and
+  `parasign_tier` alongside `plan`.
+
+- **`GET /v2/admin/usage` reported an uncapped file size for a tier that is
+  capped.** The Enterprise row says `file_mb` is unlimited, but `POST /v2/inbound`
+  takes the lower of that and the operator's `MAX_BLOB`, so the gate enforces
+  5 MB while both usage routes reported `-1`. They now report
+  `min(MAX_BLOB, tier file_mb)`, which is what an upload is actually held to.
+  Genuinely uncapped dimensions, such as Enterprise devices, still report `-1`.
+- **A legacy `business` plan no longer gets the Enterprise ParaSend ceilings.**
+  `derivePlanParasend` mapped `business` up to `enterprise` on a "never silently
+  downgrade" reading. But `business` is a ParaSign tier name: an account whose
+  unified plan says `business` never bought ParaSend, and mapping it up handed
+  it the whole enterprise row, uncapped devices and downloads per hour, 100 reads
+  per link, a 365 day device-pubkey TTL and the 10000-receipt retention. That is
+  a silent upgrade, and the enterprise row is also where the resource ceilings
+  come off. Mapping it down to `pro` would have been the opposite error (2000
+  transfers a month cut to 500, a 7 day link cut to 24 hours). It now resolves to
+  its own row with exactly the numbers it has always had: 2000 transfers, 100
+  devices, a 7 day link, 25 reads, 2000 downloads an hour, 4000 receipts. The row
+  is resolved but never sold: `POST /v2/admin/keys/set-product-plan` still
+  rejects `business` as a ParaSend tier, and `/pricing` sells Community, Pro and
+  Enterprise as before.
+
 ### Changed
 - **The ParaSend delivery receipt moved out of the response header.**
   `GET /v2/outbound/:hash` used to answer with `X-Paramant-Receipt`, the whole

--- a/docs/api.md
+++ b/docs/api.md
@@ -132,7 +132,7 @@ Three things can take it away, and all three answer with the same 404:
 | | |
 |---|---|
 | **Time** | 15 minutes from the download. |
-| **Your own volume** | The relay keeps your account's most recent receipts, up to twice your tier's hourly download ceiling: community 100, pro 1000, business 4000, enterprise 10000. Past that your oldest receipts drop. Another account's downloads can never take yours. |
+| **Your own volume** | The relay keeps your account's most recent receipts, up to twice your ParaSend tier's hourly download ceiling: Community 100, Pro 1000, legacy business 4000, Enterprise 10000. Past that your oldest receipts drop. Another account's downloads can never take yours. |
 | **A relay without redis** | A relay configured with `REDIS_URL` keeps receipts in redis, so they survive a restart of the relay process. A relay without one keeps them in memory, and then a restart or a deploy loses every outstanding receipt. |
 
 If none of that is acceptable for your use, the receipt can still be delivered
@@ -545,14 +545,45 @@ curl -X POST https://iot.paramant.app/v2/attest \
 
 ---
 
-## Rate limits
+## ParaSend limits per tier
 
-| Tier | Uploads/day | Retention |
-|------|-------------|-----------|
-| Free (pgp_) | 10 | 1 hour |
-| Community (plk_) | unlimited | 1 hour |
-| Professional | unlimited | 24 hours |
-| Enterprise | unlimited | configurable |
+Every ceiling below is enforced from one source, the account's **ParaSend**
+tier. That tier is its own axis: it is carried by `plan_parasend` on the account
+and is independent of the ParaSign tier, so buying one product does not move the
+other. A ParaSend purchase raises `plan_parasend` alone, and every gate reads
+that, so the limits a customer is held to are the limits the pricing page sold
+him. An account with no tier on file is held to Community.
+
+| | Community | Pro | Enterprise |
+|---|---|---|---|
+| Transfers per month | 10 | 500 | 1,000,000 |
+| Link lifetime (max TTL) | 1 hour | 24 hours | 7 days |
+| Reads per link (max views) | 1 | 10 | 100 |
+| Registered devices | 5 | 50 | unlimited |
+| Max blob size | 5 MB | 5 MB | 5 MB (relay `MAX_BLOB`) |
+| Downloads per hour | 50 | 500 | unlimited |
+
+Notes:
+
+- **Downloads per hour** is a sliding one-hour window per API key on
+  `GET /v2/outbound/:hash`; over it the relay answers `429`. It also sets how
+  many delivery receipts your account keeps (twice this number, see above).
+- **Max blob size** is the lower of the tier's ceiling and the operator's
+  `MAX_BLOB`, which is 5 MB on the hosted relay and bounds relay memory. The
+  operator's value is always the last word, which is why an Enterprise account
+  is held to 5 MB as well and why `GET /v2/admin/usage` reports 5 rather than
+  "uncapped" for it.
+- **Reads per link** and **link lifetime** are ceilings, not defaults: a request
+  asking for more gets the ceiling back in the upload response, so the clamp is
+  visible to the caller. Asking for less is honoured as asked.
+- **Registered devices** is a ceiling on how many device public keys an account
+  may hold, not a limit on requests. A device the account already holds may
+  always re-register, so an account that is over the ceiling keeps its existing
+  devices working and is refused only a new one.
+- A legacy `business` plan is a ParaSign tier name. On ParaSend it keeps its own
+  row (2000 transfers a month, 100 devices, a 7 day link, 25 reads, 2000
+  downloads an hour) rather than being raised to Enterprise or cut to Pro. It is
+  resolved, never sold: ParaSend cannot be bought or granted at that tier.
 
 ---
 

--- a/frontend/docs/api.md
+++ b/frontend/docs/api.md
@@ -553,14 +553,45 @@ curl -X POST https://iot.paramant.app/v2/attest \
 
 ---
 
-## Rate limits
+## ParaSend limits per tier
 
-| Tier | Uploads/day | Retention |
-|------|-------------|-----------|
-| Free (pgp_) | 10 | 1 hour |
-| Community (plk_) | unlimited | 1 hour |
-| Professional | unlimited | 24 hours |
-| Enterprise | unlimited | configurable |
+Every ceiling below is enforced from one source, the account's **ParaSend**
+tier. That tier is its own axis: it is carried by `plan_parasend` on the account
+and is independent of the ParaSign tier, so buying one product does not move the
+other. A ParaSend purchase raises `plan_parasend` alone, and every gate reads
+that, so the limits a customer is held to are the limits the pricing page sold
+him. An account with no tier on file is held to Community.
+
+| | Community | Pro | Enterprise |
+|---|---|---|---|
+| Transfers per month | 10 | 500 | 1,000,000 |
+| Link lifetime (max TTL) | 1 hour | 24 hours | 7 days |
+| Reads per link (max views) | 1 | 10 | 100 |
+| Registered devices | 5 | 50 | unlimited |
+| Max blob size | 5 MB | 5 MB | 5 MB (relay `MAX_BLOB`) |
+| Downloads per hour | 50 | 500 | unlimited |
+
+Notes:
+
+- **Downloads per hour** is a sliding one-hour window per API key on
+  `GET /v2/outbound/:hash`; over it the relay answers `429`. It also sets how
+  many delivery receipts your account keeps (twice this number, see above).
+- **Max blob size** is the lower of the tier's ceiling and the operator's
+  `MAX_BLOB`, which is 5 MB on the hosted relay and bounds relay memory. The
+  operator's value is always the last word, which is why an Enterprise account
+  is held to 5 MB as well and why `GET /v2/admin/usage` reports 5 rather than
+  "uncapped" for it.
+- **Reads per link** and **link lifetime** are ceilings, not defaults: a request
+  asking for more gets the ceiling back in the upload response, so the clamp is
+  visible to the caller. Asking for less is honoured as asked.
+- **Registered devices** is a ceiling on how many device public keys an account
+  may hold, not a limit on requests. A device the account already holds may
+  always re-register, so an account that is over the ceiling keeps its existing
+  devices working and is refused only a new one.
+- A legacy `business` plan is a ParaSign tier name. On ParaSend it keeps its own
+  row (2000 transfers a month, 100 devices, a 7 day link, 25 reads, 2000
+  downloads an hour) rather than being raised to Enterprise or cut to Pro. It is
+  resolved, never sold: ParaSend cannot be bought or granted at that tier.
 
 ---
 

--- a/relay/lib/entitlements.js
+++ b/relay/lib/entitlements.js
@@ -15,7 +15,8 @@
 //                     legacy `plan` + `parasign` flag WITHOUT downgrading.
 //
 // Products and their tier ladders (Mick's brief):
-//   parasend: community | pro | enterprise
+//   parasend: community | pro | enterprise, plus a legacy `business` row that is
+//             resolved but never sold (PARASEND_LADDER)
 //   parasign: free | pro | business | enterprise
 //
 // Hard rule -- no unbounded metered tier. Monthly METERED quotas
@@ -31,8 +32,24 @@ const tiers = require('./tiers');
 
 const PRODUCTS = Object.freeze(['parasend', 'parasign']);
 
+// The tiers a purchase or an admin may GRANT on each product. /pricing sells
+// ParaSend as these three; validateProductPlan is held to them.
 const PARASEND_TIERS = Object.freeze(['community', 'pro', 'enterprise']);
 const PARASIGN_TIERS = Object.freeze(['free', 'pro', 'business', 'enterprise']);
+
+// The full ParaSend ladder, INCLUDING the legacy `business` row. `business` is
+// a ParaSign tier name that a legacy unified `plan` can carry, so an account
+// holding it never bought ParaSend and it may not be GRANTED as a ParaSend
+// tier. It still has to RESOLVE, and to the numbers it has always had:
+//   mapping it up to enterprise is a silent UPGRADE (uncapped devices, uncapped
+//     downloads per hour, 100 views per link, a 365 day device-pubkey TTL, the
+//     10000-receipt retention) for an account that never bought the product;
+//   mapping it down to pro is a silent DOWNGRADE (2000 transfers a month to
+//     500, 100 devices to 50, a 7 day link to 24 hours, 25 views to 10).
+// So it keeps its own row, reading the same tiers.js line it always did, ranked
+// between pro and enterprise. Nothing changes for a business account, which is
+// the point: this ladder RESOLVES a stored value, it does not sell one.
+const PARASEND_LADDER = Object.freeze(['community', 'pro', 'business', 'enterprise']);
 
 // Finite ceiling for enterprise metered monthly quotas. Legacy enterprise was
 // UNLIMITED (Infinity) for transfers_month/signs_month; a real business never
@@ -47,6 +64,7 @@ const ENTERPRISE_MONTHLY_CEILING = 1_000_000;
 const PARASEND_TIER_TO_TIERS = Object.freeze({
   community: 'community',
   pro: 'pro',
+  business: 'business', // legacy row, not a tier the pricing page sells
   enterprise: 'enterprise',
 });
 const PARASIGN_TIER_TO_TIERS = Object.freeze({
@@ -75,7 +93,7 @@ function _meteredFinite(v) {
 // Clamp an arbitrary string to a valid tier for the product, defaulting to the
 // product's floor so an unknown/typo value never grants more than the base tier.
 function normaliseParasendTier(t) {
-  return PARASEND_TIERS.includes(t) ? t : 'community';
+  return PARASEND_LADDER.includes(t) ? t : 'community';
 }
 function normaliseParasignTier(t) {
   return PARASIGN_TIERS.includes(t) ? t : 'free';
@@ -195,17 +213,19 @@ function applyProductTier(rec, product, tier, paidUntil) {
 // derivePlanParasend:
 //   community/free/dev -> community   (10 transfers, as today)
 //   pro                -> pro         (500, as today)
-//   business           -> enterprise  (business today = 2000 transfers; parasend
-//                                       has no business tier, so we go UP to
-//                                       enterprise rather than down to pro. This
-//                                       over-grants the transfer ceiling for the
-//                                       few business accounts, which is the safe
-//                                       side of "no silent downgrade".)
+//   business           -> business    (its own row, see PARASEND_LADDER. It used
+//                                       to map UP to enterprise, which handed an
+//                                       account that never bought ParaSend the
+//                                       enterprise resource ceilings. It now
+//                                       keeps exactly the numbers it has always
+//                                       had: 2000 transfers, 100 devices, a 7
+//                                       day link, 25 views, 2000 downloads an
+//                                       hour. Neither an upgrade nor a cut.)
 //   enterprise/licensed -> enterprise
 function derivePlanParasend(plan) {
   const p = tiers.normalisePlan(plan); // community | pro | business | enterprise
   if (p === 'pro') return 'pro';
-  if (p === 'business') return 'enterprise';
+  if (p === 'business') return 'business';
   if (p === 'enterprise') return 'enterprise';
   return 'community';
 }
@@ -242,6 +262,10 @@ function _parasendEntitlement(tier) {
       devices: tiers.tierLimitNum(row, 'devices'),
       view_ttl_ms: tiers.tierLimitNum(row, 'view_ttl_ms'),
       max_views: tiers.tierLimitNum(row, 'max_views'),
+      // The per-hour download ceiling was the one ParaSend dimension missing
+      // here, so relay.js had to read the legacy `plan` for it while every
+      // other ceiling came off this object. Mirrors tiers.js like the rest.
+      outbound_per_hour: tiers.tierLimitNum(row, 'outbound_per_hour'),
     }),
     features: Object.freeze({
       transfers: true,
@@ -274,7 +298,7 @@ function _parasignEntitlement(tier) {
 
 // Precompute the full matrix so getEntitlements is a pure lookup.
 const PARASEND = Object.freeze(Object.fromEntries(
-  PARASEND_TIERS.map((t) => [t, _parasendEntitlement(t)]),
+  PARASEND_LADDER.map((t) => [t, _parasendEntitlement(t)]),
 ));
 const PARASIGN = Object.freeze(Object.fromEntries(
   PARASIGN_TIERS.map((t) => [t, _parasignEntitlement(t)]),
@@ -326,7 +350,9 @@ function getEntitlements(account, now) {
 //              so the paid history is not thrown away
 //   paidUntil  null means unbounded
 function _grantOf(rec, product, at) {
-  const ladder = product === 'parasign' ? PARASIGN_TIERS : PARASEND_TIERS;
+  // The RESOLVING ladder, so a stored legacy `business` ranks where it belongs
+  // instead of falling off the list and tying with community.
+  const ladder = product === 'parasign' ? PARASIGN_TIERS : PARASEND_LADDER;
   const norm = product === 'parasign' ? normaliseParasignTier : normaliseParasendTier;
   return {
     rank: ladder.indexOf(effectiveProductTier(rec, product, at).tier),
@@ -427,6 +453,7 @@ function migrateUsersData(data) {
 module.exports = {
   PRODUCTS,
   PARASEND_TIERS,
+  PARASEND_LADDER,
   PARASIGN_TIERS,
   ENTERPRISE_MONTHLY_CEILING,
   derivePlanParasend,

--- a/relay/lib/tier-gate.js
+++ b/relay/lib/tier-gate.js
@@ -15,10 +15,12 @@ const entitlements = require('./entitlements');
 function parasendTier(keyData) { return entitlements.getEntitlements(keyData || {}).parasend.tier; }
 function parasignTier(keyData) { return entitlements.getEntitlements(keyData || {}).parasign.tier; }
 
-// "Pro+" on ParaSend: pro or enterprise (community is the free floor -> denied).
+// "Pro+" on ParaSend: pro, the legacy business row, or enterprise (community is
+// the free floor -> denied). business is on the list because it is a PAID tier
+// above pro's numbers; it is resolved, never sold (entitlements.PARASEND_LADDER).
 function isParasendProPlus(keyData) {
   const t = parasendTier(keyData);
-  return t === 'pro' || t === 'enterprise';
+  return t === 'pro' || t === 'business' || t === 'enterprise';
 }
 
 // "Pro+" on ParaSign: pro, business or enterprise (free is the floor -> denied).

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1332,6 +1332,41 @@ function entitlementRecordOf(accountId) {
   const members = accountKeys.get(accountId) || (apiKeys.has(accountId) ? new Set([accountId]) : new Set());
   return entitlements.mergeAccountRecord(acct, [...members].map(m => apiKeys.get(m)));
 }
+
+// EVERY ParaSend ceiling a request is held to, off the product axis and nowhere
+// else. Reading `keyData.plan` for a limit is the fault this function exists to
+// end: the Mollie webhook upgrades an account through setProductPlan ->
+// entitlements.applyProductTier, which writes plan_parasend and deliberately
+// never touches the unified `plan`. A gate reading `plan` therefore cannot see
+// a paid ParaSend upgrade at all, so a Pro buyer would keep the community hour,
+// the single read and the 5-device cap while /pricing sells him 24 hours, 10
+// reads and 50 devices. Only the manual admin route sets `plan` as well, which
+// is why nothing was visible before self-serve billing.
+//
+// A record with no tier on file resolves to community, the strictest ParaSend
+// tier. A missing plan is not evidence of a paid one; the previous `|| 'pro'`
+// defaults on the device cap and the pubkey TTL were the mirror image of that
+// rule and handed an unplanned key the Pro ceiling.
+function parasendLimitsOf(rec) {
+  return entitlements.getEntitlements(rec || null).parasend;
+}
+
+// An entitlement number as the admin views report it. The entitlement layer
+// says Infinity for an uncapped structural limit; the admin JSON has always
+// said -1 (tiers.UNLIMITED), and JSON.stringify turns Infinity into null, which
+// an operator reads as "no data" rather than "no cap".
+function _reportLimit(v) {
+  return v === Infinity ? tiers.UNLIMITED : v;
+}
+
+// The file ceiling an upload is really held to, in MB. POST /v2/inbound takes
+// the LOWER of the operator's MAX_BLOB and the tier's file_mb, so a tier whose
+// row says "uncapped" is still held to MAX_BLOB and the views must say so.
+// Reporting the bare tier value put -1 on an enterprise row while the gate was
+// enforcing 5 MB, and that is the one number an operator would act on.
+function _effectiveFileMb(ent) {
+  return Math.min(MAX_BLOB / 1048576, ent.parasend.limits.file_mb);
+}
 const blobStore  = new Map();  // hash → {blob, ts, ttl, size, sig?}
 
 const anonInboundIpRequests = new Map(); // ip → [timestamps] for /v2/anon-inbound rate limit
@@ -1621,11 +1656,14 @@ let inFlightInbound = 0;
 // and 'business' were not in it, so a Business account, which pays for the
 // highest volume of all, was rate limited at the free 50 per hour. tiers.js
 // normalises the plan name (free/dev -> community, licensed -> enterprise), so
-// every plan the pricing page sells now resolves to its own ceiling.
+// every plan the pricing page sells now resolves to its own ceiling. It takes
+// the KEY RECORD, not a plan string: outbound_per_hour is a ParaSend ceiling
+// and resolves on the product axis with the other five, so a webhook upgrade
+// (plan_parasend only) raises it.
 const OUTBOUND_RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour sliding window
 const outboundRateMap = new Map(); // apiKey → { count, resetAt }
-function outboundRateOk(apiKey, plan) {
-  const max = tiers.tierLimitNum(plan, 'outbound_per_hour');
+function outboundRateOk(apiKey, rec) {
+  const max = parasendLimitsOf(rec).limits.outbound_per_hour;
   if (max === Infinity) return true;
   const now = Date.now();
   let c = outboundRateMap.get(apiKey);
@@ -1692,9 +1730,11 @@ const RECEIPT_UNCAPPED_TIER_MAX = Math.max(1, parseInt(process.env.PARAMANT_RECE
 // A fixed override, for tests that need to drive the eviction rule without
 // making thousands of downloads. Unset in production, where the tier decides.
 const RECEIPT_PER_ACCOUNT_OVERRIDE = parseInt(process.env.PARAMANT_RECEIPT_PER_ACCOUNT_MAX || '0', 10) || 0;
-function receiptCapFor(plan) {
+// The retention cap rides on outbound_per_hour, so it is a ParaSend ceiling too
+// and takes the key record rather than a plan string.
+function receiptCapFor(rec) {
   if (RECEIPT_PER_ACCOUNT_OVERRIDE > 0) return RECEIPT_PER_ACCOUNT_OVERRIDE;
-  const rate = tiers.tierLimitNum(plan, 'outbound_per_hour');
+  const rate = parasendLimitsOf(rec).limits.outbound_per_hour;
   const cap = Number.isFinite(rate) ? rate * 2 : RECEIPT_UNCAPPED_TIER_MAX;
   return Math.max(1, Math.min(cap, RECEIPT_UNCAPPED_TIER_MAX));
 }
@@ -1718,10 +1758,10 @@ function _dropOldestOf(owner) {
   _dropReceipt(oldest.value);
   return true;
 }
-async function storeDeliveryReceipt(json, hash, apiKey, owner, plan) {
+async function storeDeliveryReceipt(json, hash, apiKey, owner, rec) {
   const id = crypto.randomBytes(16).toString('hex');
   const bucket = owner || apiKey || '_anonymous';
-  const cap = receiptCapFor(plan);
+  const cap = receiptCapFor(rec);
   if (redisClient && redisClient.isReady) {
     try {
       const ak = RECEIPT_AK(bucket);
@@ -2063,7 +2103,19 @@ function loadTrialKeys() {
 // devices count + view TTL + max views + monthly quotas + file size).
 // _pubkeyMax now reads device caps from TIER_LIMITS via tiers.tierLimitNum so
 // there is one source of truth for the per-tier device count.
-const _pubkeyTtl = { free: 7 * 86_400_000, pro: 30 * 86_400_000, enterprise: 365 * 86_400_000 };
+// Keyed on the ParaSend tier the callers resolve, plus `free`, which is what an
+// anonymous keyless DID registration passes. It used to hold three rows and a
+// `?? free` fallback, so `community` and `business` were not in it and reached
+// the free row by accident, the same kind of hole tiers.js closed for the other
+// dimensions. Every name a caller can produce now has its own row, so a value
+// is never the result of a miss.
+const _pubkeyTtl = {
+  free:        7 * 86_400_000,
+  community:   7 * 86_400_000,
+  pro:        30 * 86_400_000,
+  business:   30 * 86_400_000, // legacy plan name; never below pro
+  enterprise: 365 * 86_400_000,
+};
 const _pubkeyMax = new Proxy({}, {
   get(_t, plan) { return tiers.tierLimitNum(plan, 'devices'); },
 });
@@ -4204,11 +4256,35 @@ const server = http.createServer(async (req, res) => {
       }
       // Non-invite: require valid API key
       if (!keyData?.active) { res.writeHead(401); return res.end(J({ error: 'Invalid API key' })); }
-      const plan = keyData.plan || 'pro';
-      // Per-plan total device limit
-      const maxDevices = _pubkeyMax[plan] ?? _pubkeyMax.free;
-      if (maxDevices !== Infinity) {
-        const keyPrefix = `:${apiKey}`;
+      // Device cap on the PRODUCT axis (parasendLimitsOf), not on the unified
+      // `plan`. This read was `keyData.plan || 'pro'`: it could not see a
+      // webhook-written plan_parasend, and its default handed a key with no
+      // plan at all the Pro cap of 50 devices - the mirror image of the fault
+      // closed on the inbound ceilings. The strictest tier is the right
+      // default; _pubkeyMax stays as the tiers.js lookup for other callers.
+      const _psend = parasendLimitsOf(keyData);
+      const plan = _psend.tier;
+      const maxDevices = _psend.limits.devices;
+      // The cap governs how many devices an account may HAVE, so it applies to a
+      // registration that would ADD one. A device this account already holds is
+      // re-registered, not added: the map entry is replaced and the count does
+      // not grow. Checking the cap first turned every re-registration by an
+      // account over its cap into a 429, and re-registration is the normal path
+      // (a community device pubkey lives 7 days and the expiry sweep runs
+      // hourly), so an account over its cap could never refresh a device it
+      // already had and would lose them one by one. Being over the cap is a real
+      // state: every account that registered while the counter matched nothing
+      // (see below), and any account moved to a lower tier afterwards.
+      const _pkSlot = `${d.device_id}:${acctOf(apiKey)}`;
+      const _alreadyHeld = pubkeys.has(_pkSlot);
+      if (maxDevices !== Infinity && !_alreadyHeld) {
+        // Count what is actually STORED. Every write and every lookup on this
+        // map is keyed `<device_id>:<account_id>` (acctOf), but this counter
+        // matched on `:<api_key>`, which equals the account id only for a key
+        // that has none. So for every real account the tally stayed 0 and the
+        // cap never fired, whatever the tier said. Counting the same suffix
+        // the route writes makes the ceiling above enforceable.
+        const keyPrefix = `:${acctOf(apiKey)}`;
         let deviceCount = 0;
         for (const k of pubkeys.keys()) { if (k.endsWith(keyPrefix)) deviceCount++; }
         if (deviceCount >= maxDevices) {
@@ -4218,13 +4294,13 @@ const server = http.createServer(async (req, res) => {
       const ttl = _pubkeyTtl[plan] ?? _pubkeyTtl.free;
       const ctEntry = ctAppend(d.device_id, d.ecdh_pub, apiKey);
       const attestResult = verifyAttestation(d.ecdh_pub, d.device_id, d.attestation || null);
-      const existingPubkey = pubkeys.get(`${d.device_id}:${acctOf(apiKey)}`);
+      const existingPubkey = pubkeys.get(_pkSlot);
       if (existingPubkey && (!existingPubkey.expires || Date.now() < existingPubkey.expires)) {
         res.writeHead(409); return res.end(J({ error: 'Pubkey already registered for this session — first registration wins' }));
       }
       const fp = computeFingerprint(d.kyber_pub || '', d.ecdh_pub);
       const regAt = new Date().toISOString();
-      pubkeys.set(`${d.device_id}:${acctOf(apiKey)}`, {
+      pubkeys.set(_pkSlot, {
         ecdh_pub: d.ecdh_pub, kyber_pub: d.kyber_pub || '',
         dsa_pub:  d.dsa_pub  || '',
         fingerprint: fp, ct_index: ctEntry.index,
@@ -4547,7 +4623,13 @@ const server = http.createServer(async (req, res) => {
       // never held. The honest client sends hash = sha256(payload bytes), so this
       // is non-breaking. Rejected before peek / ctAppendTransfer / blobStore.set.
       if (crypto.createHash('sha256').update(blob).digest('hex') !== hash) { res.writeHead(400); return res.end(J({ error: 'hash_mismatch' })); }
-      const planMaxSize = MAX_BLOB;
+      // The blob ceiling: the operator's MAX_BLOB is the hard roof (it bounds
+      // relay memory and must stay the last word), and the tier may only be
+      // stricter. Every ParaSend row in tiers.js is 5 MB today and enterprise
+      // is uncapped, so the number is unchanged; what changes is that file_mb
+      // now sits on the product axis with the other five ceilings.
+      const _psend = parasendLimitsOf(keyData);
+      const planMaxSize = Math.min(MAX_BLOB, _psend.limits.file_mb * 1048576);
       if (blob.length > planMaxSize) { res.writeHead(413); return res.end(J({ error: `Max ${Math.round(planMaxSize/1048576)}MB` })); }
 
       try { peekInboundBlob(blob); }
@@ -4567,17 +4649,18 @@ const server = http.createServer(async (req, res) => {
         sigResult = verifyDsaSignature(hash, dsa_signature, keyData.dsa_pub);
       }
 
-      // Per-tier ceilings -- single source of truth in lib/tiers.js. ONE default
-      // for both, and it is the strictest one. The two used to disagree a line
-      // apart: the TTL fell back to 'community' and max_views to 'pro', so a key
-      // with no plan was held to the community link lifetime and handed the Pro
-      // read count at the same time. A missing plan is not evidence of a paid
-      // one, so both fall to community.
-      const _plan = keyData?.plan || 'community';
-      const _maxTtl = tiers.tierLimitNum(_plan, 'view_ttl_ms');
+      // Per-tier ceilings, off the SAME ParaSend entitlement as the size gate
+      // above and the quota gate below. ONE default for both, and it is the
+      // strictest one. The two used to disagree a line apart: the TTL fell back
+      // to 'community' and max_views to 'pro', so a key with no plan was held
+      // to the community link lifetime and handed the Pro read count at the
+      // same time. That default was fixed; the SOURCE was not, and reading the
+      // unified `plan` here meant a ParaSend Pro buyer still got 1 hour and 1
+      // read, because the webhook only ever writes plan_parasend.
+      const _maxTtl = _psend.limits.view_ttl_ms;
       const ttl = Math.min(parseInt(ttl_ms || TTL_MS), _maxTtl);
       // Access policies: max_views (default 1 = burn-on-read) + Argon2id password.
-      const maxViews = Math.max(1, Math.min(parseInt(reqMaxViews || 1) || 1, tiers.tierLimitNum(_plan, 'max_views') || 1));
+      const maxViews = Math.max(1, Math.min(parseInt(reqMaxViews || 1) || 1, _psend.limits.max_views || 1));
       let pw_hash = null;
       if (password) {
         if (!argon2Lib) { res.writeHead(501); return res.end(J({ error: 'Argon2id not available on this relay' })); }
@@ -4594,12 +4677,15 @@ const server = http.createServer(async (req, res) => {
         // ParaSend entitlement: transfers_month for this account's plan_parasend
         // (falls back to the legacy plan when not yet migrated). Independent of
         // the ParaSign signs quota below.
-        const _tLimit = entitlements.getEntitlements(keyData).parasend.quotas.transfers_month;
+        const _tLimit = _psend.quotas.transfers_month;
         const _tGate  = await quota.gateTransfer(redisClient, keyData.account_id, _dedupKey, _tLimit, log);
         if (!_tGate.allowed) {
-          log('info', 'quota_transfer_declined', { account: String(keyData.account_id).slice(0, 12), plan: keyData.plan || 'community', limit: _tLimit });
+          // Report the tier that DECIDED, not the unified plan. A ParaSend Pro
+          // buyer whose `plan` still reads community would otherwise be told
+          // he is on community while being held to the Pro ceiling.
+          log('info', 'quota_transfer_declined', { account: String(keyData.account_id).slice(0, 12), plan: _psend.tier, limit: _tLimit });
           res.writeHead(402, { 'Content-Type': 'application/json' });
-          return res.end(J({ error: 'monthly_transfer_quota_reached', dimension: 'transfers_month', plan: keyData.plan || 'community', limit: _tLimit }));
+          return res.end(J({ error: 'monthly_transfer_quota_reached', dimension: 'transfers_month', plan: _psend.tier, limit: _tLimit }));
         }
       }
 
@@ -4689,7 +4775,7 @@ const server = http.createServer(async (req, res) => {
     if (!entry) { res.writeHead(404); return res.end(J({ error: 'Not found. Expired, burned, or never stored.' })); }
     if (entry.apiKey && entry.apiKey !== apiKey) { res.writeHead(403); return res.end(J({ error: 'Forbidden' })); }
     // Per-key outbound rate limit (finding #12)
-    if (!outboundRateOk(apiKey, keyData?.plan)) {
+    if (!outboundRateOk(apiKey, keyData)) {
       res.writeHead(429, { 'Content-Type': 'application/json' });
       return res.end(J({ error: 'Outbound rate limit exceeded. Retry after the hourly window resets.' }));
     }
@@ -4785,9 +4871,9 @@ const server = http.createServer(async (req, res) => {
     if (receiptHeader) {
       const receiptHash = crypto.createHash('sha3-256').update(receiptHeader).digest('hex');
       const _receiptKey = entry.apiKey || apiKey || null;
-      const _receiptPlan = (_receiptKey && apiKeys.get(_receiptKey)?.plan) || keyData?.plan || 'community';
+      const _receiptRec = (_receiptKey && apiKeys.get(_receiptKey)) || keyData || null;
       const receiptId = await storeDeliveryReceipt(receiptJson, receiptHash, _receiptKey,
-        _receiptKey ? acctOf(_receiptKey) : null, _receiptPlan);
+        _receiptKey ? acctOf(_receiptKey) : null, _receiptRec);
       outHeaders['X-Paramant-Receipt-Id'] = receiptId;
       outHeaders['X-Paramant-Receipt-Hash'] = 'sha3-256:' + receiptHash;
       outHeaders['X-Paramant-Receipt-Url'] = `/v2/transfers/${receiptId}/receipt`;
@@ -4988,9 +5074,12 @@ const server = http.createServer(async (req, res) => {
       const _didIsNew = !didRegistry.has(did); // overwrite of same did must not double-count
       didRegistry.set(did, { device_id: d.device_id, key: ownerKey, doc, ts: new Date().toISOString() });
       if (_didIsNew && ownerKey) didKeyCounts.set(ownerKey, (didKeyCounts.get(ownerKey) || 0) + 1);
-      // Pubkey TTL follows the authenticated plan; an ANONYMOUS (keyless inv_)
-      // registration gets the free-tier TTL, never the pro default.
-      const _didPlan = keyData ? (keyData.plan || 'pro') : 'free';
+      // Pubkey TTL follows the authenticated ParaSend tier; an ANONYMOUS
+      // (keyless inv_) registration gets the free-tier TTL, never the pro
+      // default. Same fix as POST /v2/pubkey: the tier comes off the product
+      // axis, and a key with no plan on file lands on community (7 days) rather
+      // than being handed the pro 30 by the `|| 'pro'` default.
+      const _didPlan = keyData ? parasendLimitsOf(keyData).tier : 'free';
       pubkeys.set(`${d.device_id}:${acctOf(apiKey)}`, { ecdh_pub: d.ecdh_pub, kyber_pub: d.kyber_pub || '', dsa_pub: d.dsa_pub || '', ts: new Date().toISOString(), expires: Date.now() + (_pubkeyTtl[_didPlan] ?? _pubkeyTtl.free) });
       const ctEntry = ctAppend(d.device_id, d.ecdh_pub, apiKey);
       incMetric('did_registrations');
@@ -5197,19 +5286,26 @@ const server = http.createServer(async (req, res) => {
       const accountId = v.account_id || k;
       const usage = await quota.readUsage(redisClient, accountId, month);
       const plan = v.plan || 'community';
+      // The limits an operator reads here are the limits the relay enforces, so
+      // they come off the same product axis the gates read and NOT off the
+      // unified `plan`, which a webhook upgrade never moves. Both product tiers
+      // ride along, because `plan` alone no longer explains the numbers.
+      const ent = entitlements.getEntitlements(v);
       out.push({
         account_id: accountId,
         api_key_prefix: k.slice(0, 12),
         plan,
+        parasend_tier: ent.parasend.tier,
+        parasign_tier: ent.parasign.tier,
         label: v.label || '',
         email: v.email || null,
         active: !!v.active,
         usage,
         limits: {
-          transfers_month: tiers.tierLimit(plan, 'transfers_month'),
-          signs_month:     tiers.tierLimit(plan, 'signs_month'),
-          file_mb:         tiers.tierLimit(plan, 'file_mb'),
-          devices:         tiers.tierLimit(plan, 'devices'),
+          transfers_month: _reportLimit(ent.parasend.quotas.transfers_month),
+          signs_month:     _reportLimit(ent.parasign.quotas.signs_month),
+          file_mb:         _effectiveFileMb(ent),
+          devices:         _reportLimit(ent.parasend.limits.devices),
         },
       });
     }
@@ -5221,6 +5317,8 @@ const server = http.createServer(async (req, res) => {
     const accountId = decodeURIComponent(usageMatch[1]);
     const entry = [...apiKeys.entries()].find(([k, v]) => (v.account_id || k) === accountId || k === accountId);
     const plan = entry ? (entry[1].plan || 'community') : 'community';
+    // Same product axis as the list above and as the gates themselves.
+    const ent = entitlements.getEntitlements(entry ? entry[1] : null);
     const month = quota.ymKey();
     const usage = await quota.readUsage(redisClient, accountId, month);
     res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -5232,11 +5330,13 @@ const server = http.createServer(async (req, res) => {
       month,
       redis_available: !!(redisClient && redisClient.isReady),
       usage,
+      parasend_tier: ent.parasend.tier,
+      parasign_tier: ent.parasign.tier,
       limits: {
-        transfers_month: tiers.tierLimit(plan, 'transfers_month'),
-        signs_month:     tiers.tierLimit(plan, 'signs_month'),
-        file_mb:         tiers.tierLimit(plan, 'file_mb'),
-        devices:         tiers.tierLimit(plan, 'devices'),
+        transfers_month: _reportLimit(ent.parasend.quotas.transfers_month),
+        signs_month:     _reportLimit(ent.parasign.quotas.signs_month),
+        file_mb:         _effectiveFileMb(ent),
+        devices:         _reportLimit(ent.parasend.limits.devices),
       },
     }));
   }
@@ -5737,7 +5837,13 @@ const server = http.createServer(async (req, res) => {
     const successRate = total > 0 ? Math.round((acked / total) * 1000) / 1000 : 1;
     return res.end(J({
       ok:              true,
-      plan:            kd.plan || 'pro',
+      // Display only, no limit hangs off it. The unified plan stays the value
+      // of this long-standing field so nothing reading it breaks, but the
+      // default was the generous one (a key with no plan on file reported
+      // itself as pro), and the tier the stats beside it are actually measured
+      // against now travels alongside.
+      plan:            kd.plan || 'community',
+      parasend_tier:   parasendLimitsOf(kd).tier,
       blobs_in_flight: pending,
       stats: {
         inbound:       stats.inbound,
@@ -5811,12 +5917,16 @@ const server = http.createServer(async (req, res) => {
       if (keyData && keyData.account_id) {
         // ParaSign entitlement: signs_month for this account's plan_parasign
         // (independent of the ParaSend transfers quota). Separate counter key.
-        const _sLimit = entitlements.getEntitlements(keyData).parasign.quotas.signs_month;
+        const _psign  = entitlements.getEntitlements(keyData).parasign;
+        const _sLimit = _psign.quotas.signs_month;
         const _sGate  = await quota.gateSign(redisClient, keyData.account_id, _sLimit, log);
         if (!_sGate.allowed) {
-          log('info', 'quota_sign_declined', { account: String(keyData.account_id).slice(0, 12), plan: keyData.plan || 'community', limit: _sLimit });
+          // The tier that DECIDED, as on the transfer gate: the unified plan
+          // does not move on a ParaSign purchase either, so reporting it here
+          // tells a paying customer he is on a tier he is not being held to.
+          log('info', 'quota_sign_declined', { account: String(keyData.account_id).slice(0, 12), plan: _psign.tier, limit: _sLimit });
           res.writeHead(402, { 'Content-Type': 'application/json' });
-          return res.end(J({ error: 'monthly_sign_quota_reached', dimension: 'signs_month', plan: keyData.plan || 'community', limit: _sLimit }));
+          return res.end(J({ error: 'monthly_sign_quota_reached', dimension: 'signs_month', plan: _psign.tier, limit: _sLimit }));
         }
       }
 

--- a/relay/test/entitlements.test.js
+++ b/relay/test/entitlements.test.js
@@ -131,13 +131,31 @@ test('specific migration cases match the brief', () => {
   assert.strictEqual(comm.parasend.quotas.transfers_month, 10);
   assert.strictEqual(comm.parasign.quotas.signs_month, 2);
 
-  // business: parasign stays business (1000); parasend goes UP to enterprise
-  // (never below its current 2000 transfers).
+  // business: parasign stays business (1000); parasend keeps its OWN row.
+  //
+  // `business` is a ParaSign tier name, so an account whose unified plan says
+  // business never bought ParaSend. It used to map UP to enterprise on a
+  // no-downgrade reading, which handed that account the whole enterprise row:
+  // uncapped devices, uncapped downloads per hour, 100 views per link, a 365
+  // day device-pubkey TTL and the 10000-receipt retention. Mapping it DOWN to
+  // pro would have been the opposite error, cutting 2000 transfers to 500 and
+  // a 7 day link to 24 hours. It resolves to its own tiers.js row instead, so
+  // it is neither raised nor cut, and it stays ungrantable by an admin.
   const biz = ent.getEntitlements(ent.migrateUserEntry({ plan: 'business' }));
   assert.strictEqual(biz.parasign.tier, 'business');
   assert.strictEqual(biz.parasign.quotas.signs_month, 1000);
-  assert.strictEqual(biz.parasend.tier, 'enterprise');
-  assert.ok(biz.parasend.quotas.transfers_month >= 2000);
+  assert.strictEqual(biz.parasend.tier, 'business');
+  assert.notStrictEqual(biz.parasend.tier, 'enterprise',
+    'a ParaSign Business plan must never grant the ParaSend enterprise row');
+  // Exactly the legacy numbers, dimension for dimension, and nothing on the row
+  // is uncapped: that is what separates it from enterprise.
+  assert.strictEqual(biz.parasend.quotas.transfers_month, 2000);
+  assert.deepStrictEqual(biz.parasend.limits, {
+    file_mb: 5, devices: 100, view_ttl_ms: 604_800_000, max_views: 25, outbound_per_hour: 2000,
+  });
+  // And it is not a tier anyone can be sold or granted.
+  assert.strictEqual(ent.PARASEND_TIERS.includes('business'), false);
+  assert.deepStrictEqual(ent.validateProductPlan('parasend', 'business'), { ok: false, error: 'invalid_tier' });
 });
 
 test('migration is idempotent and additive (keeps plan + parasign)', () => {

--- a/relay/test/route-billing-entitlements.test.js
+++ b/relay/test/route-billing-entitlements.test.js
@@ -358,7 +358,10 @@ test('the four plan ids map to the tiers and quotas the pricing rests on', async
   const expected = {
     acct_community: { parasend: 'community', parasign: 'free', transfers: 10, signs: 2 },
     acct_pro: { parasend: 'pro', parasign: 'pro', transfers: 500, signs: 100 },
-    acct_business: { parasend: 'enterprise', parasign: 'business', transfers: 1_000_000, signs: 1000 },
+    // business keeps its own ParaSend row: it is a ParaSign tier name, so the
+    // account never bought ParaSend, and it is neither raised to enterprise nor
+    // cut to pro (entitlements.PARASEND_LADDER).
+    acct_business: { parasend: 'business', parasign: 'business', transfers: 2000, signs: 1000 },
     acct_enterprise: { parasend: 'enterprise', parasign: 'enterprise', transfers: 1_000_000, signs: 1_000_000 },
   };
   for (const [account, want] of Object.entries(expected)) {
@@ -413,6 +416,80 @@ test('the admin usage view reports the same per-tier limits it enforces', async 
   assert.strictEqual(r.json.limits.signs_month, 100);
   assert.strictEqual(r.json.limits.devices, 50);
   assert.strictEqual(r.json.redis_available, false, 'this relay runs without redis, and the view says so');
+  srv.stop();
+  did();
+});
+
+test('the usage view reports the tier that is ENFORCED, not the plan billing left behind', async () => {
+  // The Mollie webhook upgrades through setProductPlan -> applyProductTier,
+  // which writes plan_parasend and deliberately never the unified `plan`. This
+  // view read `plan`, so it would tell an operator "community, 10 transfers,
+  // 5 devices" about an account the relay is holding to the Pro 500 and 50 -
+  // and, before the read paths moved onto the product axis, the relay really
+  // was holding that paying account to the community numbers.
+  const srv = await withUsers('usage-axis', [
+    // The shape the webhook writes: paid on ParaSend, unified plan untouched.
+    { key: 'pgp_v_hook', plan: 'community', plan_parasend: 'pro', active: true, account_id: 'acct_v_hook', email: 'vh@example.test' },
+    // The shape POST /v2/admin/keys/update-plan writes: unified plan set, both
+    // product plans derived from it.
+    { key: 'pgp_v_admin', plan: 'pro', plan_parasend: 'pro', plan_parasign: 'pro', active: true, account_id: 'acct_v_admin', email: 'va@example.test' },
+    // No plan at all, the shape every key minted before the field has.
+    { key: 'pgp_v_none', active: true, account_id: 'acct_v_none', email: 'vn@example.test' },
+  ]);
+
+  const hook = await srv.get('/v2/admin/usage/acct_v_hook', { headers: { 'X-Admin-Token': ADMIN } });
+  assert.strictEqual(hook.status, 200, hook.text);
+  assert.strictEqual(hook.json.plan, 'community', 'the unified plan is what billing left behind');
+  assert.strictEqual(hook.json.parasend_tier, 'pro', 'and the ParaSend tier is the one that was paid for');
+  assert.strictEqual(hook.json.limits.transfers_month, 500, 'the operator reads the limit the gate enforces');
+  assert.strictEqual(hook.json.limits.devices, 50);
+
+  // Both shapes mean ParaSend Pro, so no ParaSend dimension may disagree. They
+  // differ on ParaSign on purpose: update-plan derives plan_parasign from the
+  // unified plan, a ParaSend purchase does not.
+  const admin = await srv.get('/v2/admin/usage/acct_v_admin', { headers: { 'X-Admin-Token': ADMIN } });
+  assert.strictEqual(admin.json.parasend_tier, hook.json.parasend_tier);
+  for (const dim of ['transfers_month', 'file_mb', 'devices']) {
+    assert.strictEqual(admin.json.limits[dim], hook.json.limits[dim],
+      `the admin shape and the webhook shape must buy the same ${dim}`);
+  }
+
+  const none = await srv.get('/v2/admin/usage/acct_v_none', { headers: { 'X-Admin-Token': ADMIN } });
+  assert.strictEqual(none.json.parasend_tier, 'community', 'a missing plan is not evidence of a paid one');
+  assert.strictEqual(none.json.limits.transfers_month, 10);
+  assert.strictEqual(none.json.limits.devices, 5);
+  srv.stop();
+  did();
+});
+
+test('the usage view reports the file ceiling the upload gate really applies', async () => {
+  // POST /v2/inbound takes the LOWER of the operator's MAX_BLOB and the tier's
+  // file_mb, so an uncapped tier row is still held to MAX_BLOB. Reporting the
+  // bare tier value put -1 on an enterprise account while the gate was
+  // enforcing 5 MB, and file_mb is the one number an operator would act on.
+  const srv = await withUsers('usage-file-mb', [
+    { key: 'pgp_f_ent', plan: 'enterprise', active: true, account_id: 'acct_f_ent', email: 'fe@example.test' },
+    { key: 'pgp_f_com', plan: 'community', active: true, account_id: 'acct_f_com', email: 'fc@example.test' },
+  ]);
+  const ent = await srv.get('/v2/admin/usage/acct_f_ent', { headers: { 'X-Admin-Token': ADMIN } });
+  assert.strictEqual(ent.status, 200, ent.text);
+  assert.strictEqual(ent.json.parasend_tier, 'enterprise');
+  assert.strictEqual(ent.json.limits.file_mb, 5,
+    'the enterprise row says uncapped, the relay enforces MAX_BLOB, and the view must say what is enforced');
+  assert.notStrictEqual(ent.json.limits.file_mb, -1, 'never report uncapped for a ceiling that is capped');
+  // devices really is uncapped on enterprise, and that still reports as -1, so
+  // the fix is about the file ceiling and not about flattening every -1.
+  assert.strictEqual(ent.json.limits.devices, -1);
+
+  const com = await srv.get('/v2/admin/usage/acct_f_com', { headers: { 'X-Admin-Token': ADMIN } });
+  assert.strictEqual(com.json.limits.file_mb, 5, 'a capped tier reads its own value, unchanged');
+
+  // The list view is the same view over every account and must not disagree.
+  const list = await srv.get('/v2/admin/usage', { headers: { 'X-Admin-Token': ADMIN } });
+  assert.strictEqual(list.status, 200, list.text);
+  for (const row of list.json.accounts) {
+    assert.strictEqual(row.limits.file_mb, 5, `${row.account_id} in the list view`);
+  }
   srv.stop();
   did();
 });

--- a/relay/test/route-transfer-burn.test.js
+++ b/relay/test/route-transfer-burn.test.js
@@ -608,3 +608,228 @@ test('a caller may delete its own blob before anyone reads it, and only its own'
   assert.strictEqual((await download(PRO, b.hash)).status, 404, 'the aborted blob is really gone');
   did();
 });
+
+// ── 6. every ParaSend ceiling rides the PRODUCT axis, not the unified plan ────
+//
+// THE FAULT THIS SECTION PINS. Billing moves a customer with setProductPlan ->
+// entitlements.applyProductTier, which writes plan_parasend (or plan_parasign)
+// and never the unified `plan`. Four ceilings still resolved off `plan`:
+//   relay.js  view_ttl_ms and max_views on POST /v2/inbound
+//   relay.js  the device cap on POST /v2/pubkey
+//   relay.js  transfers_month, the only one already on the product axis
+// So the moment self-serve billing goes live, a ParaSend Pro customer keeps a
+// 1 hour link, 1 read and 5 devices while /pricing sells 24 hours, 10 reads and
+// 50 devices. It is invisible today only because billing still runs through the
+// admin route, which sets `plan` as well.
+//
+// Everything this section needs lives inside this function. Two parallel merges
+// broke main by each adding their own file-scope binding, so a new block earns
+// no new top-level name here.
+(function productAxisSection() {
+
+  // THE SHAPE THE MOLLIE WEBHOOK WRITES. setProductPlan -> applyProductTier moves
+  // plan_parasend only and deliberately leaves the unified `plan` alone, so a
+  // ParaSend Pro buyer's record still reads plan: 'community'. Every ceiling that
+  // resolved off `plan` was blind to this record.
+  const WEBHOOK = 'pgp_webhook_shape_key_for_the_transfer_suite';
+  // The shape POST /v2/admin/keys/update-plan writes: the unified plan set AND
+  // the per-product plans derived from it. It means the same thing as WEBHOOK and
+  // must be answered identically.
+  const ADMIN_SHAPE = 'pgp_admin_shape_key_for_the_transfer_suite';
+  // A key with no plan. The suite's shared relay already sits at the community
+  // edition's fixed 5-key ceiling (relay.js COMMUNITY_KEY_LIMIT), where key 6
+  // answers 402 to everything, so this section boots its own relay.
+  const AXIS_NOPLAN = 'pgp_no_plan_key_for_the_axis_section';
+
+  // One relay for the section, booted on first use and killed by the suite's
+  // after() hook along with everything else.
+  let axis = null;
+  async function axisSrv() {
+    if (!axis) {
+      axis = await boot({
+        tag: 'transfer-axis',
+        users: { api_keys: [
+          { key: WEBHOOK, plan: 'community', plan_parasend: 'pro', active: true, email: 'hook@example.test', account_id: 'acct_hook' },
+          { key: ADMIN_SHAPE, plan: 'pro', plan_parasend: 'pro', plan_parasign: 'pro', active: true, email: 'adm@example.test', account_id: 'acct_admin_shape' },
+          { key: AXIS_NOPLAN, active: true, email: 'axisnoplan@example.test', account_id: 'acct_axis_noplan' },
+        ] },
+      });
+    }
+    return axis;
+  }
+  const axisUpload = (a, key, b, extra = {}) => a.post('/v2/inbound', {
+    headers: { 'X-Api-Key': key },
+    body: { hash: b.hash, payload: b.payload.toString('base64'), ...extra },
+  });
+  const axisDownload = (a, key, hash) => a.get(`/v2/outbound/${hash}`, { headers: { 'X-Api-Key': key } });
+
+  test('a ParaSend Pro tier bought through the webhook is honoured, though `plan` still reads community', async () => {
+    const a = await axisSrv();
+    const week = 7 * 86_400_000;
+    const t = await axisUpload(a, WEBHOOK, blob('hook-ttl'), { ttl_ms: week });
+    assert.strictEqual(t.status, 200, t.text);
+    assert.strictEqual(t.json.ttl_ms, 86_400_000,
+      'the Pro day the customer paid for, not the community hour his unified plan still says');
+
+    const v = blob('hook-views');
+    assert.strictEqual((await axisUpload(a, WEBHOOK, v, { max_views: 10 })).status, 200);
+    for (let i = 1; i <= 10; i++) {
+      const r = await axisDownload(a, WEBHOOK, v.hash);
+      assert.strictEqual(r.status, 200, `read ${i} of the ten a Pro tier buys`);
+      assert.strictEqual(r.headers['x-paramant-burned'], i === 10 ? 'true' : 'false');
+    }
+    assert.strictEqual((await axisDownload(a, WEBHOOK, v.hash)).status, 404, 'and the eleventh is past the Pro ceiling');
+    did();
+  });
+
+  test('the device cap follows the ParaSend tier, and a plan-less key gets the community five', async () => {
+    // lib/tiers.js: community.devices = 5, pro.devices = 50. The read here used to
+    // be `keyData.plan || 'pro'`, so it missed the webhook record AND handed a key
+    // with no plan at all the Pro cap: the mirror image of the default fixed on
+    // the inbound ceilings.
+    const a = await axisSrv();
+    const dev = (key, n) => {
+      const id = `${key}-device-${n}`;
+      return a.post('/v2/pubkey', {
+        headers: { 'X-Api-Key': key },
+        body: { device_id: id, ecdh_pub: Buffer.from(id.padEnd(32, 'x')).toString('base64') },
+      });
+    };
+    for (let n = 1; n <= 5; n++) {
+      assert.strictEqual((await dev(AXIS_NOPLAN, n)).status, 200, `plan-less device ${n} of the community five`);
+    }
+    const sixth = await dev(AXIS_NOPLAN, 6);
+    assert.strictEqual(sixth.status, 429, 'a missing plan must not quietly buy the Pro cap of fifty devices');
+    assert.strictEqual(sixth.json.limit, 5);
+    assert.strictEqual(sixth.json.plan, 'community', 'and the 429 names the tier that decided');
+
+    for (let n = 1; n <= 6; n++) {
+      assert.strictEqual((await dev(WEBHOOK, n)).status, 200,
+        `device ${n} on a webhook-written Pro tier, which the community five would have refused at 6`);
+    }
+    did();
+  });
+
+  test('the device cap governs adding a device, never re-registering one it already holds', async () => {
+    // The cap check used to run BEFORE the already-registered check, so an
+    // account over its cap got 429 on every re-registration of a device it
+    // already had. That is the normal path, not an edge: a community device
+    // pubkey lives 7 days and the expiry sweep runs hourly, so a device comes
+    // back to this route routinely. An account over its cap would have been
+    // locked out one device at a time, and being over the cap is a real state:
+    // the counter matched nothing until this branch, so an account could hold
+    // any number, and a tier change can put an account over it at any time.
+    const KEY = 'pgp_over_cap_key_for_the_axis_section';
+    const over = await boot({
+      tag: 'transfer-axis-cap',
+      env: { ADMIN_TOKEN: 'admin-token-for-the-axis-section', INTERNAL_AUTH_TOKEN: 'internal-token-for-the-axis-section' },
+      users: { api_keys: [
+        // Starts uncapped, so the eight devices below can be registered at all.
+        { key: KEY, plan: 'community', plan_parasend: 'enterprise', active: true, email: 'cap@example.test', account_id: 'acct_over_cap' },
+      ] },
+    });
+    const reg = (n) => {
+      const id = `over-cap-device-${n}`;
+      return over.post('/v2/pubkey', {
+        headers: { 'X-Api-Key': KEY },
+        body: { device_id: id, ecdh_pub: Buffer.from(id.padEnd(32, 'x')).toString('base64') },
+      });
+    };
+    for (let n = 1; n <= 8; n++) assert.strictEqual((await reg(n)).status, 200, `device ${n} while uncapped`);
+
+    // Now move the account down to Community, whose cap is 5. It holds 8.
+    const moved = await over.post('/v2/admin/keys/set-product-plan', {
+      headers: { 'X-Admin-Token': 'admin-token-for-the-axis-section', 'X-Internal-Auth': 'internal-token-for-the-axis-section' },
+      body: { key: KEY, product: 'parasend', tier: 'community' },
+    });
+    assert.strictEqual(moved.status, 200, moved.text);
+
+    // Every device it already holds still answers on its own merits. The live
+    // entry answers 409 (first registration wins, the guard further down the
+    // route); what matters is that it is the device answer and not the quota
+    // answer. An entry whose TTL has passed but which the hourly sweep has not
+    // reached yet takes the same skip and is renewed with a 200.
+    for (let n = 1; n <= 8; n++) {
+      const again = await reg(n);
+      assert.notStrictEqual(again.status, 429,
+        `re-registering held device ${n} must not be refused for the cap the account is already over`);
+      assert.strictEqual(again.status, 409, `held device ${n} answers on device identity, not on quota`);
+    }
+
+    // A device it does NOT hold is a new one, and the cap applies to it.
+    const ninth = await reg(9);
+    assert.strictEqual(ninth.status, 429, 'a ninth device is an addition, and an account 3 over its cap gets none');
+    assert.strictEqual(ninth.json.limit, 5);
+    assert.strictEqual(ninth.json.plan, 'community');
+    over.stop();
+    did();
+  });
+
+  test('the admin route\'s record shape and the webhook\'s answer identically', async () => {
+    // update-plan sets `plan` and derives the per-product plans; the webhook sets
+    // plan_parasend alone. Both mean ParaSend Pro, so no ceiling may disagree.
+    const a = await axisSrv();
+    const week = 7 * 86_400_000;
+    const hook = await axisUpload(a, WEBHOOK, blob('shape-hook-ttl'), { ttl_ms: week });
+    const admin = await axisUpload(a, ADMIN_SHAPE, blob('shape-admin-ttl'), { ttl_ms: week });
+    assert.strictEqual(hook.json.ttl_ms, admin.json.ttl_ms, 'the two shapes must buy the same link lifetime');
+    assert.strictEqual(hook.json.ttl_ms, 86_400_000);
+
+    const hv = blob('shape-hook-views');
+    const av = blob('shape-admin-views');
+    assert.strictEqual((await axisUpload(a, WEBHOOK, hv, { max_views: 10 })).status, 200);
+    assert.strictEqual((await axisUpload(a, ADMIN_SHAPE, av, { max_views: 10 })).status, 200);
+    const h1 = await axisDownload(a, WEBHOOK, hv.hash);
+    const a1 = await axisDownload(a, ADMIN_SHAPE, av.hash);
+    assert.strictEqual(h1.headers['x-paramant-burned'], a1.headers['x-paramant-burned'],
+      'the two shapes must buy the same read count');
+    assert.strictEqual(h1.headers['x-paramant-burned'], 'false',
+      'ten reads on both, so neither burns on the first');
+    did();
+  });
+
+  test('with redis counting, the monthly transfer quota is the one the ParaSend tier bought', async () => {
+    // transfers_month is the one ceiling that was already on the product axis, so
+    // this pins the axis end to end: the same record shape, the same tier, four
+    // ceilings, one source. The gate fails open without redis (lib/quota.js), so
+    // this is the one test in the section that needs a real counter.
+    const rc = await requireRedis(DEFAULT_REDIS);
+    if (!rc) return;
+    try {
+      // Fresh account ids per run: the counter is a calendar-month key in redis
+      // and a rerun would otherwise start where the previous one stopped.
+      const tag = crypto.randomBytes(6).toString('hex');
+      const HOOK = 'pgp_quota_hook_shape';
+      const COM = 'pgp_quota_community';
+      const srv2 = await boot({
+        tag: 'transfer-quota-axis',
+        env: { REDIS_URL: process.env.REDIS_URL || DEFAULT_REDIS },
+        users: { api_keys: [
+          { key: HOOK, plan: 'community', plan_parasend: 'pro', active: true, email: 'qh@example.test', account_id: `acct_q_hook_${tag}` },
+          { key: COM, plan: 'community', active: true, email: 'qc@example.test', account_id: `acct_q_com_${tag}` },
+        ] },
+      });
+      const send = (key) => {
+        const b = blob('quota');
+        return srv2.post('/v2/inbound', { headers: { 'X-Api-Key': key }, body: { hash: b.hash, payload: b.payload.toString('base64') } });
+      };
+      // community.transfers_month = 10.
+      for (let i = 1; i <= 10; i++) assert.strictEqual((await send(COM)).status, 200, `community transfer ${i}`);
+      const over = await send(COM);
+      assert.strictEqual(over.status, 402, 'the eleventh community transfer is over the monthly cap');
+      assert.strictEqual(over.json.limit, 10);
+      assert.strictEqual(over.json.plan, 'community', 'the 402 names the tier that decided, not the unified plan');
+
+      // The webhook-shaped record has the same unified plan and must not stop at 10.
+      for (let i = 1; i <= 11; i++) {
+        assert.strictEqual((await send(HOOK)).status, 200,
+          `transfer ${i} on a webhook-written ParaSend Pro tier (500 a month, not the community 10)`);
+      }
+      srv2.stop();
+      did();
+    } finally {
+      try { await rc.quit(); } catch (_) { /* already gone */ }
+    }
+  });
+
+})();

--- a/relay/test/tier-gate.test.js
+++ b/relay/test/tier-gate.test.js
@@ -17,7 +17,7 @@ test('ParaSend Pro+: community/free denied, pro/business/enterprise allowed', ()
   assert.strictEqual(tg.isParasendProPlus({ plan: 'community' }), false);
   assert.strictEqual(tg.isParasendProPlus({ plan: 'free' }), false);
   assert.strictEqual(tg.isParasendProPlus({ plan: 'pro' }), true);
-  assert.strictEqual(tg.isParasendProPlus({ plan: 'business' }), true);   // -> parasend enterprise
+  assert.strictEqual(tg.isParasendProPlus({ plan: 'business' }), true);   // -> parasend business
   assert.strictEqual(tg.isParasendProPlus({ plan: 'enterprise' }), true);
   assert.strictEqual(tg.isParasendProPlus(null), false);                  // malformed never over-grants
   assert.strictEqual(tg.isParasendProPlus({ plan_parasend: 'bogus' }), false);


### PR DESCRIPTION
Found in review of #339 and not fixed there. Latent today, live the moment self-serve billing is switched on.

## The fault

Billing writes a purchase through `setProductPlan` -> `entitlements.applyProductTier` (relay/lib/entitlements.js), which sets `plan_parasend` or `plan_parasign` and deliberately never touches the unified `plan`. That is the Mollie webhook path (relay.js, `POST /v2/billing/webhook`). Three enforcement points still resolved their ceiling off `plan`, so they could not see a paid ParaSend upgrade at all.

A ParaSend Pro customer would keep a 1 hour link, 1 read and 5 devices while `/pricing` sells him 24 hours, 10 reads and 50 devices. It is invisible today only because billing still runs by hand through `POST /v2/admin/keys/update-plan`, which sets `plan` as well as the derived product plans.

## Per read place, old and new

| Where | Was | Now |
|---|---|---|
| `POST /v2/inbound` view TTL | `tiers.tierLimitNum(keyData.plan or 'community', 'view_ttl_ms')` | `parasendLimitsOf(keyData).limits.view_ttl_ms` |
| `POST /v2/inbound` max views | `tiers.tierLimitNum(keyData.plan or 'community', 'max_views')` | `.limits.max_views` |
| `POST /v2/inbound` blob size | `MAX_BLOB` alone, tier ignored | `Math.min(MAX_BLOB, .limits.file_mb * 1MB)`, operator value still the last word |
| `POST /v2/inbound` transfers per month | already `getEntitlements(...).parasend` | same object, reused |
| `POST /v2/pubkey` device cap | `_pubkeyMax[keyData.plan or 'pro']` | `.limits.devices` |
| `GET /v2/outbound/:hash` rate limit | `outboundRateOk(apiKey, keyData?.plan)` | `outboundRateOk(apiKey, keyData)` reading `.limits.outbound_per_hour` |
| delivery receipt retention | `receiptCapFor(plan string)` | `receiptCapFor(record)`, same derivation from `outbound_per_hour` |
| `POST /v2/did/register` pubkey TTL | `keyData.plan or 'pro'` | `parasendLimitsOf(keyData).tier` |
| 402 over transfer or sign quota | body and log said `keyData.plan or 'community'` | the tier that actually decided |
| `GET /v2/admin/usage` (both routes) | limits from `tiers.tierLimit(plan, ...)` | from the entitlement, plus `parasend_tier` and `parasign_tier`; `file_mb` is `min(MAX_BLOB, tier file_mb)` |
| device-pubkey TTL table | 3 rows behind a `?? free` fallback | a row per tier name a caller can produce |

`outbound_per_hour` was the one ParaSend dimension the entitlement layer did not carry. Added to `_parasendEntitlement`, mirroring `lib/tiers.js` exactly like the other four, so the relay never has to reach for the legacy plan for a limit again.

Left alone on purpose, all reporting or legacy inheritance and no limit hangs off them: `mintParasignKey`'s plan inheritance (it already resolves the product grants separately through `entitlementRecordOf`), the `plan` echo on key validation, `GET /v2/key-sector`, and the `plan` field on `GET /v2/monitor` (kept as the unified plan so nothing reading it breaks, but its `or 'pro'` default is now `or 'community'` and `parasend_tier` travels beside it).

## Two things found on the way

**The device cap counted nothing.** Registered pubkeys are stored and looked up under `<device_id>:<account_id>` (`acctOf`), but the cap counted map entries ending in `:<api_key>`, which equals the account id only for a key that has none. For every real account the tally stayed 0 and the cap never fired at any tier. Fixed by counting the suffix the route writes.

Because the cap never fired, accounts can be over it today, and a tier change can put one over it at any moment. So the cap governs **adding** a device, not re-registering one. `POST /v2/pubkey` for a device the account already holds skips the cap entirely and answers on the device itself: `409` while the entry is live (first registration wins), `200` renewing an entry whose TTL has passed but which the hourly sweep has not reached. Without that skip an account over its cap got `429` on every re-registration, and re-registration is the normal path rather than an edge, because a Community device pubkey lives 7 days and devices come back to this route routinely. Such an account would have lost its devices one at a time.

**Behaviour change an operator will see:** an account over its tier's device count keeps every device it already has, and is refused only its next new one.

**The strictest default.** The device cap defaulted to `pro` (50 devices) and the DID-registration pubkey TTL to `pro` (30 days) for a record with no plan on file, the mirror image of the default already closed on the inbound ceilings at :4570. Both fall to community now, 5 devices and 7 days.

**The usage view reported an uncapped file size for a tier that is capped.** The Enterprise row says `file_mb` is unlimited, but `POST /v2/inbound` takes the lower of that and the operator's `MAX_BLOB`, so the gate enforces 5 MB while both usage routes reported `-1`. They now report `min(MAX_BLOB, tier file_mb)`. Genuinely uncapped dimensions, such as Enterprise devices, still report `-1`, so this is not a flattening of every `-1`.

## The legacy `business` plan keeps its own ParaSend row

`derivePlanParasend` mapped `business` up to `enterprise` on a "never silently downgrade" reading. But `business` is a ParaSign tier name: an account whose unified plan says `business` never bought ParaSend, and mapping it up handed it the whole enterprise row, which is also where the resource ceilings come off. That is a silent upgrade: uncapped devices, uncapped downloads per hour, 100 reads per link, a 365 day device-pubkey TTL, the 10000-receipt retention.

Mapping it down to `pro` would have been the opposite error and is a real downgrade: 2000 transfers a month cut to 500, 100 devices to 50, a 7 day link to 24 hours, 25 reads to 10. It also breaks the no-downgrade invariant that `entitlements.test.js` already pins for every legacy plan.

So `business` resolves to its own row, reading the same `tiers.js` line it always read: 2000 transfers, 100 devices, a 7 day link, 25 reads, 2000 downloads an hour, 4000 receipts. Neither raised nor cut.

The row is **resolved, never sold.** `PARASEND_TIERS` stays the three tiers `/pricing` sells and is what `validateProductPlan` is held to, so `POST /v2/admin/keys/set-product-plan` still rejects `business` as a ParaSend tier. A second list, `PARASEND_LADDER`, carries the legacy row for normalising, ranking and the entitlement matrix. `docs/api.md` updated accordingly.

## Tests

`relay/test/route-transfer-burn.test.js` gains a section 6, on its own relay (the shared one is at the community edition's fixed 5-key ceiling):

- a record with `plan: community` and `plan_parasend: pro`, the exact shape the webhook writes, gets the Pro 24 hours and the Pro 10 reads;
- the same record gets the Pro device cap, while a record with no plan is refused its 6th device at the community 5;
- the admin-route shape (`plan` set, products derived) answers identically to the webhook shape on every ParaSend dimension;
- with redis counting, the community record is declined at the 11th transfer and the webhook record is not;
- an account holding 8 devices, moved to Community (cap 5) through the admin route, re-registers all 8 without a single `429` and is refused only the 9th.

`relay/test/entitlements.test.js` pins the `business` row: exactly the legacy numbers dimension for dimension, never `enterprise`, nothing uncapped on the row, and not grantable through `validateProductPlan`.

`relay/test/route-billing-entitlements.test.js` gains two: `GET /v2/admin/usage` reports the enforced tier and its limits for all three record shapes, so an operator debugging "it says I am over my limit" does not read a second opinion; and it reports `file_mb` 5 for an Enterprise account while still reporting `-1` for its genuinely uncapped device count, on both the single-account and the list route.

## Sabotage proof

One read place reverted at a time, suite run, restored:

| Reverted | Red |
|---|---|
| view TTL back to `keyData.plan` | tests 24 and 26, 2 failures |
| max views back to `keyData.plan` | tests 24 and 26, 2 failures |
| device cap back to `keyData.plan or 'pro'` | test 25, 1 failure |
| transfers per month back to `keyData.plan` | test 27, 1 failure |
| usage view limits back to `tiers.tierLimit(plan, ...)` | billing test 14, 1 failure |
| cap check ignoring an already-held device | transfer test 26, 1 failure |
| usage `file_mb` back to the bare tier value | billing test 15, 1 failure |
| `business` mapping back up to `enterprise` | entitlements test 7 and billing test 21, 2 failures |

Both new blocks live in function scope, matching #359: the transfer suite's section 6 is wrapped in a named IIFE that owns its own key constants and relay helper, and the billing addition is a single `test()` with everything inside its callback. Neither file adds a top-level binding, so a parallel merge cannot collide with it the way #336 and #339 did.

## Results

Rebased on `6e4b73b`.

- `relay/test/*.test.js` with redis on 6399: 267 tests, 267 pass, 0 fail.
- `node --test tests/*.mjs` (non-playwright): 139 pass, 2 skipped. `heartbeat-lib.test.mjs` cannot resolve `@noble/post-quantum` in this checkout, which is an environment gap and fails on `main` identically.
- `scripts/check-test-declarations.sh` (#362): OK, 110 suites parse and declare each top-level name once.
- `tests/static-sanity.sh`: PASS, checks 1 to 11 all OK.

## Not fixed, needs a product decision

`frontend/parasign.html:229` and `frontend/pricing.html:358` both sell "Unlimited receiving", and there is no field for it in `lib/tiers.js` and nothing enforcing it. Either it needs a dimension or the copy needs to say what is actually unbounded. Left alone because it is a copy and pricing question, not a code one.
