### PR TITLE
Gate the test files against duplicate top-level declarations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,24 @@ jobs:
       # parse; neither resolves names. An hourly setInterval swept a Map that no
       # longer existed and took production down 425 times before anyone looked.
       # Config: eslint.config.mjs, one rule, no style opinions.
+      # Runs BEFORE eslint, on purpose. A duplicate top-level declaration is a
+      # SyntaxError, and eslint reports it as a bare "Parsing error" in the tail
+      # of a run over the whole repo, with no hint of where it came from. This
+      # guard names the file, the line and the cause first, and emits a GitHub
+      # error annotation so the file shows up in the job summary. It also covers
+      # the half eslint never can: a duplicate top-level var/function is legal
+      # JavaScript, so it parses, lints clean, and silently replaces the earlier
+      # definition that the assertions above it were written against.
+      #
+      # Why it exists: on 2026-09-02 five pull requests each appended a block to
+      # the same flat test file within the hour. Each was green on its own; the
+      # merge of the last one put "Identifier 'tiers' has already been declared"
+      # and "'pricingVisible' has already been declared" on main and took two
+      # suites out entirely. This job is where that lands, so this is where it
+      # gets a name.
+      - name: Test-scope guard (suites parse, one declaration per name)
+        run: scripts/check-test-declarations.sh
+
       - name: no-undef over the hand-written server code
         run: npx --yes eslint@9 .
 

--- a/scripts/check-test-declarations.sh
+++ b/scripts/check-test-declarations.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Test-scope guard (SCOPE-01). Every suite in this repo is a flat top-level
+# script: tests/*.mjs and relay/test/*.js declare their fixtures with a bare
+# `const` at column 0 and read them all the way down the file. That shape is
+# fine on its own and it is what makes the suites readable, but it turns the
+# file into ONE shared namespace that every open pull request writes into.
+#
+# On 2026-09-02 five pull requests each appended a block to that namespace and
+# each was green on its own. #333, #334, #336, #339 and #354 landed within the
+# hour and main went red on the merge of the last one: `const tiers` twice in
+# relay/test/pricing-page.test.js, `const pricingVisible` twice in
+# tests/ui-truthfulness.test.mjs. Two files that no longer parse means the unit
+# suite and the eslint gate both fall over, so nothing else in either file runs.
+# No single pull request was wrong; the collision only exists in the merge.
+#
+# Two checks, and they catch different halves of the problem:
+#
+#   1. PARSE: node --check on every suite. A duplicate top-level const/let/
+#      class is an early SyntaxError, so this reports the file and the line
+#      before a single assertion runs. Locally that is the whole answer; in CI
+#      it is what turns "the eslint job is red" into "this file, this line".
+#
+#   2. SHADOW: duplicate top-level `var` and `function` names. These are LEGAL
+#      JavaScript: the second declaration silently replaces the first, the file
+#      parses, the suite runs, and every assertion above the collision is now
+#      measured against the helper from the block below it. Nothing goes red.
+#      That is the same merge collision as above, only quiet, and it is the one
+#      no parser and no lint rule will ever report.
+#
+# The SHADOW scan reads column-0 declarations only. That is a deliberate
+# heuristic and not a parser: these suites put every top-level declaration at
+# column 0 and indent everything nested, so nesting is visible without one.
+# Destructuring (`const { default: tiers } = ...`) is left to check 1, which
+# handles it exactly.
+#
+# Run: scripts/check-test-declarations.sh   (exit 0 = clean, 1 = violations)
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+fail=0
+files=()
+for pattern in tests/*.mjs tests/*.js relay/test/*.js relay/crypto/*.test.js admin/test/*.js; do
+  for f in $pattern; do
+    [ -f "$f" ] && files+=("$f")
+  done
+done
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "FAIL: no suites matched; the globs in this script are stale."
+  exit 1
+fi
+
+# ── 1. PARSE ──────────────────────────────────────────────────────────────────
+for f in "${files[@]}"; do
+  if ! out="$(node --check "$f" 2>&1)"; then
+    echo "FAIL: $f does not parse."
+    printf '%s\n' "$out" | sed 's/^/    /'
+    if printf '%s' "$out" | grep -q 'has already been declared'; then
+      echo "    Two top-level blocks in this file declare the same name. This is what a"
+      echo "    merge collision looks like: each pull request was green alone. Reuse the"
+      echo "    first declaration or give the second block its own name."
+    fi
+    # GitHub Actions annotation, so the job summary names the file, not just eslint's tail.
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+      line="$(printf '%s' "$out" | sed -nE "s#^.*${f//./\\.}:([0-9]+).*\$#\1#p" | head -1)"
+      echo "::error file=${f}${line:+,line=$line}::${f} does not parse (see the test-scope guard)"
+    fi
+    fail=$((fail + 1))
+  fi
+done
+
+# ── 2. SHADOW ─────────────────────────────────────────────────────────────────
+for f in "${files[@]}"; do
+  dupes="$(awk '
+    /^\/\*/ { inblock = 1 }
+    inblock { if (/\*\//) inblock = 0; next }
+    /^(async[ \t]+)?function[ \t]+[A-Za-z_$][A-Za-z0-9_$]*/ {
+      name = $0; sub(/^(async[ \t]+)?function[ \t]+/, "", name); sub(/[^A-Za-z0-9_$].*$/, "", name)
+      seen[name] = seen[name] " " NR; kind[name] = "function"
+    }
+    /^var[ \t]+[A-Za-z_$][A-Za-z0-9_$]*/ {
+      name = $0; sub(/^var[ \t]+/, "", name); sub(/[^A-Za-z0-9_$].*$/, "", name)
+      seen[name] = seen[name] " " NR; kind[name] = "var"
+    }
+    END {
+      for (n in seen) {
+        c = split(seen[n], at, " ")
+        if (c > 1) printf "%s %s lines%s\n", kind[n], n, seen[n]
+      }
+    }
+  ' "$f")"
+  if [ -n "$dupes" ]; then
+    echo "FAIL: $f declares a top-level name more than once:"
+    printf '%s\n' "$dupes" | sed 's/^/    /'
+    echo "    A second top-level var/function of the same name is legal and silent: it"
+    echo "    replaces the first, and every assertion above it now runs against the"
+    echo "    definition below it. Rename one, or give each block its own scope."
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+      echo "::error file=${f}::${f} declares a top-level name more than once"
+    fi
+    fail=$((fail + 1))
+  fi
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "OK: ${#files[@]} suites parse and declare each top-level name once."
+  exit 0
+fi
+echo "FAIL: $fail suite(s) with a scope problem."
+exit 1

--- a/tests/static-sanity.sh
+++ b/tests/static-sanity.sh
@@ -221,6 +221,30 @@ else
   printf "   WARN  %s not found or not executable, style guard skipped\n" "$STYLE"
 fi
 
+# ── 11. Test files keep one declaration per top-level name ──────────────
+# Every suite is a flat top-level script, so each open pull request appends to
+# the SAME namespace. On 2026-09-02 five of them did within the hour and main
+# went red on the last merge: const tiers twice in relay/test/pricing-page.test.js,
+# const pricingVisible twice in tests/ui-truthfulness.test.mjs. Each branch was
+# green alone; the collision existed only in the merge.
+# scripts/check-test-declarations.sh parses every suite (a duplicate const is a
+# SyntaxError, so the whole file stops running) and separately reports duplicate
+# top-level var/function names, which are legal, silent, and change what the
+# assertions above them measure.
+echo ""
+echo "11. Test-scope guard (scripts/check-test-declarations.sh)..."
+SCOPE="$ROOT/scripts/check-test-declarations.sh"
+if [ -x "$SCOPE" ]; then
+  if SCOPE_OUT="$("$SCOPE" 2>&1)"; then
+    printf '%s\n' "$SCOPE_OUT" | sed 's/^/   /'
+  else
+    printf '%s\n' "$SCOPE_OUT" | sed 's/^/   /'
+    FAIL=$((FAIL + 1))
+  fi
+else
+  printf "   WARN  %s not found or not executable, test-scope guard skipped\n" "$SCOPE"
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "════════ RESULT ════════"


### PR DESCRIPTION
## What broke, and why nothing caught it

Run 33667508924 put main red at 18:29Z. Two required checks, `relay - unit suite (no native deps)` and `static, every name must exist`, both on the same cause:

```
relay/test/pricing-page.test.js:498  Identifier 'tiers' has already been declared
tests/ui-truthfulness.test.mjs:821   Identifier 'pricingVisible' has already been declared
```

Every suite in this repo is a flat top-level script. Fixtures are declared with a bare `const` at column 0 and read all the way down the file. That shape is what makes the suites readable, and it also makes each file a single namespace that every open pull request writes into.

#333, #334, #336, #339 and #354 each appended a block to that namespace within the hour. Each one was green on its own, because a pull request is checked against the base it was opened on. The collision exists only in the merge, and it appeared on main the moment the last of them landed. A duplicate top-level `const` is an early SyntaxError, so the two files did not lose an assertion, they stopped running entirely and took the eslint gate down with them.

The dedupe itself is #359. This pull request is the gate.

## The gate

`scripts/check-test-declarations.sh`, over `tests/*.mjs`, `tests/*.js`, `relay/test/*.js`, `relay/crypto/*.test.js` and `admin/test/*.js`. Two checks, for the two halves of the problem.

**1. PARSE.** `node --check` on every suite. It reports the file, the line and the cause, and adds the sentence eslint cannot: two top-level blocks declare the same name, which is what a merge collision looks like. In CI it also emits a `::error file=...,line=...` annotation, so the job summary names the file instead of leaving a bare `Parsing error` at the tail of a whole-repo eslint run. That was the ask on `static, every name must exist`, and it is why this step runs ahead of eslint rather than after it.

**2. SHADOW.** Duplicate top-level `var` and `function` names. These are legal JavaScript in a CommonJS suite: the second declaration silently replaces the first, the file parses, eslint is clean, the suite runs green, and every assertion above the collision is now measured against the definition below it. Same merge collision, no red anywhere. Measured on this branch: appending a second `function ok(...)` to `relay/test/pricing-page.test.js` parses, lints and runs fine, and this scan reports `function ok lines 23 592`.

The SHADOW half reads column-0 declarations, which is a heuristic and says so in the header: these suites put every top-level declaration at column 0 and indent everything nested. Destructuring (`const { default: tiers } = ...`) is left to check 1, which handles it exactly.

Wired in two places: the `static, every name must exist` job, ahead of eslint, and as check 11 of `tests/static-sanity.sh`, the pre-commit gate.

## Evidence

- On the broken main (7c07b99) the guard is red and names exactly the two files and lines that took the run down.
- Rebased on main with #359 in: `OK: 110 suites parse and declare each top-level name once`. No false positive anywhere in the repo, including the new blocks #359 moved into function scope.
- Red on demand, verified by appending `const tiers = require('../lib/tiers');` to `relay/test/pricing-page.test.js` again: the guard fails, `tests/static-sanity.sh` fails with it, and the CI annotation reads `::error file=relay/test/pricing-page.test.js,line=700`.
- SHADOW verified red on an injected duplicate `function` and an injected duplicate `var`, neither of which node or eslint objects to.
- Battery on this branch, all green: root integration suites 152 tests (150 pass, 2 declared skips), relay unit suite 175 tests, admin unit suite 40 tests, `pricing-fold` and `navigation-shell` 5 tests under Chromium, `eslint@9` over the repo, `check-cache-bust`, `check-csp-inline`, `bash -n` over every shell script, and `tests/static-sanity.sh` (11 checks, PASS).

## The half a repo file cannot fix

This gate makes the failure fast, local and legible. It does not make it impossible, and it is worth being honest about why.

GitHub checks a pull request against a merge commit with the base at the time the check ran. Once #333 merged, the checks already recorded on #334 and the rest were green over a base that no longer existed, and nothing re-ran them. Five branches merged inside an hour against a moving main is exactly the window this opens.

Two settings close it, and both live in branch protection rather than in a file here:

- **Require branches to be up to date before merging** on main. Every pull request then re-runs against the current base before it can land, and this guard fires on the branch instead of on main.
- Or a **merge queue**, which does the same thing without serialising the humans.

The second, cheaper structural change is to the tests themselves: a suite per page group rather than one growing file per concern, or each block wrapped in its own function scope. Neither is in this pull request, because both touch the files #359 is fixing right now. Worth doing next; `tests/ui-truthfulness.test.mjs` is 981 lines and `relay/test/pricing-page.test.js` is 591, and both are still one shared namespace.
