### PR TITLE
The tampered-receipt check must actually tamper, and cover every signed field

### DIFF
--- a/relay/test/route-envelope-lifecycle.test.js
+++ b/relay/test/route-envelope-lifecycle.test.js
@@ -430,11 +430,85 @@ test('OFFLINE VERIFICATION: the receipt checks out without asking the relay anyt
 
   // (d) and the whole thing is tamper-evident: change one character of the
   //     document hash and the notary signature no longer holds.
-  const tampered = { ...unsigned, document_hash: 'f' + unsigned.document_hash.slice(1) };
+  //
+  //     The tamper must be a REAL change. This check used to write a literal
+  //     'f' over the first character of the hash, which is a no-op on the 1 run
+  //     in 16 where a sha3-256 hex hash already starts with 'f' -- the receipt
+  //     was then unmodified, verified correctly, and the suite failed with
+  //     "true !== false" (~6% of CI runs, measured at 9/100 locally). Flip to a
+  //     character the original demonstrably is not, and assert that it differs.
+  const flipped = (unsigned.document_hash[0] === 'f' ? '0' : 'f') + unsigned.document_hash.slice(1);
+  assert.notStrictEqual(flipped, unsigned.document_hash, 'the tamper must actually change the hash');
+  const tampered = { ...unsigned, document_hash: flipped };
   assert.strictEqual(eng.verify(
     Buffer.from(notary_signature, 'base64'),
     Buffer.from(parasign.canonicalJSON(tampered), 'utf8'),
     Buffer.from(psign.notary.relay_public_key, 'base64')), false,
     'a tampered receipt must not verify');
+  did();
+});
+
+// (d) above proves ONE field is under the notary signature. This proves EVERY
+// field is: it walks the receipt, sabotages exactly one leaf at a time with a
+// value that is provably different, and demands the notary signature breaks on
+// each. A field the relay adds to the receipt but leaves outside the signed
+// bytes -- the thing that would make a receipt forgeable in the field -- fails
+// here by name instead of hiding behind a check that only ever touched the
+// document hash.
+test('OFFLINE VERIFICATION: every notary-signed field is covered, one sabotage at a time', async () => {
+  if (!ready()) return;
+  IP = nextIp();
+  const { id, docHash: dh } = await createEnvelope([{ label: 'Alice' }, { label: 'Bob' }]);
+  for (const i of [0, 1]) {
+    const s = signForParty(id, dh, i);
+    assert.strictEqual((await submit(id, { party_index: i, signer_public_key: s.pubB64, signature: s.sigB64 })).status, 200);
+  }
+  const psign = (await receipt(id, OWNER)).json;
+  const { notary_signature, ...unsigned } = psign;
+
+  const sig = Buffer.from(notary_signature, 'base64');
+  const pk = Buffer.from(psign.notary.relay_public_key, 'base64');
+  const verifies = (obj) => eng.verify(sig, Buffer.from(parasign.canonicalJSON(obj), 'utf8'), pk);
+
+  // Sanity: the untouched receipt still verifies, so a `false` below is the
+  // sabotage talking and not a broken harness.
+  assert.strictEqual(verifies(unsigned), true, 'the unmodified receipt must verify');
+
+  // Every leaf path in the signed object, arrays included.
+  const leaves = [];
+  (function walk(node, path) {
+    if (node !== null && typeof node === 'object') {
+      const keys = Array.isArray(node) ? node.map((_, i) => i) : Object.keys(node);
+      if (keys.length === 0) { leaves.push(path); return; }
+      for (const k of keys) walk(node[k], path.concat(k));
+      return;
+    }
+    leaves.push(path);
+  })(unsigned, []);
+
+  // A receipt that quietly shrinks to a handful of fields must not pass this
+  // test by having nothing left to sabotage.
+  assert.ok(leaves.length >= 25, `expected a substantial receipt, got ${leaves.length} fields`);
+
+  // A value of the same shape that is provably not the original.
+  const otherValue = (v) => {
+    if (typeof v === 'string') return v === 'paramant-tampered' ? 'paramant-tampered-2' : 'paramant-tampered';
+    if (typeof v === 'number') return v + 1;
+    if (typeof v === 'boolean') return !v;
+    return 'paramant-tampered'; // null / undefined
+  };
+
+  for (const path of leaves) {
+    const copy = JSON.parse(JSON.stringify(unsigned));
+    let node = copy;
+    for (const k of path.slice(0, -1)) node = node[k];
+    const last = path[path.length - 1];
+    const before = node[last];
+    node[last] = otherValue(before);
+    const label = path.join('.');
+    assert.notDeepStrictEqual(node[last], before, `sabotage of ${label} must change the value`);
+    assert.strictEqual(verifies(copy), false,
+      `${label} is NOT covered by the notary signature: the receipt still verifies after it was changed`);
+  }
   did();
 });


### PR DESCRIPTION
## What broke

The `relay - crypto suite` job failed three times tonight on `relay/test/route-envelope-lifecycle.test.js:384`, each time green on a re-run:

```
not ok 43 - OFFLINE VERIFICATION: the receipt checks out without asking the relay anything
  location: 'relay/test/route-envelope-lifecycle.test.js:384:1'
  failureType: 'testCodeFailure'
  error: |-
    a tampered receipt must not verify

    true !== false

  code: 'ERR_ASSERTION'
  expected: false
  actual: true
  operator: 'strictEqual'
  stack: |-
    TestContext.<anonymous> (relay/test/route-envelope-lifecycle.test.js:434:10)
```

Runs [33671431688](https://github.com/Apolloccrypt/paramant-relay/actions/runs/33671431688), [33670368805](https://github.com/Apolloccrypt/paramant-relay/actions/runs/33670368805), [33667195130](https://github.com/Apolloccrypt/paramant-relay/actions/runs/33667195130). Identical assertion in all three.

## Cause (confirmed)

The tamper was not a tamper. Step (d) built it as:

```js
const tampered = { ...unsigned, document_hash: 'f' + unsigned.document_hash.slice(1) };
```

It writes a literal `f` over the first character. `document_hash` is `sha3-256` hex over random bytes, fresh per run (`docHash()`, line 55), so the first character already **is** `f` in 1 run out of 16. On those runs the "tampered" receipt is byte-identical to the signed one, the notary signature verifies exactly as it should, and the assertion demanding `false` gets `true`.

### Reproduction

100 local runs of the suite, instrumented to log the first character of the hash:

| | runs | share |
|---|---|---|
| **FAIL** | 9 | 9% |
| **PASS** | 91 | 91% |

Every one of the 9 failures had `firstchar=f`. No run with `firstchar=f` ever passed. Perfect correlation, expected rate 1/16 = 6.25%, and 9/100 sits within binomial noise of that.

The other 15 first characters were spread evenly across the passes, as a hash digest should be.

## Was the verification itself at fault? No.

`buildEnvelopePsign` (`relay/lib/parasign-open-api.js:628`) signs `canonicalJSON(psign)` over the complete receipt before `notary_signature` is attached, and `canonicalJSON` (`relay/parasign.js:50`) is a total recursive sorted-key serialiser. Every field is covered. **No relay code is changed in this PR.**

## Fix

**1. The tamper is now a real change.** Flip to a character the hash demonstrably is not, and assert that it differs:

```js
const flipped = (unsigned.document_hash[0] === 'f' ? '0' : 'f') + unsigned.document_hash.slice(1);
assert.notStrictEqual(flipped, unsigned.document_hash, 'the tamper must actually change the hash');
```

**2. A new test pins every signed field.** The old check only ever touched `document_hash`, so a field that drifted outside the signed bytes would never have been caught. The new test walks every leaf of the receipt, sabotages exactly one at a time with a provably different value, and demands the notary signature breaks on each, naming the field when it does not.

### Verified by mutation

| injected gap | old check | new check |
|---|---|---|
| `canonicalJSON` silently drops `label` | **passes** (blind to it) | **fails**: `parties.0.label is NOT covered by the notary signature: the receipt still verifies after it was changed` |
| a field added to the receipt after signing | fails | fails |

The first row is the point: a real coverage hole that the existing suite would have shipped.

## Evidence after the fix

| check | result |
|---|---|
| suite, 100 sequential runs | **100/100 green**, 0 failures |
| suite, 40 runs under load (4 parallel workers looping `route-auth-gate` + `route-transfer-burn` against the same relay and redis) | **40/40 green** |
| full CI route set (`node --test --test-reporter=tap test/route-*.test.js test/parasign-signs-quota.test.js`) | **71/71 pass** |
| silent-suite gate | `(none)` |
| `tests/static-sanity.sh` | **PASS**, 11/11 |

Nothing deployed. Test-only diff.
