### PR TITLE
First screen: pull the SES sentence and the third help answer above the fold

### DIFF
--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -39,7 +39,12 @@ h2{font-size:18px;font-weight:600;letter-spacing:-.01em;margin-bottom:20px;margi
 .buyer-qa-a a.buyer-qa-inline{color:var(--cobalt);text-decoration:underline;text-underline-offset:2px}
 .buyer-qa-link{font-family:IBM Plex Mono,monospace;font-size:12px;color:var(--cobalt);text-decoration:underline;text-decoration-color:#B2FF3F;text-decoration-thickness:2px;text-underline-offset:3px}
 .buyer-qa-link:hover{color:var(--ink)}
-@media(max-width:640px){.buyer-qa{padding:20px 18px 4px;margin-bottom:36px}.buyer-qa-q{font-size:14px}}
+/* Three questions, three answers, and on a 390x844 phone the third answer ended
+   at y=860: the line that says the documents sit at Hetzner Nuremberg under EU
+   law fell 16px past the fold. The gaps carry that, not the copy, so on a phone
+   the block, the heading, the items and the space between a question and its
+   answer all tighten. Every word of all three answers is unchanged. */
+@media(max-width:640px){.buyer-qa{padding:14px 18px 4px;margin-bottom:36px}.buyer-qa .buyer-qa-title{margin-bottom:12px}.buyer-qa-item{margin-bottom:12px}.buyer-qa-q{font-size:14px;margin-bottom:4px}.buyer-qa-a{margin-bottom:4px}}
 a{color:var(--ink);text-decoration:none}
 footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:16px}
 .footer-links{display:flex;gap:20px;flex-wrap:wrap}

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -78,8 +78,16 @@
    purpose: design-system.css is shared with pages this PR does not touch. */
 @media(max-width:640px){
   .ps-hero{padding-top:var(--space-6)}
-  #main-content .sec-head{grid-template-columns:1fr;row-gap:var(--space-2)}
+  /* The hero runs headline, lede, who, buttons, price line, SES note. The house
+     .sec-head parks 64px of margin under its rule and .ps-actions takes another
+     32px on top, which on a 390x844 phone pushed the sentence that says a
+     ParaSign signature is a Simple Electronic Signature to y=863, 19px past the
+     fold (tests/first-screen.test.mjs). Both gaps shrink here, on this page and
+     this width only. Not a word of the note changes: it is the sentence pinned
+     as SES in tests/ui-truthfulness.test.mjs and repeated at about.html:254. */
+  #main-content .sec-head{grid-template-columns:1fr;row-gap:var(--space-2);margin-bottom:var(--space-5)}
   #main-content .sec-head .num{font-size:var(--text-xl);line-height:1}
+  #main-content .ps-actions{margin-top:var(--space-5)}
 }
 </style>
 <script type="application/ld+json" data-paramant-seo="1">

--- a/tests/first-screen.test.mjs
+++ b/tests/first-screen.test.mjs
@@ -22,7 +22,7 @@
 //      and obvious on a laid-out page; /pricing shipped that defect.
 //
 // The one claim measured on a text range rather than an element is the SES
-// scope note on /parasign. Its paragraph runs from y=737 to y=911, so the block
+// scope note on /parasign. Its paragraph runs from y=753 to y=950, so the block
 // does not fit and never was meant to: what has to be readable before a buyer
 // signs is the sentence that says the signature is a Simple Electronic
 // Signature, and that is measured on its own line boxes.
@@ -41,10 +41,13 @@
 // installed by `playwright install --with-deps`; the resolved family is named in
 // every failure message, so a run on a machine without it says so.
 //
-// Two claims do not fit in DejaVu and are pinned differently, at BELOW, with the
-// reason next to each. Both are real: the pages fit on a narrow face and hang
-// over the edge on a wide one. Their pin holds the measured position, so they
-// cannot drift further while they wait to be fixed.
+// Two claims used to hang over the edge in DejaVu and were pinned in place
+// rather than at the fold: the SES sentence on /parasign at y=863 and the third
+// answer on /help at y=860. Both are fixed in the CSS of those two pages, in
+// their mobile media queries and without touching a word of the copy, so every
+// claim in this file now holds the same line: bottom <= 844. `at` records the
+// position each one was pulled back to, and a failure names it alongside the
+// value it drifted to.
 //
 // Run: node --test tests/first-screen.test.mjs
 import { chromium } from 'playwright';
@@ -165,14 +168,13 @@ const PAGES = [
     claims: [
       { name: 'the line that says who it is for', css: 'p.ps-who', text: 'For legal, finance and healthcare practices' },
       { name: 'the first action', css: '.ps-actions a.btn-primary', href: '/sign' },
-      // Not the paragraph, which runs to y=911 by design. The sentence.
-      // BELOW. In Cantarell this sentence ends at 800 and the reviewers read it on
-      // the first screen. In DejaVu the paragraph reflows and it ends at 863,
-      // 19px over the edge, so on a wide face a buyer scrolls to find out that a
-      // ParaSign signature is not a qualified one. The pin holds the measured
-      // position rather than the fold, so it cannot slide further while the page
-      // waits for a fix; raising it is a decision, not a maintenance edit.
-      { name: 'the SES scope statement', css: '.scope-note p', phrase: 'Simple Electronic Signature (SES)', below: 863 },
+      // Not the paragraph, which runs to y=950 by design. The sentence.
+      // It ended at 863 in DejaVu, 19px over the edge, so on a wide face a buyer
+      // scrolled to find out that a ParaSign signature is not a qualified one.
+      // parasign.html now closes the gap under the section rule and above the
+      // buttons on a phone, which lifts it to 815. The sentence itself is
+      // untouched and still matches about.html:254 word for word.
+      { name: 'the SES scope statement', css: '.scope-note p', phrase: 'Simple Electronic Signature (SES)', at: 815 },
       { name: 'the free limit', css: 'p.ps-fine', text: '2 signatures a month' },
     ],
   },
@@ -231,10 +233,12 @@ const PAGES = [
     claims: [
       { name: 'the first answer', css: '.buyer-qa-item p.buyer-qa-a', nth: 0, text: 'Signing a document needs an account' },
       { name: 'the second answer', css: '.buyer-qa-item p.buyer-qa-a', nth: 1, text: 'ParaSign Community is free' },
-      // BELOW, for the same reason: 819 in Cantarell, 860 in DejaVu. The third
-      // answer is where the page says the documents live in Germany, which is
-      // the answer the buyer this page was rewritten for came to read.
-      { name: 'the third answer', css: '.buyer-qa-item p.buyer-qa-a', nth: 2, text: 'Hetzner Nuremberg', below: 860 },
+      // The third answer is where the page says the documents live in Germany,
+      // which is the answer the buyer this page was rewritten for came to read.
+      // It ended at 860 in DejaVu; the Q&A block, its heading and the space
+      // between a question and its answer are tighter on a phone, which lifts it
+      // to 822 with all three answers intact.
+      { name: 'the third answer', css: '.buyer-qa-item p.buyer-qa-a', nth: 2, text: 'Hetzner Nuremberg', at: 822 },
     ],
   },
   {
@@ -277,18 +281,9 @@ for (const spec of PAGES) {
         assert.equal(hit.href, claim.href,
           `${spec.slug}: ${hit.name} points at ${hit.href}, not ${claim.href}`);
       }
-      if (claim.below) {
-        // Already over the edge, measured and named above. Two pixels of room for
-        // a Chromium rounding change, and nothing else.
-        assert.ok(hit.bottom <= claim.below + 2,
-          `${spec.slug}: ${hit.name} ends at y=${hit.bottom}, was ${claim.below}. It is already ${hit.bottom - FOLD.height}px below the ${FOLD.height}px first screen and it just moved further down (top y=${hit.top}, font ${hit.font}).`);
-        assert.ok(hit.bottom > FOLD.height,
-          `${spec.slug}: ${hit.name} now ends at y=${hit.bottom} and fits the ${FOLD.height}px first screen. Someone fixed it: drop the below:${claim.below} pin and let this claim hold the fold like the rest.`);
-      } else {
-        assert.ok(hit.bottom <= FOLD.height,
-          `${spec.slug}: ${hit.name} ends at y=${hit.bottom}, ${hit.bottom - FOLD.height}px past the ${FOLD.height}px first screen (top y=${hit.top}, font ${hit.font}). A phone reader has to scroll for it.`);
-      }
-      t.diagnostic(`${spec.slug} ${hit.name}: top ${hit.top}, bottom ${hit.bottom}${claim.below ? ' (below the fold, pinned in place)' : ''}`);
+      assert.ok(hit.bottom <= FOLD.height,
+        `${spec.slug}: ${hit.name} ends at y=${hit.bottom}, ${hit.bottom - FOLD.height}px past the ${FOLD.height}px first screen (top y=${hit.top}, font ${hit.font})${claim.at ? `. It was measured at y=${claim.at} when the CSS that pulled it onto the screen was written, so it moved ${hit.bottom - claim.at}px down since` : ''}. A phone reader has to scroll for it.`);
+      t.diagnostic(`${spec.slug} ${hit.name}: top ${hit.top}, bottom ${hit.bottom}${claim.at ? ` (was ${claim.at} when pulled onto the screen)` : ''}`);
     }
 
     // Equal to the viewport, not merely no wider than it: a page narrower than


### PR DESCRIPTION
## Wat er stuk was

`tests/first-screen.test.mjs` (#364) shipte met twee claims die het niet kon houden. Ze stonden gepind op hun plek in plaats van op de vouw, met de reden ernaast: in DejaVu Sans, het font dat CI rendert, eindigde de zin die zegt dat een ParaSign-handtekening een Simple Electronic Signature is op y=863 op `/parasign`, en het antwoord dat zegt dat de documenten bij Hetzner Neurenberg staan op y=860 op `/help`. Een 390x844-telefoon is 844 hoog. Een koper moest scrollen voor precies de twee regels waarvoor die pagina's bestaan.

## Wat er verandert

Allebei zijn het witruimtes, geen woorden, en allebei worden ze als witruimte gerepareerd.

| Claim | Was | Nu | Ruimte onder 844 |
|---|---|---|---|
| `/parasign` SES-zin | 863 | **815** | 29px |
| `/help` derde antwoord | 860 | **822** | 22px |

**`/parasign`**: de bestaande `@media(max-width:640px)` die de hero al herschikt, sluit nu ook de 64px die de huis-`.sec-head` onder zijn streep parkeert (naar 24px) en de 32px boven de knoppen (naar 24px). Samen 48px. Pagina-lokaal en alleen op telefoonbreedte, net als de rest van dat blok.

**`/help`**: het Q&A-blok verliest 6px bovenpadding, de kop 6px, elk item 8px en elke vraag-naar-antwoord-afstand 2px. Samen 38px.

Geen woord copy is verplaatst. De SES-zin is nog steeds die welke `tests/ui-truthfulness.test.mjs` pint en die letterlijk terugkomt op `about.html:254`. Het derde antwoord noemt nog steeds Hetzner Neurenberg, EU-recht, de GDPR en Resend, en de negatieve pins over sleutels zijn ongemoeid.

## De test

De twee `below:`-pins zijn gewone vouwpins geworden, dus elk claim in het bestand houdt nu dezelfde lijn: `bottom <= 844`. De `below`-tak is weg, met het commentaar over de tijdelijke pin. Wat die pin wel opleverde is bewaard als `at`: de positie waarnaar de regel is teruggehaald, die een rode run naast de gemeten waarde noemt.

```
/parasign: the SES scope statement ends at y=1191, 347px past the 844px first
screen (top y=1153, font DejaVu Sans). It was measured at y=815 when the CSS
that pulled it onto the screen was written, so it moved 376px down since.
```

## Bewijs

Sabotage met `margin-top:400px` op `.scope-note` en op het derde `.buyer-qa-a`: allebei rood, allebei met de gemeten y in de melding. Zonder sabotage 9/9 groen, gemeten in hetzelfde geforceerde DejaVu Sans dat de suite gebruikt.

Groen: first-screen, links, seo-contract, ui-truthfulness, site-claims, pricing-fold, pricing-page, frontend-loading-contract, navigation-shell, csp-inline, cache-bust, eslint, static-sanity (11 checks).

Head-elementen zijn niet aangeraakt: alleen CSS binnen de pagina-lokale `<style>`.
