### PR TITLE
Quota upgrade card: name the transfers ceiling, and stop selling it on ParaSign

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -2740,7 +2740,7 @@ api.post("/drop/upload", async (req, res) => {
   if (ipCount > 20) {
     return res.status(429).json({
       error: "rate_limited",
-      message: "Daily limit reached. Create a free account for unlimited drops.",
+      message: "Daily limit reached. Create a free account for 10 transfers a month.",
     });
   }
   const rlKey = `paramant:drop:ratelimit:${email.toLowerCase()}`;
@@ -2749,7 +2749,7 @@ api.post("/drop/upload", async (req, res) => {
   if (count > 3) {
     return res.status(429).json({
       error: "rate_limited",
-      message: "Daily limit reached. Create a free account for unlimited drops.",
+      message: "Daily limit reached. Create a free account for 10 transfers a month.",
     });
   }
   const anonRes = await relayFetch("health", "/v2/anon-inbound", "POST", req.body, false, "");

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -158,11 +158,21 @@ python3 scripts/paramant-admin.py sync
 These are **end-user plans** — they control what a `pgp_` API key holder can do.
 Set when you create a key with `--plan`.
 
-| Plan | Uploads/day | Max file size | TTL | Views/blob | Priority |
-|------|-------------|---------------|-----|------------|----------|
-| `free` | 10 | 5 MB | 1 hour | 1 | Low |
-| `pro` | Unlimited | 500 MB | 24 hours | 10 | High |
-| `enterprise` | Unlimited | Unlimited | 7 days | 100 | Highest |
+| Plan | Transfers/month | Max file size | TTL | Views/blob | Downloads/hour |
+|------|-----------------|---------------|-----|------------|----------------|
+| `free` | 10 | 5 MB | 1 hour | 1 | 50 |
+| `pro` | 500 | 5 MB | 24 hours | 10 | 500 |
+| `enterprise` | 1,000,000 | 5 MB | 7 days | 100 | unlimited |
+
+Every figure comes from `relay/lib/tiers.js`, the single source the relay reads.
+The table used to say `pro` and `enterprise` had unlimited uploads and a 500 MB
+file: transfers are metered per calendar month (`transfers_month`, HTTP 402
+`monthly_transfer_quota_reached`), never per day, and `file_mb` is bounded by
+the operator's `MAX_BLOB` (5 MB on the hosted relay), which is always the last
+word. No metered tier is unbounded: `relay/lib/entitlements.js` holds even
+`enterprise` to a finite monthly ceiling. `Priority` named no field at all and
+is replaced by `outbound_per_hour`, the per-key hourly download window the relay
+does enforce with a 429.
 
 > **Get a free `pgp_` key:** [paramant.app/request-key](https://paramant.app/request-key) — form takes 30 seconds, key arrives by email. No account or credit card needed.
 

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -222,7 +222,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1"></script>
-<script src="/js/quota-upgrade.js?v=3" defer></script>
+<script src="/js/quota-upgrade.js?v=4" defer></script>
 <script type="module" src="/co-sign.js?v=20"></script>
 </body>
 </html>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -531,6 +531,6 @@ main.pa-main { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--
 
 <script src="/nav.js?v=14" defer></script>
 <script src="/js/nav-auth.js?v=5" defer></script>
-<script src="/js/dashboard.js?v=6" defer></script>
+<script src="/js/dashboard.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/docs/paramant-ot-brief.html
+++ b/frontend/docs/paramant-ot-brief.html
@@ -546,9 +546,9 @@ curl -fsSL paramant.app/install.sh | bash</div>
   <div class="tier hl">
     <div class="tier-name">Pro</div>
     <div class="tier-price">€12<sub>/mo</sub></div>
-    <div class="tier-desc">Managed, unlimited</div>
+    <div class="tier-desc">Managed relay</div>
     <ul>
-      <li>Unlimited transfers</li>
+      <li>500 transfers a month</li>
       <li>50 MB per transfer</li>
       <li>5 OT devices</li>
       <li>WebSocket streaming</li>

--- a/frontend/docs/self-hosting.md
+++ b/frontend/docs/self-hosting.md
@@ -181,11 +181,21 @@ python3 scripts/paramant-admin.py sync
 These are **end-user plans** — they control what a `pgp_` API key holder can do.
 Set when you create a key with `--plan`.
 
-| Plan | Uploads/day | Max file size | TTL | Views/blob | Priority |
-|------|-------------|---------------|-----|------------|----------|
-| `free` | 10 | 5 MB | 1 hour | 1 | Low |
-| `pro` | Unlimited | 500 MB | 24 hours | 10 | High |
-| `enterprise` | Unlimited | Unlimited | 7 days | 100 | Highest |
+| Plan | Transfers/month | Max file size | TTL | Views/blob | Downloads/hour |
+|------|-----------------|---------------|-----|------------|----------------|
+| `free` | 10 | 5 MB | 1 hour | 1 | 50 |
+| `pro` | 500 | 5 MB | 24 hours | 10 | 500 |
+| `enterprise` | 1,000,000 | 5 MB | 7 days | 100 | unlimited |
+
+Every figure comes from `relay/lib/tiers.js`, the single source the relay reads.
+The table used to say `pro` and `enterprise` had unlimited uploads and a 500 MB
+file: transfers are metered per calendar month (`transfers_month`, HTTP 402
+`monthly_transfer_quota_reached`), never per day, and `file_mb` is bounded by
+the operator's `MAX_BLOB` (5 MB on the hosted relay), which is always the last
+word. No metered tier is unbounded: `relay/lib/entitlements.js` holds even
+`enterprise` to a finite monthly ceiling. `Priority` named no field at all and
+is replaced by `outbound_per_hour`, the per-key hourly download window the relay
+does enforce with a 429.
 
 > **Get a free `pgp_` key:** [paramant.app/request-key](https://paramant.app/request-key) — form takes 30 seconds, key arrives by email. No account or credit card needed.
 

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -114,7 +114,7 @@
   // here is an upsell. A customer who has paid should read what he bought.
   var PRODUCT_INCLUDES = {
     parasign: {
-      pro: 'ParaSign Pro: 100 signatures a month, then \u20ac0.40 each up to 1,000, 500 ParaSend transfers a month, and a connection you can plug into your own systems.',
+      pro: 'ParaSign Pro: 100 signatures a month, then \u20ac0.40 each up to 1,000, and a connection you can plug into your own systems.',
       business: 'ParaSign Business: 1,000 signatures a month, support with a name on it that answers within one business day, help answering your customers\u2019 security questionnaires, and an audit trail you can export as a file.',
       enterprise: 'ParaSign Enterprise: your own dedicated relay, a sector relay for health, legal or finance, a service level agreement with credits, a self-hosting licence and audit support.'
     },

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -114,7 +114,7 @@
   // here is an upsell. A customer who has paid should read what he bought.
   var PRODUCT_INCLUDES = {
     parasign: {
-      pro: 'ParaSign Pro: 100 signatures a month, then \u20ac0.40 each up to 1,000, unlimited transfers, and a connection you can plug into your own systems.',
+      pro: 'ParaSign Pro: 100 signatures a month, then \u20ac0.40 each up to 1,000, 500 ParaSend transfers a month, and a connection you can plug into your own systems.',
       business: 'ParaSign Business: 1,000 signatures a month, support with a name on it that answers within one business day, help answering your customers\u2019 security questionnaires, and an audit trail you can export as a file.',
       enterprise: 'ParaSign Enterprise: your own dedicated relay, a sector relay for health, legal or finance, a service level agreement with credits, a self-hosting licence and audit support.'
     },

--- a/frontend/js/quota-upgrade.js
+++ b/frontend/js/quota-upgrade.js
@@ -5,7 +5,9 @@
  * 402 input (relay JSON, passed through by the admin proxy):
  *   free sign quota:  { error:'monthly_sign_quota_reached', plan, limit, used, reset_date }
  *   pro hard cap:     { error:'monthly_sign_hard_cap_reached', plan, limit, overage_count, reset_date }
- *   transfers (as before): { error:'monthly_transfer_quota_reached', dimension, plan, limit }
+ *   transfers:        { error:'monthly_transfer_quota_reached', dimension, plan, limit }
+ *                     `plan`/`limit` are the tier that DECIDED and its ceiling
+ *                     (relay.js, #361), not the account's unified plan.
  * 200 input (sign response): quota { used, included, overage_count,
  *   overage_rate_eur, hard_cap, reset_date } -> signNotice() renders the
  *   inline notices (free second signature, pro overage). Older backends send
@@ -13,14 +15,69 @@
  *   signNotice returns ''.
  *
  * Prices shown excl. VAT and kept in ONE place here. This file only renders
- * the notices; the limits themselves live server-side and are unchanged. */
+ * the notices; the limits themselves live server-side and are unchanged. Every
+ * ceiling it prints is mirrored from relay/lib/tiers.js (see CEILINGS below)
+ * and pinned against it by relay/test/quota-upgrade-render.test.js. */
 (function () {
   'use strict';
 
   var PRODUCTS = {
-    transfers_month: { unit: 'transfers',  upgrade: 'ParaSend Pro', price: 'EUR 15/month excl. VAT' },
-    signs_month:     { unit: 'signatures', upgrade: 'ParaSign Pro', price: 'EUR 49/month excl. VAT' }
+    transfers_month: { unit: 'transfers'  },
+    signs_month:     { unit: 'signatures' }
   };
+
+  // Every monthly ceiling this file prints, per dimension and per tier, copied
+  // from relay/lib/tiers.js (transfers_month, signs_month) with the enterprise
+  // row taking the finite plafond relay/lib/entitlements.js applies to a
+  // metered dimension (ENTERPRISE_MONTHLY_CEILING). NO tier is unbounded, which
+  // is why no card here may call a ceiling absent: the ParaSign Pro pitch below
+  // promised transfers without a cap while a Pro account is held to 500 a
+  // month, the same overclaim /pricing and /parasign were corrected for. The
+  // word itself is banned from this file by the render test.
+  //
+  // Baked in because this is a plain browser script with no way to require the
+  // relay module. relay/test/quota-upgrade-render.test.js renders every card
+  // and compares each number against tiers.js and entitlements.js, so a tier
+  // edit that does not reach this file turns the suite red.
+  var CEILINGS = {
+    transfers_month: { community: 10, pro: 500, business: 2000, enterprise: 1000000 },
+    signs_month:     { community: 2,  pro: 100, business: 1000, enterprise: 1000000 }
+  };
+
+  // The rung above the tier that decided, with the ceiling that rung carries
+  // and the price /pricing lists for it (excl. btw, one basis for the whole
+  // site). A tier with no entry gets no upsell: offering ParaSend Pro to a Pro
+  // account is what a hardcoded upsell does, and since #361 the 402 says which
+  // tier it was.
+  var NEXT = {
+    transfers_month: {
+      community: { name: 'ParaSend Pro', price: 'EUR 15/month excl. VAT', limit: 500 }
+    },
+    signs_month: {
+      community: { name: 'ParaSign Pro',      price: 'EUR 49/month excl. VAT', limit: 100 },
+      pro:       { name: 'ParaSign Business', price: 'EUR 299/month excl. VAT', limit: 1000 }
+    }
+  };
+
+  // The tier that DECIDED the 402, as the relay reports it. Since #361 the
+  // monthly_transfer_quota_reached body carries `plan` = the ParaSend
+  // entitlement tier and `limit` = that tier's ceiling, instead of the unified
+  // account plan. The card printed "Community" whatever came back, so a Pro
+  // account over its 500 was told it was on Community. Unknown or absent falls
+  // back to community, which is what this card assumed unconditionally before.
+  var PLAN_LABEL = {
+    community: 'Community', free: 'Community', dev: 'Community',
+    pro: 'Pro', business: 'Business', enterprise: 'Enterprise', licensed: 'Enterprise'
+  };
+  var PLAN_KEY = {
+    community: 'community', free: 'community', dev: 'community',
+    pro: 'pro', business: 'business', enterprise: 'enterprise', licensed: 'enterprise'
+  };
+
+  function planKey(data) {
+    var v = data && typeof data.plan === 'string' ? data.plan.toLowerCase() : '';
+    return PLAN_KEY[v] || 'community';
+  }
 
   function isQuota402(status, data) {
     return status === 402 && !!data &&
@@ -52,7 +109,8 @@
     return '<div class="pa-quota-upsell pa-quota-card" role="status">' +
       '<strong>You\'ve used both signatures this month.</strong>' +
       '<span>Community gives you 2 a month, with the same encryption, the same post-quantum signatures and the same public proof log as every paid plan. You never pay for security here. You pay for volume.</span>' +
-      '<span><strong>Pro - EUR 49/month</strong><br>100 signatures a month, then EUR 0.40 each, up to 1,000. Unlimited transfers. API access.</span>' +
+      '<span><strong>Pro - EUR 49/month</strong><br>100 signatures a month, then EUR 0.40 each, up to 1,000. ' +
+        CEILINGS.transfers_month.pro + ' ParaSend transfers a month. API access.</span>' +
       '<span class="pa-quota-actions">' +
         '<a class="btn btn-primary" href="/pricing">Upgrade to Pro</a>' +
         '<button type="button" class="btn btn-secondary" data-pa-quota-dismiss>Maybe later</button>' +
@@ -73,15 +131,28 @@
   }
 
   function legacyHtml(data) {
-    var p = PRODUCTS[data && data.dimension] || PRODUCTS.transfers_month;
-    var limit = data && isFinite(Number(data.limit)) ? Number(data.limit) : null;
-    var used = limit !== null
+    var dim = (data && data.dimension) || 'transfers_month';
+    if (!PRODUCTS[dim]) dim = 'transfers_month';
+    var p = PRODUCTS[dim];
+    var plan = planKey(data);
+    // The 402 body's own limit first: that is the ceiling of the tier that
+    // actually decided. The table is the fallback for a backend older than
+    // #361, which sent no limit at all.
+    var limit = data && isFinite(Number(data.limit)) ? Number(data.limit) : CEILINGS[dim][plan];
+    var used = limit != null
       ? 'You have used all ' + limit + ' ' + p.unit + ' included in your plan this month.'
       : 'You have used all ' + p.unit + ' included in your plan this month.';
+    // Name the ceiling of the rung above. The card used to promise a vaguely
+    // higher one while the number was sitting right here; every tier has a
+    // finite plafond, so it can say which one it is.
+    var next = NEXT[dim][plan];
+    var offer = next
+      ? ' Upgrade to ' + next.name + ' (' + next.price + ') for ' + next.limit + ' ' +
+        p.unit + ' a month, or wait until your quota resets next month.'
+      : ' Your quota resets next month.';
     return '<div class="pa-quota-upsell" role="status">' +
-      '<strong>Community monthly limit reached.</strong>' +
-      '<span>' + used + ' Upgrade to ' + p.upgrade + ' (' + p.price +
-      ') for a higher limit, or wait until your quota resets next month.</span>' +
+      '<strong>' + PLAN_LABEL[plan] + ' monthly limit reached.</strong>' +
+      '<span>' + used + offer + '</span>' +
       '<a class="btn btn-primary" href="/pricing">View plans</a>' +
       '</div>';
   }

--- a/frontend/js/quota-upgrade.js
+++ b/frontend/js/quota-upgrade.js
@@ -30,10 +30,18 @@
   // from relay/lib/tiers.js (transfers_month, signs_month) with the enterprise
   // row taking the finite plafond relay/lib/entitlements.js applies to a
   // metered dimension (ENTERPRISE_MONTHLY_CEILING). NO tier is unbounded, which
-  // is why no card here may call a ceiling absent: the ParaSign Pro pitch below
-  // promised transfers without a cap while a Pro account is held to 500 a
-  // month, the same overclaim /pricing and /parasign were corrected for. The
-  // word itself is banned from this file by the render test.
+  // is why no card here may call a ceiling absent, and why the word itself is
+  // banned from this file by the render test.
+  //
+  // These are TRANSFER numbers and they belong to a TRANSFER card. The ParaSign
+  // Pro pitch below used to end by promising transfers with no cap, and the
+  // honest version of that sentence is no sentence: transfers are a ParaSend
+  // capacity on plan_parasend, and applyProductTier(acct,'parasign','pro')
+  // deliberately never touches it, so a ParaSign Pro buyer keeps the ParaSend
+  // tier he already had (10 a month for a free account). Naming 500 there would
+  // have been as untrue as naming none. relay/test/parasign-pro-perks.test.js
+  // is the source for that; relay/test/quota-upgrade-render.test.js pins the
+  // pitch negatively against it.
   //
   // Baked in because this is a plain browser script with no way to require the
   // relay module. relay/test/quota-upgrade-render.test.js renders every card
@@ -109,8 +117,7 @@
     return '<div class="pa-quota-upsell pa-quota-card" role="status">' +
       '<strong>You\'ve used both signatures this month.</strong>' +
       '<span>Community gives you 2 a month, with the same encryption, the same post-quantum signatures and the same public proof log as every paid plan. You never pay for security here. You pay for volume.</span>' +
-      '<span><strong>Pro - EUR 49/month</strong><br>100 signatures a month, then EUR 0.40 each, up to 1,000. ' +
-        CEILINGS.transfers_month.pro + ' ParaSend transfers a month. API access.</span>' +
+      '<span><strong>Pro - EUR 49/month</strong><br>100 signatures a month, then EUR 0.40 each, up to 1,000. API access.</span>' +
       '<span class="pa-quota-actions">' +
         '<a class="btn btn-primary" href="/pricing">Upgrade to Pro</a>' +
         '<button type="button" class="btn btn-secondary" data-pa-quota-dismiss>Maybe later</button>' +

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -571,7 +571,7 @@ select:focus{border-color:var(--cobalt)}
 <script src="/vendor/qrcode.min.js?v=1"></script>
 <script type="module" src="/js/parashare.inline1.js?v=3"></script>
 <script src="/js/delegate.js?v=1" defer></script>
-<script src="/js/quota-upgrade.js?v=3" defer></script>
+<script src="/js/quota-upgrade.js?v=4" defer></script>
 <script src="/js/parashare.page.js?v=2" defer></script>
 <script src="/nav.js?v=14" defer></script>
 <script src="/js/nav-auth.js?v=5" defer></script>

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -283,7 +283,6 @@
         <div class="tier-note">excl. btw &middot; <span class="incl">charged &euro;59.29/mo incl. 21% btw</span><br>Annual &euro;499 excl.</div>
         <ul>
           <li>100 signatures a month, then &euro;0.40 each, up to 1,000</li>
-          <li>500 ParaSend transfers a month</li>
           <li>Up to 500 ParaSend retrievals an hour through the API</li>
           <li>API access</li>
         </ul>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -359,7 +359,7 @@
         <ul class="tier-features">
           <li>100 signatures a month, then &euro;0.40 each, up to 1,000</li>
           <li>Past 1,000 a month, Business is cheaper anyway</li>
-          <li>500 ParaSend transfers a month - API access</li>
+          <li>API access</li>
           <li>Annual: &euro;499 excl. &middot; 15.1% off</li>
         </ul>
         <a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Pro &rarr; <span style="font-weight:400;opacity:.85">&euro;59.29/mo incl.</span></a>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -359,7 +359,7 @@
         <ul class="tier-features">
           <li>100 signatures a month, then &euro;0.40 each, up to 1,000</li>
           <li>Past 1,000 a month, Business is cheaper anyway</li>
-          <li>Unlimited transfers - API access</li>
+          <li>500 ParaSend transfers a month - API access</li>
           <li>Annual: &euro;499 excl. &middot; 15.1% off</li>
         </ul>
         <a href="/auth/login?next=/pricing" data-billing-product="parasign" data-billing-plan="pro" data-billing-interval="monthly" class="btn btn-primary" style="display:block;text-align:center;margin-top:auto">Get ParaSign Pro &rarr; <span style="font-weight:400;opacity:.85">&euro;59.29/mo incl.</span></a>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -782,7 +782,7 @@
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script src="/js/parasign-pdf-ops.js?v=1"></script>
-<script src="/js/quota-upgrade.js?v=3" defer></script>
+<script src="/js/quota-upgrade.js?v=4" defer></script>
 <script type="module" src="/sign-flow.js?v=49"></script>
 </body>
 </html>

--- a/relay/test/parasign-pro-perks.test.js
+++ b/relay/test/parasign-pro-perks.test.js
@@ -2,7 +2,7 @@
 // ParaSign Pro perk delivery. The pricing page (frontend/pricing.html, ParaSign
 // Pro card) promises, per perk:
 //   1. "100 signatures a month, then EUR 0.40 each, up to 1,000"
-//   2. "Unlimited transfers - API access"
+//   2. "500 ParaSend transfers a month - API access"
 //
 // These prove, per perk, what a per-product grant of parasign=pro (the exact
 // effect of setProductPlan(account,'parasign','pro') and of a Mollie ParaSign
@@ -88,21 +88,27 @@ test('parasign=pro leaves the unified plan and ParaSend entitlement untouched', 
   assert.strictEqual(sendAfter.quotas.transfers_month, 10, 'ParaSend transfers cap unchanged');
 });
 
-// ── FINDING (regression-locked): "Unlimited transfers" is NOT delivered ───────
-// The page's ParaSign Pro card lists "Unlimited transfers", but transfers are a
-// ParaSEND capacity (plan_parasend), which a ParaSign grant deliberately does
-// not touch. A ParaSign-Pro customer keeps their EXISTING ParaSend tier (10/mo
-// for a free account). Moreover NO ParaSend tier is truly unlimited: even
-// enterprise is capped at ENTERPRISE_MONTHLY_CEILING, not Infinity. This test
-// pins that fact so a future "unlimited transfers" claim cannot slip in silently
-// via a ParaSign grant. Mick decides: bundle a ParaSend entitlement into
-// ParaSign Pro, or drop the line from the page.
-test('FINDING: a parasign=pro grant does NOT grant unlimited transfers (page overclaim)', () => {
+// ── FINDING (regression-locked): the transfers line is NOT delivered ─────────
+// The page's ParaSign Pro card lists a ParaSend transfers allowance, but
+// transfers are a ParaSEND capacity (plan_parasend), which a ParaSign grant
+// deliberately does not touch. A ParaSign-Pro customer keeps their EXISTING
+// ParaSend tier (10/mo for a free account), so the card promises 500 that the
+// grant does not hand over.
+//
+// The card no longer says "Unlimited transfers". That half was strictly false
+// for everyone, because NO ParaSend tier is unbounded: even enterprise is
+// capped at ENTERPRISE_MONTHLY_CEILING, not Infinity, and /pricing, /parasign,
+// the dashboard and the 402 upgrade card now all quote the real 500 (see
+// tests/ui-truthfulness.test.mjs, which bans the old wording site-wide). What
+// this test still pins is the DELIVERY gap underneath the wording: a
+// parasign=pro grant moves no ParaSend ceiling at all. Mick decides: bundle a
+// ParaSend Pro entitlement into ParaSign Pro, or drop the line from the cards.
+test('FINDING: a parasign=pro grant does NOT move the ParaSend transfers ceiling (page overclaim)', () => {
   const acct = freeAccount();
   ent.applyProductTier(acct, 'parasign', 'pro');
   const transfers = ent.getEntitlements(acct).parasend.quotas.transfers_month;
-  assert.strictEqual(transfers, 10, 'ParaSign Pro grant leaves transfers at the free ParaSend cap, NOT unlimited');
-  // And the highest ParaSend tier is finite, so "unlimited" is not a real tier.
+  assert.strictEqual(transfers, 10, 'ParaSign Pro grant leaves transfers at the free ParaSend cap, NOT at the 500 the card names');
+  // And the highest ParaSend tier is finite, so no card may drop the ceiling.
   assert.strictEqual(ent.PARASEND.enterprise.quotas.transfers_month, ent.ENTERPRISE_MONTHLY_CEILING);
-  assert.notStrictEqual(ent.PARASEND.enterprise.quotas.transfers_month, Infinity, 'no ParaSend tier is truly unlimited');
+  assert.notStrictEqual(ent.PARASEND.enterprise.quotas.transfers_month, Infinity, 'no ParaSend tier is unbounded');
 });

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -80,7 +80,7 @@ const PARASIGN_COPY = [
   '&euro;49<',
   '100 signatures a month, then &euro;0.40 each, up to 1,000',
   'Past 1,000 a month, Business is cheaper anyway',
-  'Unlimited transfers - API access',
+  tiers.tierLimit('pro', 'transfers_month') + ' ParaSend transfers a month - API access',
   'Annual: &euro;499 excl. &middot; 15.1% off',
   // BUSINESS - EUR 299/month
   '&euro;299<',

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -80,7 +80,7 @@ const PARASIGN_COPY = [
   '&euro;49<',
   '100 signatures a month, then &euro;0.40 each, up to 1,000',
   'Past 1,000 a month, Business is cheaper anyway',
-  tiers.tierLimit('pro', 'transfers_month') + ' ParaSend transfers a month - API access',
+  'API access',
   'Annual: &euro;499 excl. &middot; 15.1% off',
   // BUSINESS - EUR 299/month
   '&euro;299<',
@@ -615,10 +615,45 @@ for (const [name, pageHtml] of [['parasign.html', productHtml.parasign], ['paras
   ok('"No limit on receiving" holds: no receiving dimension in tiers.js or in the entitlement quotas');
 })();
 
-// A ParaSign plan derives its ParaSend tier (entitlements.js derivePlanParasend),
-// so where /parasign quotes a transfer number it must be that tier's number.
-assert(aMonth(tiers.tierLimit('pro', 'transfers_month'), 'ParaSend transfers').test(productHtml.parasign),
-  'parasign.html must quote the ParaSend transfer ceiling a ParaSign Pro account actually derives');
+// ── A ParaSign card states no transfer figure at all ────────────────────────
+//
+// This block used to assert the opposite: "a ParaSign plan derives its ParaSend
+// tier (entitlements.js derivePlanParasend), so where /parasign quotes a
+// transfer number it must be that tier's number". derivePlanParasend only fires
+// on a legacy UNIFIED `plan`. The path that sells ParaSign Pro is
+// applyProductTier(acct,'parasign','pro') -- the Mollie webhook and the admin
+// grant -- and it writes plan_parasign alone, deliberately leaving
+// plan_parasend where it was. So a ParaSign Pro buyer derives nothing: he keeps
+// the ParaSend tier he already had, 10 transfers a month for a free account.
+// relay/test/parasign-pro-perks.test.js pins exactly that.
+//
+// The page therefore may not quote 500, and it may not go back to promising no
+// cap either. It states neither, and this asks the entitlement layer whether
+// that is still the right answer instead of hardcoding it: bundle a ParaSend
+// entitlement into ParaSign Pro and the branch flips by itself.
+(function parasignCardsClaimNoTransfers() {
+  const acct = { key: 'k', account_id: 'k', plan: 'community', plan_parasend: 'community', plan_parasign: 'free' };
+  entitlements.applyProductTier(acct, 'parasign', 'pro');
+  const delivered = entitlements.getEntitlements(acct).parasend.quotas.transfers_month;
+  const TRANSFER_FIGURE = /[\d][\d,]*\s*(?:ParaSend\s+)?transfers/i;
+  // The ParaSign half of /pricing, and the ParaSign product page's plan cards.
+  const parasignGrid = html.slice(html.indexOf('<!-- TIER CARDS: PARASIGN -->'), html.indexOf('<!-- TIER CARDS: PARASEND -->'));
+  assert(parasignGrid.length > 500, 'the ParaSign tier grid markers moved; this gate would read nothing');
+  const scopes = [['pricing.html ParaSign grid', parasignGrid], ['parasign.html', productHtml.parasign]];
+  if (delivered === entitlements.PARASEND.pro.quotas.transfers_month) {
+    for (const [name, scope] of scopes) {
+      assert(TRANSFER_FIGURE.test(scope),
+        name + ': a parasign=pro grant now delivers the ParaSend Pro ceiling, so the card may (and should) state it');
+    }
+  } else {
+    for (const [name, scope] of scopes) {
+      const m = TRANSFER_FIGURE.exec(scope);
+      assert(!m, name + ' quotes "' + (m ? m[0] : '') + '" on a ParaSign card, but a parasign=pro grant leaves ' +
+        'ParaSend at ' + delivered + ' a month (relay/test/parasign-pro-perks.test.js). Bundle the entitlement or drop the line.');
+    }
+  }
+  ok('the ParaSign cards claim no transfer ceiling the ParaSign grant does not deliver (grant gives ' + delivered + ')');
+})();
 ok('the ParaSend limits on both product pages come from relay/lib/tiers.js (' +
    tiers.tierLimit('community', 'transfers_month') + '/' + tiers.tierLimit('pro', 'transfers_month') + ' transfers, ' +
    tiers.tierLimit('community', 'file_mb') + ' MB)');

--- a/relay/test/quota-upgrade-render.test.js
+++ b/relay/test/quota-upgrade-render.test.js
@@ -9,6 +9,8 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const tiers = require('../lib/tiers');
+const ent = require('../lib/entitlements');
 
 const src = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'js', 'quota-upgrade.js'), 'utf8');
 const sandbox = { window: {}, document: { addEventListener() {} } };
@@ -17,6 +19,21 @@ const q = sandbox.window.paQuotaUpgrade;
 
 // The false "No cap, no block" claim must be gone from the source entirely.
 assert(!src.includes('No cap, no block'), 'No cap, no block must be gone from quota-upgrade.js');
+
+// And nothing in this file may promise anything unlimited. tiers.js gives every
+// metered tier a finite transfers_month and entitlements.js caps even
+// enterprise at ENTERPRISE_MONTHLY_CEILING, so a card that renders the word is
+// selling a ceiling that does not exist. The ParaSign Pro pitch said
+// "Unlimited transfers" while a Pro account is held to 500 a month. The word is
+// banned site-wide next to "transfers" by tests/ui-truthfulness.test.mjs; here
+// it is banned outright, comments included, because there is nothing in a quota
+// card that could honestly carry it.
+assert(!/unlimited/i.test(src),
+  'quota-upgrade.js must not use the word "unlimited": every tier it renders has a finite plafond');
+// "a higher limit" was the other half of the same evasion: the card knew the
+// number and printed a vague promise instead.
+assert(!src.includes('a higher limit'),
+  'the upgrade card must name the ceiling of the rung above, not promise "a higher limit"');
 
 let passed = 0;
 function ok(name) { passed++; console.log('  ok -', name); }
@@ -44,7 +61,8 @@ for (const s of [
   "You've used both signatures this month.",
   'Community gives you 2 a month, with the same encryption, the same post-quantum signatures and the same public proof log as every paid plan. You never pay for security here. You pay for volume.',
   'Pro - EUR 49/month',
-  '100 signatures a month, then EUR 0.40 each, up to 1,000. Unlimited transfers. API access.',
+  '100 signatures a month, then EUR 0.40 each, up to 1,000. ' +
+    tiers.tierLimit('pro', 'transfers_month') + ' ParaSend transfers a month. API access.',
   'Upgrade to Pro',
   'Maybe later',
   'Your limit resets on 2026-08-01.',
@@ -73,12 +91,59 @@ assert(cap.includes('Upgrade to Business') && cap.includes('href="/pricing"'), '
 assert(!cap.includes('No cap, no block'), 'the false No cap, no block claim is gone');
 ok('pro hard cap renders the upgrade card verbatim, linking to /pricing');
 
-// ── Old backend: transfers keep the prior notice ────────────────────────────
+// ── The transfer 402 card ───────────────────────────────────────────────────
 const legacy = q.html({ error: 'monthly_transfer_quota_reached', dimension: 'transfers_month', plan: 'free', limit: 10 });
 assert(legacy.includes('Community monthly limit reached.'), 'transfer 402 keeps the legacy notice');
 assert(legacy.includes('ParaSend Pro'), 'transfer 402 keeps the ParaSend upgrade');
 assert(legacy.includes('all 10 transfers'), 'transfer 402 keeps the limit interpolation');
 ok('transfer 402 falls back to the existing notice');
+
+// ── Every ceiling the cards print is the one tiers.js/entitlements.js enforce ─
+//
+// The numbers are baked into frontend/js/quota-upgrade.js because it is a plain
+// browser script that cannot require the relay module. This block is what makes
+// that safe: it renders the real cards and compares each figure against the two
+// modules the relay gates on, so a tier edit that does not reach the frontend
+// turns red here instead of shipping a card that promises the old number.
+assert(free.includes(tiers.tierLimit('pro', 'transfers_month') + ' ParaSend transfers a month.'),
+  'the ParaSign Pro pitch must quote the ParaSend Pro transfers_month tiers.js enforces');
+
+// Per deciding tier: the header names THAT tier and the body its ceiling. The
+// 402 body carries both since #361 (relay.js reports _psend.tier and its
+// quotas.transfers_month, not the account's unified plan), and the card used to
+// print "Community" and an upsell to Pro whoever was looking at it.
+for (const [plan, tier, label] of [
+  ['free', 'community', 'Community'],
+  ['community', 'community', 'Community'],
+  ['pro', 'pro', 'Pro'],
+  ['business', 'business', 'Business'],
+  ['enterprise', 'enterprise', 'Enterprise'],
+]) {
+  const limit = ent.PARASEND[tier].quotas.transfers_month;
+  assert(Number.isFinite(limit), tier + ' must have a finite transfers ceiling');
+  const card = q.html({ error: 'monthly_transfer_quota_reached', dimension: 'transfers_month', plan, limit });
+  assert(card.includes(label + ' monthly limit reached.'),
+    'the transfer 402 card must name the tier that decided (' + plan + ' -> ' + label + ')');
+  assert(card.includes('You have used all ' + limit + ' transfers included in your plan this month.'),
+    'the transfer 402 card must print the deciding tier ceiling (' + tier + ' = ' + limit + ')');
+  // Only the tier below Pro is offered an upgrade; a Pro account is not sold Pro.
+  if (tier === 'community') {
+    assert(card.includes('Upgrade to ParaSend Pro (EUR 15/month excl. VAT) for ' +
+      tiers.tierLimit('pro', 'transfers_month') + ' transfers a month'),
+      'the Community transfer card must name the ParaSend Pro ceiling from tiers.js');
+  } else {
+    assert(!card.includes('Upgrade to'), tier + ' must not be upsold the tier it already has');
+    assert(card.includes('Your quota resets next month.'), tier + ' still learns when the quota resets');
+  }
+}
+ok('transfer 402 card: tier label, ceiling and upsell all come from tiers.js/entitlements.js');
+
+// A backend older than #361 sends no limit; the card falls back to the table and
+// the table is the same tiers.js number.
+const noLimit = q.html({ error: 'monthly_transfer_quota_reached', dimension: 'transfers_month', plan: 'pro' });
+assert(noLimit.includes('all ' + tiers.tierLimit('pro', 'transfers_month') + ' transfers'),
+  'a 402 without a limit falls back to the tiers.js ceiling of the reported tier');
+ok('missing limit falls back to the tiers.js ceiling, not to Community');
 
 // ── signNotice: the inline 200-response notices ─────────────────────────────
 const second = q.signNotice({ used: 2, included: 2, overage_count: 0, overage_rate_eur: null, hard_cap: null, reset_date: '2026-08-01' });

--- a/relay/test/quota-upgrade-render.test.js
+++ b/relay/test/quota-upgrade-render.test.js
@@ -61,8 +61,7 @@ for (const s of [
   "You've used both signatures this month.",
   'Community gives you 2 a month, with the same encryption, the same post-quantum signatures and the same public proof log as every paid plan. You never pay for security here. You pay for volume.',
   'Pro - EUR 49/month',
-  '100 signatures a month, then EUR 0.40 each, up to 1,000. ' +
-    tiers.tierLimit('pro', 'transfers_month') + ' ParaSend transfers a month. API access.',
+  '100 signatures a month, then EUR 0.40 each, up to 1,000. API access.',
   'Upgrade to Pro',
   'Maybe later',
   'Your limit resets on 2026-08-01.',
@@ -105,8 +104,32 @@ ok('transfer 402 falls back to the existing notice');
 // that safe: it renders the real cards and compares each figure against the two
 // modules the relay gates on, so a tier edit that does not reach the frontend
 // turns red here instead of shipping a card that promises the old number.
-assert(free.includes(tiers.tierLimit('pro', 'transfers_month') + ' ParaSend transfers a month.'),
-  'the ParaSign Pro pitch must quote the ParaSend Pro transfers_month tiers.js enforces');
+// The ParaSign Pro pitch names NO transfer figure, and that is the point of the
+// negative pin. It used to say "Unlimited transfers", which is false for every
+// tier. Replacing it with 500 would have been false too, for a sharper reason:
+// transfers are a ParaSEND capacity held on plan_parasend, and the grant behind
+// this card (applyProductTier(acct,'parasign','pro'), the Mollie ParaSign Pro
+// purchase) deliberately never touches that field. So a ParaSign Pro buyer
+// keeps whatever ParaSend tier he already had.
+//
+// relay/test/parasign-pro-perks.test.js is the source, and it is READ here
+// rather than restated, so the day a ParaSend entitlement IS bundled into
+// ParaSign Pro this pin lifts itself instead of holding a true line off the
+// card. Until then: no transfers number in a ParaSign pitch.
+const parasignProSend = (() => {
+  const acct = { key: 'k', account_id: 'k', plan: 'community', plan_parasend: 'community', plan_parasign: 'free' };
+  ent.applyProductTier(acct, 'parasign', 'pro');
+  return ent.getEntitlements(acct).parasend.quotas.transfers_month;
+})();
+if (parasignProSend === ent.PARASEND.pro.quotas.transfers_month) {
+  assert(/transfers/i.test(free),
+    'a parasign=pro grant now DOES deliver the ParaSend Pro transfers ceiling, so the Pro pitch may state it');
+} else {
+  assert(!/transfers/i.test(free),
+    'the ParaSign Pro pitch names a transfers figure, but a parasign=pro grant leaves ParaSend at ' +
+    parasignProSend + ' a month (see relay/test/parasign-pro-perks.test.js). Bundle the entitlement or drop the line.');
+}
+ok('the ParaSign Pro pitch claims no transfers ceiling the grant does not deliver');
 
 // Per deciding tier: the header names THAT tier and the body its ceiling. The
 // 402 body carries both since #361 (relay.js reports _psend.tier and its

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 
 function read(file) { return fs.readFileSync(new URL('../' + file, import.meta.url), 'utf8'); }
 
@@ -687,7 +688,7 @@ assert.match(developerHtml, /<p class="lede">[^<]*(?:<a[^>]*>[^<]*<\/a>[^<]*)*AP
 assert.doesNotMatch(developerHtml, /your IT can check/i,
   'developer.html talks to the developer on the screen, not to their buyer');
 // Both plan lines are only true while /pricing sells API access on ParaSign Pro.
-assert.match(pricing, /transfers a month - API access/,
+assert.match(pricing, /<li>API access<\/li>/,
   'pricing.html must still list API access on the ParaSign Pro tier');
 
 // Answer 1: signing without an account. Quoted from /sign, which is pinned above.
@@ -1560,14 +1561,13 @@ console.log('ui-truthfulness: /download says the desktop app is unmaintained, an
     'no frontend page or script may promise transfers without a ceiling; tiers.js caps every tier ' +
     'and relay.js answers 402 monthly_transfer_quota_reached with that cap:\n  ' + hits.join('\n  '));
 
-  // The positive half: /pricing, /parasign and the 402 card all quote the SAME
-  // ParaSend Pro ceiling, so correcting one page can never leave another behind.
+  // Where the word DID name a real ceiling, the number replaced it. These are
+  // ParaSend contexts: the plan table a self-hoster reads and the OT brief's own
+  // Pro tier, both describing the ParaSend capacity the relay actually enforces.
   const proTransfers = 500; // relay/lib/tiers.js pro.transfers_month, pinned to the module in relay/test/
   for (const [file, rx] of [
-    ['frontend/pricing.html', new RegExp(`<li>${proTransfers} ParaSend transfers a month - API access</li>`)],
-    ['frontend/parasign.html', new RegExp(`<li>${proTransfers} ParaSend transfers a month</li>`)],
-    ['frontend/js/quota-upgrade.js', new RegExp(`${proTransfers}`)],
-    ['frontend/js/dashboard.js', new RegExp(`${proTransfers} ParaSend transfers a month`)],
+    ['frontend/docs/paramant-ot-brief.html', new RegExp(`<li>${proTransfers} transfers a month</li>`)],
+    ['frontend/docs/self-hosting.md', new RegExp(`\\| \`pro\` \\| ${proTransfers} \\|`)],
   ]) {
     assert.match(read(file), rx,
       `${file} must state the ParaSend Pro transfers ceiling where it used to say "unlimited"`);
@@ -1575,3 +1575,66 @@ console.log('ui-truthfulness: /download says the desktop app is unmaintained, an
 })();
 
 console.log('ui-truthfulness: no page or script promises transfers without a ceiling');
+
+
+// ── A ParaSign surface states no transfers figure at all ────────────────────
+//
+// The other half of the same correction, and the sharper one. "Unlimited
+// transfers" on the ParaSign Pro card was false for everyone, because no tier
+// is unbounded. Putting 500 there would have been false for a different reason:
+// transfers are a ParaSEND capacity, held on plan_parasend, and the grant that
+// sells ParaSign Pro (entitlements.applyProductTier(acct,'parasign','pro'), the
+// Mollie webhook and the admin path) writes plan_parasign alone and leaves
+// plan_parasend exactly where it was. A ParaSign Pro buyer on a free ParaSend
+// tier keeps 10 transfers a month. relay/test/parasign-pro-perks.test.js pins
+// that delivery gap; this pins the copy that must not outrun it.
+//
+// So: ParaSign Pro sells signatures and the API. It does not sell transfers,
+// and no ParaSign card, pitch or plan summary may print a transfers number
+// while the grant does not move one. The gate ASKS the entitlement layer rather
+// than restating its answer, so bundling a ParaSend entitlement into ParaSign
+// Pro flips this from "must not state" to "must state" on its own.
+(function parasignSurfacesClaimNoTransfers() {
+  // The relay is CommonJS; this file is ESM. createRequire loads the real
+  // module rather than a copy of its numbers, which is the whole point: the
+  // gate has to move when the entitlement layer does.
+  const { applyProductTier, getEntitlements, PARASEND } =
+    createRequire(import.meta.url)('../relay/lib/entitlements.js');
+  const acct = { key: 'k', account_id: 'k', plan: 'community', plan_parasend: 'community', plan_parasign: 'free' };
+  applyProductTier(acct, 'parasign', 'pro');
+  const delivered = getEntitlements(acct).parasend.quotas.transfers_month;
+  const TRANSFER_FIGURE = /[\d][\d,]*\s*(?:ParaSend\s+)?transfers/i;
+
+  // Every surface that pitches ParaSign Pro, scoped to the ParaSign part of it.
+  const pricingHtml = read('frontend/pricing.html');
+  const between = (src, a, b) => src.slice(src.indexOf(a), b ? src.indexOf(b) : undefined);
+  const dashJs = read('frontend/js/dashboard.js');
+  const quotaJs = read('frontend/js/quota-upgrade.js');
+  const scopes = [
+    ['pricing.html ParaSign grid', between(pricingHtml, '<!-- TIER CARDS: PARASIGN -->', '<!-- TIER CARDS: PARASEND -->')],
+    ['parasign.html plan cards', between(read('frontend/parasign.html'), '<h3', '')],
+    ['dashboard.js PRODUCT_INCLUDES.parasign', between(dashJs, 'parasign: {', 'parasend: {')],
+    ['quota-upgrade.js freeSignHtml', between(quotaJs, 'function freeSignHtml', 'function hardCapHtml')],
+  ];
+  for (const [name, scope] of scopes) {
+    assert.ok(scope.length > 200, `${name}: the scope markers moved; this gate would read nothing`);
+  }
+
+  if (delivered === PARASEND.pro.quotas.transfers_month) {
+    for (const [name, scope] of scopes) {
+      assert.match(scope, TRANSFER_FIGURE,
+        `${name}: a parasign=pro grant now delivers the ParaSend Pro ceiling, so this surface may state it`);
+    }
+  } else {
+    const hits = scopes
+      .map(([name, scope]) => [name, TRANSFER_FIGURE.exec(scope)])
+      .filter(([, m]) => m)
+      .map(([name, m]) => `${name}: "${m[0]}"`);
+    assert.deepEqual(hits, [],
+      'a ParaSign surface prints a transfers figure, but entitlements.applyProductTier(acct, "parasign", "pro") ' +
+      `leaves ParaSend at ${delivered} a month (relay/test/parasign-pro-perks.test.js). ` +
+      'Bundle a ParaSend entitlement into ParaSign Pro, or keep the line off the card:\n  ' + hits.join('\n  '));
+  }
+})();
+
+console.log('ui-truthfulness: no ParaSign surface sells a transfers ceiling the ParaSign grant does not deliver');

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -687,7 +687,7 @@ assert.match(developerHtml, /<p class="lede">[^<]*(?:<a[^>]*>[^<]*<\/a>[^<]*)*AP
 assert.doesNotMatch(developerHtml, /your IT can check/i,
   'developer.html talks to the developer on the screen, not to their buyer');
 // Both plan lines are only true while /pricing sells API access on ParaSign Pro.
-assert.match(pricing, /Unlimited transfers - API access/,
+assert.match(pricing, /transfers a month - API access/,
   'pricing.html must still list API access on the ParaSign Pro tier');
 
 // Answer 1: signing without an account. Quoted from /sign, which is pinned above.
@@ -1507,3 +1507,71 @@ console.log('ui-truthfulness: the messaging guide claims are pinned to the pages
 })();
 
 console.log('ui-truthfulness: /download says the desktop app is unmaintained, and the archive matches the artifacts');
+
+
+// ── "Unlimited transfers", banned across the whole site ──────────────────────
+//
+// relay/lib/tiers.js gives every metered tier a finite transfers_month (10 on
+// Community, 500 on Pro, 2,000 on Business) and relay/lib/entitlements.js holds
+// even enterprise to ENTERPRISE_MONTHLY_CEILING rather than Infinity, so no
+// page and no script may promise transfers without a ceiling. relay/relay.js
+// refuses the transfer over the cap with a 402 monthly_transfer_quota_reached
+// naming that ceiling: a visitor who read "unlimited" meets the number anyway,
+// at the worst possible moment.
+//
+// relay/test/pricing-page.test.js already forbade the phrase, but only on
+// /parasign and /parasend, and only in .html. It sat on three files that check
+// could not see: /pricing itself (the ParaSign Pro card), frontend/js/
+// quota-upgrade.js (the 402 upgrade card, which is the very screen the relay
+// shows when the cap bites) and frontend/js/dashboard.js (the summary a paying
+// customer reads). So the ban is scoped to the whole frontend here, scripts and
+// served markdown included, which is what "site-wide" has to mean for a claim
+// that travels in a template string.
+//
+// Receiving IS uncapped, and stays sayable: nothing in tiers.js or in any
+// entitlement quota meters it (#359 pins that negatively in pricing-page.test).
+// Licence capacity is uncapped too (max_keys 'unlimited' really is Infinity in
+// relay.js), as is enterprise devices/outbound_per_hour in tiers.js. So this
+// bans the word beside "transfers", not the word.
+(function noUnlimitedTransfers() {
+  const TEXT_EXT = ['.html', '.js', '.mjs', '.md'];
+  const SKIP_DIR = ['node_modules', 'vendor', 'assets'];
+  const walk = (dir) => fs.readdirSync(new URL('../' + dir, import.meta.url), { withFileTypes: true })
+    .flatMap((e) => {
+      if (e.isDirectory()) return SKIP_DIR.includes(e.name) ? [] : walk(`${dir}/${e.name}`);
+      return TEXT_EXT.some((x) => e.name.endsWith(x)) ? [`${dir}/${e.name}`] : [];
+    });
+  const files = walk('frontend');
+  assert.ok(files.length > 20, `the frontend walk found only ${files.length} text files; the ban would be vacuous`);
+
+  // Comments are stripped: a comment that explains a removed overclaim quotes
+  // the wording it exists to forbid, which is exactly how it stays forbidden.
+  const strip = (s) => s
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/^[ \t]*\/\/.*$/gm, ' ');
+
+  const hits = [];
+  for (const file of files) {
+    const m = /unlimited(?:\s|&nbsp;|<[^>]+>)+(?:\w+(?:\s|&nbsp;)+)?transfers/i.exec(strip(read(file)));
+    if (m) hits.push(`${file}: "${m[0].replace(/\s+/g, ' ')}"`);
+  }
+  assert.deepEqual(hits, [],
+    'no frontend page or script may promise transfers without a ceiling; tiers.js caps every tier ' +
+    'and relay.js answers 402 monthly_transfer_quota_reached with that cap:\n  ' + hits.join('\n  '));
+
+  // The positive half: /pricing, /parasign and the 402 card all quote the SAME
+  // ParaSend Pro ceiling, so correcting one page can never leave another behind.
+  const proTransfers = 500; // relay/lib/tiers.js pro.transfers_month, pinned to the module in relay/test/
+  for (const [file, rx] of [
+    ['frontend/pricing.html', new RegExp(`<li>${proTransfers} ParaSend transfers a month - API access</li>`)],
+    ['frontend/parasign.html', new RegExp(`<li>${proTransfers} ParaSend transfers a month</li>`)],
+    ['frontend/js/quota-upgrade.js', new RegExp(`${proTransfers}`)],
+    ['frontend/js/dashboard.js', new RegExp(`${proTransfers} ParaSend transfers a month`)],
+  ]) {
+    assert.match(read(file), rx,
+      `${file} must state the ParaSend Pro transfers ceiling where it used to say "unlimited"`);
+  }
+})();
+
+console.log('ui-truthfulness: no page or script promises transfers without a ceiling');


### PR DESCRIPTION
`relay/lib/tiers.js` geeft elke gemeten tier een eindig `transfers_month` (Community 10, Pro 500, Business 2000) en `relay/lib/entitlements.js` houdt zelfs enterprise op `ENTERPRISE_MONTHLY_CEILING` in plaats van Infinity. Op acht plekken stond toch "unlimited", waaronder de 402-kaart die de relay toont op precies het moment dat het plafond bijt.

Onderweg bleek de helft van die plekken een tweede fout te hebben, die deze PR niet zelf kan oplossen.

## Besluit voor Mick: bundelen of gescheiden houden

`/pricing` verkocht ParaSign Pro met "Unlimited transfers". Dat woord is voor geen enkele tier waar. Maar er 500 van maken zou net zo onwaar zijn geweest, om een scherpere reden.

Transfers zijn een **ParaSend**-capaciteit, opgeslagen op `plan_parasend`. Het pad dat ParaSign Pro verkoopt is `entitlements.applyProductTier(acct, 'parasign', 'pro')`: de Mollie-webhook en de admin-grant. Dat schrijft alleen `plan_parasign` en laat `plan_parasend` bewust staan. Een ParaSign Pro-koper op een gratis ParaSend-tier houdt dus **10 transfers per maand**. `relay/test/parasign-pro-perks.test.js` pint dat al sinds het geschreven werd, met de opmerking dat jij beslist.

Twee opties, allebei geldig:

1. **Bundelen.** ParaSend Pro meeleveren bij ParaSign Pro. Dan moet `applyProductTier` het ook echt schrijven, en mogen de kaarten 500 noemen. De drie negatieve pins hieronder draaien dan vanzelf om naar "moet er staan": ze vragen het de entitlement-laag, ze herhalen het antwoord niet.
2. **Gescheiden houden**, zoals nu. ParaSign Pro verkoopt handtekeningen en de API; wie transfers wil koopt ParaSend Pro. Dat is wat deze PR doet, want het is de enige stand die vandaag waar is.

Deze PR kiest niet voor je. Hij haalt de onware regel weg en zet er een hek omheen dat meebeweegt zodra je optie 1 kiest.

## Per treffer, oud en nieuw

**ParaSign-kaarten: de transfers-regel is weg.** ParaSign Pro verkoopt handtekeningen.

| Waar | Was | Nu |
|---|---|---|
| `frontend/pricing.html`, ParaSign Pro-kaart | "Unlimited transfers - API access" | "API access" |
| `frontend/parasign.html`, ParaSign Pro-kaart | "500 ParaSend transfers a month" | regel verwijderd |
| `frontend/js/quota-upgrade.js`, ParaSign Pro-pitch in de 402 | "... up to 1,000. Unlimited transfers. API access." | "... up to 1,000. API access." |
| `frontend/js/dashboard.js`, samenvatting betalende ParaSign-klant | "..., unlimited transfers, and a connection ..." | "..., and a connection ..." |

**ParaSend-contexten: het echte getal, uit `tiers.js`.** Daar handhaaft de relay het ook.

| Waar | Was | Nu |
|---|---|---|
| `frontend/js/quota-upgrade.js`, kop transfer-402 | altijd "Community monthly limit reached." | de tier die de 402 meldt |
| `frontend/js/quota-upgrade.js`, aanbod transfer-402 | "for a higher limit" | "for 500 transfers a month", en geen upsell naar een tier die je al hebt |
| `frontend/docs/paramant-ot-brief.html`, Pro-tier | "Unlimited transfers" / "Managed, unlimited" | "500 transfers a month" / "Managed relay" |
| `docs/` + `frontend/docs/self-hosting.md`, plantabel | pro/enterprise "Unlimited" uploads per dag, 500 MB, unlimited bestandsgrootte, verzonnen kolom `Priority` | de tiers.js-cijfers, met `outbound_per_hour` op de plek van `Priority` |
| `admin/server.js`, rate limit anonieme drop | "free account for unlimited drops" | "free account for 10 transfers a month" |

## Het 402-antwoord deed zijn deel al

Sinds #361 meldt `relay.js:4688` bij `monthly_transfer_quota_reached` de tier die **besliste** (`_psend.tier`) plus diens plafond (`_psend.quotas.transfers_month`), niet het samengevoegde accountplan. De kaart negeerde allebei: hij drukte "Community" af wie er ook keek, en bood ParaSend Pro aan een Pro-account aan. Aan de relay was niets te repareren; de kaart leest ze nu, met de gespiegelde tabel alleen als terugval voor een backend van voor #361.

## Wat blijft staan, en waarom het waar is

- **"No limit on receiving"** en **"unlimited receiving"** (`about.html`, `signup.html`): niets meet ontvangen, negatief gepind sinds #359.
- **"Unlimited registered devices"** op ParaSend Enterprise: `tiers.js` `devices: UNLIMITED`.
- **"unlock unlimited users"** (docs, relay): `LICENSE_MAX_KEYS` is echt `Infinity` bij `max_keys: "unlimited"`.
- **`docs/api.md`** enterprise devices en downloads per uur: spiegelt `tiers.js` correct.
- **`vs.html`**: beschrijft de opslag van een concurrent.
- CHANGELOG, ADR's, security-audit: historisch verslag, geen claim.

Gemeld, niet aangeraakt:

- `frontend/parasign.html` houdt "Up to 500 ParaSend retrievals an hour through the API" op de ParaSign Pro-kaart. Dat is `outbound_per_hour`, dezelfde soort claim als de transfers-regel en met hetzelfde leveringsgat, maar #359 heeft die regel er bewust neergezet en gepind. Valt onder hetzelfde besluit hierboven.
- `docs/businessmodel.md` verkoopt een OT-model van 12 euro per maand met "Unlimited transfers" dat nergens meer op slaat. Staat niet in `frontend/`, wordt dus niet geserveerd.
- De Evaluation-tier in de OT-brief belooft "1000 transfers / 30 days" terwijl Community er 10 heeft. Zelfde drift, buiten de opdracht "Unlimited".

## Tests

- **`tests/ui-truthfulness.test.mjs`**, twee blokken. Het eerste verbiedt "unlimited transfers" over de hele frontend, scripts en geserveerde markdown inbegrepen: `pricing-page.test.js` verbood het al, maar alleen op `/parasign` en `/parasend` en alleen in `.html`, en precies daardoor overleefde het in `frontend/js/`. Het tweede loopt vier ParaSign-scopes af (de ParaSign-grid van `/pricing`, de plankaarten van `/parasign`, `PRODUCT_INCLUDES.parasign` in `dashboard.js`, `freeSignHtml` in `quota-upgrade.js`) en faalt op elk transfers-getal zolang de grant er geen levert.
- **`relay/test/pricing-page.test.js`** vervangt de assertie die het omgekeerde beweerde. Die zei dat `/parasign` het plafond moest noemen dat een ParaSign Pro-account "actually derives" via `derivePlanParasend`, maar die helper vuurt alleen op een oud samengevoegd `plan`, nooit op het koop-pad.
- **`relay/test/quota-upgrade-render.test.js`** rendert de echte kaarten, vergelijkt elk cijfer per beslissende tier met `tiers.js`/`entitlements.js`, verbiedt het woord in dat bestand helemaal, en pint de ParaSign-pitch negatief.
- **`relay/test/parasign-pro-perks.test.js`** houdt zijn FINDING: de grant verzet nog steeds geen ParaSend-plafond.

Alle drie de negatieve pins draaien `applyProductTier` écht en vergelijken de uitkomst met `PARASEND.pro`. Kies je optie 1, dan slaan ze om naar "moet er staan", zodat het hek nooit een ware regel van de kaart houdt.

## Bewijs

Sabotage, allemaal rood:

| Sabotage | Rood in |
|---|---|
| "Unlimited transfers" terug op `/pricing` | ui-truthfulness, pricing-page |
| "unlimited transfers" terug in `js/dashboard.js` | ui-truthfulness (noemt bestand en tekst) |
| "Unlimited transfers" terug in de 402-kaart | quota-upgrade-render, ui-truthfulness |
| "Unlimited transfers" terug in de OT-brief | ui-truthfulness |
| `tiers.js` pro 500 -> 400 | quota-upgrade-render, pricing-page |
| transfers-getal terug op de `/pricing` ParaSign-kaart | ui-truthfulness, pricing-page |
| transfers-getal terug op de `/parasign` ParaSign-kaart | ui-truthfulness, pricing-page |
| transfers-getal terug in de 402 ParaSign-pitch | quota-upgrade-render, ui-truthfulness |
| transfers-getal terug in `dashboard.js` | ui-truthfulness |
| omgekeerd: `applyProductTier` schrijft wél `plan_parasend='pro'` | alle drie de pins slaan om naar "de kaart mag het nu noemen" |

Groen: ui-truthfulness, site-claims, pricing-page, quota-upgrade-render, parasign-pro-perks, frontend-loading-contract, pricing-fold, first-screen, seo-contract, links, navigation-shell, csp-inline, cache-bust, eslint, static-sanity (11 checks).

Head-elementen niet aangeraakt. `?v=` gebumpt op de scripttags onderaan de body (`quota-upgrade.js` 3 -> 4, `dashboard.js` 6 -> 7), omdat de inhoud van allebei achter een immutable cache veranderde.
