### PR TITLE
Deploy: tag rollback images by image ID, not by the recorded name

### DIFF
--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -792,8 +792,12 @@ for svc in $SVCS; do
     echo "skip $svc (not running)"
     continue
   fi
+  # Tag by image ID, not by the name compose recorded: on production the
+  # recorded name (paramant-relay-<svc>:latest) no longer resolves to an
+  # image, but the running container's image ID always does.
   img="$(docker inspect --format '{{.Config.Image}}' "$cid")"
-  docker tag "$img" "paramant-rollback/$svc:$TS"
+  iid="$(docker inspect --format '{{.Image}}' "$cid")"
+  docker tag "$iid" "paramant-rollback/$svc:$TS"
   echo "$svc|$img|paramant-rollback/$svc:$TS" >> "$MANIFEST"
 done
 ln -sfn "$MANIFEST" "$BK/rollback-images-latest.txt"


### PR DESCRIPTION
First real run of deploy/deploy-3.1.sh (20260903-0126) stopped in phase 2a: docker tag failed with No such image: paramant-relay-relay-health:latest. The name compose recorded in Config.Image does not resolve on production; the container's image ID does. Phase 2a now tags the ID; the manifest keeps the recorded name. Phases 0 and 1 had passed (CI green, static sanity clear, checkout on 41501bb, six containers healthy, env as expected). Nothing was replaced. Dry-run test 193/193, static-sanity PASS.