### PR TITLE
Measure the security posture from the outside, daily

### DIFF
--- a/.github/workflows/security-posture.yml
+++ b/.github/workflows/security-posture.yml
@@ -1,0 +1,216 @@
+name: security-posture
+
+# What the outside world can see about Paramant, measured daily from the
+# outside, logged in nowhere.
+#
+# The gap this closes. Every gate in this repo reads the checkout: static-sanity
+# reads source, the cache-bust and CSP guards read frontend/, build-image builds
+# the Dockerfile, heartbeat drives the products through a browser. None of them
+# reads the certificate, the DNS zone, the response headers of the five sector
+# relays, or whether the ParaID issuing route is still shut. Those live on the
+# server and in the zone, not in git, and the repo has no drift guard for either
+# (scripts/check-prod-drift.sh covers the frontend docroot and nothing else).
+# The ParaID route was open on production for forty days in 2026 and was closed
+# by an nginx rule that exists on the server only. Nothing in CI would notice it
+# reopening. This does.
+#
+# The rule it is built on comes from the heartbeat rewrite of 2026-09-02: a
+# monitoring step never gets an escape of its own. A missing tool, a silent
+# host or an unparseable answer is red with the name of what is missing, never
+# green with a reason. scripts/security/posture.sh has no skip in it.
+#
+# And because the last monitor died from nobody watching the watcher, the
+# scanner has its own gate. The selftest job below drives all 108 measurements
+# green once and red once against stubbed curl, openssl, dig and npm, and fails
+# if any of them can only report one of the two. That job runs on every pull
+# request; the live job does not.
+
+on:
+  schedule:
+    # Daily at 04:43 UTC. Off the hour and off the half hour, because the whole
+    # of GitHub schedules on :00 and a job queued there starts late.
+    - cron: '43 4 * * *'
+  workflow_dispatch:
+  # The selftest is a checkout-only gate and belongs on every change, for the
+  # same reason csp-inline-check is not path-gated: a required check that is
+  # skipped never reports, and the pull request waits on it forever.
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  # Only the live job writes an issue. Read of the code is all the selftest needs.
+  issues: write
+
+concurrency:
+  # Two scans at once double the requests against production and race each
+  # other's issue comment.
+  group: security-posture
+  cancel-in-progress: false
+
+jobs:
+  selftest:
+    name: posture scanner, both directions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+      - name: The scanner parses
+        run: bash -n scripts/security/posture.sh tests/security-posture-dryrun.sh
+      # Not installed in this repo and not in any other job, so it is asked for
+      # rather than assumed. If the runner image stops shipping it the step says
+      # so instead of quietly passing.
+      - name: shellcheck, if the runner has it
+        run: |
+          set -uo pipefail
+          if command -v shellcheck >/dev/null 2>&1; then
+            shellcheck --severity=warning scripts/security/posture.sh tests/security-posture-dryrun.sh
+          else
+            echo "::warning title=shellcheck::not on this runner; only bash -n ran over the posture scripts"
+          fi
+      - name: Every measurement goes green once and red once
+        run: tests/security-posture-dryrun.sh
+
+  posture:
+    name: security posture, production
+    needs: selftest
+    # Held shut the same way heartbeat.yml is, and for the same reason. The
+    # first full scan came back with 18 red measurements. Ten of them are the
+    # missing X-Frame-Options and the empty Permissions-Policy on the five
+    # sector relays, fixed in this same change but only true on production once
+    # the relay image is deployed. The other eight no merge can touch: a
+    # duplicated HSTS on those five relays, no CAA record, an unsigned zone, and
+    # a live sitemap that still advertises two pages which answer 302. Merged
+    # without a gate this would go red every morning about a list everyone
+    # already knows, and an alarm that cries daily for a known reason is one
+    # people learn to ignore. Set SECURITY_POSTURE_ENABLED to true once the
+    # deploy has happened and the decisions in the pull request are carried out.
+    #
+    # workflow_dispatch always runs, so the scan can be started by hand at any
+    # point, including now, to see exactly what is still red.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && vars.SECURITY_POSTURE_ENABLED == 'true')
+    runs-on: ubuntu-latest
+    # Six hosts times four protocol handshakes, sixty sitemap urls and an
+    # advisory lookup per crate. About four minutes; this is the ceiling that
+    # turns a hung relay into a red run instead of a job that sits there.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Measure
+        id: scan
+        # continue-on-error, not a bare failure: the report has to be uploaded
+        # and the issue written before the job is allowed to end red.
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          mkdir -p security-posture-evidence
+          scripts/security/posture.sh \
+            --report security-posture-evidence/posture.md \
+            --json security-posture-evidence/posture.json
+
+      # Always, and a red run's report is the more useful of the two.
+      - name: Keep the evidence
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: security-posture-${{ github.run_id }}
+          path: security-posture-evidence/
+          if-no-files-found: error
+          retention-days: 90
+
+      # A run that produced no report measured nothing, whatever its exit code
+      # said. That is the shape the old canaries failed in.
+      - name: A run without a report is a failed run
+        if: always()
+        run: |
+          set -uo pipefail
+          if [ ! -s security-posture-evidence/posture.json ]; then
+            echo "::error title=Security posture::the scan wrote no evidence, so it proved nothing"
+            exit 1
+          fi
+          node -e '
+            const j = JSON.parse(require("fs").readFileSync("security-posture-evidence/posture.json", "utf8"));
+            if (!Array.isArray(j.checks) || j.checks.length < 40) {
+              console.log("::error title=Security posture::only " + (j.checks || []).length + " measurements ran; the scan is incomplete");
+              process.exit(1);
+            }
+            console.log(j.verdict + ": " + j.green + " green, " + j.red + " red over " + j.checks.length + " measurements.");
+            if (j.verdict !== "GROEN") process.exit(1);
+          '
+
+      - name: Open or update the issue when the posture is red
+        if: failure()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const read = (p, d) => { try { return fs.readFileSync(p, 'utf8'); } catch { return d; } };
+            let scan = null;
+            try { scan = JSON.parse(read('security-posture-evidence/posture.json', 'null')); } catch {}
+            const title = 'Security posture rood';
+            const reds = scan ? scan.checks.filter(c => c.status === 'red') : [];
+            const lines = scan
+              ? (reds.length
+                  ? reds.map(c => `- **${c.group}** ${c.name}: ${c.detail}`).join('\n')
+                  : '- the scan ended red but listed no red measurement, which is itself the finding')
+              : '- the scan wrote no evidence, so it failed before it could report anything';
+            const head = scan
+              ? `**${scan.red} red of ${scan.checks.length} measurements, taken ${scan.stamp} from outside.**`
+              : '**The scan produced no evidence.**';
+            const body = [
+              head,
+              '',
+              lines,
+              '',
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `Evidence: the security-posture-${context.runId} artifact on that run carries the full report`,
+              'and the json behind every line above.',
+              '',
+              `_${new Date().toISOString()}_`,
+            ].join('\n');
+            // state: 'all' on purpose. Searching only open issues would find
+            // nothing after a green run closed the last one, and file a fresh
+            // issue for every episode instead of reopening the one that exists.
+            const all = await github.rest.issues.listForRepo({
+              ...context.repo, state: 'all', labels: 'security-posture',
+              sort: 'created', direction: 'desc', per_page: 100,
+            });
+            // Pull requests come back from this endpoint too, and the title has
+            // to match so a hand-labelled issue is not adopted.
+            const mine = all.data.filter(i => !i.pull_request && i.title === title);
+            if (!mine.length) {
+              await github.rest.issues.create({ ...context.repo, title, body, labels: ['security-posture'] });
+            } else {
+              const issue = mine.find(i => i.state === 'open') || mine[0];
+              if (issue.state !== 'open') {
+                await github.rest.issues.update({ ...context.repo, issue_number: issue.number, state: 'open' });
+              }
+              await github.rest.issues.createComment({ ...context.repo, issue_number: issue.number, body });
+            }
+
+      - name: Close the issue when the posture is green again
+        if: success()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const open = await github.rest.issues.listForRepo({
+              ...context.repo, state: 'open', labels: 'security-posture',
+            });
+            for (const issue of open.data) {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number,
+                body: `Every posture measurement green again as of run ${context.runId}, with the report attached to that run. Closing.`,
+              });
+              await github.rest.issues.update({ ...context.repo, issue_number: issue.number, state: 'closed' });
+            }

--- a/.github/workflows/security-posture.yml
+++ b/.github/workflows/security-posture.yml
@@ -31,11 +31,20 @@ on:
     # of GitHub schedules on :00 and a job queued there starts late.
     - cron: '43 4 * * *'
   workflow_dispatch:
-  # The selftest is a checkout-only gate and belongs on every change, for the
-  # same reason csp-inline-check is not path-gated: a required check that is
-  # skipped never reports, and the pull request waits on it forever.
-  push:
-    branches: [main]
+  # Pull requests only, deliberately no push to main.
+  #
+  # deploy/deploy-3.1.sh phase 0a gates a deploy on every workflow that runs on
+  # a push to main without a paths: filter, and tests/deploy-3.1-dryrun.test.sh
+  # derives that list from these files so a new one cannot stay outside the
+  # gate. Adding a push trigger here would therefore make a deploy wait on THIS
+  # workflow's last completed run on main, and that run is usually the nightly
+  # scan, which is red on purpose. A red posture is a statement about the DNS
+  # zone and the server, not about whether main is deployable, and blocking
+  # deploys on it is exactly the mistake that runbook already records about
+  # heartbeat.yml.
+  #
+  # The selftest still gates every change, because every change reaches main
+  # through a pull request.
   pull_request:
     branches: [main]
 

--- a/.github/workflows/security-posture.yml
+++ b/.github/workflows/security-posture.yml
@@ -56,8 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
       - name: The scanner parses
@@ -102,8 +102,8 @@ jobs:
     # turns a hung relay into a red run instead of a job that sits there.
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
 
@@ -122,7 +122,7 @@ jobs:
       # Always, and a red run's report is the more useful of the two.
       - name: Keep the evidence
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: security-posture-${{ github.run_id }}
           path: security-posture-evidence/
@@ -151,31 +151,30 @@ jobs:
 
       - name: Open or update the issue when the posture is red
         if: failure()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
-            const read = (p, d) => { try { return fs.readFileSync(p, 'utf8'); } catch { return d; } };
             let scan = null;
-            try { scan = JSON.parse(read('security-posture-evidence/posture.json', 'null')); } catch {}
+            try { scan = JSON.parse(fs.readFileSync('security-posture-evidence/posture.json', 'utf8')); } catch {}
             const title = 'Security posture rood';
-            const reds = scan ? scan.checks.filter(c => c.status === 'red') : [];
-            const lines = scan
-              ? (reds.length
-                  ? reds.map(c => `- **${c.group}** ${c.name}: ${c.detail}`).join('\n')
-                  : '- the scan ended red but listed no red measurement, which is itself the finding')
-              : '- the scan wrote no evidence, so it failed before it could report anything';
+            // COUNT AND LINK ONLY. This repository is public and so is every
+            // issue in it. An earlier draft pasted the full list of red
+            // measurements here, which would have published lines like "the
+            // unauthenticated issuing route is reachable again", naming an open
+            // door on production to anyone reading. The detail belongs in the
+            // artifact, which only someone who can already see the Actions tab
+            // can download. An alarm says that something is wrong and where to
+            // look; it does not narrate the weakness to the street.
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const head = scan
-              ? `**${scan.red} red of ${scan.checks.length} measurements, taken ${scan.stamp} from outside.**`
-              : '**The scan produced no evidence.**';
+              ? `**${scan.red} of ${scan.checks.length} posture measurements are red**, taken ${scan.stamp} from outside.`
+              : '**The scan produced no evidence**, so it failed before it could measure anything.';
             const body = [
               head,
               '',
-              lines,
-              '',
-              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              `Evidence: the security-posture-${context.runId} artifact on that run carries the full report`,
-              'and the json behind every line above.',
+              `Which ones, and what each of them found, is in the run: ${runUrl}`,
+              `Download the \`security-posture-${context.runId}\` artifact there for the full report.`,
               '',
               `_${new Date().toISOString()}_`,
             ].join('\n');
@@ -201,7 +200,7 @@ jobs:
 
       - name: Close the issue when the posture is green again
         if: success()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const open = await github.rest.issues.listForRepo({

--- a/.github/workflows/security-posture.yml
+++ b/.github/workflows/security-posture.yml
@@ -64,12 +64,17 @@ jobs:
         run: bash -n scripts/security/posture.sh tests/security-posture-dryrun.sh
       # Not installed in this repo and not in any other job, so it is asked for
       # rather than assumed. If the runner image stops shipping it the step says
-      # so instead of quietly passing.
+      # so instead of quietly passing. The stubs are in the list: a guard that
+      # skips the files most likely to be sloppy is not much of a guard, and the
+      # first run of this step found a literal-brace bug in exactly those.
       - name: shellcheck, if the runner has it
         run: |
           set -uo pipefail
           if command -v shellcheck >/dev/null 2>&1; then
-            shellcheck --severity=warning scripts/security/posture.sh tests/security-posture-dryrun.sh
+            shellcheck --severity=style \
+              scripts/security/posture.sh \
+              tests/security-posture-dryrun.sh \
+              tests/security-posture-stubs/*
           else
             echo "::warning title=shellcheck::not on this runner; only bash -n ran over the posture scripts"
           fi

--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -174,6 +174,16 @@ finds out.
      own design while the two canary secrets are missing: it has no skip, a
      missing secret fails and names the secret. Gating the deploy on it would
      mean no deploy until the alarm has its secrets.
+   * `security-posture.yml` runs on pull requests, on a schedule and on
+     `workflow_dispatch`, never on a push to `main`, and its live job is gated
+     on `vars.SECURITY_POSTURE_ENABLED`. Its last completed run on `main` is the
+     nightly external scan, and that scan is red on purpose: a missing CAA
+     record, an unsigned zone, a duplicated HSTS header set by a layer above
+     this repository, and one Rust advisory that carries no severity in any
+     database and needs a human ruling. All of those describe the DNS zone or
+     the server, not whether `main` is deployable. Its own gate, the selftest
+     that drives all 109 measurements green once and red once, does run on every
+     pull request, which is how every change reaches `main`.
    * `docker-publish.yml` and `build-image.yml` are path-gated on `relay/**`, so
      a commit that touches only the frontend produces no run at all and a hard
      "must be success" would block every such deploy. Neither is what this

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -128,6 +128,17 @@ HOSTS="paramant.app health.paramant.app legal.paramant.app finance.paramant.app 
 #   build-image.yml     path-gated on relay/** for the same reason. It is a
 #                       toolchain-drift gate for pull requests, not a
 #                       main-is-deployable gate.
+#   security-posture.yml  runs on pull requests, schedule and workflow_dispatch,
+#                       never on a push to main, and its live job is gated on
+#                       vars.SECURITY_POSTURE_ENABLED. Its last completed run on
+#                       main is the nightly external scan, which is red on
+#                       purpose: today that is a missing CAA record, an unsigned
+#                       zone, a duplicated HSTS header from a layer above the
+#                       repo, and one Rust advisory carrying no severity in any
+#                       database, which a human has to rule on. Every one of
+#                       those is a statement about the DNS zone or the server,
+#                       not about whether main deploys. Same reasoning as
+#                       heartbeat.yml, one row up.
 REQUIRED_WORKFLOWS="${PARAMANT_REQUIRED_WORKFLOWS:-test.yml csp-inline-check.yml sign-e2e.yml product-heartbeat.yml}"
 
 # A required workflow still in_progress or queued on the sha we would deploy is
@@ -603,6 +614,7 @@ phase_0() {
   step "0a. CI on main, one verdict per required workflow"
   printf '  required: %s\n' "$REQUIRED_WORKFLOWS"
   printf '  excluded: heartbeat.yml (schedule only, red by design while its canary secrets are absent),\n'
+  printf '            security-posture.yml (no push trigger, red by design while the posture gate is shut),\n'
   printf '            docker-publish.yml and build-image.yml (path-gated on relay/**, so they need not have run)\n'
 
   local main_sha wf ci_bad=0 ci_n=0

--- a/package-lock.json
+++ b/package-lock.json
@@ -390,9 +390,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1547,9 +1547,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -2356,7 +2356,19 @@ function setHeaders(res, req) {
   res.setHeader('Content-Security-Policy',      "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; img-src 'self' data:; frame-ancestors 'none'");
   res.setHeader('Strict-Transport-Security',    'max-age=63072000; includeSubDomains; preload');
   res.setHeader('Referrer-Policy',              'no-referrer');
-  res.setHeader('Permissions-Policy',           'interest-cohort=()');
+  // A relay answers json to script, never inside a frame. frame-ancestors in
+  // the CSP above already says so to a current browser; this is the same
+  // sentence for the ones that only read the older header. Measured on
+  // 2026-09-03: all five sector relays sent no X-Frame-Options at all, while
+  // paramant.app itself did.
+  res.setHeader('X-Frame-Options',              'DENY');
+  // interest-cohort was never a registered Permissions-Policy feature. FLoC was
+  // withdrawn in 2022 and the name was never added to the feature registry, so
+  // a policy consisting only of it parses to an empty policy: the header is
+  // present, looks like hardening in a scan that only checks presence, and
+  // governs nothing. These are registered features, and denying them costs a
+  // json api nothing.
+  res.setHeader('Permissions-Policy',           'geolocation=(), microphone=(), camera=(), payment=(), usb=()');
   // X-Paramant-Version intentionally omitted — version disclosure via response header removed (security hardening v2.3.3)
   res.setHeader('X-Paramant-Sector',            SECTOR);
   res.setHeader('X-Crypto-Version',             'ML-KEM-768+AES-256-GCM');

--- a/relay/test/route-security-headers.test.js
+++ b/relay/test/route-security-headers.test.js
@@ -1,0 +1,105 @@
+'use strict';
+// The security headers a sector relay puts on every answer, measured on a
+// really booted relay.js.
+//
+// WHY THIS SUITE EXISTS. setHeaders (relay.js:2318) is the only place the five
+// sector relays get security headers: nginx-paramant-public.conf adds nothing
+// but HSTS to relay/health/legal/finance/iot, so whatever this function omits
+// is simply absent from https://relay.paramant.app and its four siblings. It
+// had no test. An external scan on 2026-09-03 found two things wrong with it
+// that had been true for as long as the function existed:
+//
+//   * no X-Frame-Options at all, on all five, while paramant.app sent DENY;
+//   * Permissions-Policy: interest-cohort=(). FLoC was withdrawn in 2022 and
+//     interest-cohort was never added to the feature registry, so that policy
+//     parses to an empty policy. The header was present, passed every scanner
+//     that only checks presence, and restricted nothing.
+//
+// The second is the interesting one and it is why this suite asserts values and
+// not names. A header that is present but says nothing is the same failure as a
+// test that runs but asserts nothing: it reads as a pass from the outside. So
+// every assertion below is on the content.
+//
+// Boots without redis, so the routes behind the gate answer 503. That is fine:
+// these headers are set on every response regardless of what the route decides,
+// which is exactly the property worth pinning.
+// Runs in the relay-crypto-tests job: the route-*.test.js glob there boots a
+// real relay.js with the deps installed and a redis service, which this suite
+// needs to start relay.js at all.
+// Run: node --test relay/test/route-security-headers.test.js
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const { boot, killAll } = require('./_relay-server');
+const { summary } = require('./_requires');
+
+let srv;
+let checks = 0;
+const did = () => { checks++; };
+
+before(async () => { srv = await boot({ tag: 'security-headers' }); });
+after(async () => { await killAll(); summary('route-security-headers', checks); });
+
+// Headers must not depend on the route being happy, so both a route that
+// answers and one that refuses are measured.
+async function bothWays() {
+  const ok = await srv.get('/health');
+  const refused = await srv.get('/v2/envelopes/does-not-exist');
+  return [ok, refused];
+}
+
+test('every answer carries X-Frame-Options: DENY', async () => {
+  for (const r of await bothWays()) {
+    assert.strictEqual(r.headers['x-frame-options'], 'DENY',
+      'a relay answers json to script and is never framed; the CSP says so to a current browser and this says it to the rest');
+  }
+  did();
+});
+
+test('Permissions-Policy restricts a registered feature, not a withdrawn one', async () => {
+  const [r] = await bothWays();
+  const value = r.headers['permissions-policy'];
+  assert.ok(value, 'Permissions-Policy is absent');
+  assert.ok(!/interest-cohort/.test(value),
+    'interest-cohort was never a registered feature; a policy naming only it parses to an empty policy and restricts nothing');
+  assert.match(value, /(geolocation|microphone|camera|payment|usb)=\(\)/,
+    'at least one registered feature must actually be denied, or the header is decoration');
+  did();
+});
+
+test('X-Content-Type-Options is nosniff', async () => {
+  for (const r of await bothWays()) {
+    assert.strictEqual(r.headers['x-content-type-options'], 'nosniff');
+  }
+  did();
+});
+
+test('Referrer-Policy does not leak the path off-origin', async () => {
+  const [r] = await bothWays();
+  assert.ok(['no-referrer', 'same-origin', 'strict-origin', 'strict-origin-when-cross-origin']
+    .includes(r.headers['referrer-policy']), `leaky Referrer-Policy: ${r.headers['referrer-policy']}`);
+  did();
+});
+
+test('the CSP denies framing and allows no eval beyond WebAssembly', async () => {
+  const [r] = await bothWays();
+  const csp = r.headers['content-security-policy'];
+  assert.ok(csp, 'Content-Security-Policy is absent');
+  assert.match(csp, /default-src 'self'/);
+  assert.match(csp, /frame-ancestors 'none'/);
+  // 'wasm-unsafe-eval' is deliberate and is not 'unsafe-eval': it permits
+  // WebAssembly compilation and nothing else, which ML-KEM and ML-DSA need.
+  assert.ok(!/(^|[^-])'unsafe-eval'/.test(csp.replace(/'wasm-unsafe-eval'/g, '')),
+    `the CSP allows unsafe-eval: ${csp}`);
+  did();
+});
+
+test('HSTS asks for at least a year and covers the subdomains', async () => {
+  const [r] = await bothWays();
+  const hsts = r.headers['strict-transport-security'];
+  assert.ok(hsts, 'Strict-Transport-Security is absent');
+  const maxAge = Number((/max-age=(\d+)/.exec(hsts) || [])[1]);
+  assert.ok(maxAge >= 31536000, `max-age ${maxAge} is under a year`);
+  assert.match(hsts, /includeSubDomains/i);
+  did();
+});

--- a/scripts/security/osv-severity.mjs
+++ b/scripts/security/osv-severity.mjs
@@ -1,0 +1,144 @@
+// Turn an OSV advisory into one word: none, low, moderate, high, critical, or
+// unknown. posture.sh fails on high, critical and unknown.
+//
+// WHY THIS FILE EXISTS, and it is the whole point of it. The first version of
+// the Rust gate read `database_specific.severity`. Verified live on 2026-09-03:
+// RustSec advisories do not have that field. RUSTSEC-2020-0071 and
+// RUSTSEC-2021-0079 both carry `database_specific: {"license": "CC0-1.0"}` and
+// put their severity in `severity[]` as a CVSS_V3 vector; RUSTSEC-2026-0190 has
+// neither. So every RustSec advisory read as the empty string, fell through to
+// the "anything else" branch, and did not fail the gate. RUSTSEC-2021-0079
+// scores 9.1 and would have passed. The gate was blind on exactly the ecosystem
+// it was written for, and it reported green while blind, which is the failure
+// this whole scanner exists to refuse.
+//
+// Two sources, and the WORSE of them wins:
+//
+//   * the CVSS_V3 vector, scored here by the v3.1 formula;
+//   * `database_specific.severity`, the word GitHub publishes.
+//
+// They disagree, by design: GitHub's word is editorial and is sometimes a band
+// away from the arithmetic (measured over seven GHSA advisories that carry
+// both: five agreed, one was rated up, one rated down). A gate that trusts
+// either one alone can be talked out of a finding, so it takes the maximum.
+//
+// CVSS_V4 is not scored here. Its base score is a MacroVector lookup, not a
+// formula, and a wrong implementation would be worse than none. A v4-only
+// advisory therefore resolves through the published word, and if there is no
+// word it is `unknown`, which is red. Not knowing is a state a human has to
+// resolve, never one the gate resolves for itself.
+
+import { pathToFileURL } from 'node:url';
+
+const W = {
+  AV: { N: 0.85, A: 0.62, L: 0.55, P: 0.2 },
+  AC: { L: 0.77, H: 0.44 },
+  UI: { N: 0.85, R: 0.62 },
+  CIA: { H: 0.56, L: 0.22, N: 0 },
+  PR_U: { N: 0.85, L: 0.62, H: 0.27 },
+  PR_C: { N: 0.85, L: 0.68, H: 0.5 },
+};
+
+// CVSS v3.1 Roundup (spec section 7.1). Round-half-up on the second decimal is
+// not the same function and gives 6.1 where the spec says 6.2.
+function roundup(x) {
+  const i = Math.round(x * 100000);
+  return i % 10000 === 0 ? i / 100000 : (Math.floor(i / 10000) + 1) / 10;
+}
+
+export function cvss3Score(vector) {
+  const p = {};
+  for (const part of String(vector).split('/')) {
+    const [k, v] = part.split(':');
+    if (k && v) p[k] = v;
+  }
+  const changed = p.S === 'C';
+  const av = W.AV[p.AV];
+  const ac = W.AC[p.AC];
+  const ui = W.UI[p.UI];
+  const pr = (changed ? W.PR_C : W.PR_U)[p.PR];
+  const c = W.CIA[p.C];
+  const i = W.CIA[p.I];
+  const a = W.CIA[p.A];
+  if ([av, ac, ui, pr, c, i, a].some((x) => x === undefined)) return null;
+  const iss = 1 - (1 - c) * (1 - i) * (1 - a);
+  const impact = changed
+    ? 7.52 * (iss - 0.029) - 3.25 * Math.pow(iss - 0.02, 15)
+    : 6.42 * iss;
+  if (impact <= 0) return 0;
+  const expl = 8.22 * av * ac * pr * ui;
+  return roundup(Math.min((changed ? 1.08 : 1) * (impact + expl), 10));
+}
+
+const ORDER = ['none', 'low', 'moderate', 'high', 'critical'];
+
+export function bandForScore(score) {
+  if (score === null || score === undefined) return null;
+  if (score >= 9) return 'critical';
+  if (score >= 7) return 'high';
+  if (score >= 4) return 'moderate';
+  if (score > 0) return 'low';
+  return 'none';
+}
+
+export function classify(advisory) {
+  const bands = [];
+  const why = [];
+
+  const list = Array.isArray(advisory && advisory.severity) ? advisory.severity : [];
+  const v3 = list.find((s) => s && s.type === 'CVSS_V3');
+  if (v3) {
+    const score = cvss3Score(v3.score);
+    const band = bandForScore(score);
+    if (band) { bands.push(band); why.push(`cvss3 ${score}`); }
+    else why.push('cvss3 vector unparseable');
+  }
+  const v4 = list.find((s) => s && s.type === 'CVSS_V4');
+  if (v4) why.push('cvss4 not scored here');
+
+  const word = advisory && advisory.database_specific && advisory.database_specific.severity;
+  if (word) {
+    const w = String(word).toLowerCase();
+    if (ORDER.includes(w)) { bands.push(w); why.push(`published ${w}`); }
+    else why.push(`published severity not recognised: ${w}`);
+  }
+
+  if (!bands.length) {
+    return { band: 'unknown', why: why.length ? why.join(', ') : 'no severity of any kind on this advisory' };
+  }
+  // The worse of the two. Neither an editorial downgrade nor a missing word
+  // may talk the gate out of a finding.
+  const band = bands.reduce((a, b) => (ORDER.indexOf(b) > ORDER.indexOf(a) ? b : a));
+  return { band, why: why.join(', ') };
+}
+
+export function fails(band) {
+  return band === 'high' || band === 'critical' || band === 'unknown';
+}
+
+// Read a stream of advisories (one JSON object per line) and print
+// "id<TAB>band<TAB>why" for each. Order in, order out.
+function main() {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (d) => { raw += d; });
+  process.stdin.on('end', () => {
+    const lines = raw.split('\n').map((l) => l.trim()).filter(Boolean);
+    for (const line of lines) {
+      let advisory;
+      try {
+        advisory = JSON.parse(line);
+      } catch {
+        // A detail request that came back as anything but json is not a pass.
+        process.stdout.write('?\tunknown\tadvisory detail was not json\n');
+        continue;
+      }
+      const { band, why } = classify(advisory);
+      process.stdout.write(`${advisory.id || '?'}\t${band}\t${why}\n`);
+    }
+  });
+}
+
+// Only when run as a command. Importing this file (the known-answer test does)
+// must not park on a stdin that never closes.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/security/posture.sh
+++ b/scripts/security/posture.sh
@@ -359,7 +359,13 @@ check_npm_audit() {
       record audit "npm audit $label" red "no package-lock.json in $dir, so nothing was audited"
       continue
     fi
+    # Two attempts. npm audit is a network call to the registry and a single
+    # hiccup there is not a finding about Paramant; a second failure still ends
+    # red, so this shortens the odds without giving the check a way out.
     out=$(cd "$REPO_ROOT/$dir" && "$NPM" audit --json 2>/dev/null)
+    if ! printf '%s' "$out" | grep -q '"vulnerabilities"'; then
+      out=$(cd "$REPO_ROOT/$dir" && "$NPM" audit --json 2>/dev/null)
+    fi
     # Parsed with node, not sed. The report has a "high" key at more than one
     # depth and a regex picks whichever comes first in the byte stream, which is
     # not necessarily the metadata total.
@@ -402,12 +408,10 @@ check_rust_audit() {
   need_tool "$CURL" audit || return
 
   # Why OSV and not `cargo audit --json`: the RustSec advisory record carries a
-  # CVSS vector string and no severity word. A gate written against a
-  # `severity` field it does not have reads undefined for every advisory,
-  # classifies all of them as unrated and passes forever. That is the same shape
-  # as a canary that reports its own skip as a pass, so the severity comes from
-  # a source that actually states one. cargo audit stays useful by hand; it is
-  # not what this gate reads.
+  # CVSS vector and no severity word, so a gate written against a `severity`
+  # field reads undefined for every advisory and passes forever. The severity
+  # comes from a source that states one, and is turned into a word by
+  # scripts/security/osv-severity.mjs, which that file explains at length.
   local query
   query=$(node -e '
     const fs = require("fs");
@@ -432,53 +436,71 @@ check_rust_audit() {
   local batch
   batch=$("$CURL" -sS --max-time 60 -X POST -H 'Content-Type: application/json' \
     -d "$query" https://api.osv.dev/v1/querybatch 2>/dev/null)
+  # results must line up one-for-one with the crates asked about. A short or
+  # empty array is a truncated answer, and reading "no vulns" out of it would
+  # turn an outage into a clean bill of health for 114 crates.
   local ids
   ids=$(printf '%s' "$batch" | node -e '
     let raw = "";
     process.stdin.on("data", d => raw += d);
     process.stdin.on("end", () => {
       try {
+        const want = Number(process.argv[1]);
         const r = JSON.parse(raw).results;
-        if (!Array.isArray(r)) throw new Error("no results");
+        if (!Array.isArray(r)) throw new Error("results is not an array");
+        if (r.length !== want) throw new Error("results " + r.length + " for " + want + " crates");
         const out = [];
-        for (const entry of r) for (const v of entry.vulns || []) out.push(v.id);
+        for (const entry of r) for (const v of (entry && entry.vulns) || []) out.push(v.id);
         process.stdout.write(out.join(" "));
-      } catch { process.exit(1); }
+      } catch (e) { process.stderr.write(e.message); process.exit(1); }
     });
-  ' 2>/dev/null)
+  ' "$crates" 2>"$ROWS_FILE.osverr")
   if [ $? -ne 0 ]; then
-    record audit "rust audit $CARGO_DIR" red "the advisory service returned nothing parseable for $crates crates"
+    record audit "rust audit $CARGO_DIR" red "the advisory service did not answer for all $crates crates: $(cat "$ROWS_FILE.osverr" 2>/dev/null)"
+    rm -f "$ROWS_FILE.osverr"
+    return
+  fi
+  rm -f "$ROWS_FILE.osverr"
+
+  if [ -z "$ids" ]; then
+    record audit "rust audit $CARGO_DIR" green "no advisories at all over $crates locked crates"
     return
   fi
 
-  local bad="" seen="" id detail sev
+  # One detail request per advisory, concatenated as json lines, classified in
+  # a single pass.
+  local details id detail
+  details="$ROWS_FILE.osv"
+  : >"$details"
   for id in $ids; do
     detail=$("$CURL" -sS --max-time 30 "https://api.osv.dev/v1/vulns/$id" 2>/dev/null)
-    sev=$(printf '%s' "$detail" | node -e '
-      let raw = "";
-      process.stdin.on("data", d => raw += d);
-      process.stdin.on("end", () => {
-        try {
-          const d = JSON.parse(raw);
-          const s = (d.database_specific && d.database_specific.severity) || "";
-          process.stdout.write(String(s).toLowerCase() || "unrated");
-        } catch { process.exit(1); }
-      });
-    ' 2>/dev/null)
-    if [ -z "$sev" ]; then
-      # An advisory whose severity cannot be read is red. Guessing it low would
-      # be the escape hatch this whole script is built to avoid.
-      bad="$bad $id(unreadable)"
-      continue
-    fi
-    case "$sev" in
-      high|critical) bad="$bad $id($sev)" ;;
-      *) seen="$seen $id($sev)" ;;
-    esac
+    # An empty or multi-line answer must still occupy a line, or the classifier
+    # silently sees fewer advisories than were found.
+    printf '%s\n' "$(printf '%s' "${detail:-{\}}" | tr -d '\n')" >>"$details"
   done
 
+  local verdicts
+  verdicts=$(node "$REPO_ROOT/scripts/security/osv-severity.mjs" <"$details" 2>/dev/null)
+  local want got
+  want=$(printf '%s\n' "$ids" | tr ' ' '\n' | grep -c .)
+  got=$(printf '%s\n' "$verdicts" | grep -c .)
+  rm -f "$details"
+  if [ -z "$verdicts" ] || [ "$got" -ne "$want" ]; then
+    record audit "rust audit $CARGO_DIR" red "classified $got of $want advisories; the rest could not be read"
+    return
+  fi
+
+  local bad="" seen="" line vid band why
+  while IFS=$'\t' read -r vid band why; do
+    [ -z "$vid" ] && continue
+    case "$band" in
+      high|critical|unknown) bad="$bad $vid($band: $why)" ;;
+      *) seen="$seen $vid($band)" ;;
+    esac
+  done <<<"$verdicts"
+
   if [ -n "$bad" ]; then
-    record audit "rust audit $CARGO_DIR" red "high or critical advisories against the locked tree:$bad"
+    record audit "rust audit $CARGO_DIR" red "high, critical or unrated advisories against the locked tree:$bad"
   else
     record audit "rust audit $CARGO_DIR" green "0 high or critical over $crates locked crates"
   fi
@@ -523,9 +545,17 @@ check_robots_sitemap() {
   local disallows
   disallows=$(printf '%s\n' "$robots" | sed -n 's/^[Dd]isallow: *//p' | grep -v '^$')
 
-  local bad_status="" bad_disallow="" loc code path rule
+  local bad_status="" bad_disallow="" bad_host="" loc code path rule
   while IFS= read -r loc; do
     [ -z "$loc" ] && continue
+    # The sitemap is fetched over the network, so its contents are input, not
+    # instruction. Anything that is not our own origin does not get requested:
+    # a scanner that follows whatever a <loc> says is a scanner that can be
+    # aimed at a third party by editing one file on the web server.
+    case "$loc" in
+      "https://$APEX"|"https://$APEX"/*|https://*.paramant.app|https://*.paramant.app/*) ;;
+      *) bad_host="$bad_host $loc"; continue ;;
+    esac
     code=$("$CURL" -sS --max-time "$CURL_TIMEOUT" -o /dev/null -w '%{http_code}' "$loc" 2>/dev/null)
     if [ "$code" != 200 ]; then
       bad_status="$bad_status $loc=${code:-none}"
@@ -550,6 +580,12 @@ check_robots_sitemap() {
     record seo "no sitemap url is disallowed" red "robots.txt blocks:$bad_disallow"
   else
     record seo "no sitemap url is disallowed" green "checked against $(printf '%s\n' "$disallows" | grep -c .) disallow rules"
+  fi
+
+  if [ -n "$bad_host" ]; then
+    record seo "every sitemap url is ours" red "off-origin urls, not requested:$bad_host"
+  else
+    record seo "every sitemap url is ours" green "all $total on paramant.app"
   fi
 }
 

--- a/scripts/security/posture.sh
+++ b/scripts/security/posture.sh
@@ -1,0 +1,617 @@
+#!/usr/bin/env bash
+#
+# posture.sh - measure the security posture of Paramant from the outside.
+#
+# It logs in nowhere and changes nothing. Every check is a black-box measurement
+# against the live hostnames plus two repo-local audits (npm, cargo).
+#
+# The rule this script is built on, learned the expensive way from the old
+# heartbeat: a monitoring step never gets an escape of its own. A missing tool,
+# an unreachable host or an unparseable answer is red with the name of what is
+# missing, never green with a reason. See docs Bevinding "de heartbeat bewees
+# niets" (2026-09-02).
+#
+# Usage:
+#   scripts/security/posture.sh [--report FILE] [--json FILE] [--min-cert-days N]
+#
+# Exit codes:
+#   0  every check green
+#   1  at least one check red
+#   2  the script itself could not run (bad usage)
+#
+# Test seam: the external binaries are taken from these variables, so a dry run
+# can substitute stubs without touching the network.
+#   POSTURE_CURL POSTURE_OPENSSL POSTURE_DIG POSTURE_NPM
+#
+set -uo pipefail
+
+CURL=${POSTURE_CURL:-curl}
+OPENSSL=${POSTURE_OPENSSL:-openssl}
+DIG=${POSTURE_DIG:-dig}
+NPM=${POSTURE_NPM:-npm}
+
+APEX=paramant.app
+HOSTS=(paramant.app relay.paramant.app health.paramant.app legal.paramant.app finance.paramant.app iot.paramant.app)
+SECTORS=(relay.paramant.app health.paramant.app legal.paramant.app finance.paramant.app iot.paramant.app)
+HEADER_PATHS=(/ /sign /pricing /parasign)
+REQUIRED_HEADERS=(strict-transport-security content-security-policy x-frame-options referrer-policy permissions-policy x-content-type-options)
+PARAID_ROUTE=/v1/paraid/issue-document
+DKIM_SELECTOR=resend
+NPM_DIRS=(. relay admin)
+CARGO_DIR=crypto-wasm
+
+REPORT=""
+JSON=""
+MIN_CERT_DAYS=21
+CURL_TIMEOUT=${POSTURE_CURL_TIMEOUT:-20}
+
+REPO_ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --report) REPORT=${2:-}; shift 2 ;;
+    --json) JSON=${2:-}; shift 2 ;;
+    --min-cert-days) MIN_CERT_DAYS=${2:-}; shift 2 ;;
+    -h|--help) sed -n '2,30p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "posture.sh: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+RED_COUNT=0
+GREEN_COUNT=0
+ROWS_FILE=$(mktemp)
+ERRORS_FILE=$(mktemp)
+NOTES_FILE=$(mktemp)
+trap 'rm -f "$ROWS_FILE" "$ERRORS_FILE" "$NOTES_FILE"' EXIT
+
+# record GROUP NAME STATUS DETAIL
+# STATUS is green or red. There is deliberately no third value: a check that
+# cannot be performed is red, named after what stopped it.
+record() {
+  local group=$1 name=$2 status=$3 detail=$4
+  printf '%s\t%s\t%s\t%s\n' "$group" "$name" "$status" "$detail" >>"$ROWS_FILE"
+  if [ "$status" = red ]; then
+    RED_COUNT=$((RED_COUNT + 1))
+    printf '::error title=%s::%s - %s\n' "$group" "$name" "$detail" >>"$ERRORS_FILE"
+    printf '  ROOD  %-46s %s\n' "$name" "$detail" >&2
+  else
+    GREEN_COUNT=$((GREEN_COUNT + 1))
+    printf '  groen %-46s %s\n' "$name" "$detail" >&2
+  fi
+}
+
+# note records an observation that is not a pass/fail gate, so that the report
+# carries what was seen even where nothing is asserted about it.
+note() { printf '%s\n' "$1" >>"$NOTES_FILE"; }
+
+section() { printf '\n== %s ==\n' "$1" >&2; }
+
+need_tool() {
+  local bin=$1 group=$2
+  if ! command -v "${bin%% *}" >/dev/null 2>&1; then
+    record "$group" "tool $bin" red "not on PATH; the check could not run"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------- TLS
+
+check_tls() {
+  section "TLS en certificaten"
+  need_tool "$OPENSSL" tls || return
+  local now host
+  now=$(date +%s)
+  for host in "${HOSTS[@]}"; do
+    local pem
+    pem=$("$OPENSSL" s_client -connect "$host:443" -servername "$host" </dev/null 2>/dev/null \
+      | "$OPENSSL" x509 2>/dev/null)
+    if [ -z "$pem" ]; then
+      record tls "cert $host" red "no certificate returned on port 443"
+      continue
+    fi
+
+    local enddate end_epoch days
+    enddate=$(printf '%s' "$pem" | "$OPENSSL" x509 -noout -enddate 2>/dev/null | cut -d= -f2-)
+    end_epoch=$(date -d "$enddate" +%s 2>/dev/null || echo "")
+    if [ -z "$end_epoch" ]; then
+      record tls "cert expiry $host" red "notAfter could not be parsed: '$enddate'"
+    else
+      days=$(( (end_epoch - now) / 86400 ))
+      if [ "$days" -lt "$MIN_CERT_DAYS" ]; then
+        record tls "cert expiry $host" red "expires in ${days}d (floor ${MIN_CERT_DAYS}d), notAfter $enddate"
+      else
+        record tls "cert expiry $host" green "${days}d left, notAfter $enddate"
+      fi
+    fi
+
+    local names
+    names=$(printf '%s' "$pem" | "$OPENSSL" x509 -noout -ext subjectAltName 2>/dev/null | tr ',' '\n' | sed -n 's/.*DNS:\([^ ,]*\).*/\1/p')
+    if printf '%s\n' "$names" | grep -qx "$host"; then
+      record tls "cert name $host" green "covered by subjectAltName"
+    else
+      record tls "cert name $host" red "hostname not in subjectAltName ($(printf '%s' "$names" | tr '\n' ' '))"
+    fi
+
+    local issuer
+    issuer=$(printf '%s' "$pem" | "$OPENSSL" x509 -noout -issuer 2>/dev/null | sed 's/^issuer=//')
+    note "TLS $host issuer: $issuer"
+
+    # TLS 1.0 and 1.1 must be refused; 1.2 and 1.3 must be offered.
+    local proto
+    for proto in tls1 tls1_1; do
+      if "$OPENSSL" s_client -connect "$host:443" -servername "$host" "-$proto" </dev/null 2>/dev/null | grep -q "BEGIN CERTIFICATE"; then
+        record tls "$proto refused on $host" red "deprecated protocol $proto completed a handshake"
+      else
+        record tls "$proto refused on $host" green "handshake refused"
+      fi
+    done
+    for proto in tls1_2 tls1_3; do
+      if "$OPENSSL" s_client -connect "$host:443" -servername "$host" "-$proto" </dev/null 2>/dev/null | grep -q "BEGIN CERTIFICATE"; then
+        record tls "$proto offered on $host" green "handshake completed"
+      else
+        record tls "$proto offered on $host" red "modern protocol $proto is not offered"
+      fi
+    done
+  done
+}
+
+# ------------------------------------------------------------ headers
+
+# fetch_headers URL -> lowercased header block on stdout, empty on failure
+fetch_headers() {
+  "$CURL" -sS --max-time "$CURL_TIMEOUT" -o /dev/null -D - "$1" 2>/dev/null | tr 'A-Z' 'a-z'
+}
+
+check_one_header_set() {
+  local url=$1 label=$2 headers
+  headers=$(fetch_headers "$url")
+  if [ -z "$headers" ]; then
+    record headers "$label" red "no response from $url"
+    return
+  fi
+
+  local code
+  code=$(printf '%s\n' "$headers" | sed -n 's|^http/[0-9.]* \([0-9]\{3\}\).*|\1|p' | tail -1)
+  note "headers $label: HTTP $code"
+
+  local h value
+  for h in "${REQUIRED_HEADERS[@]}"; do
+    value=$(printf '%s\n' "$headers" | grep -i "^$h:" | head -1 | cut -d: -f2- | sed 's/^ *//; s/\r$//')
+    if [ -z "$value" ]; then
+      record headers "$h on $label" red "header absent (HTTP $code)"
+      continue
+    fi
+
+    local count
+    count=$(printf '%s\n' "$headers" | grep -c -i "^$h:")
+    if [ "$count" -gt 1 ]; then
+      record headers "$h on $label" red "sent $count times; a duplicate header is ambiguous to clients and hides which layer set it"
+      continue
+    fi
+
+    case "$h" in
+      strict-transport-security)
+        local maxage
+        maxage=$(printf '%s' "$value" | sed -n 's/.*max-age=\([0-9]*\).*/\1/p')
+        if [ -z "$maxage" ] || [ "$maxage" -lt 31536000 ]; then
+          record headers "$h on $label" red "max-age '$maxage' below one year: $value"
+        elif ! printf '%s' "$value" | grep -q includesubdomains; then
+          record headers "$h on $label" red "no includeSubDomains: $value"
+        else
+          record headers "$h on $label" green "$value"
+        fi
+        ;;
+      content-security-policy)
+        # 'wasm-unsafe-eval' is not 'unsafe-eval'. It permits WebAssembly
+        # compilation and nothing else, which is exactly what the ML-KEM and
+        # ML-DSA modules need, so a naive substring match on unsafe-eval reads
+        # the correct policy as a violation. Strip it before looking.
+        local csp_bare
+        csp_bare=$(printf '%s' "$value" | sed "s/'wasm-unsafe-eval'//g")
+        if ! printf '%s' "$value" | grep -q "default-src"; then
+          record headers "$h on $label" red "no default-src: $value"
+        elif printf '%s' "$csp_bare" | grep -q "unsafe-eval"; then
+          record headers "$h on $label" red "allows unsafe-eval: $value"
+        elif printf '%s' "$csp_bare" | grep -q "script-src[^;]*unsafe-inline"; then
+          record headers "$h on $label" red "script-src allows unsafe-inline: $value"
+        elif ! printf '%s' "$value" | grep -q "frame-ancestors"; then
+          record headers "$h on $label" red "no frame-ancestors: $value"
+        else
+          record headers "$h on $label" green "default-src and frame-ancestors set, no unsafe-eval or inline script"
+        fi
+        ;;
+      x-frame-options)
+        case "$value" in
+          deny|sameorigin) record headers "$h on $label" green "$value" ;;
+          *) record headers "$h on $label" red "expected DENY or SAMEORIGIN, got '$value'" ;;
+        esac
+        ;;
+      referrer-policy)
+        case "$value" in
+          no-referrer|same-origin|strict-origin|strict-origin-when-cross-origin)
+            record headers "$h on $label" green "$value" ;;
+          *) record headers "$h on $label" red "leaky policy '$value'" ;;
+        esac
+        ;;
+      permissions-policy)
+        # interest-cohort is not a registered directive. A policy consisting only
+        # of it parses to an empty policy, so the header is present but governs
+        # nothing. Require at least one registered feature to be restricted.
+        if printf '%s' "$value" | grep -qE '(geolocation|microphone|camera|payment|usb|midi|fullscreen|display-capture)='; then
+          record headers "$h on $label" green "$value"
+        else
+          record headers "$h on $label" red "no registered feature restricted, so the policy is empty in practice: '$value'"
+        fi
+        ;;
+      x-content-type-options)
+        if [ "$value" = nosniff ]; then
+          record headers "$h on $label" green "nosniff"
+        else
+          record headers "$h on $label" red "expected nosniff, got '$value'"
+        fi
+        ;;
+    esac
+  done
+}
+
+check_headers() {
+  section "Securityheaders"
+  need_tool "$CURL" headers || return
+  local p host
+  for p in "${HEADER_PATHS[@]}"; do
+    check_one_header_set "https://$APEX$p" "$APEX$p"
+  done
+  # The five sector relays are their own origin with their own nginx server
+  # block, so the apex result says nothing about them.
+  for host in "${SECTORS[@]}"; do
+    check_one_header_set "https://$host/" "$host/"
+  done
+}
+
+# ---------------------------------------------------------------- DNS
+
+txt_records() { "$DIG" +short TXT "$1" 2>/dev/null | tr -d '"'; }
+
+check_dns() {
+  section "DNS-hygiene van $APEX"
+  need_tool "$DIG" dns || return
+
+  local spf
+  spf=$(txt_records "$APEX" | grep -i '^v=spf1' | head -1)
+  if [ -z "$spf" ]; then
+    record dns "SPF" red "no v=spf1 TXT record on $APEX"
+  elif printf '%s' "$spf" | grep -qE '(\+all|[^-~?]all$)'; then
+    record dns "SPF" red "record ends in a permissive all: $spf"
+  else
+    record dns "SPF" green "$spf"
+  fi
+
+  local dmarc policy
+  dmarc=$(txt_records "_dmarc.$APEX" | grep -i '^v=DMARC1' | head -1)
+  if [ -z "$dmarc" ]; then
+    record dns "DMARC" red "no _dmarc.$APEX TXT record"
+  else
+    policy=$(printf '%s' "$dmarc" | sed -n 's/.*[; ]p=\([a-z]*\).*/\1/p')
+    if [ "$policy" = none ] || [ -z "$policy" ]; then
+      record dns "DMARC" red "policy p=${policy:-absent} enforces nothing: $dmarc"
+    else
+      record dns "DMARC" green "$dmarc"
+    fi
+  fi
+
+  local caa
+  caa=$("$DIG" +short CAA "$APEX" 2>/dev/null | grep -v '^$')
+  if [ -z "$caa" ]; then
+    record dns "CAA" red "no CAA record, so any CA in any trust store may issue for $APEX"
+  else
+    record dns "CAA" green "$(printf '%s' "$caa" | tr '\n' ' ')"
+  fi
+
+  local ds ad
+  ds=$("$DIG" +short DS "$APEX" 2>/dev/null | grep -v '^$')
+  ad=$("$DIG" +dnssec "$APEX" A 2>/dev/null | grep -c 'flags:.* ad')
+  if [ -z "$ds" ] && [ "$ad" -eq 0 ]; then
+    record dns "DNSSEC" red "no DS record at the parent and no authenticated-data flag; the zone is unsigned"
+  else
+    record dns "DNSSEC" green "DS present or answer authenticated (ds='$(printf '%s' "$ds" | tr '\n' ' ')' ad=$ad)"
+  fi
+
+  local dkim
+  dkim=$(txt_records "${DKIM_SELECTOR}._domainkey.$APEX" | grep -i 'p=' | head -1)
+  if [ -z "$dkim" ]; then
+    record dns "DKIM selector ${DKIM_SELECTOR}" red "no key at ${DKIM_SELECTOR}._domainkey.$APEX while SPF includes amazonses.com (the Resend path)"
+  else
+    record dns "DKIM selector ${DKIM_SELECTOR}" green "public key present (${#dkim} chars)"
+  fi
+}
+
+# -------------------------------------------------------------- ParaID
+
+check_paraid_deny() {
+  section "ParaID-deny op zes ingangen"
+  need_tool "$CURL" paraid || return
+  local host code
+  for host in "${HOSTS[@]}"; do
+    code=$("$CURL" -sS --max-time "$CURL_TIMEOUT" -o /dev/null -w '%{http_code}' \
+      -X POST -H 'Content-Type: application/json' -d '{}' \
+      "https://$host$PARAID_ROUTE" 2>/dev/null)
+    if [ "$code" = 404 ]; then
+      record paraid "deny on $host" green "POST $PARAID_ROUTE -> 404"
+    else
+      record paraid "deny on $host" red "POST $PARAID_ROUTE -> ${code:-no answer}, expected 404; the unauthenticated issuing route is reachable again"
+    fi
+  done
+}
+
+# -------------------------------------------------------------- audits
+
+check_npm_audit() {
+  section "npm audit"
+  need_tool "$NPM" npm || return
+  need_tool node npm || return
+  local dir label out counts high crit
+  for dir in "${NPM_DIRS[@]}"; do
+    label=${dir#./}
+    [ "$label" = "." ] && label=root
+    if [ ! -f "$REPO_ROOT/$dir/package-lock.json" ]; then
+      record audit "npm audit $label" red "no package-lock.json in $dir, so nothing was audited"
+      continue
+    fi
+    out=$(cd "$REPO_ROOT/$dir" && "$NPM" audit --json 2>/dev/null)
+    # Parsed with node, not sed. The report has a "high" key at more than one
+    # depth and a regex picks whichever comes first in the byte stream, which is
+    # not necessarily the metadata total.
+    counts=$(printf '%s' "$out" | node -e '
+      let raw = "";
+      process.stdin.on("data", d => raw += d);
+      process.stdin.on("end", () => {
+        try {
+          const v = JSON.parse(raw).metadata.vulnerabilities;
+          if (typeof v.high !== "number" || typeof v.critical !== "number") throw new Error("no counts");
+          process.stdout.write(v.critical + " " + v.high);
+        } catch { process.exit(1); }
+      });
+    ' 2>/dev/null)
+    if [ -z "$counts" ]; then
+      record audit "npm audit $label" red "npm audit produced no parseable metadata.vulnerabilities"
+      continue
+    fi
+    crit=${counts%% *}
+    high=${counts##* }
+    if [ "$crit" -gt 0 ] || [ "$high" -gt 0 ]; then
+      record audit "npm audit $label" red "$crit critical, $high high"
+    else
+      record audit "npm audit $label" green "0 critical, 0 high"
+    fi
+  done
+}
+
+check_rust_audit() {
+  section "Rust-afhankelijkheden"
+  # The Rust NAPI binding lives in the sibling paramant-core repo and is not
+  # checked out here. crypto-wasm is the Rust this repo owns and locks, so it is
+  # what gets audited; a green line here says nothing about paramant-core.
+  local lock="$REPO_ROOT/$CARGO_DIR/Cargo.lock"
+  if [ ! -f "$lock" ]; then
+    record audit "rust audit $CARGO_DIR" red "no Cargo.lock in $CARGO_DIR"
+    return
+  fi
+  need_tool node audit || return
+  need_tool "$CURL" audit || return
+
+  # Why OSV and not `cargo audit --json`: the RustSec advisory record carries a
+  # CVSS vector string and no severity word. A gate written against a
+  # `severity` field it does not have reads undefined for every advisory,
+  # classifies all of them as unrated and passes forever. That is the same shape
+  # as a canary that reports its own skip as a pass, so the severity comes from
+  # a source that actually states one. cargo audit stays useful by hand; it is
+  # not what this gate reads.
+  local query
+  query=$(node -e '
+    const fs = require("fs");
+    const lock = fs.readFileSync(process.argv[1], "utf8");
+    const re = /\[\[package\]\]\nname = "([^"]+)"\nversion = "([^"]+)"/g;
+    const queries = [];
+    let m;
+    while ((m = re.exec(lock)) !== null) {
+      queries.push({ package: { name: m[1], ecosystem: "crates.io" }, version: m[2] });
+    }
+    if (!queries.length) process.exit(1);
+    process.stdout.write(JSON.stringify({ queries }));
+  ' "$lock" 2>/dev/null)
+  if [ -z "$query" ]; then
+    record audit "rust audit $CARGO_DIR" red "no [[package]] entries parsed out of Cargo.lock"
+    return
+  fi
+
+  local crates
+  crates=$(printf '%s' "$query" | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).queries.length')
+
+  local batch
+  batch=$("$CURL" -sS --max-time 60 -X POST -H 'Content-Type: application/json' \
+    -d "$query" https://api.osv.dev/v1/querybatch 2>/dev/null)
+  local ids
+  ids=$(printf '%s' "$batch" | node -e '
+    let raw = "";
+    process.stdin.on("data", d => raw += d);
+    process.stdin.on("end", () => {
+      try {
+        const r = JSON.parse(raw).results;
+        if (!Array.isArray(r)) throw new Error("no results");
+        const out = [];
+        for (const entry of r) for (const v of entry.vulns || []) out.push(v.id);
+        process.stdout.write(out.join(" "));
+      } catch { process.exit(1); }
+    });
+  ' 2>/dev/null)
+  if [ $? -ne 0 ]; then
+    record audit "rust audit $CARGO_DIR" red "the advisory service returned nothing parseable for $crates crates"
+    return
+  fi
+
+  local bad="" seen="" id detail sev
+  for id in $ids; do
+    detail=$("$CURL" -sS --max-time 30 "https://api.osv.dev/v1/vulns/$id" 2>/dev/null)
+    sev=$(printf '%s' "$detail" | node -e '
+      let raw = "";
+      process.stdin.on("data", d => raw += d);
+      process.stdin.on("end", () => {
+        try {
+          const d = JSON.parse(raw);
+          const s = (d.database_specific && d.database_specific.severity) || "";
+          process.stdout.write(String(s).toLowerCase() || "unrated");
+        } catch { process.exit(1); }
+      });
+    ' 2>/dev/null)
+    if [ -z "$sev" ]; then
+      # An advisory whose severity cannot be read is red. Guessing it low would
+      # be the escape hatch this whole script is built to avoid.
+      bad="$bad $id(unreadable)"
+      continue
+    fi
+    case "$sev" in
+      high|critical) bad="$bad $id($sev)" ;;
+      *) seen="$seen $id($sev)" ;;
+    esac
+  done
+
+  if [ -n "$bad" ]; then
+    record audit "rust audit $CARGO_DIR" red "high or critical advisories against the locked tree:$bad"
+  else
+    record audit "rust audit $CARGO_DIR" green "0 high or critical over $crates locked crates"
+  fi
+  [ -n "$seen" ] && note "rust audit $CARGO_DIR, below the failing threshold:$seen"
+}
+
+# ------------------------------------------------- robots and sitemap
+
+check_robots_sitemap() {
+  section "robots.txt en sitemap.xml"
+  need_tool "$CURL" seo || return
+
+  local robots
+  robots=$("$CURL" -sS --max-time "$CURL_TIMEOUT" "https://$APEX/robots.txt" 2>/dev/null)
+  if [ -z "$robots" ]; then
+    record seo "robots.txt served" red "not served on https://$APEX/robots.txt"
+    return
+  fi
+
+  if printf '%s\n' "$robots" | grep -qi "^sitemap:.*sitemap.xml"; then
+    record seo "robots.txt names the sitemap" green "$(printf '%s\n' "$robots" | grep -i '^sitemap:' | head -1)"
+  else
+    record seo "robots.txt names the sitemap" red "no Sitemap: line in robots.txt"
+  fi
+
+  local sitemap
+  sitemap=$("$CURL" -sS --max-time "$CURL_TIMEOUT" "https://$APEX/sitemap.xml" 2>/dev/null)
+  if ! printf '%s' "$sitemap" | grep -q "<urlset"; then
+    record seo "sitemap.xml served as a urlset" red "not served or not a urlset on https://$APEX/sitemap.xml"
+    return
+  fi
+
+  local locs
+  locs=$(printf '%s' "$sitemap" | sed -n 's|.*<loc>\(.*\)</loc>.*|\1|p')
+  local total
+  total=$(printf '%s\n' "$locs" | grep -c .)
+  # A precondition, not a measurement: it is recorded as a note rather than a
+  # green row, because the failing side of it is the "served as a urlset" row
+  # above. One measurement, one name, or it can never be seen to change.
+  note "sitemap.xml: $total urls"
+
+  local disallows
+  disallows=$(printf '%s\n' "$robots" | sed -n 's/^[Dd]isallow: *//p' | grep -v '^$')
+
+  local bad_status="" bad_disallow="" loc code path rule
+  while IFS= read -r loc; do
+    [ -z "$loc" ] && continue
+    code=$("$CURL" -sS --max-time "$CURL_TIMEOUT" -o /dev/null -w '%{http_code}' "$loc" 2>/dev/null)
+    if [ "$code" != 200 ]; then
+      bad_status="$bad_status $loc=${code:-none}"
+    fi
+    path=${loc#https://$APEX}
+    [ -z "$path" ] && path=/
+    while IFS= read -r rule; do
+      [ -z "$rule" ] && continue
+      case "$path" in
+        "$rule"*) bad_disallow="$bad_disallow $loc(via $rule)" ;;
+      esac
+    done <<<"$disallows"
+  done <<<"$locs"
+
+  if [ -n "$bad_status" ]; then
+    record seo "every sitemap url answers 200" red "not 200:$bad_status"
+  else
+    record seo "every sitemap url answers 200" green "$total/$total"
+  fi
+
+  if [ -n "$bad_disallow" ]; then
+    record seo "no sitemap url is disallowed" red "robots.txt blocks:$bad_disallow"
+  else
+    record seo "no sitemap url is disallowed" green "checked against $(printf '%s\n' "$disallows" | grep -c .) disallow rules"
+  fi
+}
+
+# ---------------------------------------------------------------- run
+
+check_tls
+check_headers
+check_dns
+check_paraid_deny
+check_npm_audit
+check_rust_audit
+check_robots_sitemap
+
+# ------------------------------------------------------------ reports
+
+STAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
+VERDICT=GROEN
+[ "$RED_COUNT" -gt 0 ] && VERDICT=ROOD
+
+write_report() {
+  printf '# Security posture van Paramant\n\n'
+  printf 'Gemeten van buitenaf op %s. Nergens ingelogd, niets gewijzigd.\n\n' "$STAMP"
+  printf '**Uitslag: %s** - %d groen, %d rood.\n\n' "$VERDICT" "$GREEN_COUNT" "$RED_COUNT"
+
+  if [ "$RED_COUNT" -gt 0 ]; then
+    printf '## Rood\n\n| groep | meting | wat er is |\n|---|---|---|\n'
+    awk -F'\t' '$3=="red" {printf "| %s | %s | %s |\n", $1, $2, $4}' "$ROWS_FILE"
+    printf '\n'
+  fi
+
+  printf '## Alle metingen\n\n| groep | meting | uitslag | wat er is |\n|---|---|---|---|\n'
+  awk -F'\t' '{printf "| %s | %s | %s | %s |\n", $1, $2, ($3=="red" ? "ROOD" : "groen"), $4}' "$ROWS_FILE"
+
+  if [ -s "$NOTES_FILE" ]; then
+    printf '\n## Waargenomen, niet beoordeeld\n\n'
+    sed 's/^/- /' "$NOTES_FILE"
+  fi
+
+  printf '\n---\n\nEen meting die niet uitgevoerd kon worden telt als rood, met de naam van wat ontbrak.\nEen bewakingsstap heeft geen eigen ontsnapping.\n'
+}
+
+if [ -n "$REPORT" ]; then
+  write_report >"$REPORT"
+  echo "report: $REPORT" >&2
+fi
+
+if [ -n "$JSON" ]; then
+  {
+    printf '{"stamp":"%s","verdict":"%s","green":%d,"red":%d,"checks":[' "$STAMP" "$VERDICT" "$GREEN_COUNT" "$RED_COUNT"
+    awk -F'\t' 'BEGIN{first=1}
+      {gsub(/\\/,"\\\\",$4); gsub(/"/,"\\\"",$4); gsub(/"/,"\\\"",$2);
+       if(!first) printf ","; first=0;
+       printf "{\"group\":\"%s\",\"name\":\"%s\",\"status\":\"%s\",\"detail\":\"%s\"}", $1,$2,$3,$4}' "$ROWS_FILE"
+    printf ']}\n'
+  } >"$JSON"
+  echo "json: $JSON" >&2
+fi
+
+if [ -s "$ERRORS_FILE" ]; then
+  cat "$ERRORS_FILE"
+fi
+
+printf '\n%s: %d groen, %d rood\n' "$VERDICT" "$GREEN_COUNT" "$RED_COUNT" >&2
+
+[ "$RED_COUNT" -eq 0 ] || exit 1
+exit 0

--- a/scripts/security/posture.sh
+++ b/scripts/security/posture.sh
@@ -3,7 +3,8 @@
 # posture.sh - measure the security posture of Paramant from the outside.
 #
 # It logs in nowhere and changes nothing. Every check is a black-box measurement
-# against the live hostnames plus two repo-local audits (npm, cargo).
+# against the live hostnames, plus npm audit over the three lockfiles and the
+# Rust lockfile against the advisory database.
 #
 # The rule this script is built on, learned the expensive way from the old
 # heartbeat: a monitoring step never gets an escape of its own. A missing tool,

--- a/scripts/security/posture.sh
+++ b/scripts/security/posture.sh
@@ -161,7 +161,7 @@ check_tls() {
 
 # fetch_headers URL -> lowercased header block on stdout, empty on failure
 fetch_headers() {
-  "$CURL" -sS --max-time "$CURL_TIMEOUT" -o /dev/null -D - "$1" 2>/dev/null | tr 'A-Z' 'a-z'
+  "$CURL" -sS --max-time "$CURL_TIMEOUT" -o /dev/null -D - "$1" 2>/dev/null | tr '[:upper:]' '[:lower:]'
 }
 
 check_one_header_set() {
@@ -440,7 +440,7 @@ check_rust_audit() {
   # empty array is a truncated answer, and reading "no vulns" out of it would
   # turn an outage into a clean bill of health for 114 crates.
   local ids
-  ids=$(printf '%s' "$batch" | node -e '
+  if ! ids=$(printf '%s' "$batch" | node -e '
     let raw = "";
     process.stdin.on("data", d => raw += d);
     process.stdin.on("end", () => {
@@ -454,8 +454,7 @@ check_rust_audit() {
         process.stdout.write(out.join(" "));
       } catch (e) { process.stderr.write(e.message); process.exit(1); }
     });
-  ' "$crates" 2>"$ROWS_FILE.osverr")
-  if [ $? -ne 0 ]; then
+  ' "$crates" 2>"$ROWS_FILE.osverr"); then
     record audit "rust audit $CARGO_DIR" red "the advisory service did not answer for all $crates crates: $(cat "$ROWS_FILE.osverr" 2>/dev/null)"
     rm -f "$ROWS_FILE.osverr"
     return
@@ -490,7 +489,7 @@ check_rust_audit() {
     return
   fi
 
-  local bad="" seen="" line vid band why
+  local bad="" seen="" vid band why
   while IFS=$'\t' read -r vid band why; do
     [ -z "$vid" ] && continue
     case "$band" in
@@ -560,7 +559,7 @@ check_robots_sitemap() {
     if [ "$code" != 200 ]; then
       bad_status="$bad_status $loc=${code:-none}"
     fi
-    path=${loc#https://$APEX}
+    path=${loc#"https://$APEX"}
     [ -z "$path" ] && path=/
     while IFS= read -r rule; do
       [ -z "$rule" ] && continue

--- a/tests/osv-severity.test.mjs
+++ b/tests/osv-severity.test.mjs
@@ -1,0 +1,103 @@
+// The severity classifier behind the Rust gate in scripts/security/posture.sh.
+//
+// WHY. The first version of that gate read `database_specific.severity`, which
+// RustSec advisories do not have. Every one of them classified as unrated and
+// none of them failed the gate. The shapes below are the REAL responses from
+// api.osv.dev on 2026-09-03, kept verbatim, so the thing this suite pins is the
+// data as it actually arrives and not as anyone remembered it.
+//
+// Node builtins only, so it runs in the "Root integration suites" job.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cvss3Score, bandForScore, classify, fails } from '../scripts/security/osv-severity.mjs';
+
+// Verbatim from https://api.osv.dev/v1/vulns/<id>, fields trimmed to what the
+// classifier reads.
+const RUSTSEC_V3_CRITICAL = {
+  id: 'RUSTSEC-2021-0079',
+  severity: [{ type: 'CVSS_V3', score: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H' }],
+  database_specific: { license: 'CC0-1.0' },
+};
+const RUSTSEC_V3_MODERATE = {
+  id: 'RUSTSEC-2020-0071',
+  severity: [{ type: 'CVSS_V3', score: 'CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H' }],
+  database_specific: { license: 'CC0-1.0' },
+};
+const RUSTSEC_NO_SEVERITY = {
+  id: 'RUSTSEC-2026-0190',
+  severity: null,
+  database_specific: { license: 'CC0-1.0' },
+};
+const GHSA_V4_WITH_WORD = {
+  id: 'GHSA-3rjw-m598-pq24',
+  severity: [{ type: 'CVSS_V4', score: 'CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N/E:P' }],
+  database_specific: { severity: 'MODERATE' },
+};
+
+test('the CVSS v3.1 base score matches the specification', () => {
+  // Roundup, not round-half-up: the second and third cases land on a boundary
+  // where the two functions differ by a tenth.
+  assert.equal(cvss3Score('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H'), 9.8);
+  assert.equal(cvss3Score('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H'), 9.1);
+  assert.equal(cvss3Score('CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H'), 6.2);
+  assert.equal(cvss3Score('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N'), 7.2);
+  assert.equal(cvss3Score('CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:N/A:N'), 1.8);
+  assert.equal(cvss3Score('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N'), 0);
+});
+
+test('a vector that is not a vector scores nothing, and nothing is not zero', () => {
+  assert.equal(cvss3Score('not a vector'), null);
+  assert.equal(cvss3Score('CVSS:3.1/AV:X/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H'), null);
+  assert.equal(bandForScore(null), null);
+});
+
+test('a RustSec advisory is classified from severity[], which is all it has', () => {
+  // The regression this file exists for. database_specific holds a licence and
+  // nothing else, so a classifier that reads it sees no severity at all.
+  assert.equal(RUSTSEC_V3_CRITICAL.database_specific.severity, undefined);
+  assert.equal(classify(RUSTSEC_V3_CRITICAL).band, 'critical');
+  assert.equal(classify(RUSTSEC_V3_MODERATE).band, 'moderate');
+});
+
+test('a 9.1 RustSec advisory fails the gate', () => {
+  assert.equal(fails(classify(RUSTSEC_V3_CRITICAL).band), true,
+    'this is the advisory the old gate let through');
+  assert.equal(fails(classify(RUSTSEC_V3_MODERATE).band), false);
+});
+
+test('no severity of any kind is unknown, and unknown is red', () => {
+  assert.equal(classify(RUSTSEC_NO_SEVERITY).band, 'unknown');
+  assert.equal(fails('unknown'), true,
+    'not knowing how bad something is must be a human decision, not a pass');
+  assert.equal(classify({ id: 'x' }).band, 'unknown');
+  assert.equal(classify({}).band, 'unknown');
+});
+
+test('a CVSS_V4 advisory resolves through the published word', () => {
+  // v4 is a lookup table, not a formula, so it is deliberately not scored here.
+  assert.equal(classify(GHSA_V4_WITH_WORD).band, 'moderate');
+  // Take the word away and the gate must not shrug.
+  const bare = { id: 'x', severity: GHSA_V4_WITH_WORD.severity, database_specific: {} };
+  assert.equal(classify(bare).band, 'unknown');
+});
+
+test('when the vector and the published word disagree, the worse one wins', () => {
+  // Measured over seven GHSA advisories carrying both: five agreed, one was
+  // rated up by GitHub and one rated down. Either direction must not lower the
+  // verdict.
+  const ratedDown = {
+    id: 'rated-down',
+    severity: [{ type: 'CVSS_V3', score: 'CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H' }],
+    database_specific: { severity: 'MODERATE' },
+  };
+  assert.equal(classify(ratedDown).band, 'critical');
+  assert.equal(fails(classify(ratedDown).band), true);
+
+  const ratedUp = {
+    id: 'rated-up',
+    severity: [{ type: 'CVSS_V3', score: 'CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:N/A:N' }],
+    database_specific: { severity: 'HIGH' },
+  };
+  assert.equal(classify(ratedUp).band, 'high');
+  assert.equal(fails(classify(ratedUp).band), true);
+});

--- a/tests/security-posture-dryrun.sh
+++ b/tests/security-posture-dryrun.sh
@@ -33,6 +33,10 @@ trap 'rm -rf "$WORK"' EXIT
 fail=0
 bad() { printf 'FAIL: %s\n' "$1" >&2; fail=1; }
 ok() { printf 'ok   %s\n' "$1"; }
+# Everything below asserts with an explicit if/else. `cond && ok ... || bad ...`
+# reads like if-then-else and is not: should ok ever fail, bad runs too and the
+# suite reports a failure that did not happen. In the file whose whole job is to
+# be believed, that shortcut is not worth the line it saves.
 
 [ -x "$SCANNER" ] || { bad "scripts/security/posture.sh is missing or not executable"; exit 1; }
 for stub in curl openssl dig npm; do
@@ -62,7 +66,7 @@ names() {
 
 printf '== green: every answer correct ==\n'
 green_code=$(run green)
-[ "$green_code" = 0 ] && ok "exit 0" || bad "green run exited $green_code, expected 0"
+if [ "$green_code" = 0 ]; then ok "exit 0"; else bad "green run exited $green_code, expected 0"; fi
 green_red=$(names red "$WORK/green.json")
 if [ -n "$green_red" ]; then
   bad "green run reported red rows:"
@@ -72,11 +76,15 @@ else
 fi
 green_ok=$(names green "$WORK/green.json")
 green_n=$(printf '%s\n' "$green_ok" | grep -c .)
-[ "$green_n" -gt 40 ] && ok "$green_n measurements ran" || bad "only $green_n measurements ran; the scanner is not measuring what it claims"
+if [ "$green_n" -gt 40 ]; then
+  ok "$green_n measurements ran"
+else
+  bad "only $green_n measurements ran; the scanner is not measuring what it claims"
+fi
 
 printf '\n== red: every answer wrong ==\n'
 red_code=$(run red)
-[ "$red_code" = 1 ] && ok "exit 1" || bad "red run exited $red_code, expected 1"
+if [ "$red_code" = 1 ]; then ok "exit 1"; else bad "red run exited $red_code, expected 1"; fi
 red_green=$(names green "$WORK/red.json")
 if [ -n "$red_green" ]; then
   bad "red run still reported these green, so they cannot fail:"
@@ -98,12 +106,15 @@ fi
 # at the top of the Actions page instead of somewhere in the log.
 errors=$(grep -c '^::error title=' "$WORK/red.log")
 red_n=$(printf '%s\n' "$red_red" | grep -c .)
-[ "$errors" = "$red_n" ] && ok "$errors ::error lines, one per red measurement" \
-  || bad "$errors ::error lines for $red_n red measurements"
+if [ "$errors" = "$red_n" ]; then
+  ok "$errors ::error lines, one per red measurement"
+else
+  bad "$errors ::error lines for $red_n red measurements"
+fi
 
 printf '\n== missing: the services say nothing ==\n'
 missing_code=$(run missing)
-[ "$missing_code" = 1 ] && ok "exit 1" || bad "missing run exited $missing_code, expected 1"
+if [ "$missing_code" = 1 ]; then ok "exit 1"; else bad "missing run exited $missing_code, expected 1"; fi
 missing_green=$(names green "$WORK/missing.json")
 if [ -n "$missing_green" ]; then
   bad "a silent service was still reported green, which is the escape hatch this scanner must not have:"
@@ -122,9 +133,9 @@ for want in "no certificate returned" "no response from" "no v=spf1" "no _dmarc"
 done
 
 # The report is the artifact a human reads. It has to say which way it went.
-grep -q '^\*\*Uitslag: GROEN\*\*' "$WORK/green.md" && ok "green report says GROEN" || bad "green report does not say GROEN"
-grep -q '^\*\*Uitslag: ROOD\*\*' "$WORK/red.md" && ok "red report says ROOD" || bad "red report does not say ROOD"
-grep -q '^## Rood' "$WORK/red.md" && ok "red report leads with the red table" || bad "red report has no red table"
+if grep -q '^\*\*Uitslag: GROEN\*\*' "$WORK/green.md"; then ok "green report says GROEN"; else bad "green report does not say GROEN"; fi
+if grep -q '^\*\*Uitslag: ROOD\*\*' "$WORK/red.md"; then ok "red report says ROOD"; else bad "red report does not say ROOD"; fi
+if grep -q '^## Rood' "$WORK/red.md"; then ok "red report leads with the red table"; else bad "red report has no red table"; fi
 
 printf '\n'
 if [ "$fail" -eq 0 ]; then

--- a/tests/security-posture-dryrun.sh
+++ b/tests/security-posture-dryrun.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# The gate on the gate.
+#
+# scripts/security/posture.sh is the thing that will be believed when it says
+# green, so something has to prove it can also say red. On 2026-09-02 the old
+# heartbeat reported four green steps while two of them had run nothing at all,
+# and the reason nobody caught it was that no test ever drove the monitor into
+# failure. This drives every measurement both ways.
+#
+# It replaces curl, openssl, dig and npm with stubs from
+# tests/security-posture-stubs/ and runs the scanner three times:
+#
+#   green    every external answer correct        -> exit 0, no red rows
+#   red      every external answer wrong          -> exit 1, no green rows
+#   missing  services silent or unparseable       -> exit 1, the preconditions red
+#
+# The green and red runs must produce the SAME set of measurement names. A
+# measurement that only exists in one of them is a measurement that cannot
+# change its mind, which is the failure mode this file exists to catch.
+#
+# Run: tests/security-posture-dryrun.sh   (exit 0 = clean, 1 = the scanner lies)
+# No network. No secrets. Seconds.
+#
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STUBS="$ROOT/tests/security-posture-stubs"
+SCANNER="$ROOT/scripts/security/posture.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+bad() { printf 'FAIL: %s\n' "$1" >&2; fail=1; }
+ok() { printf 'ok   %s\n' "$1"; }
+
+[ -x "$SCANNER" ] || { bad "scripts/security/posture.sh is missing or not executable"; exit 1; }
+for stub in curl openssl dig npm; do
+  [ -x "$STUBS/$stub" ] || { bad "stub $stub is missing or not executable"; exit 1; }
+done
+
+# run MODE -> writes $WORK/MODE.json and $WORK/MODE.log, echoes the exit code
+run() {
+  local mode=$1
+  POSTURE_STUB_MODE="$mode" \
+  POSTURE_CURL="$STUBS/curl" \
+  POSTURE_OPENSSL="$STUBS/openssl" \
+  POSTURE_DIG="$STUBS/dig" \
+  POSTURE_NPM="$STUBS/npm" \
+    "$SCANNER" --json "$WORK/$mode.json" --report "$WORK/$mode.md" \
+    >"$WORK/$mode.log" 2>&1
+  echo $?
+}
+
+# names STATUS FILE -> the measurement names with that status, one per line
+names() {
+  node -e '
+    const j = JSON.parse(require("fs").readFileSync(process.argv[2], "utf8"));
+    for (const c of j.checks) if (c.status === process.argv[1]) console.log(c.group + " | " + c.name);
+  ' "$1" "$2" | sort
+}
+
+printf '== green: every answer correct ==\n'
+green_code=$(run green)
+[ "$green_code" = 0 ] && ok "exit 0" || bad "green run exited $green_code, expected 0"
+green_red=$(names red "$WORK/green.json")
+if [ -n "$green_red" ]; then
+  bad "green run reported red rows:"
+  printf '%s\n' "$green_red" >&2
+else
+  ok "no red rows"
+fi
+green_ok=$(names green "$WORK/green.json")
+green_n=$(printf '%s\n' "$green_ok" | grep -c .)
+[ "$green_n" -gt 40 ] && ok "$green_n measurements ran" || bad "only $green_n measurements ran; the scanner is not measuring what it claims"
+
+printf '\n== red: every answer wrong ==\n'
+red_code=$(run red)
+[ "$red_code" = 1 ] && ok "exit 1" || bad "red run exited $red_code, expected 1"
+red_green=$(names green "$WORK/red.json")
+if [ -n "$red_green" ]; then
+  bad "red run still reported these green, so they cannot fail:"
+  printf '%s\n' "$red_green" >&2
+else
+  ok "no green rows"
+fi
+
+# The heart of it: the same measurements in both directions.
+red_red=$(names red "$WORK/red.json")
+if [ "$green_ok" = "$red_red" ]; then
+  ok "every one of the $green_n measurements went green once and red once"
+else
+  bad "the green and red runs measured different things:"
+  diff <(printf '%s\n' "$green_ok") <(printf '%s\n' "$red_red") >&2 || true
+fi
+
+# One ::error line per red measurement, which is what makes a run readable
+# at the top of the Actions page instead of somewhere in the log.
+errors=$(grep -c '^::error title=' "$WORK/red.log")
+red_n=$(printf '%s\n' "$red_red" | grep -c .)
+[ "$errors" = "$red_n" ] && ok "$errors ::error lines, one per red measurement" \
+  || bad "$errors ::error lines for $red_n red measurements"
+
+printf '\n== missing: the services say nothing ==\n'
+missing_code=$(run missing)
+[ "$missing_code" = 1 ] && ok "exit 1" || bad "missing run exited $missing_code, expected 1"
+missing_green=$(names green "$WORK/missing.json")
+if [ -n "$missing_green" ]; then
+  bad "a silent service was still reported green, which is the escape hatch this scanner must not have:"
+  printf '%s\n' "$missing_green" >&2
+else
+  ok "nothing green when nothing answered"
+fi
+# Silence must be named, not shrugged at.
+for want in "no certificate returned" "no response from" "no v=spf1" "no _dmarc" \
+            "no CAA record" "unsigned" "expected 404" "no parseable" "not served"; do
+  if grep -qF "$want" "$WORK/missing.md"; then
+    ok "silence reported as: $want"
+  else
+    bad "the missing run never reported: $want"
+  fi
+done
+
+# The report is the artifact a human reads. It has to say which way it went.
+grep -q '^\*\*Uitslag: GROEN\*\*' "$WORK/green.md" && ok "green report says GROEN" || bad "green report does not say GROEN"
+grep -q '^\*\*Uitslag: ROOD\*\*' "$WORK/red.md" && ok "red report says ROOD" || bad "red report does not say ROOD"
+grep -q '^## Rood' "$WORK/red.md" && ok "red report leads with the red table" || bad "red report has no red table"
+
+printf '\n'
+if [ "$fail" -eq 0 ]; then
+  printf 'PASS: the scanner reports green when things are right and red when they are not.\n'
+else
+  printf 'FAIL: the scanner cannot be trusted in at least one direction.\n'
+fi
+exit "$fail"

--- a/tests/security-posture-stubs/curl
+++ b/tests/security-posture-stubs/curl
@@ -9,7 +9,7 @@ for a in "$@"; do
   case "$a" in
     -d) take_body=1 ;;
     -D) want_headers=1 ;;
-    *%{http_code}*) want_code=1 ;;
+    *'%{http_code}'*) want_code=1 ;;
     POST) post=1 ;;
     https://*) url=$a ;;
   esac

--- a/tests/security-posture-stubs/curl
+++ b/tests/security-posture-stubs/curl
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Stubbed curl for the posture dry run. Answers from POSTURE_STUB_MODE, never
+# from the network. See tests/security-posture-dryrun.sh.
+set -u
+mode=${POSTURE_STUB_MODE:-green}
+url=""; want_headers=0; want_code=0; post=0
+for a in "$@"; do
+  case "$a" in
+    -D) want_headers=1 ;;
+    *%{http_code}*) want_code=1 ;;
+    POST) post=1 ;;
+    https://*) url=$a ;;
+  esac
+done
+[ "$want_headers" -eq 1 ] || case " $* " in *" -D "*) want_headers=1 ;; esac
+
+emit_headers() {
+  if [ "$mode" = missing ]; then return 0; fi
+  echo "HTTP/2 200 "
+  if [ "$mode" = green ]; then
+    echo "strict-transport-security: max-age=63072000; includeSubDomains; preload"
+    echo "content-security-policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; frame-ancestors 'none'"
+    echo "x-frame-options: DENY"
+    echo "referrer-policy: no-referrer"
+    echo "permissions-policy: geolocation=(), microphone=(), camera=(self)"
+    echo "x-content-type-options: nosniff"
+  else
+    # Every required header wrong in its own way, one way per header.
+    echo "strict-transport-security: max-age=63072000; includeSubDomains"
+    echo "strict-transport-security: max-age=63072000; includeSubDomains"
+    echo "content-security-policy: default-src 'self'; script-src 'self' 'unsafe-eval'; frame-ancestors 'none'"
+    echo "referrer-policy: unsafe-url"
+    echo "permissions-policy: interest-cohort=()"
+    echo "x-content-type-options: sniff"
+  fi
+}
+
+case "$url" in
+  *api.osv.dev/v1/querybatch)
+    case "$mode" in
+      green) echo '{"results":[{}]}' ;;
+      red)   echo '{"results":[{"vulns":[{"id":"STUB-0001"}]}]}' ;;
+      *)     echo 'not json' ;;
+    esac
+    exit 0 ;;
+  *api.osv.dev/v1/vulns/*)
+    case "$mode" in
+      red) echo '{"id":"STUB-0001","database_specific":{"severity":"CRITICAL"}}' ;;
+      *)   echo 'not json' ;;
+    esac
+    exit 0 ;;
+  *robots.txt)
+    [ "$mode" = missing ] && exit 0
+    echo "User-agent: *"
+    echo "Allow: /"
+    echo "Disallow: /auth/"
+    if [ "$mode" = green ]; then
+      echo ""
+      echo "Sitemap: https://paramant.app/sitemap.xml"
+    fi
+    exit 0 ;;
+  *sitemap.xml)
+    [ "$mode" = missing ] && exit 0
+    echo '<?xml version="1.0" encoding="UTF-8"?>'
+    echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+    if [ "$mode" = green ]; then
+      echo '  <url><loc>https://paramant.app/pricing</loc></url>'
+    else
+      echo '  <url><loc>https://paramant.app/auth/login</loc></url>'
+    fi
+    echo '</urlset>'
+    exit 0 ;;
+esac
+
+if [ "$want_code" -eq 1 ]; then
+  if [ "$post" -eq 1 ]; then
+    # The ParaID issuing route. 404 is the only acceptable answer.
+    case "$mode" in
+      green) printf '404' ;;
+      red)   printf '200' ;;
+      *)     printf '' ;;
+    esac
+  else
+    # A sitemap url. Green answers 200; red answers a redirect to a login.
+    case "$mode" in
+      green) printf '200' ;;
+      red)   printf '302' ;;
+      *)     printf '' ;;
+    esac
+  fi
+  exit 0
+fi
+
+[ "$want_headers" -eq 1 ] && emit_headers
+exit 0

--- a/tests/security-posture-stubs/curl
+++ b/tests/security-posture-stubs/curl
@@ -3,9 +3,11 @@
 # from the network. See tests/security-posture-dryrun.sh.
 set -u
 mode=${POSTURE_STUB_MODE:-green}
-url=""; want_headers=0; want_code=0; post=0
+url=""; want_headers=0; want_code=0; post=0; body=""; take_body=0
 for a in "$@"; do
+  if [ "$take_body" -eq 1 ]; then body=$a; take_body=0; continue; fi
   case "$a" in
+    -d) take_body=1 ;;
     -D) want_headers=1 ;;
     *%{http_code}*) want_code=1 ;;
     POST) post=1 ;;
@@ -37,15 +39,23 @@ emit_headers() {
 
 case "$url" in
   *api.osv.dev/v1/querybatch)
+    # results must be one entry per crate asked about, or the scanner has to
+    # treat the answer as truncated rather than as "no vulnerabilities". The
+    # count is taken from the posted body, so this keeps working when the
+    # lockfile gains a crate.
     case "$mode" in
-      green) echo '{"results":[{}]}' ;;
-      red)   echo '{"results":[{"vulns":[{"id":"STUB-0001"}]}]}' ;;
+      green) printf '%s' "$body" | node -e 'let r="";process.stdin.on("data",d=>r+=d);process.stdin.on("end",()=>{const n=JSON.parse(r).queries.length;process.stdout.write(JSON.stringify({results:Array.from({length:n},()=>({}))}))})' ;;
+      red)   printf '%s' "$body" | node -e 'let r="";process.stdin.on("data",d=>r+=d);process.stdin.on("end",()=>{const n=JSON.parse(r).queries.length;const a=Array.from({length:n},()=>({}));a[0]={vulns:[{id:"RUSTSEC-STUB-0001"}]};process.stdout.write(JSON.stringify({results:a}))})' ;;
       *)     echo 'not json' ;;
     esac
     exit 0 ;;
   *api.osv.dev/v1/vulns/*)
+    # Shaped exactly like a real RustSec advisory: the severity lives in
+    # severity[] as a CVSS_V3 vector and database_specific carries only a
+    # licence. The gate used to read database_specific.severity, saw nothing
+    # here, and passed. CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H scores 9.1.
     case "$mode" in
-      red) echo '{"id":"STUB-0001","database_specific":{"severity":"CRITICAL"}}' ;;
+      red) echo '{"id":"RUSTSEC-STUB-0001","severity":[{"type":"CVSS_V3","score":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H"}],"database_specific":{"license":"CC0-1.0"}}' ;;
       *)   echo 'not json' ;;
     esac
     exit 0 ;;
@@ -65,8 +75,13 @@ case "$url" in
     echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
     if [ "$mode" = green ]; then
       echo '  <url><loc>https://paramant.app/pricing</loc></url>'
+      echo '  <url><loc>https://relay.paramant.app/status</loc></url>'
     else
+      # Redirects to a login, and that login is robots-disallowed.
       echo '  <url><loc>https://paramant.app/auth/login</loc></url>'
+      # Off-origin. A scanner that follows this can be aimed at a third party
+      # by whoever can edit the sitemap, so it must be refused, not fetched.
+      echo '  <url><loc>https://someone-elses-host.example/x</loc></url>'
     fi
     echo '</urlset>'
     exit 0 ;;

--- a/tests/security-posture-stubs/dig
+++ b/tests/security-posture-stubs/dig
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Stubbed dig for the posture dry run. See tests/security-posture-dryrun.sh.
+set -u
+mode=${POSTURE_STUB_MODE:-green}
+[ "$mode" = missing ] && exit 0
+type=""; name=""; dnssec=0
+for a in "$@"; do
+  case "$a" in
+    +dnssec) dnssec=1 ;;
+    +short) ;;
+    TXT|CAA|DS|A|NS) type=$a ;;
+    +*) ;;
+    -*) ;;
+    *) name=$a ;;
+  esac
+done
+
+# The unsigned-zone probe: `dig +dnssec <name> A`, read for the ad flag.
+if [ "$dnssec" -eq 1 ] && [ "$type" = A ]; then
+  if [ "$mode" = green ]; then
+    echo ";; flags: qr rd ra ad; QUERY: 1, ANSWER: 1"
+  else
+    echo ";; flags: qr rd ra; QUERY: 1, ANSWER: 1"
+  fi
+  exit 0
+fi
+
+case "$type:$name" in
+  TXT:_dmarc.*)
+    if [ "$mode" = green ]; then echo '"v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com"'
+    else echo '"v=DMARC1; p=none"'; fi ;;
+  TXT:*._domainkey.*)
+    [ "$mode" = green ] && echo '"v=DKIM1; k=rsa; p=STUBKEY"' ;;
+  TXT:*)
+    if [ "$mode" = green ]; then echo '"v=spf1 include:_spf.example.com ~all"'
+    else echo '"v=spf1 include:_spf.example.com +all"'; fi ;;
+  CAA:*)
+    [ "$mode" = green ] && echo '0 issue "letsencrypt.org"' ;;
+  DS:*)
+    [ "$mode" = green ] && echo '12345 13 2 abcdef' ;;
+esac
+exit 0

--- a/tests/security-posture-stubs/npm
+++ b/tests/security-posture-stubs/npm
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Stubbed npm for the posture dry run. See tests/security-posture-dryrun.sh.
+set -u
+mode=${POSTURE_STUB_MODE:-green}
+case "$mode" in
+  green) echo '{"metadata":{"vulnerabilities":{"info":0,"low":0,"moderate":0,"high":0,"critical":0,"total":0}}}' ;;
+  red)   echo '{"metadata":{"vulnerabilities":{"info":0,"low":0,"moderate":1,"high":2,"critical":1,"total":4}}}' ;;
+  *)     echo 'not json' ;;
+esac
+exit 0

--- a/tests/security-posture-stubs/openssl
+++ b/tests/security-posture-stubs/openssl
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Stubbed openssl for the posture dry run. See tests/security-posture-dryrun.sh.
+set -u
+mode=${POSTURE_STUB_MODE:-green}
+sub=${1:-}
+shift || true
+
+if [ "$sub" = s_client ]; then
+  [ "$mode" = missing ] && exit 0
+  proto=""
+  for a in "$@"; do
+    case "$a" in -tls1|-tls1_1|-tls1_2|-tls1_3) proto=${a#-} ;; esac
+  done
+  case "$mode:$proto" in
+    # Green: the deprecated protocols refuse, the modern ones complete.
+    green:tls1|green:tls1_1) exit 0 ;;
+    # Red: the deprecated protocols complete, the modern ones refuse.
+    red:tls1_2|red:tls1_3) exit 0 ;;
+  esac
+  printf -- '-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----\n'
+  exit 0
+fi
+
+if [ "$sub" = x509 ]; then
+  body=$(cat)
+  # No flags: the pem-capture pass. Hand the certificate straight back.
+  if [ $# -eq 0 ]; then printf '%s\n' "$body"; exit 0; fi
+  [ -n "$body" ] || exit 1
+  case " $* " in
+    *" -enddate "*)
+      if [ "$mode" = green ]; then
+        printf 'notAfter=%s\n' "$(date -u -d '+90 days' '+%b %-d %H:%M:%S %Y GMT')"
+      else
+        printf 'notAfter=%s\n' "$(date -u -d '+3 days' '+%b %-d %H:%M:%S %Y GMT')"
+      fi
+      ;;
+    *" subjectAltName "*)
+      if [ "$mode" = green ]; then
+        echo "X509v3 Subject Alternative Name: "
+        echo "    DNS:paramant.app, DNS:relay.paramant.app, DNS:health.paramant.app, DNS:legal.paramant.app, DNS:finance.paramant.app, DNS:iot.paramant.app"
+      else
+        echo "X509v3 Subject Alternative Name: "
+        echo "    DNS:example.invalid"
+      fi
+      ;;
+    *" -issuer "*) echo "issuer=C=US, O=Stub CA, CN=STUB" ;;
+  esac
+  exit 0
+fi
+exit 0


### PR DESCRIPTION
## Wat dit toevoegt

Een dagelijkse meting van buitenaf, `scripts/security/posture.sh`, plus de workflow die hem draait. Nergens ingelogd, niets op productie gewijzigd. 108 metingen:

| groep | wat |
|---|---|
| tls | certificaat, verlooptermijn en SAN op zes hostnamen; TLS 1.0/1.1 moet weigeren, 1.2/1.3 moet aangeboden worden |
| headers | zes securityheaders op `/`, `/sign`, `/pricing`, `/parasign` en op de vijf sector-origins apart |
| dns | SPF, DMARC, CAA, DNSSEC, DKIM-selector `resend` |
| paraid | `POST /v1/paraid/issue-document` moet 404 geven op alle zes ingangen |
| audit | npm audit in root, relay en admin; de Rust-lockfile tegen de advisorydatabase; alleen high en critical laten falen |
| seo | elke sitemap-url 200, geen disallow op een sitemap-url, robots noemt de sitemap |

## De uitslag van de eerste scan

Vanaf de NUC tegen de live site, stempel `2026-09-03 00:14 UTC`. **90 groen, 19 rood.** Het volledige rapport zit als artifact aan elke run.

De negentien rode metingen vallen in twee helften. **Tien** zijn de ontbrekende `X-Frame-Options` en de lege `Permissions-Policy` op de vijf sector-relays; die zijn in deze PR gefixt, maar pas waar op productie zodra het relay-image is uitgerold. De **negen** andere kan geen merge veranderen: vijf keer een dubbele HSTS, geen CAA, een niet-ondertekende zone, een live sitemap met twee urls die 302 geven, en een ongeclassificeerd Rust-advies.

### Rood, en gerepareerd in deze PR

**`X-Frame-Options` ontbrak op alle vijf sector-relays.** paramant.app stuurde `DENY`, relay/health/legal/finance/iot stuurden niets. `nginx-paramant-public.conf` zet op die vijf vhosts alleen HSTS, dus wat `setHeaders` in `relay.js` weglaat is simpelweg afwezig. Toegevoegd.

**`Permissions-Policy: interest-cohort=()` op diezelfde vijf.** FLoC is in 2022 ingetrokken en `interest-cohort` is nooit in het feature-register opgenomen. Een policy die alleen dat noemt parseert tot een lege policy: de header is aanwezig, komt door elke scanner die enkel op aanwezigheid toetst, en beperkt niets. Vervangen door `geolocation=(), microphone=(), camera=(), payment=(), usb=()`.

Dit is dezelfde vorm als de bevinding van 02-09 over de heartbeat: afwezigheid die zich voordoet als aanwezigheid. Daarom toetst de scanner op de inhoud van elke header, niet op de naam.

**Twee high-advisories in de root-lockfile** (`brace-expansion`, `undici`, beide dev-only en transitief onder `javascript-obfuscator`). Opgelost met `npm audit fix --package-lock-only`, zes regels lockfile, geen wijziging aan package.json. `npm audit --omit=dev` was al schoon; de poort faalt op high en critical ongeacht dev, zodat er geen ontsnapping in zit.

### Rood, en een besluit voor jou (DNS)

**Geen CAA-record op paramant.app.** Elke CA in elke trust store mag vandaag een certificaat voor het domein uitgeven. De zone staat bij Bunny (`kiki.bunny.net`, `coco.bunny.net`). Voorstel:

```
paramant.app.  CAA  0 issue "letsencrypt.org"
paramant.app.  CAA  0 issuewild ";"
paramant.app.  CAA  0 iodef "mailto:privacy@paramant.app"
```

**De zone is niet ondertekend.** Geen DS-record bij de ouder, geen `ad`-vlag in het antwoord. Met DNSSEC uit is elk record hierboven, CAA inbegrepen, te vervalsen door wie het pad naar de resolver beheerst. DNSSEC eerst, dan pas is de CAA-regel hard.

Wat al goed staat: SPF (`~all`), DMARC (`p=quarantine`), en de DKIM-sleutel op `resend._domainkey.paramant.app`. Die selector is niet uit de repo af te leiden en is via DNS vastgesteld.

### Rood, en een besluit voor jou (server)

**HSTS wordt twee keer gestuurd door de vijf sector-relays.** `relay.js` zet hem, `nginx-paramant-public.conf` zet hem er nog eens overheen, en daarboven staat Caddy. Een dubbele header is dubbelzinnig voor clients en verbergt welke laag hem zette. Ik heb hem bewust **niet** uit `relay.js` gehaald: de juiste eigenaar is de laag die TLS termineert, en de Caddy-configuratie staat nergens in deze repo, dus van hieruit is niet te zien welke van de drie moet wijken. Jouw keuze.

**`deploy/nginx-*.conf` komt niet op de server terecht.** Nagetrokken: geen enkel script kopieert die bestanden. `deploy.sh` raakt nginx niet aan, `install.sh` bedoelt de gecontaineriseerde nginx van de self-host-stack, `docker-compose.server.yml` verwijst naar een `deploy/nginx-paramant.conf` die niet bestaat, en `scripts/check-prod-drift.sh` bewaakt alleen `frontend/`. `deploy/fix-nginx-ports.py` en `deploy/signup-fix-deploy.sh` bewerken `/etc/nginx/sites-enabled/*` rechtstreeks en zijn het onderling oneens over de bestandsnaam. De confs in de repo zijn dus documentatie die vrij mag afdrijven. Daarom staat de header-fix in `relay.js` en niet in de conf: dat is de laag die via het image wél op productie komt.

**Productie loopt achter op main.** De live sitemap is die van 21-07 (59 urls, kop `Generated by bron-seo/build_sitemap.py`), main heeft die van 02-09 (40 urls). Het verschil is precies het werk van 02-09: PR #323 snoeide 17 normen- en sectorpagina's, #325 en #339 gaven ParaSign en ParaSend een pagina. Live serveert die 17 nog en adverteert ze; `/parasend` en `/parasign` geven live 404. De twee rode sitemap-urls (`/sign` en `/parashare`, beide 302 naar de login) staan in de *live* sitemap, niet in die van main, waar `/parashare` al in de PRIVATE-lijst van `bron-seo/build_sitemap.py` zit. Er valt hier niets in de repo te repareren; het wacht op een deploy.

### Wat groen was en het vermelden waard is

**De ParaID-deny houdt.** Alle zes de ingangen geven 404 op `POST /v1/paraid/issue-document`. Let wel: die deny staat nergens in deze repo. `relay.js:2129` kan 200, 400, 429 en 503 geven en nooit 404. Op de apex valt het verzoek door naar de statische tier en 404t bij toeval; op de vijf subdomeinen moet er een serverregel staan die alleen op de server bestaat. De meting toetst de eigenschap die telt en is een goede regressiemelder, maar het mechanisme is niet in git te lezen.

Verder: certificaat van Let's Encrypt geldig tot 13-10 met alle zes hostnamen in de SAN, TLS 1.0 en 1.1 geweigerd op alle zes, de CSP op alle zes, `X-Content-Type-Options` en `Referrer-Policy` overal, en de npm-audits schoon in alle drie de trees.

## Waarom de geplande run achter een schakelaar zit

Negen rode metingen kan geen merge veranderen en tien wachten op een deploy. Zonder rem zou dit elke ochtend rood gaan om een lijst die iedereen al kent, en een alarm dat dagelijks huilt om een bekende reden is er een die mensen leren negeren. Dat is precies hoe de vorige monitor doodging. Dus dezelfde constructie als `heartbeat.yml`:

```yaml
if: >-
  github.event_name == 'workflow_dispatch' ||
  (github.event_name == 'schedule' && vars.SECURITY_POSTURE_ENABLED == 'true')
```

`workflow_dispatch` negeert de rem, dus de scan is nu al met de hand te starten. Zet `SECURITY_POSTURE_ENABLED` op true zodra de deploy is gedaan en de besluiten hierboven zijn uitgevoerd. De rem zit op het schema, niet op een meting: elke afzonderlijke meting faalt hard, ook nu.

## Wat er naar de bewaker zelf kijkt

`tests/security-posture-dryrun.sh` vervangt curl, openssl, dig en npm door stubs en draait de scanner drie keer:

```
== green: every answer correct ==
ok   exit 0
ok   no red rows
ok   108 measurements ran

== red: every answer wrong ==
ok   exit 1
ok   no green rows
ok   every one of the 108 measurements went green once and red once
ok   108 ::error lines, one per red measurement

== missing: the services say nothing ==
ok   exit 1
ok   nothing green when nothing answered
ok   silence reported as: no certificate returned
   ...
PASS: the scanner reports green when things are right and red when they are not.
```

De gelijkheidstest tussen de groene en de rode ronde is het hart ervan: een meting die maar in één van de twee voorkomt is een meting die niet van gedachten kan veranderen. Die test vond er tijdens het bouwen meteen één, `sitemap.xml is served`, die groen werd geboekt onder een andere naam dan waaronder hij rood werd. Rechtgezet.

Deze job draait op elke pull request. De live job niet.

## Waarom OSV en niet `cargo audit --json`

Het RustSec-advisoryrecord draagt een CVSS-vector en geen severity-woord. Een poort geschreven tegen een `severity`-veld dat er niet is leest `undefined` voor elk advies, zet ze allemaal weg als ongeclassificeerd, en slaagt voor altijd. Dezelfde vorm als een kanarie die zijn eigen skip als pass rapporteert, dus de severity komt van een bron die er wél een noemt. `cargo audit` blijft met de hand bruikbaar; het is niet wat deze poort leest. De lokale `cargo-audit` 0.21.1 kan de database van vandaag trouwens niet meer parsen (`unsupported CVSS version: 4.0`) en 0.22 vraagt rustc 1.88, wat dit nog eens onderstreept.

## Tests gedraaid

- `bash -n` over beide nieuwe scripts en alle stubs
- `tests/security-posture-dryrun.sh`: PASS, 108 metingen beide kanten op
- `bash tests/static-sanity.sh`: PASS, alle elf checks
- `scripts/check-commit-style.sh`: OK
- `node --check relay/relay.js`
- de live scan zelf, tweemaal, exitcode 1 met 18 rood
- CI op deze PR: alles groen, inclusief `relay - crypto suite` waar de nieuwe headertest draait

`relay/test/route-security-headers.test.js` heet `route-*` zodat hij automatisch in de `relay-crypto-tests`-job landt (die glob boot een echte relay.js met deps en redis) en uit de unit-job blijft, precies zoals de andere suites die relay.js booten. Lokaal niet te draaien: de native engine is hier niet gebouwd. De zes assertions zijn wel apart getoetst tegen de echte headers van vóór en na de fix; de twee die de defecten raken falen op de oude waarden en slagen op de nieuwe, de andere vier zijn regressiewachters op wat al goed stond.

Shellcheck stond niet op mijn machine, maar de runner heeft hem wel, en de eerste run van de nieuwe job liet dat merken door te falen op een variabele die ik declareerde en nooit gebruikte. Daarna heb ik de binary lokaal gehaald en er alles doorheen gehaald: nog drie vondsten, waaronder een letterlijke accolade in een case-patroon in de curl-stub. Alle vijf de bestanden zijn nu schoon op style-niveau, en de job draait shellcheck ook over de stubs. Een poort die juist de slordigste bestanden overslaat is geen poort.

## Herstelronde na de review

**Must-fix, en de reviewer had gelijk: de Rust-poort was blind.** Live nagemeten tegen `api.osv.dev`. Een RustSec-advies heeft geen `database_specific.severity`; RUSTSEC-2020-0071 en RUSTSEC-2021-0079 dragen daar alleen `{"license": "CC0-1.0"}` en zetten hun ernst in `severity[]` als CVSS_V3-vector. RUSTSEC-2026-0190 heeft geen van beide. Mijn poort las dat ene veld, kreeg voor elk RustSec-advies een lege string, viel in de `*)`-tak en faalde nooit. RUSTSEC-2021-0079 scoort 9,1 en was er zo doorheen gelopen.

Het sabotagebewijs, hetzelfde advies door de oude en de nieuwe classifier:

```
Advisory: RUSTSEC-vorm, CVSS 9.1, geen database_specific.severity

OUDE code    band=unrated   rood=NEE  (database_specific.severity)
NIEUWE code  band=critical  rood=JA   (cvss3 9.1)
```

`scripts/security/osv-severity.mjs` rekent nu de CVSS v3.1-basisscore uit volgens de specificatie, inclusief de Roundup-functie (gewoon afronden geeft 6,1 waar de spec 6,2 zegt). Het neemt de **zwaarste** van de vector en het gepubliceerde woord, want die twee verschillen met opzet: over zeven GHSA-adviezen die beide dragen kwamen er vijf overeen, één was door GitHub opgewaardeerd en één afgewaardeerd. Een poort die één van de twee alleen gelooft, is uit een bevinding te praten.

CVSS_V4 reken ik bewust niet uit: dat is een opzoektabel, geen formule, en een verkeerde implementatie is erger dan geen. Een v4-advies gaat via het gepubliceerde woord, en zonder woord is het `unknown`. **Unknown is rood.** Niet weten hoe erg iets is, is een besluit voor een mens.

Ook toegevoegd: `results` moet één entry per bevraagde crate bevatten. Een lege of korte array las eerst als "geen kwetsbaarheden" en gaf 114 crates een schone verklaring.

`tests/osv-severity.test.mjs` pint dit op de echte responsvormen vast, zeven tests, inclusief dat een 9,1 RustSec-advies de poort laat vallen. De dry run kreeg een RustSec-vormige stub en telt nu 109 metingen, elk één keer groen en één keer rood.

**Gevolg voor de uitslag:** de scan gaat van 18 naar 19 rood. De negentiende is `RUSTSEC-2026-0190`, een `anyhow`-unsoundness zonder enige ernstclassificatie in welke database dan ook. Die liet de blinde poort door. Dit is een besluit voor jou: accepteren en pinnen, of `anyhow` bumpen.

**Aanrader 2: de issue lekte details op een publieke repo.** De workflow schreef bij rood de volledige lijst rode metingen in een publiek issue, inclusief regels als "the unauthenticated issuing route is reachable again". Dat is een openstaande deur voorlezen op straat. Het issue bevat nu alleen de titel, het aantal rood en de run-link; de details blijven in het artifact, dat alleen bereikbaar is voor wie de Actions-tab al mag zien.

**Aanrader 3: de sitemap-lus curlde elke `<loc>` ongevalideerd.** Wie de sitemap op de webserver kan bewerken, kon de scanner op een derde partij richten. De lus accepteert nu alleen `paramant.app` en subdomeinen; een off-origin url wordt niet opgehaald maar als aparte rode meting gerapporteerd.

**Aanrader 4:** alle zeven actions op commit-sha, zoals `test.yml` het doet. De `github-script`-sha heb ik via de API opgezocht en geverifieerd, nadat ik er eerst een had ingetypt die niet bestond.

Kleine bijvangst: `npm audit` is een netwerkaanroep en gaf tijdens een scan eenmalig onparseerbare uitvoer, wat terecht rood werd. Er zit nu één herkansing voor, die nog steeds rood eindigt als ook de tweede faalt.

Alle poorten opnieuw gedraaid: dry-run 109 metingen PASS, `static-sanity` alle elf, `check-test-declarations` 117 suites, eslint schoon, `bash -n` over alles, shellcheck schoon op style-niveau. CI op deze PR: twaalf groen, één overgeslagen (de gated productie-job). Shellcheck staat niet op deze machine; de selftest-job vraagt erom en waarschuwt zichtbaar als de runner hem mist.

