### PR TITLE
Deploy: the nginx conf names differ per server, so each slot names its candidates

### DIFF
--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -304,6 +304,55 @@ tar czf /home/paramant/backups/docroot-pre-3.1-$TS.tgz -C /home/paramant app
 cp /etc/nginx/sites-enabled/paramant-public.conf /etc/nginx/backups/paramant-public.conf.pre-3.1-$TS
 ```
 
+### The nginx conf names are not the same on every server
+
+Step 2b backs up the nginx confs, and it needs their names. Those names differ
+per machine. On the run of 03-09 production had
+`/etc/nginx/sites-enabled/paramant-public.conf` and no `paramant-live.conf` at
+all: `deploy/signup-fix-deploy.sh` edits `paramant.conf` on that same host, so
+the backend conf is called `paramant.conf` there.
+
+The script therefore works with conf **slots** instead of fixed names. A slot
+is a list of candidate names separated by `|`, slots are separated by
+whitespace, and the default is
+
+```
+paramant-public.conf paramant-live.conf|paramant.conf
+```
+
+On the server the first candidate of each slot that is really in
+`sites-enabled` is chosen, and the choice is written to the log as
+
+```
+nginxconf paramant-public.conf resolved to paramant-public.conf
+nginxconf paramant-live.conf resolved to paramant.conf
+```
+
+A slot is always named after its first candidate, so the left half of that line
+is the same everywhere and the right half is what this server actually calls
+it. Everything downstream uses the resolved name: the backup in 2b, the edits
+in 5c, the checks in 6, and both rollback steps in 8. The backups are filed
+under the resolved name (`paramant.conf.pre-3.1-$TS`), and step 8 resolves the
+same way, so a rollback looks for the file that is really there.
+
+If no candidate of a slot is present the run stops in 2b with
+
+```
+nginxconf paramant-live.conf ABSENT, none of these is in /etc/nginx/sites-enabled: paramant-live.conf paramant.conf
+```
+
+and the hint to set `PARAMANT_NGINX_CONFS`. That variable still overrides the
+whole list, now in the slot syntax:
+
+```bash
+PARAMANT_NGINX_CONFS="paramant-public.conf paramant.conf" deploy/deploy-3.1.sh
+```
+
+`paramant.conf` as a candidate is an assumption drawn from
+`deploy/signup-fix-deploy.sh`, not a confirmed reading of the live server. The
+script does not rely on the assumption being right: it checks on the server
+each run and says which name it landed on.
+
 `deploy/ops/backup-full-state.sh` exists for the data volumes; run it too if
 the users file or the CT log matter to you today (they should).
 
@@ -404,9 +453,18 @@ keep the deny:
 
 ```bash
 nginx -T 2>/dev/null | grep -n 'paraid/issue\|location = /sign\|/compliance\|location = /dicom\|/pararules'
-# edit /etc/nginx/sites-enabled/paramant-public.conf and the live conf accordingly
+# edit /etc/nginx/sites-enabled/paramant-public.conf and the backend conf accordingly
 nginx -t && systemctl reload nginx
 ```
+
+Which files those are is the slot question from step 2: the backend conf is
+`paramant-live.conf` on one server and `paramant.conf` on another. 5c resolves
+the slots exactly as 2b did and prints the same `nginxconf <slot> resolved to
+<name>` lines before it touches anything, followed by a `target <name> -> <path>`
+line per conf. Read those two first: they say which files the four edits are
+about to land in. A slot with no candidate at all is FATAL here, and a resolved
+conf without the ParaID deny is FATAL too, with the resolved names in the
+message.
 
 The ParaID deny may stay: the route is gone from the relay (#319), so the
 deny answers 404 for a path that would answer 404 anyway. Remove it in a later
@@ -594,6 +652,13 @@ tar xzf /home/paramant/backups/docroot-pre-3.1-$TS.tgz -C /home/paramant
 cp /etc/nginx/backups/paramant-public.conf.pre-3.1-$TS /etc/nginx/sites-enabled/paramant-public.conf
 nginx -t && systemctl reload nginx
 ```
+
+The backups in `/etc/nginx/backups/` carry the name step 2b resolved, so on a
+server whose backend conf is `paramant.conf` the second file is
+`paramant.conf.pre-3.1-$TS` and it goes back to
+`/etc/nginx/sites-enabled/paramant.conf`. `ls /etc/nginx/backups/` says which
+names were filed. The script does this resolution itself in step 8, and stops
+before it writes anything if a backup under the resolved name is missing.
 
 Manual fallback for a single service, from the 3.0.0 runbook:
 

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -43,8 +43,24 @@ NGINX_SITES=/etc/nginx/sites-enabled
 
 # The two server confs the runbook names. Phase 5 edits these and nothing else:
 # a wildcard loop over sites-enabled would silently rewrite a conf nobody
-# reviewed. Override only if the server names them differently.
-NGINX_CONFS="${PARAMANT_NGINX_CONFS:-paramant-public.conf paramant-live.conf}"
+# reviewed.
+#
+# The names are not the same on every machine. The run of 03-09 stopped in
+# phase 2b because production carries paramant-public.conf but no
+# paramant-live.conf: the backend conf there is called paramant.conf. So a slot
+# is a LIST of candidates separated by "|", and the server takes the first
+# candidate that is really in sites-enabled. Slots are separated by whitespace,
+# exactly as before, and PARAMANT_NGINX_CONFS still overrides the whole thing.
+#
+#   paramant-public.conf              slot 1, one candidate
+#   paramant-live.conf|paramant.conf  slot 2, live first, paramant.conf next
+#
+# paramant.conf is an assumption, drawn from deploy/signup-fix-deploy.sh, which
+# edits /etc/nginx/sites-enabled/paramant.conf on this same server. The script
+# does not trust it: it looks on the server, logs the name it resolved to, and
+# stops when a slot has no candidate at all.
+NGINX_CONF_SLOTS="${PARAMANT_NGINX_CONFS:-paramant-public.conf paramant-live.conf|paramant.conf}"
+NGINX_SLOT_COUNT="$(printf '%s' "$NGINX_CONF_SLOTS" | wc -w | tr -d ' ')"
 
 # Present on the server by design, absent from the repo. Same list as
 # scripts/check-prod-drift.sh: these are never pruned from the docroot.
@@ -275,6 +291,53 @@ remote() {
 # remote_soft: same, but the caller judges the exit code itself.
 remote_soft() { _remote_run "$@"; }
 
+# -------------------------------------------- resolving the nginx conf names --
+#
+# Every remote block that touches an nginx conf needs the same answer: given a
+# slot like "paramant-live.conf|paramant.conf", which of those names is really
+# in sites-enabled on THIS server? Only the server can answer that, so the
+# answer travels with the block. remote_nginx prepends the function below to
+# the body, which means the server runs exactly this text, and so does
+# tests/deploy-3.1-dryrun.test.sh when it extracts a block.
+NGINX_RESOLVE_SNIPPET="$(cat <<'RESOLVER'
+# resolve_conf_slots <sites-dir> <slots>: per slot, take the first candidate
+# that exists in sites-enabled. Prints one line per slot, either
+#   nginxconf <slot> resolved to <name>
+# or, when no candidate of that slot is there,
+#   nginxconf <slot> ABSENT, none of these is in <dir>: <candidates>
+# A slot is named by its first candidate, so the log reads the same whichever
+# name the server happens to use. Sets RESOLVED_CONFS to the chosen names in
+# slot order and RESOLVED_MISSING to the number of slots that resolved to
+# nothing. It never exits: the caller decides what an absent slot means.
+resolve_conf_slots() {
+  rc_sites="$1"; rc_slots="$2"
+  RESOLVED_CONFS=""
+  RESOLVED_MISSING=0
+  for rc_slot in $rc_slots; do
+    rc_chosen=""
+    rc_oldifs="$IFS"
+    IFS='|'
+    for rc_cand in $rc_slot; do
+      if [ -e "$rc_sites/$rc_cand" ]; then rc_chosen="$rc_cand"; break; fi
+    done
+    IFS="$rc_oldifs"
+    if [ -z "$rc_chosen" ]; then
+      echo "nginxconf ${rc_slot%%|*} ABSENT, none of these is in $rc_sites: $(printf '%s' "$rc_slot" | tr '|' ' ')"
+      RESOLVED_MISSING=$((RESOLVED_MISSING + 1))
+      continue
+    fi
+    echo "nginxconf ${rc_slot%%|*} resolved to $rc_chosen"
+    RESOLVED_CONFS="${RESOLVED_CONFS:+$RESOLVED_CONFS }$rc_chosen"
+  done
+}
+RESOLVER
+)"
+
+# remote_nginx: remote(), with resolve_conf_slots() already defined in the body.
+remote_nginx() {
+  { printf '%s\n' "$NGINX_RESOLVE_SNIPPET"; cat; } | remote "$@"
+}
+
 # expect: assert against the output of the last remote call. Skipped, loudly,
 # under --dry-run, because there was no measurement to judge.
 expect() {
@@ -492,7 +555,8 @@ printf '  run TS        %s\n' "$TS"
 printf '  target        %s\n' "$PROD_HOST"
 printf '  compose dir   %s\n' "$COMPOSE_DIR"
 printf '  docroot       %s\n' "$DOCROOT"
-printf '  nginx confs   %s\n' "$NGINX_CONFS"
+printf '  nginx confs   %s\n' "$NGINX_CONF_SLOTS"
+printf '                %s slot(s); the first candidate present on the server wins\n' "$NGINX_SLOT_COUNT"
 printf '  deploy ref    %s\n' "$DEPLOY_REF"
 if [ -n "$EXPECTED_HEAD" ]; then
   printf '  expected head %s (PARAMANT_EXPECTED_HEAD)\n' "$EXPECTED_HEAD"
@@ -813,10 +877,10 @@ EOF
   expect_count "after tags for this TS" 6 "six rollback images really exist on the host, not just six lines of text"
 
   step "2b. back up .env, compose state, docroot and the nginx confs"
-  remote "backups" "$COMPOSE_DIR" "$TS" "$BACKUP_DIR" "$DOCROOT" "$NGINX_BACKUP_DIR" "$NGINX_SITES" "$NGINX_CONFS" <<'EOF'
+  remote_nginx "backups" "$COMPOSE_DIR" "$TS" "$BACKUP_DIR" "$DOCROOT" "$NGINX_BACKUP_DIR" "$NGINX_SITES" "$NGINX_CONF_SLOTS" <<'EOF'
 set -euo pipefail
 cd "$1"
-TS="$2"; BK="$3"; DOCROOT="$4"; NGBK="$5"; NGSITES="$6"; CONFS="$7"
+TS="$2"; BK="$3"; DOCROOT="$4"; NGBK="$5"; NGSITES="$6"; SLOTS="$7"
 mkdir -p "$BK" "$NGBK"
 
 echo "before .env bytes = $(stat -c%s .env)"
@@ -832,15 +896,16 @@ tar czf "$BK/docroot-pre-3.1-$TS.tgz" -C "$(dirname "$DOCROOT")" "$(basename "$D
 echo "after docroot tar bytes = $(stat -c%s "$BK/docroot-pre-3.1-$TS.tgz")"
 echo "after docroot tar entries = $(tar tzf "$BK/docroot-pre-3.1-$TS.tgz" | wc -l)"
 
+# Which name does each slot have on THIS server? The backup is filed under the
+# resolved name and phase 8 resolves the same way, so a rollback looks for the
+# file that is really there.
+resolve_conf_slots "$NGSITES" "$SLOTS"
+
 # sites-enabled entries are usually symlinks into sites-available. cp -a of a
 # symlink copies the link, not the file, which is not a backup: resolve first.
 n=0
-for name in $CONFS; do
+for name in $RESOLVED_CONFS; do
   link="$NGSITES/$name"
-  if [ ! -e "$link" ]; then
-    echo "nginxconf $name ABSENT"
-    continue
-  fi
   target="$(readlink -f "$link")"
   echo "nginxconf $name -> $target ($(stat -c%s "$target") bytes)"
   cp -a "$target" "$NGBK/$name.pre-3.1-$TS"
@@ -848,6 +913,7 @@ for name in $CONFS; do
   n=$((n + 1))
 done
 echo "after nginx conf backups = $n"
+echo "after nginx slots unresolved = $RESOLVED_MISSING"
 
 if [ -x deploy/ops/backup-full-state.sh ]; then
   echo "--- deploy/ops/backup-full-state.sh ---"
@@ -864,9 +930,10 @@ EOF
   expect_min "after .env backup bytes" 1 ".env backup is a real file with content"
   expect_min "after docroot tar bytes" 1 "docroot tar is a real file with content"
   expect_min "after docroot tar entries" 1 "docroot tar holds entries"
-  expect_count "after nginx conf backups" 2 "both named nginx confs were resolved and backed up"
+  expect_count "after nginx conf backups" "$NGINX_SLOT_COUNT" \
+    "every nginx conf slot resolved to a name on the server and was backed up"
   expect_not 'nginxconf [a-z.-]+ ABSENT' \
-    "both named nginx confs exist on the server (set PARAMANT_NGINX_CONFS if they are named differently)"
+    "every nginx conf slot has a candidate on the server (set PARAMANT_NGINX_CONFS if they are named differently)"
 }
 
 # =============================================================== PHASE 3 =====
@@ -1224,19 +1291,22 @@ EOF
   fi
 
   step "5c. the four nginx changes, by hand, keeping the ParaID deny"
-  remote "nginx edits" "$TS" "$NGINX_SITES" "$NGINX_BACKUP_DIR" "$NGINX_CONFS" <<'EOF'
+  remote_nginx "nginx edits" "$TS" "$NGINX_SITES" "$NGINX_BACKUP_DIR" "$NGINX_CONF_SLOTS" <<'EOF'
 set -euo pipefail
-TS="$1"; SITES="$2"; NGBK="$3"; CONFS="$4"
+TS="$1"; SITES="$2"; NGBK="$3"; SLOTS="$4"
 
-# Resolve the two named confs to real files. A symlink is not the file.
+# Which name does each slot have here? Same question as phase 2b, answered the
+# same way, so the confs that are edited are the confs that were backed up.
+resolve_conf_slots "$SITES" "$SLOTS"
+if [ "$RESOLVED_MISSING" -ne 0 ]; then
+  echo "FATAL $RESOLVED_MISSING nginx conf slot(s) have no candidate in $SITES"
+  exit 1
+fi
+
+# Resolve the named confs to real files. A symlink is not the file.
 TARGETS=""
-for name in $CONFS; do
-  link="$SITES/$name"
-  if [ ! -e "$link" ]; then
-    echo "FATAL named nginx conf $name does not exist in $SITES"
-    exit 1
-  fi
-  t="$(readlink -f "$link")"
+for name in $RESOLVED_CONFS; do
+  t="$(readlink -f "$SITES/$name")"
   echo "target $name -> $t"
   TARGETS="$TARGETS $t"
 done
@@ -1439,7 +1509,7 @@ else
 fi
 
 if [ "$(count "$PARAID_RE")" -eq 0 ]; then
-  echo "FATAL the ParaID deny is not present; the 01-09 server edit this runbook relies on is gone"
+  echo "FATAL the ParaID deny is not present in the resolved conf(s) $RESOLVED_CONFS; the 01-09 server edit this runbook relies on is gone"
   exit 1
 fi
 if [ "$(count "$OUT_RE")" -eq 0 ]; then
@@ -1877,10 +1947,10 @@ phase_8() {
   phase 8 "Rollback to $ROLLBACK_TS (server, WRITE)" "Step 8"
 
   step "8a. the manifest, the saved images and the backups this rollback needs"
-  remote "rollback preconditions" "$COMPOSE_DIR" "$ROLLBACK_TS" "$BACKUP_DIR" "$NGINX_BACKUP_DIR" "$NGINX_CONFS" <<'EOF'
+  remote_nginx "rollback preconditions" "$COMPOSE_DIR" "$ROLLBACK_TS" "$BACKUP_DIR" "$NGINX_BACKUP_DIR" "$NGINX_SITES" "$NGINX_CONF_SLOTS" <<'EOF'
 set -euo pipefail
 cd "$1"
-TS="$2"; BK="$3"; NGBK="$4"; CONFS="$5"
+TS="$2"; BK="$3"; NGBK="$4"; SITES="$5"; SLOTS="$6"
 M="$BK/rollback-images-$TS.txt"
 [ -f "$M" ] || { echo "FATAL no manifest $M"; exit 1; }
 echo "manifest lines = $(wc -l < "$M")"
@@ -1909,7 +1979,11 @@ for f in "$BK/.env-pre-3.1-$TS" "$BK/docroot-pre-3.1-$TS.tgz"; do
     absent=$((absent + 1))
   fi
 done
-for name in $CONFS; do
+# The backups were filed under the name phase 2b resolved, so resolve again
+# instead of guessing: on this server the slot may well be paramant.conf.
+resolve_conf_slots "$SITES" "$SLOTS"
+absent=$((absent + RESOLVED_MISSING))
+for name in $RESOLVED_CONFS; do
   f="$NGBK/$name.pre-3.1-$TS"
   if [ -f "$f" ]; then
     echo "  backup present $f ($(stat -c%s "$f") bytes)"
@@ -1970,12 +2044,18 @@ EOF
   expect_count "after recreated services" 6 "all six services came back on their saved images"
 
   step "8c. restore the nginx confs and the docroot"
-  remote "rollback nginx and docroot" "$ROLLBACK_TS" "$BACKUP_DIR" "$DOCROOT" "$NGINX_BACKUP_DIR" "$NGINX_SITES" "$NGINX_CONFS" "$DOCROOT_IGNORE" <<'EOF'
+  remote_nginx "rollback nginx and docroot" "$ROLLBACK_TS" "$BACKUP_DIR" "$DOCROOT" "$NGINX_BACKUP_DIR" "$NGINX_SITES" "$NGINX_CONF_SLOTS" "$DOCROOT_IGNORE" <<'EOF'
 set -euo pipefail
-TS="$1"; BK="$2"; DOCROOT="$3"; NGBK="$4"; SITES="$5"; CONFS="$6"; IGNORE="$7"
+TS="$1"; BK="$2"; DOCROOT="$3"; NGBK="$4"; SITES="$5"; SLOTS="$6"; IGNORE="$7"
+
+resolve_conf_slots "$SITES" "$SLOTS"
+if [ "$RESOLVED_MISSING" -ne 0 ]; then
+  echo "FATAL $RESOLVED_MISSING nginx conf slot(s) have no candidate in $SITES"
+  exit 1
+fi
 
 n=0
-for name in $CONFS; do
+for name in $RESOLVED_CONFS; do
   b="$NGBK/$name.pre-3.1-$TS"
   [ -f "$b" ] || { echo "FATAL missing nginx backup $b"; exit 1; }
   target="$(readlink -f "$SITES/$name")"
@@ -2032,7 +2112,7 @@ tar xzf "$TAR" -C "$(dirname "$DOCROOT")"
 echo "after docroot files = $(find "$DOCROOT" -type f | wc -l)"
 EOF
   expect_not 'FATAL' "nginx confs and docroot restored, nginx tested clean before the reload"
-  expect_count "restored nginx confs" 2 "both named nginx confs came back"
+  expect_count "restored nginx confs" "$NGINX_SLOT_COUNT" "every resolved nginx conf came back"
   expect 'reloaded nginx' "nginx reloaded on the restored conf"
 
   step "8d. health after the rollback"

--- a/tests/deploy-3.1-dryrun.test.sh
+++ b/tests/deploy-3.1-dryrun.test.sh
@@ -42,6 +42,22 @@ check_lacks() { # file, pattern, name
   fi
 }
 
+# extract_remote <label>: the body of one remote block, verbatim from the
+# script. A block that touches an nginx conf is sent with remote_nginx, which
+# prepends NGINX_RESOLVE_SNIPPET on the wire, so the snippet is prepended here
+# too. What these tests run is then exactly what the server runs.
+extract_snippet() {
+  sed -n "/^NGINX_RESOLVE_SNIPPET=/,/^RESOLVER\$/p" "$SCRIPT" | sed '1d;$d'
+}
+extract_remote() {
+  local label="$1" line kind
+  line="$(grep -nE "^  remote(_nginx)? \"$label\"" "$SCRIPT" | head -1)"
+  [ -n "$line" ] || return 1
+  kind="$(printf '%s' "$line" | sed -E 's/^[0-9]+:[[:space:]]*([a-z_]+).*/\1/')"
+  [ "$kind" = remote_nginx ] && extract_snippet
+  sed -n "/^  remote\(_nginx\)\? \"$label\"/,/^EOF\$/p" "$SCRIPT" | sed '1d;$d'
+}
+
 echo "======== deploy-3.1.sh dry run ========"
 
 # ---------------------------------------------------------------- 1. syntax --
@@ -378,8 +394,8 @@ exit 0
 STUB
 chmod +x "$NG/bin/nginx" "$NG/bin/systemctl"
 
-# The 5c body, verbatim from the script.
-sed -n '/^  remote "nginx edits"/,/^EOF$/p' "$SCRIPT" | sed '1d;$d' > "$NG/5c.sh"
+# The 5c body, verbatim from the script, resolver and all.
+extract_remote "nginx edits" > "$NG/5c.sh"
 if [ -s "$NG/5c.sh" ]; then
   pass "the 5c remote block could be extracted from the script"
 else
@@ -602,7 +618,7 @@ echo "6h. A deploy AFTER a rollback still prunes the pages the rollback restored
 # the OLDER of the deployed commit and the runbook floor for this reason.
 RB5B="$WORK/rb5b"
 mkdir -p "$RB5B/repo" "$RB5B/docroot"
-sed -n '/^  remote "prune deleted frontend files"/,/^EOF$/p' "$SCRIPT" | sed '1d;$d' > "$RB5B/5b.sh"
+extract_remote "prune deleted frontend files" > "$RB5B/5b.sh"
 if [ -s "$RB5B/5b.sh" ]; then
   pass "the 5b remote block could be extracted from the script"
 else
@@ -674,6 +690,311 @@ fi
 check_has "$SCRIPT" 'merge-base --is-ancestor "\$FLOOR" "\$BASE"' \
   "the older-of-the-two choice is git's answer, not a guess"
 check_has "$FULL"   'before prune base'   "the dry run shows which base 5b will diff against"
+
+echo ""
+echo "6i. The conf names differ per server, so a slot is a list of candidates"
+# Production on 03-09 carries /etc/nginx/sites-enabled/paramant-public.conf and
+# no paramant-live.conf at all: deploy/signup-fix-deploy.sh edits paramant.conf
+# on that same host. Phase 2b stopped on the name it could not find, which was
+# correct but unrunnable. A slot is now a "|" separated candidate list, the
+# server takes the first candidate that is really in sites-enabled, and it logs
+# which one that was.
+SLOTS_DEFAULT="$(sed -n 's/^NGINX_CONF_SLOTS="\${PARAMANT_NGINX_CONFS:-\(.*\)}"$/\1/p' "$SCRIPT")"
+if [ "$SLOTS_DEFAULT" = "paramant-public.conf paramant-live.conf|paramant.conf" ]; then
+  pass "the default names paramant.conf as the second candidate of slot 2"
+else
+  fail "the default slots are '$SLOTS_DEFAULT', expected paramant-live.conf|paramant.conf as slot 2"
+fi
+check_has "$SCRIPT" 'PARAMANT_NGINX_CONFS' "PARAMANT_NGINX_CONFS still overrides the whole list"
+check_has "$FULL"   'nginx confs   paramant-public.conf paramant-live.conf\|paramant.conf' \
+  "the run header prints the candidates it will resolve on the server"
+
+echo ""
+echo "6i-1. resolve_conf_slots picks the first candidate that is there"
+NG2="$WORK/ng2"
+mkdir -p "$NG2/bin" "$NG2/available" "$NG2/bk" "$NG2/unit-both" "$NG2/unit-fallback" "$NG2/unit-none"
+cp "$NG/bin/nginx" "$NG/bin/systemctl" "$NG2/bin/"
+: > "$NG2/available/u-public"; : > "$NG2/available/u-live"; : > "$NG2/available/u-paramant"
+ln -sfn "$NG2/available/u-public"   "$NG2/unit-both/paramant-public.conf"
+ln -sfn "$NG2/available/u-live"     "$NG2/unit-both/paramant-live.conf"
+ln -sfn "$NG2/available/u-paramant" "$NG2/unit-both/paramant.conf"
+ln -sfn "$NG2/available/u-public"   "$NG2/unit-fallback/paramant-public.conf"
+ln -sfn "$NG2/available/u-paramant" "$NG2/unit-fallback/paramant.conf"
+ln -sfn "$NG2/available/u-public"   "$NG2/unit-none/paramant-public.conf"
+# A symlink into nothing is not a conf. -e follows the link on purpose.
+ln -sfn "$NG2/available/does-not-exist" "$NG2/unit-none/paramant-live.conf"
+
+if eval "$(extract_snippet)" 2>/dev/null && declare -F resolve_conf_slots >/dev/null; then
+  pass "resolve_conf_slots() could be extracted from the script"
+
+  SL="paramant-public.conf paramant-live.conf|paramant.conf"
+
+  # Run it in THIS shell, not in a command substitution: the answer is in
+  # RESOLVED_CONFS and RESOLVED_MISSING, and a subshell would keep them.
+  resolve_conf_slots "$NG2/unit-both" "$SL" > "$NG2/unit-out.txt"
+  OUTU="$(cat "$NG2/unit-out.txt")"
+  if [ "$RESOLVED_CONFS" = "paramant-public.conf paramant-live.conf" ] && [ "$RESOLVED_MISSING" = 0 ]; then
+    pass "with both names present, slot 2 resolves to paramant-live.conf"
+  else
+    fail "with both present it resolved to '$RESOLVED_CONFS' (missing $RESOLVED_MISSING)"
+  fi
+  if printf '%s\n' "$OUTU" | grep -q 'nginxconf paramant-live.conf resolved to paramant-live.conf'; then
+    pass "the choice is logged under the slot name"
+  else
+    fail "no 'resolved to' line for slot 2"
+    printf '%s\n' "$OUTU" | sed 's/^/        /'
+  fi
+
+  resolve_conf_slots "$NG2/unit-fallback" "$SL" > "$NG2/unit-out.txt"
+  OUTU="$(cat "$NG2/unit-out.txt")"
+  if [ "$RESOLVED_CONFS" = "paramant-public.conf paramant.conf" ] && [ "$RESOLVED_MISSING" = 0 ]; then
+    pass "with paramant-live.conf absent, slot 2 resolves to paramant.conf (production, 03-09)"
+  else
+    fail "the fallback resolved to '$RESOLVED_CONFS' (missing $RESOLVED_MISSING)"
+  fi
+  if printf '%s\n' "$OUTU" | grep -q 'nginxconf paramant-live.conf resolved to paramant.conf'; then
+    pass "the log says which name it landed on, not which name it was looking for"
+  else
+    fail "the resolved name is not in the log"
+    printf '%s\n' "$OUTU" | sed 's/^/        /'
+  fi
+
+  resolve_conf_slots "$NG2/unit-none" "$SL" > "$NG2/unit-out.txt"
+  OUTU="$(cat "$NG2/unit-out.txt")"
+  if [ "$RESOLVED_MISSING" = 1 ] && [ "$RESOLVED_CONFS" = "paramant-public.conf" ]; then
+    pass "no candidate of a slot present: the slot resolves to nothing, and says so"
+  else
+    fail "a slot with no candidate resolved to '$RESOLVED_CONFS' (missing $RESOLVED_MISSING)"
+  fi
+  # This is the exact pattern phase 2b asserts on, so the STOP still fires.
+  if printf '%s\n' "$OUTU" | grep -qE 'nginxconf [a-z.-]+ ABSENT'; then
+    pass "the ABSENT line matches the pattern phase 2b stops on"
+  else
+    fail "the ABSENT line does not match /nginxconf [a-z.-]+ ABSENT/"
+    printf '%s\n' "$OUTU" | sed 's/^/        /'
+  fi
+  if printf '%s\n' "$OUTU" | grep -q 'paramant-live.conf paramant.conf'; then
+    pass "it names every candidate it tried"
+  else
+    fail "the ABSENT line does not name the candidates it tried"
+  fi
+else
+  fail "could not extract resolve_conf_slots() from the script to test it"
+fi
+
+echo ""
+echo "6i-2. 5c on a replica that has paramant.conf instead of paramant-live.conf"
+mkdir -p "$NG2/sites-fb"
+make_conf "$NG2/available/paramant-public.conf" old old yes no
+make_conf "$NG2/available/paramant.conf"        old old yes no
+ln -sfn "$NG2/available/paramant-public.conf" "$NG2/sites-fb/paramant-public.conf"
+ln -sfn "$NG2/available/paramant.conf"        "$NG2/sites-fb/paramant.conf"
+OUT7="$(cd "$NG2" && PATH="$NG2/bin:$PATH" bash "$NG/5c.sh" 20260101-0100 "$NG2/sites-fb" "$NG2/bk" \
+        "paramant-public.conf paramant-live.conf|paramant.conf" 2>&1)"; RC7=$?
+if [ "$RC7" -eq 0 ]; then pass "5c exits 0 on a server that calls the backend conf paramant.conf"; else
+  fail "5c exits $RC7 on the production naming"
+  printf '%s\n' "$OUT7" | sed 's/^/        /' | head -25
+fi
+if printf '%s\n' "$OUT7" | grep -q 'nginxconf paramant-live.conf resolved to paramant.conf'; then
+  pass "5c logs the resolved name"
+else
+  fail "5c never logged which name it resolved slot 2 to"
+fi
+if printf '%s\n' "$OUT7" | grep -q 'target paramant.conf ->'; then
+  pass "5c edits the resolved file, not the candidate string"
+else
+  fail "5c did not name paramant.conf as a target"
+fi
+for want in "after sign gated:0" "after compliance:0" "after dicom try_files:0" "after edited files:2"; do
+  f="${want%%:*}"; v="${want##*:}"
+  if [ "$(field_5c "$OUT7" "$f")" = "$v" ]; then pass "on the production naming, $f = $v"; else
+    fail "on the production naming, $f = '$(field_5c "$OUT7" "$f")', expected $v"; fi
+done
+if [ "$(field_5c "$OUT7" 'after outbound blocks with buffer')" \
+   = "$(field_5c "$OUT7" 'after outbound locations')" ]; then
+  pass "the buffers landed in every /v2/outbound block of both resolved confs"
+else
+  fail "the buffer landed in $(field_5c "$OUT7" 'after outbound blocks with buffer') of $(field_5c "$OUT7" 'after outbound locations') blocks"
+fi
+if grep -q 'return 404' "$NG2/available/paramant.conf" \
+   && ! grep -q 'auth_request' "$NG2/available/paramant.conf" \
+   && ! grep -q 'location = /compliance' "$NG2/available/paramant.conf"; then
+  pass "the three edits really landed in the file called paramant.conf"
+else
+  fail "paramant.conf on disk did not get the edits"
+fi
+
+echo ""
+echo "6i-3. With both names present the first candidate wins and the other is left alone"
+mkdir -p "$NG2/sites-both"
+make_conf "$NG2/available/paramant-public.conf" old old yes no
+make_conf "$NG2/available/paramant-live.conf"   old old yes no
+make_conf "$NG2/available/paramant.conf"        old old yes no
+BEFORE_MD5="$(md5sum < "$NG2/available/paramant.conf")"
+ln -sfn "$NG2/available/paramant-public.conf" "$NG2/sites-both/paramant-public.conf"
+ln -sfn "$NG2/available/paramant-live.conf"   "$NG2/sites-both/paramant-live.conf"
+ln -sfn "$NG2/available/paramant.conf"        "$NG2/sites-both/paramant.conf"
+OUT8="$(cd "$NG2" && PATH="$NG2/bin:$PATH" bash "$NG/5c.sh" 20260101-0101 "$NG2/sites-both" "$NG2/bk" \
+        "paramant-public.conf paramant-live.conf|paramant.conf" 2>&1)"; RC8=$?
+if [ "$RC8" -eq 0 ] && printf '%s\n' "$OUT8" | grep -q 'nginxconf paramant-live.conf resolved to paramant-live.conf'; then
+  pass "with both present, slot 2 resolves to paramant-live.conf"
+else
+  fail "5c exited $RC8 and did not resolve slot 2 to paramant-live.conf"
+  printf '%s\n' "$OUT8" | sed 's/^/        /' | head -25
+fi
+if [ "$(field_5c "$OUT8" 'after edited files')" = "2" ]; then
+  pass "exactly two confs were rewritten, not three"
+else
+  fail "5c rewrote $(field_5c "$OUT8" 'after edited files') conf(s), expected 2"
+fi
+if [ "$(md5sum < "$NG2/available/paramant.conf")" = "$BEFORE_MD5" ]; then
+  pass "the losing candidate paramant.conf was not touched"
+else
+  fail "5c also rewrote paramant.conf, which is not in any resolved slot"
+fi
+
+echo ""
+echo "6i-4. A slot with no candidate at all is a stop, with the same hint"
+mkdir -p "$NG2/sites-none"
+make_conf "$NG2/available/paramant-public.conf" old old yes no
+ln -sfn "$NG2/available/paramant-public.conf" "$NG2/sites-none/paramant-public.conf"
+OUT9="$(cd "$NG2" && PATH="$NG2/bin:$PATH" bash "$NG/5c.sh" 20260101-0102 "$NG2/sites-none" "$NG2/bk" \
+        "paramant-public.conf paramant-live.conf|paramant.conf" 2>&1)"; RC9=$?
+if [ "$RC9" -ne 0 ] && printf '%s\n' "$OUT9" | grep -q 'FATAL 1 nginx conf slot'; then
+  pass "5c stops when a slot has no candidate on the server"
+else
+  fail "5c exited $RC9 with a slot that resolved to nothing"
+  printf '%s\n' "$OUT9" | sed 's/^/        /' | head -20
+fi
+check_has "$SCRIPT" 'set PARAMANT_NGINX_CONFS if they are named differently' \
+  "the STOP in 2b still hands over the same hint"
+
+echo ""
+echo "6i-5. A missing ParaID deny is still FATAL, and it names the resolved conf"
+mkdir -p "$NG2/sites-noparaid"
+make_conf "$NG2/available/paramant-public.conf" old old yes no
+make_conf "$NG2/available/paramant.conf"        old old yes no
+sed -i '/paraid\/issue-document/d' "$NG2/available/paramant-public.conf"
+sed -i '/paraid\/issue-document/d' "$NG2/available/paramant.conf"
+ln -sfn "$NG2/available/paramant-public.conf" "$NG2/sites-noparaid/paramant-public.conf"
+ln -sfn "$NG2/available/paramant.conf"        "$NG2/sites-noparaid/paramant.conf"
+OUT10="$(cd "$NG2" && PATH="$NG2/bin:$PATH" bash "$NG/5c.sh" 20260101-0103 "$NG2/sites-noparaid" "$NG2/bk" \
+         "paramant-public.conf paramant-live.conf|paramant.conf" 2>&1)"; RC10=$?
+if [ "$RC10" -ne 0 ] && printf '%s\n' "$OUT10" | grep -q 'FATAL the ParaID deny is not present'; then
+  pass "5c still stops when the ParaID deny anchor is gone"
+else
+  fail "5c exited $RC10 on a conf without the ParaID deny"
+  printf '%s\n' "$OUT10" | sed 's/^/        /' | head -20
+fi
+if printf '%s\n' "$OUT10" | grep -q 'FATAL the ParaID deny is not present in the resolved conf(s) paramant-public.conf paramant.conf'; then
+  pass "the FATAL names the confs it actually read, resolved names and all"
+else
+  fail "the ParaID FATAL does not name the resolved confs"
+  printf '%s\n' "$OUT10" | grep FATAL | sed 's/^/        /'
+fi
+
+echo ""
+echo "6i-6. The rollback resolves the same way, so it looks for the backup that exists"
+RBN="$WORK/rbnginx"
+RBTS=20260101-0200
+mkdir -p "$RBN/bin" "$RBN/compose" "$RBN/bk" "$RBN/ngbk" "$RBN/sites" "$RBN/available" "$RBN/root/app"
+cp "$NG/bin/nginx" "$NG/bin/systemctl" "$RBN/bin/"
+for svc in relay-main relay-health relay-finance relay-legal relay-iot admin; do
+  echo "$svc|img/$svc:3.1.0|paramant-rollback/$svc:$RBTS" >> "$RBN/bk/rollback-images-$RBTS.txt"
+done
+echo "PARAMANT=1" > "$RBN/bk/.env-pre-3.1-$RBTS"
+echo pre-rollback-index > "$RBN/root/app/index.html"
+tar czf "$RBN/bk/docroot-pre-3.1-$RBTS.tgz" -C "$RBN/root" app
+# The server calls the backend conf paramant.conf, so phase 2b filed the backup
+# under that name. A rollback that looked for paramant-live.conf would stop.
+echo "server { server_name public; }"  > "$RBN/available/paramant-public.conf"
+echo "server { server_name backend; }" > "$RBN/available/paramant.conf"
+echo "server { server_name public-backup; }"  > "$RBN/ngbk/paramant-public.conf.pre-3.1-$RBTS"
+echo "server { server_name backend-backup; }" > "$RBN/ngbk/paramant.conf.pre-3.1-$RBTS"
+ln -sfn "$RBN/available/paramant-public.conf" "$RBN/sites/paramant-public.conf"
+ln -sfn "$RBN/available/paramant.conf"        "$RBN/sites/paramant.conf"
+
+extract_remote "rollback preconditions" > "$RBN/8a.sh"
+extract_remote "rollback nginx and docroot" > "$RBN/8c.sh"
+if [ -s "$RBN/8a.sh" ] && [ -s "$RBN/8c.sh" ]; then
+  pass "the 8a and 8c remote blocks could be extracted from the script"
+else
+  fail "could not extract the rollback blocks from the script"
+fi
+
+OUT11="$(PATH="$RBN/bin:$PATH" bash "$RBN/8a.sh" "$RBN/compose" "$RBTS" "$RBN/bk" "$RBN/ngbk" \
+         "$RBN/sites" "paramant-public.conf paramant-live.conf|paramant.conf" 2>&1)"; RC11=$?
+if [ "$RC11" -eq 0 ]; then pass "8a exits 0 against the production naming"; else
+  fail "8a exits $RC11"
+  printf '%s\n' "$OUT11" | sed 's/^/        /' | head -20
+fi
+if printf '%s\n' "$OUT11" | grep -q 'nginxconf paramant-live.conf resolved to paramant.conf'; then
+  pass "8a resolves slot 2 to paramant.conf before it looks for a backup"
+else
+  fail "8a did not resolve the slot"
+fi
+if [ "$(field_5c "$OUT11" 'missing backups')" = "0" ]; then
+  pass "8a finds every backup it needs under the resolved names"
+else
+  fail "8a reports $(field_5c "$OUT11" 'missing backups') missing backup(s)"
+  printf '%s\n' "$OUT11" | grep -i backup | sed 's/^/        /'
+fi
+if printf '%s\n' "$OUT11" | grep -q 'paramant-live.conf.pre-3.1'; then
+  fail "8a is still looking for a backup named after the candidate string"
+else
+  pass "8a never looks for paramant-live.conf.pre-3.1, the name that is not there"
+fi
+
+# And with that backup gone, 8a must refuse instead of half-rolling back.
+mv "$RBN/ngbk/paramant.conf.pre-3.1-$RBTS" "$RBN/ngbk/paramant.conf.pre-3.1-$RBTS.moved"
+OUT12="$(PATH="$RBN/bin:$PATH" bash "$RBN/8a.sh" "$RBN/compose" "$RBTS" "$RBN/bk" "$RBN/ngbk" \
+         "$RBN/sites" "paramant-public.conf paramant-live.conf|paramant.conf" 2>&1)"
+if [ "$(field_5c "$OUT12" 'missing backups')" = "1" ]; then
+  pass "a missing backup under the resolved name is counted, so the rollback stops"
+else
+  fail "with the paramant.conf backup gone, 8a still reports $(field_5c "$OUT12" 'missing backups') missing"
+fi
+mv "$RBN/ngbk/paramant.conf.pre-3.1-$RBTS.moved" "$RBN/ngbk/paramant.conf.pre-3.1-$RBTS"
+
+echo bogus-added-by-deploy > "$RBN/root/app/added.html"
+OUT13="$(PATH="$RBN/bin:$PATH" bash "$RBN/8c.sh" "$RBTS" "$RBN/bk" "$RBN/root/app" "$RBN/ngbk" \
+         "$RBN/sites" "paramant-public.conf paramant-live.conf|paramant.conf" "dist" 2>&1)"; RC13=$?
+if [ "$RC13" -eq 0 ]; then pass "8c exits 0 against the production naming"; else
+  fail "8c exits $RC13"
+  printf '%s\n' "$OUT13" | sed 's/^/        /' | head -20
+fi
+if [ "$(field_5c "$OUT13" 'restored nginx confs')" = "2" ]; then
+  pass "8c restored both resolved confs"
+else
+  fail "8c restored $(field_5c "$OUT13" 'restored nginx confs') conf(s), expected 2"
+fi
+if grep -q 'backend-backup' "$RBN/available/paramant.conf"; then
+  pass "the backup really landed in the file the slot resolved to"
+else
+  fail "paramant.conf on disk is not the restored backup"
+fi
+if printf '%s\n' "$OUT13" | grep -q 'before nginx paramant.conf bytes'; then
+  pass "8c reports the restore under the resolved name"
+else
+  fail "8c never named paramant.conf in its evidence"
+fi
+
+# A slot with no candidate must stop 8c too, before it writes anything.
+OUT14="$(PATH="$RBN/bin:$PATH" bash "$RBN/8c.sh" "$RBTS" "$RBN/bk" "$RBN/root/app" "$RBN/ngbk" \
+         "$RBN/sites" "paramant-public.conf paramant-live.conf|not-there.conf" "dist" 2>&1)"; RC14=$?
+if [ "$RC14" -ne 0 ] && printf '%s\n' "$OUT14" | grep -q 'FATAL 1 nginx conf slot'; then
+  pass "8c stops when a slot resolves to nothing"
+else
+  fail "8c exited $RC14 with an unresolvable slot"
+fi
+
+# No remote block may still loop over the raw candidate string.
+if grep -nE '^for name in \$(CONFS|SLOTS)' "$SCRIPT" >/dev/null; then
+  fail "a remote block still loops over the candidate string instead of the resolved names"
+  grep -nE '^for name in \$(CONFS|SLOTS)' "$SCRIPT" | sed 's/^/        /'
+else
+  pass "every remote block loops over \$RESOLVED_CONFS, never over the candidate string"
+fi
 
 echo ""
 echo "6d. The CI gate on main is one verdict per required workflow"


### PR DESCRIPTION
## Feit uit productie

Deploy-log `deploy/logs/deploy-3.1-20260903-0141.log`, fase 2b: op de server
staat `/etc/nginx/sites-enabled/paramant-public.conf` (14355 bytes), maar
`paramant-live.conf` is er niet. Het script stopte terecht met "set
PARAMANT_NGINX_CONFS if they are named differently". De cockpit kan geen
omgevingsvariabele meegeven aan een run, dus het script moet dit zelf oplossen.

`deploy/signup-fix-deploy.sh` (regels 56-73) bewerkt op diezelfde server
`/etc/nginx/sites-enabled/paramant.conf`, met daarin `real_ip_header`. Dat is de
backend-conf. **Waarschijnlijk, niet bevestigd.**

## Fix

Elke conf is nu een slot met een kandidatenlijst, gescheiden door `|`. Default:

```
paramant-public.conf paramant-live.conf|paramant.conf
```

Op de server wordt per slot de eerste kandidaat gekozen die echt in
`sites-enabled` staat, en dat wordt gelogd als `nginxconf <slot> resolved to
<naam>`. Alles daarna gebruikt de opgeloste naam, nooit de kandidaatstring: de
2b-backup, de 5c-edits (alle vier, de `/pararules` 301 van #369 inbegrepen), de
fase 6-checks, de rollback-precondities in 8a en het herstel in 8c. De backup
wordt onder de opgeloste naam weggeschreven en fase 8 lost hetzelfde op, dus een
rollback zoekt het bestand dat er is.

Geen enkele kandidaat aanwezig blijft STOP, met dezelfde hint.
`PARAMANT_NGINX_CONFS` werkt door in de nieuwe syntaxis. Een opgeloste conf
zonder de ParaID-deny FATALt nog steeds in 5c, en die melding noemt nu de
opgeloste namen.

De resolutie is een shell-functie die meereist met elk remote-blok dat een conf
aanraakt, dus de server en de dry-run-test draaien dezelfde tekst.

## Bewijs

`bash tests/deploy-3.1-dryrun.test.sh`: 239 checks groen (was 200). Nieuw in 6i:

- de resolver los: beide namen aanwezig kiest `paramant-live.conf`, alleen
  `paramant.conf` aanwezig kiest die, geen van beide geeft een ABSENT-regel die
  matcht op het patroon waar 2b op stopt, en een kapotte symlink telt niet mee
- 5c tegen een replica met `paramant.conf` in plaats van `paramant-live.conf`:
  lost op, en alle 5c-edits landen aantoonbaar in het bestand dat
  `paramant.conf` heet
- 5c tegen een replica met beide namen: kiest `paramant-live.conf` en laat
  `paramant.conf` onaangeroerd (md5 ongewijzigd)
- 5c tegen een replica zonder een van beide: STOP
- 5c zonder ParaID-deny: FATAL, met de opgeloste namen in de melding
- 8a en 8c tegen de productie-naamgeving: 8a vindt elke backup onder de
  opgeloste naam en zoekt nooit naar `paramant-live.conf.pre-3.1-*`, 8c herstelt
  in het bestand dat het slot oploste. Backup weg is 1 missing, dus de rollback
  stopt

Verder groen: `bash tests/static-sanity.sh` (PASS, alle harde checks),
`scripts/check-test-declarations.sh` (114 suites), `scripts/check-commit-style.sh`.
Shellcheck is op deze machine niet geinstalleerd; de suite slaat hem over en
`bash -n` is schoon.

## Sabotage

De resolutie de kandidaatstring letterlijk laten teruggeven
(`rc_chosen="$rc_slot"`) maakt 26 checks rood, verdeeld over 6i-1 tot en met
6i-6: 5c en 8c exiten 1, 8a mist een backup, en de "resolved to"-regels
verdwijnen uit het log. Daarna teruggezet, 239 weer groen.

## Noot

`paramant.conf` is een aanname op grond van `deploy/signup-fix-deploy.sh`, geen
bevestigde lezing van de live server. Het script leunt er niet op: het kijkt bij
elke run op de server zelf en zegt op welke naam het uitkwam. Blijkt de
backend-conf anders te heten, dan stopt 2b nog steeds met dezelfde hint en is de
kandidaat een regel bij te werken.
