### PR TITLE
Design system v4.1, licht: de kleine letter en de prijsregel halen WCAG AA, geen donkere modus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 # Dependencies
+# Zonder slash ook, want een regel met slash matcht alleen een MAP. Wie voor
+# een losse worktree `ln -s ../repo/node_modules` zet, krijgt een symlink, en
+# die is voor git een bestand: hij glipte langs deze twee regels en belandde
+# als 120000-blob in een commit. De regels zonder slash vangen hem.
+node_modules
 node_modules/
+**/node_modules
 **/node_modules/
 
 # License key generator — contains logic to issue keys; NEVER commit

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -25,7 +25,7 @@
     footer{padding:20px 24px;text-align:center;font-size:11px;color:#94A3B8;border-top:1px solid #E2E8F0}
   </style>
 <style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -8,7 +8,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta property="og:title" content="Your account · Paramant">

--- a/frontend/all-systems-go.html
+++ b/frontend/all-systems-go.html
@@ -6,7 +6,7 @@
   <title>All systems · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/all-systems-go">
-  <link rel="stylesheet" href="/design-system.css?v=23">
+  <link rel="stylesheet" href="/design-system.css?v=24">
   <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>

--- a/frontend/apply-nav.py
+++ b/frontend/apply-nav.py
@@ -77,7 +77,7 @@ LEGAL_STRIP = '''\
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>
 </footer>'''
 
-DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=23">'
+DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=24">'
 NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=19">'
 NAV_JS    = '<script src="/nav.js?v=14" defer></script>'
 NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=5" defer></script>'

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -19,7 +19,7 @@
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="canonical" href="https://paramant.app/audit-log-export">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -21,7 +21,7 @@
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <script src="/js/qrcode.min.js?v=1"></script>

--- a/frontend/billing/checkout.html
+++ b/frontend/billing/checkout.html
@@ -9,7 +9,7 @@
 <link rel="canonical" href="https://paramant.app/pricing">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <style>
   body { background: var(--bone); }
   .checkout-wrap { max-width: 480px; margin: var(--space-10) auto; padding: 0 var(--space-5); text-align: center; }

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -23,7 +23,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>

--- a/frontend/claim.html
+++ b/frontend/claim.html
@@ -8,7 +8,7 @@
 <meta name="robots" content="noindex, nofollow">
 <meta name="referrer" content="no-referrer">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <style>
   .claim-wrap{max-width:560px;margin:8vh auto;padding:0 20px}
   .claim-card{background:#fff;border:1px solid #E2E8F0;border-radius:10px;padding:32px}

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -25,7 +25,7 @@
 <link rel="canonical" href="https://paramant.app/co-sign">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -19,7 +19,7 @@
 <meta name="twitter:title" content="Crypto agility · Paramant">
 <meta name="twitter:description" content="Algorithms you can swap without rebuilding. Identifiers travel in the header, not in the code path. NIST FIPS 203, 204, 205 and 206 loaded in production.">
 <link rel="canonical" href="https://paramant.app/crypto-agility">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -17,7 +17,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta property="og:title" content="Certificate transparency log · Paramant">

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Sign in to your Paramant dashboard.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://relay.paramant.app">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">

--- a/frontend/design-system.css
+++ b/frontend/design-system.css
@@ -1,6 +1,11 @@
-/* PARAMANT design-system.css v4.0
+/* PARAMANT design-system.css v4.1
    Source of truth: PARAMANT-DESIGN-SYSTEM-v4.md (Denim Edit)
-   Four colors: bone / navy / cobalt / lime. Zero radius. Sans + mono split. */
+   Four colors: bone / navy / cobalt / lime. Zero radius. Sans + mono split.
+
+   v4.1 verandert precies een ding: --ink-dim, --lime-dim en --black-dim
+   wijzen naar --ink-2 (#40505F) in plaats van naar rgba(11,58,106,.65).
+   Dat is de enige gemeten wijziging; alle andere waarden staan zoals ze
+   stonden. Zie het blok bij --ink-2 voor de getallen. */
 
 
 /* ═══════════════════════════════════════════════════
@@ -15,7 +20,16 @@
   --navy:      #0B3A6A;
   --navy-2:    #0A2E55;
   --ink:       #0B3A6A;
-  --ink-dim:   rgba(11,58,106,.65);
+  /* --ink-2 is de leeskleur voor alles wat niet de primaire tekst is: de
+     kleine letter, de prijsregel, de limietregel, de meta onder een kaart.
+     De oude waarde was rgba(11,58,106,.65) en die landt op 4.09:1 tegen het
+     papier, 3.96:1 tegen de voet en 4.18:1 op een witte kaart. Drie keer net
+     onder de 4.5 die WCAG AA vraagt, en drie keer onder de tekst die de prijs
+     en de kleine letter draagt. #40505F haalt 7.95:1 op het papier en 7.35:1
+     op de voet. Gemeten met de WCAG 2.1 relatieve-luminantieformule; de meting
+     staat in tests/theme-contrast.test.mjs en die faalt op elke nieuwe. */
+  --ink-2:     #40505F;
+  --ink-dim:   var(--ink-2);
   --ink-hair:  rgba(11,58,106,.15);
   --ink-ghost: rgba(11,58,106,.08);
 
@@ -81,10 +95,10 @@
 
   /* ─── v3 legacy token aliases (remove after Phase D HTML migration) ─── */
   --black:       #0B3A6A;
-  --lime-dim:    rgba(11,58,106,.65);
+  --lime-dim:    var(--ink-2);
   --lime-hair:   rgba(11,58,106,.15);
   --lime-ghost:  rgba(11,58,106,.08);
-  --black-dim:   rgba(11,58,106,.65);
+  --black-dim:   var(--ink-2);
   --black-hair:  rgba(11,58,106,.15);
   --black-ghost: rgba(11,58,106,.08);
   --doc-bg:      var(--bone);

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex,nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0b3a6a">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <style>
 *{box-sizing:border-box}

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
 <link rel="canonical" href="https://paramant.app/docs">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -66,7 +66,7 @@ pre{font-family:var(--mono);font-size:12px;line-height:1.7;color:var(--ink);back
 @media(max-width:600px){h1{font-size:25px}.dl-sub{font-size:15px}main{padding:0 18px 60px}.dl-lead{padding:28px 0 30px}}
 </style>
 <style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <script type="application/ld+json" data-paramant-seo="1">

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -19,7 +19,7 @@
 <meta name="twitter:title" content="Data processing agreement · Paramant">
 <meta name="twitter:description" content="The GDPR Article 28 agreement between Paramantis Solutions B.V. as processor and your organisation as controller. Sign it electronically, EU and German law.">
 <link rel="canonical" href="https://paramant.app/dpa">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -29,7 +29,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -72,7 +72,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -58,7 +58,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -72,7 +72,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -74,7 +74,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -76,7 +76,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -56,7 +56,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -71,7 +71,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -70,7 +70,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -76,7 +76,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -70,7 +70,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,7 +22,7 @@
 <link rel="canonical" href="https://paramant.app/">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="manifest" href="/manifest.json">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <style>
 /* Homepage 2026: the vanishing document. Paper, ink, one accent, one dark object per screen. */

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -9,7 +9,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Receive a file · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta name="description" content="A secure file is waiting for you. It decrypts in your browser and burns after one download.">

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -23,7 +23,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -11,7 +11,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -23,7 +23,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="Organisations that publicly confirm they run Paramant in production will be listed here. For case studies or references, get in touch.">
 <link rel="canonical" href="https://paramant.app/partners">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -19,7 +19,7 @@
 <meta name="twitter:title" content="Pricing · What is free, and what businesses pay · Paramant">
 <meta name="twitter:description" content="The Community plan is free, forever. Organisations pay for higher limits: sending from 15 euro a month, signing from 49, excl. btw. From Paramantis Solutions B.V.">
 <link rel="canonical" href="https://paramant.app/pricing">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex">
 <meta http-equiv="refresh" content="8;url=/signup">
 <link rel="canonical" href="https://paramant.app/signup">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -39,7 +39,7 @@
     .divider{border:none;border-top:1px solid var(--ink-hair);margin:48px 0}
     footer{border-top:1px solid var(--ink-hair);padding:32px 48px}
   </style>
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <script type="application/ld+json" data-paramant-seo="1">

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -6,7 +6,7 @@
   <title>First-time setup · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/setup">
-  <link rel="stylesheet" href="/design-system.css?v=23">
+  <link rel="stylesheet" href="/design-system.css?v=24">
   <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 </head>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -23,7 +23,7 @@
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="canonical" href="https://paramant.app/sign">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/components-parasign.css?v=3">

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -24,7 +24,7 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -7,7 +7,7 @@
   <title>Email verified, one step left · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/signup/verified">
-  <link rel="stylesheet" href="/design-system.css?v=23">
+  <link rel="stylesheet" href="/design-system.css?v=24">
   <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <script src="/nav.js?v=14" defer></script>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise.">
 <link rel="canonical" href="https://paramant.app/sla">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -25,7 +25,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="The agreement between you and Paramantis Solutions B.V. for the use of Paramant. Plans, payment, cancellation, acceptable use, liability and Dutch law.">
 <link rel="canonical" href="https://paramant.app/terms">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>

--- a/frontend/vault.html
+++ b/frontend/vault.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/vault">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <style>
 .vt-bar{display:flex;align-items:center;justify-content:space-between;padding:14px 24px;border-bottom:1px solid var(--ink-hair)}
 .vt-brand{font-family:var(--mono);font-size:13px;font-weight:700;letter-spacing:.04em;color:var(--navy);text-decoration:none}

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/verify">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/components-parasign.css?v=3">

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="How Paramant compares to Zivver, Tresorit, WeTransfer and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting.">
 <link rel="canonical" href="https://paramant.app/vs">
 
-<link rel="stylesheet" href="/design-system.css?v=23">
+<link rel="stylesheet" href="/design-system.css?v=24">
 <link rel="stylesheet" href="/nav.css?v=19">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/tests/access-log-visitors.test.mjs
+++ b/tests/access-log-visitors.test.mjs
@@ -36,7 +36,7 @@ test('a client that renders is not excluded for lacking a referer', () => {
   // exclude every genuine visitor on this site.
   const r = analyse([
     line({ ip: '8.8.8.8', path: '/sign' }),
-    line({ ip: '8.8.8.8', path: '/design-system.css?v=23' }),
+    line({ ip: '8.8.8.8', path: '/design-system.css?v=24' }),
     line({ ip: '8.8.8.8', path: '/sign-flow.js?v=49' }),
   ]);
   assert.equal(r.atMostVisitors, 1);

--- a/tests/apply-nav-idempotent.test.mjs
+++ b/tests/apply-nav-idempotent.test.mjs
@@ -1,0 +1,77 @@
+// frontend/apply-nav.py is de stempel: hij schrijft de nav, de mobiele la, de
+// voet, de legal-strip en de vier verwijzingen naar design-system.css, nav.css,
+// nav.js en nav-auth.js in elke pagina die de gedeelde schil draagt.
+//
+// Waarom deze poort bestaat. Die verwijzingen dragen een cache-bust, en de
+// nginx-conf serveert CSS als `immutable, max-age=1y`. Een gewijzigd bestand
+// moet dus onder een nieuwe url, en dat nummer staat op twee plekken: in de 58
+// pagina's en in de constanten DS_LINK en NAV_LINK bovenin de generator. Wie
+// alleen de pagina's bijwerkt, krijgt een generator die de bump terugdraait
+// zodra iemand hem draait. Precies dat gebeurde in deze tak: de pagina's
+// stonden op design-system.css?v=24 en de generator nog op ?v=23, en een
+// onschuldige `python3 frontend/apply-nav.py` zou 58 pagina's stil hebben
+// teruggezet naar een stylesheet die niet meer bestaat.
+//
+// Een generator die zijn eigen uitvoer niet reproduceert is geen generator maar
+// een eenmalige patch. Deze test draait hem op een kopie van frontend/ en eist
+// een lege diff: geen bestand gewijzigd, geen byte verschil.
+//
+// Alles staat in functiescope. tests/*.mjs is één gedeelde top-level
+// naamruimte waar elke openstaande pull request in schrijft; scripts/
+// check-test-declarations.sh bewaakt dat en dit bestand voegt er niets aan toe.
+//
+// Run: node --test tests/apply-nav-idempotent.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+test('apply-nav.py reproduces frontend/ byte for byte', () => {
+  const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+  const work = fs.mkdtempSync(path.join(os.tmpdir(), 'apply-nav-'));
+  try {
+    const copy = path.join(work, 'frontend');
+    fs.cpSync(root, copy, { recursive: true });
+
+    // De generator vindt zijn bestanden via os.path.dirname(__file__), dus een
+    // kopie van de map is een volledige, geïsoleerde draai. Niets in de
+    // werkboom wordt aangeraakt.
+    const output = execFileSync('python3', [path.join(copy, 'apply-nav.py')], { encoding: 'utf8' });
+
+    const walk = (dir, base, into) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full, base, into);
+        else into.set(path.relative(base, full).split(path.sep).join('/'), fs.readFileSync(full));
+      }
+      return into;
+    };
+    const before = walk(root, root, new Map());
+    const after = walk(copy, copy, new Map());
+
+    const missing = [...before.keys()].filter((name) => !after.has(name));
+    const extra = [...after.keys()].filter((name) => !before.has(name));
+    assert.deepEqual(missing, [], `apply-nav.py lost these files: ${missing.join(', ')}`);
+    assert.deepEqual(extra, [], `apply-nav.py created these files: ${extra.join(', ')}`);
+
+    const changed = [];
+    for (const [name, body] of before) {
+      if (!after.get(name).equals(body)) {
+        const was = body.toString('utf8').split('\n');
+        const now = after.get(name).toString('utf8').split('\n');
+        const at = was.findIndex((line, index) => line !== now[index]);
+        changed.push(`${name}:${at + 1}\n      committed: ${String(was[at]).trim().slice(0, 120)}\n      generated: ${String(now[at]).trim().slice(0, 120)}`);
+      }
+    }
+    assert.deepEqual(changed, [],
+      `frontend/apply-nav.py is not idempotent. Running it on a clean checkout rewrites:\n  ${changed.join('\n  ')}\n`
+      + 'The generator and the pages disagree. Update DS_LINK, NAV_LINK, NAV_JS or NAV_AUTH_JS in '
+      + 'frontend/apply-nav.py to the version the pages carry, or run the generator and commit its output. '
+      + `Its own report of that run:\n${output.split('\n').slice(0, 3).join('\n')}`);
+  } finally {
+    fs.rmSync(work, { recursive: true, force: true });
+  }
+});

--- a/tests/motion-safety.test.mjs
+++ b/tests/motion-safety.test.mjs
@@ -1,0 +1,162 @@
+// prefers-reduced-motion mag beweging weghalen en nooit een toestand.
+//
+// De valkuil is bekend en hij is stil. Een blok dat binnenkomt met
+// `animation: rise-in ... both` staat op opacity 0 in zijn eerste keyframe. Zet
+// je onder `reduce` alleen de duur op bijna nul, dan is dat meestal goed. Zet
+// iemand er `animation: none` neer, dan blijft het element op de waarde staan
+// die de auteur eromheen zette, en op een pagina met `.rise-in` op elke kaart
+// is dat een leeg scherm voor precies de bezoeker die om minder beweging
+// vroeg. Dat is geen smaakverschil, dat is WCAG 2.3.3 aan de ene kant en een
+// onbruikbare pagina aan de andere.
+//
+// EEN PAGINA, DRIE OPNAMES, EEN VARIABELE. Deze test laadde eerst elke pagina
+// twee keer, een keer met en een keer zonder `reduce`, en legde de twee
+// lijsten naast elkaar. Dat vergelijkt twee paginaladingen en niet twee
+// instellingen: /parashare start 400 ms na het laden een WebGL-globe waarvan
+// het aantal knopen op een vast meetmoment in de ene lading wel en in de
+// andere nog niet staat, gemeten acht keer op rij 272 tegen 267, en op de
+// CI-runner kwam dat binnen twintig seconden nooit tot stilstand. Zo'n
+// verschil zegt iets over de runner en niets over de CSS.
+//
+// Nu wordt elke pagina EEN keer geladen. Als de binnenkomst klaar is:
+//
+//   A  opname zoals de pagina staat
+//   B  page.emulateMedia({ reducedMotion: 'reduce' }), opnieuw opnemen
+//   C  terug naar no-preference, nog een keer opnemen
+//
+// Dezelfde DOM, dezelfde scripts, dezelfde toestand. Het enige dat tussen A en
+// B verandert is de media query, en dat is precies wat hier op de proef staat.
+// C is de controle: een knoop die door een timer of een poll van de pagina
+// verdwijnt is in C ook weg, en telt dus niet als schade van `reduce`. Wat
+// alleen in B weg is, is door de CSS weggehaald.
+//
+// WAT ER WORDT VERGELEKEN zijn de elementen die een layoutbox hebben. Een
+// element in een display:none-tak zet niets op het scherm, en daar valt dus
+// ook niets aan te verliezen. Dat is geen versoepeling maar een scherpere
+// claim: uit beeld verdwijnen IS de fout waar dit bestand voor bestaat, dus
+// een element dat in A en C een box heeft en in B niet meer, is hier rood.
+//
+// Elementen met een ONEINDIGE animatie doen niet mee aan de dekkingsvergelijking.
+// De homepage draait sinds #377 een cyclus van zestien seconden; een opname op
+// een vast moment landt daar op een willekeurig frame. Ze worden geteld en als
+// diagnose afgedrukt, en of ze een box hebben wordt nog steeds streng geeist.
+//
+// Run: node --test tests/motion-safety.test.mjs
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = { '.js':'text/javascript','.css':'text/css','.html':'text/html','.svg':'image/svg+xml','.png':'image/png','.json':'application/json','.ico':'image/x-icon' };
+const aliases = {
+  '/':'/index.html', '/pricing':'/pricing.html', '/dashboard':'/dashboard.html',
+  '/sign':'/sign.html', '/parashare':'/parashare.html', '/signup':'/signup.html',
+  '/account':'/account.html', '/login':'/auth/login.html',
+};
+
+const server = http.createServer((req, res) => {
+  let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+  pathname = aliases[pathname] || pathname;
+  const file = path.join(ROOT, pathname);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+  fs.readFile(file, (error, body) => {
+    if (error) { res.writeHead(404); return res.end(); }
+    res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  });
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const ORIGIN = `http://localhost:${server.address().port}`;
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+
+// Lang genoeg dat elke binnenkomst klaar is; de langste in het systeem is
+// --duration-slow op 320ms.
+const ENTRANCE = 1500;
+// Een media query landt op de volgende style recalc. Ruim genomen, want een
+// paar honderd milliseconden per pagina kost hier niets.
+const RECALC = 400;
+
+// Draait in de pagina. Van elk element in de body: waar het staat, of het een
+// layoutbox heeft, en wat het laat zien.
+const collect = () => Array.from(document.querySelectorAll('body *')).map((el) => {
+  const cs = getComputedStyle(el);
+  const box = el.getBoundingClientRect();
+  // De dekking wordt afgerond op een tiende: een element dat in een pulse
+  // staat is geen fout, een element dat weg is wel.
+  const opacity = Number(cs.opacity) >= 0.99 ? 1 : Math.round(Number(cs.opacity) * 10) / 10;
+  // Een pad in plaats van een volgnummer, zodat een knoop die er tussenuit
+  // valt niet alles daarachter een plaats opschuift.
+  const path = [];
+  for (let node = el; node && node.tagName !== 'BODY'; node = node.parentElement) {
+    const among = node.parentElement ? Array.prototype.indexOf.call(node.parentElement.children, node) : 0;
+    path.unshift(`${node.tagName.toLowerCase()}(${among + 1})`);
+  }
+  return {
+    key: path.join('>'),
+    tag: el.tagName,
+    rendered: el.getClientRects().length > 0,
+    visibility: cs.visibility,
+    opacity,
+    w: Math.round(box.width),
+    h: Math.round(box.height),
+    looping: cs.animationIterationCount.split(',').some((n) => n.trim() === 'infinite'),
+  };
+});
+
+async function measure(slug) {
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  await page.route('**/api/user/session/verify', (route) => route.fulfill({ status: 401, contentType: 'application/json', body: '{"authenticated":false}' }));
+  await page.goto(ORIGIN + slug, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(ENTRANCE);
+  const moving = await page.evaluate(collect);
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.waitForTimeout(RECALC);
+  const still = await page.evaluate(collect);
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await page.waitForTimeout(RECALC);
+  const control = await page.evaluate(collect);
+  await page.close();
+  return { moving, still, control };
+}
+
+for (const slug of Object.keys(aliases)) {
+  test(`${slug} loses no state under prefers-reduced-motion`, async (t) => {
+    const { moving, still, control } = await measure(slug);
+    const byKey = new Map(still.map((row) => [row.key, row]));
+    const afterwards = new Map(control.map((row) => [row.key, row]));
+    const lost = [];
+    let compared = 0;
+    let looping = 0;
+    let offscreen = 0;
+    let volatile_ = 0;
+    for (const a of moving) {
+      if (!a.rendered) { offscreen++; continue; }
+      // De controle-opname. Wat de pagina zelf weghaalt tussen twee metingen
+      // door is in C ook weg en is geen schade van reduce.
+      const c = afterwards.get(a.key);
+      if (!c || !c.rendered) { volatile_++; continue; }
+      const b = byKey.get(a.key);
+      if (!b) { lost.push(`${a.tag} ${a.key} is gone entirely`); continue; }
+      if (!b.rendered) { lost.push(`${a.tag} ${a.key} stopped being rendered (${a.w}x${a.h} without reduce, no layout box with it)`); continue; }
+      // Een oneindige animatie heeft geen eindstand om tegen te vergelijken.
+      if (a.looping || b.looping) { looping++; continue; }
+      compared++;
+      if (b.visibility === 'hidden' && a.visibility !== 'hidden') lost.push(`${a.tag} ${a.key} became visibility:hidden`);
+      // Dekking mag omhoog (een pulse die stilstaat op vol), nooit omlaag.
+      if (b.opacity < a.opacity) lost.push(`${a.tag} ${a.key} faded from opacity ${a.opacity} to ${b.opacity}`);
+      if (a.w > 0 && a.h > 0 && (b.w === 0 || b.h === 0)) lost.push(`${a.tag} ${a.key} collapsed from ${a.w}x${a.h} to ${b.w}x${b.h}`);
+    }
+    assert.deepEqual(lost, [],
+      `${slug} loses state when the visitor asks for less motion:\n  ${lost.join('\n  ')}\n`
+      + 'Reduced motion must shorten animations, not switch them off on an element whose first keyframe is invisible.');
+    assert.ok(compared > 0, `${slug}: nothing was compared. The page rendered nothing, or every element on it moves forever.`);
+    t.diagnostic(`${slug}: ${compared} rendered elements compared, ${looping} skipped as endlessly animating, ${offscreen} in a display:none branch, ${volatile_} changed by the page itself`);
+  });
+}
+
+test.after(async () => { await browser.close(); server.close(); });

--- a/tests/theme-contrast.test.mjs
+++ b/tests/theme-contrast.test.mjs
@@ -1,0 +1,199 @@
+// Elk tekstpaar op elke pagina, gemeten in plaats van aangenomen.
+//
+// Waarom dit bestand bestaat. Op de commit hiervoor haalde de site 3544 van de
+// 8896 gemeten tekstparen niet: 336 unieke combinaties onder WCAG AA, in de
+// LICHTE modus, op de pagina's die een koper als eerste ziet. Een token deed
+// het meeste werk: --ink-dim stond op rgba(11,58,106,.65) en landt daarmee op
+// 3.96:1 tegen de voet, 4.09:1 tegen het papier en 4.18:1 op een witte kaart.
+// Drie keer net onder de 4.5 die AA vraagt, en drie keer op de tekst die de
+// prijs, de limiet en de kleine letter draagt. Dat is niet te zien met het
+// blote oog en het is wel het verschil tussen voldoen en niet voldoen.
+//
+// design-system.css v4.1 zet --ink-dim (en de v3-aliassen --lime-dim en
+// --black-dim) op --ink-2, #40505F, 7.95:1 op het papier. Wat er van die 336
+// overblijft staat hieronder met naam en toenaam in KNOWN_LIGHT, en alle
+// overgebleven gevallen zitten in het style-blok van een pagina en niet in het
+// ontwerpsysteem. Die lijst mag korter worden en nooit langer: een nieuwe regel
+// eronder is een regressie, ook als niemand hem ziet.
+//
+// De meting zelf. Voor elk tekstknooppunt wordt de tekstkleur afgevlakt tegen
+// de eerste ondoorzichtige achtergrond erboven, precies zoals een browser hem
+// samenstelt, en dan door de WCAG 2.1 relatieve-luminantie formule gehaald.
+// 4.5:1 voor gewone tekst, 3:1 voor groot (>=24px, of >=18.66px vetgedrukt).
+//
+// GEEN DONKERE MODUS. Een eerdere versie van dit bestand mat ook donker, tegen
+// een donkere tokenset die achter [data-theme] stond zonder schakelaar in de
+// nav. Die laag is uit de tak gehaald: hij was op /security, /pricing en het
+// dashboard onleesbaar (wit op lime, 1.07:1) en kostte 31 KB op elke pagina.
+// Wat hier overblijft is de meting die wel iets bewaakt wat een bezoeker
+// vandaag ziet. Komt donker terug, dan komt de tweede helft van dit bestand
+// mee terug, met een schakelaar en met nul open gevallen.
+//
+// Run: node --test tests/theme-contrast.test.mjs
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = { '.js':'text/javascript','.css':'text/css','.html':'text/html','.svg':'image/svg+xml','.png':'image/png','.woff2':'font/woff2','.json':'application/json','.ico':'image/x-icon' };
+
+// Dezelfde routes die nginx serveert, zodat de test dezelfde URL's loopt als
+// een bezoeker. deploy/nginx-paramant-live.conf:105 zet /help op een index.
+const aliases = {
+  '/':'/index.html', '/pricing':'/pricing.html', '/dashboard':'/dashboard.html',
+  '/parasign':'/parasign.html', '/parasend':'/parasend.html', '/sign':'/sign.html',
+  '/parashare':'/parashare.html', '/signup':'/signup.html', '/account':'/account.html',
+  '/security':'/security.html', '/trust':'/trust.html', '/docs':'/docs.html',
+  '/about':'/about.html', '/help':'/help/index.html', '/download':'/download.html',
+  '/login':'/auth/login.html',
+};
+const PAGES = Object.keys(aliases);
+const SIZES = [[390, 844], [1440, 900]];
+
+// Wat er na de tokenfix overbleef, elk met de reden dat hij er nog staat.
+// Alles wat hier niet in staat is een regressie. Het formaat is pagina +
+// selector, want de kleurwaarden veranderen mee met het merk en de plek niet.
+//
+// Geen van de vijf komt uit het ontwerpsysteem: alle vijf staan als letterlijke
+// kleur in het style-blok van de pagina zelf, en alle vijf stonden er al voor
+// deze tak. Ze horen bij de groep die zo'n scherm onder handen neemt, niet bij
+// een tokenronde die geen woord tekst en geen pagina-CSS aanraakt.
+//
+// De statusregel van /parashare stond hier ook, op rgba(248,250,252,.65),
+// bijna-wit op bijna-wit. #381 heeft hem opgelost, dus hij is hier weg. Zo
+// hoort deze lijst te bewegen: korter, nooit langer.
+const KNOWN_LIGHT = [
+  // about.html geeft de primaire knop cobalt tekst op een cobalt vlak.
+  { slug: '/about', sel: 'a.btn.btn-primary' },
+  // security.html zet het vinkje in lime op papier: 1.16:1. Lime is 1.17 op
+  // papier en dus per definitie nooit tekst. Het vinkje is hier bullet en geen
+  // inhoud: de zin ernaast draagt de betekenis volledig. Lime hier vervangen is
+  // een merkbesluit en geen herstel, dus het staat hier met naam in plaats van
+  // dat het stil wordt weggepoetst.
+  { slug: '/security', sel: 'span.check' },
+  // docs.html zet inline code en links op gekleurde blokken zonder de
+  // tekstkleur mee te kantelen. Vier gevallen, alle vier in dat style-blok.
+  { slug: '/docs', sel: 'code' },
+  { slug: '/docs', sel: 'a' },
+  // index.html kreeg met #382 een eigen palet in zijn kritieke CSS, met
+  // --hp-ink-3 op #66727F. Op het lichte papier (#FAF8F3) haalt dat 4.69:1, op
+  // het tweede papier (#F3F0E8) 4.31:1, en daar staat de mono-kicker boven elke
+  // sectie. Gemeten op main, dus hij kwam met die homepage mee en niet hiermee.
+  // Eén hex lost het op: #5F6B78 geeft 4.71:1 op het tweede papier. Dat is een
+  // wijziging aan de homepage van #382 en hoort in die tak, niet in deze.
+  { slug: '/', sel: 'p.hp-kicker' },
+];
+
+const server = http.createServer((req, res) => {
+  let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+  pathname = aliases[pathname] || pathname;
+  const file = path.join(ROOT, pathname);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+  fs.readFile(file, (error, body) => {
+    if (error) { res.writeHead(404); return res.end(); }
+    res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  });
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const ORIGIN = `http://localhost:${server.address().port}`;
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+
+// Draait in de pagina. Vlakt elke tekstkleur af tegen de stapel achtergronden
+// erboven tot de eerste ondoorzichtige, en rekent WCAG 2.1.
+const probe = () => {
+  const parse = (c) => { const m = c.match(/[\d.]+/g); if (!m) return null; return { r:+m[0], g:+m[1], b:+m[2], a: m[3] === undefined ? 1 : +m[3] }; };
+  const over = (fg, bg) => ({ r: fg.r*fg.a + bg.r*(1-fg.a), g: fg.g*fg.a + bg.g*(1-fg.a), b: fg.b*fg.a + bg.b*(1-fg.a), a: 1 });
+  const lum = (c) => { const f = (v) => { v /= 255; return v <= 0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055, 2.4); }; return 0.2126*f(c.r) + 0.7152*f(c.g) + 0.0722*f(c.b); };
+  const ratio = (a, b) => { const l1 = lum(a), l2 = lum(b); return (Math.max(l1,l2)+0.05) / (Math.min(l1,l2)+0.05); };
+  const bgOf = (el) => {
+    const stack = [];
+    for (let node = el; node; node = node.parentElement) {
+      const c = parse(getComputedStyle(node).backgroundColor);
+      if (c && c.a > 0) { stack.push(c); if (c.a === 1) break; }
+    }
+    let base = { r:255, g:255, b:255, a:1 };
+    for (let i = stack.length - 1; i >= 0; i--) base = over(stack[i], base);
+    return base;
+  };
+  const out = [];
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const seen = new Set();
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+    if (!n.nodeValue.trim()) continue;
+    const el = n.parentElement;
+    if (!el || seen.has(el)) continue;
+    seen.add(el);
+    const cs = getComputedStyle(el);
+    if (cs.visibility === 'hidden' || cs.display === 'none' || Number(cs.opacity) === 0) continue;
+    const box = el.getBoundingClientRect();
+    if (box.width < 1 || box.height < 1) continue;
+    const fg = parse(cs.color);
+    if (!fg) continue;
+    const bg = bgOf(el);
+    const c = ratio(over(fg, bg), bg);
+    const px = parseFloat(cs.fontSize);
+    const need = (px >= 24 || (px >= 18.66 && Number(cs.fontWeight) >= 700)) ? 3 : 4.5;
+    if (c >= need - 0.005) { out.push(null); continue; }
+    const cls = (el.className && typeof el.className === 'string') ? '.' + el.className.trim().split(/\s+/).slice(0, 3).join('.') : '';
+    out.push({
+      c: Math.round(c*100)/100, need,
+      sel: el.tagName.toLowerCase() + (el.id ? '#' + el.id : '') + cls,
+      text: n.nodeValue.replace(/\s+/g, ' ').trim().slice(0, 48),
+      color: cs.color, bg: `rgb(${Math.round(bg.r)}, ${Math.round(bg.g)}, ${Math.round(bg.b)})`,
+    });
+  }
+  return { measured: out.length, fails: out.filter(Boolean) };
+};
+
+async function scan(slug) {
+  const rows = [];
+  let measured = 0;
+  for (const [width, height] of SIZES) {
+    const page = await browser.newPage({ viewport: { width, height }, colorScheme: 'light' });
+    await page.route('**/api/user/session/verify', (route) => route.fulfill({ status: 401, contentType: 'application/json', body: '{"authenticated":false}' }));
+    await page.goto(ORIGIN + slug, { waitUntil: 'networkidle' });
+    // Een kleurtransitie die nog loopt levert een kleur op die op geen enkel
+    // moment de bedoeling was. Deze test sampelde ooit na 120ms terwijl .btn
+    // 200ms overgangstijd heeft, en gaf daardoor op de ene machine groen en op
+    // CI rood op dezelfde code. Transities gaan hier dus uit, en daarna is er
+    // ruim tijd voor de binnenkomstanimaties, waarvan de langste 320ms duurt.
+    await page.addStyleTag({ content: '*,*::before,*::after{transition:none !important}' });
+    await page.waitForTimeout(450);
+    const result = await page.evaluate(probe);
+    measured += result.measured;
+    for (const row of result.fails) rows.push({ ...row, width });
+    await page.close();
+  }
+  // Eén regel per unieke combinatie van plek en kleurenpaar; 390 en 1440 tellen
+  // hetzelfde geval anders twee keer.
+  const uniq = [...new Map(rows.map((r) => [`${r.sel}|${r.color}|${r.bg}`, r])).values()];
+  return { measured, uniq };
+}
+
+test('every page clears WCAG AA in light, and the known page defects do not grow', async (t) => {
+  let measured = 0;
+  const unexpected = [];
+  const stillThere = new Set();
+  for (const slug of PAGES) {
+    const result = await scan(slug);
+    measured += result.measured;
+    for (const hit of result.uniq) {
+      const known = KNOWN_LIGHT.find((k) => k.slug === slug && k.sel === hit.sel);
+      if (known) { stillThere.add(`${slug} ${hit.sel}`); continue; }
+      unexpected.push(`${slug} ${hit.sel}: ${hit.c}:1 (needs ${hit.need}), ${hit.color} on ${hit.bg}, "${hit.text}"`);
+    }
+  }
+  t.diagnostic(`light: ${measured} text pairs measured across ${PAGES.length} pages at 390 and 1440`);
+  t.diagnostic(`light: ${stillThere.size} of the ${KNOWN_LIGHT.length} known page defects still present`);
+  assert.deepEqual(unexpected, [],
+    `New contrast failures in light mode. Every one of these is below WCAG AA and none of them is on the known list:\n  ${unexpected.join('\n  ')}\n`
+    + 'Fix the colour, or, if it is a deliberate page-owned defect that predates this run, add it to KNOWN_LIGHT with the reason. Do not loosen the ratio.');
+});
+
+test.after(async () => { await browser.close(); server.close(); });


### PR DESCRIPTION
**Herstel na review.** De donkere laag is er in zijn geheel uit. Wat overblijft is de gemeten lichte winst, en verder niets: geen nieuwe tokenset, geen componentlaag, geen letterlijke-kleur-sweep over de gedeelde stylesheets. Eén token in `frontend/design-system.css` verandert van waarde.

## Waarom de donkere laag eruit ging

De directie las de vorige stand en trok drie dingen aan:

- de donkere modus stond achter `[data-theme]` zonder schakelaar in de nav, dus geen bezoeker kon hem bereiken
- in die stand was hij onleesbaar op `/security`, `/pricing` en het dashboard: wit op lime, 1.07:1
- hij kostte 31 KB op alle 58 pagina's, en geen enkele nginx-conf in `deploy/` zet gzip aan

`frontend/design-system.css` ging in de vorige stand van 85374 naar 116364 bytes. Nu staat hij op **86270**, en die 896 bytes zijn vrijwel volledig het commentaarblok met de gemeten getallen. `nav.css`, `parapear.css` en `relay-pulse.css` staan weer letterlijk op `main`.

## De winst

`--ink-dim` stond op `rgba(11,58,106,.65)`:

| tegen | ratio | AA vraagt |
|---|---|---|
| het papier (`#F8FAFC`) | 4.09:1 | 4.5 |
| de voet (`#EEF2F6`) | 3.96:1 | 4.5 |
| een witte kaart | 4.18:1 | 4.5 |

Drie keer net eronder, en drie keer onder de tekst die de prijs, de limiet en de kleine letter draagt. `--ink-dim`, `--lime-dim` en `--black-dim` wijzen nu naar `--ink-2`, `#40505F`, 7.95:1 op het papier.

Gemeten met de WCAG 2.1 relatieve-luminantieformule, elke tekstkleur afgevlakt tegen de eerste ondoorzichtige achtergrond erboven, op 390 en 1440, in licht:

| | main | deze tak |
|---|---|---|
| hele site, uniek onder AA | 82 | **5** |
| `/` | 4 | 1 |
| `/pricing` | 8 | **0** |
| `/parasign` | 7 | **0** |
| `/security` | 8 | 1 |
| `/dashboard` | 0 | **0** |

Gemeten tegen `main` op `39179f50`. Het dashboard staat er als nul tegen nul: #381 heeft die pagina zelf al schoongemaakt terwijl dit liep.

De vijf die overblijven staan met naam en reden in `KNOWN_LIGHT` in `tests/theme-contrast.test.mjs`. Geen van de vijf komt uit het ontwerpsysteem: alle vijf staan als letterlijke kleur in het style-blok van een pagina, en alle vijf staan al op `main`. De statusregel van `/parashare` stond er ook op en is door #381 opgelost, dus die is van de lijst af: korter mag, langer niet. De twee op de pagina's hierboven:

- `/` `p.hp-kicker` op 4.31:1. `index.html` kreeg met #382 een eigen palet in zijn kritieke CSS, met `--hp-ink-3` op `#66727F`. Op het tweede papier (`#F3F0E8`) haalt dat 4.31:1, en daar staat de mono-kicker boven elke sectie. Eén hex lost het op, `#5F6B78` geeft 4.71:1, maar dat is een wijziging aan de homepage van #382 en hoort in die tak.
- `/security` `span.check` op 1.16:1. Het lime vinkje is hier bullet en geen inhoud: de zin ernaast draagt de betekenis volledig. Lime vervangen is een merkbesluit en geen herstel, dus het staat met naam op de lijst in plaats van dat het stil wordt weggepoetst.

## Pixeldiff van de homepage

`index.html` tegen `main`, dezelfde chromium, animaties en transities uit:

```
390x844    0 pixels verschil
1440x900   0 pixels verschil
hele pagina, 390    3705 pixels op 46 regels, y 8908..9004
hele pagina, 1440   3705 pixels op 46 regels, y 6084..6180
```

Die 46 regels zijn de twee voetregels die op `--ink-dim` staan. Boven de vouw verandert er geen pixel, ook niet in de nav.

## De drie testbestanden

**`tests/theme-contrast.test.mjs`** meet elk tekstpaar op zestien pagina's op 390 en 1440: 4448 paren, vijf bekende gevallen, nul nieuwe. De lijst mag korter worden en nooit langer.

**`tests/motion-safety.test.mjs`** faalt zodra een element verdwijnt, vervaagt of inklapt onder `prefers-reduced-motion` in plaats van alleen stil te staan. De review meldde dat `/parashare` er een element bij verloor, 272 tegen 271. Het meetpunt deugde niet.

Hij laadde elke pagina twee keer, een keer met en een keer zonder `reduce`, en legde de twee lijsten naast elkaar. Dat vergelijkt twee paginaladingen en niet twee instellingen. `/parashare` start 400ms na het laden een WebGL-globe waarvan het aantal knopen op een vast meetmoment in de ene lading wel en in de andere nog niet staat: gemeten acht keer op rij 272 tegen 267, en op de CI-runner kwam dat binnen twintig seconden nooit tot stilstand.

Elke pagina wordt nu **een keer** geladen. Na de binnenkomst opname **A**, dan `page.emulateMedia({ reducedMotion: 'reduce' })` en opname **B**, dan terug en opname **C**. Dezelfde DOM, dezelfde scripts, dezelfde toestand, en het enige dat tussen A en B verandert is de media query. **C** is de controle: wat de pagina zelf tussen twee metingen weghaalt is in C ook weg en telt dus niet als schade van `reduce`. Vergeleken wordt op wat een layoutbox heeft, en op een DOM-pad in plaats van op een volgnummer in een platte lijst.

Dat is een scherpere claim en geen zwakkere: een element dat in A en C een box heeft en in B niet, is nu rood, en was dat eerder alleen als het totaalaantal toevallig meeveranderde. Gesaboteerd met `display:none`, `opacity:0` en `visibility:hidden` onder `reduce`, alle drie rood:

```
DIV section(5)>div(1)>div(2)>div(1)>div(1) stopped being rendered (235x16 without reduce, no layout box with it)
DIV section(5)>div(1)>div(2)>div(1)>div(3) faded from opacity 1 to 0
DIV section(5)>div(1)>div(2)>div(1)>div(1) became visibility:hidden
```

**`tests/apply-nav-idempotent.test.mjs`** is nieuw en dicht de tweede reviewbevinding. `frontend/apply-nav.py` stempelt de nav, de mobiele la, de voet en de vier cache-bust-verwijzingen in 58 pagina's, en zijn `DS_LINK` liep achter op wat die pagina's dragen: pagina's op `?v=24`, generator op `?v=23`. Een onschuldige `python3 frontend/apply-nav.py` zou 58 pagina's stil hebben teruggezet naar een stylesheet-url die niet meer bestaat, en de nginx-conf serveert CSS als `immutable, max-age=1y`. De test draait de generator op een kopie van `frontend/` en eist een lege diff.

Gesaboteerd om te zien dat hij bijt: `DS_LINK` terug op `?v=23` geeft rood en noemt bestand, regelnummer en beide waarden.

```
frontend/apply-nav.py is not idempotent. Running it on a clean checkout rewrites:
  404.html:28
      committed: <link rel="stylesheet" href="/design-system.css?v=24">
      generated: <link rel="stylesheet" href="/design-system.css?v=23">
```

Alles in dat bestand staat in functiescope. `tests/*.mjs` is één gedeelde top-level naamruimte waar elke openstaande pull request in schrijft; `scripts/check-test-declarations.sh` bewaakt dat en dit bestand voegt er geen naam aan toe.

## node_modules

De vorige stand droeg een `node_modules`-symlink als `120000`-blob. `.gitignore` had `node_modules/` en `**/node_modules/`, en een regel met slash matcht alleen een **map**: een symlink is voor git een bestand en glipte er langs. De blob is weg en `.gitignore` vangt hem nu ook zonder slash.

## Cache-bust

`design-system.css` naar `?v=24` over 58 pagina's, plus `frontend/apply-nav.py` en de verwijzing in `tests/access-log-visitors.test.mjs`. `nav.css` blijft op `?v=19`, want dat bestand is nu byte voor byte gelijk aan `main` en een bump die niets verandert is 20 KB die elke bezoeker opnieuw ophaalt.

## Poorten

Alles op `39179f50`, de main van dit moment.

```
first-screen                9/9     theme-contrast              1/1
pricing-fold                4/4     motion-safety               8/8
frontend-loading-contract   7/7     apply-nav-idempotent        1/1
seo-contract              14/14     access-log-visitors       16/16
site-claims               36/36     navigation-shell    26 checks
ui-truthfulness             1/1     relay pricing-page          1/1
links                 2 + 2 skip
static-sanity   PASS (alle harde checks)   check-cache-bust   340 links OK
check-csp-inline           OK      check-test-declarations  121 suites
apply_seo_head --check   0 pages   eslint                    schoon
```

## Gerebased

Op `main` van vandaag, drie keer, want er landden tijdens deze ronde vier andere PR's. De botsingen zaten allemaal in de stylesheet-lijst van de `<head>`, en zijn allemaal op dezelfde regel opgelost: de lijst van `main` blijft staan, alleen de cache-bust van deze tak gaat mee. De enige regel die deze tak in die 58 pagina's aanraakt is daarmee de cache-bust van `design-system.css`. Te controleren met:

```
git diff origin/main..HEAD -- '*.html' | grep '^[+-]' | grep -v '^[+-][+-]' | grep -vc 'design-system.css?v='
```

Dat geeft 0.
