### PR TITLE
Deploy: phase 3a stops on a changed tracked file, not on an untracked one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,13 @@ heartbeat-evidence/
 
 # Deploy logs (deploy/deploy-3.1.sh writes one per run)
 deploy/logs/
+
+# Backups written next to the checkout. The production checkout is a working
+# directory as well as a checkout, and /opt/paramant-relay/backups turned up in
+# it during deploy run 5 (2026-09-03). No script in THIS repo writes a relative
+# backups/ (deploy/ops/backup-full-state.sh defaults to an absolute
+# /home/paramant/backups/full-state), so what created it is not established;
+# a BACKUP_ROOT or BACKUP_DIR override on the server is the likely candidate.
+# Nothing tracked has ever lived under a backups/ path, so ignoring it costs
+# nothing and keeps the server checkout clean for the next deploy.
+backups/

--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -391,13 +391,37 @@ the users file or the CT log matter to you today (they should).
 
 ```bash
 cd /opt/paramant-relay
-git status                                                   # clean, or stash and note what it was
+git status --porcelain --untracked-files=no                  # empty, or stash and note what it was
 git fetch origin && git pull --ff-only origin main
 git rev-parse --short HEAD                                   # the commit you tested locally
 
 tests/static-sanity.sh; echo "exit $?"                       # expect exit 1: checks 1 to 9 OK, only check 10 FAIL
 docker compose build                                         # relays and admin from source, containers untouched
 ```
+
+### What counts as a dirty working tree in 3a
+
+Only **tracked** changes. A modified tracked file stops the run, before the
+fetch, because a fast-forward pull would tangle it with what is coming in and
+the log would then report a merge conflict instead of the hand edit that caused
+it. Untracked paths are listed and left alone: `git pull --ff-only` cannot lose
+one.
+
+3a prints both counts, so the log says which of the two it judged:
+
+```
+before untracked paths = 1
+  untracked backups/
+before tracked changes = 0
+```
+
+Deploy run 5 (TS 20260903-0242) stopped here on `dirty ?? backups/`, an
+untracked directory in `/opt/paramant-relay` and nothing else wrong. No script
+in this repo writes a relative `backups/` (`deploy/ops/backup-full-state.sh`
+defaults to an absolute `/home/paramant/backups/full-state`), so what put it
+there is **not established**; a `BACKUP_ROOT` or `BACKUP_DIR` override on the
+server is the likely candidate. `backups/` is in the repo `.gitignore` from
+this commit on, so once the server has pulled it, 3a stops reporting it at all.
 
 Read the sanity output the way "Before you start" step 2 says: checks 1 to 9
 are the gate, check 10 (the commit style guard on the last commit) is known

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -976,9 +976,33 @@ set -euo pipefail
 cd "$1"
 echo "before HEAD = $(git rev-parse --short HEAD)"
 echo "before HEAD long = $(git rev-parse HEAD)"
-if [ -n "$(git status --porcelain)" ]; then
-  git status --porcelain | sed 's/^/  dirty /'
-  echo "FATAL working tree not clean; stash and note what it was before deploying"
+# Only TRACKED changes are dirt. An untracked path is not.
+#
+# Deploy run 5 (TS 20260903-0242) got through phases 0, 1 and 2 and stopped
+# here on "dirty ?? backups/" with nothing else wrong: an untracked directory
+# in the server checkout, which no script in this repo writes, so what put it
+# there is not established. It does not matter. `git pull --ff-only` cannot
+# lose an untracked file, and it CAN lose a modified tracked one, so the
+# tracked half is what the gate is for. The untracked half is reported and
+# left alone, because a server checkout is a working directory too, and a
+# deploy that refuses to run over a stray file it will not touch is a deploy
+# that needs a person for no reason.
+tracked="$(git status --porcelain --untracked-files=no)"
+untracked="$(git ls-files --others --directory --exclude-standard)"
+
+n_unt=0
+[ -n "$untracked" ] && n_unt="$(printf '%s\n' "$untracked" | grep -c . || true)"
+echo "before untracked paths = $n_unt"
+if [ -n "$untracked" ]; then
+  printf '%s\n' "$untracked" | sed 's/^/  untracked /'
+fi
+
+n_trk=0
+[ -n "$tracked" ] && n_trk="$(printf '%s\n' "$tracked" | grep -c . || true)"
+echo "before tracked changes = $n_trk"
+if [ -n "$tracked" ]; then
+  printf '%s\n' "$tracked" | sed 's/^/  dirty /'
+  echo "FATAL working tree not clean: $n_trk tracked file(s) changed; stash and note what it was before deploying"
   exit 1
 fi
 git fetch origin 2>&1 | sed 's/^/  fetch /' || true
@@ -988,6 +1012,14 @@ echo "after HEAD long = $(git rev-parse HEAD)"
 EOF
 
   expect_not 'FATAL working tree not clean' "server working tree was clean before the pull"
+  expect_count "before tracked changes" 0 "no tracked file in the server checkout was modified before the pull"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    local n_unt
+    n_unt="$(remote_field 'before untracked paths')"
+    if [ -n "$n_unt" ] && [ "$n_unt" != 0 ]; then
+      note "$n_unt untracked path(s) in the server checkout, listed above and left alone: a fast-forward pull cannot lose them"
+    fi
+  fi
   if [ "$DRY_RUN" -eq 0 ]; then
     local after_head before_head want
     before_head="$(remote_field 'before HEAD long')"

--- a/tests/deploy-3.1-dryrun.test.sh
+++ b/tests/deploy-3.1-dryrun.test.sh
@@ -1277,6 +1277,186 @@ else
 fi
 
 echo ""
+echo "6j. Phase 3a: an untracked path is not a dirty working tree"
+# Deploy run 5 (TS 20260903-0242) reached phase 3a for the first time and
+# stopped on
+#
+#   dirty ?? backups/
+#   FATAL working tree not clean
+#
+# An untracked directory in the server checkout, and nothing else wrong. A
+# fast-forward pull cannot lose an untracked file, so that was a stop for
+# nothing. A modified TRACKED file is a different matter and still stops the
+# run. This runs the real 3a remote block against two throwaway repositories,
+# one per case.
+G3A="$WORK/g3a"
+mkdir -p "$G3A"
+extract_remote "git pull" > "$G3A/3a.sh"
+if [ -s "$G3A/3a.sh" ]; then
+  pass "the 3a remote block could be extracted from the script"
+else
+  fail "could not extract the 3a remote block from the script"
+fi
+
+# make_3a_repo <dir>: a checkout one commit behind its origin, so 3a has a real
+# fast-forward to perform and "did it pull" is a question with an answer.
+make_3a_repo() {
+  local d="$1"
+  rm -rf "$d"
+  mkdir -p "$d"
+  (
+    set -e
+    cd "$d"
+    git init -q --bare origin.git
+    # git init --bare picks its own default branch name, and if that is not the
+    # one we push the clone comes out empty with only a warning. Say it.
+    git --git-dir=origin.git symbolic-ref HEAD refs/heads/main
+    git init -q seed && cd seed
+    git config user.email t@example.com && git config user.name t
+    git config commit.gpgsign false
+    echo one > tracked.txt
+    git add -A && git commit -qm one
+    git branch -M main
+    git remote add origin ../origin.git
+    git push -q origin main
+    cd ..
+    git clone -q origin.git checkout
+    cd checkout
+    git config user.email t@example.com && git config user.name t
+    git config commit.gpgsign false
+    cd ../seed
+    echo two > tracked.txt
+    git commit -qam two
+    git push -q origin main
+  ) >/dev/null 2>&1
+}
+
+# A silently broken fixture would make both cases below pass for the wrong
+# reason, so the fixture is checked before it is used.
+fixture_3a_ok() {   # dir
+  git -C "$1/checkout" rev-parse HEAD >/dev/null 2>&1 \
+    && [ -f "$1/checkout/tracked.txt" ] \
+    && [ -z "$(git -C "$1/checkout" status --porcelain)" ]
+}
+
+echo ""
+echo "6j-1. Only an untracked path: the deploy pulls and says what it left alone"
+make_3a_repo "$G3A/ok"
+if fixture_3a_ok "$G3A/ok"; then
+  pass "the fixture is a clean checkout one commit behind its origin"
+else
+  fail "the 3a fixture is broken, so the two cases below prove nothing"
+fi
+mkdir -p "$G3A/ok/checkout/backups"
+echo state > "$G3A/ok/checkout/backups/full-state.tar.gz.age"
+HEAD_BEFORE="$(git -C "$G3A/ok/checkout" rev-parse HEAD)"
+OUT18="$(bash "$G3A/3a.sh" "$G3A/ok/checkout" 2>&1)"; RC18=$?
+if [ "$RC18" -eq 0 ]; then pass "3a runs through with an untracked backups/ in the checkout"; else
+  fail "3a exits $RC18 on an untracked path (this is the run-5 stop)"
+  printf '%s\n' "$OUT18" | sed 's/^/        /' | head -20
+fi
+if printf '%s\n' "$OUT18" | grep -q '^  untracked backups/'; then
+  pass "it prints the untracked path instead of hiding it"
+else
+  fail "the untracked path was not reported"
+  printf '%s\n' "$OUT18" | sed 's/^/        /' | head -12
+fi
+for want in "before untracked paths:1" "before tracked changes:0"; do
+  f="${want%%:*}"; v="${want##*:}"
+  if [ "$(field_5c "$OUT18" "$f")" = "$v" ]; then pass "3a reports $f = $v"; else
+    fail "3a reports $f = '$(field_5c "$OUT18" "$f")', expected $v"; fi
+done
+if printf '%s\n' "$OUT18" | grep -q 'FATAL'; then
+  fail "3a still prints a FATAL for an untracked path"
+  printf '%s\n' "$OUT18" | grep FATAL | sed 's/^/        /'
+else
+  pass "no FATAL: an untracked path is not dirt"
+fi
+if [ "$(git -C "$G3A/ok/checkout" rev-parse HEAD)" != "$HEAD_BEFORE" ]; then
+  pass "the fast-forward pull really happened"
+else
+  fail "3a exited 0 but the checkout never moved"
+fi
+if [ -f "$G3A/ok/checkout/backups/full-state.tar.gz.age" ]; then
+  pass "the untracked file is still there, untouched by the pull"
+else
+  fail "the pull removed an untracked file"
+fi
+
+echo ""
+echo "6j-2. A modified tracked file still stops the deploy, before the pull"
+make_3a_repo "$G3A/dirty"
+if fixture_3a_ok "$G3A/dirty"; then
+  pass "the second fixture is clean before the hand edit goes in"
+else
+  fail "the 3a fixture is broken, so the stop below proves nothing"
+fi
+echo "hand edit between deploys" > "$G3A/dirty/checkout/tracked.txt"
+HEAD_BEFORE="$(git -C "$G3A/dirty/checkout" rev-parse HEAD)"
+OUT19="$(bash "$G3A/3a.sh" "$G3A/dirty/checkout" 2>&1)"; RC19=$?
+if [ "$RC19" -ne 0 ]; then pass "3a stops when a tracked file is modified"; else
+  fail "3a pulled over a modified tracked file (exit $RC19)"
+  printf '%s\n' "$OUT19" | sed 's/^/        /' | head -20
+fi
+if printf '%s\n' "$OUT19" | grep -q 'FATAL working tree not clean: 1 tracked file'; then
+  pass "the FATAL says how many tracked files, so the reason is not guesswork"
+else
+  fail "the FATAL does not name the tracked change"
+  printf '%s\n' "$OUT19" | grep FATAL | sed 's/^/        /'
+fi
+if printf '%s\n' "$OUT19" | grep -q '^  dirty  M tracked.txt'; then
+  pass "it lists the tracked file it stopped on"
+else
+  fail "the dirty listing is missing"
+  printf '%s\n' "$OUT19" | sed 's/^/        /' | head -12
+fi
+if [ "$(field_5c "$OUT19" 'before tracked changes')" = "1" ]; then
+  pass "the tracked-change count is reported, so the deploy can assert on it"
+else
+  fail "before tracked changes = '$(field_5c "$OUT19" 'before tracked changes')', expected 1"
+fi
+if [ "$(git -C "$G3A/dirty/checkout" rev-parse HEAD)" = "$HEAD_BEFORE" ]; then
+  pass "it stopped BEFORE the pull, so the hand edit is still there to look at"
+else
+  fail "3a pulled anyway; the local change is now tangled with the pull"
+fi
+# git would refuse this pull by itself, which is a net and not a gate: it would
+# report a merge conflict instead of "you have a hand edit here". Assert that
+# the fetch was never even attempted, so the gate is provably in FRONT of it.
+if printf '%s\n' "$OUT19" | grep -qE '^  (fetch|pull) '; then
+  fail "3a reached the fetch or pull with a modified tracked file; the gate is not in front of them"
+  printf '%s\n' "$OUT19" | grep -E '^  (fetch|pull) ' | sed 's/^/        /' | head -4
+else
+  pass "no fetch and no pull were attempted; the gate is the first thing 3a does"
+fi
+if grep -q 'hand edit between deploys' "$G3A/dirty/checkout/tracked.txt"; then
+  pass "the modified file is untouched, which is what makes the stop useful"
+else
+  fail "the tracked change was lost"
+fi
+
+echo ""
+echo "6j-3. The gate reads tracked and untracked separately, and says so"
+check_has "$SCRIPT" 'git status --porcelain --untracked-files=no' \
+  "the dirty gate asks git for tracked changes only"
+check_has "$SCRIPT" 'git ls-files --others --directory --exclude-standard' \
+  "untracked paths are read separately, to be reported rather than judged"
+check_lacks "$SCRIPT" '\$\(git status --porcelain\)' \
+  "the old all-or-nothing porcelain read is gone"
+check_has "$FULL" 'before untracked paths'  "the dry run shows the untracked count"
+check_has "$FULL" 'before tracked changes'  "the dry run shows the tracked count"
+check_has "$SCRIPT" 'expect_count "before tracked changes" 0' \
+  "the deploy asserts that no tracked file was modified"
+# backups/ is ignored in the repo, so a checkout that pulls this commit stops
+# reporting it at all.
+check_has "$ROOT/.gitignore" '^backups/$' "backups/ is gitignored, so the next pull makes it invisible"
+if git -C "$ROOT" check-ignore -q backups/ 2>/dev/null; then
+  pass "git agrees that backups/ is ignored"
+else
+  fail "backups/ is in .gitignore but git does not ignore it"
+fi
+
+echo ""
 echo "6d. The CI gate on main is one verdict per required workflow"
 # The old gate was `gh run list --branch main -L 5`: five runs of whichever
 # workflows happened to run last, with a stop on any `failure` among them. On


### PR DESCRIPTION
Hotfix na deploy-run 5.

## Feit uit productie

Run 5 (TS 20260903-0242, `deploy/logs/deploy-3.1-20260903-0242.log`) kwam voor
het eerst door fase 0, 1 en 2. Beide confs opgelost, backups gemaakt. Toen 3a:

```
  dirty ?? backups/
FATAL working tree not clean
```

Een untracked map in `/opt/paramant-relay`, verder niets mis. `git pull
--ff-only` kan een untracked bestand niet kwijtraken, dus dat was een stop voor
niets.

**Op de server is in run 5 niets veranderd behalve de tags en backups onder
0242.** Geen container hercreeerd, geen conf bewerkt, geen docroot geschreven.

## Wie maakt die map

**Niet vastgesteld.** Geen enkel script in deze repo schrijft een relatieve
`backups/`. `deploy/ops/backup-full-state.sh` gebruikt
`BACKUP_ROOT="${BACKUP_ROOT:-/home/paramant/backups/full-state}"`, absoluut.
`scripts/rollback-3.0.0.sh` en `deploy-3.1.sh` idem absoluut. Er staat ook geen
relatieve bind-mount in `docker-compose.yml`. Een `BACKUP_ROOT`- of
`BACKUP_DIR`-override op de server is de waarschijnlijke kandidaat, maar dat is
een vermoeden en ik schrijf het niet op als bevinding.

Dat maakt voor de fix niet uit: 3a hoort niet te weigeren om te pullen vanwege
een pad dat hij toch niet aanraakt, ongeacht wie het maakte.

## Fix

**(1)** 3a leest de twee helften apart. Tracked wijzigingen zijn vuil en stoppen
de run nog steeds, vóór de fetch: een pull zou een handmatige edit verstrengelen
met wat binnenkomt, en het log zou dan een merge-conflict melden in plaats van
de edit die het veroorzaakte. Untracked paden worden geteld, gelogd en met rust
gelaten. Beide tellers worden geprint, dus het log zegt welke van de twee hij
beoordeelde:

```
before untracked paths = 1
  untracked backups/
before tracked changes = 0
```

De deploy assert lokaal `before tracked changes = 0` en zet een `note` neer als
er untracked paden waren.

**(2)** `backups/` staat in `.gitignore`, met een comment dat eerlijk zegt wat
wel en niet vaststaat. Niets tracked heeft ooit onder een `backups/`-pad
gestaan, dus het kost niets. Let op: dit helpt pas nadat de server deze commit
heeft gepulld; de fix in 3a is wat run 6 doorlaat.

**(4)** `DEPLOY-3.1.md` fase 3a bijgewerkt: `git status --porcelain
--untracked-files=no` in het handmatige recept, plus een sectie die uitlegt wat
er wel en niet als vuil telt.

## Bewijs

`bash tests/deploy-3.1-dryrun.test.sh`: 284 checks groen, was 259. Het echte
3a-blok draait nu tegen twee wegwerp-repositories, elk een schone checkout die
één commit achterloopt op zijn origin. De fixture wordt zelf eerst gecontroleerd,
zodat een kapotte fixture beide gevallen niet om de verkeerde reden kan laten
slagen (dat gebeurde tijdens het bouwen: `git init --bare` koos een andere
default branch en de clone kwam leeg binnen).

- **6j-1** alleen untracked: exit 0, de fast-forward gebeurt echt (HEAD
  verschoven), het untracked bestand staat er nog, geen FATAL, en het pad staat
  gelogd als `untracked backups/`
- **6j-2** gewijzigd tracked bestand: exit 1, de FATAL noemt het aantal, de
  checkout is niet verschoven, de edit is onaangeroerd, en er is **geen fetch en
  geen pull geprobeerd**. Dat laatste is de scherpe check: git zou die pull uit
  zichzelf ook weigeren, maar dan als merge-conflict. Dit bewijst dat de poort
  ervoor staat en niet erachter
- **6j-3** statisch: de nieuwe leesvorm staat er, de oude
  `$(git status --porcelain)` is weg, en git bevestigt dat `backups/` genegeerd
  wordt

Sabotage, twee richtingen:

- terug naar `git status --porcelain` (untracked telt weer als vuil): 6 rood,
  waaronder "3a exits 1 on an untracked path (this is the run-5 stop)"
- de `exit 1` eruit (nooit stoppen): 2 rood, waaronder "3a reached the fetch or
  pull with a modified tracked file; the gate is not in front of them"

Beide teruggezet, 284 weer groen.

Verder groen: `tests/static-sanity.sh` PASS, `scripts/check-test-declarations.sh`
(116 suites), `scripts/check-commit-style.sh`, `shellcheck -S error` op beide
bestanden, geen em-dashes in toegevoegde regels.
