### PR TITLE
Deploy: a remote block may not read the script off its own stdin, and --verify-only finishes a run that died in the checks

### DIFF
--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -4,8 +4,9 @@
 > (`bash deploy/deploy-3.1.sh`) runs every step below, prints the command and
 > the measurement for each one, and stops at the first result the runbook did
 > not predict. `--preflight-only` does the checks and nothing else,
-> `--dry-run` prints every remote command instead of running it, and
-> `--rollback <TS>` is step 8. This file stays the readable source: the script
+> `--dry-run` prints every remote command instead of running it,
+> `--rollback <TS>` is step 8, and `--verify-only` is steps 6 and 7 on a server
+> that is already deployed. This file stays the readable source: the script
 > follows it, it does not replace it, and a step that is argued out here is
 > argued out here only.
 
@@ -575,6 +576,34 @@ edit made between deploys cannot hide behind "already applied".
 
 In the order `deploy.sh` runs them, plus the two the 3.0.0 runbook used.
 
+### Finishing a deploy that died in the checks: `--verify-only`
+
+Steps 3, 4 and 5 do the work; step 6 measures it and step 7 writes the
+deployed-head marker the next run gates on. A deploy that lands the work and
+then dies in a check leaves the server correct and the marker missing, which
+stops the NEXT run in 1a. Deploy run 6 (TS 20260903-0259) is that case: six
+containers on 3.1.0, the nginx edits applied, the site live, and then 6h
+stopped on a swallowed line, so 6h, 6i and the 7a marker never happened.
+
+```bash
+bash deploy/deploy-3.1.sh --verify-only
+```
+
+runs phases 6 and 7 and nothing else. No tags, no backups, no pull, no build,
+no recreate, no nginx edit, no `.env` write. Redoing the whole script for two
+checks and one marker would rebuild and recreate six healthy containers.
+
+It gates first, in the spirit of 1a, and refuses if the server is not already
+deployed:
+
+- the server checkout is on `origin/main` (fetched first, so the ref is real)
+- `/health` reports the same version as `package.json` in that checkout, which
+  is what says the running containers were built from it
+
+Either one off and the mode stops with "Run the full deploy instead". It does
+not combine with `--preflight-only` or `--rollback`; those three are separate
+runs and the script exits 2 if you ask for two of them.
+
 ```bash
 # 6a. deploy.sh step 4, from anywhere: public auth surface, never a 5xx
 tests/auth-smoke.sh https://paramant.app
@@ -611,6 +640,31 @@ for c in main health finance legal iot; do printf '%-8s' $c; docker logs paraman
 Stop and roll back (step 8) on: a relay that does not reach `healthy`,
 `auth-smoke.sh` exit 1, `post-deploy-verify.sh` exit 2, `/health` without
 `3.1.0`, or a `billing_config` line with `recurring:true`.
+
+## A rule for every remote block: `</dev/null`
+
+The script sends each remote step as a heredoc piped into `ssh ... bash -s`.
+That means the script text **is** the remote shell's stdin, and bash reads it
+lazily, one compound command at a time. Any command in that block that reads
+stdin therefore eats the rest of the script.
+
+Run 6 stopped in 6h on "the server never printed 'effective outbound
+buffers'". The measurement was fine; the line had been swallowed by
+
+```bash
+docker compose exec -T "$svc" sh -c '...'      # no </dev/null: reads stdin
+```
+
+The two lines above it came out normally, because the whole `for` loop was
+parsed before it ran, which is why the log read like a failed measurement and
+not like a truncated script.
+
+So: **every stdin-reading command inside a remote heredoc gets `</dev/null`**.
+That is `docker compose exec`, `docker compose run`, `docker exec`,
+`docker run`, a nested `ssh`, and any bare `read`. A `read` in a loop that is
+already redirected (`done < "$file"`, `done < <(...)`) or fed by a here-string
+is fine as it is. `tests/deploy-3.1-dryrun.test.sh` scans every remote block in
+the script for this and fails on a command that lacks it.
 
 ## Step 7: after the deploy
 

--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -596,13 +596,37 @@ checks and one marker would rebuild and recreate six healthy containers.
 It gates first, in the spirit of 1a, and refuses if the server is not already
 deployed:
 
-- the server checkout is on `origin/main` (fetched first, so the ref is real)
+- the deployed commit is **on the mainline**: `git merge-base --is-ancestor
+  HEAD $DEPLOY_REF`, asked after a fetch so the ref is real
 - `/health` reports the same version as `package.json` in that checkout, which
   is what says the running containers were built from it
 
-Either one off and the mode stops with "Run the full deploy instead". It does
-not combine with `--preflight-only` or `--rollback`; those three are separate
-runs and the script exits 2 if you ask for two of them.
+Either one off and the mode stops with "Run the full deploy instead".
+
+**Behind the tip is normal, not a fault.** main moves while a deploy runs. Run
+6 deployed `4e6de0b` and `origin/main` was already on `05bbd1b` by the time
+this mode existed, so a gate demanding equality would have refused exactly the
+state it was written for. Being *beside* the mainline is the real problem,
+because then nobody can say what is running. So the ancestor test is the gate
+and the difference from the tip is a note:
+
+```
+  note  checkout is on 4e6de0b, origin/main is 05bbd1b; this mode signs off on the DEPLOYED commit
+  note  so the deployed-head marker will name 4e6de0b, which is what the next run gates on
+```
+
+The marker phase 7a writes names the commit the checkout is **on**, not the tip
+of the ref. That is the commit that is actually deployed, and it is what the
+next run's phase 1a gates on; a later full run fast-forwards from there.
+
+`PARAMANT_VERIFY_HEAD=<sha>` names the deployed commit yourself, the way
+`PARAMANT_EXPECTED_HEAD` does in 1a, and likewise skips the test it replaces:
+the mainline check. The version check still runs.
+
+The ref is `$DEPLOY_REF`, so `DEPLOY_REF=origin/release bash
+deploy/deploy-3.1.sh --verify-only` gates against that instead. It does not
+combine with `--preflight-only` or `--rollback`; those three are separate runs
+and the script exits 2 if you ask for two of them.
 
 ```bash
 # 6a. deploy.sh step 4, from anywhere: public auth surface, never a 5xx
@@ -660,11 +684,25 @@ parsed before it ran, which is why the log read like a failed measurement and
 not like a truncated script.
 
 So: **every stdin-reading command inside a remote heredoc gets `</dev/null`**.
-That is `docker compose exec`, `docker compose run`, `docker exec`,
-`docker run`, a nested `ssh`, and any bare `read`. A `read` in a loop that is
+Two families:
+
+- **always reads, whatever its arguments**: `docker compose exec`,
+  `docker compose run`, `docker exec`, `docker run`, a nested `ssh`, and
+  `xargs`. `xargs rm -f` is not xargs-with-an-operand, it is xargs reading
+  stdin.
+- **reads only when given no file**: `cat`, `sort`, `wc`, `python -`,
+  `node -`, and any `read`. `cat "$f"` and `wc -l < "$f"` are fine; `cat` and
+  `wc -l` on their own are not.
+
+A command to the **right of a pipe** reads the pipe, not the script, so
+`... | wc -l` is fine and `wc -l` alone is not. A `read` in a loop that is
 already redirected (`done < "$file"`, `done < <(...)`) or fed by a here-string
-is fine as it is. `tests/deploy-3.1-dryrun.test.sh` scans every remote block in
-the script for this and fails on a command that lacks it.
+is fine as it is.
+
+`tests/deploy-3.1-dryrun.test.sh` scans every remote block in the script for
+this and fails on a command that lacks it. It also pins the number of blocks it
+walked, so an extraction that silently loses half the script fails instead of
+passing on an empty search.
 
 ## Step 7: after the deploy
 

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -11,10 +11,20 @@
 #   bash deploy/deploy-3.1.sh                  full deploy, phases 0 to 7
 #   bash deploy/deploy-3.1.sh --preflight-only phases 0 and 1, read-only
 #   bash deploy/deploy-3.1.sh --rollback <TS>  phase 8, back to the <TS> backup
+#   bash deploy/deploy-3.1.sh --verify-only    phases 6 and 7 only, on a server
+#                                              that is already deployed
 #   bash deploy/deploy-3.1.sh --dry-run        print every remote and gated
 #                                              command instead of running it
 #
-# Flags combine: --dry-run --preflight-only, --dry-run --rollback <TS>.
+# Flags combine with --dry-run: --dry-run --preflight-only, --dry-run
+# --rollback <TS>, --dry-run --verify-only. The three run modes are mutually
+# exclusive.
+#
+# --verify-only exists for a deploy that did its work and then died in the
+# checks. It gates on the server already being deployed (checkout on
+# origin/main, /health reporting the version that checkout describes) and then
+# runs phases 6 and 7 and nothing else: no tags, no backups, no pull, no build,
+# no recreate, no nginx edit, no .env write.
 #
 # The commit the production checkout must be on before phase 3 moves it is a
 # parameter, not a constant. PARAMANT_EXPECTED_HEAD=<commit> wins; without it
@@ -157,6 +167,7 @@ SSH_SHOWN="ssh -i <prod-key> -o BatchMode=yes -o IdentitiesOnly=yes $PROD_HOST"
 
 DRY_RUN=0
 PREFLIGHT_ONLY=0
+VERIFY_ONLY=0
 ROLLBACK_TS=""
 REMOTE_OUT=""
 REMOTE_RC=0
@@ -541,6 +552,7 @@ usage() {
 while [ $# -gt 0 ]; do
   case "$1" in
     --preflight-only) PREFLIGHT_ONLY=1; shift ;;
+    --verify-only)    VERIFY_ONLY=1; shift ;;
     --dry-run)        DRY_RUN=1; shift ;;
     --rollback)       [ $# -ge 2 ] || { echo "--rollback needs a <TS>" >&2; exit 2; }
                       ROLLBACK_TS="$2"; shift 2 ;;
@@ -551,6 +563,10 @@ done
 
 if [ -n "$ROLLBACK_TS" ] && [ "$PREFLIGHT_ONLY" -eq 1 ]; then
   echo "--rollback and --preflight-only are different runs; pick one" >&2
+  exit 2
+fi
+if [ "$VERIFY_ONLY" -eq 1 ] && { [ -n "$ROLLBACK_TS" ] || [ "$PREFLIGHT_ONLY" -eq 1 ]; }; then
+  echo "--verify-only is its own run; do not combine it with --rollback or --preflight-only" >&2
   exit 2
 fi
 if [ -n "$ROLLBACK_TS" ] && ! printf '%s' "$ROLLBACK_TS" | grep -qE '^[0-9]{8}-[0-9]{4}$'; then
@@ -571,6 +587,7 @@ exec > >(tee -a "$LOG") 2>&1
 
 MODE="full deploy"
 [ "$PREFLIGHT_ONLY" -eq 1 ] && MODE="preflight only (phases 0 and 1, read-only)"
+[ "$VERIFY_ONLY" -eq 1 ] && MODE="verify only (phases 6 and 7 on an already deployed server)"
 [ -n "$ROLLBACK_TS" ] && MODE="rollback to $ROLLBACK_TS (phase 8)"
 [ "$DRY_RUN" -eq 1 ] && MODE="$MODE, DRY RUN (nothing is executed on the server)"
 
@@ -771,9 +788,12 @@ set -euo pipefail
 cd "$1"
 for v in BILLING_MODE MOLLIE_API_KEY MOLLIE_TEST_API_KEY INTERNAL_AUTH_TOKEN ADMIN_TOKEN PARAMANT_TOTP_MASTER_KEY RELAY_REDIS_URL PARAMANT_INLINE_RECEIPT_HEADER; do
   printf 'env %-26s ' "$v"
+  # </dev/null is load bearing on EVERY stdin-reading command in a remote
+  # heredoc. The body of this block IS the ssh stdin (bash -s), so a command
+  # that reads stdin eats the rest of the script. See the note above phase 6h.
   docker compose exec -T relay-main sh -c \
     "v=\$(printenv $v); if [ -z \"\$v\" ]; then echo empty; else echo \"set, prefix \$(printf %s \"\$v\" | cut -c1-5)\"; fi" \
-    2>/dev/null || echo "unreadable"
+    </dev/null 2>/dev/null || echo "unreadable"
 done
 EOF
 
@@ -1876,13 +1896,24 @@ EOF
     fi
   fi
 
+  # Every stdin-reading command in a remote heredoc needs </dev/null.
+  #
+  # The body of a remote block is piped into `ssh ... bash -s`, so the script
+  # text IS file descriptor 0. `docker compose exec -T` reads stdin, and bash
+  # reads the script lazily, one compound command at a time: the exec swallowed
+  # everything bash had not parsed yet. Deploy run 6 (TS 20260903-0259) is what
+  # that looks like from the outside. The two `inline` lines came out fine,
+  # because the whole for-loop was already parsed before it ran, and then the
+  # echo below it was simply gone. Phase 6h stopped on "the server never
+  # printed 'effective outbound buffers'", and 6i and the phase 7a marker never
+  # ran at all, which left the next run with no marker to gate on.
   step "6h. the inline receipt opt-in really works end to end (#342)"
   remote "inline receipt config" "$COMPOSE_DIR" <<'EOF'
 set -euo pipefail
 cd "$1"
 for svc in relay-main relay-iot; do
   printf 'inline %-12s ' "$svc"
-  docker compose exec -T "$svc" sh -c 'v=$(printenv PARAMANT_INLINE_RECEIPT_HEADER); [ -n "$v" ] && echo "$v" || echo empty' 2>/dev/null || echo unreadable
+  docker compose exec -T "$svc" sh -c 'v=$(printenv PARAMANT_INLINE_RECEIPT_HEADER); [ -n "$v" ] && echo "$v" || echo empty' </dev/null 2>/dev/null || echo unreadable
 done
 # The effective config, not the file: nginx -T is what is actually loaded.
 echo "effective outbound buffers = $(nginx -T 2>/dev/null | grep -c 'proxy_buffer_size 32k' || true)"
@@ -1967,6 +1998,65 @@ for svc in relay-main relay-health relay-finance relay-legal relay-iot; do
 done
 EOF
   expect_not '"recurring":true' "every relay still reports recurring:false"
+}
+
+# =============================================================== PHASE V =====
+
+# --verify-only: finish a deploy that got its work done and then died in the
+# checks. Run 6 (TS 20260903-0259) is the case it exists for: phases 3, 4 and 5
+# all landed, six containers on 3.1.0, the nginx edits applied, the site live,
+# and then 6h stopped on a swallowed line. Re-running the whole script would
+# re-tag, re-back-up, re-pull, rebuild and recreate six healthy containers to
+# get at two checks and one marker file. This mode runs phases 6 and 7 and
+# nothing else: no tags, no backups, no pull, no build, no recreate, no nginx
+# edit, no .env write.
+#
+# That is only safe when the server really is already deployed, so this phase
+# is the gate, in the same spirit as phase 1a: the checkout has to BE the
+# commit that would have been deployed, and the containers have to be running
+# the version that checkout describes. Anything else and the mode refuses,
+# because "verify" on a half-deployed server would sign off on nothing.
+phase_v() {
+  phase V "Preconditions for --verify-only (server, read-only)" "no runbook step; this mode replaces one"
+
+  step "Va. the checkout is origin/main and the running relay matches it"
+  remote "verify preconditions" "$COMPOSE_DIR" <<'EOF'
+set -euo pipefail
+cd "$1"
+# Fetch so origin/main is the real one, not a stale ref. It moves no file.
+git fetch origin >/dev/null 2>&1 || true
+echo "verify head = $(git rev-parse HEAD)"
+echo "verify head short = $(git rev-parse --short HEAD)"
+echo "verify origin main = $(git rev-parse origin/main 2>/dev/null || echo unknown)"
+# The version the checkout describes, and the version the containers report.
+# These have to agree, or the containers were not built from this checkout.
+echo "verify package version = $(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' package.json | head -1)"
+echo "verify health version = $(curl -s --max-time 5 http://127.0.0.1:3000/health </dev/null | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' | head -1)"
+EOF
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  SKIP  assert (dry-run): the checkout is origin/main and the relay reports the package version
+'
+    return 0
+  fi
+
+  local head omain pkg health
+  head="$(remote_field 'verify head')"
+  omain="$(remote_field 'verify origin main')"
+  pkg="$(remote_field 'verify package version')"
+  health="$(remote_field 'verify health version')"
+
+  [ -n "$head" ] || die "the server never printed the commit its checkout is on"
+  [ -n "$omain" ] && [ "$omain" != unknown ]     || die "the server could not resolve origin/main, so there is nothing to compare the checkout against"
+  sha_eq "$head" "$omain"     || die "--verify-only needs a server that is already deployed: the checkout is on ${head:0:7} and origin/main is ${omain:0:7}. Run the full deploy instead"
+  ok "the server checkout is on origin/main (${head:0:7})"
+
+  [ -n "$pkg" ] || die "could not read the version out of package.json in the server checkout"
+  [ -n "$health" ] || die "/health did not report a version, so the relay is not up; --verify-only has nothing to verify"
+  [ "$pkg" = "$health" ]     || die "/health reports $health but the checkout describes $pkg, so the containers were not built from this checkout. Run the full deploy instead"
+  ok "the running relay reports $health, the version the checkout describes"
+
+  note "no tag, backup, pull, build, recreate or nginx edit will run in this mode"
 }
 
 # =============================================================== PHASE 7 =====
@@ -2218,7 +2308,7 @@ done
 echo "rollback relay health = $ok"
 echo "rollback version = $(curl -s --max-time 5 http://127.0.0.1:3000/health | grep -o '"version":"[^"]*"' || echo unknown)"
 cid="$(docker compose ps -q relay-main)"
-echo "rollback paraidAuth occurrences = $(docker exec "$cid" grep -c _paraidAuth /app/relay.js 2>/dev/null || echo 0)"
+echo "rollback paraidAuth occurrences = $(docker exec "$cid" grep -c _paraidAuth /app/relay.js </dev/null 2>/dev/null || echo 0)"
 EOF
   expect 'rollback relay health = yes' "the relay answers /health after the rollback"
 
@@ -2263,6 +2353,17 @@ if [ -n "$ROLLBACK_TS" ]; then
   echo
   hr
   echo "ROLLBACK FINISHED, warnings: $WARNINGS"
+  hr
+  exit 0
+fi
+
+if [ "$VERIFY_ONLY" -eq 1 ]; then
+  phase_v
+  phase_6
+  phase_7
+  echo
+  hr
+  echo "VERIFY ONLY FINISHED, warnings: $WARNINGS"
   hr
   exit 0
 fi

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -105,6 +105,10 @@ DEPLOY_REF="${DEPLOY_REF:-origin/main}"
 # marker names the checkout, so it stays true.
 EXPECT_PROD_COMMIT="${EXPECT_PROD_COMMIT:-41501bb}"   # runbook: where we start
 EXPECTED_HEAD="${PARAMANT_EXPECTED_HEAD:-}"           # explicit override, wins
+# --verify-only: name the deployed commit yourself. Same idea as
+# PARAMANT_EXPECTED_HEAD in phase 1a, and it likewise skips the test it
+# replaces, here the mainline-ancestor test in phase Va.
+VERIFY_HEAD="${PARAMANT_VERIFY_HEAD:-}"
 DEPLOYED_HEAD_FILE="${PARAMANT_DEPLOYED_HEAD_FILE:-$BACKUP_DIR/deployed-head}"
 EXPECT_VERSION="3.1.0"
 SERVICES="relay-main relay-health relay-finance relay-legal relay-iot admin"
@@ -2019,15 +2023,28 @@ EOF
 phase_v() {
   phase V "Preconditions for --verify-only (server, read-only)" "no runbook step; this mode replaces one"
 
-  step "Va. the checkout is origin/main and the running relay matches it"
-  remote "verify preconditions" "$COMPOSE_DIR" <<'EOF'
+  step "Va. the checkout is on the mainline and the running relay was built from it"
+  remote "verify preconditions" "$COMPOSE_DIR" "$DEPLOY_REF" <<'EOF'
 set -euo pipefail
 cd "$1"
-# Fetch so origin/main is the real one, not a stale ref. It moves no file.
+REF="$2"
+# Fetch so the ref is the real one, not a stale remote-tracking pointer. It
+# moves no file and does not check anything out.
 git fetch origin >/dev/null 2>&1 || true
 echo "verify head = $(git rev-parse HEAD)"
 echo "verify head short = $(git rev-parse --short HEAD)"
-echo "verify origin main = $(git rev-parse origin/main 2>/dev/null || echo unknown)"
+echo "verify ref = $REF"
+echo "verify ref sha = $(git rev-parse "$REF" 2>/dev/null || echo unknown)"
+# Is the deployed commit ON the mainline? Being BEHIND the ref is normal and
+# fine: main moves while a deploy runs. Being beside it is not, and that is the
+# thing worth refusing.
+if ! git rev-parse "$REF" >/dev/null 2>&1; then
+  echo "verify ancestor = unknown"
+elif git merge-base --is-ancestor HEAD "$REF" >/dev/null 2>&1; then
+  echo "verify ancestor = yes"
+else
+  echo "verify ancestor = no"
+fi
 # The version the checkout describes, and the version the containers report.
 # These have to agree, or the containers were not built from this checkout.
 echo "verify package version = $(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' package.json | head -1)"
@@ -2035,26 +2052,52 @@ echo "verify health version = $(curl -s --max-time 5 http://127.0.0.1:3000/healt
 EOF
 
   if [ "$DRY_RUN" -eq 1 ]; then
-    printf '  SKIP  assert (dry-run): the checkout is origin/main and the relay reports the package version
-'
+    printf '  SKIP  assert (dry-run): the checkout is an ancestor of %s and the relay reports the version that checkout describes\n' "$DEPLOY_REF"
     return 0
   fi
 
-  local head omain pkg health
+  local head refsha ancestor pkg health
   head="$(remote_field 'verify head')"
-  omain="$(remote_field 'verify origin main')"
+  refsha="$(remote_field 'verify ref sha')"
+  ancestor="$(remote_field 'verify ancestor')"
   pkg="$(remote_field 'verify package version')"
   health="$(remote_field 'verify health version')"
 
   [ -n "$head" ] || die "the server never printed the commit its checkout is on"
-  [ -n "$omain" ] && [ "$omain" != unknown ]     || die "the server could not resolve origin/main, so there is nothing to compare the checkout against"
-  sha_eq "$head" "$omain"     || die "--verify-only needs a server that is already deployed: the checkout is on ${head:0:7} and origin/main is ${omain:0:7}. Run the full deploy instead"
-  ok "the server checkout is on origin/main (${head:0:7})"
+
+  # 1. An explicit answer wins, the same way PARAMANT_EXPECTED_HEAD does in
+  #    phase 1a. Someone who sets this has looked at the server; the script
+  #    does not second-guess which commit is the deployed one.
+  if [ -n "$VERIFY_HEAD" ]; then
+    sha_eq "$head" "$VERIFY_HEAD" \
+      || die "PARAMANT_VERIFY_HEAD names $VERIFY_HEAD but the checkout is on ${head:0:7}"
+    ok "the checkout is on ${head:0:7}, which PARAMANT_VERIFY_HEAD names (the mainline test is skipped on your say-so)"
+  else
+    # 2. Otherwise: the deployed commit has to be ON the mainline. Equality
+    #    with the ref is NOT the test. main moves while a deploy runs, and it
+    #    did: run 6 deployed 4e6de0b and origin/main was already further along
+    #    by the time the mode existed. Refusing that would refuse exactly the
+    #    state this mode is for. Being BESIDE the mainline is the real problem,
+    #    because then nobody knows what is running.
+    case "$ancestor" in
+      yes) ok "the checkout ${head:0:7} is an ancestor of $DEPLOY_REF, so it is on the mainline" ;;
+      no)  die "the checkout ${head:0:7} is not an ancestor of $DEPLOY_REF, so what is deployed is not on the mainline. Run the full deploy instead" ;;
+      *)   die "the server could not resolve $DEPLOY_REF, so there is no mainline to check the checkout against" ;;
+    esac
+  fi
 
   [ -n "$pkg" ] || die "could not read the version out of package.json in the server checkout"
   [ -n "$health" ] || die "/health did not report a version, so the relay is not up; --verify-only has nothing to verify"
-  [ "$pkg" = "$health" ]     || die "/health reports $health but the checkout describes $pkg, so the containers were not built from this checkout. Run the full deploy instead"
+  [ "$pkg" = "$health" ] \
+    || die "/health reports $health but the checkout describes $pkg, so the containers were not built from this checkout. Run the full deploy instead"
   ok "the running relay reports $health, the version the checkout describes"
+
+  # Behind the ref is a note, not a stop. Say it plainly, because the marker
+  # phase 7a writes names THIS commit, not the tip of the ref.
+  if [ -n "$refsha" ] && [ "$refsha" != unknown ] && ! sha_eq "$head" "$refsha"; then
+    note "checkout is on ${head:0:7}, $DEPLOY_REF is ${refsha:0:7}; this mode signs off on the DEPLOYED commit"
+    note "so the deployed-head marker will name ${head:0:7}, which is what the next run gates on"
+  fi
 
   note "no tag, backup, pull, build, recreate or nginx edit will run in this mode"
 }
@@ -2364,6 +2407,11 @@ if [ "$VERIFY_ONLY" -eq 1 ]; then
   echo
   hr
   echo "VERIFY ONLY FINISHED, warnings: $WARNINGS"
+  echo "Phases 6 and 7 only. Nothing was tagged, backed up, pulled, built,"
+  echo "recreated or edited. The deployed-head marker names the commit the"
+  echo "server checkout is on, which is the commit that is actually deployed,"
+  echo "and that is what the next run's phase 1a gates on. If $DEPLOY_REF has"
+  echo "moved on since that deploy, the next full run fast-forwards to it."
   hr
   exit 0
 fi

--- a/tests/deploy-3.1-dryrun.test.sh
+++ b/tests/deploy-3.1-dryrun.test.sh
@@ -469,7 +469,7 @@ echo ""
 echo "6g-1. First run: the conf is in its pre-3.1 shape, so there is work to do"
 seed_2b_backups "$NG/sites" "$NG/bk" 20260101-0000 "paramant-public.conf paramant-live.conf"
 OUT1="$(cd "$NG" && PATH="$NG/bin:$PATH" bash "$NG/5c.sh" 20260101-0000 "$NG/sites" "$NG/bk" \
-        "paramant-public.conf paramant-live.conf" 2>&1)"; RC1=$?
+        "paramant-public.conf paramant-live.conf" </dev/null 2>&1)"; RC1=$?
 if [ "$RC1" -eq 0 ]; then pass "5c exits 0 on a conf that still needs the edits"; else
   fail "5c exits $RC1 on a conf that still needs the edits"
   printf '%s\n' "$OUT1" | sed 's/^/        /' | head -20
@@ -516,7 +516,7 @@ echo ""
 echo "6g-2. Second run on the same confs: already applied, not FATAL"
 seed_2b_backups "$NG/sites" "$NG/bk" 20260101-0001 "paramant-public.conf paramant-live.conf"
 OUT2="$(cd "$NG" && PATH="$NG/bin:$PATH" bash "$NG/5c.sh" 20260101-0001 "$NG/sites" "$NG/bk" \
-        "paramant-public.conf paramant-live.conf" 2>&1)"; RC2=$?
+        "paramant-public.conf paramant-live.conf" </dev/null 2>&1)"; RC2=$?
 if [ "$RC2" -eq 0 ]; then pass "a second 5c on an already-edited conf exits 0"; else
   fail "a second 5c on an already-edited conf exits $RC2 (this is the bug)"
   printf '%s\n' "$OUT2" | sed 's/^/        /' | head -20
@@ -548,7 +548,7 @@ make_conf "$NG/available/paramant-public.conf" absent absent no yes
 make_conf "$NG/available/paramant-live.conf"   absent absent no yes
 seed_2b_backups "$NG/sites" "$NG/bk" 20260101-0002 "paramant-public.conf paramant-live.conf"
 OUT3="$(cd "$NG" && PATH="$NG/bin:$PATH" bash "$NG/5c.sh" 20260101-0002 "$NG/sites" "$NG/bk" \
-        "paramant-public.conf paramant-live.conf" 2>&1)"; RC3=$?
+        "paramant-public.conf paramant-live.conf" </dev/null 2>&1)"; RC3=$?
 if [ "$RC3" -ne 0 ]; then pass "5c stops on a conf that is not the one the runbook describes"; else
   fail "5c accepted a conf carrying neither shape"; fi
 if printf '%s\n' "$OUT3" | grep -q "FATAL 'sign'"; then
@@ -603,7 +603,7 @@ CONF
 cp "$NG/available/paramant-public.conf" "$NG/available/paramant-live.conf"
 seed_2b_backups "$NG/sites" "$NG/bk" 20260101-0003 "paramant-public.conf paramant-live.conf"
 OUT4="$(cd "$NG" && PATH="$NG/bin:$PATH" bash "$NG/5c.sh" 20260101-0003 "$NG/sites" "$NG/bk" \
-        "paramant-public.conf paramant-live.conf" 2>&1)"; RC4=$?
+        "paramant-public.conf paramant-live.conf" </dev/null 2>&1)"; RC4=$?
 
 if [ "$(field_5c "$OUT4" 'before sign gated')" = "0" ]; then
   pass "the one-line pattern really does miss a multi-line auth_request (the trap)"
@@ -668,7 +668,7 @@ for f in nis2 iec62443 nen7510; do echo "page $f" > "$RB5B/docroot/compliance/$f
 echo index > "$RB5B/docroot/index.html"
 
 # The marker is on main, because the rollback did not move the checkout.
-OUT5="$(bash "$RB5B/5b.sh" "$RB5B/repo" "$RB5B/docroot" "$HEADC" "dist" "$FLOOR" 2>&1)"; RC5=$?
+OUT5="$(bash "$RB5B/5b.sh" "$RB5B/repo" "$RB5B/docroot" "$HEADC" "dist" "$FLOOR" </dev/null 2>&1)"; RC5=$?
 if [ "$RC5" -eq 0 ]; then pass "5b exits 0 in the deploy-after-rollback situation"; else
   fail "5b exits $RC5 in the deploy-after-rollback situation"
   printf '%s\n' "$OUT5" | sed 's/^/        /' | head -20
@@ -702,7 +702,7 @@ fi
 
 # The healthy second deploy: nothing was restored, so everything is already
 # gone. That is an OK answer and must not be a failure.
-OUT6="$(bash "$RB5B/5b.sh" "$RB5B/repo" "$RB5B/docroot" "$HEADC" "dist" "$FLOOR" 2>&1)"; RC6=$?
+OUT6="$(bash "$RB5B/5b.sh" "$RB5B/repo" "$RB5B/docroot" "$HEADC" "dist" "$FLOOR" </dev/null 2>&1)"; RC6=$?
 if [ "$RC6" -eq 0 ] && [ "$(field_5c "$OUT6" 'after already absent')" = "3" ] \
    && [ "$(field_5c "$OUT6" 'after removed')" = "0" ]; then
   pass "running 5b again prunes nothing and reports all three as already absent"
@@ -814,7 +814,7 @@ ln -sfn "$NG2/available/paramant-public.conf" "$NG2/sites-fb/paramant-public.con
 ln -sfn "$NG2/available/paramant.conf"        "$NG2/sites-fb/paramant.conf"
 seed_2b_backups "$NG2/sites-fb" "$NG2/bk" 20260101-0100 "paramant-public.conf paramant-live.conf|paramant.conf"
 OUT7="$(cd "$NG2" && PATH="$NG2/bin:$PATH" bash "$NG/5c.sh" 20260101-0100 "$NG2/sites-fb" "$NG2/bk" \
-        "paramant-public.conf paramant-live.conf|paramant.conf" 2>&1)"; RC7=$?
+        "paramant-public.conf paramant-live.conf|paramant.conf" </dev/null 2>&1)"; RC7=$?
 if [ "$RC7" -eq 0 ]; then pass "5c exits 0 on a server that calls the backend conf paramant.conf"; else
   fail "5c exits $RC7 on the production naming"
   printf '%s\n' "$OUT7" | sed 's/^/        /' | head -25
@@ -860,7 +860,7 @@ ln -sfn "$NG2/available/paramant-live.conf"   "$NG2/sites-both/paramant-live.con
 ln -sfn "$NG2/available/paramant.conf"        "$NG2/sites-both/paramant.conf"
 seed_2b_backups "$NG2/sites-both" "$NG2/bk" 20260101-0101 "paramant-public.conf paramant-live.conf|paramant.conf"
 OUT8="$(cd "$NG2" && PATH="$NG2/bin:$PATH" bash "$NG/5c.sh" 20260101-0101 "$NG2/sites-both" "$NG2/bk" \
-        "paramant-public.conf paramant-live.conf|paramant.conf" 2>&1)"; RC8=$?
+        "paramant-public.conf paramant-live.conf|paramant.conf" </dev/null 2>&1)"; RC8=$?
 if [ "$RC8" -eq 0 ] && printf '%s\n' "$OUT8" | grep -q 'nginxconf paramant-live.conf resolved to paramant-live.conf'; then
   pass "with both present, slot 2 resolves to paramant-live.conf"
 else
@@ -885,7 +885,7 @@ make_conf "$NG2/available/paramant-public.conf" old old yes no
 ln -sfn "$NG2/available/paramant-public.conf" "$NG2/sites-none/paramant-public.conf"
 seed_2b_backups "$NG2/sites-none" "$NG2/bk" 20260101-0102 "paramant-public.conf paramant-live.conf|paramant.conf"
 OUT9="$(cd "$NG2" && PATH="$NG2/bin:$PATH" bash "$NG/5c.sh" 20260101-0102 "$NG2/sites-none" "$NG2/bk" \
-        "paramant-public.conf paramant-live.conf|paramant.conf" 2>&1)"; RC9=$?
+        "paramant-public.conf paramant-live.conf|paramant.conf" </dev/null 2>&1)"; RC9=$?
 if [ "$RC9" -ne 0 ] && printf '%s\n' "$OUT9" | grep -q 'FATAL 1 nginx conf slot'; then
   pass "5c stops when a slot has no candidate on the server"
 else
@@ -906,7 +906,7 @@ ln -sfn "$NG2/available/paramant-public.conf" "$NG2/sites-noparaid/paramant-publ
 ln -sfn "$NG2/available/paramant.conf"        "$NG2/sites-noparaid/paramant.conf"
 seed_2b_backups "$NG2/sites-noparaid" "$NG2/bk" 20260101-0103 "paramant-public.conf paramant-live.conf|paramant.conf"
 OUT10="$(cd "$NG2" && PATH="$NG2/bin:$PATH" bash "$NG/5c.sh" 20260101-0103 "$NG2/sites-noparaid" "$NG2/bk" \
-         "paramant-public.conf paramant-live.conf|paramant.conf" 2>&1)"; RC10=$?
+         "paramant-public.conf paramant-live.conf|paramant.conf" </dev/null 2>&1)"; RC10=$?
 if [ "$RC10" -ne 0 ] && printf '%s\n' "$OUT10" | grep -q 'FATAL the ParaID deny is not present'; then
   pass "5c still stops when the ParaID deny anchor is gone"
 else
@@ -950,7 +950,7 @@ else
 fi
 
 OUT11="$(PATH="$RBN/bin:$PATH" bash "$RBN/8a.sh" "$RBN/compose" "$RBTS" "$RBN/bk" "$RBN/ngbk" \
-         "$RBN/sites" "paramant-public.conf paramant-live.conf|paramant.conf" 2>&1)"; RC11=$?
+         "$RBN/sites" "paramant-public.conf paramant-live.conf|paramant.conf" </dev/null 2>&1)"; RC11=$?
 if [ "$RC11" -eq 0 ]; then pass "8a exits 0 against the production naming"; else
   fail "8a exits $RC11"
   printf '%s\n' "$OUT11" | sed 's/^/        /' | head -20
@@ -975,7 +975,7 @@ fi
 # And with that backup gone, 8a must refuse instead of half-rolling back.
 mv "$RBN/ngbk/paramant.conf.pre-3.1-$RBTS" "$RBN/ngbk/paramant.conf.pre-3.1-$RBTS.moved"
 OUT12="$(PATH="$RBN/bin:$PATH" bash "$RBN/8a.sh" "$RBN/compose" "$RBTS" "$RBN/bk" "$RBN/ngbk" \
-         "$RBN/sites" "paramant-public.conf paramant-live.conf|paramant.conf" 2>&1)"
+         "$RBN/sites" "paramant-public.conf paramant-live.conf|paramant.conf" </dev/null 2>&1)"
 if [ "$(field_5c "$OUT12" 'missing backups')" = "1" ]; then
   pass "a missing backup under the resolved name is counted, so the rollback stops"
 else
@@ -985,7 +985,7 @@ mv "$RBN/ngbk/paramant.conf.pre-3.1-$RBTS.moved" "$RBN/ngbk/paramant.conf.pre-3.
 
 echo bogus-added-by-deploy > "$RBN/root/app/added.html"
 OUT13="$(PATH="$RBN/bin:$PATH" bash "$RBN/8c.sh" "$RBTS" "$RBN/bk" "$RBN/root/app" "$RBN/ngbk" \
-         "$RBN/sites" "paramant-public.conf paramant-live.conf|paramant.conf" "dist" 2>&1)"; RC13=$?
+         "$RBN/sites" "paramant-public.conf paramant-live.conf|paramant.conf" "dist" </dev/null 2>&1)"; RC13=$?
 if [ "$RC13" -eq 0 ]; then pass "8c exits 0 against the production naming"; else
   fail "8c exits $RC13"
   printf '%s\n' "$OUT13" | sed 's/^/        /' | head -20
@@ -1008,7 +1008,7 @@ fi
 
 # A slot with no candidate must stop 8c too, before it writes anything.
 OUT14="$(PATH="$RBN/bin:$PATH" bash "$RBN/8c.sh" "$RBTS" "$RBN/bk" "$RBN/root/app" "$RBN/ngbk" \
-         "$RBN/sites" "paramant-public.conf paramant-live.conf|not-there.conf" "dist" 2>&1)"; RC14=$?
+         "$RBN/sites" "paramant-public.conf paramant-live.conf|not-there.conf" "dist" </dev/null 2>&1)"; RC14=$?
 if [ "$RC14" -ne 0 ] && printf '%s\n' "$OUT14" | grep -q 'FATAL 1 nginx conf slot'; then
   pass "8c stops when a slot resolves to nothing"
 else
@@ -1058,7 +1058,7 @@ MD5_PUB="$(md5sum < "$NG3/available/paramant-public.conf")"
 MD5_BE="$(md5sum < "$NG3/available/paramant.conf")"
 
 OUT15="$(cd "$NG3" && PATH="$NG3/bin:$PATH" bash "$NG/5c.sh" 20260101-0300 "$NG3/sites" "$NG3/bk" \
-         "$SL3" 2>&1)"; RC15=$?
+         "$SL3" </dev/null 2>&1)"; RC15=$?
 if [ "$RC15" -ne 0 ]; then pass "5c stops when the conf it resolved has no 2b backup"; else
   fail "5c edited a conf that has no backup (exit $RC15)"
   printf '%s\n' "$OUT15" | sed 's/^/        /' | head -20
@@ -1094,7 +1094,7 @@ echo "6i-7b. With the backup filed under the resolved name, the same run is clea
 # Control: the stop above is about the missing backup, not about the rename.
 cp -a "$NG3/available/paramant.conf" "$NG3/bk/paramant.conf.pre-3.1-20260101-0300"
 OUT16="$(cd "$NG3" && PATH="$NG3/bin:$PATH" bash "$NG/5c.sh" 20260101-0300 "$NG3/sites" "$NG3/bk" \
-         "$SL3" 2>&1)"; RC16=$?
+         "$SL3" </dev/null 2>&1)"; RC16=$?
 if [ "$RC16" -eq 0 ] && [ "$(field_5c "$OUT16" 'before confs without a backup')" = "0" ]; then
   pass "with the backup in place the same fixture runs through"
 else
@@ -1138,7 +1138,7 @@ MD4_PUB="$(md5sum < "$NG4/available/paramant-public.conf")"
 MD4_BE="$(md5sum < "$NG4/available/paramant.conf")"
 
 OUT17="$(cd "$NG4" && PATH="$NG4/bin:$PATH" bash "$NG/5c.sh" 20260101-0400 "$NG4/sites" "$NG4/bk" \
-         "$SL3" 2>&1)"; RC17=$?
+         "$SL3" </dev/null 2>&1)"; RC17=$?
 if [ "$RC17" -ne 0 ] && printf '%s\n' "$OUT17" | grep -q 'still carry an auth_request'; then
   pass "the run reaches the post-edit FATAL, so restore() is exercised"
 else
@@ -1350,7 +1350,7 @@ fi
 mkdir -p "$G3A/ok/checkout/backups"
 echo state > "$G3A/ok/checkout/backups/full-state.tar.gz.age"
 HEAD_BEFORE="$(git -C "$G3A/ok/checkout" rev-parse HEAD)"
-OUT18="$(bash "$G3A/3a.sh" "$G3A/ok/checkout" 2>&1)"; RC18=$?
+OUT18="$(bash "$G3A/3a.sh" "$G3A/ok/checkout" </dev/null 2>&1)"; RC18=$?
 if [ "$RC18" -eq 0 ]; then pass "3a runs through with an untracked backups/ in the checkout"; else
   fail "3a exits $RC18 on an untracked path (this is the run-5 stop)"
   printf '%s\n' "$OUT18" | sed 's/^/        /' | head -20
@@ -1393,7 +1393,7 @@ else
 fi
 echo "hand edit between deploys" > "$G3A/dirty/checkout/tracked.txt"
 HEAD_BEFORE="$(git -C "$G3A/dirty/checkout" rev-parse HEAD)"
-OUT19="$(bash "$G3A/3a.sh" "$G3A/dirty/checkout" 2>&1)"; RC19=$?
+OUT19="$(bash "$G3A/3a.sh" "$G3A/dirty/checkout" </dev/null 2>&1)"; RC19=$?
 if [ "$RC19" -ne 0 ]; then pass "3a stops when a tracked file is modified"; else
   fail "3a pulled over a modified tracked file (exit $RC19)"
   printf '%s\n' "$OUT19" | sed 's/^/        /' | head -20
@@ -1481,9 +1481,53 @@ echo "6k. No remote block may let a command eat the script off stdin"
 # That covers every shape this script uses. A `read` in some other shape would
 # be flagged, which is the safe direction to be wrong in.
 STDIN_SCAN="$WORK/stdin-scan.txt"
+# The commands that read stdin when nothing feeds them. Two families:
+#   always     docker compose exec/run, docker exec/run, a nested ssh, xargs
+#   when bare  cat, sort, wc, python -, node -, and any read
+# "Bare" means no file operand and no redirect. `cat "$f"`, `wc -l < "$f"` and
+# `sort file` are fine; `cat`, `wc -l` and `sort` on their own are not. xargs is
+# in the first family on purpose: it reads stdin however many arguments it has,
+# so `xargs rm -f` is not "xargs with an operand", it is xargs reading stdin.
+#
+# A command on the RIGHT of a pipe reads the pipe, not the script, so only the
+# first segment of a pipeline is exposed. That is the whole reason the scan
+# splits on "|" rather than grepping lines: `... | wc -l` is safe and common
+# here, `wc -l` alone is the bug. Logical || is masked first so it is not read
+# as a pipe.
+#
+# Heuristic, with its limit written down: backslash continuations are joined
+# first, comments are skipped, and a `read` is accepted when the line carries a
+# here-string or the loop it belongs to is redirected by a later `done <`.
+# That covers every shape this script uses. Something in another shape gets
+# flagged, which is the safe direction to be wrong in.
 awk '
-  # A block starts at a remote call ending in the heredoc marker.
-  /^  remote(_soft|_nginx)? ".*<<'"'"'EOF'"'"'$/ {
+  # Blank every quoted span to a single token Q, so a "|" inside a string is
+  # not read as a pipe and an argument is still visibly an argument. Q keeps
+  # `cat "$f"` looking like cat-with-an-operand, which "" would not.
+  function dequote(line) {
+    gsub(/\047[^\047]*\047/, "Q", line)
+    gsub(/"[^"]*"/, "Q", line)
+    return line
+  }
+  # Everything before the first real pipe. A command to the RIGHT of a pipe
+  # reads the pipe, not the script, so only this part is exposed to stdin.
+  function exposed_segment(line,   n, seg) {
+    gsub(/\|\|/, "\001", line)
+    n = index(line, "|")
+    seg = (n > 0) ? substr(line, 1, n - 1) : line
+    gsub(/\001/, "||", seg)
+    return seg
+  }
+  function has_stdin_redirect(line) {
+    return (line ~ /<[[:space:]]*\/dev\/null/ || line ~ /<[[:space:]]*"?\$/ \
+            || line ~ /<[[:space:]]*\// || line ~ /<</ || line ~ /<[[:space:]]*Q/)
+  }
+  # The command with no operand: end of segment, or only flags after it.
+  function bare(seg, cmd,   re) {
+    re = "(^|[;&(`]|[[:space:]]|[$][(])" cmd "([[:space:]]+-[^[:space:]]+)*[[:space:]]*($|[;&)`])"
+    return (seg ~ re)
+  }
+  /^  remote(_soft|_nginx)? ".*<<\047EOF\047$/ {
     inb = 1; lbl = $0
     sub(/^  remote(_soft|_nginx)? "/, "", lbl); sub(/".*$/, "", lbl)
     ln = 0; n = 0; delete body; delete bln
@@ -1494,24 +1538,52 @@ awk '
     for (i = 1; i <= n; i++) {
       line = body[i]
       if (line ~ /^[[:space:]]*#/) continue
+
+      # Family 1: reads stdin whatever its arguments. Judged on the WHOLE line,
+      # including inside $( ) and inside quotes, because that is where two of
+      # the three real ones live. Safety is </dev/null, nothing else.
       if (line ~ /docker compose exec|docker compose run|docker exec|docker run|(^|[^a-zA-Z_])ssh[[:space:]]/) {
-        if (line !~ /<[[:space:]]*\/dev\/null/) printf "%s\t%d\t%s\n", lbl, bln[i], line
+        if (line !~ /<[[:space:]]*\/dev\/null/) printf "%s\tL%d\tALWAYS-READS\t%s\n", lbl, bln[i], line
         continue
       }
+      # xargs reads stdin whatever arguments it is given, so a command name
+      # after it is not an operand that feeds it. It is only safe behind a pipe.
+      if (exposed_segment(dequote(line)) ~ /(^|[;&(`]|[[:space:]]|[$][(])xargs([[:space:]]|$)/) {
+        if (line !~ /<[[:space:]]*\/dev\/null/) printf "%s\tL%d\tALWAYS-READS\t%s\n", lbl, bln[i], line
+        continue
+      }
+      if (line ~ /(python|python3|node)[[:space:]]+-([[:space:]]|$)/) {
+        if (line !~ /<[[:space:]]*\/dev\/null/) printf "%s\tL%d\tSTDIN-DASH\t%s\n", lbl, bln[i], line
+        continue
+      }
+      # Family 2: a read, unless it has a here-string or its loop is redirected.
       if (line ~ /(^|[;&|(][[:space:]]*|[[:space:]])read[[:space:]]/) {
         if (line ~ /<<</ || line ~ /<[[:space:]]*\/dev\/null/) continue
         redirected = 0
         for (j = i + 1; j <= n; j++) if (body[j] ~ /^[[:space:]]*done[[:space:]]*</) { redirected = 1; break }
-        if (!redirected) printf "%s\t%d\t%s\n", lbl, bln[i], line
+        if (!redirected) printf "%s\tL%d\tBARE-READ\t%s\n", lbl, bln[i], line
+        continue
+      }
+      # Family 3: reads stdin only when given no file. Pipe position decides,
+      # so this one works on the dequoted, pre-pipe part of the line.
+      # Limit: a bare one nested inside $( ) inside a quoted string is not
+      # seen. Every such case in this script is pipe-fed, and family 1 covers
+      # the nested commands that are not.
+      seg = exposed_segment(dequote(line))
+      if (has_stdin_redirect(seg)) continue
+      split("cat sort wc", risky, " ")
+      for (k in risky) {
+        if (bare(seg, risky[k])) {
+          printf "%s\tL%d\tBARE-%s\t%s\n", lbl, bln[i], risky[k], line
+          break
+        }
       }
     }
     next
   }
   inb {
     ln++
-    # Join backslash continuations, so a command whose </dev/null sits on the
-    # next line is judged whole.
-    if (pend != "") { pend = pend " " $0; pl = pl }
+    if (pend != "") { pend = pend " " $0 }
     else { pend = $0; pl = ln }
     if (pend ~ /\\$/) { sub(/\\$/, "", pend); next }
     n++; body[n] = pend; bln[n] = pl; pend = ""
@@ -1519,20 +1591,24 @@ awk '
 ' "$SCRIPT" > "$STDIN_SCAN"
 
 if [ ! -s "$STDIN_SCAN" ]; then
-  pass "every stdin-reading command in every remote block reads from /dev/null"
+  pass "every stdin-reading command in every remote block reads from somewhere that is not the script"
 else
   fail "a command in a remote block would read the rest of the script off stdin"
   sed 's/^/        /' "$STDIN_SCAN" | head -8
 fi
 
-# The scan has to be looking at something. If the block extraction breaks, the
-# check above passes on an empty search and proves nothing.
+# The scan has to be looking at something. Pinned to the REAL number of remote
+# blocks, not a floor: a floor of "at least ten" would still pass if the
+# extraction silently lost half of them, and losing the block that holds the
+# bug is exactly how this check would go quiet. Adding or removing a remote
+# block is a deliberate act, so updating this number is part of it.
 SCAN_BLOCKS="$(grep -cE "^  remote(_soft|_nginx)? \".*<<'EOF'\$" "$SCRIPT" || true)"
-if [ "$SCAN_BLOCKS" -ge 10 ]; then
-  pass "the scan walked $SCAN_BLOCKS remote blocks, so it is looking at the real script"
+if [ "$SCAN_BLOCKS" = "25" ]; then
+  pass "the scan walked all 25 remote blocks"
 else
-  fail "the scan found only $SCAN_BLOCKS remote blocks; the extraction is stale"
+  fail "the script has $SCAN_BLOCKS remote blocks, the scan expects 25; update the number here on purpose"
 fi
+
 # And the three commands that actually read stdin are still there, guarded.
 check_has "$SCRIPT" 'docker compose exec -T "\$svc" sh -c .*</dev/null' \
   "the 6h inline-receipt probe reads from /dev/null"
@@ -1573,11 +1649,16 @@ check_lacks "$VO" 'sed -i -E .location = /sign' "verify-only edits no nginx conf
 check_lacks "$VO" 'INTERNAL_AUTH_TOKEN=%s'      "verify-only writes nothing to .env"
 
 # The gate itself is a pure comparison, so both answers can be checked here.
-check_has "$VO" 'verify origin main'      "the gate reads origin/main off the server"
+check_has "$VO" 'verify ref sha'          "the gate reads the deploy ref off the server"
+check_has "$VO" 'verify ancestor'         "the gate asks whether the deployed commit is on the mainline"
 check_has "$VO" 'verify health version'   "the gate reads the version the relay reports"
 check_has "$VO" 'verify package version'  "the gate reads the version the checkout describes"
 check_has "$SCRIPT" 'Run the full deploy instead' \
   "a server that is not already deployed is sent to the full deploy, not verified"
+check_lacks "$SCRIPT" 'git rev-parse origin/main' \
+  "Va uses \$DEPLOY_REF, not a hard-coded origin/main"
+check_has "$VO" 'bash -s -- /opt/paramant-relay origin/main"   # verify preconditions' \
+  "the deploy ref is handed to the gate as an argument, so the log says which ref it judged"
 
 echo ""
 echo "6l-1. The gate says no when the checkout is not origin/main"
@@ -1605,6 +1686,148 @@ echo "6l-2. The three run modes do not combine"
 [ $? -eq 2 ] && pass "--verify-only with --rollback exits 2" \
              || fail "--verify-only and --rollback were accepted together"
 check_has "$SCRIPT" 'verify-only' "the usage header documents the mode"
+
+echo ""
+echo "6m. The verify-only gate: on the mainline, not necessarily at its tip"
+# The first spelling of this gate demanded HEAD == origin/main, which refuses
+# exactly the state it was written for. Run 6 deployed 4e6de0b and main had
+# already moved to 05bbd1b by the time the mode existed: main moves while a
+# deploy runs, and a deploy that is BEHIND the tip is the normal case, not a
+# fault. What is a fault is a checkout BESIDE the mainline, because then
+# nobody knows what is running. So the gate is merge-base --is-ancestor.
+#
+# The remote half of Va is a real git question, so it is asked of real
+# repositories here, one per answer.
+GV="$WORK/gverify"
+mkdir -p "$GV"
+extract_remote "verify preconditions" > "$GV/va.sh"
+if [ -s "$GV/va.sh" ]; then
+  pass "the Va remote block could be extracted from the script"
+else
+  fail "could not extract the Va remote block from the script"
+fi
+
+# make_va_repo <dir> <where>: a checkout that is either behind origin/main
+# (the run-6 shape) or on a branch beside it.
+make_va_repo() {
+  local d="$1" where="$2"
+  rm -rf "$d"; mkdir -p "$d"
+  (
+    set -e
+    cd "$d"
+    git init -q --bare origin.git
+    git --git-dir=origin.git symbolic-ref HEAD refs/heads/main
+    git init -q seed && cd seed
+    git config user.email t@example.com && git config user.name t
+    git config commit.gpgsign false
+    printf '{\n  "name": "p",\n  "version": "3.1.0"\n}\n' > package.json
+    git add -A && git commit -qm one
+    git branch -M main
+    git remote add origin ../origin.git
+    git push -q origin main
+    DEPLOYED="$(git rev-parse HEAD)"
+    echo two >> package.json.note && git add -A && git commit -qm two
+    git push -q origin main
+    cd ..
+    git clone -q origin.git checkout
+    cd checkout
+    git config user.email t@example.com && git config user.name t
+    git config commit.gpgsign false
+    if [ "$where" = behind ]; then
+      git checkout -q "$DEPLOYED"
+    else
+      # Beside the mainline: a commit that is not an ancestor of origin/main.
+      git checkout -q "$DEPLOYED"
+      git checkout -q -b sidetrack
+      echo sidetrack > sidetrack.txt
+      git add -A && git commit -qm "not on main"
+    fi
+  ) >/dev/null 2>&1
+}
+
+# The relay is not running here, so /health answers nothing. Stub curl to
+# report the version, which is the half of Va that is about the containers.
+mkdir -p "$GV/bin"
+cat > "$GV/bin/curl" <<'STUB'
+#!/bin/sh
+echo '{"status":"ok","version":"3.1.0"}'
+STUB
+chmod +x "$GV/bin/curl"
+
+echo ""
+echo "6m-1. A checkout one commit behind origin/main is accepted"
+make_va_repo "$GV/behind" behind
+BEHIND_HEAD="$(git -C "$GV/behind/checkout" rev-parse HEAD)"
+TIP="$(git -C "$GV/behind/checkout" rev-parse origin/main 2>/dev/null || echo none)"
+if [ "$BEHIND_HEAD" != "$TIP" ] && [ "$TIP" != none ]; then
+  pass "the fixture really is behind the tip ($(printf %s "$BEHIND_HEAD" | cut -c1-7) vs $(printf %s "$TIP" | cut -c1-7))"
+else
+  fail "the behind fixture is not behind anything, so it proves nothing"
+fi
+OUT20="$(PATH="$GV/bin:$PATH" bash "$GV/va.sh" "$GV/behind/checkout" origin/main </dev/null 2>&1)"; RC20=$?
+if [ "$RC20" -eq 0 ]; then pass "Va runs on a checkout behind the tip"; else
+  fail "Va exits $RC20 on a checkout behind the tip"
+  printf '%s\n' "$OUT20" | sed 's/^/        /' | head -12
+fi
+if [ "$(field_5c "$OUT20" 'verify ancestor')" = "yes" ]; then
+  pass "a commit behind the tip reads as on the mainline"
+else
+  fail "verify ancestor = '$(field_5c "$OUT20" 'verify ancestor')', expected yes"
+fi
+if [ "$(field_5c "$OUT20" 'verify head')" = "$BEHIND_HEAD" ]; then
+  pass "Va reports the DEPLOYED commit, which is what phase 7a writes as the marker"
+else
+  fail "Va reports head '$(field_5c "$OUT20" 'verify head')', expected $BEHIND_HEAD"
+fi
+if [ "$(field_5c "$OUT20" 'verify package version')" = "3.1.0" ] \
+   && [ "$(field_5c "$OUT20" 'verify health version')" = "3.1.0" ]; then
+  pass "the two versions are read and agree"
+else
+  fail "versions read as package='$(field_5c "$OUT20" 'verify package version')' health='$(field_5c "$OUT20" 'verify health version')'"
+fi
+
+echo ""
+echo "6m-2. A checkout beside the mainline is refused"
+make_va_repo "$GV/beside" beside
+OUT21="$(PATH="$GV/bin:$PATH" bash "$GV/va.sh" "$GV/beside/checkout" origin/main </dev/null 2>&1)"; RC21=$?
+if [ "$(field_5c "$OUT21" 'verify ancestor')" = "no" ]; then
+  pass "a commit beside the mainline reads as not an ancestor"
+else
+  fail "verify ancestor = '$(field_5c "$OUT21" 'verify ancestor')', expected no"
+  printf '%s\n' "$OUT21" | sed 's/^/        /' | head -12
+fi
+# An unresolvable ref is a third answer, and it must not read as yes.
+OUT22="$(PATH="$GV/bin:$PATH" bash "$GV/va.sh" "$GV/beside/checkout" origin/nope </dev/null 2>&1)"
+if [ "$(field_5c "$OUT22" 'verify ancestor')" = "unknown" ]; then
+  pass "a ref the server cannot resolve reads as unknown, not as yes"
+else
+  fail "an unresolvable ref reads as '$(field_5c "$OUT22" 'verify ancestor')'"
+fi
+
+echo ""
+echo "6m-3. The local half turns those three answers into a verdict"
+# Va's judgement is three lines of case, and the whole point of the review was
+# that the wrong comparison passed the tests. So assert the verdict text is
+# keyed on the ancestor answer and that equality with the tip is NOT a gate.
+check_has "$SCRIPT" 'case "\$ancestor" in' \
+  "Va decides on the ancestor answer"
+check_has "$SCRIPT" 'is not an ancestor of \$DEPLOY_REF' \
+  "the refusal names the mainline test, not an equality test"
+check_lacks "$SCRIPT" 'sha_eq "\$head" "\$omain"' \
+  "the old HEAD-equals-origin/main gate is gone"
+check_has "$SCRIPT" 'this mode signs off on the DEPLOYED commit' \
+  "being behind the ref is a note, not a stop"
+check_has "$SCRIPT" 'PARAMANT_VERIFY_HEAD' \
+  "the deployed commit can be named explicitly"
+# The note has to be a note. If "behind the tip" ever becomes a die again, the
+# word die will appear in the same branch as the note text.
+BEHIND_BRANCH="$(awk '/this mode signs off on the DEPLOYED commit/,/^  note "no tag/' "$SCRIPT")"
+if printf '%s\n' "$BEHIND_BRANCH" | grep -q '\bdie\b'; then
+  fail "the behind-the-tip branch can still stop the run"
+  printf '%s\n' "$BEHIND_BRANCH" | grep -n 'die' | sed 's/^/        /'
+else
+  pass "nothing in the behind-the-tip branch stops the run"
+fi
 
 echo ""
 echo "6d. The CI gate on main is one verdict per required workflow"

--- a/tests/deploy-3.1-dryrun.test.sh
+++ b/tests/deploy-3.1-dryrun.test.sh
@@ -1457,6 +1457,156 @@ else
 fi
 
 echo ""
+echo "6k. No remote block may let a command eat the script off stdin"
+# Deploy run 6 (TS 20260903-0259) landed phases 3, 4 and 5, six containers on
+# 3.1.0, the nginx edits applied, the site live, and then stopped in 6h on
+#
+#   STOP the server never printed 'effective outbound buffers'
+#
+# The body of a remote block is piped into `ssh ... bash -s`, so the script
+# text IS file descriptor 0, and bash reads it lazily. `docker compose exec -T`
+# reads stdin, so it swallowed everything bash had not parsed yet: the echo
+# below the for-loop was simply gone. The two lines the loop itself printed
+# came out fine, because the whole loop was parsed before it ran, which is
+# exactly what made the log look like a measurement failure rather than a
+# truncated script. 6i and the phase 7a marker never ran either, and the
+# missing marker is what would have stopped the next run in 1a.
+#
+# The rule: every stdin-reading command inside a remote heredoc gets
+# </dev/null. This scans the real blocks for the ones that do not.
+#
+# Heuristic, with its limit written down: backslash continuations are joined
+# first, comments are skipped, and a `read` is accepted when the line carries a
+# here-string or the loop it belongs to is redirected by a later `done <`.
+# That covers every shape this script uses. A `read` in some other shape would
+# be flagged, which is the safe direction to be wrong in.
+STDIN_SCAN="$WORK/stdin-scan.txt"
+awk '
+  # A block starts at a remote call ending in the heredoc marker.
+  /^  remote(_soft|_nginx)? ".*<<'"'"'EOF'"'"'$/ {
+    inb = 1; lbl = $0
+    sub(/^  remote(_soft|_nginx)? "/, "", lbl); sub(/".*$/, "", lbl)
+    ln = 0; n = 0; delete body; delete bln
+    next
+  }
+  inb && /^EOF$/ {
+    inb = 0
+    for (i = 1; i <= n; i++) {
+      line = body[i]
+      if (line ~ /^[[:space:]]*#/) continue
+      if (line ~ /docker compose exec|docker compose run|docker exec|docker run|(^|[^a-zA-Z_])ssh[[:space:]]/) {
+        if (line !~ /<[[:space:]]*\/dev\/null/) printf "%s\t%d\t%s\n", lbl, bln[i], line
+        continue
+      }
+      if (line ~ /(^|[;&|(][[:space:]]*|[[:space:]])read[[:space:]]/) {
+        if (line ~ /<<</ || line ~ /<[[:space:]]*\/dev\/null/) continue
+        redirected = 0
+        for (j = i + 1; j <= n; j++) if (body[j] ~ /^[[:space:]]*done[[:space:]]*</) { redirected = 1; break }
+        if (!redirected) printf "%s\t%d\t%s\n", lbl, bln[i], line
+      }
+    }
+    next
+  }
+  inb {
+    ln++
+    # Join backslash continuations, so a command whose </dev/null sits on the
+    # next line is judged whole.
+    if (pend != "") { pend = pend " " $0; pl = pl }
+    else { pend = $0; pl = ln }
+    if (pend ~ /\\$/) { sub(/\\$/, "", pend); next }
+    n++; body[n] = pend; bln[n] = pl; pend = ""
+  }
+' "$SCRIPT" > "$STDIN_SCAN"
+
+if [ ! -s "$STDIN_SCAN" ]; then
+  pass "every stdin-reading command in every remote block reads from /dev/null"
+else
+  fail "a command in a remote block would read the rest of the script off stdin"
+  sed 's/^/        /' "$STDIN_SCAN" | head -8
+fi
+
+# The scan has to be looking at something. If the block extraction breaks, the
+# check above passes on an empty search and proves nothing.
+SCAN_BLOCKS="$(grep -cE "^  remote(_soft|_nginx)? \".*<<'EOF'\$" "$SCRIPT" || true)"
+if [ "$SCAN_BLOCKS" -ge 10 ]; then
+  pass "the scan walked $SCAN_BLOCKS remote blocks, so it is looking at the real script"
+else
+  fail "the scan found only $SCAN_BLOCKS remote blocks; the extraction is stale"
+fi
+# And the three commands that actually read stdin are still there, guarded.
+check_has "$SCRIPT" 'docker compose exec -T "\$svc" sh -c .*</dev/null' \
+  "the 6h inline-receipt probe reads from /dev/null"
+check_has "$SCRIPT" '</dev/null 2>/dev/null \|\| echo "unreadable"' \
+  "the phase 1b env probe reads from /dev/null"
+check_has "$SCRIPT" 'docker exec "\$cid" grep -c _paraidAuth /app/relay\.js </dev/null' \
+  "the rollback paraidAuth probe reads from /dev/null"
+check_has "$FULL" 'effective outbound buffers' \
+  "the line run 6 lost is still in the 6h block"
+
+echo ""
+echo "6l. --verify-only finishes a deploy that died in the checks"
+# Run 6 did all the work and then lost 6h, 6i and the phase 7a marker. Redoing
+# the whole script to get those back would re-tag, re-back-up, re-pull, rebuild
+# and recreate six healthy containers. This mode runs phases 6 and 7 and gates
+# on the server already being deployed.
+VO="$WORK/verifyonly.txt"
+( cd "$ROOT" && bash "$SCRIPT" --dry-run --verify-only >"$VO" 2>&1 ); VO_RC=$?
+[ "$VO_RC" -eq 0 ] && pass "--dry-run --verify-only exits 0" \
+                   || fail "--dry-run --verify-only exits $VO_RC"
+check_has   "$VO" '^PHASE V: Preconditions for --verify-only' "verify-only gates before it verifies"
+check_has   "$VO" '^PHASE 6: Smoke tests'                     "verify-only runs phase 6"
+check_has   "$VO" '^PHASE 7: Summary'                         "verify-only runs phase 7"
+check_lacks "$VO" '^PHASE [0-5]: '                            "verify-only runs none of phases 0 to 5"
+check_has   "$VO" 'VERIFY ONLY FINISHED'                      "verify-only says where it stopped"
+check_has   "$VO" 'after deployed marker'                     "verify-only writes the deployed-head marker, which is the point"
+
+# The four things this mode must not do. Each is checked by the command that
+# would do it, not by a phase header, so moving a step between phases cannot
+# hide it.
+check_lacks "$VO" 'docker tag '                 "verify-only tags no rollback image"
+check_lacks "$VO" 'tar czf '                    "verify-only writes no backup"
+check_lacks "$VO" 'git pull --ff-only'          "verify-only pulls nothing"
+check_lacks "$VO" 'docker compose build'        "verify-only builds nothing"
+check_lacks "$VO" 'force-recreate'              "verify-only recreates no container"
+check_lacks "$VO" 'rsync -rc'                   "verify-only writes no docroot"
+check_lacks "$VO" 'sed -i -E .location = /sign' "verify-only edits no nginx conf"
+check_lacks "$VO" 'INTERNAL_AUTH_TOKEN=%s'      "verify-only writes nothing to .env"
+
+# The gate itself is a pure comparison, so both answers can be checked here.
+check_has "$VO" 'verify origin main'      "the gate reads origin/main off the server"
+check_has "$VO" 'verify health version'   "the gate reads the version the relay reports"
+check_has "$VO" 'verify package version'  "the gate reads the version the checkout describes"
+check_has "$SCRIPT" 'Run the full deploy instead' \
+  "a server that is not already deployed is sent to the full deploy, not verified"
+
+echo ""
+echo "6l-1. The gate says no when the checkout is not origin/main"
+# sha_eq is the same comparison phase 1a uses, and it is already extracted
+# above. These are the two ways the gate can refuse.
+if declare -F sha_eq >/dev/null; then
+  A2=aaaaaaa1111222233334444555566667777888899
+  B2=bbbbbbb1111222233334444555566667777888899
+  if sha_eq "$A2" "$A2"; then pass "the gate passes a checkout that equals origin/main"; else
+    fail "the gate would refuse a checkout that equals origin/main"; fi
+  if sha_eq "$A2" "$B2"; then fail "the gate would accept a checkout that is not origin/main"; else
+    pass "the gate refuses a checkout that is not origin/main"; fi
+  if sha_eq "$A2" ""; then fail "the gate would accept an empty origin/main"; else
+    pass "the gate refuses an unresolved origin/main"; fi
+else
+  fail "sha_eq was not available to test the verify-only gate with"
+fi
+
+echo ""
+echo "6l-2. The three run modes do not combine"
+( cd "$ROOT" && bash "$SCRIPT" --verify-only --preflight-only >/dev/null 2>&1 )
+[ $? -eq 2 ] && pass "--verify-only with --preflight-only exits 2" \
+             || fail "--verify-only and --preflight-only were accepted together"
+( cd "$ROOT" && bash "$SCRIPT" --verify-only --rollback 20260101-0000 >/dev/null 2>&1 )
+[ $? -eq 2 ] && pass "--verify-only with --rollback exits 2" \
+             || fail "--verify-only and --rollback were accepted together"
+check_has "$SCRIPT" 'verify-only' "the usage header documents the mode"
+
+echo ""
 echo "6d. The CI gate on main is one verdict per required workflow"
 # The old gate was `gh run list --branch main -L 5`: five runs of whichever
 # workflows happened to run last, with a stop on any `failure` among them. On


### PR DESCRIPTION
Hotfix na deploy-run 6.

## Feit uit productie

Run 6 (TS 20260903-0259, `deploy/logs/deploy-3.1-20260903-0259.log`) is geland.
Fase 3, 4 en 5 hebben hun werk gedaan: zes containers op 3.1.0,
`billing_config recurring:false`, docroot gesynct, de 5c-edits toegepast,
auth-smoke schoon, `/health` op 3.1.0, `/pararules` een 301 naar `/rules`. De
live site is nieuw. Toen stopte 6h op

```
STOP the server never printed 'effective outbound buffers'
```

De meting klopte. De regel was weg.

## Oorzaak

Elk remote-blok gaat als heredoc de pijp in naar `ssh ... bash -s`, dus de
scripttekst **is** stdin van de remote shell, en bash leest die lui, per
compound command. `docker compose exec -T` leest stdin, dus die slokte alles op
wat bash nog niet geparsed had. De twee `inline`-regels erboven kwamen wel
normaal, omdat de hele for-lus al geparsed was voordat hij draaide. Precies
daarom las het log als een mislukte meting en niet als een afgekapt script.

Gevolg: 6h, 6i en de 7a-marker draaiden niet. En een ontbrekende marker is wat
de volgende run in 1a zou stoppen.

## Fix 1: `</dev/null`

Op elk stdin-lezend commando in elk remote-heredoc. Er waren er drie: de
6h inline-receipt-probe, de fase 1b env-probe, en de rollback-paraidAuth-probe.

De dry-run-suite scant nu elk remote-blok in het script op de regel. Backslash-
continuaties worden eerst samengevoegd, zodat een guard op de volgende regel
meetelt; een `read` wordt geaccepteerd als zijn lus al geredirect is
(`done < "$f"`, `done < <(...)`) of als hij een here-string krijgt. De
heuristiek en haar grens staan bij de check opgeschreven. De scan controleert
ook dat hij 25 blokken zag, zodat een kapotte extractie niet stil op een lege
zoekruimte slaagt.

## Fix 2: `--verify-only`

Run 6 liet de server correct achter en de marker ontbrekend. Het hele script
opnieuw draaien voor twee checks en één bestand zou opnieuw taggen, back-uppen,
pullen, bouwen en zes gezonde containers hercreeren.

`bash deploy/deploy-3.1.sh --verify-only` draait fase 6 en 7 en verder niets:
geen tags, geen backups, geen pull, geen build, geen recreate, geen nginx-edit,
geen `.env`-schrijf.

De modus poortwachtert eerst, in de geest van 1a, en weigert tenzij:

- de server-checkout op `origin/main` staat (eerst gefetcht, dus de ref is echt)
- `/health` dezelfde versie meldt als `package.json` in die checkout, wat zegt
  dat de draaiende containers daaruit gebouwd zijn

Een van beide mis en hij stopt met "Run the full deploy instead". Combineert
niet met `--preflight-only` of `--rollback`; dat zijn drie losse runs en het
script exit 2 als je er twee vraagt.

## Bewijs

`bash tests/deploy-3.1-dryrun.test.sh`: 315 checks groen, was 284.

- **6k** de stdin-scan over alle 25 remote-blokken, plus een expliciete check op
  elk van de drie commando's, plus een check dat de regel die run 6 verloor nog
  in het 6h-blok staat
- **6l** verify-only draait V, 6 en 7, en geen enkele van fase 0 tot en met 5.
  De vier dingen die de modus niet mag doen zijn getoetst op de **commando's**
  die ze zouden doen (`docker tag`, `tar czf`, `git pull --ff-only`,
  `docker compose build`, `force-recreate`, `rsync -rc`, de 5c-`sed -i`, de
  `.env`-schrijf), niet op fase-headers, zodat het verplaatsen van een stap
  tussen fasen dit niet kan verbergen. Plus: de marker wordt wel geschreven,
  want daar is het om begonnen
- **6l-1** de poort zelf, via dezelfde `sha_eq` die 1a gebruikt: gelijk laat
  door, ongelijk weigert, een onopgeloste `origin/main` weigert
- **6l-2** de drie modi combineren niet, beide combinaties exit 2

Sabotage, drie richtingen:

- `</dev/null` van de 6h-probe halen reproduceert run 6: 2 rood
- `</dev/null` van de **meerregelige** 1b-probe halen: dezelfde 2 rood, wat
  bewijst dat de continuatie-join werkt en niet toevallig slaagt
- `--verify-only` `phase_3` laten aanroepen: 3 rood, waaronder "verify-only
  pulls nothing"

Alle drie teruggezet, 315 weer groen.

Verder groen: `tests/static-sanity.sh` PASS, `scripts/check-test-declarations.sh`
(118 suites), `scripts/check-commit-style.sh`, `shellcheck -S error` op beide
bestanden, geen em-dashes in toegevoegde regels.

## Daarna

`bash deploy/deploy-3.1.sh --verify-only` maakt 6h, 6i en de deployed-head-marker
af op de server zoals run 6 hem achterliet.
