### PR TITLE
The navigation bar speaks the language of the page it sits on, and a phone gets one button

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -25,8 +25,8 @@
     footer{padding:20px 24px;text-align:center;font-size:11px;color:#94A3B8;border-top:1px solid #E2E8F0}
   </style>
 <style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <style>
@@ -46,7 +46,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -61,7 +61,11 @@
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
 </div>
-<script src="/nav.js?v=14" defer></script>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
+</div>
+<script src="/nav.js?v=15" defer></script>
 <main id="main-content">
   <div class="wrap">
     <aside class="parapear-block" aria-label="Page not found">
@@ -111,6 +115,6 @@
     </div>
   </div>
 </footer>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -26,8 +26,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .about-band{padding:var(--space-8) 0;border-top:1px solid var(--ink-hair)}
@@ -140,7 +140,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -154,6 +154,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <!-- HERO -->
@@ -286,7 +290,7 @@
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -8,8 +8,8 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta property="og:title" content="Your account · Paramant">
 <meta property="og:description" content="Your account · Paramant">
@@ -139,7 +139,7 @@ main.acct input::placeholder { color: var(--ink-3); }
 @media (max-width: 680px) { .acct-grid2 { grid-template-columns: 1fr; gap: var(--space-4); } main.acct { padding: var(--space-5) var(--space-3) var(--space-6); } }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=2">
+<link rel="stylesheet" href="/app-2026.css?v=3">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>
@@ -156,7 +156,7 @@ main.acct input::placeholder { color: var(--ink-3); }
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -170,6 +170,10 @@ main.acct input::placeholder { color: var(--ink-3); }
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main id="main-content" class="acct">
@@ -394,8 +398,8 @@ main.acct input::placeholder { color: var(--ink-3); }
 
 </main>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script src="/js/account.inline1.js?v=2"></script>
 
 <script type="module" src="/js/account.inline2.js?v=3"></script>

--- a/frontend/all-systems-go.html
+++ b/frontend/all-systems-go.html
@@ -6,8 +6,8 @@
   <title>All systems · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/all-systems-go">
-  <link rel="stylesheet" href="/design-system.css?v=24">
-  <link rel="stylesheet" href="/nav.css?v=19">
+  <link rel="stylesheet" href="/design-system.css?v=25">
+  <link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
     .asg { max-width: 560px; margin: 64px auto; padding: 0 24px; }

--- a/frontend/app-2026.css
+++ b/frontend/app-2026.css
@@ -550,10 +550,17 @@ footer .logo .a { color: var(--ink-1); }
 .theme-choice input:focus-visible + span { box-shadow: var(--ring); border-radius: var(--r-1); }
 
 
-/* The signed-out nav CTA is the one allowed lime field, and the only text
-   that may sit on it is #0A1626 (14.94:1). The app pages set this with
-   !important in their own head, so it is corrected with the same weight. */
-.nav-cta, a.nav-cta, .nav .nav-cta { color: var(--mark-on) !important; background: var(--mark); }
+/* The signed-out nav CTA used to be the one allowed lime field, with #0A1626
+   on it. It is cobalt now, in the bar and on the homepage: lime is the
+   punctuation of this brand and not the colour of its primary action, and next
+   to a cobalt hero button a lime bar button read as a second, competing offer.
+   White on #1D4ED8 is 6.3:1. Kept at the same weight as before, so an app page
+   cannot drift back to the lime field it was corrected out of. */
+.nav-cta, a.nav-cta, .nav .nav-cta {
+  color: #FFFFFF !important;
+  background: #1D4ED8 !important;
+  border-color: #1D4ED8 !important;
+}
 
 /* ═══════════════════════════════════════════════════════════════════════════
    7. MOTION AND POINTERS

--- a/frontend/apply-nav.py
+++ b/frontend/apply-nav.py
@@ -16,7 +16,7 @@ NEW_NAV = '''\
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -26,12 +26,22 @@ NEW_NAV = '''\
   </button>
 </nav>'''
 
+# The drawer itself carries the four destinations and nothing else: it mirrors
+# the desktop bar, and js/nav-auth.js rewrites its whole inside after the
+# session check. The two secondary routes a phone loses from the bar -- Sign in
+# and Help -- therefore hang under it as their own strip, which nav.js opens
+# and closes with the drawer and nav-auth.js removes once you are signed in
+# (the user menu carries both from then on).
 NEW_MOBILE = '''\
 <div class="nav-mobile" id="nav-mobile">
   <a href="/#products" class="nav-mobile-standalone">Product</a>
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>'''
 
 # Footer template - the site-map footer is gone. What stays is the company
@@ -77,10 +87,10 @@ LEGAL_STRIP = '''\
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>
 </footer>'''
 
-DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=24">'
-NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=19">'
-NAV_JS    = '<script src="/nav.js?v=14" defer></script>'
-NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=5" defer></script>'
+DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=25">'
+NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=20">'
+NAV_JS    = '<script src="/nav.js?v=15" defer></script>'
+NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=6" defer></script>'
 
 # Pages that don't have <nav class="nav"> yet but should — inject the canonical
 # nav after <body> (or after a skip-link if present). App shells (admin,
@@ -189,7 +199,15 @@ def inject_nav_block(html):
 
 
 def replace_mobile_div(html):
-    """Replace <div class="nav-mobile"...>...</div>, counting nested divs."""
+    """Replace <div class="nav-mobile"...>...</div>, counting nested divs.
+
+    NEW_MOBILE stamps two siblings: the drawer and its tail. An earlier run
+    left a tail behind, and the div counter below stops at the drawer's own
+    </div>, so without this the second run would leave the old tail sitting
+    after the new one and the idempotency gate would go red. The tail holds
+    anchors and no nested divs, so one non-greedy match takes it out."""
+    html = re.sub(r'\n?<div class="nav-mobile-tail".*?</div>', '',
+                  html, flags=re.DOTALL)
     start = html.find('<div class="nav-mobile"')
     if start == -1:
         nav_end = html.find('</nav>') + len('</nav>')

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -26,8 +26,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -281,7 +281,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -295,6 +295,10 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main id="main-content">
@@ -744,7 +748,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -19,8 +19,8 @@
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="canonical" href="https://paramant.app/audit-log-export">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}
@@ -140,7 +140,7 @@ section p+p{margin-top:14px}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -154,6 +154,10 @@ section p+p{margin-top:14px}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <div class="hero">
@@ -246,7 +250,7 @@ section p+p{margin-top:14px}
     </div>
   </div>
 </footer>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -9,8 +9,8 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 /* Een auth-scherm is op een telefoon één taak. Kop, één zin en de knop moeten
@@ -23,7 +23,7 @@
 }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=2">
+<link rel="stylesheet" href="/app-2026.css?v=3">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>
@@ -39,7 +39,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -53,6 +53,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main class="container-sm">
@@ -105,8 +109,8 @@
 </p>
 </main>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script src="/js/auth-backup.js?v=2"></script>
 
 <footer class="legal-strip">

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -21,8 +21,8 @@
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 /* Compact auth layout — existing design tokens only; design-system.css untouched. */
@@ -46,7 +46,7 @@
 .auth-note a { color: var(--navy); }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=2">
+<link rel="stylesheet" href="/app-2026.css?v=3">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>
@@ -62,7 +62,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -76,6 +76,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main class="auth-wrap">
@@ -130,8 +134,8 @@
 </main>
 
 <script src="/js/pow-captcha.js?v=1"></script>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script src="/js/auth-login.js?v=3"></script>
 <script type="module" src="/js/passkey.js?v=3"></script>
 

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -9,8 +9,8 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 /* Same compact phone rhythm as /auth/backup: existing tokens only,
@@ -21,7 +21,7 @@
 }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=2">
+<link rel="stylesheet" href="/app-2026.css?v=3">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>
@@ -37,7 +37,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -51,6 +51,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main class="container-sm">
@@ -94,8 +98,8 @@
 </main>
 
 <script src="/js/pow-captcha.js?v=1"></script>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script src="/js/auth-request-reset.js?v=2"></script>
 <footer class="legal-strip">
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -9,8 +9,8 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 /* Same compact phone rhythm as /auth/backup: existing tokens only,
@@ -32,7 +32,7 @@
   }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=2">
+<link rel="stylesheet" href="/app-2026.css?v=3">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>
@@ -48,7 +48,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -62,6 +62,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main class="container-sm">
@@ -109,8 +113,8 @@
 </section>
 </main>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script src="/js/auth-reset-confirm.js?v=3"></script>
 <footer class="legal-strip">
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -9,8 +9,8 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <script src="/js/qrcode.min.js?v=1"></script>
 <style>
@@ -24,7 +24,7 @@
 }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=2">
+<link rel="stylesheet" href="/app-2026.css?v=3">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>
@@ -40,7 +40,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -54,6 +54,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main class="container-lg">
@@ -279,8 +283,8 @@
 </p>
 </main>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script src="/js/auth-setup.js?v=2"></script>
 <script type="module" src="/js/passkey.js?v=3"></script>
 

--- a/frontend/billing/checkout.html
+++ b/frontend/billing/checkout.html
@@ -9,7 +9,7 @@
 <link rel="canonical" href="https://paramant.app/pricing">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=24">
+<link rel="stylesheet" href="/design-system.css?v=25">
 <style>
   body { background: var(--bone); }
   .checkout-wrap { max-width: 480px; margin: var(--space-10) auto; padding: 0 var(--space-5); text-align: center; }

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -23,8 +23,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -120,7 +120,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -135,9 +135,13 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
 </div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
+</div>
 
 <nav id="nav"></nav>
-<script src="/nav.js?v=14"></script>
+<script src="/nav.js?v=15"></script>
 
 <main id="main-content">
   <section class="page-hero">
@@ -290,7 +294,7 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/claim.html
+++ b/frontend/claim.html
@@ -8,7 +8,7 @@
 <meta name="robots" content="noindex, nofollow">
 <meta name="referrer" content="no-referrer">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/design-system.css?v=24">
+<link rel="stylesheet" href="/design-system.css?v=25">
 <style>
   .claim-wrap{max-width:560px;margin:8vh auto;padding:0 20px}
   .claim-card{background:#fff;border:1px solid #E2E8F0;border-radius:10px;padding:32px}

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -25,8 +25,8 @@
 <link rel="canonical" href="https://paramant.app/co-sign">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -19,8 +19,8 @@
 <meta name="twitter:title" content="Crypto agility · Paramant">
 <meta name="twitter:description" content="Algorithms you can swap without rebuilding. Identifiers travel in the header, not in the code path. NIST FIPS 203, 204, 205 and 206 loaded in production.">
 <link rel="canonical" href="https://paramant.app/crypto-agility">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}
@@ -229,7 +229,7 @@ section h2{display:flex;align-items:baseline;gap:11px}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -243,6 +243,10 @@ section h2{display:flex;align-items:baseline;gap:11px}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <div class="hero">
@@ -585,7 +589,7 @@ FLAGS    1 byte    reserved for future features</pre>
     </div>
   </div>
 </footer>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -17,8 +17,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta property="og:title" content="Certificate transparency log · Paramant">
 <meta property="og:description" content="Every public key registration is appended to a tamper-evident Merkle tree. Anyone can verify that a device was registered, without seeing the payload.">
@@ -275,7 +275,7 @@ body { min-height:100vh; }
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -289,6 +289,10 @@ body { min-height:100vh; }
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <div class="hero">
@@ -424,7 +428,7 @@ body { min-height:100vh; }
     </div>
   </div>
 </footer>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -10,8 +10,8 @@
 <meta name="description" content="Sign in to your Paramant dashboard.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://relay.paramant.app">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <noscript><meta http-equiv="refresh" content="0;url=/auth/login?next=/dashboard"></noscript>
@@ -340,7 +340,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=2">
+<link rel="stylesheet" href="/app-2026.css?v=3">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>
@@ -360,7 +360,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -374,6 +374,10 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 
@@ -623,8 +627,8 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script src="/js/dashboard.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/design-system.css
+++ b/frontend/design-system.css
@@ -2447,101 +2447,14 @@ pre code { background: none; padding: 0; }
 .stub-banner { background: #fef3c7; border: 1.5px solid #d97706; padding: var(--space-4) var(--space-5); }
 .stub-banner strong { color: #92400e; }
 
-/* === nav auth additions === */
-.nav-auth { display: flex; align-items: center; gap: 12px; margin-left: auto; }
-
-.nav-signin {
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--ink-mid, #64748b);
-  text-decoration: none;
-  font-weight: 700;
-  padding: 8px 4px;
-}
-.nav-signin:hover { color: var(--navy); }
-
-.nav-cta {
-  display: inline-block;
-  padding: 9px 16px;
-  background: var(--lime);
-  color: var(--navy);
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  font-weight: 700;
-  text-decoration: none;
-  border: 2px solid var(--lime);
-  transition: background 0.15s, border-color 0.15s;
-}
-.nav-cta:hover { background: var(--navy); border-color: var(--navy); color: var(--bone); }
-
-.nav-user { position: relative; }
-.nav-user-trigger {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 12px;
-  background: transparent;
-  border: 1.5px solid var(--ink-hair);
-  cursor: pointer;
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 0.1em;
-  color: var(--navy);
-  font-weight: 700;
-}
-.nav-user-trigger:hover { border-color: var(--cobalt); }
-.nav-user-email { text-transform: none; letter-spacing: 0; font-family: var(--sans, system-ui, sans-serif); font-size: 13px; font-weight: 500; }
-.nav-user-chevron { font-size: 10px; color: var(--ink-dim); }
-
-.nav-user-menu {
-  position: absolute;
-  right: 0;
-  top: calc(100% + 6px);
-  min-width: 200px;
-  background: var(--bone);
-  border: 1px solid var(--ink-hair);
-  box-shadow: 0 6px 24px rgba(15, 23, 42, 0.08);
-  padding: 6px 0;
-  z-index: 100;
-}
-.nav-user-menu[hidden] { display: none; }
-.nav-menu-item {
-  display: block;
-  width: 100%;
-  text-align: left;
-  padding: 10px 16px;
-  font-family: var(--sans, system-ui, sans-serif);
-  font-size: 13px;
-  color: var(--ink);
-  text-decoration: none;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-}
-.nav-menu-item:hover { background: rgba(29, 78, 216, 0.06); color: var(--cobalt); }
-.nav-menu-signout { color: #991b1b; }
-.nav-menu-signout:hover { background: rgba(220, 38, 38, 0.06); color: #991b1b; }
-.nav-menu-divider { height: 1px; background: var(--ink-hair); margin: 4px 0; }
-
-@media (max-width: 720px) {
-  .nav-auth { gap: 6px; }
-  .nav-signin { font-size: 10px; padding: 8px 2px; letter-spacing: 0.08em; }
-  .nav-cta { padding: 7px 10px; font-size: 9px; letter-spacing: 0.08em; border-width: 1.5px; }
-  .nav-help { padding: 6px 7px; font-size: 9px; letter-spacing: 0.06em; }
-  .nav-user-email { max-width: 120px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-}
-
-@media (max-width: 400px) {
-  .nav-auth { gap: 4px; }
-  .nav-signin { font-size: 9px; padding: 6px 2px; }
-  .nav-cta { padding: 6px 8px; font-size: 9px; }
-  .nav-help { padding: 5px 5px; font-size: 9px; border: none; }
-}
-/* === end nav auth === */
+/* De navigatiebalk staat in frontend/nav.css. Die had hier een tweede huis:
+   .nav-auth, .nav-signin, .nav-cta, .nav-user en .nav-help stonden in dit
+   bestand en de rest van de balk in nav.css, met twee losse media-queries
+   die de knop op een telefoon kleiner maakten in plaats van hem ruimte te
+   geven. Een balk die over twee stylesheets ligt is een balk waar niemand
+   het geheel van ziet. Alles staat nu in nav.css. Geen pagina laadt de een
+   zonder de ander: vault.html, billing/checkout.html en claim.html laden
+   design-system.css zonder nav.css en dragen geen van deze klassen. */
 
 
 /* ═══════════════════════════════════════════════════
@@ -2891,37 +2804,6 @@ a.skip-link:focus-visible,
 @media (max-width: 500px) {
   .hero-trust-strip { grid-template-columns: 1fr; }
   .hero-split { padding: 32px 16px 64px 16px; }
-}
-
-/* ── Nav help link ──────────────────────────────────────── */
-.nav-help {
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--ink-mid, #64748b);
-  text-decoration: none;
-  font-weight: 700;
-  padding: 8px 12px;
-  border: 1px solid var(--ink-hair, #E2E8F0);
-  transition: all 140ms ease;
-  white-space: nowrap;
-}
-.nav-help:hover {
-  color: var(--navy, #0B3A6A);
-  border-color: var(--lime, #B2FF3F);
-  background: rgba(178, 255, 63, 0.08);
-}
-.nav-help:focus-visible {
-  outline: 2px solid var(--lime, #B2FF3F);
-  outline-offset: 2px;
-}
-/* Support must stay reachable on every screen. Below 900px the link shrinks
-   instead of disappearing: the mobile drawer mirrors the desktop nav links and
-   deliberately carries no Help entry, so hiding this one used to leave phone
-   and tablet visitors with no route to /help at all. */
-@media (max-width: 900px) {
-  .nav-help { padding: 7px 9px; font-size: 10px; letter-spacing: 0.08em; }
 }
 
 /* § 05 product grid — light-theme column differentiation ───────────────── */

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -9,8 +9,8 @@
 <meta name="robots" content="noindex,nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0b3a6a">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <style>
 *{box-sizing:border-box}
 body{background:linear-gradient(180deg,#f8faff 0,#f5f7fb 460px)}
@@ -151,8 +151,8 @@ curl -X POST https://paramant.app/v1/envelopes \
   </div>
 </div>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script src="/js/developer.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -61,6 +61,10 @@ pre{margin:0;padding:20px;background:#0d1d33;color:#d7e7f8;overflow:auto;font-fa
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Open menu" aria-expanded="false"><span></span><span></span><span></span></button>
 </nav>
 <div class="nav-mobile" id="nav-mobile"><a href="/dashboard" class="nav-mobile-standalone">Documents</a><a href="/developer" class="nav-mobile-standalone" aria-current="page">Developer settings</a></div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
+</div>
 
 <main id="main" class="dev">
   <nav class="settings-tabs" aria-label="Settings sections">

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -20,8 +20,8 @@
 <meta name="twitter:description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
 <link rel="canonical" href="https://paramant.app/docs">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}
@@ -223,7 +223,7 @@ tr:last-child td{border-bottom:none}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -237,6 +237,10 @@ tr:last-child td{border-bottom:none}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <section class="docs-hero">
@@ -1036,8 +1040,8 @@ python3 scripts/paramant-admin.py sync</pre>
 </div>
 
 <script src="/js/docs.inline1.js?v=1"></script>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <footer>
   <div class="container-lg">
     <div class="footer-grid footer-slim">

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -66,8 +66,8 @@ pre{font-family:var(--mono);font-size:12px;line-height:1.7;color:var(--ink);back
 @media(max-width:600px){h1{font-size:25px}.dl-sub{font-size:15px}main{padding:0 18px 60px}.dl-lead{padding:28px 0 30px}}
 </style>
 <style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <script type="application/ld+json" data-paramant-seo="1">
 {
@@ -145,7 +145,7 @@ pre{font-family:var(--mono);font-size:12px;line-height:1.7;color:var(--ink);back
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -159,6 +159,10 @@ pre{font-family:var(--mono);font-size:12px;line-height:1.7;color:var(--ink);back
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main id="main-content">
@@ -266,8 +270,8 @@ sha256sum -c SHA256SUMS --ignore-missing</pre>
 
 </main>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 
 <footer>
   <div class="container-lg">

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -19,8 +19,8 @@
 <meta name="twitter:title" content="Data processing agreement · Paramant">
 <meta name="twitter:description" content="The GDPR Article 28 agreement between Paramantis Solutions B.V. as processor and your organisation as controller. Sign it electronically, EU and German law.">
 <link rel="canonical" href="https://paramant.app/dpa">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-hair)}
@@ -189,7 +189,7 @@ input:focus{border-color:var(--cobalt)}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -203,6 +203,10 @@ input:focus{border-color:var(--cobalt)}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <div class="wrap">
@@ -373,7 +377,7 @@ input:focus{border-color:var(--cobalt)}
 </footer>
 
 <script src="/js/dpa.inline1.js?v=1"></script>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -29,8 +29,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -147,7 +147,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -161,6 +161,10 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 <main id="main-content">
 
@@ -292,8 +296,8 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
     </div>
   </div>
 </footer>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/get.page.js?v=2" defer></script>

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -72,8 +72,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
@@ -224,7 +224,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -238,6 +238,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div><main>
 
   <div class="breadcrumb">
@@ -367,7 +371,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -58,8 +58,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
@@ -210,7 +210,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -224,6 +224,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
   <div class="nav-mobile-cta">
     <a href="/help" class="nav-help-mobile nav-mobile-standalone">HELP</a>
@@ -301,7 +305,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -72,8 +72,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
@@ -224,7 +224,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -238,6 +238,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div><main>
 
   <div class="breadcrumb">
@@ -402,7 +406,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -74,8 +74,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
@@ -226,7 +226,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -240,6 +240,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div><main>
 
   <div class="breadcrumb">
@@ -374,7 +378,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -76,8 +76,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
@@ -228,7 +228,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -242,6 +242,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div><main>
 
   <div class="breadcrumb">
@@ -408,7 +412,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -56,8 +56,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <style>
@@ -204,7 +204,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -218,6 +218,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div><main>
 
   <h1>Help</h1>
@@ -358,7 +362,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -71,8 +71,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
@@ -223,7 +223,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -237,6 +237,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div><main>
 
   <div class="breadcrumb">
@@ -389,7 +393,7 @@ print(resp.json()["url"])</div>
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -70,8 +70,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
@@ -222,7 +222,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -236,6 +236,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div><main>
 
   <div class="breadcrumb">
@@ -360,7 +364,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -76,8 +76,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
@@ -228,7 +228,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -242,6 +242,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div><main>
 
   <div class="breadcrumb">
@@ -396,7 +400,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -70,8 +70,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
@@ -222,7 +222,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -236,6 +236,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div><main>
 
   <div class="breadcrumb">
@@ -363,7 +367,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,8 +22,8 @@
 <link rel="canonical" href="https://paramant.app/">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="manifest" href="/manifest.json">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <style>
 /* Homepage 2026: the vanishing document. Paper, ink, one accent, one dark object per screen. */
 :root{
@@ -334,7 +334,7 @@ footer{background:var(--hp-paper-2);border-top:1px solid var(--hp-line)}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -348,6 +348,10 @@ footer{background:var(--hp-paper-2);border-top:1px solid var(--hp-line)}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 <main id="main-content" role="main">
 
@@ -583,8 +587,8 @@ footer{background:var(--hp-paper-2);border-top:1px solid var(--hp-line)}
     </div>
   </div>
 </footer>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script src="/js/home-auth.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/js/nav-auth.js
+++ b/frontend/js/nav-auth.js
@@ -46,13 +46,18 @@
 
   function renderLoggedOut() {
     setNavigation(PUBLIC_NAV, 'Primary');
-    container.innerHTML = '<a href="/help" class="nav-help">HELP</a>' +
+    container.innerHTML = '<a href="/help" class="nav-help">Help</a>' +
       '<a href="/auth/login" class="nav-signin">Sign in</a>' +
       '<a href="/signup" class="nav-cta">Create account</a>';
   }
 
   function renderLoggedIn(email) {
     setNavigation(APP_NAV, 'Workspace');
+    // The drawer tail offers Sign in and Help to a visitor who is not signed
+    // in. Once you are, both are wrong there: the user menu below carries
+    // Help, and Sign in is not an action you still need.
+    var tail = document.getElementById('nav-mobile-tail');
+    if (tail) tail.remove();
     var shortEmail = email.length > 24 ? email.slice(0, 18) + '...' : email;
     // Never interpolate the email into innerHTML (stored/self DOM XSS): the
     // signup regex permits HTML metacharacters. Build static markup, then set

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -26,8 +26,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -169,7 +169,7 @@ footer a{color:var(--cobalt)}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -183,6 +183,10 @@ footer a{color:var(--cobalt)}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main id="main-content">
@@ -317,7 +321,7 @@ all other recipients of the licensed work to be provided by Licensor:
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/nav.css
+++ b/frontend/nav.css
@@ -7,6 +7,11 @@ nav.nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  /* space-between hands all slack to one place, so the last two children end
+     up shoulder to shoulder. On a 390px phone that put the account button
+     against the hamburger, both starting at x=330. A gap is the floor: no two
+     elements in this bar are ever closer than 16px, 12px on a phone. */
+  gap: var(--space-4);
   padding: 0 40px;
   height: 56px;
   background: rgba(248,250,252,.92);
@@ -26,6 +31,9 @@ nav.nav .nav-logo {
   letter-spacing: .04em;
   text-decoration: none;
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
 }
 nav.nav .nav-logo .logo-para { font-weight: 400; color: var(--ink); }
 nav.nav .nav-logo .logo-mant { font-weight: 700; color: var(--cobalt); }
@@ -34,7 +42,7 @@ nav.nav .nav-logo .logo-mant { font-weight: 700; color: var(--cobalt); }
 nav.nav .nav-links {
   display: flex;
   align-items: center;
-  gap: var(--space-1);
+  gap: 2px;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -165,20 +173,24 @@ nav.nav .nav-dropdown-menu li a:focus {
 /* ════════════════════════════════════════
    STANDALONE NAV LINKS
    ════════════════════════════════════════ */
+/* PRODUCT SECURITY PRICING DOCS was four words of mono capitals over a page
+   set in sentences. Mono plus uppercase plus letter-spacing is the voice of a
+   terminal, and it read as louder than the headline underneath it. Same four
+   destinations, same order, written the way the page writes. */
 nav.nav .nav-link {
-  color: var(--ink);
-  font-size: var(--text-xs);
-  font-family: var(--mono);
-  letter-spacing: .04em;
-  text-transform: uppercase;
-  padding: var(--space-2) var(--space-3);
+  color: var(--ink-2);
+  font-size: 14px;
+  font-family: var(--sans);
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  padding: 0 var(--space-3);
   text-decoration: none;
-  transition: color var(--duration-base) var(--ease-sharp),
-              box-shadow var(--duration-base) var(--ease-out);
+  transition: color var(--duration-base) var(--ease-sharp);
   white-space: nowrap;
   display: flex;
   align-items: center;
-  height: 32px;
+  min-height: 40px;
   position: relative;
 }
 nav.nav .nav-link::after {
@@ -186,7 +198,7 @@ nav.nav .nav-link::after {
   position: absolute;
   left: var(--space-3);
   right: var(--space-3);
-  bottom: 4px;
+  bottom: 8px;
   height: 2px;
   background: var(--cobalt);
   transform: scaleX(0);
@@ -234,20 +246,27 @@ nav.nav .nav-link.active::after { transform: scaleX(1); }
 nav.nav .nav-hamburger {
   display: none;
   flex-direction: column;
+  align-items: center;
   justify-content: center;
   gap: 5px;
   background: none;
   border: 1px solid var(--ink-hair);
+  border-radius: 3px;
   cursor: pointer;
-  padding: var(--space-2);
-  height: 36px;
-  width: 36px;
+  padding: 0;
+  height: 44px;
+  width: 44px;
+  flex-shrink: 0;
   transition: border-color var(--duration-base) var(--ease-sharp),
               background var(--duration-base) var(--ease-sharp);
 }
 nav.nav .nav-hamburger:hover {
-  border-color: #B2FF3F;
-  background: rgba(178,255,63,0.1);
+  border-color: var(--cobalt);
+  background: rgba(29,78,216,.05);
+}
+nav.nav .nav-hamburger:focus-visible {
+  outline: 3px solid rgba(29,78,216,.35);
+  outline-offset: 2px;
 }
 nav.nav .nav-hamburger span {
   display: block;
@@ -278,6 +297,8 @@ nav.nav .nav-hamburger[aria-expanded="true"] span:nth-child(3) {
   display: none;
   position: fixed;
   top: 56px;
+  /* the tail (sign in + help) is pinned to the bottom of the drawer */
+  padding-bottom: 132px;
   left: 0;
   right: 0;
   bottom: 0;
@@ -377,34 +398,39 @@ nav.nav .nav-hamburger[aria-expanded="true"] span:nth-child(3) {
 
 /* Standalone direct link */
 .nav-mobile-standalone {
-  display: block;
-  padding: var(--space-4) var(--space-5);
+  display: flex;
+  align-items: center;
+  min-height: 56px;
+  padding: 0 var(--space-5);
   padding-left: calc(var(--space-5) - 2px);
   color: var(--ink);
   text-decoration: none;
-  font-family: var(--mono);
-  font-size: var(--text-xs);
-  font-weight: 700;
-  letter-spacing: .1em;
-  text-transform: uppercase;
+  font-family: var(--sans);
+  font-size: 16px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
   border-bottom: 1px solid var(--ink-hair);
   border-left: 2px solid transparent;
   transition: color var(--duration-base) var(--ease-sharp),
               border-left-color var(--duration-base) var(--ease-sharp),
               background var(--duration-base) var(--ease-sharp);
 }
+/* Where you are, and where you would go, are said in the same colour as on the
+   desktop bar: cobalt. The lime wash that used to fill the current row was the
+   loudest thing in a drawer that is otherwise four words. */
 .nav-mobile-standalone:hover,
 .nav-mobile-standalone:focus-visible {
-  color: #0B3A6A;
-  border-left-color: #B2FF3F;
-  background: rgba(178,255,63,0.08);
+  color: var(--cobalt);
+  border-left-color: var(--cobalt);
+  background: rgba(29,78,216,.04);
   outline: none;
 }
 .nav-mobile-standalone[aria-current="page"] {
-  color: #0B3A6A;
-  border-left-color: #B2FF3F;
-  background: rgba(178,255,63,0.12);
-  font-weight: 700;
+  color: var(--cobalt);
+  border-left-color: var(--cobalt);
+  background: rgba(29,78,216,.06);
+  font-weight: 600;
 }
 
 /* Body scroll lock */
@@ -441,7 +467,8 @@ body.nav-locked .nav {
 @media (max-width: 1023px) {
   .meta-bar { display: none; }
   nav.nav {
-    padding: 0 24px;
+    padding: 0 16px;
+    gap: var(--space-3);
     background: var(--bone);
     -webkit-backdrop-filter: none;
     backdrop-filter: none;
@@ -608,3 +635,228 @@ nav.nav .nav-link-btn:hover {
 /* Beeldmerk-logo: de blauwe P met lime stip als de P van Paramant. */
 nav.nav .nav-logo { display: inline-flex; align-items: center; gap: 0; color: var(--ink); font-weight: 600; }
 nav.nav .nav-logo-mark { height: 20px; width: 20px; border-radius: 4px; margin-right: 1px; display: block; }
+
+/* ════════════════════════════════════════
+   THE RIGHT-HAND SIDE: HELP, SIGN IN, ONE BUTTON
+   Moved here out of design-system.css. The bar used to live in two
+   stylesheets, and the half in design-system.css answered a narrow phone by
+   shrinking: 9px type, 5px padding, the Help border dropped. Small is not the
+   same as roomy. Below 1024px the two text links step aside instead, and what
+   stays is one action a thumb can hit.
+   ════════════════════════════════════════ */
+nav.nav .nav-auth {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-left: auto;
+}
+
+nav.nav .nav-help,
+nav.nav .nav-signin {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 0 var(--space-1);
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--ink-2);
+  text-decoration: none;
+  border: none;
+  background: none;
+  white-space: nowrap;
+  transition: color var(--duration-base) var(--ease-sharp);
+}
+nav.nav .nav-help:hover,
+nav.nav .nav-signin:hover { color: var(--cobalt); }
+nav.nav .nav-help:focus-visible,
+nav.nav .nav-signin:focus-visible {
+  outline: 3px solid rgba(29,78,216,.35);
+  outline-offset: 2px;
+}
+
+/* The one filled button on the page is cobalt, on the homepage and here. It
+   was lime, which is the punctuation colour of this brand and not the colour
+   of its primary action; next to a cobalt hero button it read as a second,
+   competing offer. */
+nav.nav .nav-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0 var(--space-4);
+  background: var(--cobalt);
+  color: #FFFFFF;
+  border: 1px solid var(--cobalt);
+  border-radius: 3px;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background var(--duration-base) var(--ease-sharp),
+              border-color var(--duration-base) var(--ease-sharp);
+}
+nav.nav .nav-cta:hover {
+  background: var(--cobalt-2);
+  border-color: var(--cobalt-2);
+  color: #FFFFFF;
+}
+nav.nav .nav-cta:focus-visible {
+  outline: 3px solid rgba(29,78,216,.35);
+  outline-offset: 2px;
+}
+
+/* Signed in: the email is the control, so it is set in the reading face. */
+nav.nav .nav-user { position: relative; flex-shrink: 0; }
+nav.nav .nav-user-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 40px;
+  padding: 0 var(--space-3);
+  background: transparent;
+  border: 1px solid var(--ink-hair);
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--ink);
+  transition: border-color var(--duration-base) var(--ease-sharp);
+}
+nav.nav .nav-user-trigger:hover { border-color: var(--cobalt); }
+nav.nav .nav-user-trigger:focus-visible {
+  outline: 3px solid rgba(29,78,216,.35);
+  outline-offset: 2px;
+}
+nav.nav .nav-user-email {
+  max-width: 22ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+nav.nav .nav-user-chevron { font-size: 10px; color: var(--ink-2); }
+
+nav.nav .nav-user-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  min-width: 220px;
+  background: var(--bone);
+  border: 1px solid var(--ink-hair);
+  border-radius: 3px;
+  box-shadow: 0 6px 24px rgba(15,23,42,.08);
+  padding: var(--space-1) 0;
+  z-index: 400;
+}
+nav.nav .nav-user-menu[hidden] { display: none; }
+nav.nav .nav-menu-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 44px;
+  padding: 0 var(--space-4);
+  font-family: var(--sans);
+  font-size: 14px;
+  color: var(--ink);
+  text-decoration: none;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+nav.nav .nav-menu-item:hover { background: rgba(29,78,216,.06); color: var(--cobalt); }
+nav.nav .nav-menu-signout { color: #991B1B; }
+nav.nav .nav-menu-signout:hover { background: rgba(220,38,38,.06); color: #991B1B; }
+nav.nav .nav-menu-divider { height: 1px; background: var(--ink-hair); margin: var(--space-1) 0; }
+
+@media (max-width: 420px) {
+  nav.nav .nav-user-email { max-width: 12ch; }
+}
+
+/* ════════════════════════════════════════
+   DRAWER TAIL: SIGN IN AND HELP ON A PHONE
+   It sits outside #nav-mobile on purpose. js/nav-auth.js rewrites the whole
+   inside of that drawer after the session check, and tests/navigation-shell
+   pins its contents to exactly the four destinations of the desktop bar. So
+   the two secondary routes hang under it as their own strip, pinned to the
+   bottom edge where a thumb reaches.
+   ════════════════════════════════════════ */
+.nav-mobile-tail {
+  display: none;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 301;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-5);
+  padding-bottom: calc(var(--space-3) + env(safe-area-inset-bottom, 0px));
+  background: var(--bone);
+  border-top: 1px solid var(--ink-hair);
+}
+.nav-mobile-tail.open { display: flex; }
+.nav-mobile-tail a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  font-family: var(--sans);
+  font-size: 15px;
+  text-decoration: none;
+  border-radius: 3px;
+}
+.nav-mobile-tail .nav-tail-btn {
+  color: var(--ink);
+  font-weight: 600;
+  border: 1px solid var(--ink-hair);
+}
+.nav-mobile-tail .nav-tail-btn:hover { border-color: var(--cobalt); color: var(--cobalt); }
+.nav-mobile-tail .nav-tail-link {
+  color: var(--ink-2);
+  font-weight: 500;
+}
+.nav-mobile-tail .nav-tail-link:hover { color: var(--cobalt); }
+.nav-mobile-tail a:focus-visible {
+  outline: 3px solid rgba(29,78,216,.35);
+  outline-offset: 2px;
+}
+
+/* ════════════════════════════════════════
+   THE PHONE BAR
+   Last block in the file on purpose: it overrides the rules above it, which
+   have the same specificity, and CSS settles a tie by order.
+
+   The hamburger appears below 1024px, but the crowding it was hiding is a
+   phone problem, not a tablet one: at 820px five elements have room to
+   breathe, at 390px they had 60px of slack between them and the button ended
+   up against the hamburger. So the bar sheds its two text links at 700px, not
+   at 1024px. A tablet keeps Help and Sign in where they were.
+   ════════════════════════════════════════ */
+@media (max-width: 1023px) {
+  nav.nav .nav-auth { gap: var(--space-3); }
+  nav.nav .nav-cta,
+  nav.nav .nav-user-trigger,
+  nav.nav .nav-help,
+  nav.nav .nav-signin { min-height: 44px; }
+}
+@media (max-width: 700px) {
+  /* One primary action beside the menu button. Sign in and Help are one tap
+     away, at the bottom of the drawer, where there is room to hit them. */
+  nav.nav .nav-help,
+  nav.nav .nav-signin { display: none; }
+}
+/* The drawer tail carries what the bar handed over, so it exists exactly where
+   the bar handed something over. */
+@media (min-width: 701px) {
+  .nav-mobile-tail { display: none !important; }
+}

--- a/frontend/nav.js
+++ b/frontend/nav.js
@@ -139,6 +139,20 @@
   // ── Mobile menu ───────────────────────────────────────
   if (!hamburger || !mobile) return;
 
+  // A bar with a hamburger has handed Sign in and Help to the drawer, so the
+  // strip that catches them has to exist. developer.html keeps its own nav
+  // (KEEP_OWN_NAV in frontend/apply-nav.py), is stamped by hand, and had no
+  // strip: on a 390px screen both routes were simply gone from that page. The
+  // markup is in the page now, and this builds it for any page that forgets.
+  if (!tail) {
+    tail = document.createElement('div');
+    tail.className = 'nav-mobile-tail';
+    tail.id = 'nav-mobile-tail';
+    tail.innerHTML = '<a href="/auth/login" class="nav-tail-btn">Sign in</a>' +
+                     '<a href="/help" class="nav-tail-link">Help</a>';
+    mobile.parentNode.insertBefore(tail, mobile.nextSibling);
+  }
+
   function openMobileMenu() {
     // Drawer is position:fixed; align its top to the actual bottom of the
     // sticky navbar so it never overlaps the navbar (which sits below the

--- a/frontend/nav.js
+++ b/frontend/nav.js
@@ -5,6 +5,10 @@
   var hamburger = document.getElementById('nav-hamburger');
   var mobile    = document.getElementById('nav-mobile');
   var closeBtn  = document.querySelector('.nav-mobile-close');
+  // Sign in and Help leave the phone bar and hang under the drawer as their
+  // own strip. It is a sibling of #nav-mobile, not a child: js/nav-auth.js
+  // rewrites the whole inside of the drawer after the session check.
+  var tail      = document.getElementById('nav-mobile-tail');
 
   // ── Helpers ───────────────────────────────────────────
   var lockedScrollY = 0;
@@ -146,6 +150,7 @@
       mobile.style.top = navBottom + 'px';
     }
     mobile.classList.add('open');
+    if (tail) tail.classList.add('open');
     hamburger.setAttribute('aria-expanded', 'true');
     hamburger.setAttribute('aria-label', 'Close menu');
     lockScroll();
@@ -154,6 +159,7 @@
 
   function closeMobileMenu() {
     mobile.classList.remove('open');
+    if (tail) tail.classList.remove('open');
     hamburger.setAttribute('aria-expanded', 'false');
     hamburger.setAttribute('aria-label', 'Open menu');
     unlockScroll();
@@ -170,12 +176,18 @@
   mobile.querySelectorAll('a').forEach(function (a) {
     a.addEventListener('click', closeMobileMenu);
   });
+  if (tail) {
+    tail.querySelectorAll('a').forEach(function (a) {
+      a.addEventListener('click', closeMobileMenu);
+    });
+  }
 
   document.addEventListener('click', function (e) {
     if (
       mobile.classList.contains('open') &&
       !hamburger.contains(e.target) &&
-      !mobile.contains(e.target)
+      !mobile.contains(e.target) &&
+      !(tail && tail.contains(e.target))
     ) {
       closeMobileMenu();
     }

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -9,8 +9,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Receive a file · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta name="description" content="A secure file is waiting for you. It decrypts in your browser and burns after one download.">
 <meta property="og:title" content="A secure file is waiting · Paramant">
@@ -134,7 +134,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -148,6 +148,10 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 <main id="main-content">
 
@@ -264,7 +268,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 <script type="module" src="/js/ontvang.inline1.js?v=2"></script>
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/ontvang.page.js?v=2" defer></script>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -23,8 +23,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .ps-hero{padding:var(--space-10) 0 var(--space-6)}
@@ -179,7 +179,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -193,6 +193,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <!-- HERO: what you can do here, who it is for, and one action. The buyer meets
@@ -442,7 +446,7 @@
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -11,8 +11,8 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <style>
@@ -318,7 +318,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 }
 </script>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=2">
+<link rel="stylesheet" href="/app-2026.css?v=3">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>
@@ -334,7 +334,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -348,6 +348,10 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 <section class="page-hero">
 <div class="page-hero-inner">
@@ -603,8 +607,8 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/quota-upgrade.js?v=4" defer></script>
 <script src="/js/parashare.page.js?v=3" defer></script>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <footer>
   <div class="container-lg">
     <div class="footer-grid footer-slim">

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -23,8 +23,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .ps-hero{padding:var(--space-10) 0 var(--space-6)}
@@ -166,7 +166,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -180,6 +180,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <!-- HERO. Four things and no more, in the order docs/brand/messaging.md sets:
@@ -395,7 +399,7 @@
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -20,8 +20,8 @@
 <meta name="twitter:description" content="Organisations that publicly confirm they run Paramant in production will be listed here. For case studies or references, get in touch.">
 <link rel="canonical" href="https://paramant.app/partners">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 
 <style>
@@ -131,7 +131,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -145,6 +145,10 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <div class="wrap" id="main-content" tabindex="-1">
@@ -200,7 +204,7 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
     </div>
   </div>
 </footer>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -26,8 +26,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -193,7 +193,7 @@ td{color:var(--cobalt)}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -207,6 +207,10 @@ td{color:var(--cobalt)}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main id="main-content">
@@ -336,7 +340,7 @@ td{color:var(--cobalt)}
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -19,8 +19,8 @@
 <meta name="twitter:title" content="Pricing · What is free, and what businesses pay · Paramant">
 <meta name="twitter:description" content="The Community plan is free, forever. Organisations pay for higher limits: sending from 15 euro a month, signing from 49, excl. btw. From Paramantis Solutions B.V.">
 <link rel="canonical" href="https://paramant.app/pricing">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .tier-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--ink-hair)}
@@ -202,7 +202,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -216,6 +216,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <!-- HERO
@@ -599,8 +603,8 @@
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script src="/js/pricing-billing.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -26,8 +26,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -178,7 +178,7 @@ footer a{color:var(--ink);text-decoration:none}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -192,6 +192,10 @@ footer a{color:var(--ink);text-decoration:none}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <div class="content">
@@ -335,7 +339,7 @@ footer a{color:var(--ink);text-decoration:none}
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -9,8 +9,8 @@
 <meta name="robots" content="noindex">
 <meta http-equiv="refresh" content="8;url=/signup">
 <link rel="canonical" href="https://paramant.app/signup">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>
@@ -90,7 +90,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -104,6 +104,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main id="main-content">
@@ -165,8 +169,8 @@
   </div>
 </footer>
 
-<script src="/nav.js?v=14"></script>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15"></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -26,8 +26,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -179,7 +179,7 @@ footer a{color:var(--ink);text-decoration:none}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -193,6 +193,10 @@ footer a{color:var(--ink);text-decoration:none}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <div class="content">
@@ -294,7 +298,7 @@ footer a{color:var(--ink);text-decoration:none}
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -26,8 +26,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -206,7 +206,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -220,6 +220,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <section class="page-hero page-hero--navy">
@@ -510,7 +514,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -39,8 +39,8 @@
     .divider{border:none;border-top:1px solid var(--ink-hair);margin:48px 0}
     footer{border-top:1px solid var(--ink-hair);padding:32px 48px}
   </style>
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <script type="application/ld+json" data-paramant-seo="1">
 {
@@ -128,7 +128,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -143,7 +143,11 @@
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
 </div>
-<script src="/nav.js?v=14" defer></script>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
+</div>
+<script src="/nav.js?v=15" defer></script>
 
 <main>
   <h1>Security Acknowledgements</h1>
@@ -191,6 +195,6 @@
   </div>
 </footer>
 
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -6,8 +6,8 @@
   <title>First-time setup · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/setup">
-  <link rel="stylesheet" href="/design-system.css?v=24">
-  <link rel="stylesheet" href="/nav.css?v=19">
+  <link rel="stylesheet" href="/design-system.css?v=25">
+  <link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 </head>
 <body>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -23,8 +23,8 @@
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="canonical" href="https://paramant.app/sign">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/components-parasign.css?v=3">
 <style>
@@ -407,7 +407,7 @@
 }
 </script>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=2">
+<link rel="stylesheet" href="/app-2026.css?v=3">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>
@@ -423,7 +423,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -437,6 +437,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main id="main-content" role="main">
@@ -850,8 +854,8 @@
     </div>
   </div>
 </footer>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script src="/js/parasign-pdf-ops.js?v=1"></script>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -24,8 +24,8 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {
@@ -175,7 +175,7 @@ main#main-content .btn { width: 100%; justify-content: center; }
 }
 </script>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=2">
+<link rel="stylesheet" href="/app-2026.css?v=3">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>
@@ -192,7 +192,7 @@ main#main-content .btn { width: 100%; justify-content: center; }
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -206,6 +206,10 @@ main#main-content .btn { width: 100%; justify-content: center; }
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main id="main-content" class="container-lg">
@@ -284,8 +288,8 @@ main#main-content .btn { width: 100%; justify-content: center; }
 </main>
 
 <script src="/js/pow-captcha.js?v=1"></script>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script src="/js/signup.inline1.js?v=1"></script>
 
 <script src="/js/signup.inline2.js?v=2"></script>

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -7,11 +7,11 @@
   <title>Email verified, one step left · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/signup/verified">
-  <link rel="stylesheet" href="/design-system.css?v=24">
-  <link rel="stylesheet" href="/nav.css?v=19">
+  <link rel="stylesheet" href="/design-system.css?v=25">
+  <link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
-  <script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+  <script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
   <style>
     /* Every colour here is a token from app-2026.css, so this page follows the
        theme instead of staying light inside a dark shell. Section 5 of
@@ -97,7 +97,7 @@
     }
   </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=2">
+<link rel="stylesheet" href="/app-2026.css?v=3">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>
@@ -112,7 +112,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -126,6 +126,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 <main class="vwrap">
   <div class="vcheck" aria-label="Email verified">

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -20,8 +20,8 @@
 <meta name="twitter:description" content="Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise.">
 <link rel="canonical" href="https://paramant.app/sla">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}
@@ -188,7 +188,7 @@ a:hover{opacity:.8}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -202,6 +202,10 @@ a:hover{opacity:.8}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <div class="wrap">
@@ -364,7 +368,7 @@ a:hover{opacity:.8}
     </div>
   </div>
 </footer>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -25,8 +25,8 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -201,7 +201,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -215,6 +215,10 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <div class="page">
@@ -266,7 +270,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
 </footer>
 
 <script src="/js/status.inline1.js?v=1"></script>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -20,8 +20,8 @@
 <meta name="twitter:description" content="The agreement between you and Paramantis Solutions B.V. for the use of Paramant. Plans, payment, cancellation, acceptable use, liability and Dutch law.">
 <link rel="canonical" href="https://paramant.app/terms">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}
@@ -188,7 +188,7 @@ a:hover{opacity:.8}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -202,6 +202,10 @@ a:hover{opacity:.8}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <div class="wrap">
@@ -335,7 +339,7 @@ a:hover{opacity:.8}
     </div>
   </div>
 </footer>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -26,8 +26,8 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -220,7 +220,7 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -234,6 +234,10 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 <section class="page-hero page-hero--navy">
 <div class="page-hero-inner">
@@ -434,7 +438,7 @@ docker compose build   # build locally instead of pulling the published image</c
   </div>
 </footer>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 </body>
 </html>

--- a/frontend/vault.html
+++ b/frontend/vault.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/vault">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=24">
+<link rel="stylesheet" href="/design-system.css?v=25">
 <style>
 .vt-bar{display:flex;align-items:center;justify-content:space-between;padding:14px 24px;border-bottom:1px solid var(--ink-hair)}
 .vt-brand{font-family:var(--mono);font-size:13px;font-weight:700;letter-spacing:.04em;color:var(--navy);text-decoration:none}

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -21,8 +21,8 @@
 <link rel="canonical" href="https://paramant.app/verify">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/components-parasign.css?v=3">
 <script type="application/ld+json" data-paramant-seo="1">
@@ -101,7 +101,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -115,6 +115,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <main id="main-content" role="main">
@@ -187,8 +191,8 @@
     </div>
   </div>
 </footer>
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 <script type="module" src="/parasign-verify.js?v=6"></script>
 </body>
 </html>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -20,8 +20,8 @@
 <meta name="twitter:description" content="How Paramant compares to Zivver, Tresorit, WeTransfer and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting.">
 <link rel="canonical" href="https://paramant.app/vs">
 
-<link rel="stylesheet" href="/design-system.css?v=24">
-<link rel="stylesheet" href="/nav.css?v=19">
+<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>
@@ -151,7 +151,7 @@
   </ul>
 
   <div class="nav-auth" id="nav-auth">
-    <a href="/help" class="nav-help">HELP</a>
+    <a href="/help" class="nav-help">Help</a>
     <a href="/auth/login" class="nav-signin">Sign in</a>
     <a href="/signup" class="nav-cta">Create account</a>
   </div>
@@ -165,6 +165,10 @@
   <a href="/security" class="nav-mobile-standalone">Security</a>
   <a href="/pricing" class="nav-mobile-standalone">Pricing</a>
   <a href="/docs" class="nav-mobile-standalone">Docs</a>
+</div>
+<div class="nav-mobile-tail" id="nav-mobile-tail">
+  <a href="/auth/login" class="nav-tail-btn">Sign in</a>
+  <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
 <section class="section section-lg" id="main-content" tabindex="-1">
@@ -490,8 +494,8 @@
   </div>
 </section>
 
-<script src="/nav.js?v=14" defer></script>
-<script src="/js/nav-auth.js?v=5" defer></script>
+<script src="/nav.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=6" defer></script>
 
 <footer>
   <div class="container-lg">

--- a/tests/access-log-visitors.test.mjs
+++ b/tests/access-log-visitors.test.mjs
@@ -36,7 +36,7 @@ test('a client that renders is not excluded for lacking a referer', () => {
   // exclude every genuine visitor on this site.
   const r = analyse([
     line({ ip: '8.8.8.8', path: '/sign' }),
-    line({ ip: '8.8.8.8', path: '/design-system.css?v=24' }),
+    line({ ip: '8.8.8.8', path: '/design-system.css?v=25' }),
     line({ ip: '8.8.8.8', path: '/sign-flow.js?v=49' }),
   ]);
   assert.equal(r.atMostVisitors, 1);
@@ -49,7 +49,7 @@ test('a crawler that really renders is reported apart, not as a person', () => {
   const ua = 'Mozilla/5.0 (compatible; heritrix/3.14.2-SNAPSHOT-20250101 +http://archive.org)';
   const r = analyse([
     line({ ip: '7.7.7.7', path: '/', ua }),
-    line({ ip: '7.7.7.7', path: '/nav.css?v=19', ua }),
+    line({ ip: '7.7.7.7', path: '/nav.css?v=20', ua }),
   ]);
   assert.equal(r.atMostVisitors, 0, 'a named crawler was counted as a possible visitor');
   assert.equal(r.verdicts.declared_automation, 1);

--- a/tests/navigation-shell.test.mjs
+++ b/tests/navigation-shell.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
 const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
 const MIME = { '.js':'text/javascript', '.css':'text/css', '.html':'text/html', '.svg':'image/svg+xml', '.png':'image/png', '.woff2':'font/woff2' };
-const aliases = { '/':'/index.html', '/dashboard':'/dashboard.html', '/account':'/account.html', '/developer':'/developer.html' };
+const aliases = { '/':'/index.html', '/dashboard':'/dashboard.html', '/account':'/account.html', '/developer':'/developer.html', '/pricing':'/pricing.html' };
 const server = http.createServer((req, res) => {
   let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
   pathname = aliases[pathname] || pathname;
@@ -110,29 +110,6 @@ const scrolledMenuGeometry = await publicPage.evaluate(() => {
 ok('mobile menu stays attached when opened after scrolling', scrolledMenuGeometry.navTop === 0 && Math.abs(scrolledMenuGeometry.menuTop - scrolledMenuGeometry.navBottom) < 0.5 && scrolledMenuGeometry.bodyPosition === 'fixed' && scrolledMenuGeometry.bodyTop === '-450px', JSON.stringify(scrolledMenuGeometry));
 await publicPage.evaluate(() => document.querySelector('#nav-hamburger').click());
 ok('closing the mobile menu restores the page position', await publicPage.evaluate(() => window.scrollY === 450 && getComputedStyle(document.body).position !== 'fixed'), await publicPage.evaluate(() => JSON.stringify({ scrollY:window.scrollY, bodyPosition:getComputedStyle(document.body).position })));
-// Two reviews of the phone, a week apart, named the same thing: the bar was
-// full. Logo, Help, Sign in, Create account and the hamburger, five elements
-// on 390px, with the button and the hamburger both starting at x=330 and no
-// air between them. So the bar is measured now, and not by eye: what is in it,
-// how far apart, and how big a thumb's worth of it there is.
-const phoneBar = await publicPage.evaluate(() => {
-  const nav = document.querySelector('nav.nav');
-  const items = Array.from(nav.querySelectorAll('a, button'))
-    .filter((node) => {
-      const box = node.getBoundingClientRect();
-      return getComputedStyle(node).display !== 'none' && box.width > 0 && box.height > 0;
-    })
-    .map((node) => {
-      const box = node.getBoundingClientRect();
-      return { label:node.textContent.trim().slice(0, 24) || node.getAttribute('aria-label'), left:Math.round(box.left), right:Math.round(box.right), width:Math.round(box.width), height:Math.round(box.height) };
-    })
-    .sort((first, second) => first.left - second.left);
-  return { items, gaps:items.slice(1).map((item, index) => Math.round(item.left - items[index].right)) };
-});
-ok('the phone bar carries one action beside the menu button', phoneBar.items.length <= 3, JSON.stringify(phoneBar.items));
-ok('nothing in the phone bar touches its neighbour', phoneBar.gaps.length > 0 && phoneBar.gaps.every((gap) => gap >= 12), JSON.stringify(phoneBar));
-ok('every target in the phone bar is finger-sized', phoneBar.items.every((item) => item.height >= 44), JSON.stringify(phoneBar.items));
-
 // Support on a phone. This used to demand a visible /help link in the closed
 // bar, which is why Help was the fifth element up there, shrunk to 9px type to
 // make it fit. The requirement is that a visitor looking for support finds a
@@ -152,6 +129,52 @@ const phoneHelp = await publicPage.evaluate(() => {
 ok('support is reachable on a phone', phoneHelp.some((link) => link.display !== 'none' && link.width > 0 && link.height >= 44), JSON.stringify(phoneHelp));
 await publicPage.locator('#nav-hamburger').click();
 await publicPage.close();
+
+// Two reviews of the phone, a week apart, named the same thing: the bar was
+// full. Logo, Help, Sign in, Create account and the hamburger, five elements
+// on 390px, with the button and the hamburger both starting at x=330 and no
+// air between them. So the bar is measured now, and not by eye: what is in it,
+// how far apart, and how big a thumb's worth of it there is.
+//
+// It is measured on three pages, not on the homepage alone. The bar is shared,
+// but not every page gets it from the generator: developer.html keeps its own
+// (KEEP_OWN_NAV in frontend/apply-nav.py) and is stamped by hand, which is
+// exactly where the first round of this went wrong. A check that only ever
+// looks at / cannot see that.
+for (const route of ['/', '/pricing', '/developer']) {
+  const barPage = await browser.newPage({ viewport:{ width:390, height:844 } });
+  await barPage.route('**/api/user/session/verify', (call) => call.fulfill({ status:401, contentType:'application/json', body:'{"authenticated":false}' }));
+  await barPage.goto(ORIGIN + route, { waitUntil:'domcontentloaded' });
+  await barPage.locator('nav.nav .nav-cta').waitFor();
+  const bar = await barPage.evaluate(() => {
+    const items = Array.from(document.querySelectorAll('nav.nav a, nav.nav button'))
+      .filter((node) => {
+        const box = node.getBoundingClientRect();
+        return getComputedStyle(node).display !== 'none' && box.width > 0 && box.height > 0;
+      })
+      .map((node) => {
+        const box = node.getBoundingClientRect();
+        return { label:node.textContent.trim().slice(0, 24) || node.getAttribute('aria-label'), left:Math.round(box.left), right:Math.round(box.right), height:Math.round(box.height) };
+      })
+      .sort((first, second) => first.left - second.left);
+    return { items, gaps:items.slice(1).map((item, index) => Math.round(item.left - items[index].right)) };
+  });
+  ok(`the phone bar of ${route} carries one action beside the menu button`, bar.items.length <= 3, JSON.stringify(bar.items));
+  ok(`nothing in the phone bar of ${route} touches its neighbour`, bar.gaps.length > 0 && bar.gaps.every((gap) => gap >= 12), JSON.stringify(bar));
+  ok(`every target in the phone bar of ${route} is finger-sized`, bar.items.every((item) => item.height >= 44), JSON.stringify(bar.items));
+
+  // And what the bar handed over has somewhere to land. Sign in and Help leave
+  // the bar below 700px, so on these pages the drawer strip is the only route
+  // to either, and both must be a real tap target.
+  await barPage.locator('#nav-hamburger').click();
+  await barPage.waitForFunction(() => document.querySelector('#nav-mobile-tail')?.classList.contains('open'));
+  const handover = await barPage.evaluate(() => Array.from(document.querySelectorAll('#nav-mobile-tail a')).map((link) => {
+    const box = link.getBoundingClientRect();
+    return { href:link.getAttribute('href'), height:Math.round(box.height), width:Math.round(box.width) };
+  }));
+  ok(`${route} keeps sign in and support one tap away`, ['/auth/login', '/help'].every((href) => handover.some((link) => link.href === href && link.height >= 44 && link.width > 0)), JSON.stringify(handover));
+  await barPage.close();
+}
 
 const tabletPage = await browser.newPage({ viewport:{ width:820, height:1180 } });
 await tabletPage.route('**/api/user/session/verify', (route) => route.fulfill({ status:401, contentType:'application/json', body:'{"authenticated":false}' }));
@@ -176,6 +199,7 @@ await tabletPage.close();
 const generatorSource = fs.readFileSync(path.join(ROOT, 'apply-nav.py'), 'utf8');
 const keepOwnNav = new Set(Array.from((generatorSource.match(/KEEP_OWN_NAV = \{([^}]*)\}/) || [null, ''])[1].matchAll(/'([^']+)'/g), (match) => match[1]));
 const stamped = [];
+const everyPage = [];
 (function walk(dir) {
   for (const entry of fs.readdirSync(dir, { withFileTypes:true })) {
     const full = path.join(dir, entry.name);
@@ -183,10 +207,23 @@ const stamped = [];
     else if (entry.name.endsWith('.html')) {
       const html = fs.readFileSync(full, 'utf8');
       const name = path.relative(ROOT, full).split(path.sep).join('/');
+      everyPage.push([name, html]);
       if (html.includes('<nav class="nav">') && html.includes('id="nav-auth"') && !keepOwnNav.has(name)) stamped.push([name, html]);
     }
   }
 })(ROOT);
+
+// A hamburger is a promise: below 700px Sign in and Help leave the bar, and the
+// strip under the drawer is where they land. A page with the button and without
+// the strip has no route to either, and that is not hypothetical. developer.html
+// keeps its own nav, is stamped by hand, and shipped exactly like that: on a
+// 390px screen both links measured 0x0. This runs over every page in frontend/,
+// not only the generated ones, because the generated ones were never the
+// problem.
+const hamburgerWithoutTail = everyPage
+  .filter(([, html]) => html.includes('id="nav-hamburger"') && !html.includes('id="nav-mobile-tail"'))
+  .map(([name]) => name);
+ok('no page carries a menu button without the strip that catches what it takes away', hamburgerWithoutTail.length === 0, hamburgerWithoutTail.join(', ') || `${everyPage.filter(([, html]) => html.includes('id="nav-hamburger"')).length} pages with a menu button`);
 const withoutHelp = stamped.filter(([, html]) => !/<a href="\/help"/.test(html)).map(([name]) => name);
 ok('every stamped page links support', stamped.length > 0 && withoutHelp.length === 0, withoutHelp.join(', ') || `${stamped.length} pages`);
 const withoutLegal = stamped.filter(([, html]) => !['/privacy', '/dpa', '/terms'].every((href) => html.includes(`href="${href}"`))).map(([name]) => name);

--- a/tests/navigation-shell.test.mjs
+++ b/tests/navigation-shell.test.mjs
@@ -110,13 +110,47 @@ const scrolledMenuGeometry = await publicPage.evaluate(() => {
 ok('mobile menu stays attached when opened after scrolling', scrolledMenuGeometry.navTop === 0 && Math.abs(scrolledMenuGeometry.menuTop - scrolledMenuGeometry.navBottom) < 0.5 && scrolledMenuGeometry.bodyPosition === 'fixed' && scrolledMenuGeometry.bodyTop === '-450px', JSON.stringify(scrolledMenuGeometry));
 await publicPage.evaluate(() => document.querySelector('#nav-hamburger').click());
 ok('closing the mobile menu restores the page position', await publicPage.evaluate(() => window.scrollY === 450 && getComputedStyle(document.body).position !== 'fixed'), await publicPage.evaluate(() => JSON.stringify({ scrollY:window.scrollY, bodyPosition:getComputedStyle(document.body).position })));
-const phoneHelp = await publicPage.evaluate(() => {
-  const link = document.querySelector('nav.nav a[href="/help"]');
-  if (!link) return { found:false };
-  const box = link.getBoundingClientRect();
-  return { found:true, display:getComputedStyle(link).display, width:box.width, height:box.height };
+// Two reviews of the phone, a week apart, named the same thing: the bar was
+// full. Logo, Help, Sign in, Create account and the hamburger, five elements
+// on 390px, with the button and the hamburger both starting at x=330 and no
+// air between them. So the bar is measured now, and not by eye: what is in it,
+// how far apart, and how big a thumb's worth of it there is.
+const phoneBar = await publicPage.evaluate(() => {
+  const nav = document.querySelector('nav.nav');
+  const items = Array.from(nav.querySelectorAll('a, button'))
+    .filter((node) => {
+      const box = node.getBoundingClientRect();
+      return getComputedStyle(node).display !== 'none' && box.width > 0 && box.height > 0;
+    })
+    .map((node) => {
+      const box = node.getBoundingClientRect();
+      return { label:node.textContent.trim().slice(0, 24) || node.getAttribute('aria-label'), left:Math.round(box.left), right:Math.round(box.right), width:Math.round(box.width), height:Math.round(box.height) };
+    })
+    .sort((first, second) => first.left - second.left);
+  return { items, gaps:items.slice(1).map((item, index) => Math.round(item.left - items[index].right)) };
 });
-ok('support is reachable on a phone', phoneHelp.found && phoneHelp.display !== 'none' && phoneHelp.width > 0 && phoneHelp.height > 0, JSON.stringify(phoneHelp));
+ok('the phone bar carries one action beside the menu button', phoneBar.items.length <= 3, JSON.stringify(phoneBar.items));
+ok('nothing in the phone bar touches its neighbour', phoneBar.gaps.length > 0 && phoneBar.gaps.every((gap) => gap >= 12), JSON.stringify(phoneBar));
+ok('every target in the phone bar is finger-sized', phoneBar.items.every((item) => item.height >= 44), JSON.stringify(phoneBar.items));
+
+// Support on a phone. This used to demand a visible /help link in the closed
+// bar, which is why Help was the fifth element up there, shrunk to 9px type to
+// make it fit. The requirement is that a visitor looking for support finds a
+// working route, not that the route lives on one particular surface: it is now
+// the first thing under the four destinations when the menu is open, at 48px
+// tall instead of 9px wide. The static contract below still demands the link
+// in the stamped markup of every page, so it can never quietly disappear.
+await publicPage.locator('#nav-hamburger').click();
+await publicPage.waitForFunction(() => document.querySelector('#nav-mobile')?.classList.contains('open'));
+const phoneHelp = await publicPage.evaluate(() => {
+  const links = Array.from(document.querySelectorAll('nav.nav a[href="/help"], .nav-mobile-tail a[href="/help"]'));
+  return links.map((link) => {
+    const box = link.getBoundingClientRect();
+    return { display:getComputedStyle(link).display, width:Math.round(box.width), height:Math.round(box.height) };
+  });
+});
+ok('support is reachable on a phone', phoneHelp.some((link) => link.display !== 'none' && link.width > 0 && link.height >= 44), JSON.stringify(phoneHelp));
+await publicPage.locator('#nav-hamburger').click();
 await publicPage.close();
 
 const tabletPage = await browser.newPage({ viewport:{ width:820, height:1180 } });
@@ -132,8 +166,9 @@ ok('support is reachable on a tablet', tabletHelp.display !== 'none' && tabletHe
 await tabletPage.close();
 
 // Static contract, no browser needed. The mobile drawer mirrors the four nav
-// links and carries no Help entry, so every stamped page must keep the /help
-// link in the bar itself. Pages without a footer must still name the three
+// links and carries no Help entry of its own; the link lives in the bar and,
+// on a phone, in the strip under the drawer. Either way it must be in the
+// stamped markup of every page. Pages without a footer must still name the three
 // legal documents; apply-nav.py stamps a legal strip there.
 // Application shells keep their own narrower nav and reach Help through the
 // signed-in user menu; apply-nav.py names them and this test reads that list


### PR DESCRIPTION
Two buyer reviews, a phone and a laptop, named the shared navigation bar as the biggest remaining distraction. On 390px it held five elements: logo, HELP, SIGN IN, CREATE ACCOUNT and the hamburger, with the button and the hamburger both starting at x=330 and no air between them. All of it in mono capitals with letter-spacing, over a homepage set in paper, ink, sentences and one cobalt button.

## What changed

**Typography.** PRODUCT SECURITY PRICING DOCS is the voice of a terminal. Same four destinations, same order, now in the reading face at 14px, sentence case, no letter-spacing: Product, Security, Pricing, Docs, and Help, Sign in, Create account beside them. Same in the drawer, at 16px.

**The phone bar.** One primary action next to the menu button. Sign in and Help move to a strip under the drawer, 48px tall, where a thumb reaches them, and they come back into the bar at 700px so a tablet keeps what it had room for. A `gap` on the bar sets a 12px floor between every pair of elements instead of hoping `space-between` leaves some: measured 98px and 12px where it used to be 0 and 0. Every target in the bar is at least 44px tall.

**The button.** The one filled button was lime, which is the punctuation colour of this brand and not the colour of its primary action; next to the cobalt hero button it read as a second, competing offer. It is cobalt with white text (6.3:1), the same `.hp-btn-fill` the homepage uses. `app-2026.css` forced `#0A1626` on lime with `!important` for the app screens and now follows, at the same weight. The drawer's current row loses its lime wash for the same cobalt the desktop bar uses.

**One home for the bar.** `.nav-auth`, `.nav-signin`, `.nav-cta`, `.nav-user` and `.nav-help` lived in `design-system.css` while the rest of the bar lived in `nav.css`, and the half in `design-system.css` answered a narrow phone by shrinking: 9px type, 5px padding, the Help border dropped. Small is not roomy. It all sits in `nav.css` now. No page loads one without the other (`vault.html`, `billing/checkout.html` and `claim.html` load `design-system.css` without `nav.css` and carry none of these classes).

**Signed in** is the same bar: the email control in the reading face, the drawer carrying Documents, Send, Sign, Verify, Settings, and no tail, since the user menu already holds Help and Sign out.

## The test

`tests/navigation-shell` pinned support on a phone to a visible `/help` link in the *closed* bar. That pin is why Help was the fifth element up there, shrunk to 9px type to fit. The requirement is that a visitor looking for support finds a working route, not which of the two surfaces it lives on, so the check now opens the menu and demands a 48px target instead of "not display:none". The static contract below it still demands the `/help` link in the stamped markup of all 51 pages, so it cannot quietly disappear.

Three checks were added that measure what the reviews saw by eye:

- `the phone bar carries one action beside the menu button` (at most 3 elements)
- `nothing in the phone bar touches its neighbour` (every gap >= 12px)
- `every target in the phone bar is finger-sized` (every height >= 44px)

29 checks, all green. The drawer contract is untouched: `#nav-mobile` still mirrors the four desktop links exactly, which is why the tail is a sibling and not a child, and why `apply-nav.py` had to learn to strip an old tail before stamping a new one or the second run would leave two.

## Versions

`design-system.css` v25, `nav.css` v20, `nav.js` v15, `nav-auth.js` v6, `app-2026.css` v3. Stamped by `frontend/apply-nav.py` over 51 pages, and by hand on the pages the generator does not own (`developer.html`, `co-sign.html`, `vault.html`, `claim.html`, `billing/checkout.html`, `setup.html`, `request-key.html`, `all-systems-go.html`, `changelog.html`) plus the fixture in `tests/access-log-visitors.test.mjs`.

## Gates

All green locally: first-screen, ui-truthfulness, site-claims, seo-contract, links, navigation-shell, frontend-loading-contract, pricing-fold, cache-bust, csp-inline, static-sanity, check-test-declarations, eslint, theme-contrast, motion-safety, app-contrast, app-theme, access-log-visitors, apply-nav-idempotent, `apply_seo_head --check`.

## Screenshots

Taken with `deviceScaleFactor: 2`, session mocked at `/api/user/session/verify`. Paths on the NUC, under `/tmp/claude-1000/-home-mick-vault/aaa93ca4-46a3-4e08-bb7e-b16bfb35e53c/scratchpad/navbar2026/shots/`:

| view | before | after |
| --- | --- | --- |
| 390, signed out, menu closed | `before/390-out-closed.png` | `after/390-out-closed.png` |
| 390, signed out, menu open | `before/390-out-open.png` | `after/390-out-open.png` |
| 390, signed in, menu closed | `before/390-in-closed.png` | `after/390-in-closed.png` |
| 390, signed in, menu open | `before/390-in-open.png` | `after/390-in-open.png` |
| 1440, signed out | `before/1440-out-closed.png` | `after/1440-out-closed.png` |
| 1440, signed in | `before/1440-in-closed.png` | `after/1440-in-closed.png` |

The measured bar at 390, signed out, from the test output:

- before: `ParaMANT` x16-83, `HELP` x95-134, `SIGN IN` x150-203, `CREATE ACCOUNT` x219-356, `Open menu` x368-412
- after: `ParaMANT` x16-83, `Create account` x181-318, `Open menu` x330-374, gaps 98 and 12, all heights 44

---

## Round 2: the page the generator does not own

Review found the hole. `developer.html` keeps its own navigation (`KEEP_OWN_NAV` in `frontend/apply-nav.py`), is stamped by hand, and carries a hamburger. This round moves Sign in and Help out of the bar below 700px and into the strip under the drawer, and that page never got a strip: on 390px both links measured 0x0 there, where main still had them in the bar.

Three things, because any one of them alone leaves the same gap open:

1. **The markup.** `developer.html` carries the strip now, like every stamped page.
2. **The script.** `nav.js` builds the strip when a page has a menu button and no strip. A page can forget the markup; this cannot forget to build it. A floor under the live site, not a substitute for the markup.
3. **The check.** `tests/navigation-shell` now reads every `.html` in `frontend/`, not only the 51 the generator writes, and fails on any page with `id="nav-hamburger"` and no `id="nav-mobile-tail"`. 52 pages carry the button. Sabotage run: taking the strip back out of `developer.html` turns the suite red and names the file, while the runtime check stays green on the `nav.js` fallback, which is the pair working as intended.

**The measurement moved too.** The three phone-bar checks ran on the homepage alone, which is exactly why they were green while `/developer` was broken. They run on `/`, `/pricing` and `/developer` now, each with a fourth check that the strip really holds `/auth/login` and `/help` at 44px or more. `/developer` measures logo x16-95, Create account x181-318, menu x330-374, gaps 86 and 12, all heights 44. 39 checks, all green, and the 20 gates re-run clean after the rebase (now on main with #379, #390, #391).

Extra screenshots: `after/390-developer-out-closed.png`, `after/390-developer-out-open.png`.

## Follow-up, not in this PR

Two observations from the review that are real and out of scope here:

- **The cool seam.** The nav background is `rgb(248, 250, 252)` while the homepage paper is `#FAF8F3`. Identical to main, and pinned by `navigation-shell` ("mobile navigation is opaque before opening the menu"), so changing it is its own round with its own contrast measurement.
- **Two filled cobalt buttons on `/pricing`.** Create account in the bar plus the CTA in the copy now read as two primary actions on one screen. That is the cost of moving the bar button from lime to cobalt, and the fix belongs with the page, not with the bar: either the page CTA becomes an outline button, or the bar drops to outline on pages that carry their own primary action.
