### PR TITLE
The app screenshots stop rewriting the tracked reference images on every run

### DIFF
--- a/scripts/brand-shots-dir.mjs
+++ b/scripts/brand-shots-dir.mjs
@@ -1,0 +1,58 @@
+// Where the app screenshots are allowed to land.
+//
+// tests/app-shots.mjs renders every app screen at two viewports in two themes
+// and writes 36 PNGs. Until now it wrote them straight into
+// docs/brand/assets/app-2026/, which is tracked. So every local run of the
+// browser suites rewrote 36 tracked files, `git status` was never clean after a
+// test run, and the next `git commit -a` on that branch carried a pile of
+// screenshots nobody meant to send. Two builders reported exactly that.
+//
+// Rewriting the reference images is a deliberate act, not a side effect of
+// running the tests. So the tracked directory is opt-in:
+//
+//   node tests/app-shots.mjs                          -> a temp dir, repo clean
+//   PARAMANT_WRITE_BRAND_SHOTS=1 node tests/app-shots.mjs  -> docs/brand/assets
+//
+// APP_SHOTS_DIR still names an explicit directory and still wins, with one
+// rule: an explicit path that points back inside docs/ is refused without the
+// flag. Otherwise the opt-in would be one environment variable away from
+// meaning nothing, which is the same hole with a longer name.
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+export const DOCS_ROOT = path.join(REPO_ROOT, 'docs');
+export const TRACKED_DIR = path.join(DOCS_ROOT, 'brand', 'assets', 'app-2026');
+export const FLAG = 'PARAMANT_WRITE_BRAND_SHOTS';
+export const DIR_VAR = 'APP_SHOTS_DIR';
+export const DRY_RUN_VAR = 'APP_SHOTS_DRY_RUN';
+
+// True when `dir` is docs/ itself or anything below it. Compared on resolved
+// paths, so ../docs, a symlink-free absolute path and a relative one all give
+// the same answer.
+export function isUnderDocs(dir) {
+  const rel = path.relative(DOCS_ROOT, path.resolve(dir));
+  return rel === '' || (!rel.startsWith('..' + path.sep) && rel !== '..' && !path.isAbsolute(rel));
+}
+
+// Returns { dir, optIn, source }. Throws only for the refused case above, so a
+// caller that never sets APP_SHOTS_DIR can use it without a try.
+export function resolveBrandShotsDir(env = process.env) {
+  const optIn = env[FLAG] === '1';
+  const explicit = env[DIR_VAR];
+
+  if (explicit) {
+    const dir = path.resolve(explicit);
+    if (isUnderDocs(dir) && !optIn) {
+      throw new Error(
+        `${DIR_VAR}=${explicit} points inside docs/, which is tracked. ` +
+        `Set ${FLAG}=1 if you really mean to refresh the reference images.`,
+      );
+    }
+    return { dir, optIn, source: DIR_VAR };
+  }
+
+  if (optIn) return { dir: TRACKED_DIR, optIn, source: FLAG };
+  return { dir: path.join(os.tmpdir(), 'paramant-app-shots'), optIn, source: 'default' };
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,7 @@ Guards the auth + TOTP stack against the class of breakage that hit production r
 | `tests/auth-smoke.sh` | `deploy.sh` step 4 | 21 live HTTP assertions against production |
 | `deploy.sh` | manual deploy | Chains: sanity → build → health wait → smoke |
 | `tests/version-consistency.test.mjs` | Root integration suites | One version in one place: root `package.json` versus the relay and admin packages, both lockfiles, both image labels, the `VERSION` read in `relay.js`, the CHANGELOG section and the deploy check. Four places once gave three answers; see [docs/RELEASE.md](../docs/RELEASE.md) |
+| `tests/brand-shots-optin.test.mjs` | Root integration suites, and `tests/static-sanity.sh` (pre-commit) | The reference screenshots under `docs/brand/assets/app-2026/` are opt-in. `tests/app-shots.mjs` used to write 36 tracked PNGs on every run, so `git status` was never clean after a browser suite and the next `git commit -a` shipped them. Three layers: the resolver's own rules, a real dry run of `tests/app-shots.mjs` that has to name a directory outside the repo and leave the references byte-identical, and a scan so no other suite hardcodes the path. See [Refreshing the app screenshots](#refreshing-the-app-screenshots) |
 | `tests/env-documented.test.mjs` | Root integration suites | Every `process.env` name the relay or admin reads must be in [deploy/.env.example](../deploy/.env.example) with a purpose, a default and the file that reads it. Nothing may be documented there that no code reads, and every `read in:` pointer must name a file that exists and mentions the variable. 40 of 57 were undocumented on 2026-09-02 |
 
 ## Running manually
@@ -31,6 +32,38 @@ Guards the auth + TOTP stack against the class of breakage that hit production r
 # Smoke against staging / local
 PARAMANT_BASE=http://localhost:4200/admin ./tests/auth-smoke.sh
 ```
+
+## Refreshing the app screenshots
+
+`tests/app-shots.mjs` renders every app screen at 390x844 and 1440x900, in
+light and dark, and writes 36 PNGs. The copies under
+`docs/brand/assets/app-2026/` are tracked, so writing them is a deliberate act
+and never a side effect of running the tests.
+
+```bash
+# Default: a temp directory. The repo stays clean.
+node tests/app-shots.mjs
+
+# Only where would it write, no browser, no files.
+APP_SHOTS_DRY_RUN=1 node tests/app-shots.mjs
+
+# Refresh the tracked reference images. Review the diff before committing:
+# a screenshot that changed by two pixels of antialiasing still looks like a
+# screenshot, so a careless `git commit -a` is exactly the failure this guards.
+PARAMANT_WRITE_BRAND_SHOTS=1 node tests/app-shots.mjs
+
+# One screen only, and an explicit destination.
+APP_SHOTS_ONLY=dashboard APP_SHOTS_DIR=/tmp/shots node tests/app-shots.mjs
+```
+
+`APP_SHOTS_DIR` wins over the default, with one rule: a path pointing back
+inside `docs/` is refused unless `PARAMANT_WRITE_BRAND_SHOTS=1` is set too.
+Otherwise the opt-in would be one environment variable away from meaning
+nothing. Where the decision is made: `scripts/brand-shots-dir.mjs`.
+
+CI never consumes these images. The sign-e2e workflow runs `tests/app-shots.mjs`
+because it picks up every suite that imports playwright, and no workflow uploads
+or reads the result, so nothing there sets the flag.
 
 ## Pre-commit hook
 

--- a/tests/app-shots.mjs
+++ b/tests/app-shots.mjs
@@ -1,20 +1,37 @@
 // Screenshot harness for the app screens. Not a gate: it renders every app
 // screen at 390x844 and 1440x900, in light and dark, with the same API stubs
-// the dashboard suite uses, and writes the images to the directory given in
-// APP_SHOTS_DIR (default docs/brand/assets/app-2026/).
+// the dashboard suite uses, and writes the images.
 //
-// Run: node tests/app-shots.mjs
-// One screen only: APP_SHOTS_ONLY=dashboard node tests/app-shots.mjs
+// It writes to a temp directory by default. The tracked reference images under
+// docs/ are opt-in, because a suite that rewrites 36 tracked files on every run
+// turns `git commit -a` into a screenshot dump. See scripts/brand-shots-dir.mjs
+// for the rule and tests/brand-shots-optin.test.mjs for the guard.
+//
+// Run:                 node tests/app-shots.mjs
+// Refresh references:  PARAMANT_WRITE_BRAND_SHOTS=1 node tests/app-shots.mjs
+// One screen only:     APP_SHOTS_ONLY=dashboard node tests/app-shots.mjs
+// Where would it write: APP_SHOTS_DRY_RUN=1 node tests/app-shots.mjs
 
 import { chromium } from 'playwright';
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveBrandShotsDir, FLAG, DRY_RUN_VAR } from '../scripts/brand-shots-dir.mjs';
 
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
-const OUT = process.env.APP_SHOTS_DIR
-  || path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'docs', 'brand', 'assets', 'app-2026');
+const TARGET = resolveBrandShotsDir();
+const OUT = TARGET.dir;
+
+// Dry run: say where the images would go and touch nothing. This is what
+// tests/brand-shots-optin.test.mjs runs, so the guard measures this file rather
+// than a copy of its logic. It has to come before the mkdir below.
+if (process.env[DRY_RUN_VAR] === '1') {
+  console.log(`out-dir: ${OUT}`);
+  console.log(`opt-in: ${TARGET.optIn ? 'yes' : 'no'} (${FLAG}, resolved from ${TARGET.source})`);
+  process.exit(0);
+}
+
 fs.mkdirSync(OUT, { recursive: true });
 
 const MIME = { '.js':'text/javascript','.mjs':'text/javascript','.css':'text/css','.html':'text/html','.svg':'image/svg+xml','.png':'image/png','.jpg':'image/jpeg','.webp':'image/webp','.woff2':'font/woff2','.json':'application/json','.wasm':'application/wasm' };
@@ -152,4 +169,5 @@ if (!only || only.includes('dashboard')) {
 await browser.close();
 server.close();
 console.log(`${written.length} images in ${OUT}`);
+if (!TARGET.optIn) console.log(`Not the tracked references: set ${FLAG}=1 to refresh docs/brand/assets/app-2026.`);
 for (const name of written) console.log('  ' + name);

--- a/tests/brand-shots-optin.test.mjs
+++ b/tests/brand-shots-optin.test.mjs
@@ -1,0 +1,183 @@
+// The reference screenshots under docs/ are opt-in, and this is what holds it.
+//
+// tests/app-shots.mjs used to write 36 PNGs straight into
+// docs/brand/assets/app-2026/ on every run. Those files are tracked, so any
+// local run of the browser suites left 36 modified files behind and the next
+// `git commit -a` shipped them. Two builders hit that in the same week. Nothing
+// was broken by it, which is exactly why nobody noticed: a screenshot that
+// changed by two pixels of antialiasing still looks like a screenshot.
+//
+// Three layers, because each catches a different way back to the old
+// behaviour:
+//
+//   1. UNIT: the resolver itself. No flag means a temp dir; the flag means the
+//      tracked directory; and an explicit APP_SHOTS_DIR aimed back into docs/
+//      is refused without the flag, so the opt-in is not one variable away
+//      from meaning nothing.
+//   2. DRY RUN: the real tests/app-shots.mjs, spawned with a scrubbed
+//      environment, has to name a directory outside this repo, and the tracked
+//      directory must be byte-identical afterwards. This measures the file
+//      that does the writing, not a second copy of its rules.
+//   3. STATIC: no other suite or script may name the tracked directory unless
+//      it goes through the resolver or names the flag. A new browser suite
+//      that hardcodes the path is the obvious way this comes back.
+//
+// Remove the flag check from scripts/brand-shots-dir.mjs and layers 1, 2 and 3
+// all go red.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  resolveBrandShotsDir, isUnderDocs, REPO_ROOT, DOCS_ROOT, TRACKED_DIR, FLAG, DIR_VAR, DRY_RUN_VAR,
+} from '../scripts/brand-shots-dir.mjs';
+
+// Built from parts so the static scan below does not match its own pattern.
+const TRACKED_REL = ['docs', 'brand', 'assets'].join('/');
+const SHOTS_SUITE = path.join(REPO_ROOT, 'tests', 'app-shots.mjs');
+
+function under(parent, child) {
+  const rel = path.relative(parent, child);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+// A snapshot of the tracked directory: name, size and mtime of every file. Two
+// identical snapshots mean nothing wrote there.
+function snapshot(dir) {
+  if (!fs.existsSync(dir)) return '(absent)';
+  return fs.readdirSync(dir).sort().map((name) => {
+    const s = fs.statSync(path.join(dir, name));
+    return `${name} ${s.size} ${s.mtimeMs}`;
+  }).join('\n');
+}
+
+// ── 1. UNIT ───────────────────────────────────────────────────────────────────
+
+// The names are the contract: tests/README.md, the suite header and every
+// checklist that says how to refresh the references all spell them out. A
+// renamed constant would keep every other assertion here green while the
+// documented command silently stopped working.
+test('the documented variable names are the ones the resolver reads', () => {
+  assert.equal(FLAG, 'PARAMANT_WRITE_BRAND_SHOTS');
+  assert.equal(DIR_VAR, 'APP_SHOTS_DIR');
+  assert.equal(DRY_RUN_VAR, 'APP_SHOTS_DRY_RUN');
+});
+
+test('without the flag the shots go outside the repo', () => {
+  const { dir, optIn, source } = resolveBrandShotsDir({});
+  assert.equal(optIn, false);
+  assert.equal(source, 'default');
+  assert.ok(under(os.tmpdir(), dir), `default target must live under the system temp dir, got ${dir}`);
+  assert.ok(!under(REPO_ROOT, dir), `default target must not live in the repo, got ${dir}`);
+});
+
+test(`${FLAG}=1 is what points the shots at the tracked references`, () => {
+  const { dir, optIn, source } = resolveBrandShotsDir({ [FLAG]: '1' });
+  assert.equal(optIn, true);
+  assert.equal(source, FLAG);
+  assert.equal(dir, TRACKED_DIR);
+  assert.ok(under(DOCS_ROOT, dir));
+});
+
+test(`a value other than 1 in ${FLAG} is not an opt-in`, () => {
+  for (const value of ['0', '', 'true', 'yes']) {
+    const { dir } = resolveBrandShotsDir({ [FLAG]: value });
+    assert.ok(!under(REPO_ROOT, dir), `${FLAG}=${JSON.stringify(value)} must not reach the repo, got ${dir}`);
+  }
+});
+
+test(`${DIR_VAR} still names an explicit directory outside docs/`, () => {
+  const wanted = path.join(os.tmpdir(), 'somewhere-else');
+  const { dir, source } = resolveBrandShotsDir({ [DIR_VAR]: wanted });
+  assert.equal(dir, wanted);
+  assert.equal(source, DIR_VAR);
+});
+
+test(`${DIR_VAR} aimed back into docs/ is refused without the flag`, () => {
+  assert.throws(() => resolveBrandShotsDir({ [DIR_VAR]: TRACKED_DIR }), /tracked/);
+  assert.throws(() => resolveBrandShotsDir({ [DIR_VAR]: DOCS_ROOT }), /tracked/);
+  // Relative and dot-walked paths resolve to the same place, so they are the
+  // same refusal and not a way round it.
+  assert.throws(() => resolveBrandShotsDir({ [DIR_VAR]: `${TRACKED_REL}/app-2026` }), /tracked/);
+  assert.throws(() => resolveBrandShotsDir({ [DIR_VAR]: path.join(REPO_ROOT, 'tests', '..', 'docs', 'x') }), /tracked/);
+  // With the flag it is allowed: refreshing the references is the point.
+  assert.equal(resolveBrandShotsDir({ [DIR_VAR]: TRACKED_DIR, [FLAG]: '1' }).dir, TRACKED_DIR);
+});
+
+test('isUnderDocs answers for docs/ itself and for neighbours that merely start the same', () => {
+  assert.equal(isUnderDocs(DOCS_ROOT), true);
+  assert.equal(isUnderDocs(TRACKED_DIR), true);
+  assert.equal(isUnderDocs(path.join(REPO_ROOT, 'tests')), false);
+  assert.equal(isUnderDocs(`${DOCS_ROOT}-scratch`), false);
+  assert.equal(isUnderDocs(os.tmpdir()), false);
+});
+
+// ── 2. DRY RUN ────────────────────────────────────────────────────────────────
+
+test('a dry run of the real suite names a directory outside the repo and writes nothing', () => {
+  const before = snapshot(TRACKED_DIR);
+  // A scrubbed environment: neither variable inherited from whoever is running
+  // the suite, so this measures the default and not the caller's shell.
+  const env = { ...process.env };
+  delete env[FLAG];
+  delete env[DIR_VAR];
+  env[DRY_RUN_VAR] = '1';
+
+  const out = execFileSync(process.execPath, [SHOTS_SUITE], { env, encoding: 'utf8', timeout: 60000 });
+  const line = out.split('\n').find((l) => l.startsWith('out-dir: '));
+  assert.ok(line, `the dry run must print its target, got:\n${out}`);
+  const target = line.slice('out-dir: '.length).trim();
+
+  assert.ok(!under(REPO_ROOT, target),
+    `tests/app-shots.mjs would write into the repo without ${FLAG}: ${target}`);
+  assert.ok(!isUnderDocs(target),
+    `tests/app-shots.mjs would write under docs/ without ${FLAG}: ${target}`);
+  assert.match(out, /opt-in: no/);
+  assert.equal(snapshot(TRACKED_DIR), before, 'a dry run must leave the tracked references untouched');
+});
+
+test(`the same dry run with ${FLAG}=1 does aim at the tracked references`, () => {
+  const before = snapshot(TRACKED_DIR);
+  const env = { ...process.env, [FLAG]: '1', [DRY_RUN_VAR]: '1' };
+  delete env[DIR_VAR];
+
+  const out = execFileSync(process.execPath, [SHOTS_SUITE], { env, encoding: 'utf8', timeout: 60000 });
+  const line = out.split('\n').find((l) => l.startsWith('out-dir: '));
+  assert.ok(line, `the dry run must print its target, got:\n${out}`);
+  assert.equal(line.slice('out-dir: '.length).trim(), TRACKED_DIR);
+  assert.match(out, /opt-in: yes/);
+  // Still a dry run: naming the directory is not writing to it.
+  assert.equal(snapshot(TRACKED_DIR), before, 'a dry run must leave the tracked references untouched');
+});
+
+// ── 3. STATIC ─────────────────────────────────────────────────────────────────
+
+test('nothing else names the tracked screenshot directory without going through the resolver', () => {
+  const roots = [path.join(REPO_ROOT, 'tests'), path.join(REPO_ROOT, 'scripts')];
+  const self = path.resolve(new URL(import.meta.url).pathname);
+  const resolver = path.join(REPO_ROOT, 'scripts', 'brand-shots-dir.mjs');
+  const offenders = [];
+
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) { if (entry.name !== 'node_modules') walk(full); continue; }
+      if (!/\.(mjs|js|sh)$/.test(entry.name)) continue;
+      if (full === self || full === resolver) continue;
+      const source = fs.readFileSync(full, 'utf8');
+      const namesTracked = source.includes(TRACKED_REL)
+        || source.includes(["'docs'", "'brand'", "'assets'"].join(', '));
+      if (!namesTracked) continue;
+      const guarded = source.includes(FLAG) || source.includes('brand-shots-dir.mjs');
+      if (!guarded) offenders.push(path.relative(REPO_ROOT, full));
+    }
+  };
+  for (const root of roots) walk(root);
+
+  assert.deepEqual(offenders, [],
+    `these name ${TRACKED_REL}/ but neither import the resolver nor mention ${FLAG}. ` +
+    'The reference images are tracked: write to a temp directory by default and ' +
+    'let the flag opt in, the way tests/app-shots.mjs does.');
+});

--- a/tests/static-sanity.sh
+++ b/tests/static-sanity.sh
@@ -245,6 +245,48 @@ else
   printf "   WARN  %s not found or not executable, test-scope guard skipped\n" "$SCOPE"
 fi
 
+# ── 12. Test suites do not write into tracked docs/ by default ───────────────
+# tests/app-shots.mjs renders 36 PNGs. It used to write them straight into
+# docs/brand/assets/app-2026/, which is tracked, so every local run of the
+# browser suites left 36 modified files behind and the next `git commit -a`
+# carried them. Refreshing those references is a deliberate act:
+# PARAMANT_WRITE_BRAND_SHOTS=1. This is the pre-commit half of that rule, so a
+# suite that hardcodes the path is caught before the commit rather than in CI.
+# The full guard, including a real dry run of the suite, is
+# tests/brand-shots-optin.test.mjs.
+echo ""
+echo "12. Brand screenshots stay opt-in..."
+SHOTS_FLAG='PARAMANT_WRITE_BRAND_SHOTS'
+SHOTS_RESOLVER="$ROOT/scripts/brand-shots-dir.mjs"
+if [ ! -f "$SHOTS_RESOLVER" ]; then
+  printf "   FAIL  scripts/brand-shots-dir.mjs is gone; nothing decides where the shots land\n"
+  FAIL=$((FAIL + 1))
+elif ! grep -qE "^export const FLAG = '$SHOTS_FLAG';" "$SHOTS_RESOLVER" || ! grep -q 'env\[FLAG\]' "$SHOTS_RESOLVER"; then
+  # The assignment and the read, not a mention: the file documents the variable
+  # in its header, so a plain grep for the name stays green over a resolver that
+  # has stopped reading it.
+  printf "   FAIL  scripts/brand-shots-dir.mjs no longer reads %s, so the opt-in is gone\n" "$SHOTS_FLAG"
+  FAIL=$((FAIL + 1))
+else
+  SHOTS_BAD=""
+  while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    case "$f" in *brand-shots-dir.mjs|*brand-shots-optin.test.mjs) continue ;; esac
+    grep -qE "docs/brand/assets|'docs', 'brand', 'assets'" "$f" || continue
+    grep -qE "$SHOTS_FLAG|brand-shots-dir\.mjs" "$f" && continue
+    SHOTS_BAD="$SHOTS_BAD $f"
+  done <<< "$(find "$ROOT/tests" "$ROOT/scripts" -type f \( -name '*.mjs' -o -name '*.js' -o -name '*.sh' \) -not -path '*/node_modules/*')"
+  if [ -n "$SHOTS_BAD" ]; then
+    for f in $SHOTS_BAD; do
+      printf "   FAIL  %s names the tracked screenshot directory without the opt-in\n" "${f#"$ROOT/"}"
+    done
+    printf "         Write to a temp dir by default and let %s=1 opt in.\n" "$SHOTS_FLAG"
+    FAIL=$((FAIL + 1))
+  else
+    printf "   OK  no suite writes the tracked reference images without %s=1\n" "$SHOTS_FLAG"
+  fi
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "════════ RESULT ════════"


### PR DESCRIPTION
`tests/app-shots.mjs` wrote 36 PNGs straight into `docs/brand/assets/app-2026/`, which is tracked. Every local run of the browser suites left 15 modified files behind, and the next `git commit -a` carried them. Measured on this branch: 15 of the 36 differ run to run.

Refreshing the references is now deliberate. Default is a temp directory outside the repo; `PARAMANT_WRITE_BRAND_SHOTS=1` points the suite at `docs/brand/assets/app-2026/`. `APP_SHOTS_DIR` still names an explicit directory and still wins, except that a path pointing back inside `docs/` is refused without the flag.

The rule lives in `scripts/brand-shots-dir.mjs`. `tests/brand-shots-optin.test.mjs` holds it in three layers: the resolver's rules, a real dry run of the suite (`APP_SHOTS_DRY_RUN=1`) that must name a directory outside the repo and leave the references byte-identical, and a scan so no other suite hardcodes the path. Check 12 in `tests/static-sanity.sh` is the pre-commit half.

Sabotage-checked: dropping the flag check turns 5 of the 10 assertions red including the dry run; a suite that hardcodes the path fails the scan and static-sanity; a renamed or unread `FLAG` fails both.

Scope: only `tests/app-shots.mjs` ever wrote there. `app-contrast`, `app-theme` and the motion suites read `frontend/app-2026.css` and write nothing; the other screenshot suites were already env-gated. No workflow uploads or reads these images, so no CI job sets the flag. sign-e2e runs `app-shots.mjs` only because it selects every suite importing playwright, and that output now lands in the runner's temp dir.