### PR TITLE
Six things the signed-in journey got wrong on a phone

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -129,7 +129,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 .dh-document-name span { display: block; margin-top: 4px; font-family: var(--mono); font-size: 11px; letter-spacing: .04em; color: var(--ink-3); }
 /* The reference is a whole value or an honestly shortened one. Cut without a
    sign that it was cut, "env_waiting_..." read as the complete id. */
-.dh-doc-ref { display: inline-block; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; }
+.dh-document-name .dh-doc-ref { display: inline-block; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; }
 .dh-document-progress { min-width: 0; }
 /* Never a bar without the number next to it. */
 .dh-document-progress span { display: block; margin-bottom: 7px; font-family: var(--mono); font-size: 11px; letter-spacing: .04em; color: var(--ink-2); }
@@ -339,7 +339,9 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
      390px the filter chips and Refresh were 36px, the four quiet links 36px,
      and the two text links in a running line 19px. */
   .dh-filter, .dh-refresh, .dh-btn, .dh-quiet-links a { min-height: var(--tap); }
-  .dh-ask-foot a, footer .footer-links a { display: inline-flex; align-items: center; min-height: var(--tap); }
+  /* The links inside the answers count too: measured at 390 they were 19px
+     ("See the plans", at the end of its line) and 41px. */
+  .dh-ask-list a, .dh-ask-foot a, footer .footer-links a { display: inline-flex; align-items: center; min-height: var(--tap); }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -127,6 +127,9 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 .dh-document-name { min-width: 0; }
 .dh-document-name strong { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 15px/1.35 var(--sans); color: var(--ink-1); }
 .dh-document-name span { display: block; margin-top: 4px; font-family: var(--mono); font-size: 11px; letter-spacing: .04em; color: var(--ink-3); }
+/* The reference is a whole value or an honestly shortened one. Cut without a
+   sign that it was cut, "env_waiting_..." read as the complete id. */
+.dh-doc-ref { display: inline-block; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; }
 .dh-document-progress { min-width: 0; }
 /* Never a bar without the number next to it. */
 .dh-document-progress span { display: block; margin-bottom: 7px; font-family: var(--mono); font-size: 11px; letter-spacing: .04em; color: var(--ink-2); }
@@ -145,6 +148,8 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 .dh-empty strong { display: block; margin-bottom: 8px; font: 600 16px/1.3 var(--sans); color: var(--ink-1); }
 .dh-empty span { display: block; max-width: 52ch; margin: 0 auto; font: 14px/1.6 var(--sans); color: var(--ink-2); }
 .dh-empty .dh-refresh { margin-top: 12px; }
+.dh-empty .dh-empty-cta { margin-top: 16px; min-height: var(--tap); border-color: var(--accent); color: var(--accent); }
+.dh-empty .dh-empty-cta:hover { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); }
 
 /* Loading skeleton: the shape of a register row, so the page does not jump. */
 .dh-skel-row { display: grid; grid-template-columns: minmax(0, 1fr) 132px 148px; gap: 22px; align-items: center; padding: 17px 26px; border-bottom: 1px solid var(--line); }
@@ -330,6 +335,11 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
   .dh-doc-kv dd { margin-bottom: 10px; }
   .dh-acct-head { padding: var(--space-3) var(--space-4); }
   .dh-acct-body { padding: 0 var(--space-4) var(--space-4); }
+  /* Tap targets on a phone: padding, never smaller or larger type. Measured at
+     390px the filter chips and Refresh were 36px, the four quiet links 36px,
+     and the two text links in a running line 19px. */
+  .dh-filter, .dh-refresh, .dh-btn, .dh-quiet-links a { min-height: var(--tap); }
+  .dh-ask-foot a, footer .footer-links a { display: inline-flex; align-items: center; min-height: var(--tap); }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -629,6 +639,6 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=6" defer></script>
-<script src="/js/dashboard.js?v=8" defer></script>
+<script src="/js/dashboard.js?v=9" defer></script>
 </body>
 </html>

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -284,7 +284,12 @@
       var empty = documentFilter === 'open'
         ? ['No open requests', 'Start a signing request when you need someone to sign a document.']
         : ['Nothing here yet', 'Documents in this state will appear here automatically.'];
-      list.innerHTML = '<div class="dh-empty"><strong>' + empty[0] + '</strong><span>' + empty[1] + '</span></div>';
+      // An empty state that only describes the way out is a dead end. The one
+      // action that fills this list is a signing request, so it gets a button
+      // to the page that starts one. Send is deliberately not offered here:
+      // this list counts signing requests, not deliveries.
+      list.innerHTML = '<div class="dh-empty"><strong>' + empty[0] + '</strong><span>' + empty[1] + '</span>' +
+        '<a class="dh-btn dh-empty-cta" href="/sign?mode=invite">Start a signing request</a></div>';
       return;
     }
     list.innerHTML = visible.map(function (doc) {
@@ -293,10 +298,16 @@
       var signed = Math.max(0, Math.min(total, Number(doc.signed_count || 0)));
       var pct = total ? Math.round((signed / total) * 100) : 0;
       var name = doc.original_filename || 'Signing request';
-      var reference = String(doc.id || '').slice(0, 10);
+      // The reference used to be cut to ten characters in code, which sliced
+      // env_waiting_... into "env_waitin": a fragment that looks like a whole
+      // value and is useless for support. The full value goes in, CSS shortens
+      // it with an ellipsis when it does not fit, and the title carries it.
+      var reference = String(doc.id || '');
       return '<button type="button" class="dh-document" data-document-id="' + esc(doc.id || '') + '" aria-label="Open details for ' + esc(name) + '">' +
         '<div class="dh-document-name"><strong title="' + esc(name) + '">' + esc(name) + '</strong>' +
-        '<span>Created ' + esc(fmtDate(doc.created_at)) + (reference ? ' · Ref ' + esc(reference) : '') + '</span></div>' +
+        '<span>Created ' + esc(fmtDate(doc.created_at)) +
+        (reference ? ' <span class="dh-doc-ref" title="' + esc(reference) + '">· Ref ' + esc(reference) + '</span>' : '') +
+        '</span></div>' +
         '<div class="dh-document-progress"><span>' + signed + ' of ' + total + ' signed</span><div class="dh-progress" aria-label="' + signed + ' of ' + total + ' signed"><i style="width:' + pct + '%"></i></div></div>' +
         '<div class="dh-status ' + state + '">' + documentLabel(state) + '</div>' +
         '</button>';

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -101,6 +101,11 @@ function hide(id) { $(id).hidden = true; }
 let __firstStepRender = true;
 function setActive(stepId) {
   document.querySelectorAll('.ds-step').forEach(s => s.hidden = (s.id !== stepId));
+  // Publish the current step on <body> so the page chrome can react to it in
+  // CSS alone. sign.html uses it to collapse the hero once a document is in
+  // hand: at full height it kept the whole uploaded PDF below the fold on a
+  // 390px screen (measured: first page at y=1231 of an 844px viewport).
+  document.body.setAttribute('data-ds-step', stepId);
   // Move focus to the new step's heading so keyboard + screen-reader users land
   // on the freshly revealed content (skip the very first render at page load).
   if (!__firstStepRender) {
@@ -382,6 +387,19 @@ function initStepDoc() {
   inp.addEventListener('change', e => e.target.files[0] && onDocChosen(e.target.files[0]));
 }
 
+// The chosen file's name and size, shown next to the document itself. Without
+// it the place step never named the file: a visitor who picked the wrong one
+// out of three similar PDFs had nothing on screen to tell him.
+function showDocMeta(name, size) {
+  const wrap = $('ds-doc-meta');
+  if (!wrap) return;
+  const nameEl = $('ds-doc-meta-name');
+  const sizeEl = $('ds-doc-meta-size');
+  if (nameEl) { nameEl.textContent = name; nameEl.title = name; }
+  if (sizeEl) sizeEl.textContent = formatSize(size);
+  wrap.hidden = false;
+}
+
 function showDocError(msg) {
   const el = $('ds-doc-error');
   if (el) { el.textContent = msg; el.hidden = false; }
@@ -400,6 +418,7 @@ async function onDocChosen(file) {
     return;
   }
   state.doc = { bytes, name: file.name, size: file.size };
+  showDocMeta(file.name, file.size);
   state.signer.docImageDataUrl = null;
   state.imageType = null;
   state.extras = [];        // fresh document: drop any text/date objects from a prior file

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -59,6 +59,11 @@ body[data-ds-step]:not([data-ds-step="step-mode"]):not([data-ds-step="step-doc"]
 .ds-doc-meta-label{flex:0 0 auto;font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-3)}
 .ds-doc-meta-name{flex:0 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--ink-1);font-weight:600}
 .ds-doc-meta-size{flex:0 0 auto;color:var(--ink-3)}
+/* Two steps name the file themselves: the hash-only card and the finished
+   screen, where the name is the SIGNED one and repeating the source above it
+   would say two different things at once. */
+body[data-ds-step="step-hash-only"] #ds-doc-meta,
+body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 .ds-stepper{list-style:none;display:flex;gap:8px;padding:0;margin:0 0 32px;border-bottom:1px solid var(--line);counter-reset:dsstep}
 .ds-stepper li{flex:1;font-family:var(--mono);font-size:11px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-3);padding:14px 0;border-bottom:2px solid transparent;counter-increment:dsstep;text-align:center}
 .ds-stepper li::before{content:counter(dsstep);display:inline-block;width:20px;height:20px;border:1px solid var(--line-2);border-radius:50%;line-height:18px;font-size:10px;margin-right:6px;font-weight:600}
@@ -488,6 +493,14 @@ body[data-ds-step]:not([data-ds-step="step-mode"]):not([data-ds-step="step-doc"]
     <li data-step="sign">Sign</li>
   </ol>
 
+  <!-- The document under the whole flow, named once and shown on every step
+       after it is picked. It used to live inside the Place step, which the
+       request-signatures flow never visits: that flow went straight from the
+       file picker to the co-signers, so the file was named nowhere and the
+       last thing before "Send for signature" was a screen that did not say
+       what was being sent. -->
+  <p class="ds-doc-meta" id="ds-doc-meta" hidden><span class="ds-doc-meta-label">File</span><span class="ds-doc-meta-name" id="ds-doc-meta-name"></span><span class="ds-doc-meta-size" id="ds-doc-meta-size"></span></p>
+
   <!-- No session: say what this needs BEFORE a document is picked.
        The page used to be behind an nginx auth_request, so a visitor never got
        here at all; he got /auth/login and, measurably, stopped. Serving the page
@@ -562,7 +575,6 @@ body[data-ds-step]:not([data-ds-step="step-mode"]):not([data-ds-step="step-doc"]
   <section class="ds-step" id="step-place" hidden>
     <h2>Place your signature</h2>
     <p class="ds-sub">Click anywhere on a page to drop the stamp. Click another spot to move it. <span id="ds-place-page-count" style="font-family:var(--mono);font-size:11px;color:var(--ink-dim)"></span></p>
-    <p class="ds-doc-meta" id="ds-doc-meta" hidden><span class="ds-doc-meta-label">File</span><span class="ds-doc-meta-name" id="ds-doc-meta-name"></span><span class="ds-doc-meta-size" id="ds-doc-meta-size"></span></p>
     <p class="ds-hint" id="ds-place-hint">Click a page to drop the signature stamp.</p>
     <div class="ds-zoom" id="ds-zoom" hidden>
       <button id="ds-zoom-out" type="button" aria-label="Zoom out">&minus;</button>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -44,6 +44,21 @@
 .ds-headlink{margin:14px 0 0;font-size:13px}
 .ds-headlink a{color:var(--accent);text-decoration:underline;text-underline-offset:3px}
 .ds-anon-actions{display:flex;flex-wrap:wrap;gap:10px;margin:20px 0 0}
+/* The hero is the pitch for a visitor who has not started yet. From the step
+   after the document is chosen it is only in the way: at 390px it held the
+   whole uploaded PDF below the fold. sign-flow.js stamps the active step on
+   <body>, so this is a CSS collapse to a single line, no script in the page. */
+body[data-ds-step]:not([data-ds-step="step-mode"]):not([data-ds-step="step-doc"]) .ds-head{margin-bottom:16px;padding-bottom:10px;border-bottom:1px solid var(--line)}
+body[data-ds-step]:not([data-ds-step="step-mode"]):not([data-ds-step="step-doc"]) .ds-head .ds-kicker,
+body[data-ds-step]:not([data-ds-step="step-mode"]):not([data-ds-step="step-doc"]) .ds-head .ds-lede,
+body[data-ds-step]:not([data-ds-step="step-mode"]):not([data-ds-step="step-doc"]) .ds-head .ds-facts,
+body[data-ds-step]:not([data-ds-step="step-mode"]):not([data-ds-step="step-doc"]) .ds-head .ds-headlink{display:none}
+body[data-ds-step]:not([data-ds-step="step-mode"]):not([data-ds-step="step-doc"]) .ds-head .ds-title{font-size:15px;font-weight:600;line-height:1.4;letter-spacing:0;margin:0;max-width:none;color:var(--ink-2)}
+/* The chosen file, named where the document is worked on. */
+.ds-doc-meta{display:flex;align-items:center;gap:10px;min-width:0;margin:0 0 14px;padding:9px 12px;border:1px solid var(--line-2);border-left:2px solid var(--mark);border-radius:var(--r-1);background:var(--surface-sunk);font-family:var(--mono);font-size:12px;color:var(--ink-2)}
+.ds-doc-meta-label{flex:0 0 auto;font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-3)}
+.ds-doc-meta-name{flex:0 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--ink-1);font-weight:600}
+.ds-doc-meta-size{flex:0 0 auto;color:var(--ink-3)}
 .ds-stepper{list-style:none;display:flex;gap:8px;padding:0;margin:0 0 32px;border-bottom:1px solid var(--line);counter-reset:dsstep}
 .ds-stepper li{flex:1;font-family:var(--mono);font-size:11px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-3);padding:14px 0;border-bottom:2px solid transparent;counter-increment:dsstep;text-align:center}
 .ds-stepper li::before{content:counter(dsstep);display:inline-block;width:20px;height:20px;border:1px solid var(--line-2);border-radius:50%;line-height:18px;font-size:10px;margin-right:6px;font-weight:600}
@@ -102,6 +117,12 @@
    targets. */
 .ds-place-actions{position:sticky;bottom:0;z-index:20;margin-top:14px;padding:12px 0;background:var(--paper);border-top:1px solid var(--line);pointer-events:none}
 .ds-place-actions .btn{min-height:var(--tap)}
+/* The bar is opaque and sticky, so whatever sits directly above it scrolls
+   underneath and cannot be read while it is stuck (measured at 1440: the edit
+   tip ended 7px under it). Reserve its height at the end of the scrolling
+   content, and let the buttons clear a phone's bottom safe area. */
+.ds-place-actions{padding-bottom:calc(12px + env(safe-area-inset-bottom,0px))}
+#ds-pdf-canvas-list{padding-bottom:calc(70px + env(safe-area-inset-bottom,0px))}
 .ds-place-actions>*{pointer-events:auto}
 /* Edit toolbar + free text/date annotations (additive layer, baked as PDF vector text) */
 .ds-edit-tools{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:10px}
@@ -247,6 +268,8 @@
 @media(max-width:640px){.ds-proof-dl{grid-template-columns:1fr}}
 @media(max-width:640px){.ds-review-grid{grid-template-columns:1fr}}
 @media(max-width:640px){
+  /* Tap targets on a phone. Padding, not type: the words keep their size. */
+  .ds-headlink a,footer .footer-links a{display:inline-flex;align-items:center;min-height:var(--tap)}
   .ds-wrap{padding:0 16px;margin-top:24px}
   .ds-title{font-size:24px}
   .ds-stepper li{font-size:10px;padding:10px 0}
@@ -539,6 +562,7 @@
   <section class="ds-step" id="step-place" hidden>
     <h2>Place your signature</h2>
     <p class="ds-sub">Click anywhere on a page to drop the stamp. Click another spot to move it. <span id="ds-place-page-count" style="font-family:var(--mono);font-size:11px;color:var(--ink-dim)"></span></p>
+    <p class="ds-doc-meta" id="ds-doc-meta" hidden><span class="ds-doc-meta-label">File</span><span class="ds-doc-meta-name" id="ds-doc-meta-name"></span><span class="ds-doc-meta-size" id="ds-doc-meta-size"></span></p>
     <p class="ds-hint" id="ds-place-hint">Click a page to drop the signature stamp.</p>
     <div class="ds-zoom" id="ds-zoom" hidden>
       <button id="ds-zoom-out" type="button" aria-label="Zoom out">&minus;</button>
@@ -860,6 +884,6 @@
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script src="/js/parasign-pdf-ops.js?v=1"></script>
 <script src="/js/quota-upgrade.js?v=4" defer></script>
-<script type="module" src="/sign-flow.js?v=49"></script>
+<script type="module" src="/sign-flow.js?v=50"></script>
 </body>
 </html>

--- a/tests/access-log-visitors.test.mjs
+++ b/tests/access-log-visitors.test.mjs
@@ -37,7 +37,7 @@ test('a client that renders is not excluded for lacking a referer', () => {
   const r = analyse([
     line({ ip: '8.8.8.8', path: '/sign' }),
     line({ ip: '8.8.8.8', path: '/design-system.css?v=25' }),
-    line({ ip: '8.8.8.8', path: '/sign-flow.js?v=49' }),
+    line({ ip: '8.8.8.8', path: '/sign-flow.js?v=50' }),
   ]);
   assert.equal(r.atMostVisitors, 1);
   assert.equal(r.verdicts.possible_visitor, 1);

--- a/tests/sign-document-identity.test.mjs
+++ b/tests/sign-document-identity.test.mjs
@@ -1,0 +1,127 @@
+// The document under the signing flow must be named on every step that acts on
+// it, in every mode.
+//
+// Why this suite exists. The file name and size were added to the Place step,
+// which is the step the request-signatures flow never visits: onDocChosen()
+// sends that mode straight from the file picker to the co-signers. So a
+// customer who chose "Request signatures" picked a file, typed two email
+// addresses and pressed "Send for signature" without one screen in between
+// saying what he was sending. A koper review found it on the second pass, on a
+// phone, where the only other place the name could have been (the collapsed
+// step-1 panel) is off screen.
+//
+// It drives the real page in Chromium rather than reading the source, because
+// what is under test is whether the name is VISIBLE at that moment: the element
+// existed the whole time, in a section that was hidden.
+
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = { '.js':'text/javascript','.mjs':'text/javascript','.css':'text/css','.html':'text/html','.svg':'image/svg+xml','.json':'application/json','.png':'image/png','.wasm':'application/wasm','.woff2':'font/woff2' };
+
+const server = http.createServer((req, res) => {
+  let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+  if (pathname === '/sign') pathname = '/sign.html';
+  const file = path.join(ROOT, pathname);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+  fs.readFile(file, (error, body) => {
+    if (error) { res.writeHead(404); return res.end(); }
+    res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  });
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const ORIGIN = `http://localhost:${server.address().port}`;
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+
+const checks = [];
+function ok(name, condition, detail = '') { checks.push({ name, pass: !!condition, detail: String(detail) }); }
+
+// A phone, because that is where the finding was made: on a desktop a stray
+// name higher up the page can still be in view, on 390x844 it cannot.
+async function uploadIn(mode, filename) {
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  // Signed in: the account notice must not be what fills the screen.
+  await page.route('**/api/**', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true,"authenticated":true}' }));
+  await page.goto(`${ORIGIN}/sign?mode=${mode}`, { waitUntil: 'networkidle' });
+  await page.evaluate(async (name) => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    while (!window.PDFLib || !window.pdfjsLib) await sleep(20);
+    const doc = await window.PDFLib.PDFDocument.create();
+    doc.addPage([595, 842]).drawText('Lease', { x: 40, y: 780, size: 14 });
+    const bytes = await doc.save();
+    const input = document.getElementById('ds-doc-input');
+    const transfer = new DataTransfer();
+    transfer.items.add(new File([bytes], name, { type: 'application/pdf' }));
+    input.files = transfer.files;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    for (let i = 0; i < 300 && document.getElementById('step-doc').hidden === false; i++) await sleep(20);
+    await sleep(300);
+  }, filename);
+  await page.waitForTimeout(300);
+  return page;
+}
+
+// What the customer can actually see: the element is visible, it is inside the
+// viewport, and it is not sitting in a section the flow has hidden.
+async function documentLine(page) {
+  return page.evaluate(() => {
+    const el = document.getElementById('ds-doc-meta');
+    if (!el) return { present: false };
+    const box = el.getBoundingClientRect();
+    const step = el.closest('.ds-step');
+    return {
+      present: true,
+      visible: !el.hidden && box.height > 0 && getComputedStyle(el).display !== 'none',
+      inViewport: box.top >= 0 && box.bottom <= window.innerHeight,
+      insideHiddenStep: !!(step && step.hidden),
+      text: el.innerText.replace(/\s+/g, ' ').trim(),
+      activeStep: document.body.getAttribute('data-ds-step'),
+    };
+  });
+}
+
+// ── invite: the mode that had no Place step at all ───────────────────────────
+const invite = await uploadIn('invite', 'huur.pdf');
+const inviteLine = await documentLine(invite);
+ok('request-signatures names the file on the co-signers step',
+  inviteLine.activeStep === 'step-recipients' && inviteLine.visible && !inviteLine.insideHiddenStep &&
+  inviteLine.inViewport && /huur\.pdf/.test(inviteLine.text) && /\d/.test(inviteLine.text),
+  JSON.stringify(inviteLine));
+
+// And it is still there at the moment that matters: the screen carrying the
+// button that sends the document to other people.
+await invite.locator('#ds-recipients-continue').waitFor();
+const sendLabel = (await invite.locator('#ds-recipients-continue').innerText()).trim();
+const beforeSend = await documentLine(invite);
+ok('the file is named on the screen that sends it',
+  sendLabel === 'Send for signature' && beforeSend.visible && beforeSend.inViewport && /huur\.pdf/.test(beforeSend.text),
+  JSON.stringify({ sendLabel, ...beforeSend }));
+await invite.close();
+
+// ── sign it myself: the Place step, where the line started ───────────────────
+const alone = await uploadIn('alone', 'huur.pdf');
+const aloneLine = await documentLine(alone);
+ok('signing it yourself names the file on the place step',
+  aloneLine.activeStep === 'step-place' && aloneLine.visible && !aloneLine.insideHiddenStep && /huur\.pdf/.test(aloneLine.text),
+  JSON.stringify(aloneLine));
+await alone.close();
+
+// ── sign together: place first, co-signers after ─────────────────────────────
+const cosign = await uploadIn('cosign', 'huur.pdf');
+const cosignPlace = await documentLine(cosign);
+await cosign.locator('#ds-place-continue').waitFor();
+ok('signing together names the file on the place step',
+  cosignPlace.visible && !cosignPlace.insideHiddenStep && /huur\.pdf/.test(cosignPlace.text), JSON.stringify(cosignPlace));
+await cosign.close();
+
+for (const check of checks) console.log(`${check.pass ? 'PASS' : 'FAIL'} ${check.name}${check.detail ? ' :: ' + check.detail : ''}`);
+await browser.close();
+server.close();
+if (checks.some((check) => !check.pass)) process.exit(1);
+console.log(`\nsign-document-identity: ${checks.length} checks passed`);

--- a/tests/user-dashboard-documents.test.mjs
+++ b/tests/user-dashboard-documents.test.mjs
@@ -144,6 +144,9 @@ const taps = await page.evaluate(() => {
     quiet: h('.dh-quiet-links a'),
     help: h('.dh-ask-foot a'),
     footer: h('footer .footer-links a'),
+    // Every link inside an answer, not just the first: "See the plans" sat at
+    // the end of its line and measured 19px while its neighbours measured 41.
+    faq: Math.min(...[...document.querySelectorAll('.dh-ask-list a')].map((el) => Math.round(el.getBoundingClientRect().height))),
   };
 });
 ok('every control on the phone screen is at least a 44px tap target',

--- a/tests/user-dashboard-documents.test.mjs
+++ b/tests/user-dashboard-documents.test.mjs
@@ -106,6 +106,49 @@ await page.locator('[data-doc-filter="cancelled"]').click();
 ok('filenames are rendered as text', await page.locator('.dh-document img').count() === 0 && await page.evaluate(() => !window.dashboardInjected), await page.locator('#dh-documents').innerText());
 ok('phone viewport has no horizontal overflow', await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth) <= 1, await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth));
 ok('document status is fetched once on load', documentRequests === 1, documentRequests);
+
+// ── What the phone screen actually hands the customer ────────────────────────
+// A koper review of the signed-in journey measured this screen at 390px. Three
+// findings are pinned here, because all three were invisible to every existing
+// assertion: they are geometry and attributes, not text.
+// The All filter, because the case above cancelled the first request: Open
+// now holds one row and All still holds the four the relay stub returned.
+await page.locator('[data-doc-filter="all"]').click();
+await page.waitForFunction(() => document.querySelectorAll('.dh-document').length === 4);
+
+// 1. The reference. It used to be sliced to ten characters in dashboard.js, so
+// env_waiting_abcdefghijklmnop rendered as "env_waitin": a fragment with
+// nothing to say it was one, which is worthless when a customer reads it out
+// to support. The full value is in the DOM and in the title; when it does not
+// fit, CSS shortens it with an ellipsis rather than a silent cut.
+const reference = await page.locator('.dh-doc-ref').first().evaluate((node) => ({
+  text: node.textContent.trim(),
+  title: node.getAttribute('title'),
+  textOverflow: getComputedStyle(node).textOverflow,
+  clipped: node.scrollWidth > node.clientWidth + 1,
+}));
+ok('the document reference is never cut without an ellipsis',
+  reference.text.endsWith('Ref env_waiting_abcdefghijklmnop') &&
+  reference.title === 'env_waiting_abcdefghijklmnop' &&
+  reference.textOverflow === 'ellipsis', JSON.stringify(reference));
+
+// 2. Tap targets. Measured at 390px before this change: filter chips and
+// Refresh 36px, the four quiet links 36px, the two text links in a running
+// line 19px. The house minimum is 44, and it is reached with padding: the
+// type keeps its size.
+const taps = await page.evaluate(() => {
+  const h = (sel) => { const el = document.querySelector(sel); return el ? Math.round(el.getBoundingClientRect().height) : 0; };
+  return {
+    filter: h('.dh-filter'),
+    refresh: h('#dh-documents-refresh'),
+    quiet: h('.dh-quiet-links a'),
+    help: h('.dh-ask-foot a'),
+    footer: h('footer .footer-links a'),
+  };
+});
+ok('every control on the phone screen is at least a 44px tap target',
+  Object.values(taps).every((height) => height >= 44), JSON.stringify(taps));
+
 await page.setViewportSize({ width:1280, height:900 });
 ok('desktop uses a three-action row without overflow', await page.evaluate(() => getComputedStyle(document.querySelector('.dh-start')).gridTemplateColumns.split(' ').length === 3 && document.documentElement.scrollWidth - document.documentElement.clientWidth <= 1), await page.evaluate(() => getComputedStyle(document.querySelector('.dh-start')).gridTemplateColumns));
 
@@ -154,6 +197,16 @@ async function planCase(state) {
 
 const freePlan = await planCase({ plan:'community' });
 ok('a Community account sees the give-back band', freePlan.badge === 'Community' && freePlan.band === true, JSON.stringify(freePlan));
+
+// 3. The empty state. This page's document list is stubbed empty, so it is the
+// screen a new customer meets. It used to be two sentences and no way out: the
+// one action that fills the list now sits in it as a real button.
+const emptyCta = await planPage.locator('.dh-empty a').first();
+const emptyCtaBox = await emptyCta.boundingBox();
+ok('the empty document list offers the action that fills it',
+  await planPage.locator('.dh-empty strong').innerText() === 'No open requests' &&
+  (await emptyCta.getAttribute('href')).startsWith('/sign') &&
+  emptyCtaBox.height >= 44, JSON.stringify({ href: await emptyCta.getAttribute('href'), height: emptyCtaBox && Math.round(emptyCtaBox.height) }));
 
 const paidPlan = await planCase({ plan:'community', plan_parasign:'pro', paid_until_parasign:future });
 ok('a paid ParaSign tier is never called free', paidPlan.badge === 'Pro' && paidPlan.band === false, JSON.stringify(paidPlan));


### PR DESCRIPTION
Six findings from the koper review of the signed-in journey, measured at 390x844 and 1440x900 in Chromium, before and after, with a real PDF uploaded through the page. A second commit answers the re-review.

## /sign

**1. The hero stood above every step.** It is the pitch for a visitor who has not started, and at 390px it kept the whole uploaded PDF below the fold: the first page started at y=1231 of an 844px screen. `setActive()` in sign-flow.js now stamps the active step on `<body>` as `data-ds-step`, and sign.html collapses the hero to a single line from the step after the document is chosen. CSS only, no script in the page.

| | before | after |
|---|---|---|
| hero height after upload, 390 | 395px | 32px |
| first PDF page, 390 (fold 844) | y=1231 | y=913 |
| first PDF page, 1440 (fold 900) | y=1001 | y=677, above the fold |

**2. The file was named nowhere.** huur.pdf went in and appeared on no screen until the review step. Name and size now sit above the steps, with the full name in the `title` so a long one stays readable.

The re-review found the half of this that the first commit missed. The line went on the Place step, and request-signatures never visits it: `onDocChosen()` sends that mode straight from the picker to the co-signers. So a customer picked a file, typed two addresses and pressed "Send for signature" with nothing on screen saying what he was sending. The line now lives above the steps rather than inside one, so it holds on every step after the file is chosen, in all three modes. It hides on the two steps that name the file themselves: the hash-only card, and the finished screen, where the name is the signed one.

**3. The sticky action bar covered content.** Back/Continue is opaque, so whatever sat under it while it was stuck could not be read. Measured at 1440: the edit hint ended 7px under the bar. The scrolling content now reserves the bar's height, and the buttons clear a phone's bottom safe area (`env(safe-area-inset-bottom)`). Both sizes: no overlap at any scroll position.

## /dashboard

**4. The empty list was a dead end.** "No open requests" was two sentences and no way out. The one action that fills the list is now a 44px button in it, to `/sign?mode=invite`. Send is deliberately not offered there: this list counts signing requests, not deliveries.

**5. Tap targets at 390.** Measured before: filter chips and Refresh 36px, the four quiet links 36px, the footer links and "help centre" 19px, "What ParaSign is" 18px. The re-review added three more, the links inside the answers: 19px for the one at the end of its line, 41px for the two others. All 44px now, and through padding: the type keeps its size. The dashboard fold is unchanged, the start card sits at y=348 before and after, and horizontal overflow stays at 0.

The site already had a 44px rule for these, keyed on `pointer: coarse`. A phone-width viewport without touch emulation, which is what a review browser is, never matched it. The rules here are keyed on width, in each page's own stylesheet, so nothing outside /sign and /dashboard moves.

**6. The reference was cut mid-word.** dashboard.js sliced the id to ten characters, so `env_waiting_abcdefghijklmnop` rendered as "env_waitin": a fragment that looks like a whole value and is worthless read out to support. The full value is now in the row and in the `title`, and CSS shortens it with an ellipsis when it does not fit. The rule carries `.dh-document-name .dh-doc-ref`, because `.dh-document-name span` is more specific and had quietly won over the bare class.

## Gates

first-screen, ui-truthfulness, site-claims, seo-contract, links, navigation-shell, frontend-loading-contract, pricing-fold, cache-bust, csp-inline, static-sanity, check-test-declarations, eslint, app-contrast, app-theme, apply-nav-idempotent, user-dashboard-documents, developer-parasign-dashboard: all green. sign-full 33/33, and every browser suite in the sign-e2e job, 42 passing.

Two suites carry the findings. `tests/sign-document-identity.test.mjs` is new: it drives all three modes in Chromium at 390x844 and asserts the document line is visible, inside the viewport and not inside a hidden step. Put the line back in the Place step and its two invite checks fail. `tests/user-dashboard-documents.test.mjs` gains three checks, for the reference, the empty-state button and the 44px minimum over every link measured, including the ones in the answers; drop `.dh-ask-list a` from the rule and the tap check reports 19px and fails. All of them are geometry and attributes, which no existing assertion could see. The access-log fixture follows the sign-flow.js cache-buster, which the one-version rule requires.

## What is left

At 390 the first PDF page still starts 71px under the fold. The hero was the biggest cause and it is gone; what remains between the top and the document is the Place step's own toolbar: the edit tools take 160px and the seal choice 247px, on a 844px screen.

The proposal for the next round, not done here because it is editor surgery and a separate review: put the edit tools behind one "Add to the document" button that opens them, and move the seal choice (in the document, separate sheet, or both) below the PDF, where it is a decision about the output rather than a step before seeing the input.

## Merging

`frontend/dashboard.html` touches #396 (the signed-in shell) on two adjacent cache-bust lines only, `nav-auth.js` v7 and `dashboard.js` v9. Whoever merges second keeps both bumps and runs `scripts/check-cache-bust.sh` again.
