### PR TITLE
The signed-in shell: support a phone can reach, a homepage that stops selling, and one apology

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -115,6 +115,6 @@
     </div>
   </div>
 </footer>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -291,6 +291,6 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -399,7 +399,7 @@ main.acct input::placeholder { color: var(--ink-3); }
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script src="/js/account.inline1.js?v=2"></script>
 
 <script type="module" src="/js/account.inline2.js?v=3"></script>

--- a/frontend/apply-nav.py
+++ b/frontend/apply-nav.py
@@ -30,8 +30,10 @@ NEW_NAV = '''\
 # the desktop bar, and js/nav-auth.js rewrites its whole inside after the
 # session check. The two secondary routes a phone loses from the bar -- Sign in
 # and Help -- therefore hang under it as their own strip, which nav.js opens
-# and closes with the drawer and nav-auth.js removes once you are signed in
-# (the user menu carries both from then on).
+# and closes with the drawer. Signed in, nav-auth.js rewrites that strip down
+# to Help alone: Sign in is not an action you still need, and Help is, on the
+# one surface a phone has left for it. It used to REMOVE the strip there, which
+# is how a signed-in phone ended up with no route to support at all.
 NEW_MOBILE = '''\
 <div class="nav-mobile" id="nav-mobile">
   <a href="/#products" class="nav-mobile-standalone">Product</a>
@@ -90,7 +92,7 @@ LEGAL_STRIP = '''\
 DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=25">'
 NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=20">'
 NAV_JS    = '<script src="/nav.js?v=15" defer></script>'
-NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=6" defer></script>'
+NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=7" defer></script>'
 
 # Pages that don't have <nav class="nav"> yet but should — inject the canonical
 # nav after <body> (or after a skip-link if present). App shells (admin,

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -749,6 +749,6 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -251,6 +251,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -110,7 +110,7 @@
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script src="/js/auth-backup.js?v=2"></script>
 
 <footer class="legal-strip">

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -135,7 +135,7 @@
 
 <script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script src="/js/auth-login.js?v=3"></script>
 <script type="module" src="/js/passkey.js?v=3"></script>
 

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -99,7 +99,7 @@
 
 <script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script src="/js/auth-request-reset.js?v=2"></script>
 <footer class="legal-strip">
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -114,7 +114,7 @@
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script src="/js/auth-reset-confirm.js?v=3"></script>
 <footer class="legal-strip">
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -284,7 +284,7 @@
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script src="/js/auth-setup.js?v=2"></script>
 <script type="module" src="/js/passkey.js?v=3"></script>
 

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -295,6 +295,6 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -740,6 +740,10 @@ async function doSign() {
     else if (e && e.code === 'cancelled') msg = 'Signing cancelled. Tap Sign when you’re ready.';
     else if (e && (e.code === 'totp_invalid' || e.code === 'totp_required')) msg = 'That authenticator code didn’t match. Tap Sign and enter the current 6-digit code.';
     else if (e && e.code === 'totp_unavailable') msg = 'Set up an authenticator app on your account first (Account → Two-factor), then sign with its code.';
+    // Already translated by the signer (js/error-message.js): the message on
+    // this error is our own vetted sentence with a next step, never the wire's
+    // "http_502" or a browser's TypeError text. The detail is in the console.
+    else if (e && e.code === 'service_error') msg = e.message;
     else if (e && (e.code === 'prf_unsupported' || e.code === 'need_passkey')) msg = 'Your passkey can’t do one-tap signing here. Tap Sign to sign with your authenticator code instead.';
     else if (e && e.status) msg = 'Signing could not be completed right now (server error ' + e.status + '). Please try again in a moment.';
     else msg = 'Your passkey could not complete signing on this browser. Tap Sign to try again. If it keeps failing, try a different browser, or use the passkey on your phone.';

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -590,6 +590,6 @@ FLAGS    1 byte    reserved for future features</pre>
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -429,6 +429,6 @@ body { min-height:100vh; }
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -546,7 +546,15 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
       <dl class="dh-ask-list">
         <div class="dh-ask-item">
           <dt>What does it cost?</dt>
-          <dd>Community is free forever, with no card. Paid plans start at &euro;15 a month excl. btw, which is ParaSend Pro. <a href="/pricing">See the plans</a></dd>
+          <!-- Two products, two prices, and this answer used to name only the
+               cheaper one. "Paid plans start at &euro;15 a month" is true of
+               sending and says nothing about signing, which is what this
+               dashboard is for: /help answers the same question with
+               "ParaSign Pro &euro;49". One customer, two pages, two numbers.
+               Both amounts are on /pricing and both are pinned to
+               relay/lib/billing-catalog.js by relay/test/pricing-page.test.js,
+               so neither can move here on its own. -->
+          <dd>Community is free forever, with no card. Sending starts at &euro;15 a month excl. btw, which is ParaSend Pro; signing starts at &euro;49 a month excl. btw, which is ParaSign Pro. <a href="/pricing">See the plans</a></dd>
         </div>
         <div class="dh-ask-item">
           <dt>Who can read what I send?</dt>
@@ -640,7 +648,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script src="/js/dashboard.js?v=9" defer></script>
 </body>
 </html>

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -156,7 +156,7 @@ curl -X POST https://paramant.app/v1/envelopes \
 </div>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script src="/js/developer.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -1041,7 +1041,7 @@ python3 scripts/paramant-admin.py sync</pre>
 
 <script src="/js/docs.inline1.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <footer>
   <div class="container-lg">
     <div class="footer-grid footer-slim">

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -271,7 +271,7 @@ sha256sum -c SHA256SUMS --ignore-missing</pre>
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 
 <footer>
   <div class="container-lg">

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -378,6 +378,6 @@ input:focus{border-color:var(--cobalt)}
 
 <script src="/js/dpa.inline1.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -297,7 +297,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/get.page.js?v=2" defer></script>

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -372,6 +372,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -306,6 +306,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -407,6 +407,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -379,6 +379,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -413,6 +413,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -363,6 +363,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -394,6 +394,6 @@ print(resp.json()["url"])</div>
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -365,6 +365,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -401,6 +401,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -368,6 +368,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -67,7 +67,23 @@ main{display:block;overflow:hidden}
    the footer stay; the footer is where the legal documents are. Signed out,
    nothing here applies and the page is exactly what it was. */
 html[data-session="in"] main > section:not(.home-hero){display:none}
-html[data-session="in"] .home-hero{padding-bottom:48px}
+/* The art goes with the pitch it illustrates. It is a document that gets
+   signed, sealed and then burns, on a 16-second loop, and it exists to explain
+   the product to someone who does not have it yet. It is also the reason the
+   hero cannot simply be made shorter: .hp-doc is absolutely positioned and
+   draws about 120px BELOW the 380px box .hp-art reserves for it, which is
+   invisible while the sales page continues underneath and becomes a document
+   cut in half the moment the hero is the last thing in <main> (main has
+   overflow:hidden). Measured at 1440 signed in: hero 472px, .hp-doc bottom 80px
+   past it, receipt and signature sliced through. A phone has hidden this art
+   since it shipped, for its own reason; signed in, every width does. */
+html[data-session="in"] .hp-art{display:none}
+/* With the art gone the second grid column is empty, so the hero is one column
+   at every width. The wrap keeps its own 1120px width, which is what lines the
+   hero up with the nav and the footer; the heading, the lede and the founder
+   line carry their own ch-based measures, so nothing stretches. */
+html[data-session="in"] .home-hero .hp-wrap{grid-template-columns:minmax(0,1fr)}
+html[data-session="in"] .home-hero{padding-bottom:56px}
 
 /* ---------- hero ---------- */
 .home-hero{position:relative;padding:28px 0 32px;background:linear-gradient(180deg,#F8FAFC 0,var(--hp-paper) 160px)}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -57,6 +57,18 @@ main{display:block;overflow:hidden}
 .hp-btn:focus-visible{outline:3px solid rgba(29,78,216,.35);outline-offset:2px}
 .hp-btn:active{transform:translateY(1px)}
 
+/* ---------- signed in: the hero is the whole page ----------
+   js/home-auth.js stamps data-session="in" on <html> once the session check
+   comes back authenticated. Everything under the hero is the sales page, and a
+   customer who has already bought does not need to be sold to: on a phone the
+   three actions were followed by eight screens of pitch, ending in the founder
+   letter. The selector names the sections rather than a list of ids, so a
+   section added tomorrow is covered the day it lands. The nav, the hero and
+   the footer stay; the footer is where the legal documents are. Signed out,
+   nothing here applies and the page is exactly what it was. */
+html[data-session="in"] main > section:not(.home-hero){display:none}
+html[data-session="in"] .home-hero{padding-bottom:48px}
+
 /* ---------- hero ---------- */
 .home-hero{position:relative;padding:28px 0 32px;background:linear-gradient(180deg,#F8FAFC 0,var(--hp-paper) 160px)}
 .home-hero .hp-wrap{position:relative;display:grid;gap:28px}
@@ -588,7 +600,7 @@ footer{background:var(--hp-paper-2);border-top:1px solid var(--hp-line)}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
-<script src="/js/home-auth.js?v=1" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/home-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/js/error-message.js
+++ b/frontend/js/error-message.js
@@ -1,0 +1,68 @@
+'use strict';
+// What a customer is told when something we did not plan for goes wrong.
+//
+// The signer had one sentence for a wrong authenticator code, one for an
+// account without an authenticator, and for everything else it rethrew the
+// error it caught. That error's message is whatever the wire said: "http_500",
+// "internal_error", "Failed to fetch", or the string a browser puts on a
+// TypeError. Someone stuck halfway through signing a contract read that and
+// had no idea whether to wait, to retry, or to call someone. Two of those
+// three strings do not even name a problem.
+//
+// So there is one sentence for the unplanned case, it says what to do next,
+// and it names an address that reaches a human. The technical detail is not
+// thrown away: it goes to the console, which is where it was useful anyway.
+//
+// Loadable three ways on purpose, following js/parasign-pdf-ops.js: node
+// requires it (the suite that tests this file), a page loads it as a plain
+// script and reads self.paramantErrors (js/parashare.page.js is a classic
+// script and cannot import), and an ES module side-effect-imports it and reads
+// the same namespace. One copy of the sentence, so the two products cannot
+// drift into two different apologies.
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.paramantErrors = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+
+  var SUPPORT_FAILURE_MESSAGE =
+    'Something went wrong on our side. Try again in a minute; if it keeps happening, ' +
+    'mail privacy@paramant.app with the time and what you did.';
+
+  // The cases we DID plan for. Each tells the customer something he can act on
+  // that the generic sentence cannot, so they keep their own words. Every other
+  // code, and every error with no code at all, is unplanned by definition.
+  var KNOWN = {
+    totp_required:    'Enter the 6-digit code from your authenticator app.',
+    totp_invalid:     'That authenticator code didn’t match. Try the current 6-digit code.',
+    totp_unavailable: 'Set up an authenticator app on your account first, then sign with its code.',
+  };
+
+  function isKnownFailure(error) {
+    var code = error && error.code;
+    return typeof code === 'string' && Object.prototype.hasOwnProperty.call(KNOWN, code);
+  }
+
+  // The translator. Errors in, one readable sentence out, never a raw message.
+  // A thrown TypeError, a 500 from the relay and an error object from a browser
+  // extension all land on the same sentence, because to the person reading it
+  // they are the same event: this did not work and it was not his fault.
+  function userFacingMessage(error) {
+    return isKnownFailure(error) ? KNOWN[error.code] : SUPPORT_FAILURE_MESSAGE;
+  }
+
+  // Log the technical detail, return the error to throw in its place. `where`
+  // is a short label naming the step, so a console holding three failures still
+  // says which one broke. The replacement carries code 'service_error' unless
+  // the original had a code of its own, and callers that render a message
+  // switch on that code rather than on the sentence.
+  function reportFailure(where, error) {
+    try { console.error('[paramant] ' + where, error); } catch (ignored) { /* a missing console is never why a flow dies */ }
+    var replacement = new Error(userFacingMessage(error));
+    replacement.code = isKnownFailure(error) ? error.code : 'service_error';
+    replacement.cause = error;
+    return replacement;
+  }
+
+  return { SUPPORT_FAILURE_MESSAGE: SUPPORT_FAILURE_MESSAGE, KNOWN: KNOWN, isKnownFailure: isKnownFailure, userFacingMessage: userFacingMessage, reportFailure: reportFailure };
+});

--- a/frontend/js/home-auth.js
+++ b/frontend/js/home-auth.js
@@ -4,6 +4,15 @@
  * and is what link scrapers see). When a valid session is present, swap to the
  * logged-in variant: "Welcome back" + quick actions, marketing badges gone.
  *
+ * Swapping the hero was only half of it. Everything BELOW the hero is the sales
+ * page -- why half of it is free, the two products, what it costs, who is
+ * behind it -- and it stayed on screen for a customer who had already bought.
+ * A signed-in phone got three actions and then eight screens of pitch. So this
+ * also stamps data-session="in" on <html>, and index.html hides every section
+ * after the hero off that one attribute. The hiding is CSS, not JS: no inline
+ * script (CSP script-src 'self'), and nothing here walks the section list, so
+ * a new section is covered the day it is added.
+ *
  * Uses the same probe the nav uses (GET /api/user/session/verify, credentials
  * included). CSP-safe: external file, no inline script, no eval. Best-effort,
  * tolerant: any failure leaves the logged-out pitch in place.
@@ -30,6 +39,7 @@
 
       out.hidden = true;
       inn.hidden = false;
+      document.documentElement.setAttribute('data-session', 'in');
     })
     .catch(function () { /* stay on the logged-out pitch */ });
 })();

--- a/frontend/js/nav-auth.js
+++ b/frontend/js/nav-auth.js
@@ -53,16 +53,28 @@
 
   function renderLoggedIn(email) {
     setNavigation(APP_NAV, 'Workspace');
-    // The drawer tail offers Sign in and Help to a visitor who is not signed
-    // in. Once you are, both are wrong there: the user menu below carries
-    // Help, and Sign in is not an action you still need.
+    // Support survives signing in. The tail used to be REMOVED here, on the
+    // reasoning that the user menu carries Help from then on. On a phone that
+    // left no Help at all: the bar sheds .nav-help below 700px, the drawer is
+    // pinned to the five workspace links, and the menu behind the email
+    // address is not where anyone looks for support. A signed-in customer with
+    // a stuck signature had to type the url.
+    //
+    // So the strip stays and carries the one route the bar handed over. Sign in
+    // does go: it is not an action you still need. Help lands in the same place
+    // as it does signed out, one tap under the drawer, 48px tall.
     var tail = document.getElementById('nav-mobile-tail');
-    if (tail) tail.remove();
+    if (tail) tail.innerHTML = '<a href="/help" class="nav-tail-link">Help</a>';
     var shortEmail = email.length > 24 ? email.slice(0, 18) + '...' : email;
+    // Help sits where it sits signed out: a text link left of the account
+    // control. nav.css hides it below 700px, where the drawer tail above takes
+    // over, and gives it a 44px target from 1023px down.
+    //
     // Never interpolate the email into innerHTML (stored/self DOM XSS): the
     // signup regex permits HTML metacharacters. Build static markup, then set
     // the email via textContent (mirrors home-auth.js / dashboard.js).
     container.innerHTML =
+      '<a href="/help" class="nav-help">Help</a>' +
       '<div class="nav-user">' +
         '<button type="button" class="nav-user-trigger" aria-expanded="false">' +
           '<span class="nav-user-email"></span>' +

--- a/frontend/js/parashare.page.js
+++ b/frontend/js/parashare.page.js
@@ -15,6 +15,18 @@ let receiverPubs = null;
 
 // ── Helpers ──
 function $(id) { return document.getElementById(id); }
+// The same apology the signer gives, from the same file, so sending and signing
+// cannot drift into two different sentences. This page is a classic script and
+// cannot import, so js/error-message.js is loaded above it as a plain script and
+// hangs its namespace off the global. The fallback string exists for the case
+// where that tag is missing; it is never the normal path.
+function failureText(where, e) {
+  var errors = window.paramantErrors;
+  if (errors) return errors.reportFailure(where, e).message;
+  console.error('[paramant] ' + where, e);
+  return 'Something went wrong on our side. Try again in a minute; if it keeps happening, ' +
+         'mail privacy@paramant.app with the time and what you did.';
+}
 function showStep(id) {
   document.querySelectorAll('.step').forEach(s => s.classList.remove('active'));
   $(id).classList.add('active');
@@ -306,8 +318,7 @@ async function connectWebSocket() {
         setStatus('waiting-status', 'Receiver disconnected', 'err');
       }
     } catch(err) {
-      console.error('ws.onmessage handler error:', err);
-      setStatus('waiting-status', 'Error processing receiver message — ' + err.message, 'err');
+      setStatus('waiting-status', failureText('receiver message', err), 'err');
     }
   };
 
@@ -447,7 +458,7 @@ async function confirmFingerprint() {
       $('enc-status').className = 'status-line';
       $('enc-status').innerHTML = window.paQuotaUpgrade.html(e.quota);
     } else {
-      $('enc-status').textContent = 'Error: ' + e.message;
+      $('enc-status').textContent = failureText('encrypt and upload', e);
       $('enc-status').className = 'status-line err';
     }
   }
@@ -540,7 +551,7 @@ document.addEventListener('DOMContentLoaded', () => {
     tbDownload(tbTokens, decodeURIComponent(sp.get('n') || 'download'), decodeURIComponent(tbRelay), tbKeys)
       .catch(e => {
         $('tb-dl-status').className = 'status-line err';
-        $('tb-dl-status').textContent = 'Error: ' + e.message;
+        $('tb-dl-status').textContent = failureText('download', e);
         $('tb-dl-dot').className = 'dot red';
       });
     setTimeout(() => initGlobe(), 400);

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -6,6 +6,13 @@
 // interface without touching callers. Self-hosted deps only (CSP 'self').
 import { ml_dsa65, sha3_256 } from '/vendor/paramant-pqc.js';
 import { vaultGetPrfWrapInfo, vaultUnlockPrf, vaultAddPrfWrap, vaultCreatePrfOnly, vaultAvailable, vaultList } from '/vendor/vault.js?v=5';
+// js/error-message.js is loadable from node, from a classic script and from
+// here, which costs it its named exports: it is a UMD factory that hangs its
+// namespace off the global. Side-effect import, then read it, the same way
+// js/parasign-pdf-ops.js is reached. It owns the one sentence a customer sees
+// when we have no better answer than "not your fault, here is who to mail".
+import '/js/error-message.js?v=1';
+const paramantErrors = self.paramantErrors;
 
 // Byte-identical to relay/envelope.js SIGN_DOMAIN_DOC (recipe v3). Keep in sync
 // across relay + SDK + core.
@@ -395,7 +402,12 @@ export async function enrolEphemeralSigningKeyWithTotp({ label, totp, onStatus }
     if (errCode === 'no_totp_setup') { const err = new Error('Set up an authenticator app on your account first, then sign with its code.'); err.code = 'totp_unavailable'; throw err; }
     if (errCode === 'invalid_totp' || e.status === 403 || e.status === 401) { const err = new Error('That authenticator code didn’t match. Try the current 6-digit code.'); err.code = 'totp_invalid'; throw err; }
     if (e && (e.status === 400 || e.status === 409) && /totp/i.test(errCode)) { const err = new Error('That authenticator code didn’t match. Try the current 6-digit code.'); err.code = 'totp_invalid'; throw err; }
-    throw e;
+    // Anything else. This used to be a bare `throw e`, which put the wire's own
+    // words in front of the customer: _postJSON below builds its message out of
+    // the relay's error field or 'http_' + status, and a dropped connection
+    // arrives as a TypeError whose message is whatever the browser calls it.
+    // "http_502" is not an instruction. The console keeps the detail.
+    throw paramantErrors.reportFailure('signing-key enrolment', e);
   }
 
   const signer = new ActivatedSigner(kp.secretKey, pk_b64);   // holds the in-memory secret; caller disposes

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -322,6 +322,6 @@ all other recipients of the licensed work to be provided by Licensor:
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/nav.css
+++ b/frontend/nav.css
@@ -789,6 +789,11 @@ nav.nav .nav-menu-divider { height: 1px; background: var(--ink-hair); margin: va
    pins its contents to exactly the four destinations of the desktop bar. So
    the two secondary routes hang under it as their own strip, pinned to the
    bottom edge where a thumb reaches.
+
+   Signed in the strip is still here and carries Help alone. It used to be
+   deleted, and since the bar drops .nav-help below 700px and the drawer is
+   pinned to the five workspace links, that left a paying customer on a phone
+   with no route to support anywhere.
    ════════════════════════════════════════ */
 .nav-mobile-tail {
   display: none;

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -269,6 +269,6 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/ontvang.page.js?v=2" defer></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -447,6 +447,6 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -606,9 +606,12 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 <script type="module" src="/js/parashare.inline1.js?v=3"></script>
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/quota-upgrade.js?v=4" defer></script>
-<script src="/js/parashare.page.js?v=3" defer></script>
+<!-- One sentence for "we broke it, here is what to do", shared with the signer.
+     Plain script, above the page code that reads window.paramantErrors. -->
+<script src="/js/error-message.js?v=1" defer></script>
+<script src="/js/parashare.page.js?v=4" defer></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <footer>
   <div class="container-lg">
     <div class="footer-grid footer-slim">

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -400,6 +400,6 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -205,6 +205,6 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -341,6 +341,6 @@ td{color:var(--cobalt)}
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -604,7 +604,7 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script src="/js/pricing-billing.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -340,6 +340,6 @@ footer a{color:var(--ink);text-decoration:none}
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -171,6 +171,6 @@
 
 <script src="/nav.js?v=15"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -299,6 +299,6 @@ footer a{color:var(--ink);text-decoration:none}
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -515,6 +515,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -195,6 +195,6 @@
   </div>
 </footer>
 
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -2816,6 +2816,10 @@ async function doSign() {
     else if (e && e.code === 'cancelled') msg = 'Signing cancelled. Tap Sign now when you’re ready.';
     else if (e && (e.code === 'totp_invalid' || e.code === 'totp_required')) msg = 'That authenticator code didn’t match. Tap Sign now and enter the current 6-digit code.';
     else if (e && e.code === 'totp_unavailable') msg = 'Set up an authenticator app on your account first (Account → Two-factor), then sign with its code.';
+    // Already translated by the signer (js/error-message.js): the message on
+    // this error is our own vetted sentence with a next step, never the wire's
+    // "http_502" or a browser's TypeError text. The detail is in the console.
+    else if (e && e.code === 'service_error') msg = e.message;
     else if (e && (e.code === 'prf_unsupported' || e.code === 'need_passkey')) msg = 'Your passkey can’t do one-tap signing here. Tap Sign now to sign with your authenticator code instead.';
     else if (e && (e.status === 403 || e.status === 409 || e.status === 410)) msg = 'That signing authorization was already used or has expired. Tap Sign now to start a fresh one.';
     else if (e && e.status) msg = 'Signing could not be completed right now (server error ' + e.status + '). Please try again in a moment.';

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -891,7 +891,7 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script src="/js/parasign-pdf-ops.js?v=1"></script>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -289,7 +289,7 @@ main#main-content .btn { width: 100%; justify-content: center; }
 
 <script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script src="/js/signup.inline1.js?v=1"></script>
 
 <script src="/js/signup.inline2.js?v=2"></script>

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
   <style>
     /* Every colour here is a token from app-2026.css, so this page follows the
        theme instead of staying light inside a dark shell. Section 5 of

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -369,6 +369,6 @@ a:hover{opacity:.8}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -271,6 +271,6 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
 
 <script src="/js/status.inline1.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -340,6 +340,6 @@ a:hover{opacity:.8}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -439,6 +439,6 @@ docker compose build   # build locally instead of pulling the published image</c
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -192,7 +192,7 @@
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 <script type="module" src="/parasign-verify.js?v=6"></script>
 </body>
 </html>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -495,7 +495,7 @@
 </section>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=6" defer></script>
+<script src="/js/nav-auth.js?v=7" defer></script>
 
 <footer>
   <div class="container-lg">

--- a/relay/test/pricing-page.test.js
+++ b/relay/test/pricing-page.test.js
@@ -730,4 +730,77 @@ ok('the compliance bullet on /parasend carries its own limit');
   ok('every page that repeats a monthly limit uses one spelling ("a month")');
 })();
 
+// ── The price question on the signed-in surfaces ─────────────────────────────
+//
+// A customer who signs in lands on /dashboard, and the FAQ there answered "what
+// does it cost?" with "Paid plans start at &euro;15 a month, which is ParaSend
+// Pro". True, and beside the point on the page whose whole job is signing:
+// /help answers the same question with "ParaSign Pro at &euro;49 a month". One
+// customer, two of our own pages, two numbers, and the cheaper one on the
+// surface he reads first.
+//
+// So the dashboard answer names BOTH products with BOTH prices, and this pins
+// it the way the cards above are pinned. The chain is the same one: the amount
+// in the sentence is the excl-btw price of the monthly variant in
+// relay/lib/billing-catalog.js, which is where checkout reads what to charge.
+// billing-catalog holds prices; relay/lib/tiers.js holds LIMITS, and it is
+// pinned here too, for the plan name the same sentence uses. Neither can move
+// without this going red.
+(function dashboardPriceAnswer() {
+  const dashHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'dashboard.html'), 'utf8');
+  const visible = dashHtml.replace(/<!--[\s\S]*?-->/g, ' ');
+  const answerMatch = /<dt>What does it cost\?<\/dt>\s*<dd>([\s\S]*?)<\/dd>/.exec(visible);
+  assert(answerMatch, 'dashboard.html must still answer "What does it cost?"');
+  const answer = answerMatch[1];
+
+  // Both products, by the names /pricing sells them under.
+  for (const productName of ['ParaSend Pro', 'ParaSign Pro']) {
+    assert(answer.includes(productName),
+      'the dashboard price answer must name ' + productName + '; naming one product prices half the account');
+    assert(html.includes(productName.split(' ')[0]),
+      '/pricing no longer sells ' + productName + ', so the dashboard answer points at nothing');
+  }
+
+  // The amounts are the catalog's, read back out of it rather than typed here.
+  const exclOf = (product) => {
+    const order = catalog.resolveOrder({ product, plan: 'pro', interval: 'monthly' });
+    assert(!order.error, 'billing-catalog has no monthly Pro price for ' + product + ': ' + order.error);
+    return Math.round((parseFloat(order.amount) / 1.21) * 100) / 100;
+  };
+  const sendExcl = exclOf('parasend');
+  const signExcl = exclOf('parasign');
+  assert(sendExcl !== signExcl,
+    'sending and signing are priced apart; if the catalog ever agrees, this answer is no longer a split');
+  assert(new RegExp('&euro;' + sendExcl + ' a month excl\\. btw, which is ParaSend Pro').test(answer),
+    'the dashboard must price SENDING at the ParaSend Pro catalog amount (&euro;' + sendExcl + '), got: ' + answer.trim());
+  assert(new RegExp('&euro;' + signExcl + ' a month excl\\. btw, which is ParaSign Pro').test(answer),
+    'the dashboard must price SIGNING at the ParaSign Pro catalog amount (&euro;' + signExcl + '), got: ' + answer.trim());
+
+  // ui-truthfulness in one line: no amount here that a reader cannot find on
+  // the page he is sent to. The boundary matters -- a bare &euro;15 is
+  // satisfied by &euro;150 sitting elsewhere on /pricing.
+  const amounts = [...new Set([...answer.matchAll(/&euro;([\d.,]+)/g)].map((m) => m[1]))];
+  assert(amounts.length >= 2, 'expected the dashboard answer to quote both prices, found ' + amounts.length);
+  for (const amount of amounts) {
+    assert(new RegExp('&euro;' + amount.replace(/[.]/g, '\\.') + '(?![\\d.,])').test(html),
+      'the dashboard names &euro;' + amount + ', which is not on /pricing');
+  }
+
+  // The free plan keeps the one name the whole site uses, and tiers.js is what
+  // says that name is the canonical row 'free' folds onto.
+  assert(tiers.normalisePlan('free') === 'community',
+    'relay/lib/tiers.js no longer folds free onto community; the dashboard answer names Community');
+  assert(/\bCommunity is free forever\b/.test(answer),
+    'the dashboard answer must still name the free plan Community');
+
+  // And /help answers the same question with the same two amounts, so the two
+  // pages a customer reads in the same minute cannot disagree again.
+  const helpHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'help', 'index.html'), 'utf8');
+  for (const excl of [signExcl]) {
+    assert(new RegExp('&euro;' + excl + '(?![\\d.,])').test(helpHtml),
+      '/help must still name the ParaSign Pro price (&euro;' + excl + ') the dashboard now agrees with');
+  }
+  ok('the dashboard price answer names both products and both catalog amounts');
+})();
+
 console.log('pricing-page: ' + passed + ' checks passed');

--- a/tests/error-message.test.mjs
+++ b/tests/error-message.test.mjs
@@ -1,0 +1,132 @@
+// The sentence a customer reads when something we did not plan for breaks.
+//
+// The signing flow translated three TOTP failures into their own words and
+// rethrew everything else untouched. That rethrow is the whole bug: the errors
+// that reach it come from _postJSON in js/parasign-signer.js, whose message is
+// the relay's error field or 'http_' + status, and from fetch itself, which
+// rejects with a TypeError whose message is whatever the browser calls a lost
+// connection. So a buyer halfway through signing a contract was shown
+// "http_502", or "Load failed", and told nothing about what to do with it.
+//
+// This runs the translator, not the page: node builtins only, no browser, so it
+// lands in the "Root integration suites" CI job and costs a millisecond. The
+// case that matters is the one nobody wrote a branch for, so the TypeError is
+// the first test here.
+//
+// Sabotage that must turn this red (all four verified before commit):
+//   1. put `throw e` back in enrolEphemeralSigningKeyWithTotp
+//   2. return error.message from userFacingMessage instead of the constant
+//   3. drop 'privacy@paramant.app' or the "Try again in a minute" step
+//   4. let parashare.page.js print e.message again
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+// Required, not imported: frontend/js/error-message.js is the same UMD factory
+// shape as js/parasign-pdf-ops.js, so the browser, a classic <script> and this
+// suite all read the one file rather than three copies of one sentence.
+const errors = require('../frontend/js/error-message.js');
+const readSource = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+test('a thrown TypeError comes out as the fixed sentence, not its own message', () => {
+  const thrown = (() => { try { null.signature; } catch (e) { return e; } })();
+  assert.ok(thrown instanceof TypeError, 'the fixture must be a real TypeError');
+  assert.equal(errors.userFacingMessage(thrown), errors.SUPPORT_FAILURE_MESSAGE);
+  assert.doesNotMatch(errors.userFacingMessage(thrown), /signature|null|undefined/i,
+    'the browser\'s own words about a TypeError may never reach the customer');
+});
+
+test('the fixed sentence says it is not the customer\'s fault, what to do now, and who to reach', () => {
+  const sentence = errors.SUPPORT_FAILURE_MESSAGE;
+  assert.match(sentence, /on our side/, 'it must not read as the customer having done something wrong');
+  assert.match(sentence, /Try again in a minute/, 'it must give the next step');
+  assert.match(sentence, /privacy@paramant\.app/, 'it must name a route to a human');
+  assert.match(sentence, /the time and what you did/, 'it must say what to put in that mail');
+});
+
+test('every shape that is not a planned failure lands on the same sentence', () => {
+  const relay500 = Object.assign(new Error('http_500'), { status: 500 });
+  const relayJson = Object.assign(new Error('internal_error'), { status: 500, data: { error: 'internal_error' } });
+  const offline = new TypeError('Failed to fetch');
+  const nonsense = { toString() { return 'not an Error at all'; } };
+  for (const error of [relay500, relayJson, offline, nonsense, null, undefined, 'a bare string']) {
+    assert.equal(errors.userFacingMessage(error), errors.SUPPORT_FAILURE_MESSAGE,
+      `${String(error)} must not get a message of its own`);
+  }
+});
+
+test('the three planned failures keep their own instruction', () => {
+  assert.match(errors.userFacingMessage({ code: 'totp_invalid' }), /current 6-digit code/);
+  assert.match(errors.userFacingMessage({ code: 'totp_required' }), /Enter the 6-digit code/);
+  assert.match(errors.userFacingMessage({ code: 'totp_unavailable' }), /authenticator app on your account/);
+  assert.equal(errors.isKnownFailure({ code: 'nonesuch' }), false);
+});
+
+test('reportFailure logs the technical detail and hands back a safe error', () => {
+  const original = console.error;
+  const logged = [];
+  console.error = (...args) => logged.push(args);
+  let replacement;
+  try {
+    replacement = errors.reportFailure('signing-key enrolment', Object.assign(new Error('http_502'), { status: 502 }));
+  } finally {
+    console.error = original;
+  }
+  assert.equal(replacement.message, errors.SUPPORT_FAILURE_MESSAGE);
+  assert.equal(replacement.code, 'service_error');
+  assert.equal(replacement.cause.message, 'http_502', 'the original must survive for a debugger');
+  assert.equal(logged.length, 1, 'exactly one console line per failure');
+  assert.match(String(logged[0][0]), /signing-key enrolment/, 'the log line names the step that broke');
+  assert.equal(logged[0][1].message, 'http_502', 'the technical detail goes to the console, not the screen');
+});
+
+test('a planned failure keeps its code and its words through reportFailure', () => {
+  const original = console.error;
+  console.error = () => {};
+  let replacement;
+  try {
+    replacement = errors.reportFailure('signing-key enrolment', Object.assign(new Error('whatever'), { code: 'totp_invalid' }));
+  } finally {
+    console.error = original;
+  }
+  assert.equal(replacement.code, 'totp_invalid');
+  assert.match(replacement.message, /current 6-digit code/);
+});
+
+// ── the callers, so the translator cannot be right and unused ────────────────
+
+test('the signer no longer rethrows the error it caught', () => {
+  const signer = readSource('frontend/js/parasign-signer.js');
+  assert.match(signer, /paramantErrors\.reportFailure\('signing-key enrolment', e\)/,
+    'enrolEphemeralSigningKeyWithTotp must hand its unplanned failures to the translator');
+  const enrol = signer.slice(signer.indexOf('export async function enrolEphemeralSigningKeyWithTotp'));
+  assert.doesNotMatch(enrol.slice(0, enrol.indexOf('\n}\n')), /^\s*throw e;\s*$/m,
+    'a bare `throw e` puts the wire\'s own words back in front of the customer');
+});
+
+test('both signing surfaces render the translated sentence instead of a passkey guess', () => {
+  for (const file of ['frontend/sign-flow.js', 'frontend/co-sign.js']) {
+    assert.match(readSource(file), /e\.code === 'service_error'/,
+      `${file} must have a branch for the error the signer now throws, or it falls through to the passkey message`);
+  }
+});
+
+test('ParaSend prints the same sentence and keeps no raw message on screen', () => {
+  const page = readSource('frontend/js/parashare.page.js');
+  assert.doesNotMatch(page, /textContent = 'Error: ' \+ e\.message/,
+    'parashare.page.js must not put a raw error message on screen');
+  // Written without the separator the old line used: it was an em-dash, and
+  // scripts/check-commit-style.sh refuses one in an added line, quote or not.
+  assert.doesNotMatch(page, /receiver message[^']*' \+ err\.message/,
+    'parashare.page.js must not put a raw error message on screen');
+  assert.match(page, /failureText\(/, 'parashare.page.js must route its failures through the shared translator');
+  assert.match(page, new RegExp(errors.SUPPORT_FAILURE_MESSAGE.split(';')[0].replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    'the ParaSend fallback string must be the same sentence, character for character');
+  assert.match(readSource('frontend/parashare.html'), /<script src="\/js\/error-message\.js\?v=\d+" defer><\/script>/,
+    'parashare.html must load the file the page reads window.paramantErrors from');
+});

--- a/tests/navigation-shell.test.mjs
+++ b/tests/navigation-shell.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
 const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
 const MIME = { '.js':'text/javascript', '.css':'text/css', '.html':'text/html', '.svg':'image/svg+xml', '.png':'image/png', '.woff2':'font/woff2' };
-const aliases = { '/':'/index.html', '/dashboard':'/dashboard.html', '/account':'/account.html', '/developer':'/developer.html', '/pricing':'/pricing.html' };
+const aliases = { '/':'/index.html', '/dashboard':'/dashboard.html', '/account':'/account.html', '/developer':'/developer.html', '/pricing':'/pricing.html', '/help':'/help/index.html' };
 const server = http.createServer((req, res) => {
   let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
   pathname = aliases[pathname] || pathname;
@@ -235,8 +235,44 @@ await homePage.goto(ORIGIN + '/', { waitUntil:'domcontentloaded' });
 await homePage.locator('[data-home="in"]:not([hidden])').waitFor();
 await homePage.locator('.nav-user').waitFor();
 ok('signed-in homepage leads to the document workspace', JSON.stringify(await homePage.locator('[data-home="in"] .home-actions a').evaluateAll((nodes) => nodes.map((node) => node.getAttribute('href')))) === JSON.stringify(['/dashboard','/sign','/parashare']), await homePage.locator('[data-home="in"] .home-actions').innerText());
+// And the hero is where the signed-in homepage ENDS. Under it sat the whole
+// sales page -- why half of it is free, the two products, the price table, the
+// founder letter -- so a customer who had already bought got three actions and
+// then eight screens of pitch on a phone. js/home-auth.js stamps
+// data-session="in" on <html> and the page hides the rest off that one
+// attribute in CSS; this measures what is on screen rather than the attribute,
+// because the attribute being set is not the thing anyone cares about.
+const homeSections = await homePage.evaluate(() => {
+  const visible = Array.from(document.querySelectorAll('main > section'))
+    .filter((section) => getComputedStyle(section).display !== 'none')
+    .map((section) => section.className || section.id || section.tagName);
+  return {
+    session: document.documentElement.getAttribute('data-session'),
+    visible,
+    total: document.querySelectorAll('main > section').length,
+    scrollHeight: document.documentElement.scrollHeight,
+  };
+});
+ok('the signed-in homepage stops after the hero', homeSections.total > 1 && JSON.stringify(homeSections.visible) === JSON.stringify(['home-hero']), JSON.stringify(homeSections));
+// The founder line stays: it is the one thing on this page that says who is
+// accountable, and tests/ui-truthfulness pins its wording.
+ok('the signed-in hero keeps the name behind the product', (await homePage.locator('[data-home="in"]').innerText()).includes('Mick Beer'), await homePage.locator('[data-home="in"]').innerText());
 if (process.env.PARAMANT_HOME_SCREENSHOT_PATH) await homePage.screenshot({ path:process.env.PARAMANT_HOME_SCREENSHOT_PATH });
 await homePage.close();
+
+// Signed OUT, nothing above applies and the page is the page it was: the whole
+// pitch, in order, with no attribute on <html>.
+const homeOutPage = await browser.newPage({ viewport:{ width:390, height:844 } });
+await homeOutPage.route('**/api/user/session/verify', (route) => route.fulfill({ status:401, contentType:'application/json', body:'{"authenticated":false}' }));
+await homeOutPage.goto(ORIGIN + '/', { waitUntil:'domcontentloaded' });
+await homeOutPage.locator('[data-home="out"]:not([hidden])').waitFor();
+const homeOutSections = await homeOutPage.evaluate(() => ({
+  session: document.documentElement.getAttribute('data-session'),
+  visible: Array.from(document.querySelectorAll('main > section')).filter((section) => getComputedStyle(section).display !== 'none').length,
+  total: document.querySelectorAll('main > section').length,
+}));
+ok('the signed-out homepage still shows the whole pitch', homeOutSections.session === null && homeOutSections.visible === homeOutSections.total && homeOutSections.total > 1, JSON.stringify(homeOutSections));
+await homeOutPage.close();
 
 const appPage = await browser.newPage({ viewport:{ width:390, height:844 } });
 await appPage.route('**/api/user/session/verify', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"authenticated":true,"email":"demo@example.com"}' }));
@@ -252,7 +288,104 @@ await appPage.locator('#nav-hamburger').click();
 const appMobile = await appPage.locator('#nav-mobile a').allInnerTexts();
 ok('signed-in mobile menu matches the workspace', appMobile.map((item) => item.toLowerCase()).join(',') === appDesktop.map((item) => item.toLowerCase()).join(','), appMobile.join(', '));
 ok('developer tools are settings, not a sixth product', await appPage.locator('.nav-user-menu a', { hasText:'Developer settings' }).count() === 1 && !appMobile.includes('Developer settings'), appMobile.join(', '));
+
+// Support survives signing in, and it is measured in TAPS.
+//
+// Signed out, a phone reaches /help in two: the menu button, then the strip
+// under the drawer. Signed in, js/nav-auth.js used to delete that strip, on the
+// reasoning that the user menu carries Help from then on. What that left on a
+// 390px screen was no Help at all in the two places anyone looks: the bar sheds
+// .nav-help below 700px, and the drawer is pinned to the five workspace links
+// by the check above. The only route was the menu behind the email address,
+// which is where you go to sign out, not where you go when a signature is
+// stuck. A customer had to type the url.
+//
+// So the strip stays and carries Help alone. The drawer is open at this point
+// (one tap), so anything found here is the second tap and no deeper. Anything
+// inside .nav-user-menu is explicitly NOT counted: that menu is closed, so it
+// costs a tap of its own and would make three.
+const signedInHelp = await appPage.evaluate(() => {
+  const inClosedMenu = (node) => !!node.closest('.nav-user-menu');
+  return Array.from(document.querySelectorAll('a[href="/help"]'))
+    .filter((link) => !inClosedMenu(link))
+    .map((link) => {
+      const box = link.getBoundingClientRect();
+      return {
+        where: link.closest('#nav-mobile-tail') ? 'drawer strip' : (link.closest('nav.nav') ? 'bar' : 'page'),
+        display: getComputedStyle(link).display,
+        width: Math.round(box.width),
+        height: Math.round(box.height),
+      };
+    });
+});
+ok('signed in, support is two taps away on a phone', signedInHelp.some((link) => link.display !== 'none' && link.width > 0 && link.height >= 44), JSON.stringify(signedInHelp));
+ok('signed in, the strip under the drawer is what carries support', signedInHelp.some((link) => link.where === 'drawer strip' && link.height >= 44), JSON.stringify(signedInHelp));
+// Sign in is not an action you still need, so the strip may not keep offering
+// it. Read without a locator wait: when the strip is gone entirely (the bug
+// this replaces) the answer is "no strip", reported in a line, not a 30-second
+// timeout that buries every check under it.
+const tailState = await appPage.evaluate(() => {
+  const tail = document.getElementById('nav-mobile-tail');
+  if (!tail) return { present:false, hrefs:[] };
+  return { present:true, hrefs:Array.from(tail.querySelectorAll('a')).map((link) => link.getAttribute('href')) };
+});
+ok('the signed-in drawer keeps its strip', tailState.present, JSON.stringify(tailState));
+ok('the signed-in drawer strip drops sign in', tailState.present && !tailState.hrefs.includes('/auth/login'), JSON.stringify(tailState));
+// And the second tap goes somewhere. A 44px target on a dead link is worse
+// than no target: it looks like support and answers nothing.
+if (tailState.hrefs.includes('/help')) {
+  await appPage.locator('#nav-mobile-tail a[href="/help"]').click();
+  await appPage.waitForURL('**/help');
+}
+ok('the second tap actually opens the help centre', new URL(appPage.url()).pathname === '/help', appPage.url());
 await appPage.close();
+
+// The signed-in bar itself, on the same phone. Adding Help back to the nav is
+// only right if it does not put a fifth thing in a bar that two reviews already
+// called full: nav.css hides the text link below 700px and the strip takes over.
+const appBarPage = await browser.newPage({ viewport:{ width:390, height:844 } });
+await appBarPage.route('**/api/user/**', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{}' }));
+await appBarPage.route('**/api/user/session/verify', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"authenticated":true,"email":"demo@example.com"}' }));
+await appBarPage.goto(ORIGIN + '/dashboard', { waitUntil:'domcontentloaded' });
+await appBarPage.locator('.nav-user').waitFor();
+const appBar = await appBarPage.evaluate(() => {
+  const items = Array.from(document.querySelectorAll('nav.nav a, nav.nav button'))
+    .filter((node) => {
+      const box = node.getBoundingClientRect();
+      return getComputedStyle(node).display !== 'none' && box.width > 0 && box.height > 0 && !node.closest('.nav-user-menu');
+    })
+    .map((node) => {
+      const box = node.getBoundingClientRect();
+      return { label:node.textContent.trim().slice(0, 24) || node.getAttribute('aria-label'), left:Math.round(box.left), right:Math.round(box.right), height:Math.round(box.height) };
+    })
+    .sort((first, second) => first.left - second.left);
+  return { items, gaps:items.slice(1).map((item, index) => Math.round(item.left - items[index].right)) };
+});
+ok('the signed-in phone bar carries one account control beside the menu button', appBar.items.length <= 3, JSON.stringify(appBar.items));
+ok('nothing in the signed-in phone bar touches its neighbour', appBar.gaps.length > 0 && appBar.gaps.every((gap) => gap >= 12), JSON.stringify(appBar));
+ok('every target in the signed-in phone bar is finger-sized', appBar.items.every((item) => item.height >= 44), JSON.stringify(appBar.items));
+await appBarPage.close();
+
+// A signed-in tablet has the room the phone does not, so Help is a text link in
+// the bar there, exactly as it is signed out. One tap, and the same place the
+// same person used before he had an account.
+const appTabletPage = await browser.newPage({ viewport:{ width:820, height:1180 } });
+await appTabletPage.route('**/api/user/**', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{}' }));
+await appTabletPage.route('**/api/user/session/verify', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"authenticated":true,"email":"demo@example.com"}' }));
+await appTabletPage.goto(ORIGIN + '/dashboard', { waitUntil:'domcontentloaded' });
+await appTabletPage.locator('.nav-user').waitFor();
+// Bounded, and the failure is swallowed on purpose: when the link is gone this
+// check has to report "no Help in the bar" in one line, not stall for the
+// default thirty seconds and then throw away every result collected above it.
+await appTabletPage.waitForSelector('nav.nav .nav-auth a[href="/help"]', { timeout:5000 }).catch(() => {});
+const appTabletHelp = await appTabletPage.evaluate(() => {
+  const link = document.querySelector('nav.nav .nav-auth a[href="/help"]');
+  if (!link) return null;
+  const box = link.getBoundingClientRect();
+  return { display:getComputedStyle(link).display, width:Math.round(box.width), height:Math.round(box.height) };
+});
+ok('signed in, support is one tap in the bar on a tablet', !!appTabletHelp && appTabletHelp.display !== 'none' && appTabletHelp.width > 0 && appTabletHelp.height >= 44, JSON.stringify(appTabletHelp));
+await appTabletPage.close();
 
 const accountPage = await browser.newPage({ viewport:{ width:390, height:844 } });
 await accountPage.route('**/api/user/**', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{}' }));

--- a/tests/navigation-shell.test.mjs
+++ b/tests/navigation-shell.test.mjs
@@ -274,6 +274,64 @@ const homeOutSections = await homeOutPage.evaluate(() => ({
 ok('the signed-out homepage still shows the whole pitch', homeOutSections.session === null && homeOutSections.visible === homeOutSections.total && homeOutSections.total > 1, JSON.stringify(homeOutSections));
 await homeOutPage.close();
 
+// The hero art, on a desktop, measured against the edge that actually cuts.
+//
+// index.html gives <main> overflow:hidden, and .hp-doc inside .hp-art is
+// absolutely positioned: it draws roughly 120px BELOW the 380px box .hp-art
+// reserves for it. Signed out that overhang lands on the section underneath and
+// nobody sees it. Signed in the hero is the last thing in <main>, so main's box
+// ends where the hero ends and the overhang is simply cut off: the first review
+// of this change measured a 472px hero at 1440 with the document, the receipt
+// and the signature sliced through. That is the whole reason the art is retired
+// signed in rather than the hero being trimmed to fit around it.
+//
+// So this measures every box the art actually draws against main's own
+// rectangle, which is the clip. One exclusion, by name and with a reason:
+// .hp-art-glow is a blurred radial gradient with inset:-40% -20%, so it is
+// BUILT to bleed past its own box and has no edge that can read as cut. It has
+// hung 13px over the top of main since the art shipped. Everything else in
+// there has an outline someone can see the knife go through.
+async function artInsideTheClip(authenticated) {
+  const page = await browser.newPage({ viewport:{ width:1440, height:900 } });
+  await page.route('**/api/user/session/verify', (route) => route.fulfill({
+    status: authenticated ? 200 : 401,
+    contentType: 'application/json',
+    body: authenticated ? '{"authenticated":true,"email":"demo@example.com"}' : '{"authenticated":false}',
+  }));
+  await page.goto(ORIGIN + '/', { waitUntil:'domcontentloaded' });
+  await page.locator(authenticated ? '[data-home="in"]:not([hidden])' : '[data-home="out"]:not([hidden])').waitFor();
+  const measured = await page.evaluate(() => {
+    const main = document.querySelector('main').getBoundingClientRect();
+    const hero = document.querySelector('.home-hero').getBoundingClientRect();
+    const art = document.querySelector('.hp-art');
+    const nodes = art ? [art, ...art.querySelectorAll('*')] : [];
+    const drawn = nodes
+      .filter((node) => !node.classList || !node.classList.contains('hp-art-glow'))
+      .map((node) => {
+        const box = node.getBoundingClientRect();
+        const name = (typeof node.className === 'string' && node.className) || node.tagName.toLowerCase();
+        return { name, top:Math.round(box.top), bottom:Math.round(box.bottom), width:Math.round(box.width), height:Math.round(box.height) };
+      })
+      .filter((box) => box.width > 0 && box.height > 0);
+    return {
+      heroHeight: Math.round(hero.height),
+      mainTop: Math.round(main.top),
+      mainBottom: Math.round(main.bottom),
+      drawn: drawn.length,
+      cut: drawn.filter((box) => box.bottom > Math.round(main.bottom) || box.top < Math.round(main.top))
+        .map((box) => `${box.name} ${box.top}..${box.bottom} outside main ${Math.round(main.top)}..${Math.round(main.bottom)}`),
+    };
+  });
+  await page.close();
+  return measured;
+}
+const artIn = await artInsideTheClip(true);
+ok('signed in at 1440, no part of the hero art is cut off by the clip', artIn.cut.length === 0, JSON.stringify(artIn));
+// And the measurement above is capable of finding a box, which a vacuous pass
+// on an empty node list would not prove. Signed out the art is drawn, in full.
+const artOut = await artInsideTheClip(false);
+ok('signed out at 1440, the hero art is drawn and drawn whole', artOut.drawn > 0 && artOut.cut.length === 0, JSON.stringify(artOut));
+
 const appPage = await browser.newPage({ viewport:{ width:390, height:844 } });
 await appPage.route('**/api/user/session/verify', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"authenticated":true,"email":"demo@example.com"}' }));
 await appPage.route('**/api/user/me', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"email":"demo@example.com","label":"Demo","plan":"pro","created_at":"2026-06-01T10:00:00.000Z","backup_codes_remaining":8,"session_expires_at":"2026-07-21T16:00:00.000Z","usage_purpose":"organisation"}' }));


### PR DESCRIPTION
Four findings from a buyer review of the signed-in journey (screenshots in the review set), all on surfaces that only exist after someone has paid.

## 1. Support was unreachable on a signed-in phone

The signed-in navigation is Documents / Send / Sign / Verify / Settings, and `js/nav-auth.js` **deleted** the strip under the mobile drawer once the session check came back, on the reasoning that the account menu carries Help from then on. On 390px that leaves nothing:

- `nav.css` hides the `.nav-help` text link below 700px
- the drawer is pinned by `tests/navigation-shell` to exactly the five workspace links
- the menu behind the email address is where you go to sign out

A customer with a stuck signature had to type the url.

The strip stays now and carries Help alone. Sign in is dropped from it, because that is not an action you still need. The text link is back in the bar from 700px up, in the same place it sits signed out, with the 44px target `nav.css` already gives it.

`tests/navigation-shell.test.mjs` counts this in **taps**, not in "a link exists": the drawer is open (tap one), anything inside the closed account menu is explicitly excluded because it would cost a third, and the test then clicks the link and follows it to `/help`. A 44px target on a dead link is worse than no target.

The four public nav pins and the signed-out phone bar are untouched.

## 2. The signed-in homepage was still the sales page

It swapped the hero and left everything under it: why half of it is free, the two products, the price table, the founder letter. Three actions and then eight screens of pitch, on a phone, for someone who had already bought.

`js/home-auth.js` now stamps `data-session="in"` on `<html>`; `index.html` hides every section after the hero off that one attribute, in CSS. No inline script (CSP `script-src 'self'`), and nothing walks a list of section ids, so a section added tomorrow is covered the day it lands.

The hero keeps its three actions and the founder line (`ui-truthfulness` pins the wording). Signed out the page is what it was, and the suite checks that too: same section count, no attribute on `<html>`.

## 3. The signing error the customer could not act on

`enrolEphemeralSigningKeyWithTotp` translated three TOTP failures into their own words and rethrew everything else untouched. What reached the screen was the wire's own message: `_postJSON` builds one out of the relay's error field or `'http_' + status`, and a dropped connection arrives as a `TypeError` with whatever the browser calls it. `http_502` is not an instruction.

`frontend/js/error-message.js` owns one sentence for the unplanned case, with a next step and an address that reaches a human, and the technical detail goes to `console.error` instead of the screen. `sign-flow.js` and `co-sign.js` render it rather than falling through to their passkey guess. `js/parashare.page.js` printed `'Error: ' + e.message` in three places and now prints the same sentence from the same file (it is a classic script, so it reads the namespace off the global; the file is the same UMD shape as `js/parasign-pdf-ops.js`, which is what lets node require it).

`tests/error-message.test.mjs` runs a real thrown `TypeError` through the translator. Four sabotages verified red before commit:

| sabotage | result |
| --- | --- |
| `userFacingMessage` returns `error.message` | 3 failures |
| sentence loses the address and the next step | 1 failure |
| `throw e` back in the signer | 1 failure |
| parashare prints `e.message` again | 1 failure |

## 4. Two prices for one account

`/dashboard` answered "what does it cost?" with *"Paid plans start at 15 euro a month, which is ParaSend Pro"*; `/help` answered the same question with *"ParaSign Pro at 49 euro a month"*. One customer, two of our own pages, two numbers, and the cheaper one on the surface that exists for signing.

One answer now names both products with both prices. `relay/test/pricing-page.test.js` pins it the way the pricing cards are pinned: each amount is read back out of `relay/lib/billing-catalog.js` (excl. btw of the monthly variant checkout actually charges), the plan name is pinned to `relay/lib/tiers.js`, and every amount in the sentence has to stand on `/pricing` with a real boundary, so a bare 15 cannot be satisfied by a 150 elsewhere on the page. Sabotages verified red: dropping the signing half, quoting an amount not on `/pricing`, and moving the catalog price.

## Cache-busts

`nav-auth.js` v6 -> v7 and `home-auth.js` v1 -> v2, across every stamped page and `apply-nav.py`, because the files changed and nginx serves them immutable.

## Gates run locally

first-screen, ui-truthfulness, site-claims, seo-contract, links, navigation-shell (51 checks), frontend-loading-contract, frontend-module-scripts, pricing-fold, cache-bust, csp-inline, static-sanity, check-test-declarations, eslint, app-contrast, app-theme, apply-nav-idempotent (`apply-nav.py` updates 0 files), user-dashboard-documents, code-manifest, `apply_seo_head --check` (0 pages), sign-full (33/33), relay pricing-page (48 checks), the full browser set (41/41) and the root non-browser set.

One pre-existing environment failure, unrelated to this branch: `tests/heartbeat-lib.test.mjs` cannot resolve `@noble/post-quantum` in this checkout's shared `node_modules`. CI installs it with `npm ci`.


---

## Follow-up after review: the hero art was being cut in half

The first commit shrank the signed-in hero to 472px at 1440 with `padding-bottom:48px`. `.hp-doc` inside `.hp-art` did not shrink with it: that element is absolutely positioned and draws about 120px **below** the 380px box `.hp-art` reserves for it. Signed out that overhang lands on the section underneath and is never seen. Signed in the hero is the last thing in `<main>`, `main` carries `overflow:hidden`, and the document, the receipt and the signature were sliced through where `main` ends.

Making the hero taller does not fix it, and that is worth stating: with the padding rule removed entirely and the art left in, the overhang is still 74px past the clip. The height was never the cause.

So the art retires with the pitch it illustrates. It is a document that gets signed, sealed and then burns on a 16-second loop, and it is there to explain the product to someone who does not have it yet. A phone has hidden it since it shipped, for its own reason; signed in, every width does now. With it gone the second grid column is empty, so the hero is one column, keeping the 1120px wrap that lines it up with the nav and the footer.

**The check measures against the edge that actually cuts**: every box the art draws, at 1440, against `main`'s own rectangle, which *is* the clip. One exclusion, named and argued in the test: `.hp-art-glow` is a blurred radial gradient with `inset:-40% -20%`, built to bleed, with no edge that can read as cut, and it has hung 13px over the top of `main` since the art shipped. A signed-out control runs the same measurement and requires the art to be present **and** whole, so the signed-in pass cannot be a pass over an empty list.

| sabotage | result |
| --- | --- |
| the reviewed state (art visible, hero at 48px bottom padding) | red, `hp-doc 531..1030 outside main 56..956` |
| art visible with no padding change at all | red, same element |

`navigation-shell` is 53 checks. Rebased onto current `main` (#394).

### Known merge overlap

- **#395** conflicts in `frontend/dashboard.html`. Keep both: this branch's price answer, #395's tap-target CSS and its `dashboard.js?v=9` bump. They are complementary, and #395's `.dh-ask-list a{min-height:var(--tap)}` is about the "See the plans" link in exactly this answer.
- **#397** conflicts in `frontend/parashare.html`, on one line. Keep both: this branch's `error-message.js?v=1` tag *and* `parashare.page.js?v=4`. `frontend/js/parashare.page.js` and `frontend/js/nav-auth.js` auto-merge clean.
- **Cache-bust hazard worth naming**: both branches independently bump `parashare.page.js` to `v=4` for different edits. Whoever rebases second must take it to `v=5`, or the file ships twice under one immutable url. `scripts/check-cache-bust.sh` only checks that a version is consistent, never that it moved, so nothing turns red on this by itself.
