### PR TITLE
static-sanity runs in CI, so a PASS is no longer somebody's laptop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,40 @@ jobs:
           | xargs -0 -n1 bash -n
           echo "All shell scripts parse OK."
 
+  static-sanity:
+    name: static sanity, tests/static-sanity.sh
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 is load-bearing, not a habit. Check 10 delegates to
+      # scripts/check-commit-style.sh, which reads commit messages and the added
+      # diff lines of the commits under review. On a pull request the checkout is
+      # refs/pull/N/merge: HEAD is a merge commit with the message
+      # "Merge <sha> into <sha>" and no diff of its own, so the script's default
+      # (the last commit) would scan nothing and pass over anything. The script
+      # builds "origin/$GITHUB_BASE_REF..HEAD" instead, and that base branch is
+      # only in the clone with the full fetch. With the shallow default the check
+      # says so in the log rather than going quietly green.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # Check 1 is `node --check` over admin/server.js, admin/lib/*.js and
+      # relay/relay.js; check 11 parses all 134 suites the same way. No npm
+      # install: nothing here resolves an import.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+      # Twelve checks, no secrets, no server, no network. It was written as a
+      # pre-commit hook and deploy/deploy-3.1.sh phase 0b runs it against the
+      # commit being deployed, but until now it ran in NO workflow at all:
+      # security-posture.yml only mentioned it in a comment. Every
+      # "static-sanity PASS" on record was somebody's laptop. That is the exact
+      # shape of hole the deploy dry-run job below was added to close, and
+      # checks 10, 11 and 12 are precisely the ones a pull request can break for
+      # everybody: the style guard, the merge-collision guard on the shared test
+      # namespace, and the opt-in on the tracked brand screenshots.
+      - name: Static sanity (twelve checks)
+        run: bash tests/static-sanity.sh
+
   undefined-names:
     name: static, every name must exist
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,15 @@ en GitHub-comments volgen deze regels:
 De poort is `scripts/check-commit-style.sh`. Die scant de commit-message(s) en de
 toegevoegde diff-regels op deze fouten. Een commit die de scan laat FALEN mag niet
 gepusht worden; herschrijf de message of de diff en commit opnieuw. De scan draait
-op twee plekken:
+op drie plekken:
 
 - `bash tests/static-sanity.sh` (de gate vlak voor commit) draait de scan over de
   laatste commit, naast de bestaande checks.
+- In CI, als job `static-sanity` in `.github/workflows/test.yml`, op elke push
+  naar main en elke pull request. Daar scant hij niet de laatste commit maar
+  `origin/$GITHUB_BASE_REF..HEAD`: op een pull request is HEAD de merge-commit,
+  en die heeft geen eigen diff. Een hook die niet geinstalleerd is, of een
+  `git commit --no-verify`, komt hier alsnog boven water.
 - De committed pre-push hook `.githooks/pre-push` draait dezelfde scan over het
   push-bereik. Committed hooks activeren niet vanzelf; zet ze eenmalig aan met:
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -49,7 +49,7 @@ What is in each directory, and which test or workflow fails when you break it.
 | `scripts/directie/` | `signalen.py`: a no-model status meter. Asks GitHub over `gh` and production over `curl`, turns each answer into red/orange/green with the command it measured with. | Nothing. Documented in `docs/directie.md`. |
 | `scripts/heartbeat/` | `run.mjs` and its lib: the four hourly production proofs (`surface`, `parasend`, `parasign-receipt`, `parasign-public-sign`). Every step runs even after one fails, on purpose: a dead page must never hide a dead signer. | Its logic by `tests/heartbeat-lib.test.mjs` (runs on every push); its execution by `heartbeat.yml` (hourly) |
 | `deploy/` | `DEPLOY-3.1.md` is the runbook; `deploy-3.1.sh` executes it phase by phase and refuses to continue when a measurement disagrees. `.env.example` is the canonical env inventory (81 variables, names and purposes, no values). Plus the three nginx configs and `ops/backup-*.sh`. | `tests/env-documented.test.mjs` (every `process.env` name must be documented there, and nothing documented that no code reads); `test.yml` job `shell-syntax` (`bash -n`); `test.yml` job `deploy-dryrun` runs `tests/deploy-3.1-dryrun.test.sh` on every push and pull request, with no server and no secrets. |
-| `tests/` | 27 `node:test` `.mjs` suites (16 node-only, 11 browser), plus `static-sanity.sh`, `auth-smoke.sh`, `e2e-auth-flow.sh` and the deploy dry-run self-test. | `test.yml` (node-only set), `sign-e2e.yml` (browser set), `product-heartbeat.yml`. Of the `.sh` files, `deploy-3.1-dryrun.test.sh` runs in CI (`test.yml` job `deploy-dryrun`); the rest run at deploy time and in hooks. |
+| `tests/` | 27 `node:test` `.mjs` suites (16 node-only, 11 browser), plus `static-sanity.sh`, `auth-smoke.sh`, `e2e-auth-flow.sh` and the deploy dry-run self-test. | `test.yml` (node-only set), `sign-e2e.yml` (browser set), `product-heartbeat.yml`. Of the `.sh` files, `deploy-3.1-dryrun.test.sh` runs in CI (`test.yml` job `deploy-dryrun`) and `static-sanity.sh` does too (`test.yml` job `static-sanity`, twelve checks, no secrets and no server); `auth-smoke.sh` and `e2e-auth-flow.sh` need a live target and run at deploy time only. |
 
 Selection of browser vs node-only suites is done **by what a file imports**, never
 by a hand-kept name list (`.github/workflows/test.yml:290-296`,
@@ -139,7 +139,8 @@ Run these in order. The commands are the ones CI runs, copied from
 
 ```bash
 bash tests/static-sanity.sh
-#   10 numbered checks, ends with "PASS (all hard checks clear)".  ~1.5s
+#   12 numbered checks, ends with "PASS (all hard checks clear)".  ~1.5s
+#   Same command as test.yml job static-sanity runs on every push and pull request.
 
 npx --yes eslint@9 .
 #   silent on success.  ~5s
@@ -336,18 +337,33 @@ the commit message and the added `+` diff lines, and runs from both
 `tests/static-sanity.sh` and `.githooks/pre-push`. Default tooling adds these
 trailers for you; turn them off before your first commit.
 
-**static-sanity is eleven checks, and check 10 is the style guard.**
-`tests/static-sanity.sh` runs eleven numbered checks: syntax, redisClient
+**static-sanity is twelve checks, and check 10 is the style guard.**
+`tests/static-sanity.sh` runs twelve numbered checks: syntax, redisClient
 initialisation, TOTP helpers (warn), unsafe `req.body` access (warn), orphan code
 (warn), `/request-key` still returning 410, DID-auth replay protection, the
 open-mode envelope signer binding, installer release pinning, check 10, the
-commit and GitHub style guard delegating to `check-commit-style.sh`, and check
-11, the test-scope guard delegating to `check-test-declarations.sh`. Exit code is
-the number of hard failures. It runs in no workflow: its callers are the
-pre-commit hook and `deploy.sh:25`. Check 10 inspects the **last commit**, so on
-a branch with a non-conforming commit checks 1 to 9 pass and the script still
-exits 1; `deploy/DEPLOY-3.1.md:197-204` documents that this state does not block
-a deploy. Do not rewrite history to make it green.
+commit and GitHub style guard delegating to `check-commit-style.sh`, check 11,
+the test-scope guard delegating to `check-test-declarations.sh`, and check 12,
+the opt-in on the tracked brand screenshots. Exit code is the number of hard
+failures.
+
+It runs in CI as `test.yml` job `static-sanity`, on every push to main and every
+pull request. That is new. Until then it ran in **no** workflow at all: its only
+callers were the pre-commit hook and `deploy.sh:25`, `security-posture.yml`
+named it in a comment and nowhere else, and every "static-sanity PASS" on record
+came from somebody's laptop. If your hook is not installed, or you committed
+with `--no-verify`, the pull request now says so.
+
+Which commits check 10 reads depends on where it runs, and it has to. Locally
+and on a push it is the **last commit**, so on a branch with a non-conforming
+commit checks 1 to 9 pass and the script still exits 1;
+`deploy/DEPLOY-3.1.md:197-204` documents that this state does not block a deploy.
+On a pull request the checkout is `refs/pull/N/merge`, whose HEAD is a merge
+commit with no diff of its own, so the script scans
+`origin/$GITHUB_BASE_REF..HEAD` instead: the commits the pull request adds. That
+is why the job checks out with `fetch-depth: 0`, and why it prints which range it
+scanned. `PARAMANT_STYLE_RANGE` overrides the choice. Do not rewrite history to
+make it green.
 
 **Every claim on the site is tied to a test.** The rule, from
 `docs/brand/messaging.md:14-18`: a sentence may only go on the site if it is

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ Guards the auth + TOTP stack against the class of breakage that hit production r
 
 | Script | When it runs | What it checks |
 |---|---|---|
-| `tests/static-sanity.sh` | pre-commit hook, `deploy.sh` step 1 | Eleven numbered checks: Node syntax, redisClient init, TOTP helpers, unsafe req.body access, orphan code, 410 in source, DID-auth replay protection, the open-mode envelope signer binding, installer release pinning, the commit and GitHub style guard (`check-commit-style.sh`) and the test-scope guard (`check-test-declarations.sh`) |
+| `tests/static-sanity.sh` | `test.yml` job `static-sanity` (every push to main and every pull request), pre-commit hook, `deploy.sh` step 1, `deploy/deploy-3.1.sh` phase 0b | Twelve numbered checks: Node syntax, redisClient init, TOTP helpers, unsafe req.body access, orphan code, 410 in source, DID-auth replay protection, the open-mode envelope signer binding, installer release pinning, the commit and GitHub style guard (`check-commit-style.sh`), the test-scope guard (`check-test-declarations.sh`) and the brand-screenshot opt-in. No secrets, no server, no network |
 | `tests/redis-deadline-parity.test.mjs` | Root integration suites | `relay/lib/redis-deadline.js` and `admin/lib/redis-deadline.js` are one file. They exist twice because each Dockerfile copies only its own `lib/`, and the duplication is watched rather than hoped about. Also asserts both services really wrap their redis client with it |
 | `relay/test/redis-deadline.test.js` | Relay unit suite | The bound itself, with no redis: the outage classifier, the deadline, the proxy that puts it on every command, and the connection rebuild after two unanswered commands |
 | `relay/test/route-redis-outage.test.js` | Route suites (need redis) | A booted relay with its store behind a proxy the suite cuts and then black-holes. Every redis-backed route answers 503 inside the deadline, `/health` stays 200, `/v2/health/deep` goes red, and the relay heals by itself |
@@ -77,7 +77,22 @@ or reads the result, so nothing there sets the flag.
 
 `tests/static-sanity.sh` is installed as `.git/hooks/pre-commit`. Commits that introduce syntax errors, undefined redisClient, or a missing 410 on /request-key are blocked automatically. `.githooks/pre-push` runs the commit-style guard on its own; it needs `git config core.hooksPath .githooks` once per clone.
 
+The hook is a convenience, not the gate. Until 2026-09-03 it was the only thing
+that ran this script, together with `deploy.sh`, so a clone without the hook or a
+single `git commit --no-verify` sailed straight past all twelve checks and no
+pull request ever noticed. `test.yml` job `static-sanity` now runs the same
+`bash tests/static-sanity.sh` on ubuntu, with no secrets and no server.
+
+One difference between the two, and it is deliberate. Check 10 delegates to
+`scripts/check-commit-style.sh`, which locally scans the **last commit**. On a
+pull request GitHub checks out `refs/pull/N/merge`, and that merge commit has a
+generated message and no diff of its own, so the local default would scan an
+empty commit and pass over a branch full of em-dashes. The script therefore
+scans `origin/$GITHUB_BASE_REF..HEAD` when that variable is set, which is why the
+job uses `fetch-depth: 0`. It prints the range it scanned. Set
+`PARAMANT_STYLE_RANGE` to choose one yourself.
+
 ## Adding new checks
 
-- **Static checks** go in `tests/static-sanity.sh`. Exit 1 on failure so the pre-commit hook blocks.
+- **Static checks** go in `tests/static-sanity.sh`. Exit 1 on failure so the pre-commit hook blocks and `test.yml` job `static-sanity` goes red. Keep them free of secrets, servers and network: that is what lets the job be a checkout, a node setup and one line.
 - **Live checks** go in `tests/auth-smoke.sh`. Use `check`/`check_not` helpers. Never hardcode credentials.

--- a/tests/static-sanity.sh
+++ b/tests/static-sanity.sh
@@ -203,17 +203,52 @@ done
 
 # ── 10. Commit/GitHub style guard ────────────────────────────────────────────
 # Same gate as the secret checks: block em-dashes, emoji, and AI attribution
-# markers in the last commit message and its added diff lines.
+# markers in the commit message(s) and the added diff lines.
 # scripts/check-commit-style.sh is the single source of truth; the committed
 # pre-push hook (.githooks/pre-push) runs the same script on push.
+#
+# WHICH commits get scanned depends on where this runs, and it has to.
+# Locally and on a push the default is right: the last commit, which is the one
+# being made. On a pull request in GitHub Actions it is not. actions/checkout
+# checks out refs/pull/N/merge, so HEAD is a merge commit whose message reads
+# "Merge <sha> into <sha>" and for which git show prints no diff at all. The
+# default range would therefore scan an empty commit and report OK over a branch
+# full of em-dashes, which is a green tick bought with nothing. So when
+# GITHUB_BASE_REF is set, scan the commits the pull request actually adds.
+# The job that does this checks out with fetch-depth: 0; without the base branch
+# in the clone the range cannot be built, and the check says so rather than
+# quietly falling back to the vacuous default.
+# PARAMANT_STYLE_RANGE overrides both, for a caller that knows better.
 echo ""
 echo "10. Commit/GitHub style guard (scripts/check-commit-style.sh)..."
 STYLE="$ROOT/scripts/check-commit-style.sh"
+STYLE_RANGE="${PARAMANT_STYLE_RANGE:-}"
+STYLE_WHAT="last commit"
+if [ -n "$STYLE_RANGE" ]; then
+  STYLE_WHAT="range $STYLE_RANGE"
+elif [ -n "${GITHUB_BASE_REF:-}" ]; then
+  for base in "origin/$GITHUB_BASE_REF" "$GITHUB_BASE_REF"; do
+    if git -C "$ROOT" rev-parse --verify --quiet "$base^{commit}" >/dev/null 2>&1; then
+      STYLE_RANGE="$base..HEAD"
+      STYLE_WHAT="range $STYLE_RANGE (the commits this pull request adds)"
+      break
+    fi
+  done
+  if [ -z "$STYLE_RANGE" ]; then
+    printf "   WARN  GITHUB_BASE_REF=%s is not in this clone (needs fetch-depth: 0);\n" "$GITHUB_BASE_REF"
+    printf "         falling back to the last commit, which on a merge ref scans nothing\n"
+  fi
+fi
 if [ -x "$STYLE" ]; then
-  if STYLE_OUT="$("$STYLE" 2>&1)"; then
-    printf "   OK  last commit message + added lines are style-clean\n"
+  if [ -n "$STYLE_RANGE" ]; then
+    STYLE_OUT="$("$STYLE" "$STYLE_RANGE" 2>&1)" && STYLE_RC=0 || STYLE_RC=1
   else
-    printf "   FAIL  style guard flagged the last commit:\n"
+    STYLE_OUT="$("$STYLE" 2>&1)" && STYLE_RC=0 || STYLE_RC=1
+  fi
+  if [ "$STYLE_RC" -eq 0 ]; then
+    printf "   OK  %s: message(s) + added lines are style-clean\n" "$STYLE_WHAT"
+  else
+    printf "   FAIL  style guard flagged the %s:\n" "$STYLE_WHAT"
     printf '%s\n' "$STYLE_OUT" | sed 's/^/     /'
     FAIL=$((FAIL + 1))
   fi


### PR DESCRIPTION
## What

`tests/static-sanity.sh` is twelve checks and it ran in **no workflow at all**.
`security-posture.yml` mentions it in a comment; nothing executes it. Its only
real callers are the pre-commit hook and `deploy.sh` / `deploy-3.1.sh` phase 0b.
So a clone without the hook installed, or a single `git commit --no-verify`,
walked past all twelve and no pull request ever said a word. Every
"static-sanity PASS" on record so far was somebody's laptop.

Three of those checks are exactly the ones a pull request can break for
everybody:

- check 10, the commit and GitHub style guard (`scripts/check-commit-style.sh`):
  em-dashes, emoji, AI attribution
- check 11, the test-scope guard (`scripts/check-test-declarations.sh`): the
  merge collision on the shared top-level test namespace that put main red on
  2026-09-02
- check 12, the opt-in on the tracked brand screenshots

## How

New job `static-sanity` in `.github/workflows/test.yml`. Checkout on the same
pinned SHA as the other jobs, `actions/setup-node` on node 24, and one step:
`bash tests/static-sanity.sh`. No secrets, no services, no network.

`fetch-depth: 0` is load-bearing, not a habit. Check 10 delegates to
`scripts/check-commit-style.sh`, which scans the **last commit**. On a pull
request the checkout is `refs/pull/N/merge`: HEAD is a merge commit with a
generated message and no diff of its own, so the default would have scanned an
empty commit and reported OK over a branch full of em-dashes. A green tick
bought with nothing is worse than no tick.

So `tests/static-sanity.sh` now builds `origin/$GITHUB_BASE_REF..HEAD` when that
variable is set, which is the commits the pull request adds, and that base
branch is only in the clone with the full fetch. It prints the range it scanned,
and if the base branch is missing it says so in the log rather than falling back
quietly to the vacuous default. `PARAMANT_STYLE_RANGE` overrides. Local and
push-to-main behaviour is unchanged: still the last commit.

`node`: needed by check 1 (`node --check` over `admin/server.js`,
`admin/lib/*.js`, `relay/relay.js`) and check 11 (parses all 134 suites). No
`npm install`: nothing here resolves an import.

## Proof it actually fails

A throwaway commit with an em-dash on an added line, pushed to this branch and
then reverted. Run URLs are in the comments below.

## The deploy gate is untouched

`deploy/deploy-3.1.sh` phase 0a derives its required list from the workflows
that run on push to main without a `paths:` filter, and it derives it **per
workflow file**, not per job. A new job inside `test.yml` changes nothing there.
Checked, not assumed: `bash tests/deploy-3.1-dryrun.test.sh` passes 390 of 390,
including block 6d, which reports the derived list as
`csp-inline-check.yml product-heartbeat.yml sign-e2e.yml test.yml`, unchanged.

## Branch protection

Do **not** add `static-sanity` to the required contexts yet. Let it run green on
main three times first, then Mick adds it.

## Docs

`docs/ONBOARDING.md` (the "runs in no workflow" paragraph was the thing that
made this findable, and it is now correct), `tests/README.md`, and the
"two places" list in `AGENTS.md`, which is now three.
