### PR TITLE
A dead session stops offering its link, the app bar stops showing through, and ParaSend says "deletes" in one voice

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -139,7 +139,7 @@ main.acct input::placeholder { color: var(--ink-3); }
 @media (max-width: 680px) { .acct-grid2 { grid-template-columns: 1fr; gap: var(--space-4); } main.acct { padding: var(--space-5) var(--space-3) var(--space-6); } }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=3">
+<link rel="stylesheet" href="/app-2026.css?v=4">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>

--- a/frontend/app-2026.css
+++ b/frontend/app-2026.css
@@ -265,6 +265,21 @@ main :where(p, li, dd, .acct-lead, .ds-lede, .sub) a:not(.btn):not([class*="cta"
    corrected here rather than in six inline blocks.
    ═══════════════════════════════════════════════════════════════════════════ */
 nav.nav { background: var(--paper-blur); border-bottom: 1px solid var(--line); }
+/* nav.css turns the bar opaque under 1024px, and it is not decoration: at .92
+   with no backdrop-filter behind it the page scrolls straight through the
+   letters, which is what a review of /parashare on a 390 phone reported. This
+   file loads after nav.css and its rule above put the translucent token back on
+   every app screen, so it carries the same exception. The paint is the app's own
+   paper, not the marketing bone, because the bar has to match the page under
+   it and has to follow the theme; what tests/navigation-shell.test.mjs pins on
+   /parashare is therefore the opacity and the absent filter, not a hex. */
+@media (max-width: 1023px) {
+  nav.nav {
+    background: var(--paper);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+}
 nav.nav .nav-logo .logo-para { color: var(--ink-1); }
 nav.nav .nav-link { color: var(--ink-2); }
 nav.nav .nav-link:hover, nav.nav .nav-link[aria-current="page"] { color: var(--accent); }

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -23,7 +23,7 @@
 }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=3">
+<link rel="stylesheet" href="/app-2026.css?v=4">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -46,7 +46,7 @@
 .auth-note a { color: var(--navy); }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=3">
+<link rel="stylesheet" href="/app-2026.css?v=4">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -21,7 +21,7 @@
 }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=3">
+<link rel="stylesheet" href="/app-2026.css?v=4">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -32,7 +32,7 @@
   }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=3">
+<link rel="stylesheet" href="/app-2026.css?v=4">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -24,7 +24,7 @@
 }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=3">
+<link rel="stylesheet" href="/app-2026.css?v=4">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -352,7 +352,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 }
 </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=3">
+<link rel="stylesheet" href="/app-2026.css?v=4">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -398,7 +398,7 @@ footer{background:var(--hp-paper-2);border-top:1px solid var(--hp-line)}
     </div>
     <div class="home-state" data-home="in" hidden>
       <h2 class="paramant-h1">Your documents<span class="home-hi-name" data-home-name></span>.</h2>
-      <p class="lede">Pick up an open request, get a new document signed with ParaSign, or send a file with the ParaSend web app, which burns it on the first read.</p>
+      <p class="lede">Pick up an open request, get a new document signed with ParaSign, or send a file with the ParaSend web app, which deletes it after the first read.</p>
       <div class="home-actions">
         <a class="hp-btn hp-btn-fill" href="/dashboard">Open documents</a>
         <a class="hp-btn hp-btn-line" href="/sign">Start signing</a>

--- a/frontend/js/parashare.page.js
+++ b/frontend/js/parashare.page.js
@@ -127,6 +127,26 @@ function setLinkError(on, msg) {
     if (t) t.textContent = msg;
   }
   box.classList.toggle('is-shown', !!on);
+  setSessionCardStale(!!on);
+}
+
+// The alarm above the card said the session was gone; the card under it went on
+// offering a beating beacon, "Waiting for receiver...", the dead link and a blue
+// Copy link. A sender who copies that link sends his receiver to a session that
+// no longer exists, and finds out nothing until the receiver says so. So the
+// card is switched off with the alarm: greyed by CSS, marked aria-disabled for
+// a screen reader, and the copy button really disabled, not just dimmed. The
+// way back out is the alarm's own action, which sits outside the card.
+function setSessionCardStale(stale) {
+  var card = $('ps-session-card');
+  if (card) {
+    card.classList.toggle('is-stale', stale);
+    card.setAttribute('aria-disabled', stale ? 'true' : 'false');
+  }
+  var copy = $('ps-copy-btn');
+  if (copy) copy.disabled = stale;
+  var link = $('session-link');
+  if (link) link.setAttribute('aria-disabled', stale ? 'true' : 'false');
 }
 
 // Make a fresh session: new token, new link, new socket. The file is untouched
@@ -195,8 +215,12 @@ function setEncProgress(pct) {
 async function copyLink() {
   // The confirmation belongs on the button, not in the link box: overwriting
   // the link with "Copied!" hides the thing you just asked to see.
-  const url = $('session-link').textContent;
   const button = $('ps-copy-btn');
+  // A dead session hands out no links. pointer-events on the greyed card stops
+  // the mouse; this stops everything else, the share box's own click handler
+  // included.
+  if (button && button.disabled) return;
+  const url = $('session-link').textContent;
   let copied = true;
   await navigator.clipboard.writeText(url).catch(() => { copied = false; });
   if (!button) return;
@@ -443,12 +467,12 @@ async function connectWebSocket() {
   ws.onerror = () => {
     if (receiverPubs) return;
     setStatus('waiting-status', 'Connection lost', 'err');
-    setLinkError(true, 'The connection to the relay failed before your receiver arrived. Nothing was uploaded and your file is still here in this browser.');
+    setLinkError(true, 'The connection failed before your receiver arrived. Nothing was uploaded and your file is still here in this browser.');
   };
   ws.onclose = () => {
     if (receiverPubs) return;
     setStatus('waiting-status', 'Connection lost', 'err');
-    setLinkError(true, 'The connection to the relay dropped before your receiver arrived. Nothing was uploaded and your file is still here in this browser.');
+    setLinkError(true, 'The connection dropped before your receiver arrived. Nothing was uploaded and your file is still here in this browser.');
   };
 }
 

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -63,7 +63,7 @@ h1{font-size:clamp(26px,5vw,38px);font-weight:600;letter-spacing:-.028em;line-he
 .ps-key-mask[hidden]{display:none}
 /* Not scoped to the slim row: the same control is the way out on the error
    banner, and there it has to look like an action too. */
-.ps-key-change{background:transparent;border:none;min-height:36px;padding:4px 6px;color:var(--accent);font:inherit;font-size:11px;cursor:pointer;text-decoration:underline;text-underline-offset:3px;letter-spacing:.04em}
+.ps-key-change{background:transparent;border:none;min-height:var(--tap);padding:4px 6px;color:var(--accent);font:inherit;font-size:11px;cursor:pointer;text-decoration:underline;text-underline-offset:3px;letter-spacing:.04em}
 .ps-key-change:hover{color:var(--accent-hov)}
 .ps-key-card{display:none}
 #step-setup.manual-key .ps-key-card{display:block}
@@ -160,6 +160,17 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 .ps-caution::before{content:"!";flex:0 0 auto;width:16px;height:16px;margin-top:1px;display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--sig-wait);border-radius:50%;font:700 10px/1 var(--mono);color:var(--sig-wait)}
 
 .share-box:hover{border-color:var(--line-2)}
+
+/* Step 2 can fail with its card still on screen. A beating beacon, "Waiting for
+   receiver", a link that connects to nothing and a blue Copy link are four
+   offers a dead session cannot honour, and they sat directly under the alarm
+   that said the session was gone. So the card goes with the alarm: greyed out,
+   marked aria-disabled, its copy button switched off and nothing in it takeable.
+   The one live control is the alarm's own "Open the session again", which sits
+   above the card and is untouched by this. */
+.card.is-stale{opacity:.5;pointer-events:none}
+.card.is-stale .ps-copy{cursor:not-allowed}
+#ps-session-card.is-stale #waiting-dot{background:var(--ink-3);animation:none}
 .progress-bar-wrap{background:var(--line-2);border:0;border-radius:var(--r-0);height:3px;overflow:hidden;margin:4px 0 12px}
 .progress-bar{height:100%;background:var(--accent);width:0%;transition:width var(--d-3) var(--e-standard)}
 .label{font-family:var(--mono);font-size:11px;font-weight:600;color:var(--ink-3);letter-spacing:.14em;text-transform:uppercase;margin-bottom:8px;display:block}
@@ -368,7 +379,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 }
 </script>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=3">
+<link rel="stylesheet" href="/app-2026.css?v=4">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>
@@ -492,7 +503,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
   </div>
 
   <div class="card">
-    <div class="card-head"><div class="dot amber"></div><div class="card-head-title">Self-destruct</div></div>
+    <div class="card-head"><div class="dot amber"></div><div class="card-head-title">Deletes itself</div></div>
     <div class="card-body">
       <label class="label" for="ttl-select">Link expires after</label>
       <select id="ttl-select">
@@ -522,14 +533,14 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
   </div>
 
   <div class="ps-alert" id="ps-link-error" role="alert">
-    <p id="ps-link-error-text">The connection to the relay dropped before your receiver arrived. Nothing was uploaded and your file is still here in this browser.</p>
+    <p id="ps-link-error-text">The connection dropped before your receiver arrived. Nothing was uploaded and your file is still here in this browser.</p>
     <div class="ps-alert-actions">
       <button type="button" class="ps-alert-primary" data-click="reopenSession">Open the session again</button>
       <span class="ps-alert-note">this makes a fresh link</span>
     </div>
   </div>
 
-  <div class="card">
+  <div class="card" id="ps-session-card">
     <div class="card-head"><div class="dot amber" id="waiting-dot"></div><div class="card-head-title" id="waiting-title">Waiting for receiver...</div></div>
     <div class="card-body">
       <span class="label">One-time session link</span>
@@ -698,7 +709,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
      two different contents under one immutable url is exactly what the ?v= is
      there to prevent, and check-cache-bust cannot see it because both sides
      agree on the number. -->
-<script src="/js/parashare.page.js?v=5" defer></script>
+<script src="/js/parashare.page.js?v=6" defer></script>
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=7" defer></script>
 <footer>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -435,7 +435,7 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 }
 </script>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=3">
+<link rel="stylesheet" href="/app-2026.css?v=4">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -175,7 +175,7 @@ main#main-content .btn { width: 100%; justify-content: center; }
 }
 </script>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=3">
+<link rel="stylesheet" href="/app-2026.css?v=4">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -97,7 +97,7 @@
     }
   </style>
 <meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=3">
+<link rel="stylesheet" href="/app-2026.css?v=4">
 <script src="/js/theme.js?v=1"></script>
 </head>
 <body>

--- a/tests/navigation-shell.test.mjs
+++ b/tests/navigation-shell.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
 const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
 const MIME = { '.js':'text/javascript', '.css':'text/css', '.html':'text/html', '.svg':'image/svg+xml', '.png':'image/png', '.woff2':'font/woff2' };
-const aliases = { '/':'/index.html', '/dashboard':'/dashboard.html', '/account':'/account.html', '/developer':'/developer.html', '/pricing':'/pricing.html', '/help':'/help/index.html' };
+const aliases = { '/':'/index.html', '/dashboard':'/dashboard.html', '/account':'/account.html', '/developer':'/developer.html', '/pricing':'/pricing.html', '/parashare':'/parashare.html', '/help':'/help/index.html' };
 const server = http.createServer((req, res) => {
   let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
   pathname = aliases[pathname] || pathname;
@@ -423,6 +423,30 @@ ok('the signed-in phone bar carries one account control beside the menu button',
 ok('nothing in the signed-in phone bar touches its neighbour', appBar.gaps.length > 0 && appBar.gaps.every((gap) => gap >= 12), JSON.stringify(appBar));
 ok('every target in the signed-in phone bar is finger-sized', appBar.items.every((item) => item.height >= 44), JSON.stringify(appBar.items));
 await appBarPage.close();
+
+// The same measurement as the signed-out bar above, on an app screen. It is a
+// second check and not a second route in that loop because the answer is a
+// different colour: /parashare, /dashboard, /sign, /account and the auth pages
+// load app-2026.css AFTER nav.css, and that file paints the bar in the app's
+// own paper rather than the marketing bone. What must be identical is the
+// opacity. nav.css turns the bar opaque under 1024px on purpose, because at .92
+// with no backdrop-filter behind it the page scrolls through the letters; the
+// later stylesheet had quietly put the translucent token back, and a review of
+// /parashare on a 390 phone read it off the screen as spook letters. So this
+// pins the alpha and the absent filter and lets the theme own the hex.
+const appPaintPage = await browser.newPage({ viewport:{ width:390, height:844 } });
+await appPaintPage.route('**/api/**', (route) => route.fulfill({ status:401, contentType:'application/json', body:'{"authenticated":false}' }));
+await appPaintPage.goto(ORIGIN + '/parashare', { waitUntil:'domcontentloaded' });
+await appPaintPage.locator('nav.nav').waitFor();
+const appPaint = await appPaintPage.locator('nav.nav').evaluate((node) => ({
+  background: getComputedStyle(node).backgroundColor,
+  backdropFilter: getComputedStyle(node).backdropFilter,
+  webkitBackdropFilter: getComputedStyle(node).getPropertyValue('-webkit-backdrop-filter'),
+}));
+ok('the /parashare navigation is opaque on a phone', /^rgb\(\d+, \d+, \d+\)$/.test(appPaint.background)
+  && appPaint.backdropFilter === 'none'
+  && (!appPaint.webkitBackdropFilter || appPaint.webkitBackdropFilter === 'none'), JSON.stringify(appPaint));
+await appPaintPage.close();
 
 // A signed-in tablet has the room the phone does not, so Help is a text link in
 // the bar there, exactly as it is signed out. One tap, and the same place the

--- a/tests/parasend-session-key.test.mjs
+++ b/tests/parasend-session-key.test.mjs
@@ -47,6 +47,10 @@ const FAKE_KEY = 'pgp_livetestkey0000000000abcd';
 // ── A DOM small enough to read, big enough to run the page script ────────────
 function makeElement(id) {
   const classes = new Set();
+  // Attributes are read back now: step 2 marks its session card aria-disabled
+  // when the relay connection is gone, and a stub that swallowed setAttribute
+  // and answered null could not tell that apart from doing nothing.
+  const attributes = new Map();
   const el = {
     id, value: '', textContent: '', innerHTML: '', className: '',
     hidden: false, disabled: false, files: [], style: {},
@@ -56,7 +60,9 @@ function makeElement(id) {
       toggle: (c, on) => (on === undefined ? (classes.has(c) ? classes.delete(c) : classes.add(c)) : (on ? classes.add(c) : classes.delete(c))),
       contains: (c) => classes.has(c),
     },
-    focus() {}, blur() {}, setAttribute() {}, getAttribute: () => null,
+    focus() {}, blur() {},
+    setAttribute: (name, value) => { attributes.set(name, String(value)); },
+    getAttribute: (name) => (attributes.has(name) ? attributes.get(name) : null),
     addEventListener() {}, appendChild() {}, closest: () => null,
   };
   return el;
@@ -71,7 +77,7 @@ function runPage({ keyResponses, sectorOk = true }) {
   };
   const listeners = new Map();
   const sockets = [];
-  const calls = { key: 0, sector: 0, urls: [], timeouts: [], storage: [] };
+  const calls = { key: 0, sector: 0, urls: [], timeouts: [], storage: [], copied: [] };
   let keyTurn = 0;
 
   const respond = (spec) => ({
@@ -88,7 +94,7 @@ function runPage({ keyResponses, sectorOk = true }) {
     URLSearchParams,
     AbortSignal: { timeout: () => null },
     crypto: globalThis.crypto,
-    navigator: { clipboard: { writeText: async () => {} } },
+    navigator: { clipboard: { writeText: async (text) => { calls.copied.push(text); } } },
     location: { search: '', hash: '', origin: 'https://paramant.app', pathname: '/parashare', reload() {} },
     localStorage: {
       getItem: (k) => { calls.storage.push(['get', k]); return null; },
@@ -160,6 +166,12 @@ function pickAFile(run) {
 }
 
 const wroteTheKey = (run) => run.calls.storage.some(([op, k]) => op === 'set' && k === 'paramant_api_key');
+
+// Press Copy link the way the page does, and let the clipboard promise settle.
+async function copyLinkIn(run) {
+  await evalIn(run, 'copyLink()');
+  for (let i = 0; i < 5; i += 1) await new Promise((r) => setImmediate(r));
+}
 
 // ── 1. The endpoint answers ─────────────────────────────────────────────────
 test('a 200 from /api/user/account/key gives the slim row, a usable button, and nothing in localStorage', async () => {
@@ -335,9 +347,26 @@ test('an empty manual key field is asked to be filled in, not called invalid', a
 // the page wrote the single word "Disconnected" into a status line, which
 // answers none of the three questions a sender has: what happened, where is my
 // file, and what do I do now. Same treatment as the key banner.
+//
+// And the alarm is not the whole screen. A live review found the card still
+// under it: green beacon, "Waiting for receiver...", the dead link, the blue
+// Copy link. The page said the session was gone and offered to share it in the
+// same sentence. The card is switched off with the alarm now, and this measures
+// that as well as the words.
+//
 // Verified by sabotage: put the bare setStatus back, or drop the reopen action,
-// and this goes red.
+// and this goes red; drop the setSessionCardStale call out of setLinkError, or
+// leave the copy button enabled, and the card half goes red by name.
 test('a relay connection that drops before the receiver arrives says so, and offers a way back', async () => {
+  // The grey itself is CSS, so the class the script toggles has to have a rule
+  // behind it or the card would be marked stale and look exactly as live.
+  assert.match(PS_HTML, /<div class="card" id="ps-session-card">/,
+    'the step 2 session card must be findable by id, or nothing can switch it off');
+  assert.match(PS_HTML, /\.card\.is-stale\{opacity:[^;]+;pointer-events:none\}/,
+    '.is-stale must both grey the card and stop it taking taps');
+  assert.match(PS_HTML, /#ps-session-card\.is-stale #waiting-dot\{background:var\(--ink-3\);animation:none\}/,
+    'the beacon has an id rule of its own, so stopping it needs an id rule too');
+
   const run = await loadPage({ keyResponses: [{ status: 200, body: { api_key: FAKE_KEY, revealable: true } }] });
   pickAFile(run);
   await evalIn(run, 'createSession()');
@@ -356,6 +385,22 @@ test('a relay connection that drops before the receiver arrives says so, and off
   assert.match(said, /dropped before your receiver arrived/, 'it says what happened');
   assert.match(said, /Nothing was uploaded/, 'it says the file did not go anywhere');
   assert.match(said, /still here in this browser/, 'it says where the file is');
+  assert.ok(!/to the relay/.test(said), 'and it says it without naming the plumbing: the sender lost a connection, not a relay');
+
+  // The card under the alarm. It kept a beating beacon, "Waiting for
+  // receiver...", the dead link and a blue Copy link, so the screen said the
+  // session was gone and offered to share it in the same breath. Copying that
+  // link sends the receiver to a session that no longer exists.
+  const card = run.getElementById('ps-session-card');
+  assert.equal(card.classList.contains('is-stale'), true,
+    'the session card must grey out with the alarm; the stylesheet keys the grey and the dead beacon off .is-stale');
+  assert.equal(card.getAttribute('aria-disabled'), 'true',
+    'a reader who cannot see the grey has to be told the card is off');
+  assert.equal(run.getElementById('ps-copy-btn').disabled, true, 'the copy button is really disabled, not only dimmed');
+  assert.equal(run.getElementById('session-link').getAttribute('aria-disabled'), 'true',
+    'the link box is a click target of its own, so it is marked off as well');
+  await copyLinkIn(run);
+  assert.deepEqual(run.calls.copied, [], 'and pressing copy on a dead session puts nothing on the clipboard');
 
   // The way back: a fresh session, a new link, and the alarm cleared.
   await evalIn(run, 'reopenSession()');
@@ -364,6 +409,12 @@ test('a relay connection that drops before the receiver arrives says so, and off
   assert.notEqual(run.getElementById('session-link').textContent, firstLink,
     'and a new one-time link: the old token died with the old socket');
   assert.equal(box.classList.contains('is-shown'), false, 'the alarm clears once the session is back');
+  assert.equal(card.classList.contains('is-stale'), false, 'and the card comes back to life with it');
+  assert.equal(card.getAttribute('aria-disabled'), 'false');
+  assert.equal(run.getElementById('ps-copy-btn').disabled, false, 'the new link is copyable');
+  await copyLinkIn(run);
+  assert.deepEqual(run.calls.copied, [run.getElementById('session-link').textContent],
+    'and copy hands over the new link, not the dead one');
 
   // A socket that closes after the receiver is already known is the normal end
   // of the handshake, not a failure.


### PR DESCRIPTION
Four restpunten uit de live koperreview: /parashare stap 2 (5 van 8) en de ingelogde homepage (4 van 8).

## 1. Een dode sessie biedt zijn link niet meer aan

Step 2 answered a dropped relay connection with an alarm and left the card under it untouched: a beating beacon, "Waiting for receiver...", the link that now connects to nothing, and a blue Copy link. The screen said the session was gone and offered to share it in the same breath. A sender who copied that link sent his receiver somewhere that no longer existed, and found out only when the receiver said so.

The card now goes with the alarm. `setLinkError` drives a `setSessionCardStale`: `.is-stale` greys the card and stops it taking taps, `aria-disabled="true"` says the same to a screen reader, `#ps-copy-btn` is really disabled rather than dimmed, and `copyLink()` returns early so the share box's own click handler cannot get past the CSS either. The beacon has an id rule of its own in the page, so stopping it needs an id rule too. The one live control is the alarm's "Open the session again", which sits above the card and is untouched; reopening clears the state on the way in.

Measured in `tests/parasend-session-key.test.mjs` case 9, in the vm harness that was already there. Sabotage, all three red by name:

| sabotage | result |
| --- | --- |
| drop `setSessionCardStale(!!on)` out of `setLinkError` | red: "the session card must grey out with the alarm" |
| leave `#ps-copy-btn` enabled | red: "the copy button is really disabled, not only dimmed" |
| drop `pointer-events:none` from `.card.is-stale` | red: ".is-stale must both grey the card and stop it taking taps" |

The DOM stub grew a real attribute map for this: it used to swallow `setAttribute` and answer `null`, which cannot tell an `aria-disabled` that was set apart from one that was never written.

## 2. De nav op /parashare is ondoorzichtig

The bar was `rgba(251,250,247,.92)` with no backdrop-filter behind it, so on a 390 phone the page scrolled through the letters. nav.css already turns the bar opaque under 1024px for exactly that reason; app-2026.css loads after it and its `nav.nav` rule had quietly put the translucent token back on every app screen. That file now carries the same exception.

One deviation from the brief, stated out loud: the paint is `var(--paper)`, the app's own paper, not the marketing `rgb(248,250,252)` that navigation-shell pins on the public pages. The app screens have their own palette and a dark theme; hardcoding the marketing bone would put the bar in a different off-white than the page under it and would be white-on-dark in dark mode. So what `tests/navigation-shell.test.mjs` pins on /parashare is the opacity and the absent filter, and it lets the theme own the hex. Sabotage: remove the media block and the check goes red with `{"background":"rgba(251, 250, 247, 0.92)"}`.

The fix is in the shared stylesheet, so /dashboard, /sign, /account, /signup and the auth pages get it too.

## 3. Change is een echt tikdoel

`.ps-key-change` was `min-height:36px`. It is `var(--tap)` now, 44px, like every other control on the screen.

## 4. Een stem voor wat ParaSend doet

- Ingelogde homepage: "the ParaSend web app, which burns it on the first read" wordt "which deletes it after the first read". Block 37 of site-claims stays green: the paragraph names the client ("web app"), which is what that block requires of a burn-on-read claim, and the new wording is matched by the same ERASE/MOMENT crossing as the old one. ui-truthfulness is green.
- De foutzin op stap 2 verliest het leidingwerk: "The connection to the relay dropped" wordt "The connection dropped". The sibling `onerror` sentence went with it ("to the relay failed" to "failed"): it is the same alarm in the same block, and leaving one half naming the relay would have been the inconsistency the change is about. Case 9 now also asserts the sentence does not say "to the relay".
- De sectiekop op stap 1: "Self-destruct" wordt "Deletes itself", dezelfde belofte in dezelfde woorden als de paginakop "Send a file that deletes itself".

## Cache-busts

Both `app-2026.css` and `parashare.page.js` changed content and are served immutable, so both move: `?v=3` to `?v=4` on the eleven pages that load the stylesheet, `?v=5` to `?v=6` on the page script. `scripts/check-cache-bust.sh` green over 364 links.

## Poorten

Alle genoemde poorten lokaal groen: first-screen, ui-truthfulness, site-claims, seo-contract, links, navigation-shell (54 checks), frontend-loading-contract, cache-bust, csp-inline, static-sanity (twaalf blokken, style guard over `31fe1617..HEAD`), check-test-declarations (137 suites), eslint, app-contrast (twee suites, 44px-tikdoelen inbegrepen), app-theme, parasend-session-key (11 tests), apply-nav-idempotent.
