### PR TITLE
Ask for the signature where it belongs: one requested position in the invite flow

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -1738,6 +1738,21 @@ api.post("/user/envelopes", authUser, async (req, res) => {
   // can explicitly omit them: the requester is then the owner/coordinator, not
   // an unsigned party that would keep the envelope open forever.
   const includeRequester = req.body?.include_requester !== false;
+  // ONE requested signing position for the whole envelope: where the requester
+  // asked every party to sign. It is a request, never a commitment -- a party's
+  // signature binds the appearance they actually used (POST /user/sign/submit),
+  // so this never touches the signing message. Bounded here with the SAME
+  // 4096-byte ceiling as that route, before the relay is called at all. Shape
+  // and coordinates are validated by the relay's normaliseAppearance.
+  const requestedAppearance = req.body?.requested_appearance;
+  if (requestedAppearance !== undefined) {
+    let requestedSize = 0;
+    try { requestedSize = Buffer.byteLength(JSON.stringify(requestedAppearance), "utf8"); }
+    catch { return res.status(400).json({ error: "invalid_requested_appearance" }); }
+    if (requestedSize > 4096 || !requestedAppearance || typeof requestedAppearance !== "object" || Array.isArray(requestedAppearance)) {
+      return res.status(400).json({ error: "invalid_requested_appearance" });
+    }
+  }
   const parties = includeRequester
     ? [{ label: ((req.body?.signer_label || "") + " (you)").trim(), email }]
     : [];
@@ -1753,7 +1768,7 @@ api.post("/user/envelopes", authUser, async (req, res) => {
     const rr = await fetch(`${SECTORS.health}/v2/envelopes`, {
       method: "POST",
       headers: { "Content-Type": "application/json", "X-Api-Key": proxyApiKey(req.userSession) },
-      body: JSON.stringify({ doc_hash: docHash, parties, original_filename: originalFilename, binding_mode: "email", recipe_version: 5, creator_public_key: creatorPublicKey }),
+      body: JSON.stringify({ doc_hash: docHash, parties, original_filename: originalFilename, binding_mode: "email", recipe_version: 5, creator_public_key: creatorPublicKey, requested_appearance: requestedAppearance }),
     });
     const body = await rr.json().catch(() => ({}));
     if (rr.status !== 200) return res.status(rr.status).json({ error: body.error || "envelope_create_failed" });

--- a/admin/test/signing-appearance.test.js
+++ b/admin/test/signing-appearance.test.js
@@ -34,3 +34,47 @@ test('appearance is bounded before the one-shot activation is consumed', () => {
   assert.match(route[0], /appearance,/);
   assert.match(route[0], /appearance_hash: body\.appearance_hash/);
 });
+
+// The requester's ONE requested signing position, added for the invite flow on
+// /sign. It travels on envelope CREATION, not on a signature, so it needs its
+// own bound on the way in and it must never be mistaken for signed data.
+test('the requested signing position is bounded before the relay is called', () => {
+  const route = source.match(/api\.post\("\/user\/envelopes"[\s\S]*?\n\}\);/);
+  assert.ok(route, 'envelope route exists');
+  const gate = route[0].indexOf('requestedSize > 4096');
+  const call = route[0].indexOf('await fetch(');
+  assert.ok(gate >= 0, 'the requested position has a size ceiling');
+  assert.ok(call > gate, 'the ceiling is checked before the relay call');
+  // The SAME ceiling as POST /user/sign/submit, so one number governs both
+  // appearance manifests and neither route can drift on its own.
+  const submit = source.match(/api\.post\("\/user\/sign\/submit"[\s\S]*?\n\}\);/);
+  assert.match(submit[0], /appearanceSize > 4096/);
+  assert.match(route[0], /error: "invalid_requested_appearance"/);
+  assert.match(route[0], /requested_appearance: requestedAppearance/);
+});
+
+test('a non-object requested position is refused, whatever its size', () => {
+  const route = source.match(/api\.post\("\/user\/envelopes"[\s\S]*?\n\}\);/);
+  // An array and a bare scalar both stringify small, so the size gate alone
+  // would wave them through into the relay's normaliser.
+  assert.match(route[0], /Array\.isArray\(requestedAppearance\)/);
+  assert.match(route[0], /typeof requestedAppearance !== "object"/);
+  // undefined stays legal: an invite may ask for no position at all.
+  assert.match(route[0], /requestedAppearance !== undefined/);
+});
+
+// The ceiling is a bound on junk, not on legitimate input: prove it can never
+// reject a manifest the relay itself would accept. Behaviour, not source text.
+test('4096 bytes is above anything the relay normaliser can produce', () => {
+  const { normaliseAppearance } = require('../../relay/envelope.js');
+  const fields = [];
+  for (let i = 0; i < 8; i++) {
+    fields.push({ type: i % 2 ? 'date' : 'seal', page_index: 999, x: 0.123456, y: 0.123456, w: 0.123456, h: 0.123456 });
+  }
+  const biggest = normaliseAppearance({ version: 1, fields });
+  assert.strictEqual(biggest.fields.length, 8, 'eight fields is the relay maximum');
+  assert.ok(Buffer.byteLength(JSON.stringify(biggest), 'utf8') < 4096,
+    'the largest manifest the relay accepts fits inside the admin ceiling');
+  assert.throws(() => normaliseAppearance({ version: 1, fields: fields.concat(fields[0]) }),
+    /invalid appearance fields/, 'a ninth field is refused by the relay');
+});

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -223,6 +223,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1"></script>
 <script src="/js/quota-upgrade.js?v=4" defer></script>
-<script type="module" src="/co-sign.js?v=20"></script>
+<script type="module" src="/co-sign.js?v=21"></script>
 </body>
 </html>

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -75,18 +75,38 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 .step{display:none;animation:fadeIn .2s ease}
 .step.active{display:block}
 @keyframes fadeIn{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
-.doc-preview{margin-top:12px;border:1px solid var(--ink-hair);background:#fff;max-height:72vh;overflow:auto;padding:10px}
-.doc-page{margin:0 auto 12px;max-width:100%}
+/* The preview IS the document, so it gets the width. Nested padding (card 32,
+   card-body 18, its own 10) ate 120px of a 390px phone and left the page 229px
+   wide with a margin on either side, while the sender who placed the box was
+   looking at a 343px render of the same page. The negative margin cancels the
+   two paddings it is nested in, so the preview runs edge to edge inside the
+   card and both sides see the document at the same scale. */
+.doc-preview{margin:12px -50px 0;border:1px solid var(--ink-hair);border-left:0;border-right:0;background:#fff;max-height:72vh;overflow:auto;padding:10px 8px}
+.doc-page{position:relative;width:100%;margin:0 auto 12px;max-width:100%}
 .doc-page:last-child{margin-bottom:0}
 .doc-page canvas,.doc-page img{display:block;width:100%;height:auto;border:1px solid var(--ink-hair);background:#fff}
 .doc-page.appearance-page{position:relative;cursor:crosshair}
 .appearance-layer{position:absolute;inset:0;pointer-events:auto;cursor:crosshair}
 .appearance-field{position:absolute;display:flex;align-items:center;overflow:hidden;border:2px solid var(--cobalt);background:rgba(255,255,255,.94);color:var(--ink);padding:5px 8px;font:600 10px/1.25 var(--sans);box-shadow:0 3px 12px rgba(11,58,106,.16);pointer-events:auto}
 .appearance-field.date{border-color:#64748b;font-family:var(--mono);font-weight:500}
+/* The box the SENDER asked for, before the signer has touched it. It must not
+   look like a signature that already exists: no name, no date, no delete
+   control, a dashed outline and its own words. It becomes a real placed field
+   the moment the signer chooses Place my signature. */
+.appearance-field.requested{border:2px dashed var(--cobalt);background:rgba(11,58,106,.06);box-shadow:none;color:var(--cobalt);font-weight:600;justify-content:center;text-align:center;pointer-events:none}
 .appearance-field.prior{border-style:solid;background:rgba(239,246,255,.92);pointer-events:none}
 .appearance-remove{position:absolute;top:1px;right:2px;width:20px;height:20px;border:0;background:var(--cobalt);color:#fff;font:700 13px/1 var(--sans);cursor:pointer}
 .appearance-tools{display:flex;gap:8px;flex-wrap:wrap;margin:12px 0}
 .appearance-tools .btn{width:auto;min-width:120px}
+/* 44px: a finger, not a mouse. These were 34-36px, under every touch-target
+   guideline, on the one screen where a mis-tap costs a signature. */
+.btn,.file-cta{min-height:44px}
+.appearance-tools .btn{min-height:44px}
+/* The pointer to the requested spot. It sits ABOVE the preview because that is
+   where the reader is when the document opens; the spot itself can be three
+   pages down. */
+.requested-note{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap;margin-bottom:10px;padding:10px 14px;border:1px solid var(--cobalt);background:rgba(11,58,106,.04);font-size:12px;line-height:1.5;color:var(--cobalt)}
+.requested-note .btn{width:auto;min-width:0;padding:11px 14px;flex:0 0 auto}
 .appearance-help{font-size:12px;line-height:1.55;color:var(--ink-dim)}
 .appearance-help.active{color:var(--cobalt);font-weight:600}
 .doc-preview-meta{font-family:var(--mono);font-size:10px;letter-spacing:.04em;color:var(--ink-dim);text-align:center;padding:8px 0;line-height:1.5}
@@ -155,6 +175,10 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <label class="file-cta" for="verify-file" id="verify-file-cta">Choose the document manually if automatic loading fails</label>
       <input type="file" id="verify-file" hidden>
       <div class="banner" id="verify-result" hidden></div>
+      <div class="requested-note" id="requested-note" hidden>
+        <span id="requested-note-text">The sender marked where you sign</span>
+        <button class="btn" id="requested-note-go" type="button">Go to the spot</button>
+      </div>
       <div class="doc-preview" id="doc-preview" hidden></div>
       <div id="appearance-editor" hidden>
         <div class="appearance-tools" role="toolbar" aria-label="Visible signature fields">

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -69,6 +69,11 @@ let __blindAck = false;     // user explicitly opted to sign without opening the
 let __documentBytes = null; // verified source bytes, retained only for this page session
 let __appearanceTool = '';
 let __appearance = { version: 1, fields: [] };
+// True while __appearance is still exactly what the SENDER asked for and the
+// signer has not touched it. It is what tells the overlay to draw a dashed,
+// unnamed "requested spot" instead of a placed signature, and it goes false the
+// moment the signer places, moves or clears anything.
+let __appearanceIsSeed = false;
 let __signedPdfBytes = null;
 
 function appearanceDraftKey() {
@@ -184,10 +189,14 @@ function renderEnvelope() {
   const me = e.parties[__partyIndex] || {};
   $('me-label').textContent = (me.label || 'party ' + (__partyIndex + 1));
   $('verify-file').onchange = onVerifyFile;
+  const go = $('requested-note-go');
+  if (go) go.onclick = () => scrollToRequestedSpot('smooth');
   $('appearance-seal').onclick = () => armAppearanceTool('seal');
   $('appearance-date').onclick = () => armAppearanceTool('date');
   $('appearance-clear').onclick = () => {
     __appearance = { version: 1, fields: [] };
+    __appearanceIsSeed = false;
+    { const note = $('requested-note'); if (note) note.hidden = true; }
     saveAppearanceDraft();
     __appearanceTool = '';
     setAppearanceHelp('Your visible fields were cleared. You can place them again or sign without a visible mark.', false);
@@ -350,6 +359,7 @@ async function verifyAndRenderDocument(buf, source) {
   const draft = __hashMatches ? loadAppearanceDraft() : null;
   const seed = (__hashMatches && !draft) ? requestedAppearanceSeed() : null;
   __appearance = draft || seed || { version: 1, fields: [] };
+  __appearanceIsSeed = !!seed;
   __appearanceTool = '';
   const b = $('verify-result');
   b.hidden = false;
@@ -370,6 +380,20 @@ async function verifyAndRenderDocument(buf, source) {
   // signature binds is the position the signer actually used.
   if (seed && editorOn) {
     setAppearanceHelp('The sender asked for your signature in the marked spot. Choose Place my signature to move it: your signature binds where you actually sign, not where it was requested.', false);
+  }
+  // The requested spot can be on page three of a long agreement, so pointing at
+  // it is not enough: take the reader there, and leave a way back to it.
+  const note = $('requested-note');
+  if (note) { note.hidden = !(seed && editorOn); delete note.dataset.scrolled; }
+  if (seed && editorOn) {
+    // One frame later. The last page canvas has only just been sized, and a
+    // scroll issued before layout settles lands on an offset that no longer
+    // exists. The marker is what the browser test waits for, so "we took the
+    // reader there" is observed rather than timed.
+    requestAnimationFrame(() => {
+      scrollToRequestedSpot('instant');
+      if (note) note.dataset.scrolled = '1';
+    });
   }
   refreshSignGate();
 }
@@ -407,17 +431,24 @@ async function renderPdfPreview(bytes, host) {
   for (let i = 1; i <= maxPages; i++) {
     const page = await pdf.getPage(i);
     const base = page.getViewport({ scale: 1 });
-    const targetWidth = Math.min(820, Math.floor(((host.clientWidth || window.innerWidth) - 20) * 0.98)) || 600;
+    // Fit to width, like the sender's Place step. The canvas is laid out at
+    // 100% of the page wrapper rather than a computed pixel width, so wrapper,
+    // canvas and .appearance-layer are one and the same box: a click fraction
+    // is then exactly a fraction of the PDF page, with no few-pixel drift
+    // between the div the maths reads and the pixels the reader sees.
+    const contentWidth = Math.max(200, (host.clientWidth || window.innerWidth) - 16);
+    const targetWidth = Math.min(820, contentWidth);
     const cssScale = targetWidth / base.width;
     const viewport = page.getViewport({ scale: cssScale * dpr });
     const wrap = document.createElement('div');
     wrap.className = 'doc-page appearance-page';
     wrap.dataset.pageIndex = String(i - 1);
+    wrap.style.maxWidth = targetWidth + 'px';
     const canvas = document.createElement('canvas');
     canvas.width = Math.floor(viewport.width);
     canvas.height = Math.floor(viewport.height);
-    canvas.style.width = targetWidth + 'px';
-    canvas.style.height = Math.floor(base.height * cssScale) + 'px';
+    canvas.style.width = '100%';
+    canvas.style.height = 'auto';
     canvas.style.display = 'block';
     wrap.appendChild(canvas);
     const layer = document.createElement('div');
@@ -445,6 +476,20 @@ async function renderImagePreview(bytes, mime, host) {
   img.src = url;
   wrap.appendChild(img);
   host.appendChild(wrap);
+}
+
+// Bring the requested box into view. scrollIntoView walks every scrollable
+// ancestor, so this moves the preview's own scroller AND the page: the caller
+// only has to say when.
+function scrollToRequestedSpot(behavior) {
+  const node = document.querySelector('.appearance-field.requested');
+  if (!node) return false;
+  // 'instant' rather than 'auto': the page sets scroll-behavior:smooth, and
+  // 'auto' inherits it. A one-second animation on load means the box is still
+  // off screen while the reader is deciding what this page is.
+  try { node.scrollIntoView({ behavior: behavior || 'smooth', block: 'center', inline: 'center' }); }
+  catch { node.scrollIntoView(true); }
+  return true;
 }
 
 function setAppearanceHelp(message, active) {
@@ -481,8 +526,12 @@ function placeAppearanceField(event) {
   };
   __appearance = normaliseSigningAppearance({
     version: 1,
-    fields: __appearance.fields.filter((item) => item.type !== field.type).concat(field),
+    // Placing anything makes this the signer's own manifest: the seeded box was
+    // a request, and from here on every field in it was put there by the signer.
+    fields: (__appearanceIsSeed ? [] : __appearance.fields).filter((item) => item.type !== field.type).concat(field),
   });
+  __appearanceIsSeed = false;
+  { const note = $('requested-note'); if (note) note.hidden = true; }
   saveAppearanceDraft();
   __appearanceTool = '';
   setAppearanceHelp(field.type === 'seal'
@@ -496,15 +545,17 @@ function appearanceText(type, party, current) {
   return 'Paramant signed · ' + String(party.label || 'Signer');
 }
 
-function addAppearanceNode(layer, field, party, current) {
+function addAppearanceNode(layer, field, party, current, requested) {
   const node = document.createElement('div');
-  node.className = 'appearance-field ' + field.type + (current ? '' : ' prior');
+  node.className = 'appearance-field ' + field.type + (requested ? ' requested' : current ? '' : ' prior');
   node.style.left = (field.x * 100) + '%';
   node.style.top = (field.y * 100) + '%';
   node.style.width = (field.w * 100) + '%';
   node.style.height = (field.h * 100) + '%';
-  node.textContent = appearanceText(field.type, party, current);
-  if (current) {
+  // A requested box names nobody and carries no date: nothing has been signed
+  // there yet, and showing a name would be a signature the signer never made.
+  node.textContent = requested ? 'Requested spot · your signature goes here' : appearanceText(field.type, party, current);
+  if (current && !requested) {
     const remove = document.createElement('button');
     remove.type = 'button';
     remove.className = 'appearance-remove';
@@ -513,6 +564,7 @@ function addAppearanceNode(layer, field, party, current) {
     remove.addEventListener('click', (event) => {
       event.stopPropagation();
       __appearance = { version: 1, fields: __appearance.fields.filter((item) => item.type !== field.type) };
+      __appearanceIsSeed = false;
       saveAppearanceDraft();
       renderAppearanceOverlays();
     });
@@ -528,17 +580,17 @@ function renderAppearanceOverlays() {
     const layer = page.querySelector('.appearance-layer');
     if (layer) layer.innerHTML = '';
   }
-  const add = (field, party, current) => {
+  const add = (field, party, current, requested) => {
     const page = pages.find((node) => Number(node.dataset.pageIndex) === Number(field.page_index));
     const layer = page && page.querySelector('.appearance-layer');
-    if (layer) addAppearanceNode(layer, field, party, current);
+    if (layer) addAppearanceNode(layer, field, party, current, requested);
   };
   for (const party of (__envelope?.parties || [])) {
     if (party.index === __partyIndex || party.status !== 'signed' || !party.appearance) continue;
     for (const field of (party.appearance.fields || [])) add(field, party, false);
   }
   const me = (__envelope?.parties || [])[__partyIndex] || {};
-  for (const field of (__appearance.fields || [])) add(field, me, true);
+  for (const field of (__appearance.fields || [])) add(field, me, true, __appearanceIsSeed);
 }
 
 function downloadBytes(bytes, filename, type) {

--- a/frontend/co-sign.js
+++ b/frontend/co-sign.js
@@ -18,7 +18,7 @@
 // the view receipt. The signing path itself is same-origin via the admin
 // (/api/user/sign/*), bound to the logged-in invitee session.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, normaliseSigningAppearance, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolEphemeralSigningKeyWithTotp } from '/js/parasign-signer.js?v=14';
+import { LocalVaultSigner, buildDocSignMessage, normaliseSigningAppearance, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolEphemeralSigningKeyWithTotp } from '/js/parasign-signer.js?v=15';
 import { promptTotp } from '/js/totp-prompt.js?v=1';
 import { decryptDocumentCapsule, parseDocumentKeyFragment } from '/js/parasign-document-capsule.js?v=1';
 
@@ -75,11 +75,26 @@ function appearanceDraftKey() {
   return __envelope ? 'paramant.cosign.appearance.v1:' + __envelope.id + ':' + __partyIndex : '';
 }
 
+// null means "this signer has no draft of their own", which is what lets the
+// requested position seed the editor without ever overwriting a real draft.
 function loadAppearanceDraft() {
   try {
     const raw = sessionStorage.getItem(appearanceDraftKey());
-    return raw ? normaliseSigningAppearance(JSON.parse(raw)) : { version: 1, fields: [] };
-  } catch { return { version: 1, fields: [] }; }
+    if (!raw) return null;
+    return normaliseSigningAppearance(JSON.parse(raw));
+  } catch { return null; }
+}
+
+// The position the requester asked for, carried on the envelope. Untrusted
+// relay data, so it goes through the same normaliser as anything the signer
+// places themselves; anything malformed is simply not offered.
+function requestedAppearanceSeed() {
+  const requested = __envelope && __envelope.requested_appearance;
+  if (!requested) return null;
+  try {
+    const normalized = normaliseSigningAppearance(requested);
+    return normalized.fields.length ? normalized : null;
+  } catch { return null; }
 }
 
 function saveAppearanceDraft() {
@@ -332,7 +347,9 @@ async function verifyAndRenderDocument(buf, source) {
   __hashMatches = (h === __envelope.doc_hash);
   __blindAck = false;   // an opened file supersedes any earlier blind-sign override
   __documentBytes = __hashMatches ? new Uint8Array(buf) : null;
-  __appearance = __hashMatches ? loadAppearanceDraft() : { version: 1, fields: [] };
+  const draft = __hashMatches ? loadAppearanceDraft() : null;
+  const seed = (__hashMatches && !draft) ? requestedAppearanceSeed() : null;
+  __appearance = draft || seed || { version: 1, fields: [] };
   __appearanceTool = '';
   const b = $('verify-result');
   b.hidden = false;
@@ -347,7 +364,13 @@ async function verifyAndRenderDocument(buf, source) {
   }
   await renderDocPreview(buf);
   const editor = $('appearance-editor');
-  if (editor) editor.hidden = !(__hashMatches && isPdfBytes(buf) && Number(__envelope.recipe_version) >= 5);
+  const editorOn = __hashMatches && isPdfBytes(buf) && Number(__envelope.recipe_version) >= 5;
+  if (editor) editor.hidden = !editorOn;
+  // Say out loud whose box this is. The requested spot is a suggestion: what a
+  // signature binds is the position the signer actually used.
+  if (seed && editorOn) {
+    setAppearanceHelp('The sender asked for your signature in the marked spot. Choose Place my signature to move it: your signature binds where you actually sign, not where it was requested.', false);
+  }
   refreshSignGate();
 }
 

--- a/frontend/js/parasign-signer.js
+++ b/frontend/js/parasign-signer.js
@@ -79,6 +79,35 @@ export function normaliseSigningAppearance(value) {
   return { version: 1, fields };
 }
 
+// Pure: one stamp placed on /sign (PDF points, bottom-left origin, exactly the
+// shape of state.stamp) plus the page it sits on, turned into the normalised
+// appearance model. Fractions 0..1 of the page, y measured from the TOP, which
+// is what normaliseSigningAppearance accepts and what /co-sign paints with.
+// Returns null when there is nothing to ask for, so the caller can simply omit
+// the field instead of sending an empty manifest.
+export function requestedAppearanceFromStamp(stamp, page) {
+  if (!stamp || !page || stamp.isImage) return null;
+  const pageW = Number(page.width);
+  const pageH = Number(page.height);
+  const stampW = Number(stamp.w);
+  const stampH = Number(stamp.h);
+  if (![pageW, pageH, stampW, stampH, Number(stamp.x), Number(stamp.y)].every(Number.isFinite)) return null;
+  if (pageW <= 0 || pageH <= 0 || stampW <= 0 || stampH <= 0) return null;
+  // The manifest has a floor (a box smaller than this is not a signature mark),
+  // and a fraction can never exceed the page, so clamp rather than throw.
+  const w = Math.min(1, Math.max(0.02, stampW / pageW));
+  const h = Math.min(1, Math.max(0.01, stampH / pageH));
+  // stamp.y is the distance from the BOTTOM of the page to the bottom of the
+  // box (pdf-lib's origin); the manifest wants the top edge from the top.
+  const x = Math.min(1 - w, Math.max(0, Number(stamp.x) / pageW));
+  const y = Math.min(1 - h, Math.max(0, (pageH - Number(stamp.y) - stampH) / pageH));
+  const pageIndex = Number(stamp.pageIndex);
+  return normaliseSigningAppearance({
+    version: 1,
+    fields: [{ type: 'seal', page_index: Number.isInteger(pageIndex) && pageIndex >= 0 ? pageIndex : 0, x, y, w, h }],
+  });
+}
+
 export function signingAppearanceHash(value) {
   return sha3_256(new TextEncoder().encode(JSON.stringify(normaliseSigningAppearance(value))));
 }
@@ -455,15 +484,21 @@ async function _postJSON(url, body) {
 }
 // Create the envelope. Self-sign/co-sign include the requester as party 0;
 // request-signatures sets includeRequester=false and contains recipients only.
-export function createSigningEnvelope({ docHash, recipients, originalFilename, signerLabel, creatorPublicKey, includeRequester = true }) {
-  return _postJSON('/api/user/envelopes', {
+export function createSigningEnvelope({ docHash, recipients, originalFilename, signerLabel, creatorPublicKey, includeRequester = true, requestedAppearance }) {
+  const body = {
     doc_hash: docHash,
     recipients: recipients || [],
     original_filename: originalFilename,
     signer_label: signerLabel,
     creator_public_key: creatorPublicKey,
     include_requester: includeRequester,
-  });
+  };
+  // The position the requester asked for: one box, the same for every party.
+  // It is a request only. A signature binds the position the signer actually
+  // used (submitSignature's `appearance`), never this one, so it is sent on
+  // envelope creation and never near the signing message.
+  if (requestedAppearance) body.requested_appearance = normaliseSigningAppearance(requestedAppearance);
+  return _postJSON('/api/user/envelopes', body);
 }
 // Authorize + issue the per-document activation (pre-unlock gate). Returns
 // { activation_id, email_hash, recipe_version }.

--- a/frontend/js/signing-enrol.js
+++ b/frontend/js/signing-enrol.js
@@ -7,7 +7,7 @@
 // (parasign-signer.js) — the EXACT path /sign and /co-sign use — so this file
 // just wires the button + status and can never drift from the sign flow.
 // Self-hosted deps only (CSP script-src 'self'); no-ops if the button is absent.
-import { ensureSigningKey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=14';
+import { ensureSigningKey, resolvePasskeySigningKey } from '/js/parasign-signer.js?v=15';
 
 function wireSigningEnrol() {
   const btn = document.getElementById('signing-enrol-btn');

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -11,7 +11,7 @@
 // sign path. Signing goes through the passkey-PRF activation chain (LocalVaultSigner
 // in parasign-signer.js); sha3_256 stays for document hashing only.
 import { sha3_256 } from '/vendor/paramant-pqc.js';
-import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolEphemeralSigningKeyWithTotp } from '/js/parasign-signer.js?v=14';
+import { LocalVaultSigner, buildDocSignMessage, createSigningEnvelope, requestSignActivation, submitSignature, resolvePasskeySigningKey, ensureSigningKey, enrolEphemeralSigningKeyWithTotp, requestedAppearanceFromStamp } from '/js/parasign-signer.js?v=15';
 import { promptTotp } from '/js/totp-prompt.js?v=1';
 import { encryptDocumentCapsule } from '/js/parasign-document-capsule.js?v=1';
 
@@ -46,6 +46,7 @@ const state = {
   imageType: null,       // 'png' | 'jpg' (only when mode === 'image')
   doc:  null,            // { bytes (Uint8Array), name, size }
   stamp: null,           // PDF mode: bottom-left PDF points. Image mode: top-left image pixels.
+  stampPage: null,       // { width, height } of the page state.stamp sits on, in that page's own units.
   stampAllPages: false,  // PDF mode: repeat the seal on every page at the same relative spot.
   sealPlacement: 'inline', // PDF mode: inline, sheet, or both.
   pdfPageCount: null,    // PDF source page count, used to identify the appended sheet in the receipt.
@@ -211,7 +212,9 @@ function setStepperForMode(mode) {
   const steps = {
     alone:  ['doc', 'place', 'identity', 'sign'],
     cosign: ['doc', 'place', 'recipients', 'identity', 'sign'],
-    invite: ['doc', 'recipients', 'sign'],
+    // The invite flow places too: /sign promises the requester can point at
+    // the spot where the other party signs, and Place is where that happens.
+    invite: ['doc', 'place', 'recipients', 'sign'],
   }[mode] || ['doc', 'place', 'recipients', 'identity', 'sign'];
   document.querySelectorAll('.ds-stepper li').forEach(li => { li.hidden = !steps.includes(li.dataset.step); });
   const stepper = $('ds-stepper'); if (stepper) stepper.hidden = false;
@@ -282,6 +285,11 @@ async function sendForSignature() {
   showRecipientsHint('Creating the signing request…', false);
   try {
     const docHashForEnvelope = toHex(sha3_256(state.doc.bytes));
+    // One requested position, identical for every party. Absent when the
+    // requester placed nothing, or when the document is not a PDF.
+    const requestedAppearance = state.mode === 'pdf'
+      ? requestedAppearanceFromStamp(state.stamp, state.stampPage)
+      : null;
     const created = await createSigningEnvelope({
       docHash: docHashForEnvelope,
       recipients: state.recipients,
@@ -289,6 +297,7 @@ async function sendForSignature() {
       signerLabel: 'Requester',
       creatorPublicKey: '',   // the requester does not sign
       includeRequester: false,
+      requestedAppearance,
     });
     const envelope = created.envelope;
     showRecipientsHint('Encrypting the document for the recipients…', false);
@@ -423,6 +432,7 @@ async function onDocChosen(file) {
   state.imageType = null;
   state.extras = [];        // fresh document: drop any text/date objects from a prior file
   state.stamp = null;       // fresh document: drop the previous file's seal (QA: ghost stamp)
+  state.stampPage = null;
   state.sealPlacement = 'inline';
   state.pdfPageCount = null;
 
@@ -445,6 +455,7 @@ async function onDocChosen(file) {
   const toHashOnly = (note) => {
     state.mode = 'hash';
     state.stamp = null;
+    state.stampPage = null;
     setActive('step-hash-only');
     $('ds-hash-only-name').textContent = file.name;
     $('ds-hash-only-size').textContent = formatSize(file.size);
@@ -454,8 +465,10 @@ async function onDocChosen(file) {
     if (hint) { if (note) { hint.textContent = note; hint.hidden = false; } else { hint.hidden = true; } }
   };
 
-  if (state.signingMode === 'invite') {
-    // Requester doesn't stamp/sign — go straight to choosing who must sign.
+  if (state.signingMode === 'invite' && !isPdf) {
+    // Nothing to point at: the recipient's placement editor on /co-sign is
+    // PDF-only, so a non-PDF invite stays hash-only and skips Place entirely
+    // rather than offering a position that could never be honoured.
     enterRecipients();
   } else if (canPlaceVisually) {
     // A file can carry a valid %PDF/PNG/JPG magic and still be corrupt or
@@ -488,12 +501,52 @@ function loadImageElement(bytes, mime) {
   });
 }
 
+// The Place step serves two different jobs. Signing yourself: the full editor,
+// the seal choice and the sign-every-page toggle. Inviting someone else: ONE
+// box, the position asked of the other party, and nothing else. On a 390px
+// phone the two hidden toolbars are 160px and 247px of chrome above the PDF, so
+// in invite mode the page itself has to be what is on screen. Hence one button.
+function applyPlaceChromeForMode() {
+  const invite = state.signingMode === 'invite';
+  const heading = document.querySelector('#step-place h2');
+  const subline = document.querySelector('#step-place .ds-sub');
+  const hint = $('ds-place-hint');
+  const tools = $('ds-invite-tools');
+  if (tools) tools.hidden = !invite;
+  if (heading) heading.textContent = invite ? 'Show where they sign' : 'Place your signature';
+  if (subline && subline.firstChild) {
+    subline.firstChild.textContent = invite
+      ? 'Tap where the other party signs. They can still move the box. '
+      : 'Click anywhere on a page to drop the stamp. Click another spot to move it. ';
+  }
+  if (hint) {
+    hint.textContent = invite
+      ? 'Optional: you can continue without asking for a spot.'
+      : 'Click a page to drop the signature stamp.';
+  }
+  if (invite) {
+    // Asking for a position is a courtesy, not a requirement: the requester may
+    // always continue without one, so this step is never a dead end.
+    const cont = $('ds-place-continue'); if (cont) cont.disabled = false;
+    const btn = $('ds-invite-place');
+    if (btn) {
+      btn.textContent = state.stamp ? 'Move the signature box' : 'Place the signature box';
+      btn.onclick = () => {
+        const first = document.querySelector('#ds-pdf-canvas-list .ds-page-wrap');
+        if (first) first.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        if (hint) hint.textContent = 'Tap the spot on the page where their signature belongs.';
+      };
+    }
+  }
+}
+
 async function renderImageForPlacement() {
   $('ds-place-continue').disabled = true;
   teardownPageNav();                                  // single image: no page-nav
   { const et = $('ds-edit-tools'); if (et) et.hidden = true; }   // text/date tools are PDF-only
   { const st = $('ds-seal-tools'); if (st) st.hidden = true; }   // sign-every-page is PDF-only
   { const eh = $('ds-edit-tools-hint'); if (eh) eh.hidden = false; }  // tell the user WHY the editor is absent
+  applyPlaceChromeForMode();
   const mime = state.imageType === 'jpg' ? 'image/jpeg' : 'image/png';
   const img = await loadImageElement(state.doc.bytes, mime);
 
@@ -533,14 +586,17 @@ async function renderPdfForPlacement() {
   $('ds-place-continue').disabled = hasInlineSeal() && !state.stamp;
   teardownPageNav();
   { const zb = $('ds-zoom'); if (zb) zb.hidden = false; }
-  { const et = $('ds-edit-tools'); if (et) et.hidden = false; }   // text/date tools: PDF only
+  const inviteMode = state.signingMode === 'invite';
+  { const et = $('ds-edit-tools'); if (et) et.hidden = inviteMode; }   // text/date tools: PDF only, and not for a requester
   { const eh = $('ds-edit-tools-hint'); if (eh) eh.hidden = true; }
-  // Seal tools (sign-every-page toggle + reuse-saved-position) are PDF-only.
-  { const st = $('ds-seal-tools'); if (st) st.hidden = false; }
+  // Seal tools (sign-every-page toggle + reuse-saved-position) are PDF-only,
+  // and in invite mode there is no seal of the requester's to configure.
+  { const st = $('ds-seal-tools'); if (st) st.hidden = inviteMode; }
   { const cb = $('ds-allpages'); if (cb) cb.checked = !!state.stampAllPages; }
   { const radio = $('ds-seal-' + state.sealPlacement); if (radio) radio.checked = true; }
   refreshApplyTplBtn();
   updateSignatureSheetControls();
+  applyPlaceChromeForMode();
   const pdfjs = await waitForPdfjs();
   const copy = new Uint8Array(state.doc.bytes);
   const pdf = await pdfjs.getDocument({ data: copy, disableAutoFetch: true, disableStream: true }).promise;
@@ -751,6 +807,9 @@ function refreshVisibleSealPreviews() {
 }
 
 function updateSignatureSheetControls() {
+  // A requester is not signing, so there is no seal choice, no signature sheet
+  // and no sign-every-page here. The invite Place chrome is owned in one place.
+  if (state.signingMode === 'invite') { applyPlaceChromeForMode(); return; }
   const sheetOnly = state.sealPlacement === 'sheet';
   const withSheet = hasSignatureSheet();
   const allPages = $('ds-allpages'); if (allPages) allPages.disabled = sheetOnly;
@@ -1474,10 +1533,22 @@ function onPlaceClick(e) {
     const pdfYBottom = wrap._pdfPage.height - natYTop - stampNatH;
     state.stamp = { pageIndex: wrap._pdfPage.index, x: natX, y: pdfYBottom, w: stampNatW, h: stampNatH };
   }
+  // The page the stamp was placed on, in its own units. requestedAppearance()
+  // needs it to turn PDF points into page fractions long after the canvases are
+  // gone, and it costs one object to keep the conversion pure.
+  state.stampPage = { width: wrap._pdfPage.width, height: wrap._pdfPage.height };
 
   document.querySelectorAll('.ds-stamp-marker').forEach(el => el.remove());
   renderStampMarker(wrap, left, top, stampPxW, stampPxH);
   $('ds-place-continue').disabled = false;
+  if (state.signingMode === 'invite') {
+    // Nothing of the requester's is stamped into this document: this box is a
+    // request the other party may move, so no ghosts and no saved template.
+    $('ds-place-hint').textContent =
+      'You are asking for a signature on page ' + (wrap._pdfPage.index + 1) + '. Tap another spot to move the box.';
+    const btn = $('ds-invite-place'); if (btn) btn.textContent = 'Move the signature box';
+    return;
+  }
   reflowGhostStamps();          // update the repeated-seal ghosts to the new spot
   savePlacementTemplate();      // remember this position/scale for next time
   $('ds-place-hint').textContent = isImage
@@ -2325,6 +2396,18 @@ function stampInnerHtml() {
 // thing; this mockup is a faithful HTML/CSS approximation so the signer
 // sees the same layout before clicking Sign.
 function stampMockupHtml() {
+  // The requester does not sign, so their Place step must never show a name or
+  // a signature that does not exist. It shows the box being asked for.
+  if (state.signingMode === 'invite') {
+    return (
+      '<div class="ds-sm-band">' +
+        '<span class="ds-sm-logo">Para<span>MANT</span></span>' +
+        '<span class="ds-sm-badge">SIGNATURE REQUESTED</span>' +
+      '</div>' +
+      '<div class="ds-sm-mid"><div class="ds-sm-sig-typed">Their signature</div></div>' +
+      '<div class="ds-sm-foot"><span class="ds-sm-name">Requested position</span></div>'
+    );
+  }
   const name = (state.signer.name || 'Signer').slice(0, 40);
   const dateStr = new Date().toISOString().slice(0, 16).replace('T', ' ');
   const fp = state.signer.fingerprint ? state.signer.fingerprint.slice(0, 8) : 'pending';
@@ -3164,7 +3247,7 @@ function wireNav() {
   $('ds-place-back').addEventListener('click', () => setActive('step-doc'));
   $('ds-hash-only-back').addEventListener('click', () => setActive('step-doc'));
   $('ds-recipients-back').addEventListener('click', () => {
-    if (state.signingMode === 'invite') setActive('step-doc');
+    if (state.signingMode === 'invite') setActive(state.mode === 'pdf' ? 'step-place' : 'step-doc');
     else setActive(state.mode === 'pdf' ? 'step-place' : 'step-hash-only');
   });
   $('ds-recipients-continue').addEventListener('click', () => {

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -3408,12 +3408,34 @@ async function showSessionRequirement() {
   if (!el) return;
   const q = new URLSearchParams(location.search);
   if (q.get('envelope') || q.get('e') || q.get('invite') || q.get('token') || location.hash.length > 1) return;
-  let unauthenticated = false;
+  let status = 0;
   try {
     const r = await fetch('/api/user/check', { credentials: 'same-origin', cache: 'no-store' });
-    unauthenticated = (r.status === 401 || r.status === 403);
-  } catch { return; }
-  if (!unauthenticated) return;
+    status = r.status;
+  } catch {
+    // A thrown fetch is the browser being offline, and the browser says so
+    // better than we can. Silence, as before: guessing "not signed in" from a
+    // dead connection would show the account notice to the paying customer
+    // whose wifi dropped.
+    return;
+  }
+  // The probe answered, but it answered that IT is broken. authUser returns 503
+  // session_store_unavailable when redis is unreachable, and a proxy in front
+  // can return any 5xx of its own. None of those mean "no account": a koper
+  // review found a signed-in user reading "Signing a document needs an account"
+  // because the answer was a failure rather than a refusal. Say what actually
+  // happened, in the shared sentence, and leave the account notice hidden.
+  if (status >= 500) {
+    const note = $('ds-service-note');
+    const errors = (typeof self !== 'undefined') && self.paramantErrors;
+    if (note && errors) { note.textContent = errors.SUPPORT_FAILURE_MESSAGE; note.hidden = false; }
+    try { console.error('[paramant] session probe', status); } catch { /* no console is never why a flow dies */ }
+    return;
+  }
+  // 401/403 is the one answer that means what the notice says: this browser has
+  // no session. Anything else (200, and any 4xx that is not a refusal) leaves
+  // both the notice and the service line hidden.
+  if (status !== 401 && status !== 403) return;
   el.hidden = false;
   // The mode picker stays visible underneath: a visitor should still see what
   // the three workflows are before deciding whether the account is worth it.

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -131,6 +131,10 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 .ds-place-actions>*{pointer-events:auto}
 /* Edit toolbar + free text/date annotations (additive layer, baked as PDF vector text) */
 .ds-edit-tools{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:10px}
+/* Invite mode: the requester places one box and nothing else, so the Place step
+   gets a single-row toolbar instead of the 160px editor and the 247px seal
+   panel. That is what keeps the PDF above the fold on a 390px phone. */
+.ds-invite-tools{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:10px}
 .ds-edit-label{font-size:12px;color:var(--ink-dim);font-weight:600}
 .ds-edit-btn{font:inherit;font-size:12.5px;min-height:34px;padding:6px 13px;border:1px solid var(--line-2);background:var(--surface);color:var(--ink-1);border-radius:var(--r-1);cursor:pointer;line-height:1.4;font-weight:500}
 .ds-edit-btn:hover{border-color:var(--ink-3);background:var(--line-ghost)}
@@ -582,6 +586,9 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
       <button id="ds-zoom-in" type="button" aria-label="Zoom in">+</button>
       <button id="ds-zoom-fit" type="button">Fit</button>
     </div>
+    <div class="ds-invite-tools" id="ds-invite-tools" hidden>
+      <button class="ds-edit-btn" id="ds-invite-place" type="button">Place the signature box</button>
+    </div>
     <p class="ds-edit-hint" id="ds-edit-tools-hint" hidden>This file is an image, so you can place your signature stamp only. The full editor (+ Text, + Date, highlights, notes and page management) works on PDF files: pick a PDF to use it.</p>
     <div class="ds-edit-tools" id="ds-edit-tools" hidden>
       <span class="ds-edit-label">Add to the document:</span>
@@ -896,6 +903,6 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script src="/js/parasign-pdf-ops.js?v=1"></script>
 <script src="/js/quota-upgrade.js?v=4" defer></script>
-<script type="module" src="/sign-flow.js?v=50"></script>
+<script type="module" src="/sign-flow.js?v=51"></script>
 </body>
 </html>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -44,6 +44,7 @@
 .ds-headlink{margin:14px 0 0;font-size:13px}
 .ds-headlink a{color:var(--accent);text-decoration:underline;text-underline-offset:3px}
 .ds-anon-actions{display:flex;flex-wrap:wrap;gap:10px;margin:20px 0 0}
+.ds-service-note{margin:0 0 16px;padding:10px 14px;border:1px solid var(--line-2);border-left:2px solid var(--mark);border-radius:var(--r-1);background:var(--surface-sunk);font-size:13px;line-height:1.6;color:var(--ink-2)}
 /* The hero is the pitch for a visitor who has not started yet. From the step
    after the document is chosen it is only in the way: at 390px it held the
    whole uploaded PDF below the fold. sign-flow.js stamps the active step on
@@ -488,6 +489,13 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
     </ul>
     <p class="ds-headlink"><a href="/parasign">What ParaSign is, and what organisations pay &rarr;</a></p>
   </header>
+
+  <!-- The session probe could not answer. NOT the same event as "you are not
+       signed in", and it must never be told as one: a signed-in customer whose
+       probe hit a 500 used to be shown the account notice, which reads as
+       "your account is gone". One sentence, the shared one from
+       js/error-message.js, so ParaSign and ParaShare apologise identically. -->
+  <p class="ds-service-note" id="ds-service-note" role="status" hidden></p>
 
   <ol class="ds-stepper" id="ds-stepper" aria-label="Sign progress" hidden>
     <li data-step="doc" class="active">Document</li>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -494,7 +494,7 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
        signed in", and it must never be told as one: a signed-in customer whose
        probe hit a 500 used to be shown the account notice, which reads as
        "your account is gone". One sentence, the shared one from
-       js/error-message.js, so ParaSign and ParaShare apologise identically. -->
+       js/error-message.js, so both products apologise in the same words. -->
   <p class="ds-service-note" id="ds-service-note" role="status" hidden></p>
 
   <ol class="ds-stepper" id="ds-stepper" aria-label="Sign progress" hidden>

--- a/relay/envelope.js
+++ b/relay/envelope.js
@@ -153,6 +153,30 @@ function normaliseAppearance(value) {
   return { version: 1, fields };
 }
 
+// The REQUESTED position is a narrower thing than a signed appearance, and it
+// is held to a stricter contract.
+//
+// A signed appearance may legitimately be absent: a signer who wants no visible
+// mark submits nothing and normaliseAppearance() returns an empty manifest.
+// That leniency is wrong here. A requested position only exists because the
+// requester deliberately placed a box, so a caller sending a bare string, a
+// number or an array is a bug in that caller, and it gets a 400 instead of a
+// silently empty manifest that quietly drops the request on the floor.
+//
+// It is also seal-only. /sign issues exactly one field type in invite mode, and
+// storing a requested 'date' would be a promise no screen in the product makes.
+// The shared validator keeps accepting 'date' for the SIGNED appearance, where
+// the signer really can place one.
+function normaliseRequestedAppearance(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('invalid requested appearance');
+  if (!Array.isArray(value.fields) || value.fields.length === 0) throw new Error('invalid requested appearance');
+  const clean = normaliseAppearance(value);
+  for (const field of clean.fields) {
+    if (field.type !== 'seal') throw new Error('invalid requested appearance type');
+  }
+  return clean;
+}
+
 function canonicalAppearance(value) {
   return JSON.stringify(normaliseAppearance(value));
 }
@@ -319,7 +343,7 @@ class EnvelopeStore {
     // here, before an id is allocated, so a bad manifest leaves no record.
     let requestedJson = '';
     if (requestedAppearance !== undefined && requestedAppearance !== null) {
-      requestedJson = canonicalAppearance(requestedAppearance);   // throws -> 400 at the route
+      requestedJson = JSON.stringify(normaliseRequestedAppearance(requestedAppearance));   // throws -> 400 at the route
     }
     const now = new Date();
     const expires = new Date(now.getTime() + ttlDays * 86400_000);
@@ -891,4 +915,4 @@ class EnvelopeStore {
   }
 }
 
-module.exports = { EnvelopeStore, signMessageBytes, normaliseAppearance, canonicalAppearance, appearanceHash, partyEmailHash, safeHexEqual, newEnvelopeId, SIGN_DOMAIN_DOC, MAX_PARTIES, DEFAULT_TTL_DAYS, MAX_TTL_DAYS, SIGN_INVITE_TTL_DAYS };
+module.exports = { EnvelopeStore, signMessageBytes, normaliseAppearance, normaliseRequestedAppearance, canonicalAppearance, appearanceHash, partyEmailHash, safeHexEqual, newEnvelopeId, SIGN_DOMAIN_DOC, MAX_PARTIES, DEFAULT_TTL_DAYS, MAX_TTL_DAYS, SIGN_INVITE_TTL_DAYS };

--- a/relay/envelope.js
+++ b/relay/envelope.js
@@ -305,13 +305,22 @@ class EnvelopeStore {
   // can then still label an expired envelope instead of silently dropping it.
   _acctIndexKey(accountId) { return 'parasign:acct:' + accountId + ':envelopes'; }
 
-  async create({ creatorPkHash, creatorApiKeyHash, accountId, docHash, parties, originalFilename, expiresInDays, bindingMode, recipeVersion: recipeVersionArg }) {
+  async create({ creatorPkHash, creatorApiKeyHash, accountId, docHash, parties, originalFilename, expiresInDays, bindingMode, recipeVersion: recipeVersionArg, requestedAppearance }) {
     if (!this.available()) throw new Error('redis unavailable');
     if (!/^[0-9a-f]{64}$/.test(docHash)) throw new Error('doc_hash must be 64-char sha3-256 hex');
     if (!Array.isArray(parties) || parties.length === 0) throw new Error('parties required');
     if (parties.length > MAX_PARTIES) throw new Error('too many parties (max ' + MAX_PARTIES + ')');
     const ttlDays = Math.max(1, Math.min(MAX_TTL_DAYS,
       Number.isFinite(expiresInDays) ? expiresInDays : DEFAULT_TTL_DAYS));
+    // ONE requested signing position for the whole envelope, the same for every
+    // party: what the creator asked for. It is envelope data, never party data
+    // and never signed -- sign() hashes only the appearance the signer submits,
+    // so this field can change nothing about a signature's meaning. Validated
+    // here, before an id is allocated, so a bad manifest leaves no record.
+    let requestedJson = '';
+    if (requestedAppearance !== undefined && requestedAppearance !== null) {
+      requestedJson = canonicalAppearance(requestedAppearance);   // throws -> 400 at the route
+    }
     const now = new Date();
     const expires = new Date(now.getTime() + ttlDays * 86400_000);
 
@@ -354,6 +363,10 @@ class EnvelopeStore {
       created_at: now.toISOString(),
       expires_at: expires.toISOString(),
     };
+    if (requestedJson) {
+      hash.requested_appearance = requestedJson;
+      hash.requested_appearance_hash = crypto.createHash('sha3-256').update(requestedJson, 'utf8').digest('hex');
+    }
     // Per-party capability token: the secret embedded in the invite link.
     // Stored server-side, returned to the creator ONCE below so it can build
     // the invite emails, and NEVER exposed via getRedacted/getForParty output.
@@ -433,6 +446,11 @@ class EnvelopeStore {
       voided_at: h.voided_at || null,
       party_count: partyCount,
       signed_count: parseInt(h.signed_count, 10) || 0,
+      // The position the creator asked every party to sign at. Public on
+      // purpose: /co-sign seeds its placement editor from it. A party may move
+      // it, and their signature binds where they actually signed, not this.
+      requested_appearance: h.requested_appearance ? storedAppearance(h.requested_appearance) : null,
+      requested_appearance_hash: h.requested_appearance_hash || null,
       parties,
     };
   }
@@ -655,6 +673,9 @@ class EnvelopeStore {
       // When this email-bound invite stops being signable (created_at + 7d);
       // null for open envelopes. Lets the admin gate fail early before the PRF.
       sign_expires_at: mode === 'email' ? signInviteExpiresAt(h.created_at) : null,
+      // Same requested position as the public view: one box for every party.
+      requested_appearance: h.requested_appearance ? storedAppearance(h.requested_appearance) : null,
+      requested_appearance_hash: h.requested_appearance_hash || null,
       party: {
         index: pi,
         label: h['p' + pi + '_label'] || null,

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -6215,7 +6215,7 @@ async function handleRelayRequest(req, res) {
         ? crypto.createHash('sha3-256').update(Buffer.from(d.creator_public_key, 'base64')).digest('hex')
         : '';
       const creatorApiHash = crypto.createHash('sha3-256').update(apiKey).digest('hex');
-      const out = await store.create({ creatorPkHash, creatorApiKeyHash: creatorApiHash, accountId: acctOf(apiKey), docHash, parties, originalFilename: origFilename, expiresInDays: ttlDays, bindingMode: d.binding_mode, recipeVersion: d.recipe_version });
+      const out = await store.create({ creatorPkHash, creatorApiKeyHash: creatorApiHash, accountId: acctOf(apiKey), docHash, parties, originalFilename: origFilename, expiresInDays: ttlDays, bindingMode: d.binding_mode, recipeVersion: d.recipe_version, requestedAppearance: d.requested_appearance });
       log('info', 'envelope_created', { id: out.id, parties: out.party_count, binding_mode: out.binding_mode });
       res.writeHead(200, { 'Content-Type': 'application/json' });
       return res.end(J({ ok: true, envelope: out }));

--- a/relay/test/envelope-binding.test.js
+++ b/relay/test/envelope-binding.test.js
@@ -8,7 +8,7 @@
 const assert = require('assert');
 const crypto = require('crypto');
 const {
-  EnvelopeStore, signMessageBytes, normaliseAppearance, appearanceHash, partyEmailHash,
+  EnvelopeStore, signMessageBytes, normaliseAppearance, normaliseRequestedAppearance, appearanceHash, partyEmailHash,
 } = require('../envelope');
 
 let passed = 0;
@@ -408,6 +408,40 @@ async function main() {
     assert.ok(!seenMsg.equals(signMessageBytes(ID, DOC, 0, EMAIL_HASH, 5, PUB_A, appearanceHash(requested))),
       'the requested position is not the thing that was signed');
     ok('requested position reads back for both views and is never signed');
+  }
+
+  // 14. The requested position is validated more strictly than a signed one.
+  //     A security review found two soft edges: a bare string was normalized to
+  //     an empty manifest instead of refused, and a 'date' field was accepted
+  //     although /sign issues nothing but the seal. Both are now refusals.
+  {
+    for (const bad of ['{"fields":[]}', 42, true, [], [{ type: 'seal' }], null, undefined, '']) {
+      assert.throws(() => normaliseRequestedAppearance(bad), /invalid requested appearance/,
+        'non-object refused: ' + JSON.stringify(bad));
+    }
+    assert.throws(() => normaliseRequestedAppearance({ version: 1, fields: [] }), /invalid requested appearance/,
+      'an empty request is not a request');
+    assert.throws(() => normaliseRequestedAppearance({ version: 1, fields: [
+      { type: 'date', page_index: 0, x: .1, y: .1, w: .22, h: .055 },
+    ] }), /invalid requested appearance type/, 'a requested date is refused');
+    assert.throws(() => normaliseRequestedAppearance({ version: 1, fields: [
+      { type: 'seal', page_index: 0, x: .1, y: .1, w: .36, h: .105 },
+      { type: 'date', page_index: 0, x: .1, y: .3, w: .22, h: .055 },
+    ] }), /invalid requested appearance type/, 'one bad field fails the whole request');
+    // The signed appearance keeps its own, wider contract: a signer really can
+    // place a date, and really can choose to place nothing at all.
+    assert.deepStrictEqual(normaliseAppearance('not an object'), { version: 1, fields: [] },
+      'the signed-appearance validator is unchanged');
+    assert.strictEqual(normaliseAppearance({ version: 1, fields: [
+      { type: 'date', page_index: 0, x: .1, y: .1, w: .22, h: .055 },
+    ] }).fields[0].type, 'date', 'a signer may still place a date');
+    const good = normaliseRequestedAppearance({ version: 1, fields: [
+      { type: 'seal', page_index: 3, x: .4200004, y: .61, w: .36, h: .105 },
+    ] });
+    assert.deepStrictEqual(good, { version: 1, fields: [
+      { type: 'seal', page_index: 3, x: .42, y: .61, w: .36, h: .105 },
+    ] }, 'a real request still normalizes and passes');
+    ok('a requested position must be an object and may only ask for the seal');
   }
 }
 

--- a/relay/test/envelope-binding.test.js
+++ b/relay/test/envelope-binding.test.js
@@ -360,6 +360,55 @@ async function main() {
     assert.deepStrictEqual(await store.listAccountEnvelopes('acct_other', {}), [], 'stored account mismatch rejected');
     ok('dashboard worklist is account-scoped and capability-free');
   }
+
+  // 13. The requested signing position: ONE box for the whole envelope, chosen
+  //     by the requester in the invite flow on /sign. It is a request and never
+  //     a commitment, so it must (a) read back identically for the public view
+  //     and for the invited party, (b) be normalized like any other manifest,
+  //     and (c) stay entirely out of the signing message, which is what lets a
+  //     signer move it and still produce a signature that verifies.
+  {
+    const requested = normaliseAppearance({ version: 1, fields: [
+      { type: 'seal', page_index: 1, x: .5, y: .62, w: .4, h: .12 },
+    ] });
+    const requestedJson = JSON.stringify(requested);
+    const hash = {
+      ...emailHashOf(EMAIL_HASH),
+      recipe_version: '5',
+      p0_invite_token: 'invite-token-13',
+      requested_appearance: requestedJson,
+      requested_appearance_hash: appearanceHash(requested),
+    };
+    const store = new EnvelopeStore(fakeRedis(hash), {
+      sigVerify: () => true,
+    });
+    const publicView = await store.getRedacted(ID);
+    assert.deepStrictEqual(publicView.requested_appearance, requested, 'public view carries the requested position');
+    assert.strictEqual(publicView.requested_appearance_hash, appearanceHash(requested));
+    const partyView = await store.getForParty(ID, 0, 'invite-token-13');
+    assert.deepStrictEqual(partyView.requested_appearance, requested, 'the invited party sees the same one position');
+    assert.strictEqual(partyView.party.appearance, null, 'requested is not the party appearance');
+
+    // The signer moves the box. The message the relay verifies is built from
+    // the appearance THEY submitted; the requested one appears nowhere in it.
+    const moved = normaliseAppearance({ version: 1, fields: [
+      { type: 'seal', page_index: 0, x: .1, y: .1, w: .3, h: .09 },
+    ] });
+    let seenMsg = null;
+    const signing = new EnvelopeStore(fakeRedis({ ...hash }), {
+      sigVerify: (_sig, msg) => { seenMsg = msg; return true; },
+    });
+    const signed = await signing.sign(ID, 0, PUB_A, 'c2ln', {
+      internalTrusted: true, verifiedEmailHash: EMAIL_HASH, appearance: moved,
+    });
+    assert.strictEqual(signed.ok, true);
+    assert.deepStrictEqual(signed.appearance, moved, 'the signature records where the signer actually signed');
+    assert.ok(seenMsg.equals(signMessageBytes(ID, DOC, 0, EMAIL_HASH, 5, PUB_A, appearanceHash(moved))),
+      'signing message binds the used position, not the requested one');
+    assert.ok(!seenMsg.equals(signMessageBytes(ID, DOC, 0, EMAIL_HASH, 5, PUB_A, appearanceHash(requested))),
+      'the requested position is not the thing that was signed');
+    ok('requested position reads back for both views and is never signed');
+  }
 }
 
 main()

--- a/relay/test/parasign-envelope-index.test.js
+++ b/relay/test/parasign-envelope-index.test.js
@@ -2,6 +2,8 @@
 // ParaSign per-account envelope index + full per-envelope .psign audit-export.
 // Exercises against a REAL EnvelopeStore + REAL redis + REAL ML-DSA-65 engine:
 //   1. create() adds the envelope id to the account index (listAccountEnvelopeIds)
+//   1b. create() stores the requester's ONE requested signing position and hands
+//      it back on the public view, and refuses a manifest that is out of bounds
 //   2. the Business+ audit-export returns the completed envelope's full .psign,
 //      and a Pro key is still refused 403 even with the envelope deps present
 //   3. backfillAccountIndex() rebuilds the index from an un-indexed env:* key
@@ -54,6 +56,7 @@ async function main() {
   const rnd = crypto.randomBytes(6).toString('hex');
   const ACCT = 'acct_test_' + rnd;
   const ACCT2 = 'acct_legacy_' + rnd;
+  const ACCT_REQ = 'acct_requested_' + rnd;   // its own account, so the export below still sees exactly one
   const docHash = crypto.createHash('sha3-256').update(Buffer.from('doc-' + rnd)).digest('hex');
 
   try {
@@ -79,6 +82,34 @@ async function main() {
     await rc.zAdd(store._acctIndexKey(OTHER), { score: Date.now(), value: out.id });
     assert.deepStrictEqual(await store.listAccountEnvelopes(OTHER, {}), [], 'stored account mismatch is rejected');
     ok('dashboard summary rejects a cross-account index entry');
+
+    // 1b) the requested signing position ---------------------------------------
+    // What the invite flow on /sign sends: one seal box, the same for every
+    // party, normalized on the way in and durable across a read.
+    const requestedEnv = await store.create({
+      creatorApiKeyHash: crypto.createHash('sha3-256').update('psk_req_' + rnd).digest('hex'),
+      accountId: ACCT_REQ, docHash, parties: [{ label: 'R', email: 'r@example.com' }],
+      bindingMode: 'email', recipeVersion: 5,
+      requestedAppearance: { version: 1, fields: [{ type: 'seal', page_index: 2, x: 0.4200004, y: 0.61, w: 0.4, h: 0.12 }] },
+    });
+    const requestedView = await store.getRedacted(requestedEnv.id);
+    assert.deepStrictEqual(requestedView.requested_appearance, { version: 1, fields: [
+      { type: 'seal', page_index: 2, x: 0.42, y: 0.61, w: 0.4, h: 0.12 },
+    ] }, 'stored position is the normalized manifest');
+    assert.match(requestedView.requested_appearance_hash, /^[0-9a-f]{64}$/, 'stored position carries its hash');
+    const partyOfRequested = await store.getForParty(requestedEnv.id, 0, requestedEnv.party_links[0].invite_token);
+    assert.deepStrictEqual(partyOfRequested.requested_appearance, requestedView.requested_appearance, 'the invited party sees the same position');
+    assert.strictEqual(requestedView.parties[0].appearance, null, 'nobody has signed, so no party appearance exists');
+
+    // Out of bounds is refused BEFORE an id is allocated: no half-made envelope.
+    const envKeysBefore = (await rc.keys('env:*')).length;
+    await assert.rejects(() => store.create({
+      creatorApiKeyHash: 'x'.repeat(64), accountId: ACCT_REQ, docHash,
+      parties: [{ label: 'R', email: 'r@example.com' }], bindingMode: 'email', recipeVersion: 5,
+      requestedAppearance: { version: 1, fields: [{ type: 'seal', page_index: 0, x: 0.9, y: 0.5, w: 0.4, h: 0.12 }] },
+    }), /outside page/, 'a box that runs off the page is refused');
+    assert.strictEqual((await rc.keys('env:*')).length, envKeysBefore, 'the refused create left no envelope behind');
+    ok('create() stores one normalized requested position and refuses a bad one');
 
     // 2) complete it, then the Business+ export returns its full .psign ---------
     const r = await completeOpenEnvelope(store, eng, out, docHash);
@@ -148,9 +179,11 @@ async function main() {
     // cleanup our test keys (leave other tests' keys untouched)
     try {
       await rc.del('env:' + out.id);
+      await rc.del('env:' + requestedEnv.id);
       await rc.del('env:' + legacy.id);
       await rc.del(store._acctIndexKey(ACCT));
       await rc.del(store._acctIndexKey(ACCT2));
+      await rc.del(store._acctIndexKey(ACCT_REQ));
       await rc.del(store._acctIndexKey('acct_other_' + rnd));
     } catch { /* best effort */ }
   } finally {
@@ -158,7 +191,7 @@ async function main() {
   }
 
   summary('parasign-envelope-index', passed);
-  if (passed < 7) process.exit(1);
+  if (passed < 8) process.exit(1);
 }
 
 main().catch((e) => { console.error(e); process.exit(1); });

--- a/relay/test/parasign-envelope-index.test.js
+++ b/relay/test/parasign-envelope-index.test.js
@@ -109,6 +109,19 @@ async function main() {
       requestedAppearance: { version: 1, fields: [{ type: 'seal', page_index: 0, x: 0.9, y: 0.5, w: 0.4, h: 0.12 }] },
     }), /outside page/, 'a box that runs off the page is refused');
     assert.strictEqual((await rc.keys('env:*')).length, envKeysBefore, 'the refused create left no envelope behind');
+
+    // A security review found create() accepting a bare string and storing an
+    // empty manifest for it. Through the real store, over real redis: it is a
+    // refusal now, and so is a requested field type the product never issues.
+    for (const bad of ['{"fields":[]}', 7, [{ type: 'seal' }], { version: 1, fields: [] },
+      { version: 1, fields: [{ type: 'date', page_index: 0, x: 0.1, y: 0.1, w: 0.22, h: 0.055 }] }]) {
+      await assert.rejects(() => store.create({
+        creatorApiKeyHash: 'y'.repeat(64), accountId: ACCT_REQ, docHash,
+        parties: [{ label: 'R', email: 'r@example.com' }], bindingMode: 'email', recipeVersion: 5,
+        requestedAppearance: bad,
+      }), /invalid requested appearance/, 'refused: ' + JSON.stringify(bad));
+    }
+    assert.strictEqual((await rc.keys('env:*')).length, envKeysBefore, 'none of the refusals left an envelope behind');
     ok('create() stores one normalized requested position and refuses a bad one');
 
     // 2) complete it, then the Business+ export returns its full .psign ---------

--- a/tests/access-log-visitors.test.mjs
+++ b/tests/access-log-visitors.test.mjs
@@ -37,7 +37,7 @@ test('a client that renders is not excluded for lacking a referer', () => {
   const r = analyse([
     line({ ip: '8.8.8.8', path: '/sign' }),
     line({ ip: '8.8.8.8', path: '/design-system.css?v=25' }),
-    line({ ip: '8.8.8.8', path: '/sign-flow.js?v=50' }),
+    line({ ip: '8.8.8.8', path: '/sign-flow.js?v=51' }),
   ]);
   assert.equal(r.atMostVisitors, 1);
   assert.equal(r.verdicts.possible_visitor, 1);

--- a/tests/cosign-appearance-contract.test.mjs
+++ b/tests/cosign-appearance-contract.test.mjs
@@ -37,7 +37,7 @@ const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePa
 const page = await browser.newPage();
 await page.goto(`http://127.0.0.1:${server.address().port}/`, { waitUntil:'domcontentloaded' });
 const actual = await page.evaluate(async (input) => {
-  const signer = await import('/js/parasign-signer.js?v=14');
+  const signer = await import('/js/parasign-signer.js?v=15');
   const normalized = signer.normaliseSigningAppearance(input.appearance);
   const message = signer.buildDocSignMessage({
     envelopeId: input.envelopeId,

--- a/tests/cosign-document-delivery.test.mjs
+++ b/tests/cosign-document-delivery.test.mjs
@@ -173,6 +173,59 @@ ok('sign-in return preserves the document-key fragment', decodeURIComponent(retu
 ok('ciphertext is not requested before recipient sign-in', anonymousDocumentReads === 0, anonymousDocumentReads);
 await anonPage.close();
 
+// ── the position the requester asked for ──────────────────────────────────────
+// /sign lets the requester point at one spot. That position rides on the
+// envelope, seeds this editor, and is never binding: the signer may move it,
+// and their signature commits to where they actually signed (the recipe-5
+// message, guarded by tests/cosign-appearance-contract.test.mjs).
+const requestedPosition = { version: 1, fields: [{ type: 'seal', page_index: 0, x: 0.42, y: 0.61, w: 0.36, h: 0.105 }] };
+const seedPage = await browser.newPage({ viewport: { width: 390, height: 844 } });   // its own context, so its own sessionStorage
+await seedPage.route(`**/api/user/envelopes/${ENV_ID}/document*`, (route) =>
+  route.fulfill({ status: 200, contentType: 'application/octet-stream', body: Buffer.from(fixture.capsule) }));
+await seedPage.route('**/api/user/account', (route) => route.fulfill({
+  status: 200, contentType: 'application/json', headers: { 'Cache-Control': 'no-store' }, body: '{"email":"demo@example.com"}',
+}));
+await seedPage.route('https://health.paramant.app/v2/envelopes/**', (route) => {
+  const url = new URL(route.request().url());
+  if (url.pathname.endsWith('/view')) return route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+  return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({
+    envelope: {
+      id: ENV_ID, doc_hash: fixture.docHash, original_filename: 'agreement-demo.pdf', recipe_version: 5,
+      created_at: '2026-07-21T12:00:00.000Z', expires_at: '2026-08-20T12:00:00.000Z',
+      status: 'sent', signed_count: 0, party_count: 1,
+      parties: [{ index: 0, label: 'Signer Demo', status: 'pending' }],
+      requested_appearance: requestedPosition,
+    },
+  }) });
+});
+
+await seedPage.goto(base + fixture.fragment, { waitUntil: 'domcontentloaded' });
+await waitForDeliveryResult(seedPage);
+await seedPage.waitForFunction(() => document.querySelectorAll('.appearance-field:not(.prior)').length === 1);
+const seeded = await seedPage.evaluate(() => ({
+  fields: Array.from(document.querySelectorAll('.appearance-field:not(.prior)')).map((n) => ({ left: n.style.left, top: n.style.top, width: n.style.width })),
+  help: document.querySelector('#appearance-help')?.textContent || '',
+  draft: Array.from({ length: sessionStorage.length }, (_, i) => sessionStorage.getItem(sessionStorage.key(i))).find((v) => v && v.includes('"fields"')) || '',
+}));
+ok('the requested position seeds the recipient editor', seeded.fields.length === 1 && seeded.fields[0].left === '42%' && seeded.fields[0].top === '61%' && seeded.fields[0].width === '36%', JSON.stringify(seeded.fields));
+ok('the recipient is told it is a request they may move', /sender asked/i.test(seeded.help) && /move it/i.test(seeded.help) && /where you actually sign/i.test(seeded.help), seeded.help);
+ok('a requested position is not silently adopted as the signer draft', seeded.draft === '', seeded.draft);
+
+await seedPage.locator('#appearance-seal').click();
+await seedPage.locator('.doc-page[data-page-index="0"] .appearance-layer').click({ position: { x: 120, y: 60 } });
+const moved = await seedPage.evaluate(() => ({
+  fields: Array.from(document.querySelectorAll('.appearance-field:not(.prior)')).map((n) => ({ left: n.style.left, top: n.style.top })),
+  draft: Array.from({ length: sessionStorage.length }, (_, i) => sessionStorage.getItem(sessionStorage.key(i))).find((v) => v && v.includes('"fields"')) || '',
+}));
+ok('the recipient can move the requested box', moved.fields.length === 1 && moved.fields[0].top !== '61%' && /"type":"seal"/.test(moved.draft), JSON.stringify(moved));
+
+await seedPage.reload({ waitUntil: 'domcontentloaded' });
+await waitForDeliveryResult(seedPage);
+await seedPage.waitForFunction(() => document.querySelectorAll('.appearance-field:not(.prior)').length === 1);
+const afterReload = await seedPage.evaluate(() => Array.from(document.querySelectorAll('.appearance-field:not(.prior)')).map((n) => ({ left: n.style.left, top: n.style.top })));
+ok('the signer own draft wins over the requested position on reload', afterReload.length === 1 && afterReload[0].top === moved.fields[0].top && afterReload[0].top !== '61%', JSON.stringify({ afterReload, moved: moved.fields }));
+await seedPage.close();
+
 for (const c of checks) console.log(`${c.pass ? 'PASS' : 'FAIL'} ${c.name}${c.detail ? ' :: ' + c.detail : ''}`);
 await browser.close();
 server.close();

--- a/tests/cosign-document-delivery.test.mjs
+++ b/tests/cosign-document-delivery.test.mjs
@@ -178,7 +178,7 @@ await anonPage.close();
 // envelope, seeds this editor, and is never binding: the signer may move it,
 // and their signature commits to where they actually signed (the recipe-5
 // message, guarded by tests/cosign-appearance-contract.test.mjs).
-const requestedPosition = { version: 1, fields: [{ type: 'seal', page_index: 0, x: 0.42, y: 0.61, w: 0.36, h: 0.105 }] };
+const requestedPosition = { version: 1, fields: [{ type: 'seal', page_index: 0, x: 0.42, y: 0.72, w: 0.36, h: 0.105 }] };
 const seedPage = await browser.newPage({ viewport: { width: 390, height: 844 } });   // its own context, so its own sessionStorage
 await seedPage.route(`**/api/user/envelopes/${ENV_ID}/document*`, (route) =>
   route.fulfill({ status: 200, contentType: 'application/octet-stream', body: Buffer.from(fixture.capsule) }));
@@ -202,12 +202,76 @@ await seedPage.route('https://health.paramant.app/v2/envelopes/**', (route) => {
 await seedPage.goto(base + fixture.fragment, { waitUntil: 'domcontentloaded' });
 await waitForDeliveryResult(seedPage);
 await seedPage.waitForFunction(() => document.querySelectorAll('.appearance-field:not(.prior)').length === 1);
+// The page marks the element once the load-time scroll has run, so the check
+// below observes that it happened instead of waiting a hopeful number of ms.
+await seedPage.locator('#requested-note[data-scrolled="1"]').waitFor({ timeout: 15000 });
 const seeded = await seedPage.evaluate(() => ({
   fields: Array.from(document.querySelectorAll('.appearance-field:not(.prior)')).map((n) => ({ left: n.style.left, top: n.style.top, width: n.style.width })),
   help: document.querySelector('#appearance-help')?.textContent || '',
   draft: Array.from({ length: sessionStorage.length }, (_, i) => sessionStorage.getItem(sessionStorage.key(i))).find((v) => v && v.includes('"fields"')) || '',
 }));
-ok('the requested position seeds the recipient editor', seeded.fields.length === 1 && seeded.fields[0].left === '42%' && seeded.fields[0].top === '61%' && seeded.fields[0].width === '36%', JSON.stringify(seeded.fields));
+ok('the requested position seeds the recipient editor', seeded.fields.length === 1 && seeded.fields[0].left === '42%' && seeded.fields[0].top === '72%' && seeded.fields[0].width === '36%', JSON.stringify(seeded.fields));
+
+// A requested box is not a signature. The sender saw "SIGNATURE REQUESTED /
+// Their signature"; the recipient used to see "Paramant signed - <name> x",
+// which reads as a signature that already exists and that they could delete.
+const seededLook = await seedPage.evaluate(() => {
+  const node = document.querySelector('.appearance-field');
+  const cs = node && getComputedStyle(node);
+  return {
+    className: node && node.className,
+    text: node && node.textContent,
+    borderStyle: cs && cs.borderTopStyle,
+    hasRemove: !!(node && node.querySelector('.appearance-remove')),
+    inView: node ? (() => { const b = node.getBoundingClientRect(); return b.top >= 0 && b.bottom <= window.innerHeight; })() : null,
+    noteVisible: !document.getElementById('requested-note').hidden,
+    noteText: document.getElementById('requested-note-text')?.textContent,
+    goLabel: document.getElementById('requested-note-go')?.textContent,
+  };
+});
+ok('the seeded box wears the requested style, not the signed style',
+  /\brequested\b/.test(seededLook.className) && seededLook.borderStyle === 'dashed'
+  && /Requested spot/i.test(seededLook.text) && !/Signer Demo/.test(seededLook.text) && !seededLook.hasRemove,
+  JSON.stringify(seededLook));
+ok('the marked spot is brought into view when the document opens', seededLook.inView === true, JSON.stringify(seededLook));
+ok('a line above the document points at the spot',
+  seededLook.noteVisible && /sender marked where you sign/i.test(seededLook.noteText) && /Go to the spot/i.test(seededLook.goLabel),
+  JSON.stringify(seededLook));
+
+// Scroll away, then use the button: it has to bring the spot back.
+await seedPage.evaluate(() => { window.scrollTo(0, 0); document.getElementById('doc-preview').scrollTop = 0; });
+await seedPage.locator('#requested-note-go').click();
+await seedPage.waitForTimeout(700);
+const afterGo = await seedPage.evaluate(() => {
+  const b = document.querySelector('.appearance-field').getBoundingClientRect();
+  return { inView: b.top >= 0 && b.bottom <= window.innerHeight, top: Math.round(b.top) };
+});
+ok('Go to the spot returns to the marked box', afterGo.inView === true, JSON.stringify(afterGo));
+
+// The document gets the width. The sender placed this box on a 343px render at
+// 390; the recipient used to review it at 229px with margins on both sides.
+// The wrapper, the canvas and the click layer must also be ONE box, or a click
+// fraction is a fraction of something the reader never saw.
+const previewWidth = await seedPage.evaluate(() => {
+  const wrap = document.querySelector('.doc-page[data-page-index="0"]');
+  const canvas = wrap.querySelector('canvas');
+  const layer = wrap.querySelector('.appearance-layer');
+  return {
+    viewport: window.innerWidth,
+    wrap: Math.round(wrap.getBoundingClientRect().width),
+    canvas: Math.round(canvas.getBoundingClientRect().width),
+    layer: Math.round(layer.getBoundingClientRect().width),
+  };
+});
+ok('the document is rendered fit-to-width like the sender saw it',
+  previewWidth.canvas >= previewWidth.viewport * 0.82 && previewWidth.canvas === previewWidth.wrap && previewWidth.layer === previewWidth.wrap,
+  JSON.stringify(previewWidth));
+
+const touchTargets = await seedPage.evaluate(() => Array.from(
+  document.querySelectorAll('#appearance-editor .btn, #sign-confirm, #requested-note-go'),
+).map((b) => ({ id: b.id, h: Math.round(b.getBoundingClientRect().height) })));
+ok('every control on the signing screen is a 44px touch target',
+  touchTargets.length >= 5 && touchTargets.every((b) => b.h >= 44), JSON.stringify(touchTargets));
 ok('the recipient is told it is a request they may move', /sender asked/i.test(seeded.help) && /move it/i.test(seeded.help) && /where you actually sign/i.test(seeded.help), seeded.help);
 ok('a requested position is not silently adopted as the signer draft', seeded.draft === '', seeded.draft);
 
@@ -217,13 +281,58 @@ const moved = await seedPage.evaluate(() => ({
   fields: Array.from(document.querySelectorAll('.appearance-field:not(.prior)')).map((n) => ({ left: n.style.left, top: n.style.top })),
   draft: Array.from({ length: sessionStorage.length }, (_, i) => sessionStorage.getItem(sessionStorage.key(i))).find((v) => v && v.includes('"fields"')) || '',
 }));
-ok('the recipient can move the requested box', moved.fields.length === 1 && moved.fields[0].top !== '61%' && /"type":"seal"/.test(moved.draft), JSON.stringify(moved));
+ok('the recipient can move the requested box', moved.fields.length === 1 && moved.fields[0].top !== '72%' && /"type":"seal"/.test(moved.draft), JSON.stringify(moved));
+const afterMove = await seedPage.evaluate(() => {
+  const node = document.querySelector('.appearance-field');
+  return { className: node.className, text: node.textContent, hasRemove: !!node.querySelector('.appearance-remove'), noteHidden: document.getElementById('requested-note').hidden };
+});
+ok('once the signer places it, it is their signature and not a request',
+  !/requested/.test(afterMove.className) && /Paramant signed/.test(afterMove.text) && afterMove.hasRemove && afterMove.noteHidden === true,
+  JSON.stringify(afterMove));
 
+// Fit-to-width changed how wide the render is, so the click-to-fraction maths
+// gets its own measurement: place the box dead centre and read the fraction
+// back. Wrapper, canvas and click layer are one box, so the centre of the
+// canvas has to come back as the centre of the page.
+const centred = await seedPage.evaluate(() => {
+  const layer = document.querySelector('.doc-page[data-page-index="0"] .appearance-layer');
+  const r = layer.getBoundingClientRect();
+  return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+});
+await seedPage.locator('#appearance-seal').click();
+await seedPage.mouse.click(centred.x, centred.y);
+const roundTrip = await seedPage.evaluate(() => {
+  const raw = Array.from({ length: sessionStorage.length }, (_, i) => sessionStorage.getItem(sessionStorage.key(i))).find((v) => v && v.includes('"fields"'));
+  const field = JSON.parse(raw).fields[0];
+  return { cx: field.x + field.w / 2, cy: field.y + field.h / 2, field };
+});
+ok('a click in the middle of the page is the middle of the page',
+  Math.abs(roundTrip.cx - 0.5) < 0.01 && Math.abs(roundTrip.cy - 0.5) < 0.01, JSON.stringify(roundTrip));
+
+// The nav over a scrolling document must be opaque below 1024 (#399 fixed the
+// app-2026 pages; /co-sign loads the same nav.css and has to stay covered).
+const navPaint = await seedPage.evaluate(() => {
+  const cs = getComputedStyle(document.querySelector('.nav'));
+  return { bg: cs.backgroundColor, blur: cs.backdropFilter, position: cs.position };
+});
+ok('the co-sign nav is opaque on a phone', /^rgb\(\d+, \d+, \d+\)$/.test(navPaint.bg) && navPaint.blur === 'none', JSON.stringify(navPaint));
+
+// Whatever the signer last placed is what must survive the refresh, so read it
+// now rather than comparing against a position two placements ago.
+const beforeReload = await seedPage.evaluate(() => Array.from(document.querySelectorAll('.appearance-field:not(.prior)')).map((n) => ({ left: n.style.left, top: n.style.top })));
 await seedPage.reload({ waitUntil: 'domcontentloaded' });
 await waitForDeliveryResult(seedPage);
 await seedPage.waitForFunction(() => document.querySelectorAll('.appearance-field:not(.prior)').length === 1);
 const afterReload = await seedPage.evaluate(() => Array.from(document.querySelectorAll('.appearance-field:not(.prior)')).map((n) => ({ left: n.style.left, top: n.style.top })));
-ok('the signer own draft wins over the requested position on reload', afterReload.length === 1 && afterReload[0].top === moved.fields[0].top && afterReload[0].top !== '61%', JSON.stringify({ afterReload, moved: moved.fields }));
+ok('the signer own draft wins over the requested position on reload',
+  afterReload.length === 1 && afterReload[0].top === beforeReload[0].top && afterReload[0].left === beforeReload[0].left && afterReload[0].top !== '72%',
+  JSON.stringify({ afterReload, beforeReload }));
+const reloadedLook = await seedPage.evaluate(() => ({
+  className: document.querySelector('.appearance-field').className,
+  noteHidden: document.getElementById('requested-note').hidden,
+}));
+ok('a restored draft is never redressed as a request',
+  !/requested/.test(reloadedLook.className) && reloadedLook.noteHidden === true, JSON.stringify(reloadedLook));
 await seedPage.close();
 
 for (const c of checks) console.log(`${c.pass ? 'PASS' : 'FAIL'} ${c.name}${c.detail ? ' :: ' + c.detail : ''}`);

--- a/tests/parasign-multi-verify.test.mjs
+++ b/tests/parasign-multi-verify.test.mjs
@@ -26,7 +26,7 @@ await page.goto(origin + '/', { waitUntil:'domcontentloaded' });
 
 const fixture = await page.evaluate(async () => {
   const pqc = await import('/vendor/paramant-pqc.js');
-  const signer = await import('/js/parasign-signer.js?v=14');
+  const signer = await import('/js/parasign-signer.js?v=15');
   const enc = new TextEncoder();
   const hex = (bytes) => Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
   const b64 = (bytes) => { let value = ''; for (const byte of bytes) value += String.fromCharCode(byte); return btoa(value); };

--- a/tests/sign-document-identity.test.mjs
+++ b/tests/sign-document-identity.test.mjs
@@ -3,12 +3,16 @@
 //
 // Why this suite exists. The file name and size were added to the Place step,
 // which is the step the request-signatures flow never visits: onDocChosen()
-// sends that mode straight from the file picker to the co-signers. So a
+// sent that mode straight from the file picker to the co-signers. So a
 // customer who chose "Request signatures" picked a file, typed two email
 // addresses and pressed "Send for signature" without one screen in between
 // saying what he was sending. A koper review found it on the second pass, on a
 // phone, where the only other place the name could have been (the collapsed
 // step-1 panel) is off screen.
+//
+// A PDF invite now DOES visit Place, because that is where the requester points
+// at the spot the other party signs. The name has to hold on both of its
+// screens, so the invite case below walks the step instead of skipping it.
 //
 // It drives the real page in Chromium rather than reading the source, because
 // what is under test is whether the name is VISIBLE at that moment: the element
@@ -86,8 +90,15 @@ async function documentLine(page) {
   });
 }
 
-// ── invite: the mode that had no Place step at all ───────────────────────────
+// ── invite: place first (PDF), co-signers after ──────────────────────────────
 const invite = await uploadIn('invite', 'huur.pdf');
+const invitePlace = await documentLine(invite);
+ok('request-signatures names the file on the place step',
+  invitePlace.activeStep === 'step-place' && invitePlace.visible && !invitePlace.insideHiddenStep &&
+  /huur\.pdf/.test(invitePlace.text),
+  JSON.stringify(invitePlace));
+await invite.locator('#ds-place-continue').click();
+await invite.locator('#step-recipients:not([hidden])').waitFor();
 const inviteLine = await documentLine(invite);
 ok('request-signatures names the file on the co-signers step',
   inviteLine.activeStep === 'step-recipients' && inviteLine.visible && !inviteLine.insideHiddenStep &&

--- a/tests/sign-full.test.mjs
+++ b/tests/sign-full.test.mjs
@@ -73,7 +73,7 @@ CRED_ID = await page.evaluate(async () => {
 });
 
 const phase1 = await page.evaluate(async () => {
-  const m = await import('/js/parasign-signer.js?v=14');
+  const m = await import('/js/parasign-signer.js?v=15');
   const pqc = await import('/vendor/paramant-pqc.js');
   const vault = await import('/vendor/vault.js?v=5');
   const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
@@ -120,7 +120,7 @@ const phase1 = await page.evaluate(async () => {
 
 // Phase 2a: ensureSigningKey branching + ephemeral TOTP enrol (admin stubbed ok).
 const phase2a = await page.evaluate(async () => {
-  const m = await import('/js/parasign-signer.js?v=14');
+  const m = await import('/js/parasign-signer.js?v=15');
   const pqc = await import('/vendor/paramant-pqc.js');
   const vault = await import('/vendor/vault.js?v=5');
   const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
@@ -146,14 +146,14 @@ const phase2a = await page.evaluate(async () => {
 // Phase 2b: TOTP enrol error mapping (admin stub returns relay 403s).
 totpResp = { status: 403, body: { error: 'invalid_totp' } };
 const phase2b1 = await page.evaluate(async () => {
-  const m = await import('/js/parasign-signer.js?v=14');
+  const m = await import('/js/parasign-signer.js?v=15');
   const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
   let c=''; try { await m.enrolEphemeralSigningKeyWithTotp({ totp:'654321' }); } catch(e){ c=e.code; } ok('J1 relay 403 invalid_totp -> totp_invalid', c==='totp_invalid', c);
   return T;
 });
 totpResp = { status: 403, body: { error: 'no_totp_setup' } };
 const phase2b2 = await page.evaluate(async () => {
-  const m = await import('/js/parasign-signer.js?v=14');
+  const m = await import('/js/parasign-signer.js?v=15');
   const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
   let c=''; try { await m.enrolEphemeralSigningKeyWithTotp({ totp:'654321' }); } catch(e){ c=e.code; } ok('J2 relay 403 no_totp_setup -> totp_unavailable', c==='totp_unavailable', c);
   return T;
@@ -163,7 +163,7 @@ totpResp = { status: 200, body: { ok: true } };
 // Phase 2c: server 409 no_passkey path.
 noPasskeyMode = true;
 const phase2c = await page.evaluate(async () => {
-  const m = await import('/js/parasign-signer.js?v=14');
+  const m = await import('/js/parasign-signer.js?v=15');
   const T = []; const ok = (name, cond, detail='') => T.push({ name, pass: !!cond, detail: String(detail) });
   const delDB = () => new Promise(r => { const q = indexedDB.deleteDatabase('paramant'); q.onsuccess=q.onerror=q.onblocked=()=>r(); });
   await delDB();

--- a/tests/sign-invite-delivery.test.mjs
+++ b/tests/sign-invite-delivery.test.mjs
@@ -28,11 +28,13 @@ const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
 
 const ENV_ID = 'env_demo_abcdefghijklmnop';
 const TOKEN = 't'.repeat(43);
+let envelopeCreates = [];
 let documentUploads = [];
 let invitationCalls = [];
 let invitationAttempt = 0;
 await page.route('**/api/user/envelopes', async (route) => {
   const body = route.request().postDataJSON();
+  envelopeCreates.push(body);
   await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, envelope: {
     id: ENV_ID, party_count: body.recipients.length,
     expires_at: '2026-08-20T12:00:00.000Z',
@@ -94,6 +96,91 @@ await page.waitForFunction(() => /all email invitations/i.test(document.querySel
 ok('retry sends only failed parties', invitationCalls.length === 2 && invitationCalls[1].invitations.length === 1 && invitationCalls[1].invitations[0].party_index === 0, JSON.stringify(invitationCalls[1]?.invitations));
 ok('successful retry clears the warning', /all email invitations/i.test(await page.locator('#ds-invite-delivery-result').innerText()) && !(await page.locator('#ds-invite-retry').isVisible()), await page.locator('#ds-invite-delivery-result').innerText());
 ok('phone viewport has no horizontal overflow', await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth) <= 1, await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth));
+
+// ── PDF variant: the requester points at the spot where the other party signs ──
+// The .txt run above is the hash-only half of the invite flow: nothing can be
+// pointed at, so it must still go straight to the recipients. Everything below
+// is the PDF half, which is where /sign's promise ("show them where to sign")
+// either exists or does not.
+ok('a hash-only invite asks for no position', envelopeCreates.length === 1 && envelopeCreates[0].requested_appearance === undefined, JSON.stringify(Object.keys(envelopeCreates[0] || {})));
+
+const pdfCreates = [];
+const pdfPage = await browser.newPage({ viewport: { width: 390, height: 844 } });
+await pdfPage.route('**/api/user/envelopes', async (route) => {
+  const body = route.request().postDataJSON();
+  pdfCreates.push(body);
+  await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, envelope: {
+    id: ENV_ID, party_count: body.recipients.length,
+    expires_at: '2026-08-20T12:00:00.000Z',
+    party_links: body.recipients.map((_, party_index) => ({ party_index, sign_path: `/co-sign?env=${ENV_ID}&p=${party_index}&t=${TOKEN}`, invite_token: TOKEN })),
+  } }) });
+});
+await pdfPage.route(`**/api/user/envelopes/${ENV_ID}/document`, async (route) => {
+  await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+});
+await pdfPage.route(`**/api/user/envelopes/${ENV_ID}/invitations`, async (route) => {
+  const body = route.request().postDataJSON();
+  await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, partial_failure: false, failed_party_indexes: [], results: body.invitations.map((item) => ({ party_index: item.party_index, ok: true })) }) });
+});
+
+await pdfPage.goto(ORIGIN + '/sign', { waitUntil: 'domcontentloaded' });
+await pdfPage.locator('.ds-mode-card[data-mode="invite"]').click();
+ok('the invite stepper shows the Place step', await pdfPage.locator('.ds-stepper li[data-step="place"]').isVisible(), await pdfPage.locator('.ds-stepper').innerText());
+await pdfPage.evaluate(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  while (!window.PDFLib) await sleep(20);
+  const source = await window.PDFLib.PDFDocument.create();
+  source.addPage([300, 400]).drawText('Page one', { x: 30, y: 350, size: 14 });
+  source.addPage([300, 400]).drawText('Signature page', { x: 30, y: 350, size: 14 });
+  const transfer = new DataTransfer();
+  transfer.items.add(new File([await source.save()], 'agreement-demo.pdf', { type: 'application/pdf' }));
+  const input = document.getElementById('ds-doc-input');
+  input.files = transfer.files;
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+});
+await pdfPage.locator('#step-place:not([hidden])').waitFor({ timeout: 15000 });
+await pdfPage.locator('#ds-pdf-canvas-list .ds-page-wrap[data-page-index="1"] canvas').waitFor();
+
+// The requester is not signing, so none of the signer's chrome belongs here.
+// On a 390px phone that editor is 160px and the seal panel another 247px, which
+// is exactly the difference between seeing the document and scrolling for it.
+ok('invite Place shows one button, not the signer toolbars',
+  await pdfPage.locator('#ds-invite-tools').isVisible()
+  && await pdfPage.locator('#ds-edit-tools').isHidden()
+  && await pdfPage.locator('#ds-seal-tools').isHidden(),
+  await pdfPage.locator('#ds-invite-place').innerText());
+const fold = await pdfPage.evaluate(() => ({
+  canvasTop: Math.round(document.querySelector('#ds-pdf-canvas-list .ds-page-wrap').getBoundingClientRect().top),
+  viewport: window.innerHeight,
+  overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+}));
+ok('the document is above the fold at 390', fold.canvasTop > 0 && fold.canvasTop < fold.viewport, JSON.stringify(fold));
+ok('the Place step has no phone-width overflow', fold.overflow <= 1, JSON.stringify(fold));
+
+await pdfPage.locator('#ds-pdf-canvas-list .ds-page-wrap[data-page-index="1"]').click({ position: { x: 170, y: 100 } });
+ok('placing the box says who it is for', /asking for a signature on page 2/i.test(await pdfPage.locator('#ds-place-hint').innerText()), await pdfPage.locator('#ds-place-hint').innerText());
+ok('the marker asks rather than signs', /SIGNATURE REQUESTED/.test(await pdfPage.locator('.ds-stamp-marker').innerText()), await pdfPage.locator('.ds-stamp-marker').innerText());
+
+await pdfPage.locator('#ds-place-continue').click();
+await pdfPage.locator('#step-recipients:not([hidden])').waitFor();
+await pdfPage.locator('#ds-add-recipient').click();
+await pdfPage.locator('[data-field="label"]').fill('Signer Demo');
+await pdfPage.locator('[data-field="email"]').fill('signer@example.com');
+await pdfPage.locator('#ds-recipients-continue').click();
+await pdfPage.locator('#step-done:not([hidden])').waitFor({ timeout: 15000 });
+
+const requested = pdfCreates[0]?.requested_appearance;
+const seal = requested?.fields?.[0];
+ok('the create call carries exactly one requested position',
+  requested?.version === 1 && requested.fields.length === 1 && seal.type === 'seal',
+  JSON.stringify(requested));
+ok('the requested position names the page that was clicked', seal?.page_index === 1, JSON.stringify(seal));
+ok('the requested position is fractions of the page, y from the top',
+  seal && [seal.x, seal.y, seal.w, seal.h].every((n) => typeof n === 'number' && n >= 0 && n <= 1)
+  && seal.x + seal.w <= 1.000001 && seal.y + seal.h <= 1.000001
+  && seal.y < 0.4 && Math.abs(seal.w - 0.8) < 0.01 && Math.abs(seal.h - 0.25) < 0.01,
+  JSON.stringify(seal));
+await pdfPage.close();
 
 for (const check of checks) console.log(`${check.pass ? 'PASS' : 'FAIL'} ${check.name}${check.detail ? ' :: ' + check.detail : ''}`);
 await browser.close();

--- a/tests/sign-invite-delivery.test.mjs
+++ b/tests/sign-invite-delivery.test.mjs
@@ -65,6 +65,37 @@ await directPage.goto(ORIGIN + '/sign?mode=alone', { waitUntil: 'domcontentloade
 ok('dashboard deep link enters self-signing directly', await directPage.locator('#step-doc').isVisible() && await directPage.locator('.ds-stepper li[data-step="recipients"]').isHidden(), await directPage.locator('main').innerText());
 await directPage.close();
 
+// ── the session probe: three answers, three different things to say ──────────
+// "Signing a document needs an account" is only true when the browser HAS no
+// session. A koper review saw it while signed in, because the probe had failed
+// rather than refused. A failure gets the shared service sentence instead, and
+// a healthy answer gets neither.
+async function probeSays(status, body) {
+  const probe = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  await probe.route('**/api/user/check', (route) => route.fulfill({
+    status, contentType: 'application/json', body: body || '{}',
+  }));
+  await probe.goto(ORIGIN + '/sign', { waitUntil: 'domcontentloaded' });
+  await probe.waitForFunction(() => !!(self.paramantErrors), null, { timeout: 15000 });
+  await probe.waitForTimeout(300);
+  const seen = await probe.evaluate(() => ({
+    anon: !document.getElementById('step-anon').hidden,
+    service: !document.getElementById('ds-service-note').hidden,
+    serviceText: document.getElementById('ds-service-note').textContent,
+    support: self.paramantErrors.SUPPORT_FAILURE_MESSAGE,
+  }));
+  await probe.close();
+  return seen;
+}
+const probe401 = await probeSays(401, '{"error":"unauthenticated"}');
+ok('no session still gets the account notice', probe401.anon === true && probe401.service === false, JSON.stringify(probe401));
+const probe503 = await probeSays(503, '{"error":"session_store_unavailable"}');
+ok('a broken probe is a service failure, not a missing account',
+  probe503.anon === false && probe503.service === true && probe503.serviceText === probe503.support,
+  JSON.stringify(probe503));
+const probe200 = await probeSays(200, '');
+ok('a signed-in visitor is told nothing at all', probe200.anon === false && probe200.service === false, JSON.stringify(probe200));
+
 await page.goto(ORIGIN + '/sign', { waitUntil: 'domcontentloaded' });
 ok('landing leads with the request-signatures workflow', await page.locator('.ds-mode-card').first().getAttribute('data-mode') === 'invite' && await page.locator('.ds-mode-card').first().getAttribute('class').then((value) => value.includes('primary')), await page.locator('.ds-mode-card').first().innerText());
 ok('technical stepper stays hidden until a workflow is chosen', await page.locator('#ds-stepper').isHidden(), 'hidden');


### PR DESCRIPTION
## Why

`/sign` promises the requester can point at the spot where the other party signs. In `mode=invite` there was no Place step at all: `onDocChosen()` sent that flow straight from the file picker to the recipients. The promise had no screen behind it. This is the last of the three blockades from the koper review.

## What changed

A PDF invite now visits Place. Non-PDF invites are unchanged and still go straight to the recipients: the recipient's placement editor on `/co-sign` is PDF-only, so a position on a `.txt` or a PNG could never be honoured.

The Place step gets its own chrome in invite mode. The requester is not signing, so the 160px edit toolbar and the 247px seal panel are hidden and replaced by one button, "Place the signature box". The marker on the page reads SIGNATURE REQUESTED / Their signature, not a name and a seal that do not exist yet. Asking for a position is optional: Continue is never blocked.

## The data model

One requested position for the whole envelope, the same for every party:

```json
{ "version": 1,
  "fields": [ { "type": "seal", "page_index": 1, "x": 0.094169, "y": 0.093454, "w": 0.8, "h": 0.25 } ] }
```

Fractions 0..1 of the page, `y` measured from the TOP. That is the same model `/co-sign` already uses for the signer's own placement, so both sides share one normaliser.

The path it takes:

| Step | Where | What happens |
| --- | --- | --- |
| Place | `frontend/sign-flow.js` | `state.stamp` = PDF points, bottom-left origin; `state.stampPage` remembers the page size |
| Convert | `requestedAppearanceFromStamp()` in `frontend/js/parasign-signer.js` | pure function, points to fractions, y flipped, then through `normaliseSigningAppearance` |
| Send | `createSigningEnvelope()` | `requested_appearance` on `POST /api/user/envelopes` |
| Bound | `admin/server.js` | 4096 bytes, the same ceiling as `/user/sign/submit`, checked before the relay call; a non-object is refused whatever its size |
| Validate + store | `relay/envelope.js` `create()` | `normaliseAppearance`, then one `requested_appearance` field plus its sha3-256 hash, validated before an id is allocated so a bad manifest leaves no record |
| Read back | `getRedacted()` and `getForParty()` | `requested_appearance` + `requested_appearance_hash` |
| Seed | `frontend/co-sign.js` | seeds the placement editor when the signer has no draft of their own, and says so |

## It is a request, not a commitment

`sign()` still hashes only the appearance the signer submitted. The requested position appears nowhere in the recipe-5 signing message, so a signer can move the box and their signature still verifies, and it is never written into the receipt or the `.psign`. `tests/cosign-appearance-contract.test.mjs` guards the message bytes; the new relay unit block signs a MOVED box and asserts the message is built from that one and not from the requested one.

The recipient is told, in the editor help line: "The sender asked for your signature in the marked spot. Choose Place my signature to move it: your signature binds where you actually sign, not where it was requested." A draft of the signer's own always wins over the seed, on first load and after a refresh.

## Measured on 390

`#ds-pdf-canvas-list` top, 390x844, two-page PDF:

| Mode | Canvas top | Document visible |
| --- | --- | --- |
| invite (this PR) | 548 px | 296 px |
| sign it myself (unchanged) | 829 px | 15 px |

Sabotaging the minimal toolbar (showing the signer's two panels in invite) puts the canvas at 933 px, below the 844 px fold. That is the check, not a screenshot.

## Tests

- `tests/sign-invite-delivery.test.mjs` keeps its `.txt` run (which must still skip Place and send no position) and adds a PDF run: the Place step appears, one button instead of two panels, the fold measurement above, the box is placed on page 2, and the create call carries exactly one seal field with page 1 and y from the top.
- `tests/cosign-document-delivery.test.mjs`: the seed lands at the requested percentages, the help line names the sender, a requested position is not silently adopted as the signer's draft, the signer can move it, and their own draft wins on reload.
- `tests/sign-document-identity.test.mjs`: the invite case now walks the Place step it used to skip, and the file name has to hold on both of its screens.
- `relay/test/envelope-binding.test.js`: read-back on both views, and the signing message binds the used position rather than the requested one.
- `relay/test/parasign-envelope-index.test.js`: real redis, one normalized position stored, and an out-of-page box refused without leaving an envelope behind.
- `admin/test/signing-appearance.test.js`: the ceiling, its ordering before the relay call, the non-object refusal, and a behavioural proof that 4096 bytes is above anything the relay normaliser can produce (8 fields, its maximum).

Every pin was sabotaged one at a time and the matching check went red for all twelve.

## Gates

sign-full 33/33, sign-invite-delivery 25, cosign-document-delivery 20, cosign-appearance-contract, sign-document-identity 5, first-screen, ui-truthfulness, site-claims 37, frontend-loading-contract, csp-inline, static-sanity, check-test-declarations (137 suites), cache-bust, eslint, relay unit 199, relay routes with redis 92, relay parasign engine suites 4, admin unit 70, all browser suites 42.

Cache-busters bumped and unified: `sign-flow.js` v51, `co-sign.js` v21, `parasign-signer.js` v15.


---

## Round 2: koper herkeuring + security-review nits (a7c881ea)

### The seeded box read as a signature that already existed

The sender placed something labelled SIGNATURE REQUESTED / Their signature. The recipient saw `Paramant signed · J. Jansen ×` in the identical style as a placed field, with a delete button on it. Until the signer chooses Place my signature, the box now draws dashed, in its own colour, saying "Requested spot · your signature goes here", with no name, no date and no delete control. Placing, moving or clearing anything makes it the signer's own field; a restored draft is never redressed as a request.

### The marked spot was off screen

At 390 the requested box sat at y=2480, at 1440 at y=3029: `inView` false at both. The document now scrolls to it on load (`scrollIntoView`, `block: 'center'`) and a line above the preview says "The sender marked where you sign" with a "Go to the spot" button for after you scroll away.

The scroll is `instant`, not `auto`. `design-system.css` sets `html{scroll-behavior:smooth}`, and `auto` inherits it: the box crawled into place over a second (measured 24 → 1429 → 1595 px of scroll) while the reader was still working out what the page was. The page marks the element once the scroll has run, so the browser test observes it instead of waiting a hopeful number of milliseconds.

### The document was a quarter of the screen

Three nested paddings (card 32, card-body 18, preview 10) took 120px off a 390px phone. The preview now runs edge to edge inside its card and the canvas is laid out at 100% of its wrapper:

| Viewport | Canvas before | Canvas after | Sender side |
| --- | --- | --- | --- |
| 390 | 229 px | **340 px** | 343 px |
| 1440 | 458 px | **574 px** | - |

That also closed a drift nobody had named: the wrapper, the canvas and the click layer were three boxes 5-10px apart, and `placeAppearanceField` read the widest one, so a click fraction was a fraction of something the reader never saw. They are one box now, and a click in the dead centre of the page comes back as **0.500 / 0.4997**.

### Touch targets

Controls on the signing screen were 34-36px. All 44px now, including the new "Go to the spot".

### "Signing a document needs an account" while signed in

The probe treated every non-200 as "no session". A 503 from `authUser` (redis unreachable) or any 5xx from a proxy therefore told a paying, signed-in customer that their account was missing. Now:

| `/api/user/check` answers | What the customer is told |
| --- | --- |
| 401 / 403 | the account notice, as before |
| 5xx | the shared service sentence from `js/error-message.js` |
| 200, or any other status | nothing |
| fetch throws (offline) | nothing, as before |

### Security review nits, both now refusals in the relay

- A `requested_appearance` that is not an object was normalised to `{version:1,fields:[]}` and stored, instead of refused. `normaliseRequestedAppearance()` requires an object with at least one field, so the relay and the admin route now agree on what a request is.
- `type: 'date'` was accepted although the invite flow issues nothing but the seal. Requested is seal-only. The shared validator keeps accepting `date` for the SIGNED appearance, where the signer really can place one.

### Checked, no change needed

The nav on `/co-sign` below 1024 is already opaque: `rgb(248, 250, 252)`, `backdrop-filter: none`, from the `@media (max-width: 1023px)` rule in `nav.css` that #399 added. `/co-sign` loads the same stylesheet, so it was never outside it. It has a regression check now.

### Tests

`cosign-document-delivery` 20 → 30 checks, `sign-invite-delivery` 25 → 28, `envelope-binding` 18 → 19, plus the relay refusals through a real store on real redis in `parasign-envelope-index`. Nine new pins, each sabotaged on its own, each went red.

All gates re-run green: sign-full 33/33, browser suites 42, relay unit 199, relay routes with redis 92, relay parasign engine 4, admin 70, static-sanity, csp-inline, check-test-declarations (137 suites), cache-bust, eslint.
