### PR TITLE
The ParaSend account key never reaches the browser: a scoped session token

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -165,6 +165,38 @@ Revoking the key sweeps its tokens out of the store, and a token whose owner key
 is inactive grants no principal even when that sweep did not run: the sweep is
 the fast path, not the guarantee.
 
+#### Three things the review of this change tightened
+
+- **The stored record names its owner by hash.** It used to carry the api-key in
+  the clear. The key NAMES were already hashed, because SCAN output, keyspace
+  listings and the slowlog all show names, but the VALUE was not: an RDB
+  snapshot, a replica, a backup on a laptop or a `MONITOR` session carried live
+  `pgp_` credentials for every account that had sent a file in the last fifteen
+  minutes. The record is now `{kh, exp}`, and the relay turns the hash back into
+  a key by looking it up in the api-key table it already has in memory. Nothing
+  derives a key from a hash; a read-only copy of the store is a copy of hashes.
+  It also means key revocation and deletion arrive for free, because the lookup
+  is against the live table.
+- **The expiry is required, not optional.** A record with no `exp`, or one whose
+  `exp` is not a number, is refused. It used to fall through a `typeof` guard to
+  whatever TTL redis happened to have on the key, which meant a credential whose
+  lifetime was a property of the store alone, and no lifetime at all when the
+  store was wrong.
+- **A transfer made with a token is marked in the audit chain**, with one field,
+  `"via": "pst"`. Not a second identity: the chain is the owner's, keyed on the
+  owner's api-key exactly as for a request that carried the key. Without the
+  field an owner reading their own log cannot tell a transfer made from a
+  browser session apart from one made with the key itself, which is the
+  distinction that matters when they are working out what happened.
+
+There is also a ceiling of 20 live tokens per account, answered with `429` and a
+`Retry-After`. It is not a rate limit: the page mints one per load and one per
+refresh, so twenty is far above honest use, and what it stops is a signed-in
+session being run as a credential factory. Tokens already issued keep working,
+and room returns as they expire; the sweep index is pruned of names redis has
+already expired before a refusal is made, so nobody is refused on the strength
+of tokens that are gone.
+
 #### The new ceiling, stated plainly
 
 **A script that runs on paramant.app can still act as the signed-in user for

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -181,14 +181,28 @@ running in the first place; this only bounds what one gets if it does.
 
 #### What is still open
 
-The `GET /api/user/account/key` reveal route still exists. It is not what
-`/parashare` uses, and the page's "Use a key by hand" way out is meant for a
-self-hosted deployment with no admin panel, but the route is reachable from any
-signed-in browser and answers with the raw key. A script with fifteen minutes
-and a session cookie can call it. Closing that means deciding what the account
-page and the self-host flow do instead, which is a separate change; until then,
-the ceiling above is the ceiling for a user who has visited a page that can
-reveal, not for ParaSend alone.
+The `GET /api/user/account/key` reveal route still exists, and ParaSend was not
+its only caller. Three pages still fetch the raw key into the browser and use it
+as a relay credential:
+
+| Page | File | What it does with the key |
+|------|------|---------------------------|
+| `/account` | `frontend/js/account.inline1.js` | reveals it on the screen, deliberately |
+| `/pricing` | `frontend/js/pricing-billing.js` | `X-Api-Key` on `POST /v2/billing/checkout` |
+| `/dashboard` | `frontend/js/dashboard-history.js` | `X-Api-Key` on the usage and history reads |
+
+So the honest statement of the ceiling is this: on `/parashare` the key is gone,
+and on a browser that has loaded any of those three pages it is not. The route
+is reachable from any signed-in browser and answers with the raw key, so a
+script with a session cookie can also simply ask for it.
+
+Closing that is the next change, and it is not one line: `/pricing` and
+`/dashboard` need scoped credentials of their own (or server-side proxies, which
+is what `/api/user/documents` already does), and `/account` has to keep a way to
+show a key that a self-hoster genuinely needs. Recorded here rather than fixed,
+because a partial fix that removed the route would break three pages, and one
+that left it while claiming the key is out of the browser would be the same kind
+of untruth this section exists to correct.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -117,6 +117,81 @@ Full report: [docs/security-audit-2026-04.md](docs/security-audit-2026-04.md)
 
 ---
 
+### 2026-09-03: the ParaSend account key leaves the browser
+
+The security review of #397 accepted that /parashare had stopped keeping a key
+in `localStorage` and then said the harder thing: the key should not be in the
+browser at all. This records what was done about it and, more usefully, what is
+still true afterwards.
+
+#### The old ceiling
+
+`/parashare` fetched the account's API key from `GET /api/user/account/key` and
+held it in a variable for the life of the tab. That key is a full data-plane
+credential with no expiry and no scope. Anything that got to run script on
+paramant.app could read it out of the page and keep it: upload and download on
+the account, list and revoke its transfers, enrol a signing key, create ParaSign
+envelopes, read the audit chain. Not for fifteen minutes. Until the owner
+noticed and rotated the key, which is a thing an owner does when something has
+already gone wrong.
+
+The page's own hardening did not touch this. The key was never persisted and
+never logged; it was simply present, in a variable, which is all an injected
+script needs.
+
+#### What replaced it
+
+A `pst_` session token, minted by the admin panel on behalf of a logged-in user
+and handed to the browser instead of the key. Three properties, and the second
+is the one that matters:
+
+- **Fifteen minutes.** Held in the relay's shared Redis, so all five sectors
+  honour the same token; not an operator knob, because a deployment that could
+  set this to a week would have rebuilt the credential this removes.
+- **Five routes.** An allowlist in `relay/lib/session-token.js`, checked above
+  every route comparison in `relay.js`: `/v2/check-key`, `POST /v2/ws-ticket`,
+  `POST /v2/pubkey`, `GET /v2/pubkey/:device`, `POST /v2/inbound`. Everything
+  else is `403`, including `/v2/user/*`, `/v2/outbound`, `/v2/audit`,
+  `/v2/admin/*`, the ParaSign envelope routes, and a second mint: a token cannot
+  extend its own fifteen minutes.
+- **The same account.** Inside that scope the token authenticates as the api-key
+  it was minted for, so quota, the audit chain and the tier ceilings resolve
+  against the owner. A token is a narrower way to present an account, never a
+  second account.
+
+`POST /v2/session-token` needs `X-Internal-Auth` and a live `X-Api-Key`, so the
+admin plane is the only caller and a browser can never name another account.
+Revoking the key sweeps its tokens out of the store, and a token whose owner key
+is inactive grants no principal even when that sweep did not run: the sweep is
+the fast path, not the guarantee.
+
+#### The new ceiling, stated plainly
+
+**A script that runs on paramant.app can still act as the signed-in user for
+fifteen minutes.** It can start a transfer, publish a handshake key and upload a
+blob against the account's monthly quota. What it can no longer do is take the
+key with it: it cannot read the account's downloads or audit log, cannot enrol a
+signing identity, cannot create or sign an envelope, and cannot do any of it
+after the token expires, because minting a new one requires the session cookie
+to still be there and the mint route to be reached through the admin panel.
+
+That is a real reduction and it is not a fix for cross-site scripting. The CSP
+on the site and the escaping in the pages remain the thing that stops a script
+running in the first place; this only bounds what one gets if it does.
+
+#### What is still open
+
+The `GET /api/user/account/key` reveal route still exists. It is not what
+`/parashare` uses, and the page's "Use a key by hand" way out is meant for a
+self-hosted deployment with no admin panel, but the route is reachable from any
+signed-in browser and answers with the raw key. A script with fifteen minutes
+and a session cookie can call it. Closing that means deciding what the account
+page and the self-host flow do instead, which is a separate change; until then,
+the ceiling above is the ceiling for a user who has visited a page that can
+reveal, not for ParaSend alone.
+
+---
+
 ### 2026-09-03: login lockout and TOTP replay (internal review of #367)
 
 Two decisions came out of reviewing the site-claims work in #367, both about

--- a/admin/server.js
+++ b/admin/server.js
@@ -2469,6 +2469,55 @@ function maskIp(ip) {
 // top of this file. Audit-chain records keep the full email on purpose (admin
 // traceability); the masked form is only for stdout/journald.
 
+// POST /api/user/parasend/token
+//
+// The route that lets ParaSend stop holding an api-key. /parashare asks for a
+// pst_ session token, the relay mints one for the account this session is
+// signed in as, and the browser is handed the token and nothing else.
+//
+// Three things this route does NOT do, each on purpose:
+//   * it takes no body. The account is the session's, read server-side through
+//     proxyApiKey(); a browser cannot name another one, so there is nothing to
+//     validate and nothing to get wrong;
+//   * it never returns the api-key, not even alongside the token. The whole
+//     point of the token is that the key stops travelling;
+//   * it does not fall back to the key when the relay cannot mint. A fallback
+//     would quietly put the credential back in the browser on exactly the days
+//     something is already wrong.
+//
+// GET /api/user/account/key below stays as it is. It is the reveal a
+// self-hoster and the account page still need, and it is no longer what
+// /parashare uses.
+api.post("/user/parasend/token", authUser, async (req, res) => {
+  const key = proxyApiKey(req.userSession);
+  if (!key) return res.status(403).json({ error: "no_account_key" });
+  try {
+    const rr = await fetch(`${SECTORS.health}/v2/session-token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Internal-Auth": INTERNAL_TOKEN,
+        "X-Api-Key": key,
+      },
+      body: "{}",
+      signal: AbortSignal.timeout(10000),
+    });
+    const body = await rr.json().catch(() => ({ error: "bad_relay_response" }));
+    res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, private");
+    if (rr.status !== 200 || !body.token) {
+      // The relay's status is passed through so the page can tell an outage
+      // (503, worth a retry) from a refusal (401/403, worth the banner). The
+      // relay's body is not: it is written for an operator reading a log, and
+      // relaying it would put relay internals on a page anyone can open.
+      return res.status(rr.status === 200 ? 502 : rr.status).json({ error: "token_unavailable" });
+    }
+    return res.json({ token: body.token, expires_in_s: body.expires_in_s });
+  } catch (err) {
+    console.error("[user/parasend/token]", err.message);
+    return res.status(502).json({ error: "relay_unreachable" });
+  }
+});
+
 // GET /api/user/account/key
 api.get("/user/account/key", authUser, async (req, res) => {
   // stap 3: reveal the account's PRIMARY api-key (== user_id today), and only

--- a/admin/test/_admin-server.js
+++ b/admin/test/_admin-server.js
@@ -87,12 +87,23 @@ async function stubRelay(state) {
     req.on('end', () => {
       let body = null;
       try { body = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}'); } catch (_) { body = null; }
-      state.calls.push({ method: req.method, path: url.pathname, body });
+      // Headers are recorded as well as the body. The mint route below is
+      // authenticated entirely by headers the browser does not have, so a suite
+      // that could only see the body could not tell a correct call from one
+      // that forgot the internal token and would fail closed in production.
+      state.calls.push({ method: req.method, path: url.pathname, body, headers: req.headers });
       const send = (status, payload) => {
         res.writeHead(status, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(payload));
       };
       if (url.pathname === '/v2/admin/keys') return send(200, { keys: state.accounts });
+      // POST /v2/session-token: the ParaSend session-token mint. Only answered
+      // when a suite asked for it by setting state.mintReply, so every other
+      // suite keeps the 404 it has today.
+      if (url.pathname === '/v2/session-token' && typeof state.mintReply === 'function') {
+        const out = state.mintReply(req.headers, body || {});
+        return send(out.status || 200, out.body !== undefined ? out.body : {});
+      }
       if (url.pathname === '/v2/user/verify-totp' || url.pathname === '/v2/user/consume-backup') {
         const backup = url.pathname.endsWith('consume-backup');
         const out = backup

--- a/admin/test/parasend-token.test.js
+++ b/admin/test/parasend-token.test.js
@@ -1,0 +1,237 @@
+'use strict';
+// POST /api/user/parasend/token, on a really booted admin/server.js.
+//
+// WHY THIS SUITE EXISTS. keys-session.test.js next door is a pure-logic test of
+// admin/lib/account-keys.js, and it is the right shape for a decision. This is
+// not a decision, it is a boundary: the browser asks for a credential, the
+// admin fetches it from the relay with headers no browser has, and hands back
+// strictly less than it received. Every one of those properties is a property
+// of a REQUEST, so this suite spawns the real server, gives it a real redis for
+// its session store, and puts a stub relay behind it that records exactly what
+// the admin sent.
+//
+// What is asserted, and why each line earns its place:
+//   * no session is 401, before the relay is touched at all. The relay is
+//     reachable in this suite, so a route that leaked would leak here;
+//   * a signed-in browser gets a token, and NOTHING else. Not the api-key, not
+//     alongside it, not in a field nobody reads. That is the entire feature;
+//   * the admin authenticates to the relay with the SESSION's key plus the
+//     internal header, and takes no account id from the request. A body naming
+//     someone else's account changes nothing;
+//   * a relay that refuses, breaks, or cannot be reached is passed through as a
+//     status the page can act on, with the relay's own words dropped;
+//   * and the fallback that must never exist: no failure path returns the key.
+//
+// Verified by sabotage: return `api_key` next to the token and two cases go
+// red; read the account from req.body and the "a body cannot name an account"
+// case goes red; drop the X-Internal-Auth header and the stub records a mint
+// without it; relay 503 turned into a 200 with the key fails the outage case.
+// Run: REDIS_URL=redis://127.0.0.1:6399 node --test admin/test/parasend-token.test.js
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const { boot, killAll, stubRelay, defaultRelayState, summary } = require('./_admin-server');
+
+const DEFAULT_REDIS = 'redis://127.0.0.1:6399';
+const INTERNAL = 'internal-token-for-the-parasend-token-suite';
+const SUFFIX = crypto.randomBytes(6).toString('hex');
+const ACCOUNT_KEY = `pgp_account_key_for_the_parasend_suite_${SUFFIX}`;
+const OTHER_KEY = `pgp_other_account_key_${SUFFIX}`;
+const MINTED = `pst_${'a'.repeat(64)}`;
+
+let redis = null;
+let srv;
+let relay;
+let checks = 0;
+const did = () => { checks++; };
+
+// A redis for the admin's session store, and for planting a session directly.
+// Logging in through the real flow would need TOTP and a captcha and would
+// measure the login, not this route.
+async function connectRedis() {
+  const url = process.env.REDIS_URL || DEFAULT_REDIS;
+  let createClient;
+  try { ({ createClient } = require('redis')); }
+  catch (e) {
+    throw new Error(`unmet precondition "redis": the "redis" module is not installed: ${e.message}\n` +
+      '  Run npm ci in admin/, or, if this job is deliberately without it: ADMIN_TEST_SKIP=redis');
+  }
+  const rc = createClient({ url, socket: { connectTimeout: 800, reconnectStrategy: false } });
+  rc.on('error', () => {});
+  try { await rc.connect(); await rc.ping(); return rc; }
+  catch (e) {
+    try { await rc.disconnect(); } catch (_) { /* already gone */ }
+    if (String(process.env.ADMIN_TEST_SKIP || '').split(',').map(s => s.trim()).includes('redis')) return null;
+    throw new Error(`unmet precondition "redis": no reachable redis at ${url}: ${e.message}\n` +
+      '  Give the job a redis service, or: ADMIN_TEST_SKIP=redis');
+  }
+}
+
+// A session in the store, the shape admin/server.js writes at login.
+async function session(key = ACCOUNT_KEY) {
+  const token = crypto.randomBytes(24).toString('hex');
+  await redis.set(`paramant:user:session:${token}`, JSON.stringify({
+    user_id: key, email: `owner-${SUFFIX}@example.com`,
+    primary_api_key: key, legacy_revealable: true,
+  }), { EX: 3600 });
+  return { Cookie: `paramant_user_session=${token}` };
+}
+
+// The stub answers /v2/session-token as the relay does, and `mintReply` lets a
+// test hand the admin any of the answers a real relay can give.
+function relayState() {
+  const state = defaultRelayState([]);
+  state.mintReply = () => ({ status: 200, body: { ok: true, token: MINTED, expires_ms: Date.now() + 900_000, expires_in_s: 900 } });
+  return state;
+}
+
+before(async () => {
+  redis = await connectRedis();
+  if (!redis) return;
+  relay = await stubRelay(relayState());
+  // The stub answers the mint through state.mintReply, which relayState() set
+  // above, so no other suite in this directory sees the route at all.
+  srv = await boot({
+    redisUrl: process.env.REDIS_URL || DEFAULT_REDIS,
+    relay,
+    internalToken: INTERNAL,
+    env: { RELAY_HEALTH: relay.base },
+  });
+});
+
+after(async () => {
+  await killAll();
+  if (redis) { try { await redis.disconnect(); } catch (_) { /* already gone */ } }
+  summary('parasend-token', checks);
+});
+
+const mint = (headers = {}) => srv.post('/api/user/parasend/token', { headers });
+const mintCalls = () => relay.state.calls.filter(c => c.path === '/v2/session-token');
+
+test('no session is 401, and the relay is never asked', async (t) => {
+  if (!redis) return t.skip('no redis');
+  const before = mintCalls().length;
+  const r = await mint();
+  assert.strictEqual(r.status, 401);
+  assert.deepStrictEqual(r.json, { error: 'unauthenticated' });
+  assert.strictEqual(mintCalls().length, before,
+    'an unauthenticated caller must not cause a mint: the relay is reachable in this suite, so a leak would leak here');
+
+  // A cookie that names no live session is the same 401, one word different,
+  // and still no mint.
+  const dead = await mint({ Cookie: `paramant_user_session=${crypto.randomBytes(24).toString('hex')}` });
+  assert.strictEqual(dead.status, 401);
+  assert.strictEqual(mintCalls().length, before);
+  did();
+});
+
+test('THE POINT: a signed-in browser gets a token, and the api-key is nowhere in the answer', async (t) => {
+  if (!redis) return t.skip('no redis');
+  const r = await mint(await session());
+  assert.strictEqual(r.status, 200, r.text);
+  assert.strictEqual(r.json.token, MINTED);
+  assert.strictEqual(r.json.expires_in_s, 900);
+  assert.ok(!r.text.includes(ACCOUNT_KEY),
+    'the response carries the account key. This route exists so that it cannot.');
+  assert.ok(!r.text.includes('pgp_'), 'nothing shaped like an api-key may leave this route');
+  // Strictly less than the relay handed over: no relay internals, no expires_ms
+  // the page has no use for, no ok flag it does not read.
+  assert.deepStrictEqual(Object.keys(r.json).sort(), ['expires_in_s', 'token']);
+  assert.match(r.headers['cache-control'] || '', /no-store/,
+    'a bearer credential must not be cached by a proxy or a back button');
+  did();
+});
+
+test('the admin authenticates to the relay with the SESSION key plus the internal header', async (t) => {
+  if (!redis) return t.skip('no redis');
+  relay.state.calls.length = 0;
+  const r = await mint(await session());
+  assert.strictEqual(r.status, 200, r.text);
+  const call = mintCalls().at(-1);
+  assert.ok(call, 'the admin must actually ask the relay');
+  assert.strictEqual(call.method, 'POST');
+  assert.strictEqual(call.headers['x-api-key'], ACCOUNT_KEY,
+    'the relay must be told which account, and told it by the server from the session');
+  assert.strictEqual(call.headers['x-internal-auth'], INTERNAL,
+    'without the internal header the relay refuses, and a route that forgot it would fail closed but silently');
+  did();
+});
+
+test('a body cannot name an account: the session decides, always', async (t) => {
+  if (!redis) return t.skip('no redis');
+  relay.state.calls.length = 0;
+  const r = await srv.post('/api/user/parasend/token', {
+    headers: await session(),
+    body: { user_id: OTHER_KEY, account_id: OTHER_KEY, key: OTHER_KEY },
+  });
+  assert.strictEqual(r.status, 200, r.text);
+  const call = mintCalls().at(-1);
+  assert.strictEqual(call.headers['x-api-key'], ACCOUNT_KEY,
+    'a browser named another account and the admin passed it on. The account is the session, and only the session.');
+  did();
+});
+
+test('a relay that refuses is passed through as a status, without its words', async (t) => {
+  if (!redis) return t.skip('no redis');
+  for (const status of [401, 403]) {
+    relay.state.mintReply = () => ({ status, body: { error: 'Invalid API key', hint: 'X-Api-Key: pgp_...' } });
+    const r = await mint(await session());
+    assert.strictEqual(r.status, status, `a relay ${status} must reach the page as ${status}`);
+    assert.deepStrictEqual(r.json, { error: 'token_unavailable' });
+    assert.ok(!/X-Api-Key/.test(r.text),
+      'the relay writes for an operator reading a log; that text must not land on a page anyone can open');
+  }
+  relay.state.mintReply = relayState().mintReply;
+  did();
+});
+
+test('a store outage reaches the page as 503, so the retry is a retry and not a re-login', async (t) => {
+  if (!redis) return t.skip('no redis');
+  relay.state.mintReply = () => ({ status: 503, body: { error: 'redis_unavailable' } });
+  const r = await mint(await session());
+  assert.strictEqual(r.status, 503, r.text);
+  assert.deepStrictEqual(r.json, { error: 'token_unavailable' });
+  assert.ok(!r.text.includes(ACCOUNT_KEY),
+    'NO FALLBACK. Handing the key over when the mint fails would put the credential back in the browser on exactly the days something is already wrong.');
+  relay.state.mintReply = relayState().mintReply;
+  did();
+});
+
+test('a 200 with no token in it is a bad gateway, not a success', async (t) => {
+  if (!redis) return t.skip('no redis');
+  for (const body of [{}, { ok: true }, { token: '' }, { token: null }]) {
+    relay.state.mintReply = () => ({ status: 200, body });
+    const r = await mint(await session());
+    assert.strictEqual(r.status, 502, `a 200 carrying ${JSON.stringify(body)} answered ${r.status}`);
+    assert.deepStrictEqual(r.json, { error: 'token_unavailable' });
+  }
+  relay.state.mintReply = relayState().mintReply;
+  did();
+});
+
+test('a relay that cannot be reached at all is 502, and says so once', async (t) => {
+  if (!redis) return t.skip('no redis');
+  const offline = await boot({
+    redisUrl: process.env.REDIS_URL || DEFAULT_REDIS,
+    internalToken: INTERNAL,
+    // Nothing listens here. RELAY_HEALTH is what this route calls.
+    env: { RELAY_HEALTH: 'http://127.0.0.1:1' },
+  });
+  t.after(() => offline.stop());
+  const r = await offline.post('/api/user/parasend/token', { headers: await session() });
+  assert.strictEqual(r.status, 502, r.text);
+  assert.deepStrictEqual(r.json, { error: 'relay_unreachable' });
+  did();
+});
+
+test('the reveal route still exists: the manual way out is not collateral damage', async (t) => {
+  if (!redis) return t.skip('no redis');
+  // /parashare no longer calls it, but a self-hoster and the account page do,
+  // and removing it while removing its caller would be a silent breakage.
+  const r = await srv.get('/api/user/account/key', { headers: await session() });
+  assert.strictEqual(r.status, 200, r.text);
+  assert.strictEqual(r.json.api_key, ACCOUNT_KEY);
+  assert.strictEqual(r.json.revealable, true);
+  did();
+});

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,7 @@ Three credential types are in use across different API surfaces:
 | API key (`pgp_` prefix) | `X-Api-Key: pgp_your_key` | Data plane — uploads, downloads, CT log (developer clients) |
 | Operator key (`plk_` prefix) | `X-Api-Key: plk_your_key` | Data plane — unlimited throughput (operator license) |
 | DID signature | `X-DID: did:paramant:…` + `X-DID-Signature: <sig over request URL>` | Data plane — **active fallback** when no `X-Api-Key` is sent (see Device Identity) |
+| ParaSend session token (`pst_` prefix) | `Authorization: Bearer pst_…` | Data plane: the five ParaSend transfer routes only, 15 minutes, minted for a browser session (see below) |
 | Session cookie | `Cookie: paramant_user_session=<token>` | `/api/user/*` endpoints — set automatically after TOTP login |
 | Admin token | `X-Admin-Token: <token>` | `/admin/api/admin/*` endpoints — admin panel only |
 
@@ -34,6 +35,33 @@ Three credential types are in use across different API surfaces:
 > owner's account, not merely an attribution label: treat device private keys
 > with the same care as API keys, and revoke the DID enrollment when a device
 > is retired or compromised.
+
+> **ParaSend session tokens.** A `pst_` token is a narrow, short-lived stand-in
+> for an account API key, so a browser never has to hold the key itself. It is
+> minted by the admin panel on behalf of a logged-in user
+> (`POST /api/user/parasend/token`, session cookie), which asks the relay for it
+> over the internal channel; the browser is only ever handed the token, never
+> the key. Properties, all enforced by the relay:
+>
+> - **Scope.** An allowlist, checked above every route handler. A token opens
+>   `/v2/check-key`, `POST /v2/ws-ticket`, `POST /v2/pubkey`,
+>   `GET /v2/pubkey/:device` and `POST /v2/inbound`, and nothing else. Any other
+>   path answers `403 session_token_out_of_scope`, including `/v2/user/*`,
+>   `/v2/outbound/:hash`, `/v2/audit`, `/v2/admin/*`, the ParaSign envelope
+>   routes, and a second `POST /v2/session-token`: a token cannot mint another.
+> - **Identity.** Inside that scope the token authenticates **as the API key it
+>   was minted for**. Monthly quotas (`transfers_month`), the audit chain,
+>   device queues and per-tier limits all resolve against the owner's account,
+>   byte-identical to a request that carried the owner's `X-Api-Key`.
+> - **Lifetime.** 15 minutes, held in the relay's shared Redis so all five
+>   sectors honour the same token. It is not configurable.
+> - **Revocation.** Revoking the API key deletes every live token for it, and a
+>   token whose owner key is revoked or deleted grants no principal even if that
+>   sweep did not run.
+> - **Precedence.** A request that carries `X-Api-Key` is that key's request; the
+>   `Authorization` header is only read when no API key was sent.
+> - **Outage.** With the store unreachable a token is answered `503
+>   redis_unavailable` with `Retry-After`, never `401`.
 
 CT log and STH endpoints are **public** — no credential required.
 
@@ -438,6 +466,31 @@ curl https://relay.paramant.app/v2/pubkey/phone-001 \
 # {"device_id":"phone-001","ecdh_pub":"…","kyber_pub":"…","registered_at":"…"}
 ```
 
+### POST /v2/session-token: mint a ParaSend session token (internal)
+
+Not reachable from a browser or from the public internet. It requires the
+internal channel header **and** the account's API key, and the admin panel is
+the only caller: it sends the key of the session that asked, so a browser can
+never name an account other than the one it is signed in as. See the
+Authentication section above for what the resulting token can and cannot do.
+
+```bash
+curl -X POST https://health.paramant.app/v2/session-token \
+  -H "X-Internal-Auth: $INTERNAL_AUTH_TOKEN" \
+  -H "X-Api-Key: pgp_your_key"
+# {"ok":true,"token":"pst_…","expires_ms":1767225600000,"expires_in_s":900}
+```
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Token minted. The response never contains the API key. |
+| 401 | Missing or wrong `X-Internal-Auth`, or no live account key. The two are not distinguishable. |
+| 403 | The caller presented a session token; a token cannot mint another one. |
+| 503 | The relay store is unreachable, so no checkable token can be issued. |
+
+The browser-facing half of this is `POST /api/user/parasend/token` on the admin
+panel (session cookie, no body, returns only `token` and `expires_in_s`).
+
 ---
 
 ## Device Identity
@@ -593,7 +646,7 @@ Notes:
 |------|---------|
 | 400 | Bad request — missing or invalid fields |
 | 401 | Invalid API key or signature |
-| 403 | Forbidden — wrong API key for this blob |
+| 403 | Forbidden: wrong API key for this blob, or `session_token_out_of_scope` |
 | 404 | No blob / no STH at that timestamp |
 | 429 | Rate limit exceeded |
 | 503 | ML-DSA-65 not available on this relay |

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,7 +54,17 @@ Three credential types are in use across different API surfaces:
 >   device queues and per-tier limits all resolve against the owner's account,
 >   byte-identical to a request that carried the owner's `X-Api-Key`.
 > - **Lifetime.** 15 minutes, held in the relay's shared Redis so all five
->   sectors honour the same token. It is not configurable.
+>   sectors honour the same token. It is not configurable. The stored record
+>   carries the owner as a SHA-256 hash, never as an API key, and the relay
+>   resolves it against the key table it already holds in memory; a read-only
+>   copy of the store therefore contains no usable credential. A record without
+>   a numeric expiry is refused outright.
+> - **Ceiling.** At most 20 live tokens per account. The 21st mint answers
+>   `429 session_token_cap_reached` with `Retry-After`; tokens already issued
+>   keep working, and room returns as they expire.
+> - **Audit.** A transfer made with a token appears in the owner's audit chain
+>   like any other, with one extra field, `"via": "pst"`. It is a note on the
+>   credential, not a second identity.
 > - **Revocation.** Revoking the API key deletes every live token for it, and a
 >   token whose owner key is revoked or deleted grants no principal even if that
 >   sweep did not run.
@@ -486,6 +496,7 @@ curl -X POST https://health.paramant.app/v2/session-token \
 | 200 | Token minted. The response never contains the API key. |
 | 401 | Missing or wrong `X-Internal-Auth`, or no live account key. The two are not distinguishable. |
 | 403 | The caller presented a session token; a token cannot mint another one. |
+| 429 | The account already holds 20 live tokens. `Retry-After: 60`. |
 | 503 | The relay store is unreachable, so no checkable token can be issued. |
 
 The browser-facing half of this is `POST /api/user/parasend/token` on the admin

--- a/frontend/js/parashare.page.js
+++ b/frontend/js/parashare.page.js
@@ -10,6 +10,13 @@ const RELAY_SECTORS = {
 let RELAY_API = RELAY_SECTORS.health; // updated after key validation
 
 let apiKey = '', keyValid = false, selectedFile = null, selectedFiles = [];
+// The credential this page really runs on. `sessionAuth` is a pst_ session
+// token: fifteen minutes, scoped by the relay to the five routes a transfer
+// walks, and minted per browser session. `apiKey` above is now only ever the
+// manual way out, for a self-hosted relay with no /api/user/parasend/token.
+// Exactly one of the two is set; relayAuthHeaders() is the one place that
+// decides which header goes on a request.
+let sessionAuth = '', sessionAuthExp = 0, sessionAuthPending = null;
 // Sector discovery is its own question, kept apart from keyValid: a key can be
 // perfectly good while not one of the four sectors answers. relayReady says a
 // sector was found; relayError carries the reason it was not.
@@ -18,8 +25,16 @@ let relayReady = false, relayError = '';
 // be able to stop it: a second poll on a dead token would keep asking forever.
 let pubkeyPoll = null;
 // nginx puts /api/user/ in the relay_auth zone (burst 5). One fetch for the
-// account key, and at most one retry, 2 s later, when that fetch is throttled.
+// session token, and at most one retry, 2 s later, when that fetch is throttled.
 const KEY_RETRY_MS = 2000;
+// Where the token comes from. The admin mints it against the account this
+// browser is signed in as; the page never sees the account key.
+const TOKEN_URL = '/api/user/parasend/token';
+// Refresh a minute before the relay would stop honouring it. A sender who
+// spends twenty minutes choosing a 4 GB file and comparing a fingerprint must
+// not hit an expiry at the upload, which is the one step that cannot be
+// cheaply retried.
+const TOKEN_MARGIN_MS = 60000;
 let sessionToken = '', ws = null;
 let receiverPubs = null;
 
@@ -69,12 +84,16 @@ function setStepperStage(key) {
 }
 
 // Show the full API-key card. Two callers: the "Change" link in the slim row,
-// and the way out on the error banner, which is the path a self-hoster without
-// /api/user/account/key takes.
+// and the way out on the error banner, which is the path a self-hoster whose
+// deployment cannot mint a session token takes.
 function expandApiKeyCard() {
   var s = $('step-setup');
   if (s) s.classList.add('manual-key');
   setKeyError(false);
+  // Asking for the box means taking over from the session token, so the token
+  // is dropped here rather than left as a second credential the page might
+  // still reach for. One credential at a time, always.
+  sessionAuth = ''; sessionAuthExp = 0; sessionAuthPending = null;
   var inp = $('api-key');
   if (inp) { inp.value = ''; inp.focus(); onKeyInput(); }
   // Legacy only. This page no longer writes the key to localStorage; this
@@ -84,17 +103,15 @@ function expandApiKeyCard() {
 
 // The slim row is the default state of step 1. This fills it in once the
 // session key has really arrived: the mask, the label, and the green dot.
-function applySlimApiKeyView() {
-  var inp = $('api-key');
-  if (!inp || !inp.value) return;
+function applySlimApiKeyView(shown) {
+  if (!shown) return;
   var mask = $('ps-key-mask');
   if (mask) {
-    var v = inp.value;
-    mask.textContent = v.length > 14 ? v.slice(0, 8) + '...' + v.slice(-4) : v;
+    mask.textContent = shown.length > 14 ? shown.slice(0, 8) + '...' + shown.slice(-4) : shown;
     mask.hidden = false;
   }
   var label = $('ps-key-slim-label');
-  if (label) label.textContent = 'Using your account key';
+  if (label) label.textContent = 'Using your account';
   var row = $('ps-key-slim');
   if (row) { row.classList.remove('is-loading'); row.hidden = false; }
   var s = $('step-setup');
@@ -277,16 +294,101 @@ async function showReceiverConnected(kyberPub, ecdhPub) {
   renderFingerprintQR(fp);
 }
 
+// ── The credential, and the one place that presents it ──────────────────────
+// Every relay call on this page goes through relayFetch. Two reasons it is one
+// function and not five copies: the header depends on which credential the page
+// is running (a Bearer token from the session, or a hand-typed key on a
+// self-host), and a token can die halfway through a long send. Spread over five
+// call sites, one of them would eventually be written without the refresh.
+function relayAuthHeaders(extra) {
+  var h = {};
+  for (var k in (extra || {})) if (Object.prototype.hasOwnProperty.call(extra, k)) h[k] = extra[k];
+  if (sessionAuth) h['Authorization'] = 'Bearer ' + sessionAuth;
+  else if (apiKey) h['X-Api-Key'] = apiKey;
+  return h;
+}
+
+// Ask the admin for a token. The account is the one this browser is signed in
+// as; there is nothing to send and nothing the page could name.
+async function fetchSessionToken() {
+  var r = await fetch(TOKEN_URL, { method: 'POST', credentials: 'include' });
+  // nginx rate-limits /api/user/ (zone relay_auth, burst 5). A 429 here is the
+  // page arriving next to its own siblings, not a broken account, so it earns
+  // exactly one retry and then gives up.
+  if (r.status === 429) {
+    await new Promise(function (res) { setTimeout(res, KEY_RETRY_MS); });
+    r = await fetch(TOKEN_URL, { method: 'POST', credentials: 'include' });
+  }
+  // Expected, and marked so: a browser with no session gets 401/403, and a
+  // self-host that never built this endpoint answers 404. Both mean "no token
+  // here", the banner is the whole answer, and neither is worth a line in the
+  // console of every signed-out visitor.
+  if (!r.ok) {
+    var refused = new Error('session token: HTTP ' + r.status);
+    refused.expected = r.status === 401 || r.status === 403 || r.status === 404;
+    throw refused;
+  }
+  var d = await r.json();
+  if (!d || !d.token) {
+    var none = new Error('session token: none for this session');
+    none.expected = true;
+    throw none;
+  }
+  return d;
+}
+
+// One refresh at a time. Two uploads racing an expiry would otherwise mint two
+// tokens and each keep the other's, and the loser would carry a token it had
+// already replaced.
+function refreshSessionAuth() {
+  if (sessionAuthPending) return sessionAuthPending;
+  sessionAuthPending = fetchSessionToken().then(function (d) {
+    sessionAuth = d.token;
+    sessionAuthExp = Date.now() + (d.expires_in_s || 0) * 1000;
+    sessionAuthPending = null;
+    return true;
+  }).catch(function () {
+    // The token is left as it was. A failed refresh is not proof the old one is
+    // dead, and throwing the credential away here would turn a blip in the
+    // admin into a dead page.
+    sessionAuthPending = null;
+    return false;
+  });
+  return sessionAuthPending;
+}
+
+// One relay call, with whichever credential this page is running, and exactly
+// one recovery: a token that expired mid-session is replaced and the call is
+// made again. Once. A 401 that survives a fresh token is a real 401.
+async function relayFetch(url, opts) {
+  opts = opts || {};
+  if (sessionAuth && sessionAuthExp && Date.now() > sessionAuthExp - TOKEN_MARGIN_MS) {
+    await refreshSessionAuth();
+  }
+  var send = {};
+  for (var k in opts) if (Object.prototype.hasOwnProperty.call(opts, k) && k !== 'retried') send[k] = opts[k];
+  send.headers = relayAuthHeaders(opts.headers);
+  var r = await fetch(url, send);
+  if (r.status === 401 && sessionAuth && !opts.retried) {
+    if (await refreshSessionAuth()) {
+      var again = {};
+      for (var k2 in opts) if (Object.prototype.hasOwnProperty.call(opts, k2)) again[k2] = opts[k2];
+      again.retried = true;
+      return relayFetch(url, again);
+    }
+  }
+  return r;
+}
+
 // ── Relay discovery: try all sectors in parallel, pick first valid ──
 // It used to fold two different failures into one null: "a sector answered and
 // refused this key" and "not one sector answered". The first is about the key,
 // the second is about the network, and only the first should ever disable the
 // button. So the two are reported apart.
-async function discoverRelay(key) {
+async function discoverRelay() {
   const results = await Promise.allSettled(
     Object.entries(RELAY_SECTORS).map(async ([sector, url]) => {
-      const r = await fetch(`${url}/v2/check-key`, {
-        headers: { 'X-Api-Key': key },
+      const r = await relayFetch(`${url}/v2/check-key`, {
         signal: AbortSignal.timeout(5000)
       });
       const d = await r.json();
@@ -303,12 +405,58 @@ async function discoverRelay(key) {
   };
 }
 
-// ── Key validation ──
-// The key is never written to localStorage. It comes from the session
-// (/api/user/account/key) or, on a self-host without that endpoint, from the
-// manual card. Persisting it bought nothing and put a bearer credential in a
-// store that outlives the sign-out that was documented to clear it.
+// ── Credential validation ──
+// Nothing is written to localStorage, and on the hosted relay nothing that
+// reaches this page is an API key at all: the credential is a pst_ session
+// token, minted per browser session and scoped by the relay to the five routes
+// a transfer walks. The manual card below is the self-host path, and it is the
+// only one that still holds a pgp_ key.
+//
+// The two paths share everything after the credential: find a sector that
+// accepts the account, and report the result without holding the button
+// hostage to a sector that will not answer.
+async function discoverAndReport() {
+  setStatus('key-status', 'Checking...');
+  updateBtn();
+  let d;
+  try {
+    d = await discoverRelay();
+  } catch (e) {
+    d = { answered: false, rejected: false, found: null };
+  }
+  if (d.found) {
+    RELAY_API = d.found.url;
+    relayReady = true;
+    const sectorLabel = d.found.sector !== 'health' ? ` · ${d.found.sector}` : '';
+    setStatus('key-status', `✓ Valid, plan: ${d.found.plan}${sectorLabel}`, 'ok');
+  } else if (d.rejected) {
+    // A sector answered and said no. On the session path that is a verdict on
+    // the account, not on anything the sender typed, so it is not called a bad
+    // key: there is no key here to be bad.
+    setStatus('key-status', sessionAuth ? 'This account is not active on any relay sector' : 'Invalid or revoked key', 'err');
+    keyValid = false;
+  } else {
+    // Nothing answered. Say so where the user is looking, and let the button
+    // stay live: the failure belongs at the press, with a reason attached.
+    relayError = 'No relay sector answered. Check your connection and press Create secure session again.';
+    setStatus('key-status', 'Could not reach a relay sector. You can still continue.', 'err');
+  }
+  updateBtn();
+}
+
+// The session path: a token is already in hand, so there is nothing to check
+// about its shape and the sector question is the only one left.
+async function useSessionToken() {
+  apiKey = '';
+  keyValid = true; relayReady = false; relayError = '';
+  await discoverAndReport();
+}
+
+// The manual card, for a self-hosted relay with no token endpoint. Typing a key
+// takes over from the session token; expandApiKeyCard has already dropped it,
+// and this drops it again for the case where the box was filled another way.
 async function onKeyInput() {
+  sessionAuth = ''; sessionAuthExp = 0; sessionAuthPending = null;
   apiKey = $('api-key').value.trim();
   setCreateStatus('');
   // An empty box has nothing wrong with it yet. Calling it invalid is what the
@@ -322,33 +470,8 @@ async function onKeyInput() {
     setStatus('key-status', 'That does not look like a key. It starts with pgp_.', 'err');
     keyValid = false; relayReady = false; relayError = ''; updateBtn(); return;
   }
-  // A well-formed key that came from the session is usable now. Whether a
-  // sector answers is a separate question, and it is answered below without
-  // holding the button hostage.
   keyValid = true; relayReady = false; relayError = '';
-  setStatus('key-status', 'Checking...');
-  updateBtn();
-  let d;
-  try {
-    d = await discoverRelay(apiKey);
-  } catch (e) {
-    d = { answered: false, rejected: false, found: null };
-  }
-  if (d.found) {
-    RELAY_API = d.found.url;
-    relayReady = true;
-    const sectorLabel = d.found.sector !== 'health' ? ` · ${d.found.sector}` : '';
-    setStatus('key-status', `✓ Valid, plan: ${d.found.plan}${sectorLabel}`, 'ok');
-  } else if (d.rejected) {
-    setStatus('key-status', 'Invalid or revoked key', 'err');
-    keyValid = false;
-  } else {
-    // Nothing answered. Say so where the user is looking, and let the button
-    // stay live: the failure belongs at the press, with a reason attached.
-    relayError = 'No relay sector answered. Check your connection and press Create secure session again.';
-    setStatus('key-status', 'Could not reach a relay sector. You can still continue.', 'err');
-  }
-  updateBtn();
+  await discoverAndReport();
 }
 
 function setCreateStatus(msg, cls) {
@@ -388,7 +511,11 @@ async function createSession() {
   // answer, say so out loud instead of going quiet.
   if (!relayReady) {
     setCreateStatus('Looking for a relay sector...');
-    await onKeyInput();
+    // The sector question only, not the credential question. Calling onKeyInput
+    // here would re-read the manual box, and on the session path that box is
+    // empty by design: the retry would throw away a working token and report a
+    // missing key instead of a missing sector.
+    await discoverAndReport();
     if (!relayReady) {
       // relayError is the planned sentence. Reaching here without one is a state
       // we did not plan for, so it gets the page's one sentence for that.
@@ -417,7 +544,7 @@ async function connectWebSocket() {
   try {
     // Ticket must come from the same relay host the WS connects to (relay-main)
     const wsHttpBase = RELAY_WS.replace('wss://', 'https://').replace('ws://', 'http://');
-    const tr = await fetch(`${wsHttpBase}/v2/ws-ticket`, {method:'POST',headers:{'X-Api-Key':apiKey},signal:AbortSignal.timeout(5000)});
+    const tr = await relayFetch(`${wsHttpBase}/v2/ws-ticket`, {method:'POST',signal:AbortSignal.timeout(5000)});
     if (tr.ok) { const td = await tr.json(); if (td.ticket) wsUrl += '?ticket=' + encodeURIComponent(td.ticket); }
   } catch {}
   ws = new WebSocket(wsUrl);
@@ -433,7 +560,7 @@ async function connectWebSocket() {
   if (pubkeyPoll) clearInterval(pubkeyPoll);
   pubkeyPoll = setInterval(async () => {
     try {
-      const r = await fetch(`${RELAY_API}/v2/pubkey/${encodeURIComponent(sessionToken)}`, { headers: { 'X-Api-Key': apiKey }, signal: AbortSignal.timeout(3000) });
+      const r = await relayFetch(`${RELAY_API}/v2/pubkey/${encodeURIComponent(sessionToken)}`, { signal: AbortSignal.timeout(3000) });
       if (r.ok) {
         const d = await r.json();
         if (d.kyber_pub && d.ecdh_pub) {
@@ -550,9 +677,9 @@ async function confirmFingerprint() {
         const hashBuf = await crypto.subtle.digest('SHA-256', padded);
         const hash = u8toHex(new Uint8Array(hashBuf));
 
-        const ur = await fetch(RELAY_API + '/v2/inbound', {
+        const ur = await relayFetch(RELAY_API + '/v2/inbound', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-Api-Key': apiKey },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             hash, payload: toB64(padded), ttl_ms: ttlMs,
             // file_name omitted — filename is only in the encrypted payload (finding #4)
@@ -584,9 +711,9 @@ async function confirmFingerprint() {
     $('enc-status').textContent = 'Notifying receiver...';
 
     const isVault = files.length > 1;
-    await fetch(RELAY_API + '/v2/pubkey', {
+    await relayFetch(RELAY_API + '/v2/pubkey', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-Api-Key': apiKey },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         device_id: sessionToken + '_ready',
         ecdh_pub: isVault ? JSON.stringify(vaultFiles) : vaultFiles[0].tokens.join(','),
@@ -708,56 +835,37 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  loadAccountKey();
+  loadSessionCredential();
   // Small delay so DOM is fully painted before Globe.gl reads dimensions
   setTimeout(() => initGlobe(), 400);
 });
 
-// The session is the only source of the key. localStorage used to be a second
-// one, and it is what the buyer review caught: a stale or hand-typed key sat
-// there, the slim row said "using your account key", and Send died on a key
-// that belonged to nobody. One source, one failure mode, one banner.
-async function fetchAccountKey() {
-  let r = await fetch('/api/user/account/key', { credentials: 'include' });
-  // nginx rate-limits /api/user/ (zone relay_auth, burst 5). A 429 here is the
-  // page arriving next to its own siblings, not a broken account, so it earns
-  // exactly one retry and then gives up.
-  if (r.status === 429) {
-    await new Promise(res => setTimeout(res, KEY_RETRY_MS));
-    r = await fetch('/api/user/account/key', { credentials: 'include' });
-  }
-  // Expected, and marked so: a browser with no session gets 401/403, and a
-  // self-host that never built this endpoint answers 404. Both mean "no key
-  // here", the banner is the whole answer, and neither is worth a line in the
-  // console of every signed-out visitor.
-  if (!r.ok) {
-    const noSession = new Error('account key: HTTP ' + r.status);
-    noSession.expected = r.status === 401 || r.status === 403 || r.status === 404;
-    throw noSession;
-  }
-  const d = await r.json();
-  if (!d || !d.api_key) {
-    const noKey = new Error('account key: none on this session');
-    noKey.expected = true;
-    throw noKey;
-  }
-  return d.api_key;
-}
-
-async function loadAccountKey() {
+// The session is the only source of the credential, and the credential is no
+// longer the account key. The page asks the admin for a pst_ session token; the
+// key stays on the server. What the buyer review caught first was a second
+// source of truth in localStorage, and what the security review caught after it
+// was the key itself: a credential with no expiry and no scope, held for the
+// life of the tab, readable by anything that got to run on the page. There is
+// one source, it hands over something that expires in fifteen minutes, and it
+// opens five routes.
+async function loadSessionCredential() {
   try {
-    const key = await fetchAccountKey();
-    $('api-key').value = key;
-    applySlimApiKeyView();
-    await onKeyInput();
+    const d = await fetchSessionToken();
+    sessionAuth = d.token;
+    sessionAuthExp = Date.now() + (d.expires_in_s || 0) * 1000;
+    // The slim row shows the token, masked, and not the key: there is no key
+    // here to show. The manual box stays empty, which is what makes the two
+    // credentials impossible to confuse.
+    applySlimApiKeyView(d.token);
+    await useSessionToken();
   } catch (e) {
     setKeyError(true);
     // The banner carries the sentence either way. Only the unplanned half gets
     // reported: a 500, or a fetch that never arrived. Reporting the planned half
     // would put a console error on every signed-out page load, which is both
     // noise and a false alarm for the heartbeat that reads that console.
-    if (!e || !e.expected) failureText('account key', e);
-    setStatus('key-status', 'Account key could not be loaded', 'err');
+    if (!e || !e.expected) failureText('session token', e);
+    setStatus('key-status', 'Account session could not be started', 'err');
     keyValid = false;
     updateBtn();
   }

--- a/frontend/js/parashare.page.js
+++ b/frontend/js/parashare.page.js
@@ -362,14 +362,19 @@ function refreshSessionAuth() {
 // made again. Once. A 401 that survives a fresh token is a real 401.
 async function relayFetch(url, opts) {
   opts = opts || {};
+  // A refresh already tried and failed on this call means minting is broken
+  // right now, and a 401 below is not something a second attempt will fix. Two
+  // mints per call, against an endpoint nginx allows a burst of five, is how a
+  // page turns one bad minute into a rate limit of its own.
+  var minted = true;
   if (sessionAuth && sessionAuthExp && Date.now() > sessionAuthExp - TOKEN_MARGIN_MS) {
-    await refreshSessionAuth();
+    minted = await refreshSessionAuth();
   }
   var send = {};
   for (var k in opts) if (Object.prototype.hasOwnProperty.call(opts, k) && k !== 'retried') send[k] = opts[k];
   send.headers = relayAuthHeaders(opts.headers);
   var r = await fetch(url, send);
-  if (r.status === 401 && sessionAuth && !opts.retried) {
+  if (r.status === 401 && sessionAuth && !opts.retried && minted) {
     if (await refreshSessionAuth()) {
       var again = {};
       for (var k2 in opts) if (Object.prototype.hasOwnProperty.call(opts, k2)) again[k2] = opts[k2];

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -45,7 +45,7 @@ h1{font-size:clamp(26px,5vw,38px);font-weight:600;letter-spacing:-.028em;line-he
 .ps-guide strong{color:var(--ink-1);font-weight:600}
 .ps-guide .ps-guide-kicker{display:block;font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-3);margin-bottom:5px;font-weight:600}
 
-/* The account key comes from the session and from nowhere else, so the slim row
+/* The credential comes from the session and from nowhere else, so the slim row
    is the DEFAULT state of step 1 and the manual card is the exception. It used
    to be the other way round: the card was the default and the slim row appeared
    only after a key had been fetched, which is why a signed-in sender was shown
@@ -70,7 +70,7 @@ h1{font-size:clamp(26px,5vw,38px);font-weight:600;letter-spacing:-.028em;line-he
 #step-setup.manual-key .ps-key-slim{display:none}
 
 /* One alert style, used by both places on this page where something can fail
-   in front of the user: the account key that will not load, and the relay
+   in front of the user: the account session that will not start, and the relay
    connection that drops while step 2 is waiting. Each says what happened, what
    the file is doing meanwhile, and offers the one action that helps. */
 .ps-alert{display:none;flex-direction:column;align-items:flex-start;gap:10px;margin-bottom:16px;padding:12px 14px;border:1px solid var(--line-2);border-left:3px solid var(--sig-stop);border-radius:var(--r-1);background:var(--sig-stop-bg);font:13px/1.62 var(--sans);color:var(--ink-1)}
@@ -466,13 +466,13 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
     <strong>Choose a file and say how long the link should live.</strong> The file stays on your own computer until step 4. We never hold it in a form we could open.
   </div>
 
-  <div class="ps-key-slim is-loading" id="ps-key-slim" aria-label="Account key">
-    <span class="ps-key-status"><span id="ps-key-slim-label">Loading your account key</span> <span class="ps-key-mask" id="ps-key-mask" hidden></span></span>
+  <div class="ps-key-slim is-loading" id="ps-key-slim" aria-label="Account session">
+    <span class="ps-key-status"><span id="ps-key-slim-label">Starting your account session</span> <span class="ps-key-mask" id="ps-key-mask" hidden></span></span>
     <button type="button" class="ps-key-change" data-click="expandApiKeyCard">Change</button>
   </div>
 
   <div class="ps-alert" id="ps-key-error" role="alert">
-    <p>Your account key could not be loaded. Sign in again; if it keeps happening, mail <a href="mailto:privacy@paramant.app">privacy@paramant.app</a>.</p>
+    <p>Your account session could not be started. Sign in again; if it keeps happening, mail <a href="mailto:privacy@paramant.app">privacy@paramant.app</a>.</p>
     <div class="ps-alert-actions">
       <a class="ps-alert-primary" href="/auth/login">Sign in again</a>
       <span class="ps-alert-secondary">
@@ -709,7 +709,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
      two different contents under one immutable url is exactly what the ?v= is
      there to prevent, and check-cache-bust cannot see it because both sides
      agree on the number. -->
-<script src="/js/parashare.page.js?v=6" defer></script>
+<script src="/js/parashare.page.js?v=7" defer></script>
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=7" defer></script>
 <footer>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -268,9 +268,16 @@ footer a{color:var(--ink);text-decoration:none}
 <li><strong>Passkey / WebAuthn credentials</strong>: your passkey&rsquo;s private key is created and held by your device or password manager. PARAMANT only ever stores its <em>public</em> key, server-side; the private key never leaves your device.</li>
 <li><strong>ParaSign signing vault</strong> (IndexedDB): if you sign documents, your post-quantum signing key (ML-DSA-65) is generated and kept in your browser&rsquo;s IndexedDB, encrypted either with your passkey (WebAuthn-PRF &rarr; HKDF &rarr; AES-256-GCM) or, if your passkey provider cannot do that, with a passphrase (PBKDF2 &rarr; AES-256-GCM). The private key never leaves your device; only its public half is registered to your account.</li>
 </ul>
-<p><strong>Your account key is not on that list, and it is not in your browser at all.</strong> Sending a file needs a credential, and the page is never given the API key that would be one. It asks our server for a <em>session token</em> instead. That token lives fifteen minutes, the relay accepts it on the five requests a transfer makes and refuses it on everything else, and it is held in the page&rsquo;s memory only: it is not written to local storage, so closing the tab ends it and there is nothing left for a later visit to find. Revoking your API key revokes every token minted from it. On a self-hosted relay without our admin panel you can still type a key by hand, and then it is in that browser for as long as the tab is open, which is why the page says so where it offers that.</p>
-
 <p>You can delete all local data at any time: browser settings &rarr; paramant.app &rarr; Clear site data.</p>
+
+<h2>Your API key, and which pages hold it</h2>
+<p>Your account has an API key. It is stored on our servers; nothing in the list above keeps it in your browser, and no page writes it to local storage. Some pages do load it into memory for as long as their tab is open, and we would rather name them than leave you to guess.</p>
+<ul>
+<li><strong>Sending a file (<code>/parashare</code>) does not.</strong> It asks our server for a <em>session token</em> instead. That token lives fifteen minutes, the relay accepts it on the five requests a transfer makes and refuses it on everything else, and it is held in the page&rsquo;s memory only, so closing the tab ends it. Revoking your API key revokes every token minted from it. On a self-hosted relay without our admin panel you can still type a key by hand on that page, and then it is in that browser for as long as the tab is open, which is why the page says so where it offers it.</li>
+<li><strong>Your account page (<code>/account</code>) does</strong>, on purpose: showing you your key is what the page is for.</li>
+<li><strong>The pricing and dashboard pages (<code>/pricing</code>, <code>/dashboard</code>) do</strong>, because they still authenticate to the relay with the key itself to start a checkout and to read your usage. We are moving them to the same kind of scoped token; until we have, a tab on either of those pages holds the key in memory.</li>
+</ul>
+<p>Nothing on this list survives the tab. Closing the page ends it, and a later visit starts again from the server.</p>
 
 <h2>Servers &amp; jurisdiction</h2>
 <p>All relay servers run on <strong>Hetzner</strong> infrastructure in <strong>Nuremberg, Germany (EU/DE)</strong>. There is no infrastructure in the United States or outside the EU. No CLOUD Act exposure. All data is subject to EU/GDPR jurisdiction only.</p>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -268,6 +268,8 @@ footer a{color:var(--ink);text-decoration:none}
 <li><strong>Passkey / WebAuthn credentials</strong>: your passkey&rsquo;s private key is created and held by your device or password manager. PARAMANT only ever stores its <em>public</em> key, server-side; the private key never leaves your device.</li>
 <li><strong>ParaSign signing vault</strong> (IndexedDB): if you sign documents, your post-quantum signing key (ML-DSA-65) is generated and kept in your browser&rsquo;s IndexedDB, encrypted either with your passkey (WebAuthn-PRF &rarr; HKDF &rarr; AES-256-GCM) or, if your passkey provider cannot do that, with a passphrase (PBKDF2 &rarr; AES-256-GCM). The private key never leaves your device; only its public half is registered to your account.</li>
 </ul>
+<p><strong>Your account key is not on that list, and it is not in your browser at all.</strong> Sending a file needs a credential, and the page is never given the API key that would be one. It asks our server for a <em>session token</em> instead. That token lives fifteen minutes, the relay accepts it on the five requests a transfer makes and refuses it on everything else, and it is held in the page&rsquo;s memory only: it is not written to local storage, so closing the tab ends it and there is nothing left for a later visit to find. Revoking your API key revokes every token minted from it. On a self-hosted relay without our admin panel you can still type a key by hand, and then it is in that browser for as long as the tab is open, which is why the page says so where it offers that.</p>
+
 <p>You can delete all local data at any time: browser settings &rarr; paramant.app &rarr; Clear site data.</p>
 
 <h2>Servers &amp; jurisdiction</h2>

--- a/relay/lib/session-token.js
+++ b/relay/lib/session-token.js
@@ -1,0 +1,169 @@
+'use strict';
+// ParaSend session tokens (pst_): a narrow, short-lived stand-in for an account
+// api-key, so /parashare never has to hold a pgp_ key in the browser.
+//
+// WHAT PROBLEM THIS SOLVES. Until now the ParaSend page fetched the account's
+// real api-key from GET /api/user/account/key and kept it in a variable for the
+// life of the tab. That is a full data-plane credential with no expiry: any
+// script that got to run on the page could read it, and then keep it. The
+// security review of #397 said as much, and this is the answer it named. The
+// page now asks the admin for a pst_ token, the token lives fifteen minutes,
+// and it opens only the five routes a transfer actually walks. The XSS ceiling
+// drops from "a key, forever" to "these five routes, for fifteen minutes".
+//
+// WHY REDIS AND NOT A MAP. The five sector relays are separate processes behind
+// one shared redis (docker-compose.yml). A Map would mint on health and be
+// unknown on legal, and the page discovers its sector at run time, so the token
+// has to live where all five can see it.
+//
+// This module is the decision layer, with the redis client injected, so every
+// rule below is unit-testable without a relay: relay/test/session-token.test.js
+// covers it against a fake store, relay/test/route-session-token.test.js drives
+// the real thing over HTTP.
+
+const crypto = require('crypto');
+
+// Fifteen minutes. Long enough for a sender to pick a file, compare a
+// fingerprint and upload it; short enough that a stolen token is a window and
+// not a key. Not configurable on purpose: an operator who could set this to a
+// week would silently rebuild the credential this module exists to remove.
+const TTL_S = 900;
+
+const PREFIX = 'pst_';
+// 32 bytes of CSPRNG, hex. The shape is pinned here rather than guessed at the
+// call sites, so a malformed Authorization header is refused before it ever
+// reaches the store.
+const TOKEN_RE = /^pst_[0-9a-f]{64}$/;
+
+// token -> owner record.
+const tokenKey = (token) => `paramant:pst:${token}`;
+// owner key -> the set of tokens minted for it, so a revocation can sweep them.
+// The owner key is hashed: redis keyspace listings, SCAN output and slowlog
+// entries all show key NAMES, and an api-key in a key name is an api-key in
+// every one of those places.
+const ownerKey = (key) =>
+  `paramant:pst:owner:${crypto.createHash('sha256').update(String(key)).digest('hex')}`;
+
+function isSessionToken(value) {
+  return typeof value === 'string' && TOKEN_RE.test(value);
+}
+
+// The token out of an Authorization header, or ''. Only the Bearer form is
+// unwrapped, and only when it is the whole header: `Bearer a b` is not a token.
+function bearerToken(header) {
+  if (typeof header !== 'string') return '';
+  const m = /^Bearer[ \t]+([^\s]+)$/i.exec(header.trim());
+  return m ? m[1] : '';
+}
+
+// ── Scope ────────────────────────────────────────────────────────────────────
+// An ALLOWLIST, deliberately, and the whole point of the feature. A pst_ token
+// is not a small api-key, it is a different credential that happens to
+// authenticate as the same account: it opens the five routes /parashare walks
+// and nothing else. Anything not named here is refused, including routes that
+// do not exist yet, which is what keeps this list honest as relay.js grows.
+//
+// What is NOT here, and why each absence matters:
+//   /v2/user/*      the account's own session surface (TOTP, signing keys,
+//                   document worklist). A token minted for a file transfer must
+//                   never be able to enrol a signing key.
+//   /v2/keys        anything that hands out or lists credentials.
+//   /v2/outbound    downloading is the receiver's half of the flow and needs no
+//                   account credential; letting a token do it would make a
+//                   stolen token a way to drain the account's blobs.
+//   /v2/audit       the account's history.
+//   /v2/admin/*     never, under any credential but ADMIN_TOKEN.
+//   /v2/session-token itself: a token may not mint another one, so the fifteen
+//                   minutes cannot be rolled forward from inside the browser.
+const SCOPE = [
+  // Sector discovery. The page races four sectors to find the one that accepts
+  // the account; the answer is valid/plan and nothing else.
+  { method: null, path: '/v2/check-key' },
+  // The one-time ticket for the signalling socket.
+  { method: 'POST', path: '/v2/ws-ticket' },
+  // Publishing the sender's half of the handshake, and reading the receiver's.
+  { method: 'POST', path: '/v2/pubkey' },
+  { method: 'GET', re: /^\/v2\/pubkey\/[^/]+$/ },
+  // The upload itself.
+  { method: 'POST', path: '/v2/inbound' },
+];
+
+function scopeAllows(method, path) {
+  const m = String(method || '').toUpperCase();
+  // A preflight carries no Authorization header, so it never gets here with a
+  // token; if one ever does, it is answered by the CORS handler, not by us.
+  if (m === 'OPTIONS') return true;
+  return SCOPE.some((rule) => {
+    if (rule.method && rule.method !== m) return false;
+    return rule.re ? rule.re.test(path) : rule.path === path;
+  });
+}
+
+// ── Store ────────────────────────────────────────────────────────────────────
+
+// Mint a token for `owner` (an api-key). Returns { token, expires_ms,
+// expires_in_s }. Throws when there is no store: a token that cannot be written
+// must not be handed out, because the holder would then carry a credential no
+// relay can check.
+async function mint(redisClient, owner, now = Date.now()) {
+  if (!redisClient) throw new Error('session-token: no redis client');
+  if (!owner || typeof owner !== 'string') throw new Error('session-token: no owner key');
+  const token = PREFIX + crypto.randomBytes(32).toString('hex');
+  const expires_ms = now + TTL_S * 1000;
+  // exp is stored INSIDE the record as well as being the redis TTL. Redis is
+  // what expires it; the field is what catches a record that outlived its TTL
+  // through a restore, a replica lag or a hand-written key.
+  await redisClient.set(tokenKey(token), JSON.stringify({ key: owner, exp: expires_ms }), { EX: TTL_S });
+  // The sweep index. Its own TTL is the token's plus a minute, refreshed on
+  // every mint, so the set never outlives the last token it points at by more
+  // than that. Entries for tokens that already expired are harmless: the
+  // revocation deletes names, and deleting a name that is gone is a no-op.
+  await redisClient.sAdd(ownerKey(owner), token);
+  await redisClient.expire(ownerKey(owner), TTL_S + 60);
+  return { token, expires_ms, expires_in_s: TTL_S };
+}
+
+// The owner key a token stands for, or null. Null covers every refusal there
+// is: a malformed token, one that expired, one that was revoked, and one whose
+// record is not the shape this module writes. The caller cannot tell them
+// apart, and must not: that separation would be an oracle for guessing tokens.
+//
+// A redis failure is NOT null. It throws, and the route turns that into a 503,
+// because answering 401 on an outage would tell a legitimate holder their token
+// is bad and send them to re-authenticate over a store that is merely down.
+async function resolve(redisClient, token, now = Date.now()) {
+  if (!isSessionToken(token)) return null;
+  if (!redisClient) throw new Error('session-token: no redis client');
+  const raw = await redisClient.get(tokenKey(token));
+  if (!raw) return null;
+  let rec;
+  try { rec = JSON.parse(raw); } catch (_) { return null; }
+  if (!rec || typeof rec.key !== 'string' || !rec.key) return null;
+  if (typeof rec.exp === 'number' && now > rec.exp) return null;
+  return { key: rec.key, expires_ms: typeof rec.exp === 'number' ? rec.exp : null };
+}
+
+// Every live token for one api-key, gone. Called when the key is revoked.
+//
+// This is belt AND braces, and both halves are load-bearing. The braces are
+// here: the tokens are deleted, so they stop resolving on every sector at once.
+// The belt is in relay.js: a resolved token is looked up in apiKeys like any
+// other credential, so a token whose owner is no longer an active key yields no
+// principal even if this sweep never ran (a sector that was restarting, a redis
+// that was briefly unreachable). Neither alone is enough; a revocation that
+// depends on a best-effort write is not a revocation.
+async function revokeForKey(redisClient, owner) {
+  if (!redisClient || !owner) return 0;
+  const idx = ownerKey(owner);
+  const tokens = await redisClient.sMembers(idx);
+  if (tokens && tokens.length) await redisClient.del(tokens.map(tokenKey));
+  await redisClient.del(idx);
+  return (tokens || []).length;
+}
+
+module.exports = {
+  TTL_S, PREFIX, SCOPE,
+  isSessionToken, bearerToken, scopeAllows,
+  mint, resolve, revokeForKey,
+  tokenKey, ownerKey,
+};

--- a/relay/lib/session-token.js
+++ b/relay/lib/session-token.js
@@ -30,19 +30,41 @@ const crypto = require('crypto');
 const TTL_S = 900;
 
 const PREFIX = 'pst_';
+// At most this many live tokens per account. A ceiling, not a rate limit: the
+// page mints one per load and one per refresh, so twenty is far above any
+// honest use, and it stops a signed-in session (or a script inside one) from
+// turning the mint route into an unbounded credential factory. The index is
+// pruned before the cap is believed, so nobody is refused because of tokens
+// redis has already expired.
+const MAX_LIVE_PER_ACCOUNT = 20;
 // 32 bytes of CSPRNG, hex. The shape is pinned here rather than guessed at the
 // call sites, so a malformed Authorization header is refused before it ever
 // reaches the store.
 const TOKEN_RE = /^pst_[0-9a-f]{64}$/;
 
+// SHA-256 of an api-key, hex. The ONE way an owner is named anywhere in this
+// module: in the redis key names AND in the record body.
+//
+// WHY THE BODY TOO. The key names were hashed from the start, because SCAN
+// output, keyspace listings and the slowlog all show names. The VALUE was the
+// api-key in the clear, which meant an RDB snapshot, a replica, a backup on
+// someone's laptop or a MONITOR session carried live pgp_ credentials for every
+// account that had sent a file in the last fifteen minutes. A read-only leak of
+// the store is now a leak of hashes: to use one you would have to already hold
+// the key it is a hash of.
+//
+// Preimage resistance is not what does the work here, and it should not have
+// to: an api-key is 32 random bytes, so the hash is not guessable, but the real
+// property is that the relay resolves a hash by looking it up in the api-key
+// table it already has in memory. Nothing derives a key from a hash. Anyone
+// without that table has a hash and nothing else.
+const keyHash = (key) => crypto.createHash('sha256').update(String(key)).digest('hex');
+const HASH_RE = /^[0-9a-f]{64}$/;
+
 // token -> owner record.
 const tokenKey = (token) => `paramant:pst:${token}`;
 // owner key -> the set of tokens minted for it, so a revocation can sweep them.
-// The owner key is hashed: redis keyspace listings, SCAN output and slowlog
-// entries all show key NAMES, and an api-key in a key name is an api-key in
-// every one of those places.
-const ownerKey = (key) =>
-  `paramant:pst:owner:${crypto.createHash('sha256').update(String(key)).digest('hex')}`;
+const ownerKey = (key) => `paramant:pst:owner:${keyHash(key)}`;
 
 function isSessionToken(value) {
   return typeof value === 'string' && TOKEN_RE.test(value);
@@ -101,46 +123,92 @@ function scopeAllows(method, path) {
 
 // ── Store ────────────────────────────────────────────────────────────────────
 
+// Drop the names of tokens redis has already expired from an owner index, and
+// return how many are really live. The index is a set of NAMES; redis expires
+// the records those names point at, not the names, so the set drifts upward
+// until something looks. Only the cap below looks, and only when it is about to
+// refuse, so this costs nothing on the ordinary path.
+async function pruneOwnerIndex(redisClient, idx) {
+  const names = await redisClient.sMembers(idx);
+  if (!names || !names.length) return 0;
+  const alive = await Promise.all(names.map((n) => redisClient.exists(tokenKey(n))));
+  const dead = names.filter((_, i) => !alive[i]);
+  if (dead.length) await redisClient.sRem(idx, dead);
+  return names.length - dead.length;
+}
+
 // Mint a token for `owner` (an api-key). Returns { token, expires_ms,
-// expires_in_s }. Throws when there is no store: a token that cannot be written
-// must not be handed out, because the holder would then carry a credential no
-// relay can check.
+// expires_in_s }, or { capped: true, live, cap } when the account already holds
+// the maximum number of live tokens. Throws when there is no store: a token
+// that cannot be written must not be handed out, because the holder would then
+// carry a credential no relay can check.
 async function mint(redisClient, owner, now = Date.now()) {
   if (!redisClient) throw new Error('session-token: no redis client');
   if (!owner || typeof owner !== 'string') throw new Error('session-token: no owner key');
+  const idx = ownerKey(owner);
+
+  // The ceiling. sCard first because it is one round trip and almost always
+  // under the cap; the prune runs only when the cheap count says we are about
+  // to refuse, so a refusal is never made on the strength of dead names.
+  let live = await redisClient.sCard(idx);
+  if (live >= MAX_LIVE_PER_ACCOUNT) {
+    live = await pruneOwnerIndex(redisClient, idx);
+    if (live >= MAX_LIVE_PER_ACCOUNT) {
+      return { capped: true, live, cap: MAX_LIVE_PER_ACCOUNT };
+    }
+  }
+
   const token = PREFIX + crypto.randomBytes(32).toString('hex');
   const expires_ms = now + TTL_S * 1000;
-  // exp is stored INSIDE the record as well as being the redis TTL. Redis is
-  // what expires it; the field is what catches a record that outlived its TTL
-  // through a restore, a replica lag or a hand-written key.
-  await redisClient.set(tokenKey(token), JSON.stringify({ key: owner, exp: expires_ms }), { EX: TTL_S });
+  // The owner is named by HASH, never in the clear: see keyHash above for why
+  // the value matters as much as the key name. exp is stored inside the record
+  // as well as being the redis TTL. Redis is what expires it; the field is what
+  // catches a record that outlived its TTL through a restore, a replica lag or
+  // a hand-written key.
+  await redisClient.set(tokenKey(token), JSON.stringify({ kh: keyHash(owner), exp: expires_ms }), { EX: TTL_S });
   // The sweep index. Its own TTL is the token's plus a minute, refreshed on
   // every mint, so the set never outlives the last token it points at by more
-  // than that. Entries for tokens that already expired are harmless: the
-  // revocation deletes names, and deleting a name that is gone is a no-op.
-  await redisClient.sAdd(ownerKey(owner), token);
-  await redisClient.expire(ownerKey(owner), TTL_S + 60);
+  // than that.
+  await redisClient.sAdd(idx, token);
+  await redisClient.expire(idx, TTL_S + 60);
   return { token, expires_ms, expires_in_s: TTL_S };
 }
 
 // The owner key a token stands for, or null. Null covers every refusal there
-// is: a malformed token, one that expired, one that was revoked, and one whose
-// record is not the shape this module writes. The caller cannot tell them
-// apart, and must not: that separation would be an oracle for guessing tokens.
+// is: a malformed token, one that expired, one that was revoked, one whose
+// record is not the shape this module writes, and one whose owner hash no
+// longer resolves to a key. The caller cannot tell them apart, and must not:
+// that separation would be an oracle for guessing tokens.
+//
+// `resolveOwner` turns the stored hash back into the api-key. It is injected,
+// and in relay.js it is a lookup in the api-key table already in memory. That
+// is the whole reason hashing the record is free: nothing derives a key from a
+// hash, it is looked up in a table only the relay has.
+//
+// EXP IS REQUIRED. A record with no exp, or an exp that is not a number, is
+// refused. It used to be optional, checked with a typeof, so a record that
+// somehow lost the field fell back to whatever TTL redis had on it, and one
+// written by hand with no field at all never expired on the wall clock at all.
+// A credential whose lifetime is a property of the store alone has no lifetime
+// when the store is wrong.
 //
 // A redis failure is NOT null. It throws, and the route turns that into a 503,
 // because answering 401 on an outage would tell a legitimate holder their token
 // is bad and send them to re-authenticate over a store that is merely down.
-async function resolve(redisClient, token, now = Date.now()) {
+async function resolve(redisClient, token, resolveOwner, now = Date.now()) {
   if (!isSessionToken(token)) return null;
   if (!redisClient) throw new Error('session-token: no redis client');
+  if (typeof resolveOwner !== 'function') throw new Error('session-token: no owner resolver');
   const raw = await redisClient.get(tokenKey(token));
   if (!raw) return null;
   let rec;
   try { rec = JSON.parse(raw); } catch (_) { return null; }
-  if (!rec || typeof rec.key !== 'string' || !rec.key) return null;
-  if (typeof rec.exp === 'number' && now > rec.exp) return null;
-  return { key: rec.key, expires_ms: typeof rec.exp === 'number' ? rec.exp : null };
+  if (!rec || typeof rec.kh !== 'string' || !HASH_RE.test(rec.kh)) return null;
+  if (typeof rec.exp !== 'number' || !Number.isFinite(rec.exp)) return null;
+  if (now > rec.exp) return null;
+  const key = resolveOwner(rec.kh);
+  if (!key || typeof key !== 'string') return null;
+  return { key, expires_ms: rec.exp };
 }
 
 // Every live token for one api-key, gone. Called when the key is revoked.
@@ -162,8 +230,8 @@ async function revokeForKey(redisClient, owner) {
 }
 
 module.exports = {
-  TTL_S, PREFIX, SCOPE,
-  isSessionToken, bearerToken, scopeAllows,
-  mint, resolve, revokeForKey,
+  TTL_S, PREFIX, SCOPE, MAX_LIVE_PER_ACCOUNT,
+  isSessionToken, bearerToken, scopeAllows, keyHash,
+  mint, resolve, revokeForKey, pruneOwnerIndex,
   tokenKey, ownerKey,
 };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -33,6 +33,7 @@ const redisCounter  = require('./lib/redis-counter');   // INCR that always carr
 const rateLimit     = require('./lib/rate-limit');
 const authThrottle  = require('./lib/auth-throttle');
 const authGate      = require('./lib/auth-gate');
+const sessionTokens = require('./lib/session-token'); // pst_ ParaSend session tokens
 const userSigning   = require('./lib/user-signing');
 const userWebauthn  = require('./lib/user-webauthn');
 const tiers         = require('./lib/tiers');
@@ -210,7 +211,7 @@ const ALLOWED = {
                '/v2/webhook','/v2/audit','/v2/check-key','/v2/stream',
                '/v2/ack','/v2/monitor',
                '/v2/did','/v2/ct','/v2/attest','/v2/admin','/metrics','/v2/dl',
-               '/v2/key-sector','/v2/team','/v2/reload-users','/v2/session',
+               '/v2/key-sector','/v2/team','/v2/reload-users','/v2/session','/v2/session-token',
                '/v2/ws-ticket','/v2/fingerprint','/v2/relays','/v2/sign-dpa',
                '/v2/sth','/v2/verify-receipt','/v2/transfers','/v2/capabilities','/v2/health','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
                '/v2/sign','/v2/verify','/v2/lookup-signer','/v2/envelopes','/v2/billing','/v2/claim','/v2/parasign','/v1'],
@@ -218,7 +219,7 @@ const ALLOWED = {
                '/v2/webhook','/v2/audit','/v2/check-key','/v2/stream','/v2/stream-next',
                '/v2/ack','/v2/monitor',
                '/v2/did','/v2/ct','/v2/attest','/v2/admin','/metrics','/v2/dl',
-               '/v2/key-sector','/v2/team','/v2/reload-users','/v2/session',
+               '/v2/key-sector','/v2/team','/v2/reload-users','/v2/session','/v2/session-token',
                '/v2/relays','/v2/sign-dpa','/v2/sth','/v2/verify-receipt','/v2/transfers',
                '/v2/capabilities','/v2/health','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
                '/v2/sign','/v2/verify','/v2/lookup-signer','/v2/envelopes','/v2/billing','/v2/claim','/v2/parasign','/v1'],
@@ -2485,7 +2486,13 @@ async function handleRelayRequest(req, res) {
   const parsed  = url_.parse(req.url, true);
   const path    = parsed.pathname;
   const query   = parsed.query;
-  const apiKey  = (req.headers['x-api-key'] || '').trim();
+  // `let`, not `const`: a ParaSend session token (pst_) resolves BELOW into the
+  // api-key it was minted for, and everything downstream -- acctOf, the audit
+  // chain, the device queues, the quota gates -- then behaves exactly as it
+  // would for a request that carried that key itself. That identity is the
+  // point: a token is a narrower way to present the same account, never a
+  // second account with a history of its own.
+  let apiKey = (req.headers['x-api-key'] || '').trim();
   // Reject any request that passes the API key as a query-string parameter.
   // Query strings appear in server logs, browser history, and proxy access logs.
   if (query.k) {
@@ -2502,6 +2509,34 @@ async function handleRelayRequest(req, res) {
   if (!apiKey && didHeader && didSig) {
     didAuthEntry = authByDid(didHeader, didSig, { method: req.method, url: req.url, ts: didTs, nonce: didNonce });
     if (didAuthEntry) log('info', 'did_auth_mode', { did: didHeader.slice(0,30) });
+  }
+  // ── ParaSend session token (Authorization: Bearer pst_...) ─────────────────
+  // Only when no X-Api-Key was sent: a request that carries a real key is that
+  // key's request, and a token may never widen or narrow it. The token resolves
+  // to the api-key it was minted for; from here on the request IS that key's,
+  // with one difference, enforced a few lines down: the scope allowlist.
+  //
+  // The refusals are all silent by design. A bad token yields no principal and
+  // the ordinary 401 gate answers it, the same 401 an unknown api-key gets, so
+  // nothing here separates "no such token" from "expired" from "revoked".
+  //
+  // Redis down is NOT a refusal. Without a store no token can be checked, and
+  // answering 401 would tell a legitimate holder their credential is bad. It is
+  // a 503, so the browser retries instead of throwing the sender back to login.
+  const _bearer = sessionTokens.bearerToken(req.headers['authorization'] || '');
+  let viaSessionToken = false;
+  if (!apiKey && sessionTokens.isSessionToken(_bearer)) {
+    if (!redisClient) {
+      res.writeHead(503, { 'Content-Type': 'application/json', 'Retry-After': '5' });
+      return res.end(J({ error: 'redis_unavailable', hint: 'session tokens need the relay store' }));
+    }
+    try {
+      const _pst = await sessionTokens.resolve(redisClient, _bearer);
+      if (_pst) { apiKey = _pst.key; viaSessionToken = true; }
+    } catch (err) {
+      if (redisOutage503(err, res)) return;
+      throw err;
+    }
   }
   const dsaSig  = req.headers['x-dsa-signature'] || '';
   // DID-auth NEVER mints its own principal. A DID only authenticates as the API
@@ -2546,6 +2581,25 @@ async function handleRelayRequest(req, res) {
     return res.end(J({ ok: true, relay: SECTOR, version: VERSION, status: 'operational', protocol: 'ghost-pipe-v2', docs: 'https://paramant.app/docs' }));
   }
   if (!modeAllows(path)) { res.writeHead(405); return res.end(J({ error: 'Not available in this relay mode', mode: RELAY_MODE })); }
+
+  // ── The scope of a ParaSend session token ──────────────────────────────────
+  // Here, and not inside the five routes it opens. A gate that each route had
+  // to remember to call is a gate that the sixty-ninth route forgets, and the
+  // whole value of this credential is that it is provably narrower than an
+  // api-key. So it sits above every route comparison in this function: an
+  // allowlist, checked once, with no way past it.
+  //
+  // 403 rather than 401 on purpose. The token is real and the account is real;
+  // what is missing is authority for THIS route, and a 401 would send the page
+  // off to mint a replacement that would be refused in exactly the same way.
+  if (viaSessionToken && !sessionTokens.scopeAllows(req.method, path)) {
+    log('warn', 'session_token_out_of_scope', { method: req.method, path });
+    res.writeHead(403, { 'Content-Type': 'application/json' });
+    return res.end(J({
+      error: 'session_token_out_of_scope',
+      hint: 'a pst_ session token opens the ParaSend transfer routes only; use an API key for anything else',
+    }));
+  }
 
   // ── Code-transparency manifest: publiek leesbaar, vóór de /v1-Bearer-gate ───
   // The SHA3-256 inventory of the deployed frontend, CT-anchored on publish.
@@ -2922,6 +2976,56 @@ async function handleRelayRequest(req, res) {
   function _internalReject() {
     res.writeHead(401, { "Content-Type": "application/json" });
     res.end(J({ error: "unauthorized" }));
+  }
+
+  // ── POST /v2/session-token: mint a ParaSend session token ──────────────────
+  // Called by the admin panel on behalf of a logged-in user, never by a
+  // browser. Two credentials have to line up:
+  //
+  //   X-Internal-Auth   the admin plane speaking, same gate as every /v2/user/*
+  //                     route. Not configured means closed (auth-gate treats a
+  //                     missing token as closed), like every internal endpoint.
+  //   X-Api-Key         the account the token will speak for. The admin sends
+  //                     the session's own key through proxyApiKey(), so the
+  //                     browser never gets to name an account: it can only ever
+  //                     be handed a token for the account it is signed in as.
+  //
+  // A token may not mint another token. It cannot reach here anyway -- the
+  // scope allowlist refuses this path far above -- but the check is written out
+  // rather than inferred, because "an unreachable path" is a property of code
+  // somewhere else and this is the line that must not be wrong.
+  if (req.method === 'POST' && path === '/v2/session-token') {
+    if (!_internalOk()) return _internalReject();
+    if (viaSessionToken) {
+      res.writeHead(403, { 'Content-Type': 'application/json' });
+      return res.end(J({ error: 'session_token_out_of_scope', hint: 'a session token cannot mint another one' }));
+    }
+    const owner = apiKeys.get(apiKey);
+    if (!owner || !owner.active) {
+      res.writeHead(401, { 'Content-Type': 'application/json' });
+      return res.end(J({ error: 'Invalid API key', hint: 'X-Api-Key: pgp_...' }));
+    }
+    if (!redisClient) {
+      res.writeHead(503, { 'Content-Type': 'application/json', 'Retry-After': '5' });
+      return res.end(J({ error: 'redis_unavailable', hint: 'session tokens need the relay store' }));
+    }
+    try {
+      const minted = await sessionTokens.mint(redisClient, apiKey);
+      log('info', 'session_token_minted', {
+        account: String(owner.account_id || apiKey).slice(0, 12),
+        ttl_s: minted.expires_in_s,
+      });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(J({
+        ok: true,
+        token: minted.token,
+        expires_ms: minted.expires_ms,
+        expires_in_s: minted.expires_in_s,
+      }));
+    } catch (err) {
+      if (redisOutage503(err, res)) return;
+      throw err;
+    }
   }
 
   // POST /v2/user/setup-totp
@@ -5584,6 +5688,18 @@ async function handleRelayRequest(req, res) {
         ud.updated = new Date().toISOString();
       }).then(() => log('info', 'key_revoked_via_admin', { key: revokedKey.slice(0,16), persisted: true }))
         .catch(we => log('warn', 'key_revoke_persist_failed', { err: we.message }));
+      // Every live ParaSend session token for this key, gone from the shared
+      // store, so the other four sectors stop honouring them too. Not awaited:
+      // the revocation itself is already done above (the key is inactive in
+      // this process and being persisted), and a slow redis must not hold up
+      // the answer. It is also not the only thing standing between a revoked
+      // key and a live token -- a resolved token is looked up in apiKeys like
+      // any other credential, so this sweep is the fast path, not the guarantee.
+      if (redisClient) {
+        sessionTokens.revokeForKey(redisClient, revokedKey)
+          .then(n => { if (n) log('info', 'session_tokens_revoked', { key: revokedKey.slice(0, 16), count: n }); })
+          .catch(e => log('warn', 'session_token_revoke_failed', { err: e.message }));
+      }
       // Fix 12: close active WebSocket connections for the revoked key
       const revokedWsClients = wsClients.get(revokedKey);
       if (revokedWsClients) {

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1340,6 +1340,37 @@ const apiKeys    = new Map();  // key → {plan, active, label, dsa_pub, account
 const accounts   = new Map();  // account_id → {account_id, plan, email, primary_api_key, label}  (stap 1: account_id == key)
 const accountKeys = new Map(); // account_id → Set<api_key>  (reverse index for per-account cap + listing)
 const kidIndex   = new Map();  // kid → api_key  (non-secret key id for URLs/listings)
+// sha256(api_key) → api_key. A ParaSend session-token record names its owner by
+// hash, never in the clear, so a read-only leak of the store (an RDB snapshot,
+// a replica, a backup, a MONITOR session) carries no live pgp_ key. This map is
+// the way back, and it exists only in this process's memory: nothing derives a
+// key from a hash, it is looked up in the table the relay already has.
+const apiKeyByHash = new Map();
+let _hashIndexBuiltAt = 0;
+function rebuildApiKeyHashIndex() {
+  apiKeyByHash.clear();
+  for (const k of apiKeys.keys()) apiKeyByHash.set(sessionTokens.keyHash(k), k);
+  _hashIndexBuiltAt = Date.now();
+  return apiKeyByHash.size;
+}
+// Resolve a hash, self-healing. The index is rebuilt on load and on
+// /v2/reload-users, which is where the table normally changes, but keys are
+// also created at run time (/v2/admin/keys, team keys, the claim flow) without
+// going through either. So a miss rebuilds and asks again, and a hit is checked
+// against apiKeys, which means a stale entry can never resolve to a key that is
+// gone. The rebuild is bounded: it runs when the table changed size, and
+// otherwise at most once a second, so a flood of invented hashes cannot turn a
+// lookup into a full scan per request.
+function apiKeyFromHash(hash) {
+  const hit = apiKeyByHash.get(hash);
+  if (hit && apiKeys.has(hit)) return hit;
+  if (apiKeyByHash.size !== apiKeys.size || Date.now() - _hashIndexBuiltAt > 1000) {
+    rebuildApiKeyHashIndex();
+    const again = apiKeyByHash.get(hash);
+    if (again && apiKeys.has(again)) return again;
+  }
+  return null;
+}
 // Resolve a key to its account_id. For every loaded key account_id is preset
 // (stap 1); for a legacy 1:1 key account_id === apiKey, so device/pubkey/webhook
 // keys built from acctOf(apiKey) are byte-identical to the old apiKey-scoped
@@ -2085,7 +2116,7 @@ function mintParasignKey(accountId, opts = {}) {
 
 function loadUsers() {
   if (process.env.USERS_JSON) {
-    try { const d = JSON.parse(process.env.USERS_JSON); (d.api_keys||[]).forEach(k => { if(k.active) apiKeys.set(k.key,{plan:k.plan,label:k.label||"",email:k.email||"",active:true,created:k.created||null,...keysTable.parseAccountFields(k)}); }); keysTable.rebuildKeyIndexes(apiKeys,accounts,accountKeys,kidIndex,log); log("info","users_loaded",{count:apiKeys.size,source:"env"}); return; } catch(e) { log("error","users_json_parse",{err:e.message}); }
+    try { const d = JSON.parse(process.env.USERS_JSON); (d.api_keys||[]).forEach(k => { if(k.active) apiKeys.set(k.key,{plan:k.plan,label:k.label||"",email:k.email||"",active:true,created:k.created||null,...keysTable.parseAccountFields(k)}); }); keysTable.rebuildKeyIndexes(apiKeys,accounts,accountKeys,kidIndex,log); rebuildApiKeyHashIndex(); log("info","users_loaded",{count:apiKeys.size,source:"env"}); return; } catch(e) { log("error","users_json_parse",{err:e.message}); }
   }
   try {
     const d = JSON.parse(fs.readFileSync(USERS_FILE, 'utf8'));
@@ -2101,6 +2132,7 @@ function loadUsers() {
       });
     });
     keysTable.rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex, log);
+    rebuildApiKeyHashIndex();
     log('info', 'users_loaded', { count: apiKeys.size, sector: SECTOR });
   } catch(e) { log('warn', 'no_users_file'); }
 }
@@ -2126,7 +2158,7 @@ function loadTrialKeys() {
         }
       } catch {}
     }
-    if (loaded > 0) { keysTable.rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex, log); log('info', 'trial_keys_loaded', { count: loaded }); }
+    if (loaded > 0) { keysTable.rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex, log); rebuildApiKeyHashIndex(); log('info', 'trial_keys_loaded', { count: loaded }); }
   } catch(e) { /* file may not exist yet */ }
 }
 
@@ -2531,7 +2563,7 @@ async function handleRelayRequest(req, res) {
       return res.end(J({ error: 'redis_unavailable', hint: 'session tokens need the relay store' }));
     }
     try {
-      const _pst = await sessionTokens.resolve(redisClient, _bearer);
+      const _pst = await sessionTokens.resolve(redisClient, _bearer, apiKeyFromHash);
       if (_pst) { apiKey = _pst.key; viaSessionToken = true; }
     } catch (err) {
       if (redisOutage503(err, res)) return;
@@ -3011,6 +3043,17 @@ async function handleRelayRequest(req, res) {
     }
     try {
       const minted = await sessionTokens.mint(redisClient, apiKey);
+      // The per-account ceiling. Twenty live tokens is far above any honest
+      // use of a page that mints one per load, so this is a signed-in session
+      // being used as a credential factory. 429 rather than 403: the account is
+      // fine and the answer changes on its own as the tokens expire.
+      if (minted.capped) {
+        log('warn', 'session_token_capped', {
+          account: String(owner.account_id || apiKey).slice(0, 12), live: minted.live, cap: minted.cap,
+        });
+        res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': '60' });
+        return res.end(J({ error: 'session_token_cap_reached', cap: minted.cap }));
+      }
       log('info', 'session_token_minted', {
         account: String(owner.account_id || apiKey).slice(0, 12),
         ttl_s: minted.expires_in_s,
@@ -4521,6 +4564,7 @@ async function handleRelayRequest(req, res) {
     apiKeys.clear();
     candidate.forEach((v, k) => apiKeys.set(k, v));
     keysTable.rebuildKeyIndexes(apiKeys, accounts, accountKeys, kidIndex, log);
+    rebuildApiKeyHashIndex();
 
     applyKeyLimitEnforcement();
     log('info', 'reload_users', { prev: prevCount, now: apiKeys.size, delta: apiKeys.size - prevCount });
@@ -5012,7 +5056,14 @@ async function handleRelayRequest(req, res) {
       const deviceId = meta?.device_id;
       incMetric('blobs_stored'); incMetric('bytes_in_total', blob.length);
       stats.inbound++; stats.bytes_in += blob.length;
-      auditAppend(apiKey, 'inbound', { hash: hash.slice(0,16)+'...', bytes: blob.length, device: deviceId, sig: sigResult.valid ? 'ML-DSA-OK' : 'unsigned' });
+      // `via` marks the credential, not a second identity. The chain is the
+      // owner's, keyed on the owner's api-key exactly as it is for a request
+      // that carried the key, and only the field says the fifteen-minute token
+      // was what presented it. Without it an account owner reading their own
+      // audit log cannot tell a transfer made from a browser session apart from
+      // one made with the key itself, which is the difference that matters when
+      // they are trying to work out what happened.
+      auditAppend(apiKey, 'inbound', { hash: hash.slice(0,16)+'...', bytes: blob.length, device: deviceId, sig: sigResult.valid ? 'ML-DSA-OK' : 'unsigned', ...(viaSessionToken ? { via: 'pst' } : {}) });
       log('info', 'blob_stored', { hash: hash.slice(0,16), size: blob.length, sig: sigResult.valid });
       // ParaSend Pro upload notification (no-op below Pro+ or without RESEND key).
       transferNotify.maybeNotify({ keyData, event: 'upload', hashPrefix: hash, bytes: blob.length, sendEmail: sendResendEmail });

--- a/relay/test/route-auth-gate.test.js
+++ b/relay/test/route-auth-gate.test.js
@@ -109,6 +109,43 @@ test('a WRONG key also cannot reach validation: still 401, not 400', async () =>
   did();
 });
 
+test('a Bearer that looks like a session token opens nothing on a relay with no store', async () => {
+  // The gate now has a second credential in front of it: an Authorization
+  // Bearer pst_ token, resolved against redis (relay/lib/session-token.js, and
+  // route-session-token.test.js for what it does when there IS a store). This
+  // suite boots WITHOUT redis, which makes it the right place to pin the two
+  // ways that credential must not weaken this gate.
+  //
+  // 1. A pst_-shaped Bearer with no store behind it is 503, not 200 and not a
+  //    principal. Fail closed: "we cannot check this" may never read as "fine".
+  const shaped = await srv.post('/v2/envelopes', {
+    headers: { Authorization: `Bearer pst_${'a'.repeat(64)}` },
+    body: { doc_hash: 'a'.repeat(64), parties: [{ label: 'Demo' }] },
+  });
+  assert.strictEqual(shaped.status, 503, `expected the store-unavailable 503, got ${shaped.status} ${shaped.text}`);
+  assert.strictEqual(shaped.json.error, 'redis_unavailable');
+
+  // 2. Anything that is NOT that exact shape is not a credential at all, so it
+  //    falls straight through to the ordinary 401. In particular the ADMIN
+  //    token as a Bearer stays an admin token and does not become a data-plane
+  //    principal, and an api-key offered as a Bearer is still not an api-key.
+  for (const value of [
+    `Bearer pst_${'z'.repeat(64)}`,   // right prefix, not hex
+    'Bearer pst_short',
+    `Bearer ${LIVE_KEY}`,             // the api-key, in the wrong header
+    `Bearer ${ADMIN}`,                // the admin token, in the wrong plane
+    'Bearer',
+  ]) {
+    const r = await srv.post('/v2/envelopes', {
+      headers: { Authorization: value },
+      body: { doc_hash: 'a'.repeat(64), parties: [{ label: 'Demo' }] },
+    });
+    assert.strictEqual(r.status, 401, `${value} was treated as a credential (${r.status})`);
+    assert.deepStrictEqual(r.json, { error: 'Invalid API key', hint: 'X-Api-Key: pgp_...' });
+  }
+  did();
+});
+
 test('a VALID key gets past the gate: the 503 behind it proves the gate opened', async () => {
   // No redis in this boot, so the envelope store is null (relay.js:5669). The
   // point of the assertion is the code, not the failure: 503 can only be

--- a/relay/test/route-session-token.test.js
+++ b/relay/test/route-session-token.test.js
@@ -294,9 +294,27 @@ test('AUDIT: the upload lands in the owner chain, under the owner key', async (t
   // opened a chain of its own, this would not find the entry.
   const audit = await srv.get('/v2/audit?limit=50', { headers: { 'X-Api-Key': OWNER } });
   assert.strictEqual(audit.status, 200, audit.text);
-  const found = (audit.json.entries || []).some(e =>
+  const entry = (audit.json.entries || []).find(e =>
     e.event === 'inbound' && String(e.hash || '').startsWith(b.hash.slice(0, 16)));
-  assert.ok(found, `the token upload is missing from the owner audit chain: ${audit.text.slice(0, 400)}`);
+  assert.ok(entry, `the token upload is missing from the owner audit chain: ${audit.text.slice(0, 400)}`);
+
+  // And it is marked. `via` names the credential, not a second identity: the
+  // chain is still the owner's, keyed on the owner's api-key. Without the field
+  // an owner reading their own log cannot tell a transfer made from a browser
+  // session apart from one made with the key itself.
+  assert.strictEqual(entry.via, 'pst',
+    'an upload made with a session token must be marked in the audit chain');
+
+  // The other half, and the one that makes the first mean something: the same
+  // upload with the key carries no such field.
+  const k = blob('audit-with-key');
+  assert.strictEqual((await upload({ 'X-Api-Key': OWNER }, k)).status, 200);
+  const after = await srv.get('/v2/audit?limit=50', { headers: { 'X-Api-Key': OWNER } });
+  const plain = (after.json.entries || []).find(e =>
+    e.event === 'inbound' && String(e.hash || '').startsWith(k.hash.slice(0, 16)));
+  assert.ok(plain, 'the key upload must be in the chain too');
+  assert.strictEqual(plain.via, undefined,
+    'a transfer made with the api-key must carry no via field, or the marker says nothing');
   did();
 });
 
@@ -329,7 +347,7 @@ test('a record that outlived its own TTL is refused on the wall clock inside it'
   // came back from a backup or from a replica that lagged through the expiry.
   const token = `pst_${crypto.randomBytes(32).toString('hex')}`;
   await rc.set(sessionTokens.tokenKey(token),
-    JSON.stringify({ key: OWNER, exp: Date.now() - 1000 }), { EX: 300 });
+    JSON.stringify({ kh: sessionTokens.keyHash(OWNER), exp: Date.now() - 1000 }), { EX: 300 });
   const r = await upload(bearer(token), blob('stale-record'));
   assert.strictEqual(r.status, 401, 'a record past its own exp must not authenticate, TTL or no TTL');
   await rc.del(sessionTokens.tokenKey(token));
@@ -368,7 +386,7 @@ test('and a token whose owner is revoked is refused even when the sweep never ra
   // credential, and a revoked key is not there.
   const token = `pst_${crypto.randomBytes(32).toString('hex')}`;
   await rc.set(sessionTokens.tokenKey(token),
-    JSON.stringify({ key: REVOKE_ME, exp: Date.now() + 600_000 }), { EX: 600 });
+    JSON.stringify({ kh: sessionTokens.keyHash(REVOKE_ME), exp: Date.now() + 600_000 }), { EX: 600 });
   const r = await upload(bearer(token), blob('revoked-owner'));
   assert.strictEqual(r.status, 401, 'a live record for a revoked key must not authenticate');
   assert.strictEqual((await srv.get('/v2/check-key', { headers: bearer(token) })).json.valid, false);
@@ -413,7 +431,181 @@ test('a malformed or foreign Bearer is simply not a credential', async (t) => {
   did();
 });
 
-// ── 8. No store ──────────────────────────────────────────────────────────────
+// ── 8. What the store actually holds ─────────────────────────────────────────
+
+test('THE STORE HOLDS NO KEY: a leak of redis is a leak of hashes', async (t) => {
+  if (!rc) return t.skip('no redis');
+  // The threat is read-only and unexciting: an RDB snapshot, a replica, a
+  // backup on a laptop, a MONITOR session. Before the record was hashed, every
+  // one of those carried live pgp_ credentials for every account that had sent
+  // a file in the last fifteen minutes. This reads the real store the same way
+  // any of those would.
+  const { token } = (await mint()).json;
+  const raw = await rc.get(sessionTokens.tokenKey(token));
+  assert.ok(raw, 'the record must be there to be inspected');
+  assert.ok(!raw.includes(OWNER), 'the record body carries the api-key in the clear');
+  assert.ok(!/pgp_/.test(raw), 'nothing shaped like an api-key may be in the record');
+  const rec = JSON.parse(raw);
+  assert.strictEqual(rec.kh, sessionTokens.keyHash(OWNER), 'the owner is named by sha256 of the key');
+  assert.strictEqual(rec.key, undefined, 'and by nothing else');
+
+  // Key names as well as values, because SCAN, the keyspace listing and the
+  // slowlog all show names. Scanned over the whole prefix, so the sweep index
+  // is included.
+  const names = [];
+  for await (const k of rc.scanIterator({ MATCH: 'paramant:pst:*', COUNT: 500 })) {
+    names.push(...(Array.isArray(k) ? k : [k]));
+  }
+  assert.ok(names.length > 0, 'the scan must find something, or this asserts nothing');
+  assert.ok(!names.some((n) => /pgp_/.test(String(n))), 'a redis key NAME carries an api-key');
+
+  // And resolution still works, which is the half that makes the hash useful
+  // rather than merely safe: the relay looks the hash up in the api-key table
+  // it already has in memory.
+  const ck = await srv.get('/v2/check-key', { headers: bearer(token) });
+  assert.deepStrictEqual(ck.json, { valid: true, plan: 'community' },
+    'hashing the record must not cost the relay the ability to resolve it');
+  did();
+});
+
+test('a hash that resolves to no key in the table is refused, whatever the store says', async (t) => {
+  if (!rc) return t.skip('no redis');
+  // Written by hand, well-formed, unexpired, and pointing at a key this relay
+  // has never heard of. The resolver is a lookup in the live api-key table, so
+  // key deletion and revocation arrive here for free.
+  const token = `pst_${crypto.randomBytes(32).toString('hex')}`;
+  await rc.set(sessionTokens.tokenKey(token),
+    JSON.stringify({ kh: sessionTokens.keyHash('pgp_this_key_never_existed'), exp: Date.now() + 600_000 }),
+    { EX: 300 });
+  const r = await upload(bearer(token), blob('unknown-owner'));
+  assert.strictEqual(r.status, 401);
+  await rc.del(sessionTokens.tokenKey(token));
+  did();
+});
+
+test('EXP IS REQUIRED over HTTP too: a record without one authenticates nobody', async (t) => {
+  if (!rc) return t.skip('no redis');
+  const kh = sessionTokens.keyHash(OWNER);
+  for (const rec of [{ kh }, { kh, exp: null }, { kh, exp: 'soon' }, { kh, exp: '9999999999999' }]) {
+    const token = `pst_${crypto.randomBytes(32).toString('hex')}`;
+    // A 300 s redis TTL on purpose: the store says this record is live, and the
+    // missing expiry is the only reason it must not be.
+    await rc.set(sessionTokens.tokenKey(token), JSON.stringify(rec), { EX: 300 });
+    const r = await upload(bearer(token), blob('no-exp'));
+    assert.strictEqual(r.status, 401, `${JSON.stringify(rec)} authenticated somebody`);
+    await rc.del(sessionTokens.tokenKey(token));
+  }
+  did();
+});
+
+test('a key created AFTER boot still resolves: the hash index heals itself', async (t) => {
+  if (!rc) return t.skip('no redis');
+  // The index is rebuilt on load and on /v2/reload-users, which is where the
+  // api-key table normally changes. It is not the only way it changes: keys are
+  // also created at run time through /v2/admin/keys, the team route and the
+  // claim flow, none of which go near either. A token minted for such a key
+  // would carry a hash the index had never seen, and without the self-healing
+  // rebuild it would resolve to nothing, which is a credential that mints fine
+  // and then does not work.
+  const created = await srv.post('/v2/admin/keys', {
+    headers: { 'X-Admin-Token': ADMIN },
+    body: { plan: 'community', label: 'fresh', email: `fresh-${SUFFIX}@example.com` },
+  });
+  assert.strictEqual(created.status, 200, created.text);
+  const fresh = created.json.key;
+  assert.match(fresh, /^pgp_/);
+
+  const minted = await mint(fresh);
+  assert.strictEqual(minted.status, 200, minted.text);
+  const ck = await srv.get('/v2/check-key', { headers: bearer(minted.json.token) });
+  assert.strictEqual(ck.json.valid, true,
+    'a token for a key created after boot must resolve; the hash index has to rebuild on a miss');
+
+  const up = await upload(bearer(minted.json.token), blob('fresh-key'));
+  assert.strictEqual(up.status, 200, up.text);
+  did();
+});
+
+test('a users reload does not break the tokens already in flight', async (t) => {
+  if (!rc) return t.skip('no redis');
+  // /v2/reload-users clears and refills the whole api-key table, and the hash
+  // index is rebuilt with it. A reload that left the index behind would strand
+  // every live token on the relay at once, which is the kind of outage a deploy
+  // would cause and nobody would connect to the reload.
+  //
+  // Said honestly: the self-healing rebuild above would carry this case too, so
+  // deleting the explicit rebuild in the reload handler does NOT turn this red.
+  // What this pins is the PROPERTY -- a reload does not strand live tokens --
+  // and that property has two mechanisms behind it on purpose. The explicit
+  // rebuild is also what keeps a reload costing one rebuild instead of a
+  // rebuild per miss for the second after it.
+  const { token } = (await mint()).json;
+  assert.strictEqual((await srv.get('/v2/check-key', { headers: bearer(token) })).json.valid, true);
+
+  const reload = await srv.post('/v2/reload-users', { headers: { 'X-Api-Key': ADMIN } });
+  assert.strictEqual(reload.status, 200, reload.text);
+  assert.ok(reload.json.loaded > 0, 'the reload must actually load the table');
+
+  const after = await srv.get('/v2/check-key', { headers: bearer(token) });
+  assert.strictEqual(after.json.valid, true, 'a live token must survive a users reload');
+  const up = await upload(bearer(token), blob('after-reload'));
+  assert.strictEqual(up.status, 200, up.text);
+  did();
+});
+
+// ── 9. The ceiling ───────────────────────────────────────────────────────────
+
+test('an account is held to twenty live tokens, and the twenty-first is a 429', async (t) => {
+  if (!rc) return t.skip('no redis');
+  // A separate key, so the cap this test fills does not sit on OWNER for the
+  // rest of the suite.
+  const CAP_KEY = `pgp_cap_key_for_the_session_token_suite_${SUFFIX}`;
+  const capSrv = await boot({
+    tag: 'sesstok-cap',
+    // OWNER rides along so the per-account claim below is made on the SAME
+    // relay and the SAME store as the account that is at its ceiling.
+    users: { api_keys: [
+      { key: CAP_KEY, plan: 'community', active: true, email: 'cap@example.test', account_id: `acct_cap_${SUFFIX}` },
+      { key: OWNER, plan: 'community', active: true, email: 'owner@example.test', account_id: OWNER_ACCT },
+    ] },
+    env: { INTERNAL_AUTH_TOKEN: INTERNAL, REDIS_URL: process.env.REDIS_URL || DEFAULT_REDIS },
+  });
+  t.after(async () => {
+    await capSrv.stop();
+    try { await rc.del(sessionTokens.ownerKey(CAP_KEY)); } catch (_) { /* gone */ }
+  });
+
+  const first = [];
+  for (let i = 0; i < 20; i += 1) {
+    const r = await mint(CAP_KEY, capSrv);
+    assert.strictEqual(r.status, 200, `mint ${i + 1} answered ${r.status}: ${r.text}`);
+    first.push(r.json.token);
+  }
+  const over = await mint(CAP_KEY, capSrv);
+  assert.strictEqual(over.status, 429, over.text);
+  assert.strictEqual(over.json.error, 'session_token_cap_reached');
+  assert.strictEqual(over.json.cap, 20);
+  assert.strictEqual(over.headers['retry-after'], '60', 'a cap that clears on its own says when to come back');
+  assert.ok(!over.text.includes(CAP_KEY), 'and the refusal names no key');
+
+  // A cap is not a revocation: everything already minted keeps working.
+  const still = await capSrv.get('/v2/check-key', { headers: bearer(first[0]) });
+  assert.strictEqual(still.json.valid, true, 'tokens minted under the cap must keep working');
+
+  // Another account is not affected by this one's ceiling.
+  const other = await mint(OWNER, capSrv);
+  assert.strictEqual(other.status, 200, `the cap must be per account: ${other.text}`);
+
+  // And room made by an expiry is room again. Two of the twenty are removed the
+  // way redis would remove them, and the next mint succeeds through the prune.
+  await rc.del(sessionTokens.tokenKey(first[0]));
+  await rc.del(sessionTokens.tokenKey(first[1]));
+  const again = await mint(CAP_KEY, capSrv);
+  assert.strictEqual(again.status, 200, `with two expired there is room again: ${again.text}`);
+  did();
+});
+
+// ── 10. No store ─────────────────────────────────────────────────────────────
 
 test('FAIL CLOSED: a relay with no store answers 503 to a token, never 401', async (t) => {
   if (!rc) return t.skip('no redis');

--- a/relay/test/route-session-token.test.js
+++ b/relay/test/route-session-token.test.js
@@ -1,0 +1,440 @@
+'use strict';
+// ParaSend session tokens over HTTP, on a really booted relay with a real redis.
+//
+// WHY THIS SUITE EXISTS. The security review of #397 said the account key must
+// stop reaching the browser at all, and this is the credential that replaces
+// it. Everything that makes it safer than the key is a property of a REQUEST:
+// which routes it opens, which account it counts against, what happens when the
+// key behind it is revoked, and what the relay says when the store is gone.
+// None of that can be read off the source, so none of it is asserted from the
+// source here.
+//
+// The pure decisions (the allowlist, the token shape, the store contract) are
+// session-token.test.js, which needs nothing and runs in the unit job. This one
+// needs redis and the installed deps, so it rides in the route job.
+//
+// What is pinned, and why:
+//   * minting needs BOTH X-Internal-Auth and a live X-Api-Key, and a relay with
+//     no INTERNAL_AUTH_TOKEN mints nothing at all (fail closed);
+//   * a token authenticates AS the owner key on the five ParaSend routes;
+//   * and on nothing else: /v2/keys, /v2/user/*, /v2/outbound, /v2/audit,
+//     /v2/admin/* and a second mint are all 403, above every route handler;
+//   * QUOTA AND AUDIT SEE THE OWNER. An upload made with a token increments the
+//     owner's monthly counter and lands in the owner's audit chain, and the
+//     owner's 402 over quota is the token's 402 too. If this were wrong the
+//     token would be a free account hiding inside a paid one;
+//   * expiry is honoured, in both directions: the store's TTL and the wall
+//     clock inside the record;
+//   * revoking the key kills every live token, and does so twice over: swept
+//     from the store, and refused on lookup even when the sweep is undone;
+//   * an X-Api-Key on the request always wins, so a token can never widen or
+//     narrow a request that carries a real key;
+//   * redis unreachable is 503 with Retry-After, never 401.
+//
+// Run: REDIS_URL=redis://127.0.0.1:6399 node --test relay/test/route-session-token.test.js
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const { boot, killAll } = require('./_relay-server');
+const { requireRedis, summary } = require('./_requires');
+const sessionTokens = require('../lib/session-token');
+const quota = require('../lib/quota');
+
+const DEFAULT_REDIS = 'redis://127.0.0.1:6399';
+const INTERNAL = 'internal-token-for-the-session-token-suite';
+const ADMIN = 'admin-token-for-the-session-token-suite';
+// Fresh per run: this suite shares one redis with every other route suite, and
+// the quota counters below are keyed on the account id.
+const SUFFIX = crypto.randomBytes(6).toString('hex');
+const OWNER = `pgp_owner_key_for_the_session_token_suite_${SUFFIX}`;
+const OWNER_ACCT = `acct_sesstok_${SUFFIX}`;
+const DEAD = `pgp_dead_key_for_the_session_token_suite_${SUFFIX}`;
+const REVOKE_ME = `pgp_revoke_key_for_the_session_token_suite_${SUFFIX}`;
+const REVOKE_ACCT = `acct_sesstok_rev_${SUFFIX}`;
+
+let rc = null;      // this suite's own redis handle, for planting and reading
+let srv;            // relay with INTERNAL_AUTH_TOKEN + ADMIN_TOKEN + redis
+let noInternal;     // relay with neither, to prove the mint fails closed
+let checks = 0;
+const did = () => { checks++; };
+
+const users = () => ({
+  api_keys: [
+    { key: OWNER, plan: 'community', active: true, email: 'owner@example.test', account_id: OWNER_ACCT },
+    { key: DEAD, plan: 'pro', active: false, email: 'dead@example.test', account_id: `acct_dead_${SUFFIX}` },
+    { key: REVOKE_ME, plan: 'community', active: true, email: 'rev@example.test', account_id: REVOKE_ACCT },
+  ],
+});
+
+before(async () => {
+  rc = await requireRedis(DEFAULT_REDIS);
+  const env = {
+    INTERNAL_AUTH_TOKEN: INTERNAL,
+    ADMIN_TOKEN: ADMIN,
+    REDIS_URL: process.env.REDIS_URL || DEFAULT_REDIS,
+  };
+  srv = await boot({ tag: 'sesstok', users: users(), env, usersFile: true });
+  noInternal = await boot({ tag: 'sesstok-noint', users: users(), env: { REDIS_URL: env.REDIS_URL } });
+});
+
+after(async () => {
+  await killAll();
+  if (rc) { try { await rc.disconnect(); } catch (_) { /* already gone */ } }
+  summary('route-session-token', checks);
+});
+
+// Mint the way the admin does: the internal header plus the session's own key.
+async function mint(key = OWNER, server = srv) {
+  const r = await server.post('/v2/session-token', {
+    headers: { 'X-Internal-Auth': INTERNAL, 'X-Api-Key': key },
+  });
+  return r;
+}
+const bearer = (token) => ({ Authorization: `Bearer ${token}` });
+
+// A fresh blob every time: the store is keyed on the sha256 and rejects a
+// repeat with 409.
+function blob(label) {
+  const payload = Buffer.from(`${label}-${crypto.randomBytes(8).toString('hex')}`);
+  return { payload, hash: crypto.createHash('sha256').update(payload).digest('hex') };
+}
+const upload = (headers, b) => srv.post('/v2/inbound', {
+  headers, body: { hash: b.hash, payload: b.payload.toString('base64') },
+});
+
+// ── 1. Minting ───────────────────────────────────────────────────────────────
+
+test('the admin mints a token with the internal header and the account key', async (t) => {
+  if (!rc) return t.skip('no redis');
+  const r = await mint();
+  assert.strictEqual(r.status, 200, r.text);
+  assert.strictEqual(r.json.ok, true);
+  assert.match(r.json.token, /^pst_[0-9a-f]{64}$/);
+  assert.strictEqual(r.json.expires_in_s, 900, 'fifteen minutes, the number SECURITY.md states');
+  assert.ok(r.json.expires_ms > Date.now(), 'the expiry is in the future');
+  assert.ok(!r.text.includes(OWNER), 'THE WHOLE POINT: the mint response must never carry the api-key');
+  did();
+});
+
+test('the mint needs the internal header, and needs it to be right', async (t) => {
+  if (!rc) return t.skip('no redis');
+  for (const headers of [
+    { 'X-Api-Key': OWNER },
+    { 'X-Api-Key': OWNER, 'X-Internal-Auth': '' },
+    { 'X-Api-Key': OWNER, 'X-Internal-Auth': INTERNAL + 'x' },
+    // The admin token is a different credential and must not stand in for it.
+    { 'X-Api-Key': OWNER, 'X-Internal-Auth': ADMIN },
+  ]) {
+    const r = await srv.post('/v2/session-token', { headers });
+    assert.strictEqual(r.status, 401, `${JSON.stringify(headers)} minted a token`);
+    assert.deepStrictEqual(r.json, { error: 'unauthorized' });
+  }
+  did();
+});
+
+test('the mint needs a LIVE account key, and says nothing about which failed', async (t) => {
+  if (!rc) return t.skip('no redis');
+  const none = await srv.post('/v2/session-token', { headers: { 'X-Internal-Auth': INTERNAL } });
+  const unknown = await mint('pgp_no_such_key_anywhere');
+  const revoked = await mint(DEAD);
+  for (const [name, r] of [['no key', none], ['unknown key', unknown], ['revoked key', revoked]]) {
+    assert.strictEqual(r.status, 401, `${name} minted a token`);
+  }
+  assert.deepStrictEqual(revoked.json, unknown.json,
+    'a de-activated key must answer exactly like an unknown one, or the mint is a key-existence oracle');
+  did();
+});
+
+test('a relay with no INTERNAL_AUTH_TOKEN mints nothing: unconfigured is closed, not open', async (t) => {
+  if (!rc) return t.skip('no redis');
+  for (const headers of [{ 'X-Api-Key': OWNER }, { 'X-Api-Key': OWNER, 'X-Internal-Auth': 'anything' }]) {
+    const r = await noInternal.post('/v2/session-token', { headers });
+    assert.strictEqual(r.status, 401, `unconfigured relay answered ${r.status}`);
+  }
+  did();
+});
+
+// ── 2. The token is the owner, on the routes it opens ────────────────────────
+
+test('a token authenticates as the owner on all five ParaSend routes', async (t) => {
+  if (!rc) return t.skip('no redis');
+  const { token } = (await mint()).json;
+  const h = bearer(token);
+
+  // Sector discovery. This is the one that used to read the raw X-Api-Key
+  // header rather than the resolved principal: with a token it would have
+  // reported valid:false and the page would have refused its own credential.
+  const ck = await srv.get('/v2/check-key', { headers: h });
+  assert.strictEqual(ck.status, 200);
+  assert.deepStrictEqual(ck.json, { valid: true, plan: 'community' },
+    'a token must report the owner as valid, with the owner plan');
+
+  const ticket = await srv.post('/v2/ws-ticket', { headers: h });
+  assert.strictEqual(ticket.status, 200, ticket.text);
+  assert.match(ticket.json.ticket, /^wst_/);
+
+  const device = `inv_${crypto.randomBytes(16).toString('hex')}`;
+  const pub = await srv.post('/v2/pubkey', {
+    headers: h, body: { device_id: device, ecdh_pub: 'aa'.repeat(32), kyber_pub: 'bb'.repeat(32) },
+  });
+  assert.strictEqual(pub.status, 200, pub.text);
+
+  const read = await srv.get(`/v2/pubkey/${device}`, { headers: h });
+  assert.strictEqual(read.status, 200, read.text);
+  assert.strictEqual(read.json.ecdh_pub, 'aa'.repeat(32));
+
+  const up = await upload(h, blob('token-upload'));
+  assert.strictEqual(up.status, 200, up.text);
+  assert.strictEqual(up.json.ok, true);
+  assert.ok(up.json.download_token, 'the upload really stored a blob');
+  did();
+});
+
+// ── 3. And on nothing else ───────────────────────────────────────────────────
+
+test('THE SCOPE: every route outside the transfer path is 403, above the handler', async (t) => {
+  if (!rc) return t.skip('no redis');
+  const { token } = (await mint()).json;
+  const h = bearer(token);
+  const shut = [
+    // Credentials.
+    ['GET', '/v2/keys', undefined],
+    // The account's own session surface.
+    ['GET', '/v2/user/signing-key', undefined],
+    ['POST', '/v2/user/signing-key', { user_id: OWNER, public_key: 'AA==' }],
+    ['POST', '/v2/user/envelopes', { user_id: OWNER }],
+    ['GET', '/v2/user/history', undefined],
+    ['POST', '/v2/user/setup-totp', { user_id: OWNER }],
+    // The receiver's half, and the account's history.
+    ['GET', `/v2/outbound/${'a'.repeat(64)}`, undefined],
+    ['GET', '/v2/audit', undefined],
+    // Admin.
+    ['GET', '/v2/admin/keys', undefined],
+    ['POST', '/v2/admin/keys/revoke', { key: OWNER }],
+    // ParaSign, a different product on the same account.
+    ['POST', '/v2/envelopes', { doc_hash: 'a'.repeat(64), parties: [{ label: 'Demo' }] }],
+  ];
+  for (const [method, path, body] of shut) {
+    const r = await srv.req(method, path, { headers: h, body });
+    assert.strictEqual(r.status, 403, `${method} ${path} answered ${r.status}, not 403: ${r.text}`);
+    assert.strictEqual(r.json.error, 'session_token_out_of_scope');
+  }
+  did();
+});
+
+test('a token cannot mint another token, even holding the internal header', async (t) => {
+  if (!rc) return t.skip('no redis');
+  // The fifteen minutes are a ceiling on what a script that got onto the page
+  // can do. A token that could roll them forward would have no ceiling at all.
+  const { token } = (await mint()).json;
+  const r = await srv.post('/v2/session-token', {
+    headers: { ...bearer(token), 'X-Internal-Auth': INTERNAL },
+  });
+  assert.strictEqual(r.status, 403, r.text);
+  assert.strictEqual(r.json.error, 'session_token_out_of_scope');
+  did();
+});
+
+test('the refusal is a scope refusal, not a 404: the routes exist and stay reachable with the key', async (t) => {
+  if (!rc) return t.skip('no redis');
+  // A 403 that was really "no such route" would make the scope test vacuous.
+  // The same paths, with the owner's real api-key, must not be 403.
+  const withKey = await srv.get('/v2/audit', { headers: { 'X-Api-Key': OWNER } });
+  assert.strictEqual(withKey.status, 200, `the audit route must work with the key: ${withKey.text}`);
+  const admin = await srv.get('/v2/admin/keys', { headers: { 'X-Admin-Token': ADMIN } });
+  assert.strictEqual(admin.status, 200);
+  did();
+});
+
+// ── 4. Quota and audit see the owner ─────────────────────────────────────────
+
+test('QUOTA: an upload made with a token counts on the owner account', async (t) => {
+  if (!rc) return t.skip('no redis');
+  const counter = quota.transfersKey(OWNER_ACCT);
+  const before = parseInt((await rc.get(counter)) || '0', 10);
+
+  const { token } = (await mint()).json;
+  const up = await upload(bearer(token), blob('quota-owner'));
+  assert.strictEqual(up.status, 200, up.text);
+
+  const after = parseInt((await rc.get(counter)) || '0', 10);
+  assert.strictEqual(after, before + 1,
+    `the transfer must be counted on ${OWNER_ACCT}; a token that counted somewhere else would be a free account hiding inside a paid one`);
+  did();
+});
+
+test('QUOTA: the owner over its monthly cap is the token over its cap too', async (t) => {
+  if (!rc) return t.skip('no redis');
+  // community transfers_month is 10 (relay/lib/tiers.js). Planted directly, so
+  // the suite does not have to spend ten uploads to reach it.
+  const counter = quota.transfersKey(OWNER_ACCT);
+  const saved = await rc.get(counter);
+  await rc.set(counter, '10', { EX: 300 });
+  try {
+    const { token } = (await mint()).json;
+    const r = await upload(bearer(token), blob('quota-over'));
+    assert.strictEqual(r.status, 402, `over the cap the token must be declined like the key: ${r.text}`);
+    assert.strictEqual(r.json.error, 'monthly_transfer_quota_reached');
+    assert.strictEqual(r.json.dimension, 'transfers_month');
+    assert.strictEqual(r.json.limit, 10);
+  } finally {
+    if (saved === null) await rc.del(counter); else await rc.set(counter, saved, { EX: 300 });
+  }
+  did();
+});
+
+test('AUDIT: the upload lands in the owner chain, under the owner key', async (t) => {
+  if (!rc) return t.skip('no redis');
+  const { token } = (await mint()).json;
+  const b = blob('audit-owner');
+  assert.strictEqual((await upload(bearer(token), b)).status, 200);
+
+  // Read the chain the way the owner does: with the key. If the token had
+  // opened a chain of its own, this would not find the entry.
+  const audit = await srv.get('/v2/audit?limit=50', { headers: { 'X-Api-Key': OWNER } });
+  assert.strictEqual(audit.status, 200, audit.text);
+  const found = (audit.json.entries || []).some(e =>
+    e.event === 'inbound' && String(e.hash || '').startsWith(b.hash.slice(0, 16)));
+  assert.ok(found, `the token upload is missing from the owner audit chain: ${audit.text.slice(0, 400)}`);
+  did();
+});
+
+// ── 5. Expiry ────────────────────────────────────────────────────────────────
+
+test('the store expires the token, and the relay refuses it the moment it is gone', async (t) => {
+  if (!rc) return t.skip('no redis');
+  const { token } = (await mint()).json;
+  assert.strictEqual((await srv.get('/v2/check-key', { headers: bearer(token) })).json.valid, true);
+
+  // The TTL redis is really holding, rather than the one the response claimed.
+  const ttl = await rc.ttl(sessionTokens.tokenKey(token));
+  assert.ok(ttl > 800 && ttl <= 900, `the token record must carry the 900 s TTL; redis reports ${ttl}`);
+
+  await rc.del(sessionTokens.tokenKey(token));
+  const gone = await srv.get('/v2/check-key', { headers: bearer(token) });
+  assert.strictEqual(gone.status, 200, 'check-key is public, so an expired token is simply not a principal');
+  assert.strictEqual(gone.json.valid, false, 'an expired token must not authenticate anybody');
+  // And on a gated route it is the ordinary 401, the same one an unknown key
+  // gets: nothing here says "this token expired" to whoever is holding it.
+  const up = await upload(bearer(token), blob('expired'));
+  assert.strictEqual(up.status, 401);
+  assert.deepStrictEqual(up.json, { error: 'Invalid API key', hint: 'X-Api-Key: pgp_...' });
+  did();
+});
+
+test('a record that outlived its own TTL is refused on the wall clock inside it', async (t) => {
+  if (!rc) return t.skip('no redis');
+  // Redis is what expires a token; this is the second lock, for a record that
+  // came back from a backup or from a replica that lagged through the expiry.
+  const token = `pst_${crypto.randomBytes(32).toString('hex')}`;
+  await rc.set(sessionTokens.tokenKey(token),
+    JSON.stringify({ key: OWNER, exp: Date.now() - 1000 }), { EX: 300 });
+  const r = await upload(bearer(token), blob('stale-record'));
+  assert.strictEqual(r.status, 401, 'a record past its own exp must not authenticate, TTL or no TTL');
+  await rc.del(sessionTokens.tokenKey(token));
+  did();
+});
+
+// ── 6. Revocation, twice over ────────────────────────────────────────────────
+
+test('revoking the key sweeps its live tokens out of the shared store', async (t) => {
+  if (!rc) return t.skip('no redis');
+  const a = (await mint(REVOKE_ME)).json.token;
+  const b = (await mint(REVOKE_ME)).json.token;
+  assert.strictEqual((await srv.get('/v2/check-key', { headers: bearer(a) })).json.valid, true);
+
+  const rev = await srv.post('/v2/admin/keys/revoke', {
+    headers: { 'X-Admin-Token': ADMIN }, body: { key: REVOKE_ME },
+  });
+  assert.strictEqual(rev.status, 200, rev.text);
+
+  // The sweep is fire-and-forget, so give it a moment to land in redis.
+  for (let i = 0; i < 40 && await rc.exists(sessionTokens.tokenKey(a)); i += 1) {
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  assert.strictEqual(await rc.exists(sessionTokens.tokenKey(a)), 0, 'the first token is gone from the store');
+  assert.strictEqual(await rc.exists(sessionTokens.tokenKey(b)), 0, 'and so is the second');
+  assert.strictEqual((await srv.get('/v2/check-key', { headers: bearer(a) })).json.valid, false);
+  did();
+});
+
+test('and a token whose owner is revoked is refused even when the sweep never ran', async (t) => {
+  if (!rc) return t.skip('no redis');
+  // The belt to the sweep's braces. A sector that was restarting, or a redis
+  // that was briefly unreachable, can miss the sweep. So the record is put back
+  // by hand here, exactly as the sweep failing would leave it, and the relay
+  // must still refuse: a resolved token is looked up in apiKeys like any other
+  // credential, and a revoked key is not there.
+  const token = `pst_${crypto.randomBytes(32).toString('hex')}`;
+  await rc.set(sessionTokens.tokenKey(token),
+    JSON.stringify({ key: REVOKE_ME, exp: Date.now() + 600_000 }), { EX: 600 });
+  const r = await upload(bearer(token), blob('revoked-owner'));
+  assert.strictEqual(r.status, 401, 'a live record for a revoked key must not authenticate');
+  assert.strictEqual((await srv.get('/v2/check-key', { headers: bearer(token) })).json.valid, false);
+  await rc.del(sessionTokens.tokenKey(token));
+  did();
+});
+
+// ── 7. A token never overrides a key ─────────────────────────────────────────
+
+test('an X-Api-Key on the request always wins: a token cannot widen or narrow it', async (t) => {
+  if (!rc) return t.skip('no redis');
+  const { token } = (await mint()).json;
+
+  // A request that carries a bad key is that key's request, and stays a 401.
+  // Reading the Bearer here would let a page smuggle a working credential past
+  // a caller that thought it was sending its own.
+  const wrong = await srv.post('/v2/inbound', {
+    headers: { ...bearer(token), 'X-Api-Key': 'pgp_wrong_key' },
+    body: { hash: 'a'.repeat(64), payload: 'AA==' },
+  });
+  assert.strictEqual(wrong.status, 401, 'the api-key decides; the token must not rescue it');
+
+  // And with the real key present, the token does not narrow the request
+  // either: a route outside the token scope stays open to the key.
+  const audit = await srv.get('/v2/audit', { headers: { ...bearer(token), 'X-Api-Key': OWNER } });
+  assert.strictEqual(audit.status, 200, `the scope gate must not fire on a key-authenticated request: ${audit.text}`);
+  did();
+});
+
+test('a malformed or foreign Bearer is simply not a credential', async (t) => {
+  if (!rc) return t.skip('no redis');
+  for (const value of [
+    'Bearer pst_short',
+    `Bearer pst_${'z'.repeat(64)}`,
+    `Bearer ${OWNER}`,                       // the api-key, offered as a Bearer
+    `Basic pst_${'a'.repeat(64)}`,
+    'Bearer',
+  ]) {
+    const r = await upload({ Authorization: value }, blob('bad-bearer'));
+    assert.strictEqual(r.status, 401, `${value} was accepted as a credential`);
+  }
+  did();
+});
+
+// ── 8. No store ──────────────────────────────────────────────────────────────
+
+test('FAIL CLOSED: a relay with no store answers 503 to a token, never 401', async (t) => {
+  if (!rc) return t.skip('no redis');
+  // A 401 during an outage tells a sender holding a perfectly good token that
+  // it is bad, and sends them to sign in again over a store that cannot answer
+  // that either. 503 with Retry-After is the honest answer, and it is the one
+  // the page's refresh path is written against.
+  const noRedis = await boot({ tag: 'sesstok-nostore', users: users(), env: { INTERNAL_AUTH_TOKEN: INTERNAL } });
+  t.after(() => noRedis.stop());
+
+  const token = `pst_${crypto.randomBytes(32).toString('hex')}`;
+  const used = await noRedis.get('/v2/check-key', { headers: bearer(token) });
+  assert.strictEqual(used.status, 503, used.text);
+  assert.strictEqual(used.json.error, 'redis_unavailable');
+  assert.strictEqual(used.headers['retry-after'], '5');
+
+  // And no token is handed out that no relay could ever check.
+  const minted = await noRedis.post('/v2/session-token', {
+    headers: { 'X-Internal-Auth': INTERNAL, 'X-Api-Key': OWNER },
+  });
+  assert.strictEqual(minted.status, 503, minted.text);
+  assert.strictEqual(minted.json.error, 'redis_unavailable');
+  did();
+});

--- a/relay/test/session-token.test.js
+++ b/relay/test/session-token.test.js
@@ -1,0 +1,329 @@
+'use strict';
+// The decision layer of ParaSend session tokens: relay/lib/session-token.js.
+//
+// This suite is the one that needs nothing -- no relay, no redis, no native
+// binding -- so it runs in the unit job and gates the rules a reviewer would
+// otherwise have to read the route for. The HTTP behaviour of the same rules,
+// against a real relay and a real redis, is route-session-token.test.js.
+//
+// What is pinned here, and why each line earns its place:
+//   * the scope allowlist, from both ends: the five routes a transfer walks are
+//     open, and the routes the review named as the danger (/v2/keys,
+//     /v2/user/*, /v2/outbound, /v2/admin/*, minting another token) are shut.
+//     The closed half is asserted by name, because an allowlist that is only
+//     tested from the open side passes just as well when it is `() => true`;
+//   * the token shape, so a malformed Authorization header never reaches the
+//     store;
+//   * the Bearer parse, including the forms that are NOT a token;
+//   * mint/resolve/revoke against a fake store, including the TTL that is
+//     written and the expiry that is honoured even when the store forgot it;
+//   * a store that is absent or broken THROWS rather than returning null,
+//     which is what makes the route answer 503 instead of 401.
+//
+// Verified by sabotage:
+//   * make scopeAllows return true and the six closed-route cases go red;
+//   * drop the OPTIONS branch and the preflight case goes red;
+//   * loosen TOKEN_RE to /^pst_/ and the shape case goes red;
+//   * return null instead of throwing on a missing client and the fail-closed
+//     case goes red, which is the exact bug that would turn an outage into a
+//     silent 401 storm;
+//   * drop the `exp` check in resolve and the "store forgot the TTL" case goes
+//     red.
+// Run: node --test relay/test/session-token.test.js
+
+const { test, after } = require('node:test');
+const assert = require('assert');
+const st = require('../lib/session-token');
+const { summary } = require('./_requires');
+
+let checks = 0;
+const did = () => { checks++; };
+after(() => summary('session-token', checks));
+
+// A redis stand-in with the four commands this module uses. TTLs are recorded
+// rather than slept through, and `fail` turns the whole thing into the outage.
+function fakeRedis() {
+  const store = new Map();   // key -> string
+  const ttls = new Map();    // key -> seconds
+  const sets = new Map();    // key -> Set
+  const api = {
+    fail: null,
+    calls: [],
+    _guard(op) { api.calls.push(op); if (api.fail) throw api.fail; },
+    async get(k) { api._guard(['get', k]); return store.has(k) ? store.get(k) : null; },
+    async set(k, v, opts) { api._guard(['set', k]); store.set(k, v); if (opts && opts.EX) ttls.set(k, opts.EX); },
+    async sAdd(k, v) { api._guard(['sAdd', k]); if (!sets.has(k)) sets.set(k, new Set()); sets.get(k).add(v); },
+    async sMembers(k) { api._guard(['sMembers', k]); return [...(sets.get(k) || [])]; },
+    async expire(k, s) { api._guard(['expire', k]); ttls.set(k, s); },
+    async del(k) {
+      api._guard(['del', k]);
+      const keys = Array.isArray(k) ? k : [k];
+      let n = 0;
+      for (const one of keys) { if (store.delete(one)) n++; sets.delete(one); ttls.delete(one); }
+      return n;
+    },
+    store, ttls, sets,
+  };
+  return api;
+}
+
+// ── 1. The scope allowlist, from the open side ───────────────────────────────
+
+test('the five routes a ParaSend transfer walks are the routes the token opens', () => {
+  const walk = [
+    // Sector discovery races four hosts and reads valid/plan.
+    ['GET', '/v2/check-key'],
+    // The one-time ticket for the signalling socket.
+    ['POST', '/v2/ws-ticket'],
+    // The sender publishes its half of the handshake and polls the receiver's.
+    ['POST', '/v2/pubkey'],
+    ['GET', '/v2/pubkey/inv_0123456789abcdef0123456789abcdef'],
+    // And the upload.
+    ['POST', '/v2/inbound'],
+  ];
+  for (const [method, path] of walk) {
+    assert.strictEqual(st.scopeAllows(method, path), true,
+      `${method} ${path} is on the path a sender walks; a token that cannot do it is not a usable credential`);
+  }
+  did();
+});
+
+test('a preflight is never refused by scope: it carries no credential to judge', () => {
+  assert.strictEqual(st.scopeAllows('OPTIONS', '/v2/keys'), true);
+  assert.strictEqual(st.scopeAllows('options', '/v2/user/signing-key'), true);
+  did();
+});
+
+// ── 2. The closed side, which is the whole point ─────────────────────────────
+
+test('THE POINT: everything the security review named is shut, by name', () => {
+  const shut = [
+    // The credential surface. A token minted to send a file must never be able
+    // to list, mint or reveal a key.
+    ['GET', '/v2/keys'],
+    ['POST', '/v2/keys'],
+    // The account's own session surface. Enrolling a signing key with a token
+    // stolen from a page would be the whole ParaSign trust model, gone.
+    ['POST', '/v2/user/signing-key'],
+    ['GET', '/v2/user/signing-key'],
+    ['DELETE', '/v2/user/signing-key'],
+    ['POST', '/v2/user/setup-totp'],
+    ['POST', '/v2/user/envelopes'],
+    ['GET', '/v2/user/history'],
+    // Downloading is the receiver's half and needs no account credential.
+    ['GET', '/v2/outbound/' + 'a'.repeat(64)],
+    // The account's history.
+    ['GET', '/v2/audit'],
+    // Admin, under any credential but ADMIN_TOKEN.
+    ['GET', '/v2/admin/keys'],
+    ['POST', '/v2/admin/keys/revoke'],
+    // A token may not roll its own fifteen minutes forward.
+    ['POST', '/v2/session-token'],
+    // ParaSign, which is a different product on the same account.
+    ['POST', '/v2/envelopes'],
+    ['POST', '/v1/envelopes'],
+  ];
+  for (const [method, path] of shut) {
+    assert.strictEqual(st.scopeAllows(method, path), false,
+      `${method} ${path} is reachable with a session token; the allowlist is the only thing that makes this credential narrower than an API key`);
+  }
+  did();
+});
+
+test('the method is part of the rule, not decoration', () => {
+  // POST /v2/pubkey publishes; GET /v2/pubkey is the RELAY's identity key and
+  // is not on the sender's path. The one that is on the path is the per-device
+  // read below it.
+  assert.strictEqual(st.scopeAllows('GET', '/v2/pubkey'), false,
+    'GET /v2/pubkey is the relay identity route, not a step in a transfer');
+  assert.strictEqual(st.scopeAllows('DELETE', '/v2/inbound'), false);
+  assert.strictEqual(st.scopeAllows('GET', '/v2/inbound'), false);
+  assert.strictEqual(st.scopeAllows('GET', '/v2/ws-ticket'), false);
+  did();
+});
+
+test('the per-device pubkey read is exactly one path segment deep', () => {
+  assert.strictEqual(st.scopeAllows('GET', '/v2/pubkey/inv_abc'), true);
+  // Not a prefix match: a deeper path is a different route and gets no ride.
+  assert.strictEqual(st.scopeAllows('GET', '/v2/pubkey/inv_abc/secret'), false);
+  assert.strictEqual(st.scopeAllows('GET', '/v2/pubkey/'), false, 'an empty device id is not a route');
+  // POST under the same prefix is /v2/pubkey/verify, and it is not in scope.
+  assert.strictEqual(st.scopeAllows('POST', '/v2/pubkey/verify'), false);
+  did();
+});
+
+// ── 3. The token shape ───────────────────────────────────────────────────────
+
+test('only a pst_ token of the exact minted shape is ever looked up', () => {
+  assert.strictEqual(st.isSessionToken('pst_' + 'a'.repeat(64)), true);
+  const no = [
+    '', null, undefined, 42, {},
+    'pgp_a_real_api_key_would_be_a_disaster_here',
+    'pst_',
+    'pst_' + 'a'.repeat(63),          // one short
+    'pst_' + 'a'.repeat(65),          // one long
+    'pst_' + 'A'.repeat(64),          // uppercase is not what randomBytes.hex makes
+    'pst_' + 'g'.repeat(64),          // not hex
+    ' pst_' + 'a'.repeat(64),         // leading space
+    'pst_' + 'a'.repeat(64) + '\n',
+  ];
+  for (const v of no) {
+    assert.strictEqual(st.isSessionToken(v), false, `${JSON.stringify(v)} must not be treated as a token`);
+  }
+  did();
+});
+
+test('the Bearer parse takes the token and nothing else', () => {
+  const tok = 'pst_' + 'b'.repeat(64);
+  assert.strictEqual(st.bearerToken(`Bearer ${tok}`), tok);
+  assert.strictEqual(st.bearerToken(`bearer ${tok}`), tok, 'the scheme is case-insensitive per RFC 7235');
+  assert.strictEqual(st.bearerToken(`  Bearer ${tok}  `), tok, 'surrounding whitespace is not part of the credential');
+  assert.strictEqual(st.bearerToken(`Bearer\t${tok}`), tok);
+  for (const bad of ['', null, undefined, 42, tok, `Basic ${tok}`, `Bearer ${tok} extra`, 'Bearer']) {
+    assert.strictEqual(st.bearerToken(bad), '', `${JSON.stringify(bad)} is not a Bearer credential`);
+  }
+  did();
+});
+
+// ── 4. Mint ──────────────────────────────────────────────────────────────────
+
+test('mint writes one record under the token, with the TTL it promises', async () => {
+  const r = fakeRedis();
+  const out = await st.mint(r, 'pgp_owner_demo', 1_000_000);
+
+  assert.ok(st.isSessionToken(out.token), 'a minted token must satisfy the shape the resolver demands');
+  assert.strictEqual(out.expires_in_s, st.TTL_S);
+  assert.strictEqual(st.TTL_S, 900, 'fifteen minutes is the number SECURITY.md and /privacy both state');
+  assert.strictEqual(out.expires_ms, 1_000_000 + 900_000);
+
+  const rk = st.tokenKey(out.token);
+  assert.deepStrictEqual(JSON.parse(r.store.get(rk)), { key: 'pgp_owner_demo', exp: 1_900_000 });
+  assert.strictEqual(r.ttls.get(rk), 900, 'redis must be the thing that expires the token, not a sweeper');
+  did();
+});
+
+test('two mints are two different tokens, and the owner key is never a redis key name', async () => {
+  const r = fakeRedis();
+  const a = await st.mint(r, 'pgp_owner_demo');
+  const b = await st.mint(r, 'pgp_owner_demo');
+  assert.notStrictEqual(a.token, b.token, 'a token that repeats is a token an attacker can wait for');
+
+  // Key NAMES show up in SCAN output, slowlog entries and keyspace listings. An
+  // api-key in a key name is an api-key in every one of those.
+  for (const name of r.store.keys()) assert.ok(!name.includes('pgp_owner_demo'), `redis key name leaks the api-key: ${name}`);
+  for (const name of r.sets.keys()) assert.ok(!name.includes('pgp_owner_demo'), `redis set name leaks the api-key: ${name}`);
+  assert.match(st.ownerKey('pgp_owner_demo'), /^paramant:pst:owner:[0-9a-f]{64}$/);
+  did();
+});
+
+test('the sweep index holds both tokens and outlives neither by much', async () => {
+  const r = fakeRedis();
+  const a = await st.mint(r, 'pgp_owner_demo');
+  const b = await st.mint(r, 'pgp_owner_demo');
+  const idx = st.ownerKey('pgp_owner_demo');
+  assert.deepStrictEqual([...r.sets.get(idx)].sort(), [a.token, b.token].sort());
+  assert.strictEqual(r.ttls.get(idx), st.TTL_S + 60,
+    'the index must expire on its own; a set that lives forever is a slow leak with an api-key hash in the name');
+  did();
+});
+
+// ── 5. Resolve ───────────────────────────────────────────────────────────────
+
+test('a minted token resolves to the api-key it was minted for', async () => {
+  const r = fakeRedis();
+  const { token, expires_ms } = await st.mint(r, 'pgp_owner_demo', 5_000);
+  assert.deepStrictEqual(await st.resolve(r, token, 6_000), { key: 'pgp_owner_demo', expires_ms });
+  did();
+});
+
+test('every refusal looks the same: null, with no way to tell them apart', async () => {
+  const r = fakeRedis();
+  const { token } = await st.mint(r, 'pgp_owner_demo', 5_000);
+
+  // Never minted.
+  assert.strictEqual(await st.resolve(r, 'pst_' + 'c'.repeat(64)), null);
+  // Not even a token.
+  assert.strictEqual(await st.resolve(r, 'pgp_a_real_key'), null);
+  assert.strictEqual(await st.resolve(r, ''), null);
+  // Revoked out from under it.
+  await r.del(st.tokenKey(token));
+  assert.strictEqual(await st.resolve(r, token), null);
+  did();
+});
+
+test('an expired record is refused even when the store still holds it', async () => {
+  // Redis is what expires a token. This is the second lock: a record restored
+  // from a backup, or served by a replica that lagged through the expiry, still
+  // carries the wall-clock expiry it was minted with, and that is checked.
+  const r = fakeRedis();
+  const { token, expires_ms } = await st.mint(r, 'pgp_owner_demo', 5_000);
+  assert.ok(await st.resolve(r, token, expires_ms), 'a token AT its expiry ms is still live');
+  assert.strictEqual(await st.resolve(r, token, expires_ms + 1), null, 'one millisecond past it, it is not');
+  did();
+});
+
+test('a record that is not the shape this module writes is refused, not trusted', async () => {
+  const r = fakeRedis();
+  const tok = 'pst_' + 'd'.repeat(64);
+  for (const junk of ['not json', 'null', '[]', '{}', '{"key":""}', '{"key":123}']) {
+    await r.set(st.tokenKey(tok), junk);
+    assert.strictEqual(await st.resolve(r, tok), null, `a record of ${junk} must not yield a principal`);
+  }
+  did();
+});
+
+// ── 6. Fail closed ───────────────────────────────────────────────────────────
+
+test('FAIL CLOSED: no store is a throw, never a quiet null', async () => {
+  // The distinction is the whole difference between a 503 and a 401. A null
+  // here would tell a sender holding a perfectly good token that it is bad, and
+  // send them back to sign in, during an outage where signing in cannot work.
+  await assert.rejects(() => st.resolve(null, 'pst_' + 'e'.repeat(64)), /no redis client/);
+  await assert.rejects(() => st.mint(null, 'pgp_owner_demo'), /no redis client/);
+  did();
+});
+
+test('a broken store propagates, so the route can answer 503 instead of 401', async () => {
+  const r = fakeRedis();
+  const { token } = await st.mint(r, 'pgp_owner_demo');
+  r.fail = new Error('redis command timed out after 1000ms');
+  await assert.rejects(() => st.resolve(r, token), /timed out/);
+  await assert.rejects(() => st.mint(r, 'pgp_owner_demo'), /timed out/);
+  did();
+});
+
+test('mint refuses to hand out a token with no owner on it', async () => {
+  const r = fakeRedis();
+  for (const bad of ['', null, undefined, 42]) {
+    await assert.rejects(() => st.mint(r, bad), /no owner key/);
+  }
+  did();
+});
+
+// ── 7. Revoke ────────────────────────────────────────────────────────────────
+
+test('revoking a key takes every one of its live tokens with it', async () => {
+  const r = fakeRedis();
+  const a = await st.mint(r, 'pgp_owner_demo');
+  const b = await st.mint(r, 'pgp_owner_demo');
+  const other = await st.mint(r, 'pgp_owner_other');
+
+  const n = await st.revokeForKey(r, 'pgp_owner_demo');
+  assert.strictEqual(n, 2, 'both tokens are reported swept');
+  assert.strictEqual(await st.resolve(r, a.token), null);
+  assert.strictEqual(await st.resolve(r, b.token), null);
+  assert.ok(await st.resolve(r, other.token), 'another account is untouched: revocation is per key, not per store');
+  assert.strictEqual(r.sets.has(st.ownerKey('pgp_owner_demo')), false, 'the index goes too, or it grows forever');
+  did();
+});
+
+test('revoking a key with no tokens is a no-op, not an error', async () => {
+  const r = fakeRedis();
+  assert.strictEqual(await st.revokeForKey(r, 'pgp_owner_never_used'), 0);
+  // And a caller with no store at all (a relay without REDIS_URL) gets 0 rather
+  // than a throw: the revocation itself has already happened in users.json, and
+  // a relay with no store has no tokens to sweep.
+  assert.strictEqual(await st.revokeForKey(null, 'pgp_owner_demo'), 0);
+  assert.strictEqual(await st.revokeForKey(fakeRedis(), ''), 0);
+  did();
+});

--- a/relay/test/session-token.test.js
+++ b/relay/test/session-token.test.js
@@ -54,6 +54,14 @@ function fakeRedis() {
     async set(k, v, opts) { api._guard(['set', k]); store.set(k, v); if (opts && opts.EX) ttls.set(k, opts.EX); },
     async sAdd(k, v) { api._guard(['sAdd', k]); if (!sets.has(k)) sets.set(k, new Set()); sets.get(k).add(v); },
     async sMembers(k) { api._guard(['sMembers', k]); return [...(sets.get(k) || [])]; },
+    async sCard(k) { api._guard(['sCard', k]); return (sets.get(k) || new Set()).size; },
+    async sRem(k, v) {
+      api._guard(['sRem', k]);
+      const set = sets.get(k); if (!set) return 0;
+      let n = 0; for (const one of (Array.isArray(v) ? v : [v])) { if (set.delete(one)) n++; }
+      return n;
+    },
+    async exists(k) { api._guard(['exists', k]); return store.has(k) ? 1 : 0; },
     async expire(k, s) { api._guard(['expire', k]); ttls.set(k, s); },
     async del(k) {
       api._guard(['del', k]);
@@ -66,6 +74,16 @@ function fakeRedis() {
   };
   return api;
 }
+
+// The resolver relay.js injects: a lookup in the api-key table it already holds.
+// Written out here rather than stubbed with `() => key`, because the point of
+// hashing the record is that resolution needs a table, and a test that handed
+// the key straight back would prove nothing about that.
+function ownerTable(...keys) {
+  const byHash = new Map(keys.map((k) => [st.keyHash(k), k]));
+  return (hash) => byHash.get(hash) || null;
+}
+const OWNERS = ownerTable('pgp_owner_demo', 'pgp_owner_other');
 
 // ── 1. The scope allowlist, from the open side ───────────────────────────────
 
@@ -197,8 +215,31 @@ test('mint writes one record under the token, with the TTL it promises', async (
   assert.strictEqual(out.expires_ms, 1_000_000 + 900_000);
 
   const rk = st.tokenKey(out.token);
-  assert.deepStrictEqual(JSON.parse(r.store.get(rk)), { key: 'pgp_owner_demo', exp: 1_900_000 });
+  assert.deepStrictEqual(JSON.parse(r.store.get(rk)), { kh: st.keyHash('pgp_owner_demo'), exp: 1_900_000 });
   assert.strictEqual(r.ttls.get(rk), 900, 'redis must be the thing that expires the token, not a sweeper');
+  did();
+});
+
+test('THE RECORD HOLDS NO KEY. Everything written to the store is a hash', async () => {
+  // A read-only leak of redis is an RDB snapshot, a replica, a backup on
+  // someone's laptop, a MONITOR session. Before this, every one of those
+  // carried live pgp_ credentials for every account that had sent a file in the
+  // last fifteen minutes. Now they carry hashes, and a hash is only a key to
+  // somebody who already holds the api-key table.
+  const r = fakeRedis();
+  const out = await st.mint(r, 'pgp_owner_demo');
+
+  const everything = [...r.store.keys(), ...r.store.values(), ...r.sets.keys(),
+    ...[...r.sets.values()].flatMap((set) => [...set])].join('\n');
+  assert.ok(!everything.includes('pgp_owner_demo'),
+    'the api-key appears somewhere in the store. Key names AND values must both be hashes.');
+  assert.ok(!/pgp_/.test(everything), 'nothing shaped like an api-key may be written to the store');
+
+  // And the hash really is the sha256 of the key, not some other digest that
+  // happens not to contain the string.
+  const rec = JSON.parse(r.store.get(st.tokenKey(out.token)));
+  assert.strictEqual(rec.kh, require('crypto').createHash('sha256').update('pgp_owner_demo').digest('hex'));
+  assert.strictEqual(Object.keys(rec).sort().join(','), 'exp,kh', 'the record carries exactly the hash and the expiry');
   did();
 });
 
@@ -229,10 +270,26 @@ test('the sweep index holds both tokens and outlives neither by much', async () 
 
 // ── 5. Resolve ───────────────────────────────────────────────────────────────
 
-test('a minted token resolves to the api-key it was minted for', async () => {
+test('a minted token resolves to the api-key it was minted for, through the table', async () => {
   const r = fakeRedis();
   const { token, expires_ms } = await st.mint(r, 'pgp_owner_demo', 5_000);
-  assert.deepStrictEqual(await st.resolve(r, token, 6_000), { key: 'pgp_owner_demo', expires_ms });
+  assert.deepStrictEqual(await st.resolve(r, token, OWNERS, 6_000), { key: 'pgp_owner_demo', expires_ms });
+  did();
+});
+
+test('a hash the api-key table does not know resolves to nothing', async () => {
+  // This is revocation and key deletion arriving for free: the resolver is a
+  // lookup in the live table, so a key that is gone from it cannot be reached
+  // through a token, whatever the store still holds.
+  const r = fakeRedis();
+  const { token } = await st.mint(r, 'pgp_owner_gone', 5_000);
+  assert.strictEqual(await st.resolve(r, token, OWNERS, 6_000), null,
+    'the record is live and well-formed; the owner is simply not in the table any more');
+  // And a resolver that answers with something that is not a key is refused
+  // rather than trusted.
+  for (const bad of [() => null, () => undefined, () => '', () => 42, () => ({})]) {
+    assert.strictEqual(await st.resolve(r, token, bad, 6_000), null);
+  }
   did();
 });
 
@@ -241,13 +298,13 @@ test('every refusal looks the same: null, with no way to tell them apart', async
   const { token } = await st.mint(r, 'pgp_owner_demo', 5_000);
 
   // Never minted.
-  assert.strictEqual(await st.resolve(r, 'pst_' + 'c'.repeat(64)), null);
+  assert.strictEqual(await st.resolve(r, 'pst_' + 'c'.repeat(64), OWNERS), null);
   // Not even a token.
-  assert.strictEqual(await st.resolve(r, 'pgp_a_real_key'), null);
-  assert.strictEqual(await st.resolve(r, ''), null);
+  assert.strictEqual(await st.resolve(r, 'pgp_a_real_key', OWNERS), null);
+  assert.strictEqual(await st.resolve(r, '', OWNERS), null);
   // Revoked out from under it.
   await r.del(st.tokenKey(token));
-  assert.strictEqual(await st.resolve(r, token), null);
+  assert.strictEqual(await st.resolve(r, token, OWNERS), null);
   did();
 });
 
@@ -257,17 +314,51 @@ test('an expired record is refused even when the store still holds it', async ()
   // carries the wall-clock expiry it was minted with, and that is checked.
   const r = fakeRedis();
   const { token, expires_ms } = await st.mint(r, 'pgp_owner_demo', 5_000);
-  assert.ok(await st.resolve(r, token, expires_ms), 'a token AT its expiry ms is still live');
-  assert.strictEqual(await st.resolve(r, token, expires_ms + 1), null, 'one millisecond past it, it is not');
+  assert.ok(await st.resolve(r, token, OWNERS, expires_ms), 'a token AT its expiry ms is still live');
+  assert.strictEqual(await st.resolve(r, token, OWNERS, expires_ms + 1), null, 'one millisecond past it, it is not');
+  did();
+});
+
+test('EXP IS REQUIRED: a record without a usable expiry is refused, not given the store default', async () => {
+  // It used to be optional, guarded with a typeof, so a record that lost the
+  // field fell back to whatever TTL redis happened to have on it, and one
+  // written by hand with no field never expired on the wall clock at all. A
+  // credential whose lifetime is a property of the store alone has no lifetime
+  // when the store is wrong.
+  const r = fakeRedis();
+  const tok = 'pst_' + 'f'.repeat(64);
+  const kh = st.keyHash('pgp_owner_demo');
+  for (const exp of [undefined, null, 'soon', '1900000', {}, [], NaN, Infinity, -Infinity]) {
+    const rec = exp === undefined ? { kh } : { kh, exp };
+    await r.set(st.tokenKey(tok), JSON.stringify(rec));
+    assert.strictEqual(await st.resolve(r, tok, OWNERS, 1000), null,
+      `a record with exp=${JSON.stringify(exp)} must not authenticate anybody`);
+  }
+  // The control: the same record with a real expiry does resolve, so the case
+  // above is measuring the expiry and not some other refusal.
+  await r.set(st.tokenKey(tok), JSON.stringify({ kh, exp: 2000 }));
+  assert.deepStrictEqual(await st.resolve(r, tok, OWNERS, 1000), { key: 'pgp_owner_demo', expires_ms: 2000 });
   did();
 });
 
 test('a record that is not the shape this module writes is refused, not trusted', async () => {
   const r = fakeRedis();
   const tok = 'pst_' + 'd'.repeat(64);
-  for (const junk of ['not json', 'null', '[]', '{}', '{"key":""}', '{"key":123}']) {
-    await r.set(st.tokenKey(tok), junk);
-    assert.strictEqual(await st.resolve(r, tok), null, `a record of ${junk} must not yield a principal`);
+  const junk = [
+    'not json', 'null', '[]', '{}',
+    '{"kh":""}', '{"kh":123}',
+    // The old shape, with the owner in the clear. It must be refused rather
+    // than read: accepting it would keep a plaintext record working, which is
+    // the thing this shape exists to stop.
+    '{"key":"pgp_owner_demo","exp":9999999999999}',
+    // A hash that is not one.
+    '{"kh":"not-a-hash","exp":9999999999999}',
+    `{"kh":"${'g'.repeat(64)}","exp":9999999999999}`,
+    `{"kh":"${'A'.repeat(64)}","exp":9999999999999}`,
+  ];
+  for (const one of junk) {
+    await r.set(st.tokenKey(tok), one);
+    assert.strictEqual(await st.resolve(r, tok, OWNERS), null, `a record of ${one} must not yield a principal`);
   }
   did();
 });
@@ -278,8 +369,14 @@ test('FAIL CLOSED: no store is a throw, never a quiet null', async () => {
   // The distinction is the whole difference between a 503 and a 401. A null
   // here would tell a sender holding a perfectly good token that it is bad, and
   // send them back to sign in, during an outage where signing in cannot work.
-  await assert.rejects(() => st.resolve(null, 'pst_' + 'e'.repeat(64)), /no redis client/);
+  await assert.rejects(() => st.resolve(null, 'pst_' + 'e'.repeat(64), OWNERS), /no redis client/);
   await assert.rejects(() => st.mint(null, 'pgp_owner_demo'), /no redis client/);
+  // And a caller that forgot the resolver is a programming error, not a silent
+  // refusal: without a table there is no way to turn a hash back into a key,
+  // and returning null would look exactly like a bad token.
+  const r = fakeRedis();
+  const { token } = await st.mint(r, 'pgp_owner_demo');
+  await assert.rejects(() => st.resolve(r, token), /no owner resolver/);
   did();
 });
 
@@ -287,7 +384,7 @@ test('a broken store propagates, so the route can answer 503 instead of 401', as
   const r = fakeRedis();
   const { token } = await st.mint(r, 'pgp_owner_demo');
   r.fail = new Error('redis command timed out after 1000ms');
-  await assert.rejects(() => st.resolve(r, token), /timed out/);
+  await assert.rejects(() => st.resolve(r, token, OWNERS), /timed out/);
   await assert.rejects(() => st.mint(r, 'pgp_owner_demo'), /timed out/);
   did();
 });
@@ -310,9 +407,9 @@ test('revoking a key takes every one of its live tokens with it', async () => {
 
   const n = await st.revokeForKey(r, 'pgp_owner_demo');
   assert.strictEqual(n, 2, 'both tokens are reported swept');
-  assert.strictEqual(await st.resolve(r, a.token), null);
-  assert.strictEqual(await st.resolve(r, b.token), null);
-  assert.ok(await st.resolve(r, other.token), 'another account is untouched: revocation is per key, not per store');
+  assert.strictEqual(await st.resolve(r, a.token, OWNERS), null);
+  assert.strictEqual(await st.resolve(r, b.token, OWNERS), null);
+  assert.ok(await st.resolve(r, other.token, OWNERS), 'another account is untouched: revocation is per key, not per store');
   assert.strictEqual(r.sets.has(st.ownerKey('pgp_owner_demo')), false, 'the index goes too, or it grows forever');
   did();
 });
@@ -325,5 +422,79 @@ test('revoking a key with no tokens is a no-op, not an error', async () => {
   // a relay with no store has no tokens to sweep.
   assert.strictEqual(await st.revokeForKey(null, 'pgp_owner_demo'), 0);
   assert.strictEqual(await st.revokeForKey(fakeRedis(), ''), 0);
+  did();
+});
+
+// ── 8. The ceiling on live tokens per account ────────────────────────────────
+
+test('an account can hold twenty live tokens, and the twenty-first is refused', async () => {
+  // A ceiling, not a rate limit. The page mints one per load and one per
+  // refresh, so twenty is far above honest use; what it stops is a signed-in
+  // session being run as a credential factory, each token good for fifteen
+  // minutes on five routes.
+  const r = fakeRedis();
+  assert.strictEqual(st.MAX_LIVE_PER_ACCOUNT, 20);
+  const minted = [];
+  for (let i = 0; i < st.MAX_LIVE_PER_ACCOUNT; i += 1) {
+    const out = await st.mint(r, 'pgp_owner_demo');
+    assert.ok(out.token, `mint ${i + 1} of the cap must succeed`);
+    minted.push(out.token);
+  }
+  const over = await st.mint(r, 'pgp_owner_demo');
+  assert.strictEqual(over.capped, true, 'the twenty-first must be refused');
+  assert.strictEqual(over.cap, 20);
+  assert.strictEqual(over.token, undefined, 'a refused mint hands out no token');
+  // The tokens already minted keep working: a cap is not a revocation.
+  assert.ok(await st.resolve(r, minted[0], OWNERS));
+  did();
+});
+
+test('the cap is per account, and it counts LIVE tokens, not names left in the index', async () => {
+  const r = fakeRedis();
+  for (let i = 0; i < st.MAX_LIVE_PER_ACCOUNT; i += 1) await st.mint(r, 'pgp_owner_demo');
+  // Another account is unaffected.
+  assert.ok((await st.mint(r, 'pgp_owner_other')).token, 'one account at its cap must not block another');
+
+  // Redis expires the RECORDS, not the names in the sweep index, so the set
+  // drifts upward. A caller refused because of tokens that no longer exist
+  // would be locked out for the rest of the window by nothing at all. The
+  // prune runs before the cap is believed.
+  const idx = st.ownerKey('pgp_owner_demo');
+  const names = [...r.sets.get(idx)];
+  for (const n of names.slice(0, 5)) await r.del(st.tokenKey(n));   // redis expiry, by hand
+  assert.strictEqual(r.sets.get(idx).size, 20, 'the index still names all twenty');
+
+  const out = await st.mint(r, 'pgp_owner_demo');
+  assert.ok(out.token, 'with five of the twenty expired there is room, and the mint must succeed');
+  assert.strictEqual(r.sets.get(idx).size, 16, 'and the dead names are gone from the index: 20 - 5 + 1');
+  did();
+});
+
+test('the prune only ever removes names whose record is gone', async () => {
+  const r = fakeRedis();
+  const a = await st.mint(r, 'pgp_owner_demo');
+  const b = await st.mint(r, 'pgp_owner_demo');
+  const idx = st.ownerKey('pgp_owner_demo');
+  assert.strictEqual(await st.pruneOwnerIndex(r, idx), 2, 'nothing to prune when both are live');
+  await r.del(st.tokenKey(a.token));
+  assert.strictEqual(await st.pruneOwnerIndex(r, idx), 1);
+  assert.deepStrictEqual([...r.sets.get(idx)], [b.token], 'the live one survives the prune');
+  assert.ok(await st.resolve(r, b.token, OWNERS), 'and it still resolves');
+  // An index that is empty or absent is not an error.
+  assert.strictEqual(await st.pruneOwnerIndex(r, st.ownerKey('pgp_never_minted')), 0);
+  did();
+});
+
+test('the cheap count is what runs on the ordinary path: no prune under the cap', async () => {
+  // The prune is O(live) round trips. Paying it on every mint would make the
+  // common case the expensive one for a ceiling almost nobody reaches.
+  const r = fakeRedis();
+  await st.mint(r, 'pgp_owner_demo');
+  r.calls.length = 0;
+  await st.mint(r, 'pgp_owner_demo');
+  const ops = r.calls.map(([op]) => op);
+  assert.ok(ops.includes('sCard'), 'the cap is checked');
+  assert.ok(!ops.includes('sMembers'), `an under-cap mint must not walk the index; it ran ${ops.join(', ')}`);
+  assert.ok(!ops.includes('exists'), 'and must not probe every token');
   did();
 });

--- a/relay/test/v1-bearer-gate.test.js
+++ b/relay/test/v1-bearer-gate.test.js
@@ -42,6 +42,14 @@ for (const [label, header] of [
   ['a Bearer token that is not a psk_ key', 'Bearer abc123'],
   ['an unknown psk_ key', 'Bearer psk_live_neverissued0000000'],
   ['a revoked psk_ key', `Bearer ${REVOKED}`],
+  // The boundary between the two Bearer credentials this relay now has. A pst_
+  // ParaSend session token is resolved in relay.js, against redis, and it opens
+  // five /v2 routes; /v1 is the ParaSign developer API and knows only psk_
+  // keys. Neither may be mistaken for the other, and the direction that would
+  // hurt is this one: a token minted for a browser must not become a developer
+  // credential on an open API. The prefix is what separates them, so the case
+  // is written out rather than assumed.
+  ['a pst_ ParaSend session token', `Bearer pst_${'a'.repeat(64)}`],
 ]) {
   const r = openApi.authenticateBearer(header, keys);
   assert.strictEqual(r.ok, false, `${label} was accepted`);
@@ -70,5 +78,18 @@ const revoked = openApi.authenticateBearer(`Bearer ${REVOKED}`, keys);
 assert.strictEqual(unknown.code, revoked.code, 'unknown and revoked answer with different codes');
 assert.strictEqual(unknown.error, revoked.error, 'unknown and revoked answer with different errors');
 ok('an unknown key and a revoked key are indistinguishable from outside');
+
+// And the same boundary from the other side, so a reader of either suite finds
+// it: relay/lib/session-token.js refuses a psk_ key as a session token, and its
+// scope allowlist contains no /v1 path at all. Cheap to assert, and it is the
+// pair of facts that keeps the two Bearer namespaces from drifting together.
+const sessionTokens = require('../lib/session-token');
+assert.strictEqual(sessionTokens.isSessionToken(KEY), false, 'a psk_ key must not be readable as a session token');
+assert.strictEqual(sessionTokens.bearerToken(`Bearer ${KEY}`), KEY,
+  'the parse is shared and takes any Bearer; it is isSessionToken that refuses this one');
+assert.strictEqual(sessionTokens.scopeAllows('POST', '/v1/envelopes'), false,
+  'a session token must not reach the ParaSign developer API');
+assert.strictEqual(sessionTokens.scopeAllows('GET', '/v1/code-manifest'), false);
+ok('a psk_ key is not a session token, and a session token opens no /v1 route');
 
 console.log(`\nv1-bearer-gate: ${passed} checks passed`);

--- a/tests/parasend-session-key.test.mjs
+++ b/tests/parasend-session-key.test.mjs
@@ -623,4 +623,20 @@ test('a token that expires during a long session is replaced, before and after t
   const still = await evalIn(stubborn, "relayFetch('https://health.paramant.app/v2/inbound', { method: 'POST' })");
   assert.equal(still.status, 401, 'a 401 that survives a fresh token is a real 401 and is handed to the caller');
   assert.ok(stubborn.calls.key - before <= 1, 'one mint, never a loop');
+
+  // (c) and when minting itself is what is broken, one call spends one attempt,
+  // not two. nginx allows a burst of five on /api/user/, and a page that tries
+  // twice per relay call turns one bad minute into a rate limit of its own.
+  const mintDown = await loadPage({
+    keyResponses: [
+      { status: 200, body: { token: FAKE_TOKEN, expires_in_s: 30 } },
+      { status: 503, body: { error: 'token_unavailable' } },
+    ],
+    relayStatus: (url) => (url.includes('/v2/inbound') ? { status: 401, body: { error: 'Invalid API key' } } : null),
+  });
+  const spent = mintDown.calls.key;
+  const answer = await evalIn(mintDown, "relayFetch('https://health.paramant.app/v2/inbound', { method: 'POST' })");
+  assert.equal(answer.status, 401);
+  assert.equal(mintDown.calls.key - spent, 1,
+    'a call whose refresh already failed must not mint a second time on the 401 it was always going to get');
 });

--- a/tests/parasend-session-key.test.mjs
+++ b/tests/parasend-session-key.test.mjs
@@ -1,31 +1,39 @@
-// ParaSend takes its API key from the session and from nowhere else.
+// ParaSend runs on a session token, and the account key never reaches the
+// browser at all.
 //
-// The bug a buyer walked into: Send in the signed-in navigation opened
-// /parashare on a card headed "Your API key" with an empty box in it, and the
-// key he typed there was not the key of the account he was signed in with. The
-// page had two sources of truth. GET /api/user/account/key was one; a
-// localStorage entry written by any earlier visit, on any account, was the
-// other, and the second outlived the first. A stale or hand-typed key sails
-// past the format check, fails at the relay, and the only thing the sender sees
-// is a button that will not light up.
+// TWO FINDINGS, ONE PAGE. The first was a buyer's: Send in the signed-in
+// navigation opened /parashare on a card headed "Your API key" with an empty box
+// in it, and the key he typed there was not the key of the account he was signed
+// in with. The page had two sources of truth, GET /api/user/account/key and a
+// localStorage entry any earlier visit could have written, and the second
+// outlived the first. That was closed by making the session the only source.
 //
-// So: one source. frontend/js/parashare.page.js reads the account key from the
-// session on every load, keeps it in memory, and never writes it to
-// localStorage. This suite runs that page script for real, in a vm context
-// with a hand-built DOM and a stubbed fetch, node builtins only, so it runs in
-// the "Root integration suites" job next to the other tests/*.mjs, and it
-// measures the three answers the endpoint can give.
+// The second was the security review of #397, and it is about what that single
+// source hands over. An account API key has no expiry and no scope: fetched into
+// a variable, it stays a full data-plane credential for the life of the tab, and
+// anything that gets to run on the page can read it and keep it. So the page now
+// asks POST /api/user/parasend/token and is handed a pst_ session token instead:
+// fifteen minutes, and scoped by the relay to the five routes a transfer walks.
+// The key stays on the server.
 //
-// Verified by sabotage, both directions:
-//   • put `localStorage.setItem('paramant_api_key', apiKey)` back into
+// This suite runs the page script for real, in a vm context with a hand-built
+// DOM and a stubbed fetch, node builtins only, so it runs in the "Root
+// integration suites" job next to the other tests/*.mjs. What it measures is
+// what the page holds, what it sends, and what it does when the token runs out.
+//
+// Verified by sabotage, in both directions:
+//   * put `localStorage.setItem('paramant_api_key', apiKey)` back into
 //     onKeyInput and the "never persists" case goes red (and so does row 28 of
 //     site-claims.test.mjs);
-//   • drop the 429 retry, or make the 500 path silent instead of showing the
+//   * send X-Api-Key instead of the Bearer on any of the five relay calls and
+//     the header case goes red by name;
+//   * drop the 401 refresh, or the proactive one, and the expiry cases go red;
+//   * drop the 429 retry, or make the 500 path silent instead of showing the
 //     banner, and the matching case goes red;
-//   • make keyValid depend on discoverRelay again and "a dead sector does not
+//   * make keyValid depend on discoverRelay again and "a dead sector does not
 //     disable the button" goes red;
-//   • and each case was run against an unpatched parashare.page.js, where the
-//     slim-row, banner and retry cases fail and only the happy path passes.
+//   * and each case was run against an unpatched parashare.page.js, where every
+//     token case fails and only the shape of the old key flow passes.
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -41,7 +49,8 @@ const PS_HTML = fs.readFileSync(path.join(PS_ROOT, 'frontend/parashare.html'), '
 // close it over this process's console, and half of what this suite measures is
 // what the page does or does not write to the browser's.
 const PS_ERRORS_JS = fs.readFileSync(path.join(PS_ROOT, 'frontend/js/error-message.js'), 'utf8');
-const KEY_URL = '/api/user/account/key';
+const TOKEN_URL = '/api/user/parasend/token';
+const FAKE_TOKEN = 'pst_' + 'ab12cd34'.repeat(8);
 const FAKE_KEY = 'pgp_livetestkey0000000000abcd';
 
 // ── A DOM small enough to read, big enough to run the page script ────────────
@@ -69,7 +78,7 @@ function makeElement(id) {
 }
 
 // A run of the page: the vm context, the DOM it saw, and what it asked for.
-function runPage({ keyResponses, sectorOk = true }) {
+function runPage({ keyResponses, sectorOk = true, relayStatus = null }) {
   const elements = new Map();
   const getElementById = (id) => {
     if (!elements.has(id)) elements.set(id, makeElement(id));
@@ -77,7 +86,9 @@ function runPage({ keyResponses, sectorOk = true }) {
   };
   const listeners = new Map();
   const sockets = [];
-  const calls = { key: 0, sector: 0, urls: [], timeouts: [], storage: [], copied: [] };
+  // `relay` records every relay call with the headers it carried, which is the
+  // only way to see which credential the page presented.
+  const calls = { key: 0, sector: 0, urls: [], timeouts: [], storage: [], copied: [], relay: [] };
   let keyTurn = 0;
 
   const respond = (spec) => ({
@@ -123,16 +134,22 @@ function runPage({ keyResponses, sectorOk = true }) {
       send() {}
       close() { this.closed = true; }
     },
-    fetch: async (url) => {
+    fetch: async (url, opts) => {
       calls.urls.push(url);
-      if (String(url).endsWith(KEY_URL)) {
+      if (String(url).endsWith(TOKEN_URL)) {
         calls.key += 1;
         const spec = keyResponses[Math.min(keyTurn++, keyResponses.length - 1)];
         return respond(spec);
       }
+      const headers = (opts && opts.headers) || {};
+      calls.relay.push({ url: String(url), method: (opts && opts.method) || 'GET', headers });
       calls.sector += 1;
       if (!sectorOk) throw new Error('sector unreachable');
-      return respond({ status: 200, body: { valid: true, plan: 'pro' } });
+      // A test can make the relay refuse, which is how the mid-session expiry
+      // is driven: the page has to notice a 401 and mint a replacement.
+      const forced = relayStatus && relayStatus(String(url), calls.relay.length);
+      if (forced) return respond(forced);
+      return respond({ status: 200, body: { valid: true, plan: 'pro', ok: true, ticket: 'wst_x', download_token: 'dl_x' } });
     },
   };
   context.window = context;
@@ -166,6 +183,10 @@ function pickAFile(run) {
 }
 
 const wroteTheKey = (run) => run.calls.storage.some(([op, k]) => op === 'set' && k === 'paramant_api_key');
+// The credential every relay call carried, in order. This is the assertion the
+// whole feature rests on: a Bearer, and never an X-Api-Key.
+const relayAuth = (run) => run.calls.relay.map((c) => c.headers.Authorization || c.headers['X-Api-Key'] || null);
+const ok200 = { status: 200, body: { token: FAKE_TOKEN, expires_in_s: 900 } };
 
 // Press Copy link the way the page does, and let the clipboard promise settle.
 async function copyLinkIn(run) {
@@ -174,26 +195,36 @@ async function copyLinkIn(run) {
 }
 
 // ── 1. The endpoint answers ─────────────────────────────────────────────────
-test('a 200 from /api/user/account/key gives the slim row, a usable button, and nothing in localStorage', async () => {
-  const run = await loadPage({ keyResponses: [{ status: 200, body: { api_key: FAKE_KEY, revealable: true } }] });
+test('a 200 from /api/user/parasend/token gives the slim row, a usable button, and no key anywhere', async () => {
+  const run = await loadPage({ keyResponses: [ok200] });
 
-  assert.equal(run.calls.key, 1, 'the account key is fetched exactly once when the endpoint answers');
-  assert.equal(run.getElementById('api-key').value, FAKE_KEY, 'the session key is the key the page holds');
+  assert.equal(run.calls.key, 1, 'the session token is fetched exactly once when the endpoint answers');
+  assert.equal(evalIn(run, 'sessionAuth'), FAKE_TOKEN, 'the token is the credential the page holds');
+  assert.equal(evalIn(run, 'apiKey'), '', 'THE POINT: no API key is held in the page at all');
+  assert.equal(run.getElementById('api-key').value, '',
+    'and the manual box stays empty, so the two credentials cannot be confused');
 
   // The slim row is the state the sender lands in: no empty "API key" box.
   const slim = run.getElementById('ps-key-slim');
   assert.equal(slim.hidden, false, 'the slim row is shown');
   assert.equal(slim.classList.contains('is-loading'), false, 'the slim row stops claiming to be loading');
-  assert.equal(run.getElementById('ps-key-slim-label').textContent, 'Using your account key');
-  assert.equal(run.getElementById('ps-key-mask').hidden, false, 'the masked key is revealed next to the label');
-  assert.match(run.getElementById('ps-key-mask').textContent, /^pgp_.*\.\.\..{4}$/, 'the row shows a masked key, not the whole one');
+  assert.equal(run.getElementById('ps-key-slim-label').textContent, 'Using your account');
+  assert.equal(run.getElementById('ps-key-mask').hidden, false, 'the masked credential is shown next to the label');
+  assert.match(run.getElementById('ps-key-mask').textContent, /^pst_.*\.\.\..{4}$/,
+    'the row shows a masked session token, and it says pst_ because that is what the page is holding');
   assert.equal(run.getElementById('step-setup').classList.contains('manual-key'), false,
     'the manual card stays closed: #step-setup only carries .manual-key when the user asks for the box');
   assert.equal(run.getElementById('ps-key-error').classList.contains('is-shown'), false, 'no banner on the happy path');
 
-  assert.equal(evalIn(run, 'keyValid'), true, 'the key is usable');
+  assert.equal(evalIn(run, 'keyValid'), true, 'the credential is usable');
   assert.equal(pickAFile(run), true, 'pick a file and "Create secure session" is live');
-  assert.equal(wroteTheKey(run), false, 'the account key is never written to localStorage');
+  assert.equal(wroteTheKey(run), false, 'nothing is written to localStorage');
+
+  // Sector discovery is the first thing the token is spent on, and it goes out
+  // as a Bearer. An X-Api-Key here would mean the page still had a key to send.
+  assert.ok(run.calls.relay.length >= 4, 'all four sectors were asked');
+  assert.deepEqual([...new Set(relayAuth(run))], [`Bearer ${FAKE_TOKEN}`],
+    'every relay call must carry the session token as a Bearer, and nothing must carry X-Api-Key');
 });
 
 // ── 2. nginx throttles the page ─────────────────────────────────────────────
@@ -201,34 +232,29 @@ test('a 200 from /api/user/account/key gives the slim row, a usable button, and 
 // burst 5). /parashare loads next to nav-auth's session check and the quota
 // call, so a 429 here is the page arriving in its own crowd, not a broken
 // account. One retry, 2 s later, and then it gives up.
-test('a 429 on the account key is retried once, two seconds later, and then succeeds', async () => {
-  const run = await loadPage({
-    keyResponses: [
-      { status: 429, body: {} },
-      { status: 200, body: { api_key: FAKE_KEY, revealable: true } },
-    ],
-  });
+test('a 429 on the session token is retried once, two seconds later, and then succeeds', async () => {
+  const run = await loadPage({ keyResponses: [{ status: 429, body: {} }, ok200] });
 
   assert.equal(run.calls.key, 2, 'exactly one retry: the rate limiter must not be hammered');
   assert.ok(run.calls.timeouts.includes(2000), `the retry waits 2000 ms; delays asked for were ${run.calls.timeouts.join(', ')}`);
-  assert.equal(run.getElementById('api-key').value, FAKE_KEY, 'the retry is what delivers the key');
+  assert.equal(evalIn(run, 'sessionAuth'), FAKE_TOKEN, 'the retry is what delivers the token');
   assert.equal(run.getElementById('ps-key-slim').hidden, false, 'the slim row is reached through the retry');
   assert.equal(run.getElementById('ps-key-error').classList.contains('is-shown'), false, 'a throttled first try is not an error to the user');
   assert.equal(evalIn(run, 'keyValid'), true);
-  assert.equal(wroteTheKey(run), false, 'the account key is never written to localStorage');
+  assert.equal(wroteTheKey(run), false, 'nothing is written to localStorage');
 });
 
 // ── 3. The endpoint is broken ───────────────────────────────────────────────
-test('a 500 on the account key shows the banner, hides the slim row, and offers a key by hand', async () => {
+test('a 500 on the session token shows the banner, hides the slim row, and offers a key by hand', async () => {
   const run = await loadPage({ keyResponses: [{ status: 500, body: {} }] });
 
   assert.equal(run.calls.key, 1, 'a 500 is not a rate limit: no retry');
   assert.equal(run.getElementById('ps-key-error').classList.contains('is-shown'), true, 'the failure is stated, not swallowed');
   assert.equal(run.getElementById('ps-key-slim').hidden, true,
-    'the slim row may not say "using your account key" when there is no account key');
+    'the slim row may not say "using your account" when there is no session credential');
   assert.equal(evalIn(run, 'keyValid'), false);
-  assert.equal(pickAFile(run), false, 'without a key the button stays disabled, and the banner says why');
-  assert.equal(wroteTheKey(run), false, 'the account key is never written to localStorage');
+  assert.equal(pickAFile(run), false, 'without a credential the button stays disabled, and the banner says why');
+  assert.equal(wroteTheKey(run), false, 'nothing is written to localStorage');
 
   // The way out for a self-host whose deployment has no such endpoint.
   evalIn(run, 'expandApiKeyCard()');
@@ -238,7 +264,7 @@ test('a 500 on the account key shows the banner, hides the slim row, and offers 
 
 // ── 4. The banner's words, and the default state of the markup ──────────────
 test('/parashare ships the banner copy and opens on the slim row, not the manual card', () => {
-  assert.ok(PS_HTML.includes('Your account key could not be loaded. Sign in again; if it keeps happening, mail <a href="mailto:privacy@paramant.app">privacy@paramant.app</a>.'),
+  assert.ok(PS_HTML.includes('Your account session could not be started. Sign in again; if it keeps happening, mail <a href="mailto:privacy@paramant.app">privacy@paramant.app</a>.'),
     'the banner must name the one thing to do and the one address to write to');
   assert.match(PS_HTML, /data-click="expandApiKeyCard">Use a key by hand</, 'the banner must carry the manual way out');
   // error-message.js is a plain script and parashare.page.js reads
@@ -260,6 +286,19 @@ test('/parashare ships the banner copy and opens on the slim row, not the manual
     'parashare.page.js must not persist the account key');
   assert.ok(!/localStorage\.getItem\(\s*['"]paramant_api_key/.test(PS_JS),
     'parashare.page.js must not read a key back out of localStorage: the session is the only source');
+
+  // The reveal route is not what this page runs on any more. It still exists,
+  // for the account page and for a self-hoster, but a call to it from here
+  // would put the key back in the browser through the door this PR closed.
+  assert.ok(!PS_JS.includes('/api/user/account/key'),
+    'parashare.page.js must not fetch the account key: it asks for a session token');
+  assert.ok(PS_JS.includes('/api/user/parasend/token'), 'and it must ask for the token');
+
+  // One place decides which header goes on a relay call. Five copies is how one
+  // of them eventually ships without the refresh, or with the wrong header.
+  const xApiKey = [...PS_JS.matchAll(/X-Api-Key/g)].length;
+  assert.equal(xApiKey, 1,
+    `X-Api-Key appears ${xApiKey} times in parashare.page.js; it belongs only in relayAuthHeaders, which is the manual self-host path`);
 });
 
 // ── 5. A dead sector is an error, not a dead button ─────────────────────────
@@ -267,10 +306,10 @@ test('/parashare ships the banner copy and opens on the slim row, not the manual
 // nothing about the key, and it used to leave the button greyed out with no
 // reason on screen. The key and the sector are now separate questions.
 test('a sector that will not answer leaves the button live and reports itself at the press', async () => {
-  const run = await loadPage({ keyResponses: [{ status: 200, body: { api_key: FAKE_KEY, revealable: true } }], sectorOk: false });
+  const run = await loadPage({ keyResponses: [ok200], sectorOk: false });
 
   assert.ok(run.calls.sector >= 4, 'all four sectors were tried');
-  assert.equal(evalIn(run, 'keyValid'), true, 'the session key is good; only the sector is unreachable');
+  assert.equal(evalIn(run, 'keyValid'), true, 'the session token is good; only the sector is unreachable');
   assert.equal(evalIn(run, 'relayReady'), false);
   assert.equal(pickAFile(run), true, 'the button is usable: a silent disabled button explains nothing');
 
@@ -367,7 +406,7 @@ test('a relay connection that drops before the receiver arrives says so, and off
   assert.match(PS_HTML, /#ps-session-card\.is-stale #waiting-dot\{background:var\(--ink-3\);animation:none\}/,
     'the beacon has an id rule of its own, so stopping it needs an id rule too');
 
-  const run = await loadPage({ keyResponses: [{ status: 200, body: { api_key: FAKE_KEY, revealable: true } }] });
+  const run = await loadPage({ keyResponses: [ok200] });
   pickAFile(run);
   await evalIn(run, 'createSession()');
   for (let i = 0; i < 10; i += 1) await new Promise((r) => setImmediate(r));
@@ -467,27 +506,121 @@ test('steps 1 and 2 are written for the sender, with the jargon moved into "How 
 // the endpoint gets 404, and the banner is the whole answer to both. Reporting
 // them would put a console error on every signed-out visit, and
 // tests/product-heartbeat.test.mjs reads that console: it caught exactly this
-// and went red on "account key: HTTP 404". A 500 is a different thing and does
+// and went red on "session token: HTTP 404". A 500 is a different thing and does
 // get reported. Verified by sabotage in both directions: report the expected
 // half and the 404 case goes red; stop reporting the 500 and the 500 case does.
-test('a missing session key is not a console error, and a broken endpoint is', async () => {
+test('a missing session token is not a console error, and a broken endpoint is', async () => {
   for (const status of [401, 403, 404]) {
     const quiet = await loadPage({ keyResponses: [{ status, body: {} }] });
     assert.equal(quiet.getElementById('ps-key-error').classList.contains('is-shown'), true,
-      `a ${status} must still raise the banner: the sender has to know why there is no key`);
+      `a ${status} must still raise the banner: the sender has to know why there is no credential`);
     assert.deepEqual(quiet.consoleErrors, [],
       `a ${status} is the ordinary "no key here" answer and may not write to the console of every signed-out visit`);
   }
 
   const broken = await loadPage({ keyResponses: [{ status: 500, body: {} }] });
   assert.equal(broken.getElementById('ps-key-error').classList.contains('is-shown'), true);
-  assert.ok(broken.consoleErrors.some((line) => /\[paramant\] account key/.test(line)),
+  assert.ok(broken.consoleErrors.some((line) => /\[paramant\] session token/.test(line)),
     'a 500 is unplanned, and its detail belongs in the console through the one reporter');
 
-  // A 200 that carries no key is the non-revealable account, which is planned
-  // as well: the reveal route says so in as many words.
-  const noKey = await loadPage({ keyResponses: [{ status: 200, body: { api_key: null, revealable: false } }] });
-  assert.equal(noKey.getElementById('ps-key-error').classList.contains('is-shown'), true);
-  assert.deepEqual(noKey.consoleErrors, [],
-    'an account whose key is not revealable is a documented state, not a fault to report');
+  // A 200 that carries no token is an account the relay would not mint for,
+  // which is planned as well: the admin says so with a token_unavailable body.
+  const noToken = await loadPage({ keyResponses: [{ status: 200, body: { error: 'token_unavailable' } }] });
+  assert.equal(noToken.getElementById('ps-key-error').classList.contains('is-shown'), true);
+  assert.deepEqual(noToken.consoleErrors, [],
+    'an account the relay will not mint for is a documented state, not a fault to report');
+});
+
+// ── 12. The self-host way out still sends a key ─────────────────────────────
+// The token endpoint is part of the hosted admin panel. A self-hosted relay may
+// not have it, and for that deployment the banner's "Use a key by hand" is the
+// whole product. So the manual path must still work, and it must send the
+// header a plain relay understands: X-Api-Key, not a Bearer for a token nobody
+// minted. Verified by sabotage: make relayAuthHeaders always send the Bearer
+// and this fails on the header; drop the sessionAuth reset out of onKeyInput
+// and it fails because a dead token is still being presented.
+test('a hand-typed key on a self-host sends X-Api-Key, and takes over from the token', async () => {
+  // Start on the happy path, so there IS a token to take over from. That is the
+  // case that can go wrong quietly: a page that keeps both credentials.
+  const run = await loadPage({ keyResponses: [ok200] });
+  assert.equal(evalIn(run, 'sessionAuth'), FAKE_TOKEN);
+
+  evalIn(run, 'expandApiKeyCard()');
+  assert.equal(evalIn(run, 'sessionAuth'), '',
+    'asking for the box drops the token: one credential at a time, or the page has two sources of truth again');
+
+  run.calls.relay.length = 0;
+  run.getElementById('api-key').value = FAKE_KEY;
+  await evalIn(run, 'onKeyInput()');
+  await new Promise((r) => setImmediate(r));
+
+  assert.equal(evalIn(run, 'apiKey'), FAKE_KEY, 'the typed key is the credential now');
+  assert.equal(evalIn(run, 'keyValid'), true);
+  assert.ok(run.calls.relay.length >= 4, 'the typed key is checked against the sectors');
+  assert.deepEqual([...new Set(relayAuth(run))], [FAKE_KEY],
+    'the self-host path must send the key as X-Api-Key; a plain relay knows nothing about pst_ tokens');
+  for (const c of run.calls.relay) {
+    assert.equal(c.headers.Authorization, undefined, 'and it must not still be waving a token it gave up');
+  }
+});
+
+// ── 13. The token runs out mid-session ──────────────────────────────────────
+// Fifteen minutes is short on purpose, and a send is not. A sender can pick a
+// 4 GB file, wait for a receiver to open the link, compare a fingerprint on the
+// phone and only then press Send, and the upload is the one step that cannot be
+// cheaply retried. There are two guards, and this measures both: the page mints
+// a replacement before the expiry it knows about, and if it is wrong about that
+// it takes one 401 from the relay and mints on the spot.
+//
+// Verified by sabotage: drop the margin refresh and the first case goes red;
+// drop the 401 retry and the second does; make the retry unconditional and the
+// last case never returns at all, which is the loop it exists to forbid.
+test('a token that expires during a long session is replaced, before and after the fact', async () => {
+  const SECOND = 'pst_' + '99887766'.repeat(8);
+
+  // (a) proactively. The page is handed a token that is already inside its
+  // refresh margin, so the very next relay call has to mint first.
+  const soon = await loadPage({
+    keyResponses: [
+      { status: 200, body: { token: FAKE_TOKEN, expires_in_s: 30 } },
+      { status: 200, body: { token: SECOND, expires_in_s: 900 } },
+    ],
+  });
+  assert.equal(soon.calls.key, 2, 'a token inside the margin is replaced before it is spent again');
+  assert.equal(evalIn(soon, 'sessionAuth'), SECOND);
+
+  // (b) after the fact. The token looks healthy, and the relay says otherwise:
+  // a restart, a revocation somewhere else, a clock that disagreed. One 401,
+  // one mint, one retry, and the call succeeds on the second token.
+  let refused = 0;
+  const dead = await loadPage({
+    keyResponses: [ok200, { status: 200, body: { token: SECOND, expires_in_s: 900 } }],
+    // Only the upload is refused, and only while the first token is being used.
+    relayStatus: (url) => {
+      if (!url.includes('/v2/inbound')) return null;
+      refused += 1;
+      return refused === 1 ? { status: 401, body: { error: 'Invalid API key' } } : null;
+    },
+  });
+  assert.equal(dead.calls.key, 1, 'nothing is minted until something is actually refused');
+
+  dead.calls.relay.length = 0;
+  const r = await evalIn(dead, "relayFetch('https://health.paramant.app/v2/inbound', { method: 'POST' })");
+  assert.equal(r.status, 200, 'the retry after a fresh token is what the caller ends up with');
+  assert.equal(dead.calls.key, 2, 'exactly one replacement token was minted');
+  assert.equal(evalIn(dead, 'sessionAuth'), SECOND);
+  assert.deepEqual(dead.calls.relay.map((c) => c.headers.Authorization),
+    [`Bearer ${FAKE_TOKEN}`, `Bearer ${SECOND}`],
+    'the first attempt carried the dead token and the second carried the new one');
+
+  // And it stops there. A relay that keeps saying 401 must not become a mint
+  // loop against a rate-limited endpoint.
+  const stubborn = await loadPage({
+    keyResponses: [ok200],
+    relayStatus: (url) => (url.includes('/v2/inbound') ? { status: 401, body: { error: 'Invalid API key' } } : null),
+  });
+  const before = stubborn.calls.key;
+  const still = await evalIn(stubborn, "relayFetch('https://health.paramant.app/v2/inbound', { method: 'POST' })");
+  assert.equal(still.status, 401, 'a 401 that survives a fresh token is a real 401 and is handed to the caller');
+  assert.ok(stubborn.calls.key - before <= 1, 'one mint, never a loop');
 });

--- a/tests/site-claims.test.mjs
+++ b/tests/site-claims.test.mjs
@@ -2232,20 +2232,23 @@ test('every page that promises burn-on-read says which client and which plan it 
   }
 });
 
-// 36 ── The account key and the browser. /privacy now states, in the storage
-// section, that the key is not in the browser at all and that a fifteen-minute
-// session token stands in for it. Three of the four things that sentence claims
-// are facts about code in this repository, so they are checked against it:
-// where the page gets its credential, what the relay honours, and how long.
-// The fourth, that the token is not persisted, is row 28 above.
+// 36 ── The account key and the browser. /privacy now has a section that names
+// which pages hold the API key in memory and which do not, and the list is a
+// claim about code: /parashare runs on a fifteen-minute session token, /account
+// reveals on purpose, /pricing and /dashboard still authenticate with the key
+// itself. Every one of those is checked against the file that does it.
 //
 // This row exists because the previous version of that paragraph was untrue for
 // months: it said paramant_api_key was "removed when you sign out" and nothing
-// removed it. A privacy page that describes a credential has to be pinned to
-// the credential.
-// Verified by sabotage: move TTL_S off 900, point the page back at
-// /api/user/account/key, or add a sixth route to the relay allowlist, and this
-// fails by name.
+// removed it. The first draft of THIS paragraph was untrue too, in the other
+// direction: it said the key was "not in your browser at all", which was true of
+// /parashare and false of three other pages. A privacy page that describes a
+// credential has to be pinned to the credential, in both directions, or it goes
+// stale the first time a page changes.
+// Verified by sabotage: move TTL_S off 900, add a sixth route to the relay
+// allowlist, point /parashare back at /api/user/account/key, or take the key
+// fetch out of pricing-billing.js without rewriting the page, and this fails by
+// name.
 test('the ParaSend credential /privacy describes is the credential the code implements', () => {
   const priv = visible(page('privacy'));
 
@@ -2266,20 +2269,47 @@ test('the ParaSend credential /privacy describes is the credential the code impl
   assert.ok(priv.includes('the relay accepts it on the five requests a transfer makes and refuses it on everything else'),
     'privacy: the storage section must state what the token can and cannot do');
 
-  // 3. The page really asks for a token, and really does not ask for the key.
+  // 3. /parashare really asks for a token, and really does not ask for the key.
   const ps = read('frontend/js/parashare.page.js');
   assert.ok(ps.includes('/api/user/parasend/token'),
-    'parashare.page.js must fetch a session token; /privacy says the browser is never given the key');
+    'parashare.page.js must fetch a session token; /privacy says the send page is never given the key');
   assert.ok(!ps.includes('/api/user/account/key'),
-    'parashare.page.js fetches the account key again, and /privacy says the page is never given it');
-  assert.ok(priv.includes('it is not in your browser at all'),
+    'parashare.page.js fetches the account key again, and /privacy says the send page is not given it');
+  assert.ok(priv.includes('Sending a file (<code>/parashare</code>) does not.'),
     'privacy: the claim itself must be on the page');
 
-  // 4. The manual self-host escape is named rather than hidden. It is the one
-  // case where a key IS in the browser, and a privacy page that described only
-  // the happy path would be the same half-truth as the last one.
-  assert.ok(priv.includes('On a self-hosted relay without our admin panel you can still type a key by hand'),
-    'privacy: the self-host exception must be stated, because on that path a key really is in the browser');
+  // 4. THE OTHER DIRECTION, and the half a privacy page usually gets wrong. The
+  // pages /privacy admits still hold the key must be exactly the pages that do.
+  // A page that stops fetching it and is still listed is a page telling you it
+  // holds something it does not; one that starts and is not listed is worse.
+  const HOLDERS = {
+    '/account': 'frontend/js/account.inline1.js',
+    '/pricing': 'frontend/js/pricing-billing.js',
+    '/dashboard': 'frontend/js/dashboard-history.js',
+  };
+  for (const [where, file] of Object.entries(HOLDERS)) {
+    assert.ok(read(file).includes('/api/user/account/key'),
+      `${file} no longer fetches the account key, and /privacy still says ${where} holds it. Rewrite the page with the code.`);
+    assert.ok(priv.includes(`<code>${where}</code>`),
+      `privacy: ${where} fetches the account key and the page must name it`);
+  }
+  // And nothing else in the frontend may fetch it without being named. This is
+  // what catches a fourth page joining the list quietly.
+  const fetchers = [];
+  (function walk(dir, prefix) {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (e.isDirectory()) { if (!['node_modules', 'vendor', 'pkg'].includes(e.name)) walk(path.join(dir, e.name), `${prefix}${e.name}/`); continue; }
+      if (!/\.(js|mjs|html)$/.test(e.name)) continue;
+      const rel = `${prefix}${e.name}`;
+      if (/fetch\(\s*['"`]\/api\/user\/account\/key/.test(stripJsComments(read(`frontend/${rel}`)))) fetchers.push(`frontend/${rel}`);
+    }
+  })(path.join(ROOT, 'frontend'), '');
+  assert.deepEqual(fetchers.sort(), Object.values(HOLDERS).sort(),
+    'a frontend file fetches the account key and /privacy does not name the page it is on');
+
+  // 5. The manual self-host escape on /parashare is named rather than hidden.
+  assert.ok(priv.includes('you can still type a key by hand on that page'),
+    'privacy: the self-host exception must be stated, because on that path a key really is typed into the browser');
   assert.match(page('parashare'), /data-click="expandApiKeyCard">Use a key by hand/,
     'and /parashare must still offer it, or /privacy describes a door that is not there');
 });

--- a/tests/site-claims.test.mjs
+++ b/tests/site-claims.test.mjs
@@ -1504,7 +1504,15 @@ test('the browser storage /privacy lists is the storage the frontend writes', ()
   // sender had typed by hand, because localStorage was a second source of truth
   // next to the session. There is one source now, and it is not this store.
   assert.ok(!keys.has('paramant_api_key'),
-    'a frontend file reads or writes paramant_api_key again. ParaSend takes the account key from GET /api/user/account/key on every load and keeps it in memory; /privacy no longer lists this key, so putting it back in localStorage makes that page untrue.');
+    'a frontend file reads or writes paramant_api_key again. ParaSend runs on a session token fetched from POST /api/user/parasend/token and held in memory; /privacy no longer lists this key, so putting it back in localStorage makes that page untrue.');
+  // And the token that replaced it must not become the next entry on the list.
+  // A pst_ token is a bearer credential with fifteen minutes on it: in
+  // localStorage it would outlive the tab that earned it, and /privacy says in
+  // as many words that it does not.
+  for (const k of keys) {
+    assert.ok(!/pst|parasend[._-]?token|session[._-]?token/i.test(k),
+      `a frontend file stores "${k}". The ParaSend session token is held in memory only, and /privacy says so.`);
+  }
 
   const priv = visible(page('privacy'));
   const list = priv.slice(priv.indexOf('<h2>Local storage in your browser</h2>'), priv.indexOf('</ul>', priv.indexOf('<h2>Local storage in your browser</h2>')));
@@ -2222,4 +2230,56 @@ test('every page that promises burn-on-read says which client and which plan it 
     assert.ok(flatten(bodyOf(page(slug))).includes(sentence),
       `${slug}: must spell the per-plan read counts as "${sentence}", the numbers tiers.js sets`);
   }
+});
+
+// 36 ── The account key and the browser. /privacy now states, in the storage
+// section, that the key is not in the browser at all and that a fifteen-minute
+// session token stands in for it. Three of the four things that sentence claims
+// are facts about code in this repository, so they are checked against it:
+// where the page gets its credential, what the relay honours, and how long.
+// The fourth, that the token is not persisted, is row 28 above.
+//
+// This row exists because the previous version of that paragraph was untrue for
+// months: it said paramant_api_key was "removed when you sign out" and nothing
+// removed it. A privacy page that describes a credential has to be pinned to
+// the credential.
+// Verified by sabotage: move TTL_S off 900, point the page back at
+// /api/user/account/key, or add a sixth route to the relay allowlist, and this
+// fails by name.
+test('the ParaSend credential /privacy describes is the credential the code implements', () => {
+  const priv = visible(page('privacy'));
+
+  // 1. Fifteen minutes, from the relay, not from the copywriter.
+  const ttl = /^const TTL_S = (\d+);/m.exec(stripJsComments(read('relay/lib/session-token.js')));
+  assert.ok(ttl, 'relay/lib/session-token.js must still declare TTL_S');
+  assert.equal(Number(ttl[1]), 900,
+    `the session token now lives ${ttl[1]} s; /privacy says fifteen minutes, so rewrite the sentence deliberately`);
+  assert.ok(priv.includes('That token lives fifteen minutes'),
+    'privacy: the storage section must state the token lifetime');
+
+  // 2. Five requests, and the relay's allowlist is what decides that.
+  const scope = stripJsComments(read('relay/lib/session-token.js'));
+  const rules = (scope.slice(scope.indexOf('const SCOPE = ['), scope.indexOf('function scopeAllows'))
+    .match(/\{ method:/g) || []).length;
+  assert.equal(rules, 5,
+    `the relay allowlist now has ${rules} entries; /privacy says five, so change the page with the code`);
+  assert.ok(priv.includes('the relay accepts it on the five requests a transfer makes and refuses it on everything else'),
+    'privacy: the storage section must state what the token can and cannot do');
+
+  // 3. The page really asks for a token, and really does not ask for the key.
+  const ps = read('frontend/js/parashare.page.js');
+  assert.ok(ps.includes('/api/user/parasend/token'),
+    'parashare.page.js must fetch a session token; /privacy says the browser is never given the key');
+  assert.ok(!ps.includes('/api/user/account/key'),
+    'parashare.page.js fetches the account key again, and /privacy says the page is never given it');
+  assert.ok(priv.includes('it is not in your browser at all'),
+    'privacy: the claim itself must be on the page');
+
+  // 4. The manual self-host escape is named rather than hidden. It is the one
+  // case where a key IS in the browser, and a privacy page that described only
+  // the happy path would be the same half-truth as the last one.
+  assert.ok(priv.includes('On a self-hosted relay without our admin panel you can still type a key by hand'),
+    'privacy: the self-host exception must be stated, because on that path a key really is in the browser');
+  assert.match(page('parashare'), /data-click="expandApiKeyCard">Use a key by hand/,
+    'and /parashare must still offer it, or /privacy describes a door that is not there');
 });


### PR DESCRIPTION
The security review of #397 accepted that /parashare had stopped keeping a key
in `localStorage` and then said the harder thing: the key should not be in the
browser at all. It named the answer, and this is it.

`/parashare` used to fetch the account API key and hold it in a variable for the
life of the tab. That key has no expiry and no scope: anything that got to run
script on the page could read it and keep it, and use it for uploads, downloads,
the audit chain, signing-key enrolment and ParaSign envelopes, until the owner
noticed and rotated. The page now holds a `pst_` session token instead. Fifteen
minutes. Five routes. No key.

## Relay

`relay/lib/session-token.js` mints the tokens into the shared Redis rather than a
Map, because the five sectors are separate processes behind one store and the
page discovers its sector at run time.

Inside an allowlist of five routes the token authenticates **as the api-key it
was minted for**: `/v2/check-key`, `POST /v2/ws-ticket`, `POST /v2/pubkey`,
`GET /v2/pubkey/:device`, `POST /v2/inbound`. Quota, the audit chain, device
queues and the per-tier limits therefore resolve against the owner account,
byte-identical to a request that carried the key. Every other path is
`403 session_token_out_of_scope`, decided above every route handler so the
sixty-ninth route cannot forget to ask: `/v2/user/*`, `/v2/outbound`,
`/v2/audit`, `/v2/admin/*`, the ParaSign routes, and a second mint.

`POST /v2/session-token` needs `X-Internal-Auth` **and** a live `X-Api-Key`, so
the admin plane is the only caller and a browser can never name an account other
than the one it is signed in as. An unconfigured internal token means closed.

Revoking a key sweeps its live tokens out of the store, and a token whose owner
key is inactive grants no principal even when that sweep never ran. Two locks,
because a revocation that rests on a best-effort write is not a revocation.

Store unreachable is `503` with `Retry-After`, never `401`: a 401 in an outage
tells a sender holding a good token that it is bad, and sends them to sign in
over a store that cannot do that either.

## Admin

`POST /api/user/parasend/token`, behind `authUser`. It takes no body: the account
comes from the session through `proxyApiKey`, so a browser cannot name another
one. It returns the token and its lifetime, and nothing else. It does not fall
back to the key when the mint fails, because that would put the credential back
in the browser on exactly the days something is already wrong.

`GET /api/user/account/key` stays. It is not what `/parashare` uses any more, and
the account page and a self-hoster still need it.

## Frontend

One function decides which header a relay call carries, so the five call sites
cannot drift: a Bearer on the hosted path, `X-Api-Key` on the manual self-host
path. `X-Api-Key` now appears exactly once in `parashare.page.js`, and a test
holds it there.

A token can die during a long send, so there are two guards: a refresh a minute
before the expiry the page knows about, and one 401 from the relay answered with
one mint and one retry. Never a loop. Typing a key by hand drops the token, so
the page never holds two credentials.

## Hardening from the security review (commit `499be50d`)

- **The stored record names its owner by hash.** It carried the api-key in the
  clear. Key *names* were already hashed (SCAN, keyspace listings and the
  slowlog all show names); the *value* was not, so an RDB snapshot, a replica, a
  backup or a `MONITOR` session held live `pgp_` credentials for every account
  that had sent a file in the last fifteen minutes. The record is now
  `{kh, exp}` and the relay resolves the hash through an index over the api-key
  table it already holds in memory. Built on load and on `/v2/reload-users`, and
  self-healing on a miss, because keys are also created at run time by routes
  that touch neither.
- **The expiry is required.** It was optional behind a `typeof`, so a record
  that lost the field fell back to whatever TTL redis had, and one written
  without it never expired on the wall clock at all.
- **`via: "pst"` on the audit entry** when the action ran through a token. A note
  on the credential, not a second identity: the chain stays keyed on the owner's
  api-key.
- **A ceiling of 20 live tokens per account**, `429` with `Retry-After`. The
  sweep index is pruned of names redis already expired before a refusal is made,
  and the prune runs only when the cheap `sCard` says the cap is in reach.

Sabotages for each: put the key back in the record, restore the `typeof` guard
on `exp`, drop the audit field, set the cap to `Infinity`, make the prune remove
live tokens, and stop the hash index healing on a miss. All six go red by name.
The route suite also reads the real store the way a leak would (`SCAN` over the
whole prefix plus the record bodies) and asserts nothing shaped like an api-key
is in it.

Suites are now 26 (unit) + 24 (route) + 9 (admin) + 13 (page) checks.

## What this does NOT fix, said out loud

ParaSend was not the only caller of the reveal route. Three pages still fetch
the raw key into the browser and use it as a relay credential:

| Page | File | What it does with the key |
|------|------|---------------------------|
| `/account` | `frontend/js/account.inline1.js` | reveals it on screen, deliberately |
| `/pricing` | `frontend/js/pricing-billing.js` | `X-Api-Key` on `POST /v2/billing/checkout` |
| `/dashboard` | `frontend/js/dashboard-history.js` | `X-Api-Key` on the usage and history reads |

So the honest statement is: on `/parashare` the key is gone, and on a browser
that has loaded any of those three it is not. The first draft of the `/privacy`
paragraph in this PR said "not in your browser at all", which was true of one
page and false of three, and that is the same failure as the
`paramant_api_key` line it replaced, one draft later. `/privacy` now names all
four pages and says what each does, and site-claims row 36 holds the list from
both ends: a listed page that stops fetching the key fails, and a fourth page
that starts fetching it without being listed fails too.

`SECURITY.md` carries the same table under "what is still open", with what
closing it would take: `/pricing` and `/dashboard` need scoped credentials of
their own or server-side proxies, and `/account` has to keep a way to show a key
a self-hoster genuinely needs. Recorded rather than fixed, because that is a
separate change and a partial one would break three pages.

It also states the new ceiling plainly: a script on the site can still act as
the signed-in user for fifteen minutes, and this is a reduction, not a fix for
cross-site scripting.

## Tests

| Suite | Checks | Job |
|---|---|---|
| `relay/test/session-token.test.js` | 19 | relay unit (no redis, no deps) |
| `relay/test/route-session-token.test.js` | 18 | relay crypto/route (booted relay + redis) |
| `admin/test/parasend-token.test.js` | 9 | admin unit (booted admin + stub relay + redis) |
| `tests/parasend-session-key.test.mjs` | 13 | root integration (the page in a vm) |
| `tests/site-claims.test.mjs` rows 28 and 36 | | root integration |
| `relay/test/route-auth-gate.test.js` and `v1-bearer-gate.test.js` | +2 | the boundary between the two Bearer credentials |

The route suite is the one that matters most: an upload made with a token
increments the owner's monthly counter and lands in the owner's audit chain, the
owner over its cap is the token over its cap, expiry is honoured on both the
store TTL and the wall clock inside the record, revocation works twice over, and
an `X-Api-Key` on the request always wins.

Verified by sabotage, seventeen of them, each against the suite that should
catch it. Relay: `scopeAllows` returning true, `resolve` returning null instead
of throwing on a missing store, dropping the `exp` check, moving the TTL to an
hour, dropping the revocation sweep, letting a Bearer override an `X-Api-Key`,
removing the scope gate. Admin: leaking the key next to the token, reading the
account from the body, forgetting the internal header, falling back to the key.
Frontend: sending `X-Api-Key` on the hosted path, dropping either refresh,
making the retry unconditional (it never returns, which is the loop it forbids),
keeping the token when a key is typed, persisting the key again. Claims: moving
`TTL_S`, adding a sixth route to the allowlist, pointing the page back at
`/api/user/account/key`, storing the token.



