### PR TITLE
A screenshot is not a gate: app-shots leaves the browser suites, and every capture goes through one settled helper

### DIFF
--- a/.github/workflows/sign-e2e.yml
+++ b/.github/workflows/sign-e2e.yml
@@ -36,5 +36,15 @@ jobs:
       # dashboards, the navigation shell, multi-verify and invite delivery had
       # no CI at all. Selected by import, so a new browser suite is picked up
       # here the day it is written. product-heartbeat has its own workflow.
+      #
+      # Selected by import means anything in tests/ that drives a browser lands
+      # here, gate or not. app-shots was a screenshot generator that asserted
+      # nothing, and on 2026-09-03 its `page.screenshot: Timeout 30000ms
+      # exceeded` took this workflow red on main and blocked the deploy, which
+      # needs sign-e2e green in phase 0a. It now lives in scripts/app-shots.mjs
+      # with the other generators, so this line did not have to grow an
+      # exception. The rule: tests/ is for files that assert something, and a
+      # file that only produces artefacts goes in scripts/, browser or not.
+      # Same move as the heartbeat canaries in test.yml. See tests/README.md.
       - name: Browser suites
         run: node --test $(grep -l "from 'playwright'" tests/*.mjs | grep -vE 'sign-full|product-heartbeat')

--- a/docs/brand/design-direction.md
+++ b/docs/brand/design-direction.md
@@ -508,7 +508,7 @@ niet met een media query.
     query of een attribuut dat niemand kan zetten is geen functie maar 31 KB.
     Dat is #380, en het is de duurste les van deze reeks.
 11. **Geen verzonnen data in een screenshot dat als bewijs dient.** De
-    documentrijen in de app-screenshots zijn stubdata uit `tests/app-shots.mjs`
+    documentrijen in de app-screenshots zijn stubdata uit `scripts/app-shots.mjs`
     en mogen nooit als bewijs van werking gelden.
 
 ---
@@ -544,7 +544,7 @@ BRAND_SHOTS_DRY_RUN=1 node scripts/brand-shots-direction.mjs         zeg alleen 
 ```
 
 De app-schermen hebben hun eigen 36 referentiebeelden in
-`docs/brand/assets/app-2026/`, geschoten door `tests/app-shots.mjs` onder
+`docs/brand/assets/app-2026/`, geschoten door `scripts/app-shots.mjs` onder
 dezelfde vlag.
 
 ### 7.2 Wat gemeten is, en waar

--- a/scripts/app-shots.mjs
+++ b/scripts/app-shots.mjs
@@ -1,23 +1,35 @@
-// Screenshot harness for the app screens. Not a gate: it renders every app
-// screen at 390x844 and 1440x900, in light and dark, with the same API stubs
-// the dashboard suite uses, and writes the images.
+// Screenshot generator for the app screens. It renders every app screen at
+// 390x844 and 1440x900, in light and dark, with the same API stubs the
+// dashboard suite uses, and writes the images.
+//
+// This is a generator and not a gate, which is why it lives in scripts/ next to
+// brand-shots-direction.mjs and shot-dashboard.mjs. It used to sit in tests/,
+// where it was picked up by the sign-e2e workflow's "Browser suites" step: that
+// step runs every tests/*.mjs that imports playwright, and this file imports
+// playwright. It asserts nothing, so a green run proved nothing, and on
+// 2026-09-03 a `page.screenshot: Timeout 30000ms exceeded` in here took sign-e2e
+// red on main and blocked the deploy (run 33746496749). A picture is not a
+// gate. Moving the file out of tests/ takes it out of that selection without
+// touching the selection itself, so every real browser suite still runs.
 //
 // It writes to a temp directory by default. The tracked reference images under
-// docs/ are opt-in, because a suite that rewrites 36 tracked files on every run
-// turns `git commit -a` into a screenshot dump. See scripts/brand-shots-dir.mjs
-// for the rule and tests/brand-shots-optin.test.mjs for the guard.
+// docs/ are opt-in, because a generator that rewrites 36 tracked files on every
+// run turns `git commit -a` into a screenshot dump. See
+// scripts/brand-shots-dir.mjs for the rule and tests/brand-shots-optin.test.mjs
+// for the guard.
 //
-// Run:                 node tests/app-shots.mjs
-// Refresh references:  PARAMANT_WRITE_BRAND_SHOTS=1 node tests/app-shots.mjs
-// One screen only:     APP_SHOTS_ONLY=dashboard node tests/app-shots.mjs
-// Where would it write: APP_SHOTS_DRY_RUN=1 node tests/app-shots.mjs
+// Run:                 node scripts/app-shots.mjs
+// Refresh references:  PARAMANT_WRITE_BRAND_SHOTS=1 node scripts/app-shots.mjs
+// One screen only:     APP_SHOTS_ONLY=dashboard node scripts/app-shots.mjs
+// Where would it write: APP_SHOTS_DRY_RUN=1 node scripts/app-shots.mjs
 
 import { chromium } from 'playwright';
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolveBrandShotsDir, FLAG, DRY_RUN_VAR } from '../scripts/brand-shots-dir.mjs';
+import { resolveBrandShotsDir, FLAG, DRY_RUN_VAR } from './brand-shots-dir.mjs';
+import { stableScreenshot } from './stable-screenshot.mjs';
 
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
 const TARGET = resolveBrandShotsDir();
@@ -123,7 +135,7 @@ for (const screen of SCREENS) {
       try { await page.locator(screen.ready).first().waitFor({ timeout:6000 }); } catch { /* render what there is */ }
       await page.waitForTimeout(500);
       const file = path.join(OUT, `${screen.name}-${vp.w}x${vp.h}-${theme}.png`);
-      await page.screenshot({ path:file, fullPage:true });
+      await stableScreenshot(page, { path:file, fullPage:true });
       written.push(path.basename(file));
       await context.close();
     }
@@ -143,13 +155,18 @@ if (!only || only.includes('dashboard')) {
     await page.goto(ORIGIN + '/dashboard', { waitUntil:'domcontentloaded' });
     await page.waitForTimeout(700);
     const file = path.join(OUT, `dashboard-1440x900-${theme}-loading.png`);
-    await page.screenshot({ path:file });
+    // No network settle here: /api/user/me is the request that never answers,
+    // so this page can never go idle and waiting for it would only cost time.
+    await stableScreenshot(page, { path:file, networkIdleMs:0 });
     written.push(path.basename(file));
     await context.close();
   }
 }
 
 // One reduced-motion pair, to prove nothing disappears when motion is off.
+// This still says something even though every capture freezes animations:
+// scripts/stable-screenshot.mjs freezes them for the capture only, while
+// prefers-reduced-motion is a media query the page renders differently for.
 if (!only || only.includes('dashboard')) {
   for (const theme of THEMES) {
     const context = await browser.newContext({ viewport:{ width:1440, height:900 }, deviceScaleFactor:2, colorScheme:theme, reducedMotion:'reduce' });
@@ -160,7 +177,7 @@ if (!only || only.includes('dashboard')) {
     try { await page.locator('#dh-root:not([hidden]) .dh-document').first().waitFor({ timeout:6000 }); } catch { /* */ }
     await page.waitForTimeout(400);
     const file = path.join(OUT, `dashboard-1440x900-${theme}-reduced-motion.png`);
-    await page.screenshot({ path:file, fullPage:true });
+    await stableScreenshot(page, { path:file, fullPage:true });
     written.push(path.basename(file));
     await context.close();
   }

--- a/scripts/brand-shots-dir.mjs
+++ b/scripts/brand-shots-dir.mjs
@@ -1,6 +1,6 @@
 // Where the app screenshots are allowed to land.
 //
-// tests/app-shots.mjs renders every app screen at two viewports in two themes
+// scripts/app-shots.mjs renders every app screen at two viewports in two themes
 // and writes 36 PNGs. Until now it wrote them straight into
 // docs/brand/assets/app-2026/, which is tracked. So every local run of the
 // browser suites rewrote 36 tracked files, `git status` was never clean after a
@@ -10,8 +10,8 @@
 // Rewriting the reference images is a deliberate act, not a side effect of
 // running the tests. So the tracked directory is opt-in:
 //
-//   node tests/app-shots.mjs                          -> a temp dir, repo clean
-//   PARAMANT_WRITE_BRAND_SHOTS=1 node tests/app-shots.mjs  -> docs/brand/assets
+//   node scripts/app-shots.mjs                          -> a temp dir, repo clean
+//   PARAMANT_WRITE_BRAND_SHOTS=1 node scripts/app-shots.mjs  -> docs/brand/assets
 //
 // APP_SHOTS_DIR still names an explicit directory and still wins, with one
 // rule: an explicit path that points back inside docs/ is refused without the

--- a/scripts/stable-screenshot.mjs
+++ b/scripts/stable-screenshot.mjs
@@ -1,0 +1,105 @@
+// One screenshot call that does not flake.
+//
+// On 2026-09-03 sign-e2e went red on main with `page.screenshot: Timeout
+// 30000ms exceeded` (run 33746496749). The same failure had already been seen
+// on a pull request. It is not a product bug: a fullPage capture at
+// deviceScaleFactor 2 on a loaded ubuntu runner simply needs more than
+// Playwright's 30 s default, and a page that is still fetching, still swapping
+// a webfont or still running an animation makes the capture wait for a stable
+// frame that never comes.
+//
+// So every screenshot in this repo goes through here and gets three things:
+//
+//   1. SETTLE     network quiet and document.fonts.ready before the capture,
+//                 both bounded, both best-effort. A page that never goes idle
+//                 (an API stub that deliberately never answers, for instance)
+//                 must still be photographable, so a timeout here is not a
+//                 failure: it falls through to the capture.
+//   2. ANIMATIONS `animations: 'disabled'`, which is Playwright's own knob:
+//                 finite CSS animations and transitions are fast-forwarded to
+//                 their end state and infinite ones are cancelled to their
+//                 initial state, for the duration of the capture only. This is
+//                 deliberately NOT page.emulateMedia({ reducedMotion:'reduce' }):
+//                 that changes what the page renders, which would silently
+//                 rewrite assertions taken after the shot and would make
+//                 scripts/app-shots.mjs' reduced-motion pair identical to its
+//                 normal pair, so the picture would stop proving anything.
+//   3. RETRY      60 s, and on a timeout one more attempt at 120 s. Measured,
+//                 not guessed: ten runs of the generator under sixteen busy
+//                 cores put one capture past 60 s with a call log reading
+//                 "taking page screenshot / disabled all CSS animations", so
+//                 the page had settled and the raster itself was starved. No
+//                 wait condition fixes that; only more budget does. A
+//                 screenshot has no side effect, so taking it twice is safe,
+//                 and a second attempt that still times out is reported rather
+//                 than swallowed.
+//
+// Callers: scripts/app-shots.mjs and the suites that write a screenshot as a
+// byproduct when PARAMANT_*_SCREENSHOT_PATH is set (navigation-shell,
+// cosign-document-delivery, user-dashboard-documents, sign-invite-delivery,
+// developer-parasign-dashboard). Those calls are env-gated and never run in CI;
+// they are still routed through here because a screenshot a builder takes by
+// hand on a busy laptop hits the same wall.
+//
+// This file lives in scripts/ and not in tests/ on purpose: tests/*.mjs is a
+// glob that two workflows run as suites, so a helper there would be executed as
+// a test by test.yml.
+
+// Playwright's default is 30 s. Everything here is one screenshot, never a gate,
+// so the first attempt gets double that and a retry gets double again.
+export const SCREENSHOT_TIMEOUT_MS = 60_000;
+export const SCREENSHOT_RETRY_TIMEOUT_MS = 120_000;
+
+// How long we are willing to wait for the page to go quiet before shooting it
+// anyway. Bounded on purpose: some shots are OF a pending state.
+const SETTLE_TIMEOUT_MS = 5_000;
+
+// Best effort, both of them. A page that never reaches networkidle, or a
+// browser without the fonts API, is photographed as it is rather than failing.
+export async function settleForShot(page, { networkIdleMs = SETTLE_TIMEOUT_MS, fontsMs = SETTLE_TIMEOUT_MS } = {}) {
+  if (networkIdleMs > 0) {
+    try { await page.waitForLoadState('networkidle', { timeout: networkIdleMs }); } catch { /* still busy: shoot it anyway */ }
+  }
+  if (fontsMs > 0) {
+    // page.evaluate has no timeout of its own, so the bound is ours. A font
+    // that never arrives must not hold the capture forever.
+    const fonts = page.evaluate(() => (document.fonts ? document.fonts.ready.then(() => true) : true));
+    let timer;
+    try {
+      await Promise.race([fonts, new Promise((resolve) => { timer = setTimeout(resolve, fontsMs); })]);
+    } catch { /* no fonts API, or the page went away: shoot it anyway */ }
+    clearTimeout(timer);
+    fonts.catch(() => { /* already handled, and an unobserved rejection would kill the run */ });
+  }
+}
+
+// Takes the shot. `target` is a Page or a Locator, so an element screenshot
+// gets the same treatment as a full page one. Options are passed straight to
+// Playwright, so a caller can still say fullPage, type, quality or clip, and
+// can override the timeout or animations if it ever has a reason to.
+export async function stableScreenshot(target, options = {}) {
+  const { settle = true, networkIdleMs, fontsMs, ...shot } = options;
+  const page = typeof target.page === 'function' ? target.page() : target;
+  if (settle) await settleForShot(page, { networkIdleMs, fontsMs });
+
+  const budgets = [SCREENSHOT_TIMEOUT_MS, SCREENSHOT_RETRY_TIMEOUT_MS];
+  let last;
+  for (const timeout of budgets) {
+    try {
+      return await target.screenshot({ timeout, animations: 'disabled', ...shot });
+    } catch (error) {
+      // Only a timeout is worth trying again. A bad path, a closed page or a
+      // detached element is a real error and must surface on the first attempt.
+      if (error?.name !== 'TimeoutError') throw error;
+      last = error;
+      // Loud on purpose: a run that quietly took twice as long is how a
+      // machine that is too slow for this work stays undiagnosed.
+      if (timeout !== budgets[budgets.length - 1]) {
+        console.warn(`screenshot timed out after ${timeout} ms, one more attempt at ${SCREENSHOT_RETRY_TIMEOUT_MS} ms`);
+        // Let the machine breathe before asking it for the same frame again.
+        await page.waitForTimeout(1000);
+      }
+    }
+  }
+  throw last;
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,7 +22,7 @@ Guards the auth + TOTP stack against the class of breakage that hit production r
 | `tests/auth-smoke.sh` | `deploy.sh` step 4 | 21 live HTTP assertions against production |
 | `deploy.sh` | manual deploy | Chains: sanity → build → health wait → smoke |
 | `tests/version-consistency.test.mjs` | Root integration suites | One version in one place: root `package.json` versus the relay and admin packages, both lockfiles, both image labels, the `VERSION` read in `relay.js`, the CHANGELOG section and the deploy check. Four places once gave three answers; see [docs/RELEASE.md](../docs/RELEASE.md) |
-| `tests/brand-shots-optin.test.mjs` | Root integration suites, and `tests/static-sanity.sh` (pre-commit) | The reference screenshots under `docs/brand/assets/app-2026/` are opt-in. `tests/app-shots.mjs` used to write 36 tracked PNGs on every run, so `git status` was never clean after a browser suite and the next `git commit -a` shipped them. Three layers: the resolver's own rules, a real dry run of `tests/app-shots.mjs` that has to name a directory outside the repo and leave the references byte-identical, and a scan so no other suite hardcodes the path. See [Refreshing the app screenshots](#refreshing-the-app-screenshots) |
+| `tests/brand-shots-optin.test.mjs` | Root integration suites, and `tests/static-sanity.sh` (pre-commit) | The reference screenshots under `docs/brand/assets/app-2026/` are opt-in. `scripts/app-shots.mjs` used to write 36 tracked PNGs on every run, so `git status` was never clean after a browser suite and the next `git commit -a` shipped them. Three layers: the resolver's own rules, a real dry run of `scripts/app-shots.mjs` that has to name a directory outside the repo and leave the references byte-identical, and a scan so no other suite hardcodes the path. See [Refreshing the app screenshots](#refreshing-the-app-screenshots) |
 | `tests/env-documented.test.mjs` | Root integration suites | Every `process.env` name the relay or admin reads must be in [deploy/.env.example](../deploy/.env.example) with a purpose, a default and the file that reads it. Nothing may be documented there that no code reads, and every `read in:` pointer must name a file that exists and mentions the variable. 40 of 57 were undocumented on 2026-09-02 |
 
 ## Running manually
@@ -41,27 +41,82 @@ Guards the auth + TOTP stack against the class of breakage that hit production r
 PARAMANT_BASE=http://localhost:4200/admin ./tests/auth-smoke.sh
 ```
 
-## Refreshing the app screenshots
+## Screenshots
 
-`tests/app-shots.mjs` renders every app screen at 390x844 and 1440x900, in
-light and dark, and writes 36 PNGs. The copies under
-`docs/brand/assets/app-2026/` are tracked, so writing them is a deliberate act
-and never a side effect of running the tests.
+### A screenshot is not a gate
+
+`scripts/app-shots.mjs` renders every app screen at 390x844 and 1440x900, in
+light and dark, and writes 36 PNGs. It lives in `scripts/`, next to
+`brand-shots-direction.mjs` and `shot-dashboard.mjs`, and it is deliberately not
+in `tests/`.
+
+It used to be `tests/app-shots.mjs`, and that is a real scar. The sign-e2e
+workflow's `Browser suites` step runs every `tests/*.mjs` that imports
+playwright, selected by import so a new browser suite is picked up the day it is
+written. This generator imports playwright, so it was picked up too. It asserts
+nothing, so a green run proved nothing, but a red one blocked everything: on
+2026-09-03 `page.screenshot: Timeout 30000ms exceeded` in this file took sign-e2e
+red on main (run 33746496749) and with it the deploy, which needs sign-e2e green
+in phase 0a. The same flake had already been seen on a pull request.
+
+Moving the file changes nothing about the workflow's selection line. The real
+browser suites it selects are the same sixteen minus this one:
+
+```bash
+# What the sign-e2e Browser suites step runs, before and after:
+grep -l "from 'playwright'" tests/*.mjs | grep -vE 'sign-full|product-heartbeat'
+```
+
+The rule this leaves behind: a file under `tests/` is a gate and asserts
+something. A file that only produces artefacts belongs in `scripts/`, whether or
+not it drives a browser.
+
+### Every screenshot goes through one helper
+
+`scripts/stable-screenshot.mjs`. It waits for network quiet and
+`document.fonts.ready` first (both bounded, both best-effort, so a page that is
+*meant* to be pending is still photographable), passes `animations: 'disabled'`
+so the capture is not waiting on a frame that never settles, and gives the shot
+60 s instead of Playwright's 30, with one retry at 120 s.
+
+The retry is measured, not guessed. Ten runs of the generator under sixteen busy
+cores put one capture past 60 s, and its call log read `taking page screenshot /
+disabled all CSS animations`: the page had settled and the raster itself was
+starved of CPU. No wait condition fixes that, only more budget does. A screenshot
+has no side effect, so taking it twice is safe; the retry warns on stderr, and a
+second timeout is thrown rather than swallowed.
+
+`animations: 'disabled'` and not `page.emulateMedia({ reducedMotion: 'reduce' })`,
+on purpose. Playwright freezes animations for the capture only; the media
+emulation changes what the page renders from that point on, which would silently
+move the ground under assertions taken after the shot and would make the
+reduced-motion pair in `app-shots.mjs` identical to the normal pair.
+
+The suites that write a screenshot as a byproduct call it too: `navigation-shell`,
+`cosign-document-delivery`, `user-dashboard-documents`, `sign-invite-delivery`
+and `developer-parasign-dashboard`. Those calls are gated on a
+`PARAMANT_*_SCREENSHOT_PATH` variable and never fire in CI, but a builder taking
+one by hand on a busy laptop hits the same wall the runner did.
+
+### Refreshing the app screenshots
+
+The copies under `docs/brand/assets/app-2026/` are tracked, so writing them is a
+deliberate act and never a side effect of running the tests.
 
 ```bash
 # Default: a temp directory. The repo stays clean.
-node tests/app-shots.mjs
+node scripts/app-shots.mjs
 
 # Only where would it write, no browser, no files.
-APP_SHOTS_DRY_RUN=1 node tests/app-shots.mjs
+APP_SHOTS_DRY_RUN=1 node scripts/app-shots.mjs
 
 # Refresh the tracked reference images. Review the diff before committing:
 # a screenshot that changed by two pixels of antialiasing still looks like a
 # screenshot, so a careless `git commit -a` is exactly the failure this guards.
-PARAMANT_WRITE_BRAND_SHOTS=1 node tests/app-shots.mjs
+PARAMANT_WRITE_BRAND_SHOTS=1 node scripts/app-shots.mjs
 
 # One screen only, and an explicit destination.
-APP_SHOTS_ONLY=dashboard APP_SHOTS_DIR=/tmp/shots node tests/app-shots.mjs
+APP_SHOTS_ONLY=dashboard APP_SHOTS_DIR=/tmp/shots node scripts/app-shots.mjs
 ```
 
 `APP_SHOTS_DIR` wins over the default, with one rule: a path pointing back
@@ -69,9 +124,10 @@ inside `docs/` is refused unless `PARAMANT_WRITE_BRAND_SHOTS=1` is set too.
 Otherwise the opt-in would be one environment variable away from meaning
 nothing. Where the decision is made: `scripts/brand-shots-dir.mjs`.
 
-CI never consumes these images. The sign-e2e workflow runs `tests/app-shots.mjs`
-because it picks up every suite that imports playwright, and no workflow uploads
-or reads the result, so nothing there sets the flag.
+CI never consumes these images, and since 2026-09-03 no workflow runs the
+generator at all. `tests/brand-shots-optin.test.mjs` still spawns it in dry-run
+mode, so the opt-in is measured against the file that does the writing rather
+than against a second copy of its rules.
 
 ## Pre-commit hook
 

--- a/tests/brand-shots-optin.test.mjs
+++ b/tests/brand-shots-optin.test.mjs
@@ -1,6 +1,6 @@
 // The reference screenshots under docs/ are opt-in, and this is what holds it.
 //
-// tests/app-shots.mjs used to write 36 PNGs straight into
+// scripts/app-shots.mjs used to write 36 PNGs straight into
 // docs/brand/assets/app-2026/ on every run. Those files are tracked, so any
 // local run of the browser suites left 36 modified files behind and the next
 // `git commit -a` shipped them. Two builders hit that in the same week. Nothing
@@ -14,7 +14,7 @@
 //      tracked directory; and an explicit APP_SHOTS_DIR aimed back into docs/
 //      is refused without the flag, so the opt-in is not one variable away
 //      from meaning nothing.
-//   2. DRY RUN: the real tests/app-shots.mjs, spawned with a scrubbed
+//   2. DRY RUN: the real scripts/app-shots.mjs, spawned with a scrubbed
 //      environment, has to name a directory outside this repo, and the tracked
 //      directory must be byte-identical afterwards. This measures the file
 //      that does the writing, not a second copy of its rules.
@@ -36,7 +36,7 @@ import {
 
 // Built from parts so the static scan below does not match its own pattern.
 const TRACKED_REL = ['docs', 'brand', 'assets'].join('/');
-const SHOTS_SUITE = path.join(REPO_ROOT, 'tests', 'app-shots.mjs');
+const SHOTS_SUITE = path.join(REPO_ROOT, 'scripts', 'app-shots.mjs');
 
 function under(parent, child) {
   const rel = path.relative(parent, child);
@@ -131,9 +131,9 @@ test('a dry run of the real suite names a directory outside the repo and writes 
   const target = line.slice('out-dir: '.length).trim();
 
   assert.ok(!under(REPO_ROOT, target),
-    `tests/app-shots.mjs would write into the repo without ${FLAG}: ${target}`);
+    `scripts/app-shots.mjs would write into the repo without ${FLAG}: ${target}`);
   assert.ok(!isUnderDocs(target),
-    `tests/app-shots.mjs would write under docs/ without ${FLAG}: ${target}`);
+    `scripts/app-shots.mjs would write under docs/ without ${FLAG}: ${target}`);
   assert.match(out, /opt-in: no/);
   assert.equal(snapshot(TRACKED_DIR), before, 'a dry run must leave the tracked references untouched');
 });
@@ -179,5 +179,5 @@ test('nothing else names the tracked screenshot directory without going through 
   assert.deepEqual(offenders, [],
     `these name ${TRACKED_REL}/ but neither import the resolver nor mention ${FLAG}. ` +
     'The reference images are tracked: write to a temp directory by default and ' +
-    'let the flag opt in, the way tests/app-shots.mjs does.');
+    'let the flag opt in, the way scripts/app-shots.mjs does.');
 });

--- a/tests/cosign-document-delivery.test.mjs
+++ b/tests/cosign-document-delivery.test.mjs
@@ -3,6 +3,7 @@
 // network APIs. No Redis, account, production request or persistent test data.
 
 import { chromium } from 'playwright';
+import { stableScreenshot } from '../scripts/stable-screenshot.mjs';
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -110,7 +111,7 @@ let appearanceState = await page.evaluate(() => ({
 }));
 ok('recipient places a visible signature and date on the PDF', appearanceState.fields.length === 2 && appearanceState.fields.some((field) => /Paramant signed/i.test(field.text)) && appearanceState.fields.some((field) => /2026|2027/i.test(field.text)), JSON.stringify(appearanceState));
 ok('placement draft stores coordinates only for refresh recovery', /"type":"seal"/.test(appearanceState.draft) && !/example\.com|agreement/i.test(appearanceState.draft), appearanceState.draft);
-if (process.env.PARAMANT_COSIGN_SCREENSHOT_PATH) await page.screenshot({ path:process.env.PARAMANT_COSIGN_SCREENSHOT_PATH, fullPage:true });
+if (process.env.PARAMANT_COSIGN_SCREENSHOT_PATH) await stableScreenshot(page, { path:process.env.PARAMANT_COSIGN_SCREENSHOT_PATH, fullPage:true });
 const renderedPdf = await page.evaluate(async () => {
   const raw = Array.from({ length: sessionStorage.length }, (_, i) => sessionStorage.getItem(sessionStorage.key(i))).find((value) => value && value.includes('"fields"'));
   // Read the url off the page: a repeated ?v= here becomes a second module

--- a/tests/developer-parasign-dashboard.test.mjs
+++ b/tests/developer-parasign-dashboard.test.mjs
@@ -1,6 +1,7 @@
 // Real Chromium coverage for the ParaSign-only developer dashboard.
 
 import { chromium } from 'playwright';
+import { stableScreenshot } from '../scripts/stable-screenshot.mjs';
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -58,7 +59,7 @@ ok('dashboard does not request the obsolete tool catalogue', toolsRequests === 0
 ok('signing usage ignores transfer usage', await page.locator('#sign-used').innerText() === '18' && !/400/.test(await page.locator('[aria-labelledby="usage-title"]').innerText()), await page.locator('[aria-labelledby="usage-title"]').innerText());
 ok('existing ParaSign key is visible', /psk_live_abc/.test(await page.locator('#psk-keys').innerText()), await page.locator('#psk-keys').innerText());
 ok('phone viewport has no horizontal overflow', await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth) <= 1, await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth));
-if (process.env.PARAMANT_SCREENSHOT_PATH) await page.screenshot({ path:process.env.PARAMANT_SCREENSHOT_PATH, fullPage:true });
+if (process.env.PARAMANT_SCREENSHOT_PATH) await stableScreenshot(page, { path:process.env.PARAMANT_SCREENSHOT_PATH, fullPage:true });
 
 await page.locator('#psk-new').click();
 await page.locator('#psk-label').fill('Invoice integration');

--- a/tests/navigation-shell.test.mjs
+++ b/tests/navigation-shell.test.mjs
@@ -1,4 +1,5 @@
 import { chromium } from 'playwright';
+import { stableScreenshot } from '../scripts/stable-screenshot.mjs';
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -257,7 +258,7 @@ ok('the signed-in homepage stops after the hero', homeSections.total > 1 && JSON
 // The founder line stays: it is the one thing on this page that says who is
 // accountable, and tests/ui-truthfulness pins its wording.
 ok('the signed-in hero keeps the name behind the product', (await homePage.locator('[data-home="in"]').innerText()).includes('Mick Beer'), await homePage.locator('[data-home="in"]').innerText());
-if (process.env.PARAMANT_HOME_SCREENSHOT_PATH) await homePage.screenshot({ path:process.env.PARAMANT_HOME_SCREENSHOT_PATH });
+if (process.env.PARAMANT_HOME_SCREENSHOT_PATH) await stableScreenshot(homePage, { path:process.env.PARAMANT_HOME_SCREENSHOT_PATH });
 await homePage.close();
 
 // Signed OUT, nothing above applies and the page is the page it was: the whole
@@ -482,7 +483,7 @@ ok('legacy account key is advanced instead of the first task', await accountPage
 ok('billing settings do not claim live checkout is a stub', !/stub mode|no real payments/i.test(await accountPage.locator('#billing-section').innerText()), await accountPage.locator('#billing-section').innerText());
 ok('account action describes deactivation instead of erasure', /account record is retained/i.test(await accountPage.locator('.acct-card.danger').innerText()) && !/permanent|delete account/i.test(await accountPage.locator('.acct-card.danger').innerText()), await accountPage.locator('.acct-card.danger').innerText());
 ok('settings fit the phone viewport', await accountPage.evaluate(() => document.documentElement.scrollWidth === document.documentElement.clientWidth), await accountPage.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth));
-if (process.env.PARAMANT_SETTINGS_SCREENSHOT_PATH) await accountPage.screenshot({ path:process.env.PARAMANT_SETTINGS_SCREENSHOT_PATH, fullPage:true });
+if (process.env.PARAMANT_SETTINGS_SCREENSHOT_PATH) await stableScreenshot(accountPage, { path:process.env.PARAMANT_SETTINGS_SCREENSHOT_PATH, fullPage:true });
 await accountPage.close();
 
 const developerPage = await browser.newPage({ viewport:{ width:1280, height:900 } });

--- a/tests/sign-invite-delivery.test.mjs
+++ b/tests/sign-invite-delivery.test.mjs
@@ -2,6 +2,7 @@
 // Uses the real page and WebCrypto. Only same-origin APIs are stubbed.
 
 import { chromium } from 'playwright';
+import { stableScreenshot } from '../scripts/stable-screenshot.mjs';
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -100,7 +101,7 @@ await page.goto(ORIGIN + '/sign', { waitUntil: 'domcontentloaded' });
 ok('landing leads with the request-signatures workflow', await page.locator('.ds-mode-card').first().getAttribute('data-mode') === 'invite' && await page.locator('.ds-mode-card').first().getAttribute('class').then((value) => value.includes('primary')), await page.locator('.ds-mode-card').first().innerText());
 ok('technical stepper stays hidden until a workflow is chosen', await page.locator('#ds-stepper').isHidden(), 'hidden');
 ok('landing has no phone-width overflow', await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth) <= 1, await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth));
-if (process.env.PARAMANT_SIGN_SCREENSHOT_PATH) await page.screenshot({ path:process.env.PARAMANT_SIGN_SCREENSHOT_PATH, fullPage:true });
+if (process.env.PARAMANT_SIGN_SCREENSHOT_PATH) await stableScreenshot(page, { path:process.env.PARAMANT_SIGN_SCREENSHOT_PATH, fullPage:true });
 await page.locator('.ds-mode-card[data-mode="invite"]').click();
 await page.locator('#ds-doc-input').setInputFiles({ name: 'agreement-demo.txt', mimeType: 'text/plain', buffer: Buffer.from('agreement document for invite delivery') });
 await page.locator('#step-recipients:not([hidden])').waitFor();

--- a/tests/static-sanity.sh
+++ b/tests/static-sanity.sh
@@ -281,7 +281,7 @@ else
 fi
 
 # ── 12. Test suites do not write into tracked docs/ by default ───────────────
-# tests/app-shots.mjs renders 36 PNGs. It used to write them straight into
+# scripts/app-shots.mjs renders 36 PNGs. It used to write them straight into
 # docs/brand/assets/app-2026/, which is tracked, so every local run of the
 # browser suites left 36 modified files behind and the next `git commit -a`
 # carried them. Refreshing those references is a deliberate act:

--- a/tests/user-dashboard-documents.test.mjs
+++ b/tests/user-dashboard-documents.test.mjs
@@ -1,6 +1,7 @@
 // Real Chromium coverage for the document-focused user dashboard.
 
 import { chromium } from 'playwright';
+import { stableScreenshot } from '../scripts/stable-screenshot.mjs';
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -83,7 +84,7 @@ await page.locator('[data-pa-action="document-cancel"]').click();
 await page.waitForFunction(() => document.querySelector('#dh-document-dialog-body')?.textContent.includes('closed'));
 ok('cancel is owner action and updates measured status', cancelRequests === 1 && /Cancelled/.test(await page.locator('#dh-document-dialog-body').innerText()), await page.locator('#dh-document-dialog-body').innerText());
 await page.locator('[data-pa-action="document-close"]').click();
-if (process.env.PARAMANT_DASHBOARD_SCREENSHOT_PATH) await page.screenshot({ path:process.env.PARAMANT_DASHBOARD_SCREENSHOT_PATH, fullPage:true });
+if (process.env.PARAMANT_DASHBOARD_SCREENSHOT_PATH) await stableScreenshot(page, { path:process.env.PARAMANT_DASHBOARD_SCREENSHOT_PATH, fullPage:true });
 
 await page.locator('[data-doc-filter="completed"]').click();
 ok('completed filter shows only completed work', await page.locator('.dh-document').count() === 1 && /Completed contract/.test(await page.locator('#dh-documents').innerText()), await page.locator('#dh-documents').innerText());
@@ -99,7 +100,7 @@ const completedDialogInViewport = !completedDialogMetrics.hidden && completedDia
 ok('completed document exposes proof export with honest storage guidance', completedDialogInViewport && await page.locator('a[download]').getAttribute('href') === '/api/user/documents/env_complete_abcdefghijklmnop/receipt' && /not a plaintext copy/i.test(await page.locator('#dh-document-dialog-body').innerText()), JSON.stringify(completedDialogMetrics));
 if (process.env.PARAMANT_DASHBOARD_DETAIL_SCREENSHOT_PATH) {
   await page.waitForTimeout(100);
-  await page.locator('#dh-document-dialog').screenshot({ path:process.env.PARAMANT_DASHBOARD_DETAIL_SCREENSHOT_PATH });
+  await stableScreenshot(page.locator('#dh-document-dialog'), { path:process.env.PARAMANT_DASHBOARD_DETAIL_SCREENSHOT_PATH });
 }
 await page.locator('[data-pa-action="document-close"]').click();
 await page.locator('[data-doc-filter="cancelled"]').click();


### PR DESCRIPTION
## What went wrong

`sign-e2e` went red on main with `page.screenshot: Timeout 30000ms exceeded` (`TimeoutError`), job **Browser suites**, [run 33746496749](https://github.com/Apolloccrypt/paramant-relay/actions/runs/33746496749). That check is required in deploy phase 0a, so the deploy was blocked. The same flake had been seen earlier on a pull request, and a plain re-run of that job went green, which is the signature of a flake rather than a break.

The stack pointed at `tests/app-shots.mjs:126`, the `fullPage` capture at `deviceScaleFactor: 2`. Everything else in that job was green: 41 of 42 tests passed and the one failure was the screenshot generator.

## Why it was in CI at all

The Browser suites step selects by import:

```
node --test $(grep -l "from 'playwright'" tests/*.mjs | grep -vE 'sign-full|product-heartbeat')
```

That is a good rule for suites and it is why every real browser suite is picked up the day it is written. `app-shots.mjs` imports playwright but asserts nothing, so a green run proved nothing and a red one stopped the deploy.

## What changed

**The generator moves out of `tests/`.** `tests/app-shots.mjs` becomes `scripts/app-shots.mjs`, next to `brand-shots-direction.mjs` and `shot-dashboard.mjs`, which already live there for the same reason. The selection line is untouched, so the fifteen real browser suites are selected exactly as before and the no-browser job in `test.yml` is unchanged. Same move as the heartbeat canaries.

The rule this leaves behind, written into `tests/README.md` and the workflow comment: `tests/` is for files that assert something. A file that only produces artefacts belongs in `scripts/`, browser or not.

**Every capture goes through one helper.** New `scripts/stable-screenshot.mjs`:

- Waits for network quiet and `document.fonts.ready` before shooting. Both bounded, both best-effort, so a page that is *meant* to be pending (the dashboard loading shot holds `/api/user/me` open on purpose) is still photographable.
- `animations: 'disabled'`, Playwright's own knob: finite animations fast-forwarded, infinite ones cancelled, for the duration of the capture only.
- 60 s instead of Playwright's 30, **with one retry at 120 s**.

The retry is measured, not guessed. A first round of ten runs with 60 s and no retry put one capture past 60 s under load 28, and its call log read `taking page screenshot / disabled all CSS animations`: the page had settled and the raster itself was starved of CPU. No wait condition fixes that, only more budget does. A screenshot has no side effect, so taking it twice is safe; it warns on stderr, and a second timeout is thrown rather than swallowed.

Deliberately **not** `page.emulateMedia({ reducedMotion: 'reduce' })`. That changes what the page renders from that point on, which would silently move the ground under assertions taken after a shot, and would make the reduced-motion pair in `app-shots.mjs` identical to its normal pair, so the picture would stop proving anything.

The five suites that write a screenshot as a byproduct when `PARAMANT_*_SCREENSHOT_PATH` is set now call the helper too: navigation shell, cosign delivery, user dashboard, invite delivery, developer dashboard. **No assertion is weakened and no wait is removed** - the only change at each site is which function takes the picture.

**The opt-in guard follows the file.** `tests/brand-shots-optin.test.mjs` still spawns the real generator in dry-run mode, so the tracked references under `docs/brand/assets/app-2026/` are still measured against the file that does the writing. Its layer-3 static scan already walked `scripts/` as well as `tests/`, so nothing there had to be loosened.

## Evidence

### The workflow selection is unchanged for the real suites

`grep -l "from 'playwright'" tests/*.mjs | grep -vE 'sign-full|product-heartbeat'`

| before (16) | after (15) |
|---|---|
| `tests/app-contrast.test.mjs` | `tests/app-contrast.test.mjs` |
| **`tests/app-shots.mjs`** | *(gone: now `scripts/app-shots.mjs`)* |
| `tests/app-theme.test.mjs` | `tests/app-theme.test.mjs` |
| `tests/cosign-appearance-contract.test.mjs` | `tests/cosign-appearance-contract.test.mjs` |
| `tests/cosign-document-delivery.test.mjs` | `tests/cosign-document-delivery.test.mjs` |
| `tests/developer-parasign-dashboard.test.mjs` | `tests/developer-parasign-dashboard.test.mjs` |
| `tests/first-screen.test.mjs` | `tests/first-screen.test.mjs` |
| `tests/motion-safety.test.mjs` | `tests/motion-safety.test.mjs` |
| `tests/navigation-shell.test.mjs` | `tests/navigation-shell.test.mjs` |
| `tests/parasign-multi-verify.test.mjs` | `tests/parasign-multi-verify.test.mjs` |
| `tests/pricing-fold.test.mjs` | `tests/pricing-fold.test.mjs` |
| `tests/sign-document-identity.test.mjs` | `tests/sign-document-identity.test.mjs` |
| `tests/sign-invite-delivery.test.mjs` | `tests/sign-invite-delivery.test.mjs` |
| `tests/theme-contrast.test.mjs` | `tests/theme-contrast.test.mjs` |
| `tests/user-dashboard-documents.test.mjs` | `tests/user-dashboard-documents.test.mjs` |
| `tests/vault-filename.test.mjs` | `tests/vault-filename.test.mjs` |

`diff` between the two lists is exactly one removed line. The `test.yml` no-browser selection (`grep -L ...`, 22 files) is byte-identical before and after.

### The generator, ten times green under a CPU hog

Sixteen busy cores on a sixteen-core box, load 22 to 29 throughout. Idle, one run takes 35 s; under the hog, 115 to 130 s.

```
== app-shots : 10 runs, 16 cpu hogs busy
  run 1/10 PASS 122s  load 23.97      run  6/10 PASS 117s  load 23.45
  run 2/10 PASS 123s  load 23.25      run  7/10 PASS 124s  load 22.87
  run 3/10 PASS 121s  load 23.40      run  8/10 PASS 116s  load 22.80
  run 4/10 PASS 121s  load 24.70      run  9/10 PASS 115s  load 23.68
  run 5/10 PASS 115s  load 22.04      run 10/10 PASS 130s  load 28.99
== app-shots : 10 passed, 0 failed
```

The earlier round, the one that justified the retry, with 60 s and no retry:

```
  run 5/10 PASS 117s  load 24.18
  run 6/10 FAIL  90s  load 27.98
      page.screenshot: Timeout 60000ms exceeded.
      Call log:
        - taking page screenshot
        - disabled all CSS animations
      name: 'TimeoutError'
  run 7/10 PASS 127s  load 25.07
```

The `origin/main` file, unchanged, under the same hog: 3 of 3 passed at load 21, which is why this needs contention to show at all.

### The real suites, one full pass under the same hog

`node --test` over the 15 selected files, load 30: **1 passed, 0 failed**, 78 s.

### CI on this branch

`sign-e2e` **pass** in 1m56s (was 2m30 to 2m46 with the generator in it). The Browser suites step reports **41 tests, 41 pass, 0 fail**. The red run reported 42 tests, 41 pass, 1 fail: same 41 passing tests, minus the generator. Every other check on the PR is green.