### PR TITLE
/pricing tells the buyer how payment works, and keeps one filled button per card

### DIFF
--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -282,8 +282,13 @@
       For a one-person practice, a volunteer board or a household, and for the offices that sign and send every week.
     </p>
     <div style="display:flex;flex-wrap:wrap;gap:var(--space-3);align-items:center;margin-bottom:var(--space-4)">
-      <a href="/signup" class="btn btn-primary">Create a free account &rarr;</a>
-      <a href="#plans" class="btn btn-secondary">Compare plans</a>
+<!-- Besluit 22 (one filled accent per screen): the nav carries the filled
+           cobalt "Create account" on every page and it is sticky, so a filled
+           hero button put two of them on the first screen. This page has its own
+           primary action, the button in each plan card, so the two text CTAs on
+           it are outlined. The plan cards keep one filled button each. -->
+      <a href="/signup" class="btn btn-secondary">Create a free account &rarr;</a>
+      <a href="#plans" class="btn btn-tertiary">Compare plans</a>
     </div>
     <p style="font-size:var(--text-sm);color:var(--ink-dim);line-height:1.6;margin:0 0 var(--space-6)">
       Built in Harderwijk by <strong style="color:var(--navy)">Mick Beer</strong>, privacy and security researcher, founder of
@@ -398,6 +403,23 @@
       </p>
     </div>
     <p style="font-family:var(--mono);font-size:var(--text-xs);color:var(--ink-dim);margin-top:var(--space-4)">Prices shown excl. btw (VAT). Checkout charges incl. 21% btw: Pro &euro;59.29/mo or &euro;603.79/yr, Business &euro;361.79/mo or &euro;3,617.90/yr.</p>
+    <!-- HOW PAYMENT WORKS. Every sentence here is what the code does today.
+         relay/lib/mollie.js: BILLING_MODE is unset in production, so
+         billingStance().recurring is false and relay/lib/billing-recurring.js
+         skips the customer, the mandate and the subscription; the checkout in
+         relay.js is a plain one-off Mollie payment. relay/lib/billing.js
+         periodEnd() turns the interval into one calendar month or twelve, and
+         relay/lib/entitlements.js effectiveProductTier() drops the product to
+         its floor tier (Community for ParaSend, the free tier for ParaSign) as
+         soon as that date passes, per product. /privacy and /terms carry the
+         same claim in the same words; tests/site-claims.test.mjs pins all three
+         against mollie.js. -->
+    <div style="text-align:left;max-width:760px;margin:var(--space-6) auto 0;padding:var(--space-4) var(--space-5);border:1px solid var(--ink-hair);border-left:3px solid var(--cobalt);background:var(--bone)">
+      <p style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;font-weight:700;color:var(--cobalt);margin:0 0 var(--space-3)">How payment works</p>
+      <p style="font-size:var(--text-base);color:var(--ink);line-height:1.7;margin:0">
+        Payment runs through Mollie. Every payment is a one-off for the term you buy: one month, or one year paid up front. Automatic renewal is not switched on, so there is no direct debit mandate and no subscription that renews by itself. ParaSign and ParaSend each carry their own paid term. When a term ends, that product falls back to its free Community plan, and nothing is charged again unless you buy the next term yourself.
+      </p>
+    </div>
   </div>
 </section>
 
@@ -526,7 +548,7 @@
         <p style="font-size:var(--text-base);font-weight:700;margin-bottom:var(--space-2)">Not sure which plan fits?</p>
         <p style="font-size:var(--text-sm);color:var(--ink)">Start on the Community plan. No card, no time limit; upgrade when you outgrow the limits.</p>
       </div>
-      <a href="/signup" class="btn btn-primary">Create account →</a>
+      <a href="/signup" class="btn btn-secondary">Create account →</a>
     </div>
   </div>
 </section>

--- a/tests/site-claims.test.mjs
+++ b/tests/site-claims.test.mjs
@@ -1640,6 +1640,14 @@ test('the Mollie row on /dpa is the payload relay.js sends, and the stance the p
   assert.ok(termsPage.includes('Automatic renewal is not switched on'),
     'terms: the payment paragraph must say renewal is not automatic while the recurring layer is off');
 
+  // /pricing is where the money is asked for, so the same stance has to stand
+  // next to the prices, not only in the legal pages a buyer never opens.
+  const pricingPage = visible(page('pricing'));
+  assert.ok(pricingPage.includes('Every payment is a one-off for the term you buy'),
+    'pricing: the payment block next to the prices must describe one-off payments, the stance mollie.js takes');
+  assert.ok(pricingPage.includes('Automatic renewal is not switched on'),
+    'pricing: the payment block must say renewal is not automatic while the recurring layer is off');
+
   const stale = [];
   for (const slug of publicPages()) {
     const text = visible(page(slug));


### PR DESCRIPTION
## Wat en waarom

Twee dingen op `/pricing`, allebei in `frontend/pricing.html`. Geen CSS aangeraakt, dus geen cache-bust nodig. De JS van pricing is niet aangeraakt.

### 1. Betaalwaarheid bij de prijzen

De verkoop-one-pager belooft: betalen via Mollie, eenmalig voor een termijn, geen incasso, geen abonnement dat doorloopt. Op `/pricing` stond daar niets van: het woord Mollie stond alleen in HTML-commentaar bij de ParaSend Pro-knop. `/privacy` en `/terms` zeggen het al wel; de pagina die om het geld vraagt was de enige die zweeg.

Er staat nu een blok "How payment works" direct onder de ParaSign-prijzen, boven het ParaSend-blok, dus iedereen die prijzen leest komt er langs. Elke zin is gecontroleerd tegen de code:

| Claim | Bron |
| --- | --- |
| Betaling loopt via Mollie | `relay.js` `/v2/billing/checkout` roept `mollie.createPayment` |
| Elke betaling is eenmalig voor de gekochte termijn | `relay/lib/mollie.js` `billingStance()`: `BILLING_MODE` leeg in productie, dus `recurring:false` |
| Geen mandaat, geen abonnement | `relay/lib/billing-recurring.js` slaat customer, mandaat en subscription over zolang `recurring` uit staat |
| Een maand of een jaar vooruit | `relay/lib/billing.js` `periodEnd()`: 1 of 12 kalendermaanden |
| Per product een eigen termijn | `paid_until_parasend` / `paid_until_parasign` in `relay/lib/entitlements.js` |
| Na afloop terug naar het gratis Community-plan, account blijft bestaan | `effectiveProductTier()` valt terug op de floor tier zodra `paid_until` voorbij is |

Blok 31 van `tests/site-claims.test.mjs` pinde `/privacy` en `/terms` al tegen `mollie.js`. `/pricing` is aan diezelfde pin toegevoegd, dus de nieuwe alinea kan niet wegdrijven van wat de code doet.

### 2. Besluit 22: een gevuld accent per scherm

De navigatieknop "Create account" is kobalt en de balk is sticky, dus een gevulde heroknop zette twee gevulde kobaltknoppen op het eerste scherm. Deze pagina heeft een eigen primaire actie, namelijk de knop in elke prijskaart. De twee losse tekst-CTA's zijn daarom omlijnd geworden:

- hero: "Create a free account" van `btn-primary` naar `btn-secondary`, en "Compare plans" van `btn-secondary` naar `btn-tertiary`, zodat de hero hierarchie houdt in plaats van twee identieke omlijnde knoppen
- de losse CTA "Not sure which plan fits?" onderaan: `btn-primary` naar `btn-secondary`

De prijskaarten zijn ongemoeid: elke kaart houdt precies een gevulde knop.

## Poorten

Alle groen:

- `tests/ui-truthfulness.test.mjs`, `tests/site-claims.test.mjs`, `tests/seo-contract.test.mjs`: 53 tests, 0 fail
- `tests/theme-contrast.test.mjs`: 4448 tekstparen over 16 pagina's, bekende defecten niet gegroeid
- `tests/pricing-fold.test.mjs`: 4/4, het eerste scherm op 390px draagt bedrag, publiek, oprichter en actie nog steeds
- `tests/product-heartbeat.test.mjs` + `tests/frontend-loading-contract.test.mjs`: 16/16
- `relay/test/pricing-page.test.js`: groen, bedragen kloppen nog met de catalogus
- `bash tests/static-sanity.sh`: PASS

`tests/cache-bust.test.mjs` bestaat niet in deze repo; de `?v=`-consistentie zit in `tests/frontend-loading-contract.test.mjs` en die is gedraaid. Er is geen CSS gewijzigd, dus er hoefde geen versie op.
