### PR TITLE
The limit_req zones live in a tracked snippet, and the links test reads docs/

### DIFF
--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -627,6 +627,53 @@ block, `access_log off` inside **every** `:8090` block, and `nginx -t` clean
 before the reload. A run that changed nothing still tests and reloads nginx, so a hand
 edit made between deploys cannot hide behind "already applied".
 
+### Step 5d: the limit_req zones, from a tracked file
+
+Both site confs rate limit on named zones (`relay_auth`, `relay_trial`,
+`relay_inbound`, `relay_outbound`, `api`) and neither conf defines one, because
+`limit_req_zone` is an http-level directive and a `server {}` block is not that
+level. On the live server all five were typed into `/etc/nginx/nginx.conf` by
+hand, so nothing in the repo said what they were: a conf review could not see
+them, and a rebuilt server would have had locations pointing at zones that did
+not exist.
+
+`deploy/nginx/snippets/paramant-limit-req.conf` is now that record, and step 5d
+places it at `/etc/nginx/conf.d/paramant-limit-req.conf`
+(`PARAMANT_LIMIT_REQ_DEST` overrides the path). The rates are the ones the
+tracked self-host config already sets for the same jobs; the rates on the live
+server were never in the repo and the snippet does not guess at them.
+
+A zone may be bound only **once**. A second `limit_req_zone` with a name that
+is already bound is not a warning, it is a config nginx refuses to load. So 5d
+does not copy the file blindly:
+
+1. it reads `nginx -T`, the config nginx really loads, minus the destination
+   file itself, and collects the zone names that are already bound there
+2. it writes the snippet with those lines commented out, each with a line
+   saying which zone was left where it was
+3. `nginx -t`, and on failure the previous file goes back, byte for byte (or
+   is removed again when there was none), then a reload of the old config
+4. `nginx -T` again, to prove the file it wrote is in the list of files nginx
+   loaded. A file in a directory no `include` reaches passes `nginx -t` and
+   defines nothing, and only the dump tells those two apart
+5. every zone the resolved site confs reference has to be bound in that dump.
+   This is the check that catches `relay_auth` disappearing out of a
+   hand-edited `nginx.conf` while `/api/user/` still limits on it
+
+On the server as it stands all five names are already bound in `nginx.conf`, so
+the phase writes a file that changes no rate and says so:
+`after zone lines written = 0`, `after zone lines left elsewhere = 5`. Move a
+zone out of `nginx.conf` and the next deploy supplies it from the snippet
+instead. The counters to read are `before duplicate zones`,
+`after zone lines written`, `after snippet loaded` and
+`after zones referenced and undefined`.
+
+Doing it by hand:
+
+```bash
+nginx -T 2>/dev/null | grep -c 'limit_req_zone .* zone=relay_auth'   # must be 1, never 2
+```
+
 ## Step 6: smoke tests
 
 In the order `deploy.sh` runs them, plus the two the 3.0.0 runbook used.

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -51,6 +51,14 @@ BACKUP_DIR="${PARAMANT_BACKUP_DIR:-/home/paramant/backups}"
 NGINX_BACKUP_DIR=/etc/nginx/backups
 NGINX_SITES=/etc/nginx/sites-enabled
 
+# Where the tracked limit_req snippet lands. conf.d is the directory the stock
+# nginx.conf includes at http level, which is the only level a limit_req_zone
+# may sit at: the site confs in sites-enabled are inside server blocks, so the
+# zones cannot live with the locations that use them. Phase 5d proves with
+# nginx -T that the file it wrote is really loaded, and puts the previous file
+# back when it is not.
+LIMIT_REQ_DEST="${PARAMANT_LIMIT_REQ_DEST:-/etc/nginx/conf.d/paramant-limit-req.conf}"
+
 # The two server confs the runbook names. Phase 5 edits these and nothing else:
 # a wildcard loop over sites-enabled would silently rewrite a conf nobody
 # reviewed.
@@ -605,6 +613,7 @@ printf '  target        %s\n' "$PROD_HOST"
 printf '  compose dir   %s\n' "$COMPOSE_DIR"
 printf '  docroot       %s\n' "$DOCROOT"
 printf '  nginx confs   %s\n' "$NGINX_CONF_SLOTS"
+printf '  limit_req     %s\n' "$LIMIT_REQ_DEST"
 printf '                %s slot(s); the first candidate present on the server wins\n' "$NGINX_SLOT_COUNT"
 printf '  deploy ref    %s\n' "$DEPLOY_REF"
 if [ -n "$EXPECTED_HEAD" ]; then
@@ -1882,6 +1891,234 @@ EOF
       ok "the ParaID deny survived the edit ($pa line(s), was $pb)"
     else
       die "the ParaID deny changed from ${pb:-?} to ${pa:-?} lines; the runbook keeps it in this round"
+    fi
+  fi
+  step "5d. the limit_req zones, from the tracked snippet, without binding one twice"
+  note "the site confs write limit_req zone=NAME in their locations but define no"
+  note "zone: limit_req_zone is an http-level directive. The five zones the two"
+  note "confs use lived only in the server's own nginx.conf, so nothing in git"
+  note "said what they were. deploy/nginx/snippets/paramant-limit-req.conf is now"
+  note "that record, and this step places it."
+  remote_nginx "limit_req zones" "$COMPOSE_DIR" "$TS" "$NGINX_BACKUP_DIR" "$LIMIT_REQ_DEST" "$NGINX_SITES" "$NGINX_CONF_SLOTS" <<'EOF'
+set -euo pipefail
+CO="$1"; TS="$2"; NGBK="$3"; DEST="$4"; SITES="$5"; SLOTS="$6"
+SRC="$CO/deploy/nginx/snippets/paramant-limit-req.conf"
+DEST_BASE="$(basename "$DEST")"
+BK="$NGBK/$DEST_BASE.pre-3.1-$TS"
+
+if [ ! -f "$SRC" ]; then
+  echo "FATAL the tracked snippet $SRC is not in the checkout, so there is nothing to place."
+  echo "FATAL phase 3 pulls main before this runs, so a missing file here means the pull"
+  echo "FATAL did not land. Nothing was written."
+  exit 1
+fi
+
+# zone_names <file>: the zone names a file defines, one per line, sorted.
+zone_names() {
+  sed -nE 's/^[[:space:]]*limit_req_zone[[:space:]]+[^[:space:]]+[[:space:]]+zone=([A-Za-z0-9_]+).*/\1/p' "$1" | sort -u
+}
+# zones_used <file...>: the zone names a conf REFERENCES from a location.
+zones_used() {
+  sed -nE 's/^[[:space:]]*limit_req[[:space:]]+zone=([A-Za-z0-9_]+).*/\1/p' "$@" | sort -u
+}
+count_words() { printf '%s' "$1" | wc -w | tr -d ' '; }
+
+# What nginx already loads, minus this file. `nginx -T` is the authority and a
+# walk over /etc/nginx is not: a *.conf lying there that no include picks up
+# defines nothing, and a zone can just as well come from a file that is not
+# called *.conf at all. Get that wrong in either direction and this phase
+# either binds a zone twice (nginx refuses the whole config) or comments out
+# the only definition of one (every rate-limited location stops loading).
+DUMP="/tmp/paramant-limitreq-dump.$$"
+rc=0
+nginx -T > "$DUMP" 2>/dev/null || rc=$?
+if [ "$rc" -ne 0 ] || [ ! -s "$DUMP" ]; then
+  rm -f "$DUMP"
+  echo "FATAL nginx -T exited $rc or printed nothing, so this phase cannot tell which"
+  echo "FATAL limit_req zones the running config already defines. Nothing was written."
+  exit 1
+fi
+# nginx -T prefixes each file it dumps with "# configuration file <path>:".
+# Drop the block that belongs to DEST, so a snippet a previous deploy already
+# placed does not read as "this zone is defined elsewhere" and get commented
+# out of its own file.
+LOADED="/tmp/paramant-limitreq-loaded.$$"
+awk -v dest="$DEST" '
+/^# configuration file .*:$/ {
+  f = $0
+  sub(/^# configuration file /, "", f)
+  sub(/:$/, "", f)
+  skip = (f == dest)
+  next
+}
+!skip { print }
+' "$DUMP" > "$LOADED"
+rm -f "$DUMP"
+
+SNIP_ZONES="$(zone_names "$SRC")"
+ELSE_ZONES="$(zone_names "$LOADED")"
+rm -f "$LOADED"
+echo "before snippet zones = $(count_words "$SNIP_ZONES")"
+echo "before zones defined elsewhere = $(count_words "$ELSE_ZONES")"
+
+# The intersection is the set this phase must NOT write: nginx answers a second
+# limit_req_zone with the same name with "is already bound to key", and that is
+# a config that does not load at all, not a warning.
+DUPS=""
+for z in $SNIP_ZONES; do
+  for e in $ELSE_ZONES; do
+    if [ "$z" = "$e" ]; then DUPS="${DUPS:+$DUPS }$z"; break; fi
+  done
+done
+echo "before duplicate zones = $(count_words "$DUPS")"
+if [ -n "$DUPS" ]; then
+  echo "before duplicate zone names = $DUPS"
+fi
+
+TMP="/tmp/paramant-limitreq.$$"
+awk -v dups=" $DUPS " '
+$0 ~ /^[[:space:]]*limit_req_zone/ {
+  z = $0
+  sub(/.*zone=/, "", z)
+  sub(/[^A-Za-z0-9_].*/, "", z)
+  if (index(dups, " " z " ") > 0) {
+    print "# zone " z " is already bound by the config nginx loads, so this deploy left"
+    print "# the definition where it is rather than binding the same name twice:"
+    print "# " $0
+    next
+  }
+}
+{ print }
+' "$SRC" > "$TMP"
+echo "after zone lines written = $(grep -cE '^[[:space:]]*limit_req_zone' "$TMP" || true)"
+echo "after zone lines left elsewhere = $(grep -cE '^# zone [A-Za-z0-9_]+ is already bound' "$TMP" || true)"
+
+mkdir -p "$(dirname "$DEST")" "$NGBK"
+if [ -f "$DEST" ]; then
+  echo "before dest existed = yes"
+  cp -a "$DEST" "$BK"
+  echo "after snippet backup bytes = $(stat -c%s "$BK")"
+else
+  echo "before dest existed = no"
+  echo "after snippet backup bytes = 0"
+fi
+if [ -f "$DEST" ] && cmp -s "$TMP" "$DEST"; then
+  echo "after snippet changed = no"
+else
+  echo "after snippet changed = yes"
+fi
+
+# Put it back the way it was: the backup when there was one, and gone when
+# there was not. Same promise as the 5c restore, for a file that may not have
+# existed before this run.
+restore_snippet() {
+  if [ -f "$BK" ]; then
+    cp -a "$BK" "$DEST"
+    echo "restored $DEST from $BK"
+  else
+    rm -f "$DEST"
+    echo "removed $DEST again; there was no file there before this phase"
+  fi
+}
+
+cat "$TMP" > "$DEST"
+chmod 0644 "$DEST"
+rm -f "$TMP"
+echo "after snippet bytes = $(stat -c%s "$DEST")"
+
+rc=0
+nginx -t > "/tmp/paramant-limitreq-t.$$" 2>&1 || rc=$?
+sed 's/^/  nginxt /' "/tmp/paramant-limitreq-t.$$"
+rm -f "/tmp/paramant-limitreq-t.$$"
+if [ "$rc" -ne 0 ]; then
+  echo "FATAL nginx -t failed with the limit_req snippet in place, restoring"
+  restore_snippet
+  nginx -t 2>&1 | sed 's/^/  restoredtest /' || true
+  systemctl reload nginx && echo "restored and reloaded the previous nginx conf"
+  exit 1
+fi
+
+# A file on disk that no include reaches is not a zone. Read the dump again and
+# look for DEST in the list of files nginx says it loaded.
+DUMP2="/tmp/paramant-limitreq-dump2.$$"
+rc=0
+nginx -T > "$DUMP2" 2>/dev/null || rc=$?
+if [ "$rc" -ne 0 ] || [ ! -s "$DUMP2" ]; then
+  rm -f "$DUMP2"
+  echo "FATAL nginx -T exited $rc after the write, so the phase cannot prove what got loaded"
+  restore_snippet
+  exit 1
+fi
+if grep -qF "# configuration file $DEST:" "$DUMP2"; then
+  echo "after snippet loaded = yes"
+else
+  echo "after snippet loaded = no"
+  echo "FATAL nginx -T does not list $DEST among the files it loaded. The snippet is on"
+  echo "FATAL disk and nginx never reads it, so the zones in it do not exist. Point"
+  echo "FATAL PARAMANT_LIMIT_REQ_DEST at a directory nginx.conf includes at http level."
+  rm -f "$DUMP2"
+  restore_snippet
+  exit 1
+fi
+
+# Close the loop the other way round: every zone the site confs rate limit on
+# has to be defined in the config that is now loaded. This is the check that
+# would have caught relay_auth disappearing out of a hand-edited nginx.conf.
+resolve_conf_slots "$SITES" "$SLOTS"
+DEFINED="$(zone_names "$DUMP2")"
+rm -f "$DUMP2"
+USED=""
+if [ "$RESOLVED_MISSING" -eq 0 ]; then
+  TARGETS=""
+  for name in $RESOLVED_CONFS; do
+    TARGETS="$TARGETS $(readlink -f "$SITES/$name")"
+  done
+  USED="$(zones_used $TARGETS)"
+fi
+UNDEF=""
+for u in $USED; do
+  found=0
+  for d in $DEFINED; do
+    if [ "$u" = "$d" ]; then found=1; break; fi
+  done
+  if [ "$found" -eq 0 ]; then UNDEF="${UNDEF:+$UNDEF }$u"; fi
+done
+echo "after zones referenced = $(count_words "$USED")"
+echo "after zones defined = $(count_words "$DEFINED")"
+echo "after zones referenced and undefined = $(count_words "$UNDEF")"
+if [ -n "$UNDEF" ]; then
+  echo "FATAL the site conf(s) rate limit on zone(s) the loaded config does not define: $UNDEF"
+  restore_snippet
+  exit 1
+fi
+
+systemctl reload nginx
+echo "reloaded nginx for the limit_req snippet"
+EOF
+
+  expect_not 'FATAL' "the limit_req snippet is in place and the config tests clean"
+  expect 'after snippet loaded = yes' \
+    "nginx really loads the limit_req snippet, it is not just a file on disk"
+  expect_min "before snippet zones" 1 "the tracked snippet defines at least one zone"
+  expect_count "after zones referenced and undefined" 0 \
+    "every limit_req zone the site confs use is defined in the config nginx loaded"
+  expect 'reloaded nginx for the limit_req snippet' "nginx reloaded after the snippet"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    local sz dz wz lz
+    sz="$(remote_field 'before snippet zones')"
+    dz="$(remote_field 'before duplicate zones')"
+    wz="$(remote_field 'after zone lines written')"
+    lz="$(remote_field 'after zone lines left elsewhere')"
+    [ -n "$sz" ] && [ -n "$dz" ] && [ -n "$wz" ] && [ -n "$lz" ] \
+      || die "could not read the limit_req zone counts from the server"
+    [ "$((wz + lz))" -eq "$sz" ] \
+      || die "the snippet has $sz zone(s) but the deploy accounted for $wz written plus $lz left elsewhere"
+    [ "$lz" = "$dz" ] \
+      || die "$dz zone(s) were already bound elsewhere but $lz line(s) were commented out; one of them would be defined twice"
+    if [ "$dz" -eq 0 ]; then
+      ok "limit_req: all $wz zone(s) came from the tracked snippet, none was already bound elsewhere"
+    else
+      ok "limit_req: $wz zone(s) written, $lz left to the config that already binds them ($(remote_field 'before duplicate zone names'))"
     fi
   fi
 }

--- a/deploy/nginx/snippets/paramant-limit-req.conf
+++ b/deploy/nginx/snippets/paramant-limit-req.conf
@@ -1,0 +1,45 @@
+# The limit_req zones the paramant.app vhosts use, in a tracked file.
+#
+# deploy/nginx-paramant-public.conf and deploy/nginx-paramant-live.conf write
+# `limit_req zone=NAME` in their locations but define no zone: a limit_req_zone
+# is an http-level directive and cannot sit in a server block. On the live
+# server the five zones below were typed straight into /etc/nginx/nginx.conf by
+# hand, so nothing in git said what they were. Delete one there and the site
+# confs stop loading, with no repo file to compare against. This is that file.
+#
+# It deploys to /etc/nginx/conf.d/paramant-limit-req.conf (phase 5d of
+# deploy/deploy-3.1.sh, override with PARAMANT_LIMIT_REQ_DEST), which nginx
+# includes at http level. The deploy tests the config with nginx -t before it
+# reloads, and restores the previous file when that test fails.
+#
+# A zone that is ALREADY defined somewhere else under /etc/nginx is left to
+# that file: the deploy comments the line out here rather than defining the
+# zone twice, which nginx refuses with "limit_req_zone is already bound to
+# key". So on the current server, where nginx.conf holds all five, this file
+# changes no rate. It takes effect on a server that does not have them yet, and
+# it is the written record either way.
+#
+# The rates are the ones the tracked self-host config sets for the same job
+# (deploy/nginx-selfhost.conf): auth 10r/m, api 60r/m, inbound 5r/m,
+# sign-dpa 3r/m. The rates the hand-typed nginx.conf on the live server uses
+# were never in the repo and are not guessed at here.
+#
+# Every zone is keyed on $binary_remote_addr, so every limit below is per
+# client IP address and never per API key or per account. /help/iot-integration
+# says so in those words and tests/site-claims.test.mjs holds it there.
+
+# /api/user/ on the main vhost. Burst 5, set at the location.
+limit_req_zone $binary_remote_addr zone=relay_auth:10m     rate=10r/m;
+
+# The general API surface: /api/sign-dpa and the /v2/ catch-all. Burst 3 and 10.
+limit_req_zone $binary_remote_addr zone=api:10m            rate=60r/m;
+
+# Uploads on relay.paramant.app, stricter than the general API zone on purpose.
+limit_req_zone $binary_remote_addr zone=relay_inbound:10m  rate=5r/m;
+
+# Downloads on relay.paramant.app. The self-host config puts /v2/outbound in
+# its api zone, so the rate is the api rate.
+limit_req_zone $binary_remote_addr zone=relay_outbound:10m rate=60r/m;
+
+# /v2/sign-dpa, the unauthenticated trial signature. Low volume, small zone.
+limit_req_zone $binary_remote_addr zone=relay_trial:1m     rate=3r/m;

--- a/docs/security-audit-2026-04.md
+++ b/docs/security-audit-2026-04.md
@@ -3,7 +3,7 @@
 **Auditor:** Ryan Williams · Director, [Smart Cyber Solutions Pty Ltd](https://www.linkedin.com/in/ryan-williams-4068351b8/) (Victoria, AU)
 **Scope:** Full codebase review — relay, frontend, SDKs, admin panel, nginx, Docker stack
 **Method:** Independent, uncompensated voluntary review. No prior access to internals.
-**Raw report:** [pentest-report-2026-04-08.txt](../pentest-report-2026-04-08.txt)
+**Raw report:** `pentest-report-2026-04-08.txt`
 **Summary:** 4 critical · 5 high · 6 medium · 5 low
 
 > All findings are being addressed publicly. This page is updated as patches ship.

--- a/docs/security.md
+++ b/docs/security.md
@@ -373,7 +373,7 @@ Or with ParaShare (browser):
 ## Audit
 
 Pentest by Ryan Williams · Smart Cyber Solutions Pty Ltd (AU) · April 2026  
-Report: [pentest-report-2026-04-08.txt](../pentest-report-2026-04-08.txt)  
+Report: `pentest-report-2026-04-08.txt`  
 Full writeup: [security-audit-2026-04.md](./security-audit-2026-04.md)
 
 All critical/high/medium findings addressed in v2.4.5.

--- a/frontend/docs/security-audit-2026-04.md
+++ b/frontend/docs/security-audit-2026-04.md
@@ -3,7 +3,7 @@
 **Auditor:** Ryan Williams · Director, [Smart Cyber Solutions Pty Ltd](https://www.linkedin.com/in/ryan-williams-4068351b8/) (Victoria, AU)
 **Scope:** Full codebase review — relay, frontend, SDKs, admin panel, nginx, Docker stack
 **Method:** Independent, uncompensated voluntary review. No prior access to internals.
-**Raw report:** [pentest-report-2026-04-08.txt](../pentest-report-2026-04-08.txt)
+**Raw report:** `pentest-report-2026-04-08.txt`
 **Summary:** 4 critical · 5 high · 6 medium · 5 low
 
 > All findings are being addressed publicly. This page is updated as patches ship.

--- a/frontend/docs/security.md
+++ b/frontend/docs/security.md
@@ -373,7 +373,7 @@ Or with ParaShare (browser):
 ## Audit
 
 Pentest by Ryan Williams · Smart Cyber Solutions Pty Ltd (AU) · April 2026  
-Report: [pentest-report-2026-04-08.txt](../pentest-report-2026-04-08.txt)  
+Report: `pentest-report-2026-04-08.txt`  
 Full writeup: [security-audit-2026-04.md](./security-audit-2026-04.md)
 
 All critical/high/medium findings addressed in v2.4.5.

--- a/tests/deploy-3.1-dryrun.test.sh
+++ b/tests/deploy-3.1-dryrun.test.sh
@@ -1832,10 +1832,10 @@ fi
 # bug is exactly how this check would go quiet. Adding or removing a remote
 # block is a deliberate act, so updating this number is part of it.
 SCAN_BLOCKS="$(grep -cE "^  remote(_soft|_nginx)? \".*<<'EOF'\$" "$SCRIPT" || true)"
-if [ "$SCAN_BLOCKS" = "25" ]; then
-  pass "the scan walked all 25 remote blocks"
+if [ "$SCAN_BLOCKS" = "26" ]; then
+  pass "the scan walked all 26 remote blocks"
 else
-  fail "the script has $SCAN_BLOCKS remote blocks, the scan expects 25; update the number here on purpose"
+  fail "the script has $SCAN_BLOCKS remote blocks, the scan expects 26; update the number here on purpose"
 fi
 
 # And the three commands that actually read stdin are still there, guarded.
@@ -2341,6 +2341,422 @@ for phase in 2 3 4 5; do
     fail "phase $phase is missing evidence lines (before=$b after=$a)"
   fi
 done
+
+echo ""
+echo "6o. The limit_req zones come from a tracked snippet, never bound twice"
+# Until this round the five zones the two site confs rate limit on were typed
+# into /etc/nginx/nginx.conf on the server by hand. Nothing in the repo said
+# what they were, so a conf review could not see them and a rebuilt server
+# would have had site confs referencing zones that did not exist.
+#
+# The snippet is now tracked, and phase 5d places it. The hard part is that a
+# limit_req_zone may be bound only ONCE: writing a second definition of a name
+# the server already binds is not a warning, it is a config that does not load.
+# So 5d reads what nginx really loads, comments out the lines it would double,
+# and proves with nginx -T that the file it wrote is loaded at all.
+SNIPPET="$ROOT/deploy/nginx/snippets/paramant-limit-req.conf"
+if [ -f "$SNIPPET" ]; then pass "deploy/nginx/snippets/paramant-limit-req.conf exists"; else
+  fail "deploy/nginx/snippets/paramant-limit-req.conf is missing"; fi
+if git -C "$ROOT" ls-files --error-unmatch deploy/nginx/snippets/paramant-limit-req.conf >/dev/null 2>&1; then
+  pass "the snippet is tracked by git, which was the whole point"
+else
+  fail "the snippet is not tracked by git"
+fi
+
+# The zones the two repo confs REFERENCE, and the zones the snippet DEFINES.
+# A referenced zone the snippet does not define is a zone that only exists
+# because someone typed it on the server, which is the situation this closes.
+zones_defined() {
+  sed -nE 's/^[[:space:]]*limit_req_zone[[:space:]]+[^[:space:]]+[[:space:]]+zone=([A-Za-z0-9_]+).*/\1/p' "$@" | sort -u
+}
+zones_referenced() {
+  sed -nE 's/^[[:space:]]*limit_req[[:space:]]+zone=([A-Za-z0-9_]+).*/\1/p' "$@" | sort -u
+}
+SNIP_DEF="$(zones_defined "$SNIPPET" 2>/dev/null || true)"
+CONF_REF="$(zones_referenced "$ROOT/deploy/nginx-paramant-public.conf" "$ROOT/deploy/nginx-paramant-live.conf" 2>/dev/null || true)"
+MISSING=""
+for z in $CONF_REF; do
+  printf '%s\n' "$SNIP_DEF" | grep -qx "$z" || MISSING="${MISSING:+$MISSING }$z"
+done
+if [ -n "$CONF_REF" ]; then
+  pass "the repo confs reference $(printf '%s' "$CONF_REF" | wc -w | tr -d ' ') limit_req zone(s)"
+else
+  fail "no limit_req zone reference found in the repo confs; this check is looking at nothing"
+fi
+if [ -z "$MISSING" ]; then
+  pass "the snippet defines every zone the two repo confs rate limit on"
+else
+  fail "the snippet defines no zone called: $MISSING"
+fi
+# Every zone is per client IP. /help/iot-integration says so in those words and
+# tests/site-claims.test.mjs holds it there, so a key change here would make
+# the site lie.
+if [ -n "$SNIP_DEF" ] \
+   && [ "$(grep -cE '^[[:space:]]*limit_req_zone[[:space:]]+\$binary_remote_addr' "$SNIPPET")" \
+      = "$(grep -cE '^[[:space:]]*limit_req_zone' "$SNIPPET")" ]; then
+  pass "every zone in the snippet is keyed on \$binary_remote_addr, so the limits stay per IP"
+else
+  fail "a zone in the snippet is keyed on something other than \$binary_remote_addr"
+fi
+if grep -qE '^[[:space:]]*limit_req_zone[^#]*rate=[0-9]+r/m;' "$SNIPPET" 2>/dev/null; then
+  pass "the zones carry an explicit rate"
+else
+  fail "a zone in the snippet has no rate= of its own"
+fi
+check_has "$FULL" '5d\. the limit_req zones'          "phase 5 reaches step 5d"
+check_has "$FULL" 'paramant-limit-req\.conf'          "the deploy names the tracked snippet"
+check_has "$FULL" 'nginx -T'                          "5d reads the LOADED config, not the file tree"
+check_has "$FULL" 'limit_req     /etc/nginx/conf\.d/' "the run header says where the snippet lands"
+
+# ------ the real 5d block, against a fixture nginx ------
+LR="$WORK/lr"
+mkdir -p "$LR/bin" "$LR/sites/../available" "$LR/bk" "$LR/etc" "$LR/co/deploy/nginx/snippets"
+mkdir -p "$LR/sites" "$LR/available"
+cp "$SNIPPET" "$LR/co/deploy/nginx/snippets/paramant-limit-req.conf"
+LR_DEST="$LR/etc/paramant-limit-req.conf"
+
+# nginx stub. -t is the config test, -T the dump of every file nginx loaded.
+# LRT_FILES is what the server's own config holds; the destination file is
+# added on top, the way conf.d/*.conf is included by nginx.conf, unless
+# LRT_NO_INCLUDE says this server does not include that directory.
+cat > "$LR/bin/nginx" <<'STUB'
+#!/bin/sh
+case "${1:-}" in
+  -t)
+    if [ "${LRT_T_FAIL:-0}" = 1 ]; then
+      echo 'nginx: [emerg] limit_req_zone "api" is already bound to key "$binary_remote_addr"' >&2
+      exit 1
+    fi
+    echo "nginx: configuration file test is successful"
+    ;;
+  -T)
+    if [ "${LRT_BIG_FAIL:-0}" = 1 ]; then exit 1; fi
+    for f in $LRT_FILES; do
+      [ -f "$f" ] || continue
+      echo "# configuration file $f:"
+      cat "$f"
+    done
+    if [ "${LRT_NO_INCLUDE:-0}" != 1 ] && [ -f "$LRT_DEST" ]; then
+      echo "# configuration file $LRT_DEST:"
+      cat "$LRT_DEST"
+    fi
+    ;;
+esac
+exit 0
+STUB
+cat > "$LR/bin/systemctl" <<'STUB'
+#!/bin/sh
+exit 0
+STUB
+chmod +x "$LR/bin/nginx" "$LR/bin/systemctl"
+
+# A site conf that rate limits, and a server nginx.conf that binds zones.
+cat > "$LR/available/paramant-public.conf" <<'CONF'
+server {
+    server_name paramant.app;
+    location = /v1/paraid/issue-document { deny all; }
+    location ~ ^/v2/inbound {
+        limit_req zone=relay_inbound burst=20 nodelay;
+    }
+    location ~ ^/v2/outbound {
+        limit_req zone=relay_outbound burst=10 nodelay;
+    }
+}
+CONF
+cat > "$LR/available/paramant-live.conf" <<'CONF'
+server {
+    location /api/user/ {
+        limit_req        zone=relay_auth burst=5 nodelay;
+    }
+    location /v2/ {
+        limit_req        zone=api burst=10 nodelay;
+    }
+}
+CONF
+ln -sfn "$LR/available/paramant-public.conf" "$LR/sites/paramant-public.conf"
+ln -sfn "$LR/available/paramant-live.conf"   "$LR/sites/paramant-live.conf"
+LR_SLOTS="paramant-public.conf paramant-live.conf"
+
+# The server config in three shapes: binds nothing, binds everything (which is
+# production today), binds one of the five.
+printf 'http {\n    server_tokens off;\n}\n' > "$LR/etc/nginx-none.conf"
+{
+  echo 'http {'
+  sed -nE 's/^[[:space:]]*(limit_req_zone.*)$/    \1/p' "$SNIPPET"
+  echo '}'
+} > "$LR/etc/nginx-all.conf"
+{
+  echo 'http {'
+  echo '    limit_req_zone $binary_remote_addr zone=relay_auth:10m rate=10r/m;'
+  echo '}'
+} > "$LR/etc/nginx-one.conf"
+
+extract_remote "limit_req zones" > "$LR/5d.sh"
+if [ -s "$LR/5d.sh" ]; then
+  pass "the 5d remote block could be extracted from the script"
+else
+  fail "could not extract the 5d remote block from the script"
+fi
+# The extraction has to be the block and nothing else: the call is one line on
+# purpose, because sed '1d' would otherwise leave half a continuation line of
+# shell in front of the body.
+# remote_nginx prepends the resolver, so the extract is resolver + body. What
+# may NOT be in there is a stray line of the CALL: extract_remote drops one
+# line, so a call spread over two lines would leave its continuation, an
+# argument list, sitting in front of the body as shell to execute.
+if [ "$(grep -cE '^set -euo pipefail$' "$LR/5d.sh")" = "1" ]; then
+  pass "the extracted 5d block carries exactly one strict-mode line"
+else
+  fail "the extracted 5d block has $(grep -cE '^set -euo pipefail$' "$LR/5d.sh") strict-mode lines"
+fi
+if grep -qE '^[[:space:]]+"\$[A-Z_]+"' "$LR/5d.sh"; then
+  fail "the 5d extract carries a leftover argument line, so the call spans more than one line"
+  grep -nE '^[[:space:]]+"\$[A-Z_]+"' "$LR/5d.sh" | head -3 | sed 's/^/        /'
+else
+  pass "no leftover argument line in the 5d extract, so the whole call fits one line"
+fi
+
+run_5d() {   # server-conf, ts, [extra env assignments...]
+  local conf="$1" ts="$2"; shift 2
+  ( cd "$LR" && PATH="$LR/bin:$PATH" LRT_FILES="$conf $LR/available/paramant-public.conf $LR/available/paramant-live.conf" \
+      LRT_DEST="$LR_DEST" env "$@" bash "$LR/5d.sh" "$LR/co" "$ts" "$LR/bk" "$LR_DEST" "$LR/sites" "$LR_SLOTS" </dev/null 2>&1 )
+}
+# zones bound exactly once across everything nginx would load
+bound_once() {   # server-conf
+  local dup
+  dup="$(zones_defined "$1" "$LR_DEST" 2>/dev/null | sort | uniq -d)"
+  [ -z "$dup" ]
+}
+# a name counted across the server conf and the placed file together
+bound_total() { zones_defined "$1" "$LR_DEST" 2>/dev/null | wc -l | tr -d ' '; }
+
+echo ""
+echo "6o-1. A server that binds none of the zones: the snippet supplies all five"
+rm -f "$LR_DEST"
+OUTA="$(run_5d "$LR/etc/nginx-none.conf" 20260101-0000 LRT_X=1)"; RCA=$?
+if [ "$RCA" -eq 0 ]; then pass "5d exits 0 on a server that binds no zone"; else
+  fail "5d exits $RCA on a server that binds no zone"
+  printf '%s\n' "$OUTA" | sed 's/^/        /' | head -20
+fi
+for want in "before duplicate zones:0" "after zone lines left elsewhere:0" \
+            "after snippet loaded:yes" "after zones referenced and undefined:0" \
+            "before dest existed:no" "after snippet changed:yes"; do
+  f="${want%%:*}"; v="${want##*:}"
+  if [ "$(field_5c "$OUTA" "$f")" = "$v" ]; then pass "5d reports $f = $v"; else
+    fail "5d reports $f = '$(field_5c "$OUTA" "$f")', expected $v"; fi
+done
+SNIP_N="$(printf '%s\n' "$SNIP_DEF" | grep -c . || true)"
+if [ "$(field_5c "$OUTA" 'after zone lines written')" = "$SNIP_N" ]; then
+  pass "all $SNIP_N zone(s) of the snippet were written"
+else
+  fail "5d wrote $(field_5c "$OUTA" 'after zone lines written') zone line(s), expected $SNIP_N"
+fi
+if [ -f "$LR_DEST" ]; then pass "the snippet really landed on the server"; else
+  fail "5d reported success but wrote no file"; fi
+if [ "$(zones_defined "$LR_DEST" | wc -l | tr -d ' ')" = "$SNIP_N" ]; then
+  pass "the placed file defines the same $SNIP_N zone(s) as the tracked snippet"
+else
+  fail "the placed file defines $(zones_defined "$LR_DEST" | wc -l | tr -d ' ') zone(s), the snippet has $SNIP_N"
+fi
+if printf '%s\n' "$OUTA" | grep -q 'reloaded nginx for the limit_req snippet'; then
+  pass "5d reloads nginx after placing the snippet"
+else
+  fail "5d never reloaded nginx"
+fi
+if bound_once "$LR/etc/nginx-none.conf"; then
+  pass "no zone is bound twice across the server config and the placed file"
+else
+  fail "a zone is bound twice: $(zones_defined "$LR/etc/nginx-none.conf" "$LR_DEST" | sort | uniq -d | tr '\n' ' ')"
+fi
+
+echo ""
+echo "6o-2. Run it again with the file already there: the snippet is not its own duplicate"
+# The dump nginx -T returns now INCLUDES the file 5d placed a moment ago. Read
+# that naively and every zone reads as "already bound elsewhere", so the second
+# deploy would comment out all five lines and delete the zones it just created.
+OUTB="$(run_5d "$LR/etc/nginx-none.conf" 20260101-0001 LRT_X=1)"; RCB=$?
+if [ "$RCB" -eq 0 ]; then pass "a second 5d over the same state exits 0"; else
+  fail "a second 5d exits $RCB"
+  printf '%s\n' "$OUTB" | sed 's/^/        /' | head -20
+fi
+if printf '%s\n' "$OUTB" | grep -q FATAL; then
+  fail "a second 5d prints FATAL"
+  printf '%s\n' "$OUTB" | grep FATAL | sed 's/^/        /'
+else
+  pass "a second 5d prints no FATAL"
+fi
+for want in "before duplicate zones:0" "after zone lines left elsewhere:0" \
+            "before dest existed:yes" "after snippet changed:no"; do
+  f="${want%%:*}"; v="${want##*:}"
+  if [ "$(field_5c "$OUTB" "$f")" = "$v" ]; then pass "second run reports $f = $v"; else
+    fail "second run reports $f = '$(field_5c "$OUTB" "$f")', expected $v"; fi
+done
+if [ "$(field_5c "$OUTB" 'after zone lines written')" = "$SNIP_N" ]; then
+  pass "the second run keeps all $SNIP_N zone(s), it does not comment out its own file"
+else
+  fail "the second run left $(field_5c "$OUTB" 'after zone lines written') zone line(s) of $SNIP_N"
+fi
+if [ "$(field_5c "$OUTB" 'after snippet backup bytes')" -gt 0 ] 2>/dev/null; then
+  pass "the second run backed the existing file up before writing"
+else
+  fail "the second run wrote over the existing file with no backup"
+fi
+if [ -f "$LR/bk/paramant-limit-req.conf.pre-3.1-20260101-0001" ]; then
+  pass "the backup is filed under the run TS, the way 2b files the site confs"
+else
+  fail "no backup at bk/paramant-limit-req.conf.pre-3.1-20260101-0001"
+fi
+
+echo ""
+echo "6o-3. The server already binds every zone: the deploy binds none of them again"
+# This is production as it stands: all five names are in the server's own
+# nginx.conf. Writing them a second time is an nginx that does not start.
+rm -f "$LR_DEST"
+OUTC="$(run_5d "$LR/etc/nginx-all.conf" 20260101-0002 LRT_X=1)"; RCC=$?
+if [ "$RCC" -eq 0 ]; then pass "5d exits 0 when every zone is already bound"; else
+  fail "5d exits $RCC when every zone is already bound"
+  printf '%s\n' "$OUTC" | sed 's/^/        /' | head -20
+fi
+for want in "after zone lines written:0" "after snippet loaded:yes" \
+            "after zones referenced and undefined:0"; do
+  f="${want%%:*}"; v="${want##*:}"
+  if [ "$(field_5c "$OUTC" "$f")" = "$v" ]; then pass "5d reports $f = $v"; else
+    fail "5d reports $f = '$(field_5c "$OUTC" "$f")', expected $v"; fi
+done
+if [ "$(field_5c "$OUTC" 'before duplicate zones')" = "$SNIP_N" ] \
+   && [ "$(field_5c "$OUTC" 'after zone lines left elsewhere')" = "$SNIP_N" ]; then
+  pass "all $SNIP_N zone(s) were recognised as already bound and left where they are"
+else
+  fail "5d saw $(field_5c "$OUTC" 'before duplicate zones') duplicate(s) and commented out $(field_5c "$OUTC" 'after zone lines left elsewhere')"
+fi
+if [ "$(zones_defined "$LR_DEST" | wc -l | tr -d ' ')" = "0" ]; then
+  pass "the placed file defines no zone at all, so nothing is bound twice"
+else
+  fail "the placed file still defines $(zones_defined "$LR_DEST" | wc -l | tr -d ' ') zone(s) the server already binds"
+fi
+if [ "$(bound_total "$LR/etc/nginx-all.conf")" = "$SNIP_N" ] && bound_once "$LR/etc/nginx-all.conf"; then
+  pass "every zone is bound exactly once across the server config and the placed file"
+else
+  fail "the zones are bound $(bound_total "$LR/etc/nginx-all.conf") time(s) in total, expected $SNIP_N"
+fi
+if grep -qE '^# zone [A-Za-z0-9_]+ is already bound' "$LR_DEST"; then
+  pass "the placed file says in writing which zone it left to the other config"
+else
+  fail "the placed file drops the duplicate lines without saying so"
+fi
+
+echo ""
+echo "6o-4. The server binds one of the five: the other four come from the snippet"
+rm -f "$LR_DEST"
+OUTD="$(run_5d "$LR/etc/nginx-one.conf" 20260101-0003 LRT_X=1)"; RCD=$?
+if [ "$RCD" -eq 0 ]; then pass "5d exits 0 on a partly bound server"; else
+  fail "5d exits $RCD on a partly bound server"
+  printf '%s\n' "$OUTD" | sed 's/^/        /' | head -20
+fi
+if [ "$(field_5c "$OUTD" 'before duplicate zones')" = "1" ] \
+   && [ "$(field_5c "$OUTD" 'after zone lines written')" = "$((SNIP_N - 1))" ] \
+   && [ "$(field_5c "$OUTD" 'after zone lines left elsewhere')" = "1" ]; then
+  pass "one zone left where it was, $((SNIP_N - 1)) written from the snippet"
+else
+  fail "5d wrote $(field_5c "$OUTD" 'after zone lines written') and left $(field_5c "$OUTD" 'after zone lines left elsewhere'), expected $((SNIP_N - 1)) and 1"
+fi
+if [ "$(field_5c "$OUTD" 'before duplicate zone names')" = "relay_auth" ]; then
+  pass "5d names the zone it left alone (relay_auth)"
+else
+  fail "5d named '$(field_5c "$OUTD" 'before duplicate zone names')' as the already bound zone"
+fi
+if [ "$(bound_total "$LR/etc/nginx-one.conf")" = "$SNIP_N" ] && bound_once "$LR/etc/nginx-one.conf"; then
+  pass "still exactly one binding per zone, and all $SNIP_N of them exist"
+else
+  fail "$(bound_total "$LR/etc/nginx-one.conf") binding(s) across the two files, expected $SNIP_N with no duplicate"
+fi
+FIX_REF="$(zones_referenced "$LR/available/paramant-public.conf" "$LR/available/paramant-live.conf" | wc -l | tr -d ' ')"
+if [ "$(field_5c "$OUTD" 'after zones referenced')" = "$FIX_REF" ]; then
+  pass "5d counted every zone the site confs reference ($FIX_REF)"
+else
+  fail "5d counted $(field_5c "$OUTD" 'after zones referenced') referenced zone(s), expected $FIX_REF"
+fi
+
+echo ""
+echo "6o-5. A destination nginx never reads is a FATAL, not a silent no-op"
+# The file can be written, chmodded and still define nothing, because the
+# directory it sits in is not included anywhere. nginx -t passes either way,
+# so only the dump can tell the difference.
+rm -f "$LR_DEST"
+OUTE="$(run_5d "$LR/etc/nginx-none.conf" 20260101-0004 LRT_NO_INCLUDE=1)"; RCE=$?
+if [ "$RCE" -ne 0 ]; then pass "5d exits non-zero when nginx does not load the file it wrote"; else
+  fail "5d exited 0 while nginx never loaded the snippet"; fi
+if printf '%s\n' "$OUTE" | grep -q 'after snippet loaded = no'; then
+  pass "5d says the snippet was not loaded"
+else
+  fail "5d never reported that the snippet was not loaded"
+fi
+if printf '%s\n' "$OUTE" | grep -q 'PARAMANT_LIMIT_REQ_DEST'; then
+  pass "the FATAL names the override that fixes it"
+else
+  fail "the FATAL does not say how to point the snippet somewhere nginx reads"
+fi
+if [ ! -f "$LR_DEST" ]; then
+  pass "the file it wrote is gone again, so a failed 5d leaves no orphan in conf.d"
+else
+  fail "5d left $LR_DEST behind after failing"
+fi
+
+echo ""
+echo "6o-6. nginx -t failing puts the previous file back, byte for byte"
+rm -f "$LR_DEST"
+printf '# an older snippet\nlimit_req_zone $binary_remote_addr zone=leftover:1m rate=1r/m;\n' > "$LR_DEST"
+cp "$LR_DEST" "$LR/etc/expected-restore.conf"
+OUTF="$(run_5d "$LR/etc/nginx-none.conf" 20260101-0005 LRT_T_FAIL=1)"; RCF=$?
+if [ "$RCF" -ne 0 ]; then pass "5d exits non-zero when nginx -t rejects the config"; else
+  fail "5d exited 0 after nginx -t failed"; fi
+if printf '%s\n' "$OUTF" | grep -q 'FATAL nginx -t failed'; then
+  pass "5d says nginx -t was what failed"
+else
+  fail "5d did not report the nginx -t failure"
+fi
+if cmp -s "$LR_DEST" "$LR/etc/expected-restore.conf"; then
+  pass "the file that was there before the phase is back, unchanged"
+else
+  fail "5d left a rewritten file behind after nginx -t failed"
+fi
+
+echo ""
+echo "6o-7. A zone the site confs use that nothing binds is a stop"
+# The bug this catches: relay_auth deleted from the server's nginx.conf while
+# /api/user/ still rate limits on it. nginx would refuse the config, but the
+# deploy should say which zone and why, not leave that to a config test.
+rm -f "$LR_DEST"
+cat > "$LR/available/paramant-live.conf" <<'CONF'
+server {
+    location /api/user/ {
+        limit_req        zone=nowhere_at_all burst=5 nodelay;
+    }
+}
+CONF
+OUTG="$(run_5d "$LR/etc/nginx-none.conf" 20260101-0006 LRT_X=1)"; RCG=$?
+if [ "$RCG" -ne 0 ]; then pass "5d exits non-zero on a zone nothing binds"; else
+  fail "5d exited 0 while a location rate limits on a zone that does not exist"; fi
+if printf '%s\n' "$OUTG" | grep -q 'nowhere_at_all'; then
+  pass "the FATAL names the zone that is missing"
+else
+  fail "the FATAL does not name the missing zone"
+fi
+if [ ! -f "$LR_DEST" ]; then
+  pass "that failure rolls the snippet back too"
+else
+  fail "5d left the snippet in place after the referenced-zone check failed"
+fi
+
+echo ""
+echo "6o-8. A checkout without the snippet stops before anything is written"
+rm -f "$LR_DEST" "$LR/co/deploy/nginx/snippets/paramant-limit-req.conf"
+OUTH="$(run_5d "$LR/etc/nginx-none.conf" 20260101-0007 LRT_X=1)"; RCH=$?
+if [ "$RCH" -ne 0 ]; then pass "5d exits non-zero when the tracked snippet is not in the checkout"; else
+  fail "5d exited 0 with no snippet to place"; fi
+if [ ! -f "$LR_DEST" ]; then pass "and it wrote nothing"; else
+  fail "5d wrote a file anyway"; fi
+cp "$SNIPPET" "$LR/co/deploy/nginx/snippets/paramant-limit-req.conf"
 
 # ---------------------------------------------------------------- 7. secrets --
 echo ""

--- a/tests/links.test.mjs
+++ b/tests/links.test.mjs
@@ -187,3 +187,134 @@ test('every external link answers', { skip: !process.env.CHECK_EXTERNAL_LINKS &&
     `\n  These external destinations are gone:\n  ` + dood.sort().join('\n  ') +
     `\n\n  A download button or a payment link that 404s is worse than not offering it.\n`);
 });
+
+// ---------------------------------------------------------------------------
+// The same two questions, for docs/.
+//
+// Everything above guards frontend/, where a dead link is a visitor on the 404
+// page. docs/ has the quieter version of the same failure: a reader following
+// [pentest-report-2026-04-08.txt](../pentest-report-2026-04-08.txt) to a file
+// that the v2.4.0 repo cleanup deleted. Nothing noticed, because nothing looked.
+//
+// Two rules, both resolved on disk with no network:
+//   a link to a path in the repo must reach a file (or a directory, for the
+//   ones that deliberately point at a folder), and a #fragment must exist as a
+//   heading, an id or a name in the file it points into.
+//
+// Code is not prose: fenced blocks, inline spans and HTML comments are removed
+// before anything is read as a link, so a <script src="/js/ready.js"> in an
+// example stays an example. Template placeholders (<naam>, {x}, $VAR) are not
+// destinations either.
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DOCS = path.join(REPO, 'docs');
+
+// Anything with a scheme, or protocol-relative, is somebody else's uptime: the
+// hourly external run above owns those, a pull request does not.
+const EXTERN = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+const PLACEHOLDER = /[<>{}$|]/;
+
+function docFiles(dir) {
+  const uit = [];
+  for (const naam of fs.readdirSync(dir)) {
+    const p = path.join(dir, naam);
+    const st = fs.statSync(p);
+    if (st.isDirectory()) { if (naam !== 'node_modules') uit.push(...docFiles(p)); }
+    else if (/\.(md|html)$/.test(naam)) uit.push(p);
+  }
+  return uit;
+}
+
+// Fences, inline spans and comments out. An example that shows a link is not a
+// link, and treating it as one is how a link checker earns its reputation.
+function zonderCode(src) {
+  const uit = [];
+  let hek = null;
+  for (const regel of src.replace(/<!--[\s\S]*?-->/g, '').split('\n')) {
+    const m = regel.match(/^\s{0,3}(`{3,}|~{3,})/);
+    if (hek) { if (m && m[1][0] === hek[0] && m[1].length >= hek.length) hek = null; uit.push(''); continue; }
+    if (m) { hek = m[1]; uit.push(''); continue; }
+    uit.push(regel.replace(/`+[^`]*`+/g, ''));
+  }
+  return uit.join('\n');
+}
+
+// Markdown: inline links, reference definitions, and the raw HTML that markdown
+// allows. HTML: the same attributes the frontend scan reads.
+function docDestinations(file) {
+  const ruw = fs.readFileSync(file, 'utf8');
+  const src = file.endsWith('.md') ? zonderCode(ruw) : ruw;
+  const uit = new Set();
+  if (file.endsWith('.md')) {
+    for (const m of src.matchAll(/\[[^\]]*\]\(\s*<?([^)\s>]+)>?(?:\s+["'][^"']*["'])?\s*\)/g)) uit.add(m[1]);
+    for (const m of src.matchAll(/^\s{0,3}\[[^\]]+\]:\s*<?(\S+)>?/gm)) uit.add(m[1]);
+  }
+  for (const m of src.matchAll(/(?:href|src|action)\s*=\s*["']([^"']+)["']/g)) uit.add(m[1]);
+  return [...uit];
+}
+
+// GitHub's heading slug: lowercase, punctuation dropped, spaces to hyphens.
+// A repeated heading gets -1, -2, which is why the counter is here.
+function slug(tekst) {
+  return tekst
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[`*_~]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N} \-_]/gu, '')
+    .replace(/ +/g, '-');
+}
+
+// Every fragment a reader can land on in one file.
+function ankers(file) {
+  const ruw = fs.readFileSync(file, 'utf8');
+  const uit = new Set();
+  for (const m of ruw.matchAll(/(?:id|name)\s*=\s*["']([^"']+)["']/g)) uit.add(m[1]);
+  if (!file.endsWith('.md')) return uit;
+  const geteld = new Map();
+  for (const m of zonderCode(ruw).matchAll(/^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/gm)) {
+    const s = slug(m[1]);
+    if (!s) continue;
+    const n = geteld.get(s) || 0;
+    geteld.set(s, n + 1);
+    uit.add(n ? `${s}-${n}` : s);
+  }
+  return uit;
+}
+
+const ankerCache = new Map();
+function heeftAnker(file, fragment) {
+  if (!ankerCache.has(file)) ankerCache.set(file, ankers(file));
+  return ankerCache.get(file).has(fragment) || ankerCache.get(file).has(decodeURIComponent(fragment));
+}
+
+const docs = docFiles(DOCS).flatMap((f) => docDestinations(f).map((d) => ({ d, f })));
+
+test('every link in docs/ points at something that exists', () => {
+  assert(docs.length, 'no links found under docs/ at all, which means the scan stopped reading the files');
+
+  const dood = [];
+  for (const { d, f } of docs) {
+    if (EXTERN.test(d) || PLACEHOLDER.test(d)) continue;
+    const [pad, anker] = [d.split('#')[0].split('?')[0], d.split('#').slice(1).join('#')];
+
+    // A path from the site root is a route, not a file next to the doc, so it
+    // is answered by the same rules as the frontend scan above.
+    if (pad.startsWith('/')) {
+      if (SERVER_ROUTES.some((r) => r.test(pad)) || resolvesOnDisk(pad)) continue;
+      dood.push(`${d}   (from ${path.relative(REPO, f)})`);
+      continue;
+    }
+
+    const doel = pad ? path.resolve(path.dirname(f), decodeURIComponent(pad)) : f;
+    if (!doel.startsWith(REPO)) { dood.push(`${d}   (from ${path.relative(REPO, f)}: leaves the repo)`); continue; }
+    if (!fs.existsSync(doel)) { dood.push(`${d}   (from ${path.relative(REPO, f)})`); continue; }
+    if (!anker) continue;
+    if (!fs.statSync(doel).isFile() || !/\.(md|html)$/.test(doel)) continue;   // no headings to have
+    if (!heeftAnker(doel, anker)) dood.push(`${d}   (from ${path.relative(REPO, f)}: no such heading or id)`);
+  }
+
+  assert.deepEqual([...new Set(dood)].sort(), [],
+    `\n  These links in docs/ lead nowhere:\n  ` +
+    [...new Set(dood)].sort().join('\n  ') +
+    `\n\n  Point them at the file or heading that exists, or take the link off.\n`);
+});


### PR DESCRIPTION
Two gaps from the directie backlog.

## 1. limit_req zones in a tracked snippet (new deploy phase 5d)

The five zones the site confs rate limit on (`relay_auth`, `relay_trial`, `relay_inbound`, `relay_outbound`, `api`) were typed into `/etc/nginx/nginx.conf` on the server by hand. Nothing in the repo said what they were, so a conf review could not see them and a rebuilt server would have had locations pointing at zones that did not exist. `limit_req_zone` is an http-level directive, so it cannot live in the site confs themselves.

`deploy/nginx/snippets/paramant-limit-req.conf` is now that record. The rates are the ones the tracked self-host config (`deploy/nginx-selfhost.conf`) already sets for the same jobs. The rates on the live server were never in the repo and are not guessed at here.

New phase 5d places it at `/etc/nginx/conf.d/paramant-limit-req.conf` (`PARAMANT_LIMIT_REQ_DEST` overrides the path). A zone may be bound only once, and a second `limit_req_zone` with a name that is already bound is not a warning but a config nginx refuses to load. So the phase:

1. reads `nginx -T`, minus the destination file itself, for the names already bound
2. writes the snippet with those lines commented out, each saying which zone was left where
3. `nginx -t` before the reload, previous file back byte for byte on failure (or removed again when there was none)
4. `nginx -T` a second time, because a file in a directory no `include` reaches passes `nginx -t` and defines nothing
5. asserts every zone the resolved site confs reference is bound in that dump. That is the check that catches `relay_auth` disappearing out of a hand-edited `nginx.conf` while `/api/user/` still limits on it

On the server as it stands all five are already bound, so the phase writes a file that changes no rate and reports exactly that (`after zone lines written = 0`, `after zone lines left elsewhere = 5`).

`tests/deploy-3.1-dryrun.test.sh` grows section 6o, which runs the real 5d block against a fixture nginx in eight shapes: nothing bound, everything bound, one of five bound, a second run over the file it just placed (the snippet must not read as its own duplicate), a destination nginx never loads, a failing `nginx -t`, a referenced zone nothing binds, and a checkout without the snippet. **390 checks to 449, all green.**

## 2. The links test reads docs/

`tests/links.test.mjs` only walked `frontend/**`, so no internal link and no anchor in `docs/` was checked anywhere. It now walks `docs/**/*.md` and `docs/**/*.html`: inline links, reference definitions, `href`/`src`/`action` in embedded html, and every `#anchor` against the headings and ids of the target. Code fences, inline code and html comments are stripped first, so a `<script src>` in a documented example is not read as a link. 66 files, 20 internal links, 12 external skipped.

One dead target found, in four places: `../pentest-report-2026-04-08.txt`, deleted in `b91ac6a5` and nowhere in the repo since. The link is gone, the file name stays as text. The `frontend/docs/` copies of both files are byte-identical to the `docs/` ones and carried the same link, so they got the same edit and stay identical.

## Verification

- `bash tests/deploy-3.1-dryrun.test.sh`: 449 passed, 0 failed
- `node --test tests/links.test.mjs`: 3 pass, 2 skipped (the external and docroot checks want `CHECK_EXTERNAL_LINKS=1`), 0 fail
- `bash tests/static-sanity.sh`: PASS
- `bash scripts/check-commit-style.sh`: OK

Nothing was deployed and no ssh was made.
