### PR TITLE
The passkey button survives what a phone puts in the email field, and says something useful when it cannot

### DIFF
--- a/admin/lib/webauthn.js
+++ b/admin/lib/webauthn.js
@@ -62,6 +62,69 @@ function scopeHash(s) {
   return crypto.createHash('sha256').update(String(s || '')).digest('hex').slice(0, 32);
 }
 
+// ── The address a phone actually sends ───────────────────────────────────────
+// /login/options is the only passkey route that depends on a typed field, and
+// it answered 400 invalid_email to anything its shape check disliked. The
+// browser turned that into "could_not_start (400)" and the customer was stuck,
+// while the cross-device link right below it kept working because it sends no
+// address at all. That asymmetry is the whole bug report of 2026-09-04.
+//
+// What arrives here is not always a bare address. A phone keyboard and an
+// autofill entry both add things that are invisible on screen:
+//
+//   - a no-break space (U+00A0) or a zero-width space (U+200B) pasted along
+//     with the address, in the MIDDLE of it, where .trim() cannot reach;
+//   - a newline or tab from a paste out of a mail client;
+//   - the display form "Mick <mick@example.com>", which is what a contact card
+//     yields when it is dropped into a text field.
+//
+// None of those change which account is meant, so none of them are a reason to
+// refuse to start the ceremony. Stripping them is safe here in a way it would
+// not be elsewhere: this address only selects which credential ids to offer.
+// Identity is established at /login/verify from the assertion itself, never
+// from this field, so a normalisation that picked the wrong account would still
+// hand out nothing a passkey holder could use.
+//
+// Deliberately NOT normalised: anything that changes which mailbox is named.
+// No dots removed, no plus-tag stripped, no unicode confusables folded.
+const INVISIBLE_G = /[\u0000-\u0020\u007f\u00a0\u1680\u2000-\u200f\u2028\u2029\u202f\u205f\u2060\u3000\ufeff]/g;
+const INVISIBLE_1 = new RegExp(INVISIBLE_G.source);
+const ANGLED_RE   = /<([^<>]+)>[^<>]*$/;
+const EMAIL_SHAPE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function normalizeLoginEmail(raw) {
+  let s = String(raw == null ? '' : raw);
+  const angled = s.match(ANGLED_RE);
+  if (angled) s = angled[1];                 // "Name <a@b.com>" -> "a@b.com"
+  s = s.replace(INVISIBLE_G, '');            // anywhere, not only at the ends
+  return s.toLowerCase();
+}
+
+// Is this a usable sign-in address, after normalisation?
+function isLoginEmail(s) { return typeof s === 'string' && s.length > 0 && EMAIL_SHAPE.test(s); }
+
+// What the process log is allowed to say about an address it refused.
+//
+// Not the address, not a hash of it, not its domain: only the shape facts that
+// tell the next reader WHICH check failed and why. A length and a handful of
+// booleans identify nobody, and they are exactly what was missing when this
+// came in from a phone we cannot attach a debugger to.
+function loginEmailShape(raw) {
+  const s = String(raw == null ? '' : raw);
+  const n = normalizeLoginEmail(s);
+  return {
+    len: s.length,
+    at_count: (s.match(/@/g) || []).length,
+    dot_after_at: /@[^@]*\./.test(s),
+    invisible: INVISIBLE_1.test(s),
+    inner_space: /\S[ \t\u00a0]+\S/.test(s),
+    angled: ANGLED_RE.test(s),
+    non_ascii: /[^\x20-\x7e]/.test(s),
+    normalised_ok: isLoginEmail(n),
+    changed_by_normalise: n !== s.toLowerCase().trim(),
+  };
+}
+
 // ── One-shot challenge / flow store ──────────────────────────────────────────
 // The flow record holds the expected challenge plus the identity the options
 // step bound it to. Consumed (deleted) at verify BEFORE any crypto, so a
@@ -101,5 +164,6 @@ module.exports = {
   RP_ID, RP_NAME, EXPECTED_ORIGIN,
   counterIsAcceptable,
   LIMITS, rateHit, rateHitCounted, scopeHash,
+  normalizeLoginEmail, isLoginEmail, loginEmailShape,
   newFlowId, putAuthFlow, takeAuthFlow, putRegFlow, takeRegFlow,
 };

--- a/admin/server.js
+++ b/admin/server.js
@@ -1287,8 +1287,25 @@ api.post("/user/auth/webauthn/login/options", async (req, res) => {
   const L = webauthn.LIMITS.loginOptions;
   if (!(await webauthn.rateHit(redis(), `lo:ip:${ip}`, L.ip, L.windowSec)))
     return res.status(429).json({ error: "rate_limited" });
-  const email = (req.body?.email || "").toString().toLowerCase().trim();
-  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return res.status(400).json({ error: "invalid_email" });
+  // The typed field is the ONLY thing that separates this route from the
+  // cross-device one below, which sends no address and therefore never failed.
+  // A phone adds invisible characters to it (no-break space, zero-width space,
+  // a pasted newline, the "Name <addr>" display form), and this route used to
+  // answer 400 to every one of them; see webauthn.normalizeLoginEmail.
+  const rawEmail = (req.body?.email || "").toString();
+  const email = webauthn.normalizeLoginEmail(rawEmail);
+  if (!webauthn.isLoginEmail(email)) {
+    // The diagnostic that was missing on 2026-09-04: which check refused, and
+    // the SHAPE of what arrived. No address, no hash of one, no domain, no IP.
+    logRedacted('warn', '[webauthn/login/options] refused invalid_email', JSON.stringify(webauthn.loginEmailShape(rawEmail)));
+    return res.status(400).json({ error: "invalid_email" });
+  }
+  // A request that only worked BECAUSE of the normalisation above is the
+  // evidence that names the cause the next time this is reported. One line, no
+  // address, and only on the path that would previously have been a 400.
+  if (!webauthn.isLoginEmail(rawEmail.toLowerCase().trim())) {
+    logRedacted('warn', '[webauthn/login/options] accepted after normalise', JSON.stringify(webauthn.loginEmailShape(rawEmail)));
+  }
   if (!(await webauthn.rateHit(redis(), `lo:acct:${webauthn.scopeHash(email)}`, L.account, L.windowSec)))
     return res.status(429).json({ error: "rate_limited" });
 

--- a/admin/test/_admin-server.js
+++ b/admin/test/_admin-server.js
@@ -97,6 +97,14 @@ async function stubRelay(state) {
         res.end(JSON.stringify(payload));
       };
       if (url.pathname === '/v2/admin/keys') return send(200, { keys: state.accounts });
+      // GET /v2/user/webauthn/credentials?user_id= : the passkey list the
+      // login/options route uses to build allowCredentials. Answered only when
+      // a suite asked for it by setting state.webauthnCredentials, so every
+      // other suite keeps the 404 it has today (which is the no-passkey path).
+      if (url.pathname === '/v2/user/webauthn/credentials' && state.webauthnCredentials) {
+        const forUser = state.webauthnCredentials[url.searchParams.get('user_id')];
+        return forUser ? send(200, { credentials: forUser }) : send(404, { error: 'no_credentials' });
+      }
       // POST /v2/session-token: the ParaSend session-token mint. Only answered
       // when a suite asked for it by setting state.mintReply, so every other
       // suite keeps the 404 it has today.

--- a/admin/test/passkey-login-options.test.js
+++ b/admin/test/passkey-login-options.test.js
@@ -1,0 +1,230 @@
+'use strict';
+// The two passkey start calls the login page can make, against a real admin.
+//
+// THE REPORT (2026-09-04, iPhone/Safari, paramant.app/auth/login). With the
+// email address filled in, the blue "Sign in with a passkey" button answered
+// "could_not_start (400)" in the error box. The link right under it, "My
+// passkey is on another device", worked on the first tap: Face ID, signed in.
+// Same phone, same account, same page load.
+//
+// WHAT SEPARATES THE TWO. /login/options is the only passkey route that reads a
+// typed field; /login/discoverable/options sends an empty body and cannot fail
+// on one. And the ONLY 400 the whole of /login/options can produce is
+// invalid_email, so the address that left the phone did not pass its shape
+// check. This suite pins that: the shapes a phone keyboard and an autofill
+// entry produce (a no-break space or a zero-width space inside the address, a
+// newline from a paste, the "Name <addr>" display form) now start the ceremony
+// with the account's real credential ids, and the contrast with the
+// cross-device route is asserted in the same run.
+//
+// It also pins what the process log may say when a request IS refused: which
+// check failed and the shape of what arrived, never the address.
+//
+// Sabotage that must turn this red (each verified before commit):
+//   1. drop webauthn.normalizeLoginEmail back to .toLowerCase().trim()
+//   2. put the address (or its domain) into the refusal log line
+//   3. let a bare "not-an-address" through into a ceremony
+//
+// Run: REDIS_URL=redis://127.0.0.1:6399 node --test admin/test/passkey-login-options.test.js
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const { boot, killAll, stubRelay, defaultRelayState, summary } = require('./_admin-server');
+const wa = require('../lib/webauthn');
+
+const DEFAULT_REDIS = 'redis://127.0.0.1:6399';
+const RUN = crypto.randomBytes(5).toString('hex');
+const OWNER_KEY = `pgp_passkey_owner_${RUN}`;
+const OWNER_EMAIL = `passkey_${RUN}@example.com`;
+// A credential id in the shape the relay stores them: base64url, no padding.
+const CRED_ID = crypto.randomBytes(16).toString('base64url');
+
+// Its own /8 per run: the per-IP window on /login/options is fifteen minutes
+// and thirty hits wide, and a rerun inside that window must not inherit them.
+const NET = 20 + Math.floor(Math.random() * 200);
+let _ipN = 0;
+const nextIp = () => { _ipN++; return `${NET}.${(_ipN >> 8) & 255}.${_ipN & 255}.9`; };
+
+let srv = null;
+let relay = null;
+let redisClient = null;
+let checks = 0;
+const did = () => { checks++; };
+
+before(async () => {
+  const url = process.env.REDIS_URL || DEFAULT_REDIS;
+  let createClient;
+  try { ({ createClient } = require('redis')); }
+  catch (e) {
+    // Same doctrine as login-http.test.js: an unmet precondition is declared by
+    // name on the runner or it is a hard failure. A silent pass over nothing is
+    // worse than red.
+    if (String(process.env.ADMIN_TEST_SKIP || '').split(',').includes('redis')) {
+      console.log('  SKIP [redis] - the "redis" module is not installed (declared via ADMIN_TEST_SKIP)');
+      return;
+    }
+    throw new Error(
+      'unmet precondition "redis": the redis module is not installed, so this suite\n' +
+      '  cannot boot an admin. Run npm ci in admin/, or, if this job is deliberately\n' +
+      '  without it, say so on the runner: ADMIN_TEST_SKIP=redis');
+  }
+  const rc = createClient({ url, socket: { connectTimeout: 800, reconnectStrategy: false } });
+  rc.on('error', () => {});
+  try { await rc.connect(); await rc.ping(); }
+  catch (e) {
+    try { await rc.disconnect(); } catch (_) { /* never connected */ }
+    if (String(process.env.ADMIN_TEST_SKIP || '').split(',').includes('redis')) {
+      console.log(`  SKIP [redis] - no reachable redis at ${url} (declared via ADMIN_TEST_SKIP)`);
+      return;
+    }
+    throw new Error(`unmet precondition "redis": no reachable redis at ${url}: ${e.message}`);
+  }
+  redisClient = rc;
+
+  const state = defaultRelayState([{ key: OWNER_KEY, email: OWNER_EMAIL, active: true }]);
+  // One account with one passkey on it, so a started ceremony is telling apart
+  // from the decoy the route hands to an address it does not know.
+  state.webauthnCredentials = {
+    [OWNER_KEY]: [{ credId: CRED_ID, transports: ['internal', 'hybrid'], counter: 0 }],
+  };
+  relay = await stubRelay(state);
+  srv = await boot({ redisUrl: url, relay });
+});
+
+after(async () => {
+  await killAll();
+  if (redisClient) { try { await redisClient.disconnect(); } catch (_) { /* already gone */ } }
+  summary('passkey-login-options', checks);
+});
+
+const ready = () => srv !== null;
+
+function options(body) {
+  return srv.post('/api/user/auth/webauthn/login/options', { headers: { 'X-Real-IP': nextIp() }, body });
+}
+
+// Did the answer offer THIS account's passkey, or the stable decoy the route
+// gives an address it cannot place? That difference is the whole ceremony.
+function offersOwnerCredential(res) {
+  const list = res.json && res.json.options && res.json.options.allowCredentials;
+  return Array.isArray(list) && list.some((c) => c.id === CRED_ID);
+}
+
+test('the address a phone sends still starts the ceremony', async (t) => {
+  if (!ready()) return t.skip('no redis');
+  // Each of these renders on screen as the address the owner typed. Every one
+  // of them was a 400 before, and the customer was told "could_not_start (400)".
+  const fromAPhone = {
+    'plain address': OWNER_EMAIL,
+    'trailing space': `${OWNER_EMAIL} `,
+    'trailing no-break space': `${OWNER_EMAIL} `,
+    'leading and trailing no-break space': ` ${OWNER_EMAIL} `,
+    'zero-width space at the end': `${OWNER_EMAIL}​`,
+    'zero-width space in the middle': OWNER_EMAIL.replace('@', '​@'),
+    'no-break space in the middle': OWNER_EMAIL.replace('@', '@ '),
+    'newline from a paste': `${OWNER_EMAIL}\n`,
+    'tab from a paste': `\t${OWNER_EMAIL}`,
+    'byte order mark': `﻿${OWNER_EMAIL}`,
+    'contact-card display form': `Mick <${OWNER_EMAIL}>`,
+    'shouted by autocapitalisation': OWNER_EMAIL.toUpperCase(),
+  };
+  for (const [what, value] of Object.entries(fromAPhone)) {
+    const r = await options({ email: value });
+    assert.equal(r.status, 200, `${what}: expected a ceremony, got ${r.status} ${r.text}`);
+    assert.ok(offersOwnerCredential(r),
+      `${what}: the answer must offer the account's own credential, got ${JSON.stringify(r.json.options.allowCredentials)}`);
+  }
+  did();
+});
+
+test('a challenge is still one-shot and account-scoped, not a static answer', async (t) => {
+  if (!ready()) return t.skip('no redis');
+  const a = await options({ email: OWNER_EMAIL });
+  const b = await options({ email: ` ${OWNER_EMAIL}` });
+  assert.equal(a.status, 200);
+  assert.equal(b.status, 200);
+  assert.notEqual(a.json.flowId, b.json.flowId, 'two starts must not share a flow id');
+  assert.notEqual(a.json.options.challenge, b.json.options.challenge, 'two starts must not share a challenge');
+  assert.match(a.json.options.rpId || a.json.options.rpID || '', /\S/, 'the options must carry an rpId');
+  did();
+});
+
+test('input that names no mailbox is still refused, and says so once', async (t) => {
+  if (!ready()) return t.skip('no redis');
+  // Normalisation is not permission: what is left after it still has to be an
+  // address, or there is nothing to look a passkey up by.
+  for (const value of ['', 'not-an-address', 'no-at-sign.example.com', 'a@nodot', '@example.com', ' ​', 'a@b@c.com']) {
+    const r = await options({ email: value });
+    assert.equal(r.status, 400, `${JSON.stringify(value)} must be refused, got ${r.status}`);
+    assert.equal(r.json && r.json.error, 'invalid_email');
+  }
+  const missing = await options({});
+  assert.equal(missing.status, 400, 'a body without an email field is refused');
+  did();
+});
+
+test('the refusal is logged with the shape of the input and nothing about the person', async (t) => {
+  if (!ready()) return t.skip('no redis');
+  const marker = `zzz_${crypto.randomBytes(4).toString('hex')}`;
+  await options({ email: `${marker} not an address` });
+  // The admin writes to stdout/stderr; the harness collects both.
+  const log = srv.log();
+  assert.ok(log.includes('[webauthn/login/options] refused invalid_email'),
+    `the refusal must leave a diagnostic line, got:\n${log.slice(-1200)}`);
+  assert.ok(!log.includes(marker), 'the log may not carry any part of what was typed');
+  assert.ok(!log.includes(OWNER_EMAIL), 'the log may not carry the account address');
+  assert.doesNotMatch(log, /[A-Za-z0-9._%+-]{2,}@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/,
+    'no plaintext address may reach the process log');
+  did();
+});
+
+test('the cross-device route is the contrast: no address, no shape check', async (t) => {
+  if (!ready()) return t.skip('no redis');
+  const r = await srv.post('/api/user/auth/webauthn/login/discoverable/options', {
+    headers: { 'X-Real-IP': nextIp() }, body: {},
+  });
+  assert.equal(r.status, 200, 'the cross-device start never depended on a typed field');
+  assert.deepEqual(r.json.options.allowCredentials, [],
+    'discoverable means an empty allowCredentials, so the browser offers its QR');
+  // The report in one assertion: the same input that used to sink the primary
+  // button has no bearing on this route at all.
+  did();
+});
+
+// ── The pure part, without a server ─────────────────────────────────────────
+
+test('normalizeLoginEmail strips what is invisible and nothing that names a mailbox', (t) => {
+  assert.equal(wa.normalizeLoginEmail('  A@B.com  '), 'a@b.com');
+  assert.equal(wa.normalizeLoginEmail('a​@b.com'), 'a@b.com');
+  assert.equal(wa.normalizeLoginEmail('Mick <a@b.com>'), 'a@b.com');
+  assert.equal(wa.normalizeLoginEmail(null), '');
+  assert.equal(wa.normalizeLoginEmail(undefined), '');
+  // What it must NOT do: two addresses that reach different mailboxes must
+  // stay different. No dot-folding, no plus-tag stripping, no case folding of
+  // anything but the ASCII case the RFC already treats as equal.
+  assert.notEqual(wa.normalizeLoginEmail('a.b@gmail.com'), wa.normalizeLoginEmail('ab@gmail.com'));
+  assert.notEqual(wa.normalizeLoginEmail('a+tag@b.com'), wa.normalizeLoginEmail('a@b.com'));
+  assert.ok(wa.isLoginEmail('a@b.com'));
+  assert.ok(!wa.isLoginEmail('a@b'));
+  assert.ok(!wa.isLoginEmail(''));
+  did();
+});
+
+test('loginEmailShape records facts about the input and none about the person', (t) => {
+  const shape = wa.loginEmailShape('Mick <mick.bruinsma@example.com> ');
+  assert.equal(typeof shape.len, 'number');
+  assert.equal(shape.angled, true);
+  assert.equal(shape.invisible, true);
+  assert.equal(shape.normalised_ok, true);
+  assert.equal(shape.changed_by_normalise, true);
+  const line = JSON.stringify(shape);
+  assert.ok(!line.includes('mick'), 'no part of the local part may appear');
+  assert.ok(!line.includes('example.com'), 'not even the domain');
+  assert.doesNotMatch(line, /[A-Za-z0-9._%+-]{2,}@/, 'nothing address-shaped at all');
+  // A shape that would NOT have been refused before must say so, or the flag
+  // proves nothing when it appears in a real log.
+  assert.equal(wa.loginEmailShape('a@b.com').changed_by_normalise, false);
+  assert.equal(wa.loginEmailShape('not-an-address').normalised_ok, false);
+  did();
+});

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -403,7 +403,7 @@ main.acct input::placeholder { color: var(--ink-3); }
 <script src="/js/account.inline1.js?v=2"></script>
 
 <script type="module" src="/js/account.inline2.js?v=3"></script>
-<script type="module" src="/js/passkey.js?v=3"></script>
+<script type="module" src="/js/passkey.js?v=4"></script>
 <script type="module" src="/js/signing-enrol.js?v=14"></script>
 <script src="/js/account-theme.js?v=1" defer></script>
 

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -137,7 +137,7 @@
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=7" defer></script>
 <script src="/js/auth-login.js?v=3"></script>
-<script type="module" src="/js/passkey.js?v=3"></script>
+<script type="module" src="/js/passkey.js?v=4"></script>
 
 <footer class="legal-strip">
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -286,7 +286,7 @@
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=7" defer></script>
 <script src="/js/auth-setup.js?v=2"></script>
-<script type="module" src="/js/passkey.js?v=3"></script>
+<script type="module" src="/js/passkey.js?v=4"></script>
 
 <footer class="legal-strip">
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>

--- a/frontend/js/passkey.js
+++ b/frontend/js/passkey.js
@@ -21,12 +21,70 @@ async function postJSON(url, body) {
   return { ok: r.ok, status: r.status, data };
 }
 
-function setStatus(el, text, isError) {
+// The status line. `techCode`, when present, is the raw technical detail: it
+// goes on a second, quieter line UNDER the sentence instead of being the whole
+// message. "could_not_start (400)" was the entire thing a customer saw on the
+// login page, which names an HTTP status and no next step. Support still needs
+// the code, so it is kept rather than dropped.
+//
+// Built with createElement/textContent, never innerHTML: this file runs under
+// script-src 'self' with no inline script anywhere (scripts/check-csp-inline.sh).
+function setStatus(el, text, isError, techCode) {
   if (!el) return;
-  el.textContent = text;
+  el.textContent = '';
+  el.appendChild(document.createTextNode(text));
+  if (techCode) {
+    el.appendChild(document.createElement('br'));
+    const code = document.createElement('span');
+    code.className = 'small';
+    code.style.color = 'var(--ink-dim, #6b7280)';
+    code.style.opacity = '.85';
+    code.textContent = techCode;
+    el.appendChild(code);
+  }
   el.classList.toggle('error', !!isError);
   el.classList.add('visible');
   el.style.display = '';
+}
+
+// Why the passkey prompt never opened, said to somebody who wants to sign in.
+//
+// The start call is the one step that can fail before the device is ever asked
+// anything, and the page used to print the bare `could_not_start (<status>)`
+// for all of it. That sentence tells a customer nothing they can act on, and on
+// 2026-09-04 it was the whole of what a real sign-in attempt produced while the
+// cross-device link right below it worked on the first tap. So: plain language
+// plus the one route that is known to still work, and the code kept small
+// underneath for support.
+const PASSKEY_START_FALLBACK =
+  'We could not start the passkey prompt on this device. '
+  + 'Try “My passkey is on another device”, or use a 6-digit code.';
+// Creating a passkey is a different screen with different exits: the
+// cross-device link and the 6-digit code are not on it, so the sign-in sentence
+// would send somebody looking for a button that is not there.
+const PASSKEY_CREATE_FALLBACK =
+  'We could not start the passkey setup on this device. '
+  + 'Reload this page and try again, or set up the authenticator app instead.';
+
+// `kind` picks which exits the sentence may point at: 'login' (default) or
+// 'create'. The technical code is the same in both.
+function passkeyStartFailure(status, serverError, kind) {
+  let text = kind === 'create' ? PASSKEY_CREATE_FALLBACK : PASSKEY_START_FALLBACK;
+  if (serverError === 'invalid_email') {
+    text = 'That email address does not look complete, so we could not look up your passkey. '
+      + 'Check it and try again, or use “My passkey is on another device”.';
+  } else if (serverError === 'setup_token_required' || serverError === 'invalid_setup_token') {
+    text = 'This setup link is no longer valid. Ask for a new one on the sign-in page '
+      + 'under “Email me a new setup link”.';
+  } else if (status === 429) {
+    text = kind === 'create'
+      ? 'Too many attempts from this internet connection. Wait a few minutes and try again.'
+      : 'Too many sign-in attempts from this internet connection. Wait a few minutes, '
+        + 'then try again or use a 6-digit code.';
+  }
+  const e = new Error(text);
+  e.techCode = 'could_not_start (' + status + (serverError ? ' ' + serverError : '') + ')';
+  return e;
 }
 
 function esc(s) {
@@ -51,7 +109,7 @@ function passkeyAuthErrorMessage(e) {
   }
   // NotAllowedError and anything else: ambiguous. Give the actionable options.
   return 'No passkey was used on this device. Sign in with your email and code above, '
-    + 'or tap “Use a passkey on another device” to sign in with the passkey on your phone. '
+    + 'or tap “My passkey is on another device” to sign in with the passkey on your phone. '
     + 'If you cancelled, just try again.';
 }
 
@@ -75,7 +133,7 @@ function wireSetupPasskey() {
     setStatus(status, 'Follow your device prompt to create the passkey…', false);
     try {
       const opt = await postJSON('/api/user/auth/webauthn/register/options', { setup_token: setupToken });
-      if (!opt.ok) throw new Error(opt.data && opt.data.error ? opt.data.error : 'could_not_start (' + opt.status + ')');
+      if (!opt.ok) throw passkeyStartFailure(opt.status, opt.data && opt.data.error, 'create');
 
       let attResp;
       try {
@@ -94,7 +152,7 @@ function wireSetupPasskey() {
 
       showRecoveryCodes(Array.isArray(ver.data.recovery_codes) ? ver.data.recovery_codes : []);
     } catch (e) {
-      setStatus(status, e.message || 'Passkey registration failed.', true);
+      setStatus(status, e.message || 'Passkey registration failed.', true, e.techCode);
       btn.disabled = false;
     }
   });
@@ -176,7 +234,7 @@ function wireLoginPasskey() {
     setStatus(status, 'Follow your device prompt to sign in…', false);
     try {
       const opt = await postJSON('/api/user/auth/webauthn/login/options', { email });
-      if (!opt.ok) throw new Error('could_not_start (' + opt.status + ')');
+      if (!opt.ok) throw passkeyStartFailure(opt.status, opt.data && opt.data.error);
 
       let asseResp;
       try {
@@ -199,7 +257,7 @@ function wireLoginPasskey() {
 
       window.location = returnUrl;
     } catch (e) {
-      setStatus(status, e.message || 'Passkey sign-in failed.', true);
+      setStatus(status, e.message || 'Passkey sign-in failed.', true, e.techCode);
       btn.disabled = false;
     }
   });
@@ -252,7 +310,7 @@ function wireAccountPasskey() {
     try {
       const opt = await postJSON('/api/user/account/webauthn/register/options', { totp });
       if (opt.status === 403) throw new Error('That TOTP code was not accepted. Try the current code from your authenticator.');
-      if (!opt.ok) throw new Error(opt.data && opt.data.error ? opt.data.error : 'could_not_start (' + opt.status + ')');
+      if (!opt.ok) throw passkeyStartFailure(opt.status, opt.data && opt.data.error, 'create');
 
       setStatus(status, 'Follow your device prompt to create the passkey…', false);
       let attResp;
@@ -271,7 +329,7 @@ function wireAccountPasskey() {
       if (totpEl) totpEl.value = '';
       refresh();
     } catch (e) {
-      setStatus(status, e.message || 'Could not activate passkey.', true);
+      setStatus(status, e.message || 'Could not activate passkey.', true, e.techCode);
       btn.disabled = false;
     }
   });
@@ -303,7 +361,7 @@ function wireDiscoverablePasskey() {
     setStatus(status, 'Your browser will show a QR code — scan it with your phone to sign in…', false);
     try {
       const opt = await postJSON('/api/user/auth/webauthn/login/discoverable/options', {});
-      if (!opt.ok) throw new Error('could_not_start (' + opt.status + ')');
+      if (!opt.ok) throw passkeyStartFailure(opt.status, opt.data && opt.data.error);
 
       let asseResp;
       try {
@@ -320,7 +378,7 @@ function wireDiscoverablePasskey() {
 
       window.location = returnUrl;
     } catch (e) {
-      setStatus(status, e.message || 'Cross-device passkey sign-in failed.', true);
+      setStatus(status, e.message || 'Cross-device passkey sign-in failed.', true, e.techCode);
       btn.disabled = false;
     }
   });

--- a/tests/passkey-start-error.test.mjs
+++ b/tests/passkey-start-error.test.mjs
@@ -1,0 +1,115 @@
+// The sentence a customer reads when the passkey prompt never opens.
+//
+// On 2026-09-04 an owner on an iPhone tapped "Sign in with a passkey" with his
+// address filled in and got, as the entire message, "could_not_start (400)".
+// That names an HTTP status and no next step, and the one thing that did work
+// (the "My passkey is on another device" link directly below it) was not
+// mentioned. The cause is fixed in admin/lib/webauthn.js and pinned by
+// admin/test/passkey-login-options.test.js; this suite pins the words, because
+// the next unforeseen 4xx on that call will produce this sentence too.
+//
+// The function is lifted out of frontend/js/passkey.js and run for real, the
+// way admin/test/log-redact.test.js lifts its three log statements: the module
+// itself cannot be imported here (it is a browser entry point that imports
+// /vendor/... by absolute path), and a copy of the sentence in a test file
+// would agree with a broken page. Node builtins only, so this lands in the
+// "Root integration suites" CI job and costs a millisecond.
+//
+// Sabotage that must turn this red (each verified before commit):
+//   1. return the bare 'could_not_start (' + status + ')' as the message again
+//   2. drop the technical code, leaving support with nothing to grep
+//   3. rename the login button without changing the sentence that points at it
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PASSKEY_JS = path.join(ROOT, 'frontend', 'js', 'passkey.js');
+const LOGIN_HTML = path.join(ROOT, 'frontend', 'auth', 'login.html');
+
+const source = fs.readFileSync(PASSKEY_JS, 'utf8');
+const loginHtml = fs.readFileSync(LOGIN_HTML, 'utf8');
+
+// Lift the shipped builder, constants and all, and hand back a callable.
+function loadFailureBuilder() {
+  const from = source.indexOf('const PASSKEY_START_FALLBACK');
+  assert.notEqual(from, -1, 'frontend/js/passkey.js must define PASSKEY_START_FALLBACK');
+  const marker = '\n}\n';
+  const to = source.indexOf(marker, source.indexOf('function passkeyStartFailure'));
+  assert.notEqual(to, -1, 'frontend/js/passkey.js must define passkeyStartFailure');
+  const block = source.slice(from, to + marker.length);
+  return new Function(`${block}\nreturn passkeyStartFailure;`)();
+}
+
+const passkeyStartFailure = loadFailureBuilder();
+const RAW_CODE = /^could_not_start \(\d+/;
+
+test('the message a customer reads is a sentence, never the raw code', () => {
+  for (const [status, serverError] of [[400, 'invalid_email'], [400, null], [429, 'rate_limited'],
+    [500, 'internal'], [502, 'relay_unreachable'], [503, null]]) {
+    const e = passkeyStartFailure(status, serverError);
+    assert.doesNotMatch(e.message, RAW_CODE, `${status}/${serverError}: the code may not be the message`);
+    assert.ok(e.message.length > 40, `${status}/${serverError}: too short to say anything: ${e.message}`);
+    assert.match(e.message, /[.]$/, `${status}/${serverError}: must be a finished sentence`);
+  }
+});
+
+test('every message names something the customer can do next', () => {
+  const NEXT_STEP = /another device|6-digit code|try again|Reload this page|setup link/i;
+  for (const [status, serverError] of [[400, 'invalid_email'], [400, 'unforeseen'], [429, 'rate_limited'],
+    [500, 'internal'], [502, 'relay_unreachable']]) {
+    const e = passkeyStartFailure(status, serverError);
+    assert.match(e.message, NEXT_STEP, `${status}/${serverError} leaves the customer nowhere: ${e.message}`);
+  }
+});
+
+test('the technical code survives, alongside the sentence and not instead of it', () => {
+  const e = passkeyStartFailure(400, 'invalid_email');
+  assert.equal(e.techCode, 'could_not_start (400 invalid_email)');
+  assert.equal(passkeyStartFailure(502).techCode, 'could_not_start (502)');
+  assert.notEqual(e.techCode, e.message, 'the code is the second line, not the message');
+});
+
+test('an unforeseen failure points at the exit that is known to still work', () => {
+  // The report is exactly this case: the primary call failed and the
+  // cross-device link worked. A generic answer has to say so.
+  const e = passkeyStartFailure(418, 'something_new');
+  assert.match(e.message, /My passkey is on another device/,
+    'the fallback must name the cross-device route');
+  assert.match(e.message, /6-digit code/, 'and the code route');
+});
+
+test('creating a passkey is not offered the sign-in exits', () => {
+  // The setup and account screens have neither the cross-device link nor the
+  // 6-digit field, so pointing at them sends somebody looking for a button
+  // that is not on the page.
+  const e = passkeyStartFailure(500, 'internal', 'create');
+  assert.doesNotMatch(e.message, /another device|6-digit code/);
+  assert.match(e.message, /Reload this page|authenticator app/);
+});
+
+test('the sentence quotes the label that is actually on the login page', () => {
+  const quoted = passkeyStartFailure(418, null).message.match(/“([^”]+)”/);
+  assert.ok(quoted, 'the fallback quotes a control by name');
+  assert.ok(loginHtml.includes(`>${quoted[1]}<`),
+    `/auth/login has no control labelled "${quoted[1]}"`);
+});
+
+test('no start failure is rendered as a bare code anywhere in passkey.js', () => {
+  const offenders = source.split('\n')
+    .map((line, i) => [i + 1, line])
+    .filter(([, line]) => /throw new Error\(\s*'could_not_start/.test(line)
+      || /setStatus\([^)]*'could_not_start/.test(line));
+  assert.deepEqual(offenders, [], `a raw code is still shown to a customer:\n${offenders.join('\n')}`);
+});
+
+test('the status line renders the code as a node, never as markup', () => {
+  // script-src 'self' with no inline script: the second line is built with
+  // createElement/textContent, and innerHTML has no business in setStatus.
+  const fn = source.slice(source.indexOf('function setStatus'), source.indexOf('// Why the passkey prompt'));
+  assert.match(fn, /createElement\('span'\)/);
+  assert.match(fn, /code\.textContent = techCode/);
+  assert.doesNotMatch(fn, /innerHTML/, 'setStatus may not build markup from a string');
+});


### PR DESCRIPTION
## The report

2026-09-04, 13:57, iPhone/Safari, `paramant.app/auth/login`. With the email
address filled in, the blue **Sign in with a passkey** button put
`could_not_start (400)` in the error box. The link directly under it, **My
passkey is on another device**, worked on the first tap: Face ID, signed in.
Same phone, same account, same page load.

## The cause

The asymmetry is the whole finding. `/api/user/auth/webauthn/login/options` is
the only passkey route that reads a typed field; the cross-device route posts an
empty body and cannot fail on one. And the entire `/login/options` handler can
produce exactly one 400, `invalid_email`. So the address that left the phone did
not pass its shape check.

Confirmed against a booted admin (`admin/test/_admin-server.js`), the old
handler answered **400** to each of these, every one of which renders on screen
as the address the owner typed:

| what arrived | old | new |
| --- | --- | --- |
| `owner@example.com` | 200, real credential | 200, real credential |
| `owner@ example.com` (no-break space inside) | **400** | 200, real credential |
| `owner@example.com` with a zero-width space | 200, **decoy** credential | 200, real credential |
| `owner@example.com\n` from a paste | 200, decoy | 200, real credential |
| `Mick <owner@example.com>` (contact-card form) | **400** | 200, real credential |
| `not-an-address` | 400 | 400 |
| discoverable / cross-device | 200 | 200 |

`.trim()` reaches neither a character in the middle of the string nor the
display form, and the zero-width cases slipped past the regex into the decoy
credential, so the ceremony started and then failed with `NotAllowedError`.

**Which exact character it was on that phone is not proven.** It cannot be from
here: the input never reached a log. That is fixed below, so the next report
carries its own evidence.

## The fix

`webauthn.normalizeLoginEmail` strips what is invisible (space-like and
zero-width codepoints, anywhere in the string, not only at the ends) and unwraps
`Name <addr>`, then the same shape check runs. Safe here in a way it would not
be elsewhere: this address only selects which credential ids to offer, and
identity is established at `/login/verify` from the assertion itself, never from
this field. Nothing that names a different mailbox is touched: no dot folding,
no plus-tag stripping. Input that still names no mailbox is still refused with
the same `400 invalid_email`.

## The diagnostic

A refusal now writes one line with the *shape* of what arrived and nothing about
the person: length, at-count, and flags for `dot_after_at`, `invisible`,
`inner_space`, `angled`, `non_ascii`. No address, no domain, no hash of one, no
IP; it goes through `logRedacted`, and the suite asserts nothing address-shaped
can appear. A request that only succeeded *because* of the normalisation writes
the same record under `accepted after normalise`, which is what will name the
cause the next time this happens.

```
[webauthn/login/options] accepted after normalise {"len":31,"at_count":1,"dot_after_at":true,
 "invisible":true,"inner_space":true,"angled":true,"non_ascii":false,
 "normalised_ok":true,"changed_by_normalise":true}
```

## The message

`could_not_start (400)` was the entire sentence a customer read. It names an
HTTP status, gives no next step, and does not mention the one route that was
working. Now:

> We could not start the passkey prompt on this device. Try "My passkey is on
> another device", or use a 6-digit code.
> <br><small>could_not_start (400 invalid_email)</small>

The technical code is kept, small, on a second line. `invalid_email` and 429 get
their own sentence, and the setup/account screens get wording of their own,
because the cross-device link and the 6-digit field are not on them. The
ambiguous-assertion message also now quotes the label that is actually on the
page ("My passkey is on another device", not "Use a passkey on another device"),
and a test holds it to the button.

The second line is built with `createElement`/`textContent`, no `innerHTML`, no
inline script: `scripts/check-csp-inline.sh` stays green.

## Evidence

- `admin/test/passkey-login-options.test.js` (new, 7 checks): both payloads
  against a real booted admin. Verified **red** against the pre-fix handler via
  `ADMIN_SERVER_JS`, on two of its cases.
- `tests/passkey-start-error.test.mjs` (new, 8 checks): the shipped
  `passkeyStartFailure` lifted out of `frontend/js/passkey.js` and run for real.
- Admin unit suite: 86/86, no silent suites.
- Root integration suites: green (`heartbeat-lib` and `brand-shots-optin` fail
  locally on missing optional deps, `@noble/post-quantum` and `playwright`, on
  `main` as well).
- `bash tests/static-sanity.sh`: PASS. `./scripts/check-csp-inline.sh`: OK.
- `passkey.js ?v=3 -> ?v=4` on all three pages that load it.

## Not done

Not deployed, not merged, no ssh. The exact character the iPhone sent is not
reproduced and is reported as **not proven**; the diagnostic line exists so the
next occurrence proves it.
