### PR TITLE
De navbalk neemt het papier van de pagina, en de actiebalk op /sign laat de hint met rust

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -26,7 +26,7 @@
   </style>
 <style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <style>

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .about-band{padding:var(--space-8) 0;border-top:1px solid var(--ink-hair)}

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -9,7 +9,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta property="og:title" content="Your account · Paramant">
 <meta property="og:description" content="Your account · Paramant">

--- a/frontend/all-systems-go.html
+++ b/frontend/all-systems-go.html
@@ -7,7 +7,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/all-systems-go">
   <link rel="stylesheet" href="/design-system.css?v=25">
-  <link rel="stylesheet" href="/nav.css?v=20">
+  <link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
     .asg { max-width: 560px; margin: 64px auto; padding: 0 24px; }

--- a/frontend/apply-nav.py
+++ b/frontend/apply-nav.py
@@ -90,7 +90,7 @@ LEGAL_STRIP = '''\
 </footer>'''
 
 DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=25">'
-NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=20">'
+NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=21">'
 NAV_JS    = '<script src="/nav.js?v=15" defer></script>'
 NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=7" defer></script>'
 
@@ -229,16 +229,35 @@ def replace_mobile_div(html):
     return html
 
 
+def renumber_shared_assets(fpath, html):
+    """Carry the ?v= of design-system.css and nav.css to pages the generator
+    otherwise leaves alone.
+
+    co-sign.html and developer.html keep their own nav, and setup.html and
+    all-systems-go.html carry no shared nav at all, but all four still LINK
+    these two stylesheets. Bumping the version here and nowhere else left them
+    pointing at the old cache key, which scripts/check-cache-bust.sh fails on
+    ("one file, two cache keys") while the idempotency gate stayed green. This
+    only rewrites links that are already there; it injects nothing."""
+    updated = re.sub(r'<link rel="stylesheet" href="/design-system\.css(?:\?v=\d+)?">', DS_LINK, html)
+    updated = re.sub(r'<link rel="stylesheet" href="/nav\.css(?:\?v=\d+)?">', NAV_LINK, updated)
+    if updated == html:
+        return False
+    with open(fpath, 'w', encoding='utf-8') as f:
+        f.write(updated)
+    return True
+
+
 def process(fpath):
     with open(fpath, encoding='utf-8') as f:
         original = f.read()
     rel = os.path.relpath(fpath, frontend).replace(os.sep, '/')
     if rel in KEEP_OWN_NAV:
-        return False
+        return renumber_shared_assets(fpath, original)
     content = original
     if '<nav class="nav">' not in content:
         if rel not in ADD_NAV_TO:
-            return False
+            return renumber_shared_assets(fpath, original)
         content = inject_nav_block(content)
         if '<nav class="nav">' not in content:
             return False

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -20,7 +20,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <link rel="canonical" href="https://paramant.app/audit-log-export">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -10,7 +10,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 /* Een auth-scherm is op een telefoon één taak. Kop, één zin en de knop moeten

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -22,7 +22,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 /* Compact auth layout — existing design tokens only; design-system.css untouched. */

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -10,7 +10,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 /* Same compact phone rhythm as /auth/backup: existing tokens only,

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -10,7 +10,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 /* Same compact phone rhythm as /auth/backup: existing tokens only,

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -10,7 +10,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <script src="/js/qrcode.min.js?v=1"></script>
 <style>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -24,7 +24,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -26,7 +26,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="Algorithms you can swap without rebuilding. Identifiers travel in the header, not in the code path. NIST FIPS 203, 204, 205 and 206 loaded in production.">
 <link rel="canonical" href="https://paramant.app/crypto-agility">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:none}

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -18,7 +18,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta property="og:title" content="Certificate transparency log · Paramant">
 <meta property="og:description" content="Every public key registration is appended to a tamper-evident Merkle tree. Anyone can verify that a device was registered, without seeing the payload.">

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -11,7 +11,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://relay.paramant.app">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <noscript><meta http-equiv="refresh" content="0;url=/auth/login?next=/dashboard"></noscript>

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -10,7 +10,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0b3a6a">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <style>
 *{box-sizing:border-box}
 body{background:linear-gradient(180deg,#f8faff 0,#f5f7fb 460px)}

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/docs">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -67,7 +67,7 @@ pre{font-family:var(--mono);font-size:12px;line-height:1.7;color:var(--ink);back
 </style>
 <style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <script type="application/ld+json" data-paramant-seo="1">
 {

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="The GDPR Article 28 agreement between Paramantis Solutions B.V. as processor and your organisation as controller. Sign it electronically, EU and German law.">
 <link rel="canonical" href="https://paramant.app/dpa">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 a{color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-hair)}

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -30,7 +30,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -73,7 +73,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -59,7 +59,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -73,7 +73,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -75,7 +75,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -77,7 +77,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -57,7 +57,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <style>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -72,7 +72,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -71,7 +71,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -77,7 +77,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -71,7 +71,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,7 +23,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="manifest" href="/manifest.json">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <style>
 /* Homepage 2026, night edition: the same hand as BeerWeer. Warm night ground,
    cream ink, one ochre accent, mono for the small facts, a drawn band at the

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/nav.css
+++ b/frontend/nav.css
@@ -1,5 +1,9 @@
 /* PARAMANT shared navbar v4 — design-system.css v4 tokens only */
 
+/* --nav-paper / --nav-paper-blur: the paper the bar, the drawer and the drawer
+   tail paint themselves in. A page sets them when its own paper is not the
+   cool bone; every page that sets nothing renders exactly as before. */
+
 /* ════════════════════════════════════════
    NAV BAR
    ════════════════════════════════════════ */
@@ -14,7 +18,13 @@ nav.nav {
   gap: var(--space-4);
   padding: 0 40px;
   height: 56px;
-  background: rgba(248,250,252,.92);
+  /* The bar paints the paper of the page it sits on, not a fixed hex. The
+     homepage runs on warm paper (#FAF8F3) while the bar was pinned to the cool
+     bone (#F8FAFC), and the two met in a visible band under the bar as soon as
+     the page scrolled. app-2026.css already does this for the app screens
+     (var(--paper)); --nav-paper is the same idea for the marketing pages. Any
+     page that sets no token keeps the exact value it had. */
+  background: var(--nav-paper-blur, rgba(248,250,252,.92));
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border-bottom: 1px solid var(--ink-hair);
@@ -302,7 +312,7 @@ nav.nav .nav-hamburger[aria-expanded="true"] span:nth-child(3) {
   left: 0;
   right: 0;
   bottom: 0;
-  background: var(--bone);
+  background: var(--nav-paper, var(--bone));
   border-top: 1px solid var(--ink-hair);
   z-index: 299;
   overflow-y: auto;
@@ -450,7 +460,7 @@ body.nav-locked {
    menu form one continuous opaque surface. */
 body.nav-locked .meta-bar,
 body.nav-locked .nav {
-  background: var(--bone);
+  background: var(--nav-paper, var(--bone));
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
 }
@@ -469,7 +479,7 @@ body.nav-locked .nav {
   nav.nav {
     padding: 0 16px;
     gap: var(--space-3);
-    background: var(--bone);
+    background: var(--nav-paper, var(--bone));
     -webkit-backdrop-filter: none;
     backdrop-filter: none;
   }
@@ -806,7 +816,7 @@ nav.nav .nav-menu-divider { height: 1px; background: var(--ink-hair); margin: va
   gap: var(--space-2);
   padding: var(--space-3) var(--space-5);
   padding-bottom: calc(var(--space-3) + env(safe-area-inset-bottom, 0px));
-  background: var(--bone);
+  background: var(--nav-paper, var(--bone));
   border-top: 1px solid var(--ink-hair);
 }
 .nav-mobile-tail.open { display: flex; }

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -10,7 +10,7 @@
 <title>Receive a file · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <meta name="description" content="A secure file is waiting for you. It decrypts in your browser and burns after one download.">
 <meta property="og:title" content="A secure file is waiting · Paramant">

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -24,7 +24,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .ps-hero{padding:var(--space-10) 0 var(--space-6)}

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -12,7 +12,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/parapear.css?v=1">
 <style>

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -24,7 +24,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .ps-hero{padding:var(--space-10) 0 var(--space-6)}

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/partners">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 
 <style>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="The Community plan is free, forever. Organisations pay for higher limits: sending from 15 euro a month, signing from 49, excl. btw. From Paramantis Solutions B.V.">
 <link rel="canonical" href="https://paramant.app/pricing">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .tier-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--ink-hair)}

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -10,7 +10,7 @@
 <meta http-equiv="refresh" content="8;url=/signup">
 <link rel="canonical" href="https://paramant.app/signup">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -40,7 +40,7 @@
     footer{border-top:1px solid var(--ink-hair);padding:32px 48px}
   </style>
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <script type="application/ld+json" data-paramant-seo="1">
 {

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -7,7 +7,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/setup">
   <link rel="stylesheet" href="/design-system.css?v=25">
-  <link rel="stylesheet" href="/nav.css?v=20">
+  <link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 </head>
 <body>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -24,7 +24,7 @@
 <link rel="canonical" href="https://paramant.app/sign">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/components-parasign.css?v=3">
 <style>
@@ -123,6 +123,15 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
    targets. */
 .ds-place-actions{position:sticky;bottom:0;z-index:20;margin-top:14px;padding:12px 0;background:var(--paper);border-top:1px solid var(--line);pointer-events:none}
 .ds-place-actions .btn{min-height:var(--tap)}
+/* A sticky bottom bar floats over everything ABOVE it in its containing block.
+   With the whole step as that block the opaque bar landed on the rows the step
+   is explaining: at 390x844 it covered the page switcher, at 320 and 360 it cut
+   through the "sign every page" hint. Wrapping the page list and the bar in
+   .ds-place-doc makes the document the containing block, so the bar can hover
+   over pages (which reserve room for it below) and over nothing else. It comes
+   into view together with the first page, which is also the first moment there
+   is anything to press Continue about. */
+.ds-place-doc{position:relative}
 /* The bar is opaque and sticky, so whatever sits directly above it scrolls
    underneath and cannot be read while it is stuck (measured at 1440: the edit
    tip ended 7px under it). Reserve its height at the end of the scrolling
@@ -204,6 +213,13 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 .ds-disclaimer strong{display:block;font-family:var(--mono);font-size:11px;font-weight:600;letter-spacing:.14em;text-transform:uppercase;margin-bottom:5px;color:var(--sig-wait)}
 .ds-actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:18px}
 .ds-actions .btn{flex:0 1 auto;min-width:160px}
+/* Back and Continue keep one row down to 320. Two 160px buttons plus the gap
+   need 330px, so on the narrowest phone they wrapped and the bar grew to 123px
+   of the 844 it had. */
+@media (max-width:520px){
+  .ds-place-actions{flex-wrap:nowrap}
+  .ds-place-actions .btn{flex:1 1 0;min-width:0}
+}
 .ds-banner{padding:11px 14px;font-size:12.5px;border:1px solid var(--line);border-radius:var(--r-1);background:var(--surface-sunk);color:var(--ink-2);margin-top:12px;line-height:1.6;font-family:var(--mono)}
 .ds-banner.err{border-color:var(--line-2);border-left:3px solid var(--sig-stop);color:var(--ink-1);background:var(--sig-stop-bg)}
 .ds-banner.ok{border-color:var(--line-2);border-left:3px solid var(--sig-done);color:var(--ink-1);background:var(--sig-done-bg)}
@@ -627,10 +643,16 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
       <input id="ds-page-nav-jump" type="number" min="1" aria-label="Go to page">
       <button id="ds-page-nav-next" type="button" aria-label="Next page">&#8595;</button>
     </div>
-    <div id="ds-pdf-canvas-list"></div>
-    <div class="ds-actions ds-place-actions">
-      <button class="btn btn-tertiary" id="ds-place-back" type="button">Back</button>
-      <button class="btn btn-primary" id="ds-place-continue" type="button" disabled>Continue</button>
+    <!-- The sticky action bar belongs to the document, not to the whole step:
+         it is wrapped together with the page list so it can never float up
+         over the hint line, the seal options or the page switcher. See
+         .ds-place-doc in the stylesheet above. -->
+    <div class="ds-place-doc">
+      <div id="ds-pdf-canvas-list"></div>
+      <div class="ds-actions ds-place-actions">
+        <button class="btn btn-tertiary" id="ds-place-back" type="button">Back</button>
+        <button class="btn btn-primary" id="ds-place-continue" type="button" disabled>Continue</button>
+      </div>
     </div>
   </section>
 

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -25,7 +25,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 .nav-help {

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -8,7 +8,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/signup/verified">
   <link rel="stylesheet" href="/design-system.css?v=25">
-  <link rel="stylesheet" href="/nav.css?v=20">
+  <link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=7" defer></script>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/sla">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/terms">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#0B3A6A">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -22,7 +22,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#0B3A6A">
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/components-parasign.css?v=3">
 <script type="application/ld+json" data-paramant-seo="1">

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/vs">
 
 <link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=20">
+<link rel="stylesheet" href="/nav.css?v=21">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>

--- a/tests/access-log-visitors.test.mjs
+++ b/tests/access-log-visitors.test.mjs
@@ -49,7 +49,7 @@ test('a crawler that really renders is reported apart, not as a person', () => {
   const ua = 'Mozilla/5.0 (compatible; heritrix/3.14.2-SNAPSHOT-20250101 +http://archive.org)';
   const r = analyse([
     line({ ip: '7.7.7.7', path: '/', ua }),
-    line({ ip: '7.7.7.7', path: '/nav.css?v=20', ua }),
+    line({ ip: '7.7.7.7', path: '/nav.css?v=21', ua }),
   ]);
   assert.equal(r.atMostVisitors, 0, 'a named crawler was counted as a possible visitor');
   assert.equal(r.verdicts.declared_automation, 1);

--- a/tests/navigation-shell.test.mjs
+++ b/tests/navigation-shell.test.mjs
@@ -52,6 +52,7 @@ const publicMobilePaint = await publicPage.locator('nav.nav').evaluate((node) =>
   background: getComputedStyle(node).backgroundColor,
   backdropFilter: getComputedStyle(node).backdropFilter,
   webkitBackdropFilter: getComputedStyle(node).getPropertyValue('-webkit-backdrop-filter'),
+  paper: getComputedStyle(document.body).backgroundColor,
 }));
 // Pinned to the bone hex until 4 September 2026; the homepage now paints the bar in the night colour, so the pin is what it always guarded: fully opaque, no blur.
 ok('mobile navigation is opaque before opening the menu', /^rgb\(/.test(publicMobilePaint.background) && publicMobilePaint.backdropFilter === 'none' && (!publicMobilePaint.webkitBackdropFilter || publicMobilePaint.webkitBackdropFilter === 'none'), JSON.stringify(publicMobilePaint));

--- a/tests/sign-place-toolbar.test.mjs
+++ b/tests/sign-place-toolbar.test.mjs
@@ -1,0 +1,140 @@
+// Geometry gate for the Place step on /sign.
+//
+// The step ends in a sticky Back/Continue bar. A sticky bottom bar floats over
+// everything above it inside its containing block, and with the whole step as
+// that block the opaque bar landed on the rows the step is explaining: a buyer
+// review on a 390x844 phone reported the bar cutting through the hint line, and
+// at 320 and 360 it covered the "sign every page" hint and the page switcher.
+//
+// The fix is structural: the bar is wrapped together with the page list in
+// .ds-place-doc, so the document is its containing block and the bar can hover
+// over pages (which reserve room for it) and over nothing else. This test pins
+// that with bounding boxes, at the four widths the review used, at three scroll
+// positions each. It is a layout gate only; the signing behaviour itself is
+// covered by tests/sign-full.test.mjs.
+//
+// Run: node tests/sign-place-toolbar.test.mjs
+// Local: PLAYWRIGHT_CHROMIUM_PATH=<chrome binary> node tests/sign-place-toolbar.test.mjs
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = { '.js':'text/javascript','.mjs':'text/javascript','.css':'text/css','.html':'text/html','.svg':'image/svg+xml','.json':'application/json','.wasm':'application/wasm','.png':'image/png','.woff2':'font/woff2' };
+
+const server = http.createServer((req, res) => {
+  const p = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+  const file = path.join(ROOT, p);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+  fs.readFile(file, (e, b) => {
+    if (e) { res.writeHead(404); return res.end(); }
+    res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(b);
+  });
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const ORIGIN = `http://localhost:${server.address().port}`;
+
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+const checks = [];
+const ok = (name, pass, detail = '') => checks.push({ name, pass: !!pass, detail: String(detail) });
+
+// Every row of the step that carries words. None of them may end up under the
+// bar, at any scroll offset, at any of the four widths.
+const READABLE = [
+  '#ds-place-hint',
+  '#step-place .ds-sub',
+  '#ds-zoom',
+  '#ds-invite-tools',
+  '#ds-edit-tools-hint',
+  '#step-place .ds-edit-tip',
+  '#ds-seal-tools',
+  '#ds-seal-tip',
+  '#ds-page-nav',
+];
+
+for (const [width, height] of [[320, 844], [360, 844], [390, 844], [1440, 900]]) {
+  const context = await browser.newContext({ viewport: { width, height } });
+  const page = await context.newPage();
+  await page.route('**/api/**', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' }));
+  await page.goto(`${ORIGIN}/sign.html`, { waitUntil: 'domcontentloaded' });
+
+  const reached = await page.evaluate(async () => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    for (let i = 0; i < 400 && !(window.PDFLib && window.pdfjsLib); i++) await sleep(20);
+    if (!window.PDFLib || !window.pdfjsLib) return false;
+    const source = await window.PDFLib.PDFDocument.create();
+    for (let i = 0; i < 3; i++) source.addPage([595, 842]).drawText('Page ' + (i + 1), { x: 40, y: 780, size: 18 });
+    const bytes = await source.save();
+    const input = document.getElementById('ds-doc-input');
+    const transfer = new DataTransfer();
+    transfer.items.add(new File([bytes], 'toolbar-probe.pdf', { type: 'application/pdf' }));
+    input.files = transfer.files;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    for (let i = 0; i < 400 && document.getElementById('step-place').hidden; i++) await sleep(20);
+    await sleep(300);
+    return !document.getElementById('step-place').hidden;
+  });
+  ok(`${width}px reaches the Place step`, reached);
+
+  ok(`${width}px keeps the action bar inside the document wrapper`,
+    await page.evaluate(() => {
+      const bar = document.querySelector('.ds-place-actions');
+      const list = document.getElementById('ds-pdf-canvas-list');
+      return !!bar && !!list && bar.parentElement.classList.contains('ds-place-doc') && list.parentElement === bar.parentElement;
+    }));
+
+  for (const offset of [0, 200, 100000]) {
+    await page.evaluate((y) => window.scrollTo(0, y), offset);
+    await page.waitForTimeout(150);
+    const frame = await page.evaluate((selectors) => {
+      const rect = (selector) => {
+        const el = document.querySelector(selector);
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        if (r.width === 0 || r.height === 0) return null;
+        if (getComputedStyle(el).visibility === 'hidden') return null;
+        return { selector, top: r.top, bottom: r.bottom, left: r.left, right: r.right };
+      };
+      return { bar: rect('.ds-place-actions'), rows: selectors.map(rect).filter(Boolean), scrollY: window.scrollY };
+    }, READABLE);
+
+    ok(`${width}px @${offset === 100000 ? 'bottom' : offset} has a measurable action bar`, !!frame.bar, JSON.stringify(frame.bar));
+    const hit = frame.bar
+      ? frame.rows.filter((row) => row.bottom > frame.bar.top && row.top < frame.bar.bottom && row.right > frame.bar.left && row.left < frame.bar.right)
+      : [];
+    ok(`${width}px @${offset === 100000 ? 'bottom' : offset} the action bar overlaps no row of words`,
+      frame.bar && hit.length === 0,
+      JSON.stringify({ bar: frame.bar, hit }));
+  }
+
+  // Scrolled into the document the bar has to be on screen: that is the whole
+  // point of making it sticky.
+  await page.evaluate(() => document.getElementById('ds-pdf-canvas-list').scrollIntoView({ block: 'start' }));
+  await page.waitForTimeout(150);
+  const pinned = await page.evaluate(() => {
+    const r = document.querySelector('.ds-place-actions').getBoundingClientRect();
+    return { top: r.top, bottom: r.bottom, height: r.height, viewport: window.innerHeight };
+  });
+  ok(`${width}px pins the action bar to the bottom once the document is in view`,
+    pinned.bottom <= pinned.viewport + 1 && pinned.top >= 0,
+    JSON.stringify(pinned));
+  // One row of buttons, not two: at 320 the two 160px minimums wrapped and the
+  // bar took 123px of an 844px screen.
+  ok(`${width}px keeps the action bar to a single row`, pinned.height < 90, JSON.stringify(pinned));
+
+  if (process.env.PARAMANT_PLACE_SHOT_DIR) {
+    await page.screenshot({ path: path.join(process.env.PARAMANT_PLACE_SHOT_DIR, `place-toolbar-${width}.png`) });
+  }
+  await context.close();
+}
+
+for (const check of checks) console.log(`${check.pass ? 'PASS' : 'FAIL'} ${check.name}${check.detail ? ' :: ' + check.detail : ''}`);
+await browser.close();
+server.close();
+server.closeAllConnections();
+if (checks.some((check) => !check.pass)) process.exit(1);
+console.log(`\nsign-place-toolbar: ${checks.length} checks passed`);


### PR DESCRIPTION
Twee visuele restpunten uit de koperreview (de ingelogde reis stokt op drie plekken).

## 1. Nav-naad

De balk stond op een vaste koele hex (`#F8FAFC`) terwijl de homepage op warm papier draait (`#FAF8F3`). Zodra de pagina scrolde zag je de twee elkaar raken als een band onder de balk.

De balk, de mobiele lade en de ladevoet lezen nu `--nav-paper` / `--nav-paper-blur`, met de oude waarden als fallback. Dat is dezelfde constructie die `app-2026.css` al gebruikt om de app-schermen aan `var(--paper)` te koppelen. Alleen `index.html` zet die tokens, dus elke andere pagina rendert exact zoals hij deed. Het hero-verloop van koel naar warm over de eerste 160px kon weg: dat verstopte de naad en werd er zelf een zodra de balk meeging.

Dit is de tweede keuze uit besluit 23 ("nav mee naar warm papier, test aanpassen"), niet de genoteerde default ("laten"). De naad verdwijnt niet zonder die keuze: op een telefoon is de balk bewust dekkend, dus koele balk op warm papier geeft altijd een harde rand.

`tests/navigation-shell.test.mjs` pinde die koele hex. Hij pint nu wat de check werkelijk bewaakt: dekkend, geen backdrop-filter, en dezelfde kleur als het papier eronder. Dat is dezelfde formulering die /parashare al had.

De navbalk komt van `frontend/apply-nav.py`. Die is opnieuw gedraaid, is byte-voor-byte idempotent (`tests/apply-nav-idempotent.test.mjs` groen, tweede run wijzigt 0 bestanden), en zet `?v=21` nu ook op de vier pagina's die hij verder met rust laat (co-sign, developer, setup, all-systems-go). Zonder dat draait `scripts/check-cache-bust.sh` rood terwijl de idempotentie-poort groen blijft.

## 2. Actiebalk over de hintregel op /sign, stap velden plaatsen

Een sticky bottom-balk zweeft over alles wat in zijn containing block boven hem staat. Met de hele stap als dat blok landde de dekkende balk op de regels die de stap uitlegt: op 390x844 over de paginakiezer, op 320 en 360 dwars door de hint bij "sign every page".

De paginalijst en de balk zitten nu samen in `.ds-place-doc`, dus het document is het containing block van de balk. Hij mag over pagina's zweven (die reserveren al ruimte voor hem) en over niets anders. Hij komt in beeld samen met de eerste pagina, wat ook het eerste moment is waarop er iets te bevestigen valt. Onder 520px staan Back en Continue op een rij: twee knoppen met `min-width:160px` plus de gap pasten niet op 320, waardoor de balk 123px van de 844 innam.

Gemeten voor en na, op 320, 360, 390 en 1440, op drie scrollposities per breedte. Nul overlappingen na, negen gefaalde checks tegen de oude opmaak.

## Tests

- nieuw `tests/sign-place-toolbar.test.mjs`, 40 checks, bounding-box-geometrie
- `navigation-shell` 55, `apply-nav-idempotent`, `first-screen`, `motion-safety`, `app-contrast`, `theme-contrast`, `links`, `seo-contract`, `ui-truthfulness`, `site-claims`, `frontend-loading-contract`, `frontend-module-scripts`, `user-dashboard-documents`, `pricing-fold`
- sign-suite: `sign-full`, `sign-invite-delivery`, `sign-document-identity`, `cosign-appearance-contract`, `cosign-document-delivery`
- `tests/static-sanity.sh`, `scripts/check-cache-bust.sh`, `scripts/check-csp-inline.sh`, `scripts/check-commit-style.sh`

## Aanrakingen buiten de kern

`?v=21` staat op elke pagina die nav.css laadt, ook op pricing.html en auth/login.html. Dat is een regel per bestand en het gevolg van de cache-bust-poort, die weigert dat een asset onder twee versienummers bestaat.
