### PR TITLE
/verify also checks the delivery receipt, in the browser, offline

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -220,6 +220,12 @@ Pass this to `POST /v2/verify-receipt` to cryptographically confirm delivery.
 
 Public. No API key required.
 
+This endpoint asks the relay to check its own signature. To check a receipt
+without the relay, and without a network connection at all, open
+[https://paramant.app/verify#receipt](https://paramant.app/verify#receipt) and
+drop the receipt in. That page carries the relay identity key and repeats the
+same four checks in the browser.
+
 ```bash
 curl -X POST https://relay.paramant.app/v2/verify-receipt \
   -H "Content-Type: application/json" \

--- a/frontend/docs/api.md
+++ b/frontend/docs/api.md
@@ -162,6 +162,12 @@ Pass this to `POST /v2/verify-receipt` to cryptographically confirm delivery.
 
 Public. No API key required.
 
+This endpoint asks the relay to check its own signature. To check a receipt
+without the relay, and without a network connection at all, open
+[https://paramant.app/verify#receipt](https://paramant.app/verify#receipt) and
+drop the receipt in. That page carries the relay identity key and repeats the
+same four checks in the browser.
+
 ```bash
 curl -X POST https://relay.paramant.app/v2/verify-receipt \
   -H "Content-Type: application/json" \

--- a/frontend/js/receipt-verify.js
+++ b/frontend/js/receipt-verify.js
@@ -1,0 +1,373 @@
+// ParaSend transfer-receipt verifier. Runs entirely in the browser.
+//
+// A ParaSend delivery receipt is the proof that a specific encrypted transfer
+// was handed over at a specific moment and then destroyed. Until now the only
+// way to check one was POST /v2/verify-receipt, which asks the relay to grade
+// its own homework and needs an API key. This module does the same four checks
+// with the same primitives on the visitor's machine, so the receipt can be
+// checked without Paramant and without a network connection.
+//
+// The checks mirror relay.js POST /v2/verify-receipt and relay/lib/ct-hash.js
+// byte for byte. Keep them in sync.
+import { sha3_256, ml_dsa65 } from '/vendor/paramant-pqc.js';
+import { defaultAnchor, anchorByFingerprint, PUBKEY_URL } from '/js/relay-trust-anchors.js';
+
+const LEAF_TRANSFER = 0x02; // domain separator for blob/transfer leaves
+const NODE = 0x01;          // domain separator for inner Merkle nodes
+const ML_DSA65_PK_BYTES = 1952;
+
+const $ = (id) => document.getElementById(id);
+const enc = new TextEncoder();
+
+const esc = (s) => String(s == null ? '' : s)
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;').replace(/'/g, '&#x27;');
+
+const toHex = (u8) => Array.from(u8, (b) => b.toString(16).padStart(2, '0')).join('');
+
+function hexToBytes(s) {
+  const h = String(s || '');
+  if (h.length % 2 !== 0 || /[^0-9a-fA-F]/.test(h)) throw new Error('not a hexadecimal value');
+  const out = new Uint8Array(h.length >> 1);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(h.substr(i * 2, 2), 16);
+  return out;
+}
+
+function fromB64(s) {
+  const padded = String(s || '').replace(/-/g, '+').replace(/_/g, '/');
+  const bin = atob(padded + '='.repeat((4 - (padded.length % 4)) % 4));
+  const u8 = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i);
+  return u8;
+}
+
+function concatBytes(parts) {
+  let n = 0;
+  for (const p of parts) n += p.length;
+  const out = new Uint8Array(n);
+  let o = 0;
+  for (const p of parts) { out.set(p, o); o += p.length; }
+  return out;
+}
+
+// Byte-identical to relay.js canonicalJSON: sorted keys, no whitespace.
+function canonicalJSON(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonicalJSON).join(',') + ']';
+  return '{' + Object.keys(value).sort()
+    .map((k) => JSON.stringify(k) + ':' + canonicalJSON(value[k])).join(',') + '}';
+}
+
+// relay/lib/ct-hash.js blobLeafHash
+function blobLeafHash(blobHashHex, sector, ts) {
+  const data = concatBytes([
+    hexToBytes(blobHashHex),
+    sha3_256(enc.encode(sector || 'relay')),
+    enc.encode(String(ts)),
+  ]);
+  return toHex(sha3_256(concatBytes([new Uint8Array([LEAF_TRANSFER]), data])));
+}
+
+// relay/lib/ct-hash.js ctNodeHash
+function nodeHash(leftHex, rightHex) {
+  return toHex(sha3_256(concatBytes([
+    new Uint8Array([NODE]), hexToBytes(leftHex), hexToBytes(rightHex),
+  ])));
+}
+
+// ── Reading whatever the visitor drops in ───────────────────────────────────
+// Receipts travel as base64url (the X-Paramant-Receipt-* handover and the body
+// of POST /v2/verify-receipt), but people paste the decoded JSON just as often,
+// and some tools wrap it as {"receipt": "..."}. All three are the same receipt.
+export function parseReceipt(input) {
+  const text = String(input || '').trim();
+  if (!text) throw new Error('There is nothing here to check yet.');
+  let obj = null;
+  if (text[0] === '{') {
+    try { obj = JSON.parse(text); } catch { throw new Error('This looks like JSON but it is damaged, so it cannot be read.'); }
+    if (obj && typeof obj.receipt === 'string') return parseReceipt(obj.receipt);
+  } else {
+    const compact = text.replace(/\s+/g, '');
+    let decoded;
+    try { decoded = new TextDecoder().decode(fromB64(compact)); }
+    catch { throw new Error('This is not a receipt. Paste the receipt text, or drop the receipt file.'); }
+    try { obj = JSON.parse(decoded); } catch { throw new Error('This is not a receipt. Paste the receipt text, or drop the receipt file.'); }
+  }
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+    throw new Error('This is not a receipt. Paste the receipt text, or drop the receipt file.');
+  }
+  if (!obj.blob_hash || !obj.inclusion_proof) {
+    throw new Error('This file is not a ParaSend transfer receipt. A receipt names the file it covers and carries its place in the transparency log.');
+  }
+  return obj;
+}
+
+// ── The verification itself ─────────────────────────────────────────────────
+// Every check runs; nothing short-circuits, so a bad receipt says everything
+// that is wrong with it at once.
+export function verifyReceipt(receipt, relayKeyBytes) {
+  // `ok` is true, false, or null for "could not be checked here". Only an
+  // outright false makes the receipt untrustworthy; a null makes it unproven.
+  const checks = [];
+  const add = (id, ok, label, detail) => { checks.push({ id, ok, label, detail: detail || '' }); return ok; };
+  const proof = receipt.inclusion_proof || {};
+
+  // 1. Does the receipt point at this exact transfer?
+  let leafOk = false;
+  try {
+    const expected = blobLeafHash(receipt.blob_hash, receipt.sector, receipt.ts);
+    leafOk = expected === proof.leaf_hash;
+    add('leaf', leafOk,
+      leafOk ? 'The receipt is about this file and no other.'
+             : 'The receipt does not match the file it names.',
+      leafOk ? '' : 'The entry it points to in the transparency log belongs to a different file, or the fingerprint inside the receipt was changed afterwards.');
+  } catch (e) {
+    add('leaf', false, 'The receipt does not match the file it names.', 'The file fingerprint inside it could not be read (' + e.message + ').');
+  }
+
+  // 2. Does the log entry really sit in the tree the receipt claims?
+  let rootOk = false;
+  try {
+    let computed = proof.leaf_hash;
+    for (const step of (proof.audit_path || [])) {
+      computed = step.position === 'right' ? nodeHash(computed, step.hash) : nodeHash(step.hash, computed);
+    }
+    rootOk = !!computed && computed === proof.root;
+    add('tree', rootOk,
+      rootOk ? 'It really is in the public transparency log.'
+             : 'It is not in the transparency log it claims to be in.',
+      rootOk ? '' : 'Recomputing the log from the entry gives a different result, so the proof of inclusion does not hold.');
+  } catch (e) {
+    add('tree', false, 'It is not in the transparency log it claims to be in.', 'The proof of inclusion could not be recomputed (' + e.message + ').');
+  }
+
+  // 3. The relay's signature over the whole receipt.
+  const { signature, ...unsigned } = receipt;
+  let sigOk = false;
+  let keyKnown = null;
+  let fingerprint = '';
+  if (!relayKeyBytes) {
+    add('signature', null, 'The signature was not checked.',
+      'No server key was available to check it against. Everything else on this page was still checked.');
+  } else if (!signature) {
+    add('signature', false, 'This receipt carries no signature at all.',
+      'A genuine receipt is always signed by the server that handed the file over.');
+  } else {
+    try {
+      fingerprint = toHex(sha3_256(relayKeyBytes));
+      sigOk = ml_dsa65.verify(relayKeyBytes, enc.encode(canonicalJSON(unsigned)), fromB64(signature));
+    } catch { sigOk = false; }
+    keyKnown = anchorByFingerprint(fingerprint);
+    add('signature', sigOk,
+      sigOk ? 'The signature holds, so not one character has been altered.'
+            : 'The signature does not hold.',
+      sigOk ? '' : 'Either the receipt was edited after it was signed, or it was signed by a different key than the one used to check it.');
+  }
+
+  // 4. The relay's signature over the log snapshot the proof refers to.
+  const sth = proof.sth || null;
+  if (sth && sth.signature) {
+    if (!relayKeyBytes) {
+      add('sth', null, 'The log snapshot was not checked.', 'No server key was available to check its signature against.');
+    } else {
+      const { signature: sthSig, ...sthPayload } = sth;
+      let sthOk = false;
+      try { sthOk = ml_dsa65.verify(relayKeyBytes, enc.encode(canonicalJSON(sthPayload)), fromB64(sthSig)); } catch { sthOk = false; }
+      const rootMatch = sth.sha3_root === proof.root;
+      add('sth', sthOk && rootMatch,
+        (sthOk && rootMatch) ? 'The log itself was signed at that moment too.'
+                             : 'The log snapshot inside the receipt does not hold up.',
+        !sthOk ? 'The signature over the log snapshot does not check out.'
+               : (!rootMatch ? 'The snapshot describes a different state of the log than the proof does.' : ''));
+    }
+  }
+
+  const failed = checks.filter((c) => c.ok === false);
+  return {
+    valid: failed.length === 0,
+    checkedSignature: !!relayKeyBytes,
+    checks,
+    fingerprint,
+    keyName: keyKnown ? keyKnown.name : null,
+    receipt,
+  };
+}
+
+// ── Plain language ──────────────────────────────────────────────────────────
+function formatMoment(value) {
+  const d = value == null ? null : new Date(typeof value === 'number' ? value : String(value));
+  if (!d || isNaN(d.getTime())) return null;
+  const date = new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'long', year: 'numeric', timeZone: 'UTC' }).format(d);
+  const time = new Intl.DateTimeFormat('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'UTC' }).format(d);
+  return date + ' at ' + time + ' UTC';
+}
+
+function shortHost(relayId) {
+  const raw = String(relayId || '').trim();
+  if (!raw) return '';
+  try { return new URL(raw).host; } catch { return raw; }
+}
+
+function keySentence(result) {
+  const fp = result.fingerprint;
+  if (!result.checkedSignature) {
+    return 'Nobody could be identified as the signer, because no key was available to compare against.';
+  }
+  const short = esc(fp.slice(0, 16));
+  if (result.keyName) {
+    return 'It was signed by ' + esc(result.keyName) + ', key <code class="mono">' + short + '</code>.';
+  }
+  return 'It was signed by a key this page does not recognise, fingerprint <code class="mono">' + short
+    + '</code>. Compare that against the key Paramant publishes before you trust it.';
+}
+
+export function renderResult(result, target) {
+  const r = result.receipt;
+  const out = [];
+  const signedFully = result.valid && result.checkedSignature;
+
+  if (signedFully && result.keyName) {
+    out.push('<div class="ps-banner ok"><strong>This receipt is genuine.</strong> It was issued by '
+      + esc(result.keyName) + ' and not one character has changed since.</div>');
+  } else if (signedFully) {
+    // Every check passed, but against a key this page has never seen. Saying
+    // "genuine" there would launder an unknown signer into a Paramant promise.
+    out.push('<div class="ps-banner ok"><strong>This receipt is unchanged.</strong> It all still matches the key you gave, and this page does not know that key.</div>');
+  } else if (result.valid) {
+    out.push('<div class="ps-banner info"><strong>The receipt holds together.</strong> Its signature was not checked, because no server key was available.</div>');
+  } else {
+    out.push('<div class="ps-banner err"><strong>Do not trust this receipt.</strong> It failed at least one check below.</div>');
+  }
+
+  const facts = [];
+  facts.push(keySentence(result));
+  const when = formatMoment(r.retrieved_at);
+  if (when) facts.push('The file was handed over on ' + esc(when) + '.');
+  const issued = formatMoment(r.ts);
+  if (issued && issued !== when) facts.push('It was accepted by the server on ' + esc(issued) + '.');
+  const host = shortHost(r.relay_id);
+  if (host) facts.push('The handover was done by <code class="mono">' + esc(host) + '</code>.');
+  facts.push('The file it covers has fingerprint <code class="mono">' + esc(String(r.blob_hash)) + '</code>.');
+  if (r.burn_confirmed === true) facts.push('The server destroyed its copy of the file as it was handed over.');
+  else if (r.burn_confirmed === false) facts.push('The server kept its copy after this download, because the transfer allowed more than one download.');
+  const proof = r.inclusion_proof || {};
+  if (proof.leaf_index != null && proof.tree_size != null) {
+    facts.push('It is entry ' + esc(String(proof.leaf_index + 1)) + ' in a public log that held '
+      + esc(String(proof.tree_size)) + ' entries at that moment.');
+  }
+
+  // A receipt that failed a check has not earned the word "says": from here on
+  // its contents are a claim, and the heading has to read that way.
+  out.push('<h3 class="rv-sub">' + (result.valid ? 'What this receipt says' : 'What this receipt claims')
+    + '</h3><ul class="rv-facts">');
+  for (const f of facts) out.push('<li>' + f + '</li>');
+  out.push('</ul>');
+
+  out.push('<h3 class="rv-sub">What was checked</h3><ul class="rv-checks">');
+  for (const c of result.checks) {
+    const state = c.ok === true ? 'ok' : (c.ok === false ? 'bad' : 'skip');
+    const mark = { ok: '\u2713', bad: '\u2715', skip: '\u2013' }[state];
+    const words = { ok: 'Passed', bad: 'Failed', skip: 'Not checked' }[state];
+    out.push('<li class="rv-' + state + '"><span class="rv-mark" aria-hidden="true">' + mark
+      + '</span><span class="rv-body"><span class="rv-sr">' + words + ': </span>'
+      + esc(c.label) + (c.detail ? '<span class="rv-detail">' + esc(c.detail) + '</span>' : '') + '</span></li>');
+  }
+  out.push('</ul>');
+
+  out.push('<details class="rv-raw"><summary>Show the receipt as it was written</summary><pre class="mono">'
+    + esc(JSON.stringify(r, null, 2)) + '</pre></details>');
+
+  target.innerHTML = out.join('');
+}
+
+// ── Page wiring ─────────────────────────────────────────────────────────────
+// A pasted key wins over the pinned one, so a receipt from another relay, or
+// from a relay that has rotated its key, stays checkable without a redeploy.
+function resolveKey(pastedKey) {
+  const raw = String(pastedKey || '').replace(/\s+/g, '');
+  if (raw) {
+    let bytes;
+    try { bytes = fromB64(raw); } catch { throw new Error('That key is not readable. It is one unbroken block of letters and digits.'); }
+    if (bytes.length !== ML_DSA65_PK_BYTES) {
+      throw new Error('That is not a Paramant signing key: it is ' + bytes.length + ' bytes long instead of ' + ML_DSA65_PK_BYTES + '.');
+    }
+    return bytes;
+  }
+  const anchor = defaultAnchor();
+  return anchor ? fromB64(anchor.key) : null;
+}
+
+export function initReceiptVerifier() {
+  const input = $('rv-input');
+  const button = $('rv-check');
+  const result = $('rv-result');
+  const drop = $('rv-drop');
+  const file = $('rv-file');
+  const keyField = $('rv-key');
+  if (!input || !button || !result) return;
+
+  const fail = (message) => {
+    result.hidden = false;
+    result.innerHTML = '<div class="ps-banner err"><strong>' + esc(message) + '</strong></div>';
+  };
+
+  const run = () => {
+    result.hidden = false;
+    result.innerHTML = '<div class="ps-banner info">Checking on this device…</div>';
+    let receipt;
+    try { receipt = parseReceipt(input.value); } catch (e) { return fail(e.message); }
+    let key = null;
+    try { key = resolveKey(keyField ? keyField.value : ''); } catch (e) { return fail(e.message); }
+    try {
+      renderResult(verifyReceipt(receipt, key), result);
+    } catch (e) {
+      fail('This receipt could not be checked: ' + e.message);
+    }
+  };
+
+  button.addEventListener('click', run);
+
+  const loadFile = async (f) => {
+    if (!f) return;
+    try {
+      input.value = await f.text();
+      if ($('rv-file-info')) $('rv-file-info').textContent = f.name + ' loaded';
+      run();
+    } catch { fail('That file could not be read.'); }
+  };
+
+  if (file) file.addEventListener('change', (e) => loadFile(e.target.files && e.target.files[0]));
+  if (drop) {
+    const stop = (e) => { e.preventDefault(); e.stopPropagation(); };
+    ['dragenter', 'dragover'].forEach((n) => drop.addEventListener(n, (e) => { stop(e); drop.classList.add('rv-over'); }));
+    ['dragleave', 'drop'].forEach((n) => drop.addEventListener(n, (e) => { stop(e); drop.classList.remove('rv-over'); }));
+    drop.addEventListener('drop', (e) => loadFile(e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0]));
+  }
+
+  const keyHint = $('rv-key-hint');
+  if (keyHint) keyHint.textContent = PUBKEY_URL;
+}
+
+// The page holds two unrelated proofs. Tabs keep one URL, /verify, and
+// /verify#receipt opens straight on the receipt side for a link in an email.
+export function initTabs() {
+  const pairs = [
+    { tab: $('tab-doc'), panel: $('panel-doc'), hash: '' },
+    { tab: $('tab-receipt'), panel: $('panel-receipt'), hash: '#receipt' },
+  ];
+  if (pairs.some((p) => !p.tab || !p.panel)) return;
+
+  const show = (chosen) => {
+    for (const p of pairs) {
+      const on = p === chosen;
+      p.tab.setAttribute('aria-selected', on ? 'true' : 'false');
+      p.panel.hidden = !on;
+    }
+  };
+  for (const p of pairs) p.tab.addEventListener('click', () => show(p));
+  const wanted = pairs.find((p) => p.hash && p.hash === location.hash);
+  show(wanted || pairs[0]);
+}
+
+initTabs();
+initReceiptVerifier();

--- a/frontend/js/relay-trust-anchors.js
+++ b/frontend/js/relay-trust-anchors.js
@@ -1,0 +1,35 @@
+// The relay identity keys this site ships with, so a transfer receipt can be
+// checked without asking anything of the network.
+//
+// These are ML-DSA-65 public keys, exactly as GET /v2/pubkey publishes them.
+// Public keys are not secrets; pinning them here is what makes /verify work
+// with the network switched off. Each entry carries the SHA3-256 fingerprint of
+// its own key, and the verifier recomputes that fingerprint rather than
+// trusting the string below.
+//
+// If a relay ever rotates its identity key, receipts signed by the new key show
+// up as "signed by a key this page does not recognise" and stay checkable by
+// pasting the current key. That is the intended failure mode: never a false
+// "genuine", never a false "forged". Refresh a pin from the endpoint in
+// PUBKEY_URL and update the fingerprint in the same commit.
+//
+// relay.paramant.app, pinned 2026-09-03 from https://relay.paramant.app/v2/pubkey
+export const PUBKEY_URL = 'https://relay.paramant.app/v2/pubkey';
+
+export const RELAY_TRUST_ANCHORS = [
+  {
+    name: 'the Paramant relay',
+    host: 'relay.paramant.app',
+    alg: 'ML-DSA-65',
+    fingerprint: '3d9b960c107a5145dc7412b5953d52c0f5d5b89a654f2da296b1133164befd61',
+    key: 'pQBxlRq4NjpdWefUxWEZTtsxaKzEb4/GLRyRg9XDolu/Q2/LRPGM0pLa1fcDf3Kkiu0AHKG7Ll9GiEHJLYH1Nq/9ACbQfIDeKOO6Nq1JbtEG8jqdQ0R7SYr43jmvYp7a3KqhHeDmbtPJ1cU1G0QMWiIEpnbBxFNVvg8Ood0KPr9b2mCEjd3i0x6dS0aTx612uLuEUW87OIgSuz7Mt5KJMWta8zdYRC1CwDtNUOIjgvKeSzQDDQqQn1veCuYAHUeNIs+gag12ZcmzQ6FiKuwSPmMRwDzWKYNXOQVn6SN+Fvxf3uvuLhY0d8PmakStbMVzbdSbLSmAtrxJkuu6xagGsE+dNaPdjrZoxpYb3LCJSa4e9EdzZX43EzmD+tvKrEwPMn9QFOuzXKwsi6IZ7wQmi/1DPu6FJca13B2UdmS1AlmN4UMLISWQVV1AlE+uhyukTVjHSZuEVnIr44CbMirTCDASy6zugeN6E2FRo1DRoSj0E8b6jH/KdrRa3ittLj3DlWQ44xuBlHMOS8Rt2hBRpoQtMl1LbssA3LQGpUuwtfUjgIAk5ncHZouVaV310xhVJa2LwVjbtTHePY9wSbWkGz8mZjlTJr8ojmqs2/ukpp68fZlKDVUOxRPcVLnwmAi8qVBzlahND9J3w+m58bVcr71MeQvTyJmaksrRKfnP/gdkt8edgQSbCQKfbLwZitjm3UVlNBs5oy9Ut1GfutttpngdNxNvud5Kg2pu+gt9A+HZFXikZbFqzl8cpM488SSOmkJhjPS2wJCbL5GDoeiYx33WAsTcDtT3BVNq7KVM0Jl+c2BSuKYPVbzfEWxpPoWtJBybWuY8SL4m+vwdzMpWQBXbaWP2U9eiyiem3uoSjqrRbGBiCNTAbT4ihwCOdD2hQaIhfM40xcutD+EBU3/mF2C1Z3/PhJqWpCQdENFq+6fShoRwIlu2HxGif087dFFCIlwzbKEL9LSk3QYee80MHYnud/vw2IY3YjSPlcooWUW0XptTOMVQdi5aj7NiopyBMB5Sh5zG5lcbgKsg/muqAg4LqOHXviQ1Zc2IS9/JOxEXtptbYH9TACBe4M6AsuHzeHvmwDLyiSctxW5B8UbksCjZGgxrpUvvkezaQAxqTs6c00/f+kt1P32yv9xVrFeyZFflXVxoQdsEJAUxoTBgWsiplSwUmsVst7R21qiYQ1+2TwHNN7cIREjMwCNNqXnNlSPVvrPt0gLVO6rWPC2Dk5jTvDnjdQrSdvpL83Mh7NjdjvZAzK6M084gECIGRdz1lT9TIOkFWs1GdFmSrEc8paVLJp1MAs1qtQKnYiR+vJiBkvNE2WMFXddkY22WPPOnTdId40Pr8L36T2uBHWvyH72M7il4cuGWfAWMcfh4Fo1R3aaWbLNIVOmcPRL7pCXJ3JGs4+J6wtRWsUOHg42ys/1H8AEecdolqTTgAFFICq3Pg74XTdXHjZ/JOcfPlIt7RVapxv+NmLZR4vKOKsKYHXcEHCSl5NOJUAASdc7Kj9nbeU9fy+swXPfXdmAYXu2IQNtJXZ6gv+BlSKF9yNxAHjAVa0prNG81eKhFc7mES4SGTpNIfJcZG+thVtxpwZGJPmEfW14RwMm5VZYwe7gxfOoxapW+jkH6iA4ffTdb8Ge+xs6YM8g649e7J+IMh0VvwdcK/Z1VV34oopL1D09h4OBLHI6a7jaqUy3/BRwQa8QnjAWM1Ya8B2AjuoAU25i8CiFOzAJD7jHKJXjfmhrSy4X7QgzpLREEc/pTkaEyoQjN+PPgdQctRXAV8uU/4saiOvwJKF01ZCxeguM0XAH2mzlMx0Z/L/13gUztgu2Mco2pF77CXYBUDRK0MrnjNM0zaTui49jcDGICSDsvwrGiud59lX80Kt9czIEDhDyV0ikFodjl09Zl25UsYSDceC/tn/eU3FGZYWlOudGsDhAQAUz9ZXCD0fCX/IlWv2qVf024eJd5qYpKr2QaqJ+vu/Q0+I3UDh+cNjrV61+bagjU4GepzOTH9pxY1ClSMIGZbJn20GrdXghVkSqubkhaYUbnUhLQXPmhtTVn8SN35hTRLimrC0FU1ArDEeTHCyDTc2lZg5fGmf1tzp5OH6JX/HcRIX8v887p8G9YvEUoKZY/Yi3cpqK/gP1BtuWoWtDyrwzYenZwTGCKgoVSNK+TgS8n8Ualc8PCuv3oTA4fo0St6u2cGQEpOIImtPUsx/6sXJoCAu7xD7eTCbyjSmqA1iOrWYcy6tro86vBpMRdK72COBnnZVgLbFroGkQ3UzGOAIgGW9IsYWznyUg+XC01Szgxp1dX21uXaiSJzBUb//h8Uz6s7yg38Lr4Rqjl+qsodkSwEMk6T/9ies3N//TeaTuGxo/W9zGNUnPf++j6EGswMvTiGyo6b5AKaITb83ZfVT4LHnJxDq+cZ0ZrHYvMsJ1vnw+E6QVdhN583KVjDON1gB1PGHDvbD7wlgF+9GEgygScbWS1BjEOC60kLOy7AZ7OesaGSffARtkGEEqRD6smIkhlEZ9LwmQAhJ74MenE0/fCkpZ9hBa+66qhkv4yRFS9dUiRKKvMwx58GVLpeOzFnjpgyw2XrpMrKgFjCrO1fKU=',
+  },
+];
+
+export function defaultAnchor() {
+  return RELAY_TRUST_ANCHORS[0] || null;
+}
+
+export function anchorByFingerprint(fingerprint) {
+  return RELAY_TRUST_ANCHORS.find((a) => a.fingerprint === fingerprint) || null;
+}

--- a/frontend/receipt-verify.css
+++ b/frontend/receipt-verify.css
@@ -1,0 +1,73 @@
+/* /verify, the transfer-receipt checker.
+   Only this page loads it, so it can stay small and specific. Colours come
+   from design-system.css tokens; nothing here introduces a new palette. */
+
+.rv-tabs {
+  display: flex; gap: var(--space-2); margin-bottom: var(--space-5);
+  border-bottom: 1px solid var(--ink-hair);
+}
+.rv-tab {
+  appearance: none; background: none; border: 0; cursor: pointer;
+  padding: var(--space-3) var(--space-4); margin-bottom: -1px;
+  font-family: var(--sans); font-size: var(--text-sm); font-weight: 600;
+  color: var(--ink-dim); border-bottom: 2px solid transparent;
+}
+.rv-tab:hover { color: var(--ink); }
+.rv-tab[aria-selected="true"] { color: var(--ink); border-bottom-color: var(--navy); }
+.rv-tab:focus-visible { outline: 2px solid var(--navy); outline-offset: 2px; }
+
+.rv-drop {
+  display: block; padding: var(--space-5); border: 1.5px dashed var(--ink-hair);
+  border-radius: 10px; text-align: center; cursor: pointer; background: var(--ink-ghost);
+  transition: border-color .15s, background .15s;
+}
+.rv-drop:hover, .rv-drop.rv-over { border-color: var(--navy); }
+.rv-drop input[type=file] { display: none; }
+.rv-drop-cta { display: block; font-weight: 600; margin-bottom: var(--space-1); }
+.rv-drop-meta { display: block; font-family: var(--mono); font-size: var(--text-xs); color: var(--ink-dim); }
+
+.rv-paste {
+  width: 100%; min-height: 8rem; margin-top: var(--space-4);
+  padding: var(--space-3); border: 1.5px solid var(--ink-hair); border-radius: 8px;
+  font-family: var(--mono); font-size: var(--text-xs); line-height: 1.6;
+  background: var(--bone); color: var(--ink); resize: vertical;
+}
+.rv-paste:focus { outline: none; border-color: var(--navy); }
+
+.rv-sub { font-size: var(--text-sm); margin: var(--space-5) 0 var(--space-2); }
+.rv-facts, .rv-checks { margin: 0; padding: 0; list-style: none; }
+.rv-facts li {
+  font-size: var(--text-sm); line-height: 1.6; color: var(--ink);
+  padding: var(--space-1) 0; border-bottom: 1px solid var(--ink-hair);
+}
+.rv-facts li:last-child { border-bottom: 0; }
+.rv-facts code { word-break: break-all; }
+
+.rv-checks li {
+  display: grid; grid-template-columns: 1rem 1fr; gap: 0 var(--space-3);
+  font-size: var(--text-sm); line-height: 1.6; padding: var(--space-2) 0;
+}
+.rv-mark { font-family: var(--mono); font-weight: 700; }
+.rv-body { min-width: 0; }
+.rv-detail { display: block; }
+.rv-ok .rv-mark { color: var(--lime-ink, var(--navy)); }
+.rv-bad .rv-mark { color: var(--ink); }
+.rv-skip .rv-mark, .rv-skip { color: var(--ink-dim); }
+.rv-detail { color: var(--ink-dim); }
+.rv-sr {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+}
+
+.rv-raw { margin-top: var(--space-5); }
+.rv-raw summary { font-size: var(--text-sm); color: var(--ink-dim); cursor: pointer; }
+.rv-raw pre {
+  margin-top: var(--space-3); padding: var(--space-3); border-radius: 8px;
+  background: var(--bone-2, var(--ink-ghost)); overflow-x: auto;
+  font-size: var(--text-xs); line-height: 1.6; max-height: 24rem;
+}
+
+@media (max-width: 600px) {
+  .rv-tabs { gap: 0; }
+  .rv-tab { padding: var(--space-3) var(--space-3); }
+}

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -4,19 +4,19 @@
 <meta charset="UTF-8">
 <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Check whether a signed document was changed · Paramant</title>
+<title>Check a signed document or a delivery receipt · Paramant</title>
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Check whether a signed document was changed after it was signed. It happens in your browser, without an account and without uploading the file.">
-<meta property="og:title" content="Check whether a signed document was changed · Paramant">
-<meta property="og:description" content="Check whether a signed document was changed after it was signed. It happens in your browser, without an account and without uploading the file.">
+<meta name="description" content="Check a signed document, or the receipt that proves a file was delivered. Both happen in your browser, without an account and without uploading anything.">
+<meta property="og:title" content="Check a signed document or a delivery receipt · Paramant">
+<meta property="og:description" content="Check a signed document, or the receipt that proves a file was delivered. Both happen in your browser, without an account and without uploading anything.">
 <meta property="og:url" content="https://paramant.app/verify">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Check whether a signed document was changed · Paramant">
-<meta name="twitter:description" content="Check whether a signed document was changed after it was signed. It happens in your browser, without an account and without uploading the file.">
+<meta name="twitter:title" content="Check a signed document or a delivery receipt · Paramant">
+<meta name="twitter:description" content="Check a signed document, or the receipt that proves a file was delivered. Both happen in your browser, without an account and without uploading anything.">
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="canonical" href="https://paramant.app/verify">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -25,6 +25,7 @@
 <link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
 <link rel="stylesheet" href="/components-parasign.css?v=3">
+<link rel="stylesheet" href="/receipt-verify.css?v=1">
 <script type="application/ld+json" data-paramant-seo="1">
 {
   "@context": "https://schema.org",
@@ -33,7 +34,7 @@
       "@type": "WebPage",
       "@id": "https://paramant.app/verify#webpage",
       "url": "https://paramant.app/verify",
-      "name": "Check whether a signed document was changed · Paramant",
+      "name": "Check a signed document or a delivery receipt · Paramant",
       "isPartOf": {
         "@id": "https://paramant.app/#website"
       },
@@ -41,7 +42,7 @@
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Check whether a signed document was changed after it was signed. It happens in your browser, without an account and without uploading the file."
+      "description": "Check a signed document, or the receipt that proves a file was delivered. Both happen in your browser, without an account and without uploading anything."
     },
     {
       "@type": "SoftwareApplication",
@@ -124,10 +125,17 @@
 <main id="main-content" role="main">
 <div class="ps-wrap">
   <header class="ps-head">
-    <p class="ps-kicker">Verify signature</p>
-    <h1 class="ps-title">Verify a .psign envelope</h1>
-    <p class="ps-lede">Check that a document has not been altered since signing. Everything runs in your browser &mdash; the document never leaves your device, and current signatures verify offline with no account or API key.</p>
+    <p class="ps-kicker">Verify</p>
+    <h1 class="ps-title">Check a Paramant proof</h1>
+    <p class="ps-lede">Two kinds of proof come out of Paramant: a signed document, and a receipt that says a file was delivered and then destroyed. Both are checked here, on your own device. Nothing you drop in is uploaded, and neither check needs an account.</p>
   </header>
+
+  <div class="rv-tabs" role="tablist" aria-label="What do you want to check">
+    <button class="rv-tab" type="button" id="tab-doc" role="tab" aria-selected="true" aria-controls="panel-doc">Signed document</button>
+    <button class="rv-tab" type="button" id="tab-receipt" role="tab" aria-selected="false" aria-controls="panel-receipt">Delivery receipt</button>
+  </div>
+
+  <div id="panel-doc" role="tabpanel" aria-labelledby="tab-doc">
 
   <section class="card ps-panel" aria-labelledby="v1">
     <div class="ps-panel-head"><span class="ps-step">1</span><h2 id="v1" class="ps-panel-title">Original document</h2></div>
@@ -160,7 +168,50 @@
     <p class="ps-help">Signatures verify entirely in your browser &mdash; no account, no API key, works offline.</p>
     <p><a href="/dashboard">Open your dashboard &rarr;</a></p>
   </aside>
-</div>
+  </div>
+
+  <div id="panel-receipt" role="tabpanel" aria-labelledby="tab-receipt" hidden>
+    <section class="card ps-panel" aria-labelledby="r1">
+      <div class="ps-panel-head"><span class="ps-step">1</span><h2 id="r1" class="ps-panel-title">The receipt</h2></div>
+      <p class="ps-help">A delivery receipt is the small block of text you get when a file you sent is picked up. It says which file was handed over, at what moment, and whether the copy on the server was destroyed.</p>
+      <label class="rv-drop" id="rv-drop">
+        <input type="file" id="rv-file" accept=".txt,.json,.receipt,application/json,text/plain">
+        <span class="rv-drop-cta">Drop the receipt file here, or choose one</span>
+        <span class="rv-drop-meta" id="rv-file-info">Nothing loaded yet</span>
+      </label>
+      <div class="ps-field">
+        <label class="ps-label" for="rv-input">Or paste the receipt</label>
+        <textarea class="rv-paste" id="rv-input" spellcheck="false" placeholder="Paste the receipt text here. Both the long single-line form and the readable one work."></textarea>
+      </div>
+    </section>
+
+    <section class="card ps-panel" aria-labelledby="r2">
+      <div class="ps-panel-head"><span class="ps-step">2</span><h2 id="r2" class="ps-panel-title">Check it</h2></div>
+      <button class="btn btn-primary" id="rv-check" type="button">Check this receipt</button>
+      <div class="ps-result" id="rv-result" hidden role="status" aria-live="polite"></div>
+    </section>
+
+    <details class="card ps-panel" id="rv-keyblock">
+      <summary class="ps-panel-title">Checking a receipt from another server</summary>
+      <p class="ps-help">This page carries the signing key of the Paramant server, so the usual receipt is checked without asking anything of the network. A receipt from a server you run yourself is checked by pasting that server's key below.</p>
+      <div class="ps-field">
+        <label class="ps-label" for="rv-key">Signing key of the server that issued the receipt</label>
+        <textarea class="rv-paste" id="rv-key" spellcheck="false" placeholder="Leave this empty to use the key that came with this page."></textarea>
+        <p class="ps-help">Paramant publishes its own key at <code class="mono" id="rv-key-hint"></code>.</p>
+      </div>
+    </details>
+
+    <aside class="ps-info">
+      <h2>What is checked</h2>
+      <ul>
+        <li>The receipt is about the file it names and no other</li>
+        <li>The entry it points to really sits in the public transparency log</li>
+        <li>The signature over the whole receipt holds, so nothing was altered</li>
+        <li>The log snapshot the receipt leans on was signed too</li>
+      </ul>
+      <p class="ps-help">All four run on this device. Once the page has loaded you can pull the plug and the answer is the same.</p>
+    </aside>
+  </div>
 </main>
 
 <footer>
@@ -194,5 +245,6 @@
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=7" defer></script>
 <script type="module" src="/parasign-verify.js?v=6"></script>
+<script type="module" src="/js/receipt-verify.js?v=1"></script>
 </body>
 </html>

--- a/tests/receipt-verify.test.mjs
+++ b/tests/receipt-verify.test.mjs
@@ -1,0 +1,231 @@
+// /verify, the delivery-receipt half.
+//
+// The page promises a receipt anyone can check "without us". This suite holds
+// it to that literally: the browser is switched to offline and every request is
+// aborted BEFORE the receipt is checked, so a verdict can only come from code
+// that already ran. It also builds its receipts with the relay's own hash
+// primitives (relay/lib/ct-hash.js) and the same ML-DSA-65 implementation the
+// browser loads, so a drift between relay.js and the client verifier fails here
+// instead of on a customer's screen.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(HERE, '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const SHOTS = process.env.RECEIPT_SHOTS_DIR || '';
+
+const require = createRequire(import.meta.url);
+const { ctTreeHash, ctInclusionProof, blobLeafHash } = require('../relay/lib/ct-hash.js');
+const pqc = await import(path.join(ROOT, 'vendor', 'paramant-pqc.js'));
+
+const MIME = {
+  '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css',
+  '.html': 'text/html', '.svg': 'image/svg+xml', '.png': 'image/png',
+  '.woff2': 'font/woff2', '.json': 'application/json', '.ico': 'image/x-icon',
+};
+const aliases = { '/verify': '/verify.html' };
+
+// Byte-identical to relay.js canonicalJSON.
+function canonicalJSON(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonicalJSON).join(',') + ']';
+  return '{' + Object.keys(value).sort()
+    .map((k) => JSON.stringify(k) + ':' + canonicalJSON(value[k])).join(',') + '}';
+}
+
+// A receipt exactly as relay.js builds one at GET /v2/outbound/:hash, signed by
+// a throwaway relay identity so the suite needs no secret and no live relay.
+function buildReceipt() {
+  const keys = pqc.ml_dsa65.keygen(new Uint8Array(32).fill(7));
+  const sign = (msg) => Buffer.from(pqc.ml_dsa65.sign(keys.secretKey, Buffer.from(msg, 'utf8'))).toString('base64');
+  const sector = 'relay';
+  const ts = '2026-09-01T10:15:30.123Z';
+  const blobHash = crypto.createHash('sha3-256').update('a delivered payload').digest('hex');
+
+  const entries = [];
+  for (let i = 0; i < 4; i++) entries.push({ leaf_hash: crypto.createHash('sha3-256').update('other-' + i).digest('hex') });
+  const leafHash = blobLeafHash(blobHash, sector, ts);
+  entries.push({ leaf_hash: leafHash });
+  const index = entries.length - 1;
+  const root = ctTreeHash(entries);
+
+  const sthPayload = {
+    relay_id: 'https://relay.paramant.app', sha3_root: root,
+    timestamp: Date.parse('2026-09-01T10:15:31Z'), tree_size: entries.length, version: 1,
+  };
+  const sth = { ...sthPayload, signature: sign(canonicalJSON(sthPayload)) };
+
+  const payload = {
+    blob_hash: blobHash, ts,
+    retrieved_at: Date.parse('2026-09-01T14:22:07Z'),
+    sector, relay_id: 'https://relay.paramant.app',
+    tree_size_at_retrieval: entries.length,
+    inclusion_proof: {
+      leaf_hash: leafHash, leaf_index: index, tree_size: entries.length,
+      audit_path: ctInclusionProof(entries, index), root, sth, sth_signature: sth.signature,
+    },
+    burn_confirmed: true,
+  };
+  const receipt = { ...payload, signature: sign(canonicalJSON(payload)) };
+  const tampered = JSON.parse(JSON.stringify(receipt));
+  tampered.blob_hash = tampered.blob_hash.slice(0, -1) + (tampered.blob_hash.endsWith('a') ? 'b' : 'a');
+
+  return {
+    key: Buffer.from(keys.publicKey).toString('base64'),
+    valid: Buffer.from(JSON.stringify(receipt)).toString('base64url'),
+    tampered: Buffer.from(JSON.stringify(tampered)).toString('base64url'),
+    blobHash,
+  };
+}
+
+function startServer() {
+  const server = http.createServer((req, res) => {
+    let name = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+    name = aliases[name] || name;
+    const file = path.join(ROOT, name);
+    if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+    fs.readFile(file, (err, body) => {
+      if (err) { res.writeHead(404); return res.end(); }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      res.end(body);
+    });
+  });
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve(server)));
+}
+
+// Load the page, then take the network away and keep a record of anything that
+// still tries to leave. Everything after this point is the offline promise.
+async function offlinePage(browser, origin) {
+  const context = await browser.newContext({ viewport: { width: 1100, height: 900 } });
+  const page = await context.newPage();
+  await page.goto(origin + '/verify', { waitUntil: 'load' });
+  await page.waitForFunction(() => !!document.getElementById('rv-check'));
+  await page.waitForLoadState('networkidle');
+
+  const attempted = [];
+  await page.route('**/*', (route) => { attempted.push(route.request().url()); return route.abort(); });
+  await context.setOffline(true);
+  return { context, page, attempted };
+}
+
+async function checkReceipt(page, text, key) {
+  await page.click('#tab-receipt');
+  await page.evaluate(() => { document.getElementById('rv-keyblock').open = true; });
+  await page.fill('#rv-input', text);
+  await page.fill('#rv-key', key);
+  await page.click('#rv-check');
+  await page.waitForSelector('#rv-result .rv-checks li');
+  return page.textContent('#rv-result');
+}
+
+const fixture = buildReceipt();
+const server = await startServer();
+const ORIGIN = 'http://127.0.0.1:' + server.address().port;
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+
+test('a genuine receipt is confirmed with the network switched off', async () => {
+  const { context, page, attempted } = await offlinePage(browser, ORIGIN);
+  const text = await checkReceipt(page, fixture.valid, fixture.key);
+
+  // Signed by a throwaway key, so the verdict may not borrow Paramant's name:
+  // every check passes, and the page says so without calling it "genuine".
+  assert.match(text, /This receipt is unchanged/,
+    'a receipt built with the relay own primitives must pass every check');
+  assert.doesNotMatch(text, /This receipt is genuine/,
+    'an unrecognised signer must never be presented as a Paramant receipt');
+  assert.match(text, /The receipt is about this file and no other/);
+  assert.match(text, /It really is in the public transparency log/);
+  assert.match(text, /The signature holds/);
+  assert.match(text, /The log itself was signed at that moment too/);
+
+  // Plain language, not field names: a reader gets the key, the moment and the
+  // file fingerprint in sentences.
+  assert.match(text, /It was signed by a key this page does not recognise/,
+    'a throwaway key must be named as unrecognised rather than silently trusted');
+  assert.match(text, /handed over on 1 September 2026 at 14:22 UTC/);
+  assert.ok(text.includes(fixture.blobHash), 'the fingerprint of the file must be on screen in full');
+  assert.match(text, /destroyed its copy of the file/);
+  assert.match(text, /entry 5 in a public log that held 5 entries/);
+  assert.doesNotMatch(text, /signature valid|valid: true|blob_hash:/i,
+    'the verdict is written for a reader, not for a developer');
+
+  assert.deepEqual(attempted, [],
+    'checking a receipt must not touch the network: ' + attempted.join(', '));
+
+  if (SHOTS) await page.evaluate(() => window.scrollTo(0, 0));
+  if (SHOTS) await page.screenshot({ path: path.join(SHOTS, 'receipt-valid.png'), fullPage: true });
+  await context.close();
+});
+
+test('a receipt with one character changed is refused, offline, with a reason', async () => {
+  const { context, page, attempted } = await offlinePage(browser, ORIGIN);
+  const text = await checkReceipt(page, fixture.tampered, fixture.key);
+
+  assert.match(text, /Do not trust this receipt/);
+  assert.match(text, /The receipt does not match the file it names/);
+  assert.match(text, /The signature does not hold/);
+  assert.deepEqual(attempted, [],
+    'refusing a receipt must not touch the network either: ' + attempted.join(', '));
+
+  // The reason a check failed is the whole point of the failure screen, so it
+  // may not end up squeezed into a column one character wide.
+  const reason = await page.locator('.rv-bad .rv-detail').first().boundingBox();
+  assert.ok(reason && reason.width > 300,
+    'the explanation of a failed check must get the width of the panel, got ' + JSON.stringify(reason));
+
+  if (SHOTS) await page.evaluate(() => window.scrollTo(0, 0));
+  if (SHOTS) await page.screenshot({ path: path.join(SHOTS, 'receipt-tampered.png'), fullPage: true });
+  await context.close();
+});
+
+test('the page ships the relay key it needs, so no key has to be pasted', async () => {
+  const { context, page } = await offlinePage(browser, ORIGIN);
+  const pinned = await page.evaluate(async () => {
+    const mod = await import('/js/relay-trust-anchors.js');
+    const anchor = mod.defaultAnchor();
+    return { key: anchor && anchor.key, fingerprint: anchor && anchor.fingerprint, host: anchor && anchor.host };
+  });
+  assert.equal(Buffer.from(pinned.key, 'base64').length, 1952, 'an ML-DSA-65 public key is 1952 bytes');
+  assert.equal(
+    crypto.createHash('sha3-256').update(Buffer.from(pinned.key, 'base64')).digest('hex'),
+    pinned.fingerprint,
+    'the pinned fingerprint must be the fingerprint of the pinned key');
+  assert.equal(pinned.host, 'relay.paramant.app');
+  await context.close();
+});
+
+test('rubbish in the box gets a sentence, not a stack trace', async () => {
+  const { context, page } = await offlinePage(browser, ORIGIN);
+  await page.click('#tab-receipt');
+  await page.fill('#rv-input', 'this is just a note to myself');
+  await page.click('#rv-check');
+  await page.waitForSelector('#rv-result .ps-banner');
+  const text = await page.textContent('#rv-result');
+  assert.match(text, /This is not a receipt/);
+  assert.doesNotMatch(text, /undefined|TypeError|SyntaxError/);
+  await context.close();
+});
+
+test('the receipt tab opens straight from /verify#receipt', async () => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto(ORIGIN + '/verify#receipt', { waitUntil: 'load' });
+  await page.waitForFunction(() => !!document.getElementById('rv-check'));
+  assert.equal(await page.isVisible('#panel-receipt'), true);
+  assert.equal(await page.isVisible('#panel-doc'), false);
+  await context.close();
+});
+
+test.after(async () => {
+  await browser.close();
+  server.close();
+  server.closeAllConnections();
+});

--- a/tests/seo-contract.test.mjs
+++ b/tests/seo-contract.test.mjs
@@ -425,9 +425,12 @@ const PINNED = {
     title: 'Sign a PDF in your browser · Paramant',
     desc: 'Sign a PDF in your browser. The document text and your signing key never leave it, and anyone can check the finished document afterwards.',
   },
+  // Updated when /verify grew a second tab: it now also checks the delivery
+  // receipt a ParaSend transfer leaves behind, so the promise in the preview
+  // had to cover both proofs instead of only the signed document.
   verify: {
-    title: 'Check whether a signed document was changed · Paramant',
-    desc: 'Check whether a signed document was changed after it was signed. It happens in your browser, without an account and without uploading the file.',
+    title: 'Check a signed document or a delivery receipt · Paramant',
+    desc: 'Check a signed document, or the receipt that proves a file was delivered. Both happen in your browser, without an account and without uploading anything.',
   },
   download: {
     title: 'The Paramant desktop app is no longer maintained',

--- a/tests/theme-contrast.test.mjs
+++ b/tests/theme-contrast.test.mjs
@@ -50,7 +50,7 @@ const aliases = {
   '/parashare':'/parashare.html', '/signup':'/signup.html', '/account':'/account.html',
   '/security':'/security.html', '/trust':'/trust.html', '/docs':'/docs.html',
   '/about':'/about.html', '/help':'/help/index.html', '/download':'/download.html',
-  '/login':'/auth/login.html',
+  '/login':'/auth/login.html', '/verify':'/verify.html',
 };
 const PAGES = Object.keys(aliases);
 const SIZES = [[390, 844], [1440, 900]];


### PR DESCRIPTION
## Why

The site promises "a proof you can check yourself, without us". For a signed document that has been true since the v3 recipe: `/verify` verifies a `.psign` envelope entirely client-side. For the receipt a ParaSend transfer leaves behind it was not. The only route was `POST /v2/verify-receipt`, which asks the relay to check its own signature, over a network the reader has to trust. Backlog item "transfer-receipt client verifier".

## What

`/verify` grows a second tab, `Delivery receipt`. Drop the receipt file in, or paste it (base64url, plain JSON, or the `{"receipt": "..."}` wrapper all work), and the four checks `relay.js` does run on the visitor's own device:

1. the leaf hash is recomputed from `blob_hash + sector + ts`, so the proof is bound to this transfer rather than to some entry in the tree
2. the audit path is walked back to the claimed Merkle root
3. the ML-DSA-65 signature over the canonical receipt is verified
4. the signed tree head is verified and its root compared to the proof

Same primitives as `relay/lib/ct-hash.js` and `relay.js`, reused through the frontend's existing `/vendor/paramant-pqc.js`. No new dependency, no CDN, and no `fetch` anywhere in the verification path.

## The signing key

A receipt does not carry the key that signed it, so the page ships it. `frontend/js/relay-trust-anchors.js` pins the relay identity public key that `GET /v2/pubkey` publishes, together with its SHA3-256 fingerprint, and the verifier recomputes that fingerprint instead of trusting the string. That is what makes the page work with the network off.

Failure modes were chosen so neither of them lies:

- a receipt from another server, or from a relay that has rotated its key, is checked by pasting that key
- a key the page does not recognise is never laundered into a Paramant promise: the verdict reads "This receipt is unchanged. It all still matches the key you gave, and this page does not know that key", not "genuine"

## Plain language

Written for the person holding the receipt. Instead of `signature valid: true`:

> **This receipt is genuine.** It was issued by the Paramant relay and not one character has changed since.
>
> It was signed by the Paramant relay, key `3d9b960c107a5145`.
> The file was handed over on 1 September 2026 at 14:22 UTC.
> The file it covers has fingerprint `8ab0b7cc8fc9...`.
> The server destroyed its copy of the file as it was handed over.
> It is entry 5 in a public log that held 5 entries at that moment.

A failed check names which one failed and what it means, and the facts above it change heading from "What this receipt says" to "What this receipt claims".

## The offline proof

`tests/receipt-verify.test.mjs` builds its receipts with the relay's own hash primitives and the same ML-DSA-65 implementation the browser loads, then, after the page has finished loading, aborts every request and switches the browser context offline **before** checking anything. It asserts zero requests were attempted. A drift between `relay.js` and the client verifier now fails there instead of on a customer's screen.

## Pins moved on purpose

- `tests/seo-contract.test.mjs`: the pinned title and description for `/verify` covered only the signed document; the page now carries both proofs
- `tests/theme-contrast.test.mjs`: `/verify` added to the measured pages. It clears WCAG AA in light at 390 and 1440 with **no** new `KNOWN_LIGHT` entry

## Tests

```
scripts/check-csp-inline.sh                                   OK
scripts/check-cache-bust.sh                                   OK
bron-seo/apply_seo_head.py --check                            would change: 0 pages
tests/static-sanity.sh                                        PASS
node --test $(grep -L "from 'playwright'" tests/*.mjs)        225 pass, 0 fail
node --test $(grep -l "from 'playwright'" tests/*.mjs | ...)   47 pass, 0 fail
node --test tests/receipt-verify.test.mjs                       5 pass, 0 fail
node --test tests/product-heartbeat.test.mjs                    9 pass, 0 fail
npx eslint@9 .                                                clean
```

`tests/theme-contrast.test.mjs` now measures 4532 text pairs across 17 pages.

## Files

| File | |
|---|---|
| `frontend/verify.html` | tab shell, receipt panel, new title and description |
| `frontend/js/receipt-verify.js` | the verifier and the plain-language rendering |
| `frontend/js/relay-trust-anchors.js` | the pinned relay identity key |
| `frontend/receipt-verify.css` | page-local styles, design-system tokens only |
| `tests/receipt-verify.test.mjs` | the offline proof |
| `tests/seo-contract.test.mjs`, `tests/theme-contrast.test.mjs` | pins |
| `docs/api.md`, `frontend/docs/api.md` | point at `/verify#receipt` under the endpoint |

Nothing in `relay/` changed. `POST /v2/verify-receipt` stays exactly as it is.
