### PR TITLE
One note is enough: the founder line leaves every page but /about

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -349,7 +349,7 @@ main.acct input::placeholder { color: var(--ink-3); }
          business plans pay for it, and one link is the whole upgrade path. -->
     <div class="acct-plan-band free" id="billing-community" hidden>
       <p class="acct-plan-kicker">Community &middot; &euro;0</p>
-      <p class="acct-plan-lede">You are on the Community plan and it stays free. It is Mick Beer, privacy and security researcher and founder of Paramantis Solutions B.V., giving something back to society; the business plans pay for it.</p>
+      <p class="acct-plan-lede">You are on the Community plan and it stays free. The business plans pay for the servers and keep it that way.</p>
       <p class="acct-plan-adds">They raise 2 signatures a month to 100 or 1,000, keep links open longer, keep a record of what you sent, give you support with a name on it, and an audit trail you can export and hand over.</p>
       <a class="acct-plan-cta" href="/pricing">See the business plans &rarr;</a>
     </div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -468,7 +468,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
     <aside class="dh-community" id="dh-community" aria-label="Your plan" hidden>
       <div>
         <p class="dh-community-kicker">Community &middot; &euro;0</p>
-        <p class="dh-community-lede">You are on the Community plan and it stays free. It is Mick Beer, privacy and security researcher and founder of Paramantis Solutions B.V., giving something back to society; the business plans pay for it.</p>
+        <p class="dh-community-lede">You are on the Community plan and it stays free. The business plans pay for the servers and keep it that way.</p>
         <p class="dh-community-adds">They raise 2 signatures a month to 100 or 1,000, keep links open longer, keep a record of what you sent, give you support with a name on it, and an audit trail you can export and hand over.</p>
       </div>
       <a class="dh-community-cta" href="/pricing">See the business plans &rarr;</a>

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -192,7 +192,7 @@ pre{font-family:var(--mono);font-size:12px;line-height:1.7;color:var(--ink);back
 
   <section>
     <h2>Who is behind it</h2>
-    <p>Paramant is built by Mick Beer, privacy and security researcher and founder of Paramantis Solutions B.V. in Harderwijk. The Community plan is his way of giving something back to society; the business plans pay for it. <a href="/about">About Paramant</a>.</p>
+    <p>Paramant is built by Paramantis Solutions B.V. in Harderwijk. The Community plan is free and stays free; the business plans pay for the servers and keep it that way. <a href="/about">About Paramant</a>.</p>
   </section>
 
   <details>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -102,10 +102,6 @@ html[data-session="in"] .home-hero{padding-bottom:56px}
 .home-actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:24px}
 .hero-note{font-size:13.5px;line-height:1.5;color:var(--fg-dim);margin:12px 0 0;max-width:46ch}
 .hero-note b{color:var(--fg);font-weight:600}
-.hero-by{display:flex;align-items:center;gap:12px;margin:16px 0 0;padding-top:14px;border-top:1px solid var(--line);font-size:13.5px;line-height:1.45;color:var(--fg-mid);max-width:52ch}
-.hero-by .hp-mono{font-family:var(--hp-mono);font-size:11px;color:var(--fg-dim);letter-spacing:.04em}
-.hero-by strong{color:var(--fg);font-weight:600}
-.hero-by .by-mark{flex:0 0 auto;width:36px;height:36px;border-radius:50%;border:1px solid var(--line-2);display:grid;place-items:center;font-family:var(--hp-mono);font-size:11px;color:var(--fg);background:var(--card)}
 .home-hi-name{color:var(--ochre)}
 .hp-proof{font-size:14.5px;line-height:1.5;color:var(--fg-mid);margin:10px 0 0;max-width:40ch}
 @media (min-width:900px){.hp-proof{display:none}}
@@ -435,7 +431,6 @@ footer a{color:var(--fg)}
         <a class="hp-btn hp-btn-line" href="/pricing">Business plans</a>
       </div>
       <p class="hero-note">Free on the <b>Community plan</b>, for good. Paid business plans from &euro;15 a month.</p>
-      <p class="hero-by"><span class="by-mark" aria-hidden="true">MB</span><span><strong>Mick Beer</strong>, privacy and security researcher.<br><span class="hp-mono">Founder, Paramantis Solutions B.V. &middot; Harderwijk</span></span></p>
       <p class="hp-proof">When the file is gone, the proof stays. Anyone can check it without us.</p>
     </div>
     <div class="home-state" data-home="in" hidden>
@@ -446,7 +441,6 @@ footer a{color:var(--fg)}
         <a class="hp-btn hp-btn-line" href="/sign">Start signing</a>
         <a class="hp-btn hp-btn-line" href="/parashare">Send securely</a>
       </div>
-      <p class="hero-by"><span class="by-mark" aria-hidden="true">MB</span><span><strong>Mick Beer</strong>, privacy and security researcher.<br><span class="hp-mono">Founder, Paramantis Solutions B.V. &middot; Harderwijk</span></span></p>
     </div>
     <div class="hp-art" aria-hidden="true">
       <div class="hp-art-glow"></div>

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -285,10 +285,10 @@
 <section class="ps-band">
   <div class="container-md">
     <span class="mono-eyebrow">04 / Who is behind it</span>
-    <h2 style="margin-top:var(--space-2)">Built by a named person, in Harderwijk</h2>
+    <h2 style="margin-top:var(--space-2)">Built in Harderwijk, in the Netherlands</h2>
     <div class="person-card">
-      <p>Paramant is a product of <strong>Paramantis Solutions B.V.</strong> in Harderwijk, the Netherlands, founded by <strong>Mick Beer, privacy and security researcher</strong>. That background shapes the choices: post-quantum signatures, a public transparency log, offline-verifiable documents, and source code you can inspect yourself.</p>
-      <p>The Community plan is his way of giving something back to society; the business plans pay for it. Paramantis Solutions B.V. is the contracting and responsible party; the founder is the origin of the work, not the service itself.</p>
+      <p>Paramant is a product of <strong>Paramantis Solutions B.V.</strong> in Harderwijk, the Netherlands. The product is built on choices you can check for yourself: post-quantum signatures, a public transparency log, offline-verifiable documents, and source code you can inspect yourself.</p>
+      <p>The Community plan is free and stays free; the business plans pay for the servers and keep it that way. Paramantis Solutions B.V. is the contracting and responsible party.</p>
       <p><a href="/about">More about Paramant &rarr;</a></p>
     </div>
   </div>

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -266,7 +266,7 @@
       </div>
       <div>
         <div class="k" style="font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.14em;text-transform:uppercase;font-weight:700;color:var(--navy)">Why it is free</div>
-        <p>Paramant is built by <strong>Mick Beer, privacy and security researcher</strong>, founder of Paramantis Solutions B.V. (see the <a href="/about">about page</a>). The Community plan is his way of giving something back: whoever needs to sign a document without handing it to an American cloud can do that here, at no cost, with the same cryptography a paying customer gets.</p>
+        <p>Paramant is built by <strong>Paramantis Solutions B.V.</strong> in Harderwijk (see the <a href="/about">about page</a>). The Community plan is what the company gives back: whoever needs to sign a document without handing it to an American cloud can do that here, at no cost, with the same cryptography a paying customer gets.</p>
         <p>It is not a limited edition of the product. Community gets the same signatures, the same encryption and the same public proof log as Business. What a paid plan buys is volume, an API, support and accountability. Never security.</p>
       </div>
     </div>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -291,8 +291,8 @@
       <a href="#plans" class="btn btn-tertiary">Compare plans</a>
     </div>
     <p style="font-size:var(--text-sm);color:var(--ink-dim);line-height:1.6;margin:0 0 var(--space-6)">
-      Built in Harderwijk by <strong style="color:var(--navy)">Mick Beer</strong>, privacy and security researcher, founder of
-      Paramantis Solutions B.V. (KvK 42115132). <a href="/about" style="color:var(--cobalt)">About Paramant &rarr;</a>
+      Built in Harderwijk by <strong style="color:var(--navy)">Paramantis Solutions B.V.</strong> (KvK 42115132).
+      <a href="/about" style="color:var(--cobalt)">About Paramant &rarr;</a>
     </p>
     <div style="max-width:760px;margin:0 0 var(--space-4);padding:var(--space-4) var(--space-5);border:1px solid var(--ink-hair);border-left:3px solid var(--lime);background:var(--bone)">
       <p style="font-size:var(--text-base);color:var(--ink);line-height:1.7;margin:0">

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -232,7 +232,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   <h1>Security</h1>
   <p class="lede">Break into our own server and you still cannot read the documents on it: they are encrypted on your device before they leave it, and the key never reaches us. That holds for the ParaSend web app and the official SDKs. The Chromium and Outlook extensions still encrypt on our server, which means we can read what you upload through them until that is changed; the detail is further down this page.</p>
   <p class="lede">This is the evidence under everything the rest of the site promises, and it covers every plan: the Community tier gets exactly the same protection as the paid ones.</p>
-  <p class="hero-by">Paramant is a product of Paramantis Solutions B.V. in Harderwijk, the Netherlands, KvK 42115132, founded by Mick Beer, privacy and security researcher.</p>
+  <p class="hero-by">Paramant is a product of Paramantis Solutions B.V. in Harderwijk, the Netherlands, KvK 42115132.</p>
   <div class="hero-cta">
     <a href="/pricing" class="btn btn-primary">See pricing &rarr;</a>
     <a href="/verify" class="btn btn-secondary">Verify a document &rarr;</a>

--- a/tests/first-screen.test.mjs
+++ b/tests/first-screen.test.mjs
@@ -160,9 +160,9 @@ const PAGES = [
       // tier named, on the first screen.
       { name: 'the Community and business plans split', css: '[data-home="out"] p.hero-note', text: 'Community plan', also: ['business plans from'] },
       { name: 'the first action', css: '[data-home="out"] .home-actions a', href: '/sign' },
-      // The founder, by name and title, before the visitor scrolls: the homepage
-      // sells a gift from a person, so the person has to be on the first screen.
-      { name: 'the founder', css: '[data-home="out"] .hero-by', text: 'Mick Beer, privacy and security researcher' },
+      // Mick, 4 September: one note is enough. The founder line left both hero
+      // states; the letter signature further down the page is the one place the
+      // homepage still names him, and tests/ui-truthfulness pins that block.
       { name: 'the heading of the five facts, which now come before the gift (panel of 4 September: facts convince, the letter can wait)', css: '#check-h', text: 'Five things you can check' },
     ],
   },

--- a/tests/navigation-shell.test.mjs
+++ b/tests/navigation-shell.test.mjs
@@ -256,9 +256,9 @@ const homeSections = await homePage.evaluate(() => {
   };
 });
 ok('the signed-in homepage stops after the hero', homeSections.total > 1 && JSON.stringify(homeSections.visible) === JSON.stringify(['home-hero']), JSON.stringify(homeSections));
-// The founder line stays: it is the one thing on this page that says who is
-// accountable, and tests/ui-truthfulness pins its wording.
-ok('the signed-in hero keeps the name behind the product', (await homePage.locator('[data-home="in"]').innerText()).includes('Mick Beer'), await homePage.locator('[data-home="in"]').innerText());
+// Mick, 4 September: one note is enough. The founder line left both hero states,
+// so what the signed-in hero has to carry is the workspace a customer came for.
+ok('the signed-in hero opens on the documents', (await homePage.locator('[data-home="in"]').innerText()).includes('Your documents'), await homePage.locator('[data-home="in"]').innerText());
 if (process.env.PARAMANT_HOME_SCREENSHOT_PATH) await stableScreenshot(homePage, { path:process.env.PARAMANT_HOME_SCREENSHOT_PATH });
 await homePage.close();
 

--- a/tests/pricing-fold.test.mjs
+++ b/tests/pricing-fold.test.mjs
@@ -71,11 +71,11 @@ async function open(width, height, slug = 'pricing') {
 // is a span, and the amount in the promise sits inside a <strong>.
 //
 // A pattern may ask for the enclosing BLOCK instead of the element holding the
-// matched text. The founder claim is the case that needs it: "Mick Beer" is a
-// <strong> that ends at y=726, but the claim a reader has to be able to read is
-// the whole line, title and KvK number included, and that ends 40px lower. An
-// earlier version measured the <strong> and would have called the line visible
-// with its registration clipped off the bottom of the screen.
+// matched text. The company claim is the case that needs it: the name of the
+// company is a <strong>, but the claim a reader has to be able to read is the
+// whole line, where it is built and the KvK number included, and that ends
+// lower. An earlier version measured the <strong> and would have called the
+// line visible with its registration clipped off the bottom of the screen.
 const measure = (page, needles) => page.evaluate((patterns) => {
   const out = {};
   const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
@@ -98,7 +98,7 @@ const measure = (page, needles) => page.evaluate((patterns) => {
     out[name] = {
       top: Math.round(rect.top + window.scrollY),
       bottom: Math.round(rect.bottom + window.scrollY),
-      // A block claim is reported whole enough to assert on: the founder line
+      // A block claim is reported whole enough to assert on: the company line
       // runs past 100 characters before it reaches the registration number.
       text: (block ? el.textContent : hit.text).replace(/\s+/g, ' ').trim().slice(0, block ? 240 : 100),
     };
@@ -110,7 +110,7 @@ const measure = (page, needles) => page.evaluate((patterns) => {
   return out;
 }, needles);
 
-test('the first screen at 390px carries the amount, the audience, the founder and an action', async () => {
+test('the first screen at 390px carries the amount, the audience, the company and an action', async () => {
   const page = await open(FOLD.width, FOLD.height);
   const seen = await measure(page, [
     ['h1', '^Pricing$'],
@@ -122,8 +122,10 @@ test('the first screen at 390px carries the amount, the audience, the founder an
     ['sending', '€15 a month'],
     ['signing', '€49 a month'],
     ['audience', 'one-person practice, a volunteer board or a household'],
-    // Whole line: the name, the title /about gives him, and the registration.
-    ['founder', 'Mick Beer', true],
+    // Mick, 4 September: the name and the title left every page but /about and
+    // the letter on the homepage. What the first screen still has to carry is
+    // who is accountable: the company, where it sits, and its registration.
+    ['company', 'Paramantis Solutions B.V.', true],
   ]);
   const cta = await page.evaluate(() => {
     // The hero's own action, not the nav's: the nav carries a /signup link on
@@ -143,12 +145,12 @@ test('the first screen at 390px carries the amount, the audience, the founder an
       `the ${name} line ends at y=${hit.bottom}, past the ${FOLD.height}px first screen: a buyer has to scroll for it`);
   }
   // Order is the argument: what it does, then what it costs, then who it is
-  // for, then who is behind it, and only then the button.
+  // for, and only then the button. The company line closes the block.
   assert.ok(seen.what.top < seen.amount.top, 'what the product does stands above what it costs');
   assert.ok(seen.amount.top <= seen.audience.top, 'the amount stands above the audience line');
   assert.ok(seen.audience.top < cta.top, 'the audience line stands above the first action');
-  assert.match(seen.founder.text, /privacy and security researcher.*KvK 42115132/,
-    'the measured founder line must be the whole claim, not just the name in bold');
+  assert.match(seen.company.text, /Harderwijk.*KvK 42115132/,
+    'the measured company line must be the whole claim: where it is built and the registration');
 });
 
 test('the first screen at 390px spends no words on jargon', async () => {

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -516,12 +516,13 @@ assert.ok(aboutText.includes(`Mick Beer, ${SANCTIONED_TITLE}`),
 // Direction two: the qualifier that follows his name must use only words
 // /about itself uses, so no new credential can be smuggled in beside it.
 const ABOUT_WORDS = new Set(aboutText.toLowerCase().match(/[a-z]+/g) || []);
-// Pages that SELL on the founder. On these the line is required, not optional:
-// an if-includes gate lets the sentence be deleted and stays green, and the
-// give-back promise is the one thing the signed-in pages are there to make.
-const FOUNDER_REQUIRED = ['index', 'dashboard', 'account'];
+// Mick, 4 September: one note is enough. The name and the title left every page
+// but /about; on the homepage exactly one place keeps them, the signature under
+// the letter, which is checked as a block further down. So index is the only
+// page still required to name him, and no other page may be forced to.
+const FOUNDER_REQUIRED = ['index'];
 // Pages that MAY name him. If they do, the same rules apply.
-const FOUNDER_OPTIONAL = ['pricing', 'parasign'];
+const FOUNDER_OPTIONAL = ['pricing', 'parasign', 'dashboard', 'account'];
 for (const slug of [...FOUNDER_REQUIRED, ...FOUNDER_OPTIONAL]) {
   const text = flatten(read(`frontend/${slug}.html`));
   if (FOUNDER_REQUIRED.includes(slug)) {
@@ -666,11 +667,13 @@ assert.match(pricingVisible, /The architecture is built to support your NIS2 and
   'pricing.html must say what the architecture does and what Paramant does not hold');
 
 // Who is behind it, on the page where a buyer decides to upload client files.
-// The name stood at 1128px, a screen and a half down; pricing-fold.test.mjs
-// measures where it lands now, this pins that it is there at all and that it
-// carries the accountable registration beside it.
-assert.match(pricingVisible, /Mick Beer<\/strong>, privacy and security researcher, founder of\s+Paramantis Solutions B\.V\. \(KvK 42115132\)/,
-  'pricing.html must name the founder with the title /about gives him and the company registration');
+// Mick, 4 September: the name and the title left this page. What has to stay is
+// the party that is accountable, with the registration beside it;
+// pricing-fold.test.mjs measures where that lands on a phone.
+assert.match(pricingVisible, /Built in Harderwijk by <strong[^>]*>Paramantis Solutions B\.V\.<\/strong> \(KvK 42115132\)/,
+  'pricing.html must name the company that is accountable, with its registration');
+assert.doesNotMatch(pricingVisible, /Mick Beer/,
+  'pricing.html must not name the founder in its body copy; /about and the homepage letter carry that');
 
 // The free cards send a visitor to /signup. They used to send them to
 // /dashboard, a page nobody without an account can open.
@@ -947,9 +950,15 @@ assert.doesNotMatch(signVisibleText, /\bFree accounts\b|tier named Free|the tier
 
 // The founder, with the exact title and nothing added to it. No award, no year
 // count, no prior employer, no certification: none of that is on the site.
+// Mick, 4 September: one note is enough, so /about is the only page that still
+// carries the line. The product pages name the company instead.
 const FOUNDER = 'Mick Beer, privacy and security researcher';
-for (const [name, text] of [['about', aboutVisible], ['parasign', parasign], ['parasend', parasend]]) {
-  assert.ok(text.includes(FOUNDER), `${name}.html must name the founder with his exact title`);
+assert.ok(aboutVisible.includes(FOUNDER), 'about.html must name the founder with his exact title');
+for (const [name, text] of [['parasign', parasign], ['parasend', parasend]]) {
+  assert.ok(!text.includes('Mick Beer'),
+    `${name}.html must not name the founder in its body copy; /about carries that line`);
+  assert.ok(text.includes('Paramantis Solutions B.V.'),
+    `${name}.html must still name the company that is accountable`);
 }
 
 // Sentence three of the founder paragraph. It was the one claim on these pages
@@ -957,7 +966,10 @@ for (const [name, text] of [['about', aboutVisible], ['parasign', parasign], ['p
 // than composed, and it is pinned to both ends of the quote.
 const GIVE_BACK = 'The Community plan is his way of giving something back to society; the business plans pay for it.';
 assert.ok(aboutVisible.includes(GIVE_BACK), 'about.html lost the give-back sentence the product pages quote');
-assert.ok(parasend.includes(GIVE_BACK), 'parasend.html must quote the give-back sentence as /about states it');
+// Mick, 4 September: parasend states the same promise without the person, since
+// "his" has nothing to point at once the name is gone.
+assert.ok(parasend.includes('The Community plan is free and stays free; the business plans pay for the servers and keep it that way.'),
+  'parasend.html must keep the promise that the free plan stays free and say what pays for it');
 
 // The limits, stated in the same voice as the promises. Both already shipped
 // before the product pages existed and neither may be softened or moved into
@@ -1226,7 +1238,9 @@ console.log('ui-truthfulness: the messaging guide claims are pinned to the pages
     'security.html must offer a next step in the first screen, not only at the foot of the page');
   assert.match(securityHero, /href="\/verify" class="btn btn-secondary"/,
     'security.html must offer the verify step in the first screen');
-  assert.match(securityHero, /Paramantis Solutions B\.V\. in Harderwijk, the Netherlands, KvK 42115132, founded by Mick Beer, privacy and security researcher/,
+  // Mick, 4 September: the founder line left this page. Who is accountable is
+  // the company, where it sits and its registration, and that has to stay.
+  assert.match(securityHero, /Paramantis Solutions B\.V\. in Harderwijk, the Netherlands, KvK 42115132/,
     'security.html says "why you can trust us", so it must name who that is, under the lede');
 
   // The hero promise is bounded where the code is bounded. It used to read "Even


### PR DESCRIPTION
"'mick beer privacy en security researcher', dat zie je nu overal. dat is overdreven. Een kleine note op de homepage is genoeg." -- Mick, 4 September.

The name and the title stood in the running copy of nine pages. They now stand in two places: **/about**, which is the page about the company and the person, and the **signature under the letter on the homepage**, which is the one note he asked for and which carries KvK 42115132 in the same block.

What replaces them everywhere else is the party that is actually accountable: Paramantis Solutions B.V. in Harderwijk, with the registration where it already stood. Every sentence is rewritten to stand on its own rather than to have the name cut out of it, because "his way of giving something back" has nothing to point at once the person is gone.

## Per page

| page | before | after |
| --- | --- | --- |
| index (hero, signed out and signed in) | `Mick Beer, privacy and security researcher.` / `Founder, Paramantis Solutions B.V. · Harderwijk` | gone, both states |
| index (letter signature) | `Mick Beer, privacy and security researcher` + `Founder of Paramantis Solutions B.V. · Harderwijk, the Netherlands · KvK 42115132` | unchanged, this is the one note |
| pricing | Built in Harderwijk by **Mick Beer**, privacy and security researcher, founder of Paramantis Solutions B.V. (KvK 42115132). | Built in Harderwijk by **Paramantis Solutions B.V.** (KvK 42115132). |
| account | You are on the Community plan and it stays free. It is Mick Beer, privacy and security researcher and founder of Paramantis Solutions B.V., giving something back to society; the business plans pay for it. | You are on the Community plan and it stays free. The business plans pay for the servers and keep it that way. |
| dashboard | same sentence as account | same rewrite as account |
| security | Paramant is a product of Paramantis Solutions B.V. in Harderwijk, the Netherlands, KvK 42115132, founded by Mick Beer, privacy and security researcher. | Paramant is a product of Paramantis Solutions B.V. in Harderwijk, the Netherlands, KvK 42115132. |
| parasend (h2) | Built by a named person, in Harderwijk | Built in Harderwijk, in the Netherlands |
| parasend (p1) | ...founded by **Mick Beer, privacy and security researcher**. That background shapes the choices: post-quantum signatures... | ...in Harderwijk, the Netherlands. The product is built on choices you can check for yourself: post-quantum signatures... |
| parasend (p2) | The Community plan is his way of giving something back to society; the business plans pay for it. Paramantis Solutions B.V. is the contracting and responsible party; the founder is the origin of the work, not the service itself. | The Community plan is free and stays free; the business plans pay for the servers and keep it that way. Paramantis Solutions B.V. is the contracting and responsible party. |
| parasign | Paramant is built by **Mick Beer, privacy and security researcher**, founder of Paramantis Solutions B.V. (see the about page). The Community plan is his way of giving something back: ... | Paramant is built by **Paramantis Solutions B.V.** in Harderwijk (see the about page). The Community plan is what the company gives back: ... |
| download | Paramant is built by Mick Beer, privacy and security researcher and founder of Paramantis Solutions B.V. in Harderwijk. The Community plan is his way of giving something back to society; the business plans pay for it. | Paramant is built by Paramantis Solutions B.V. in Harderwijk. The Community plan is free and stays free; the business plans pay for the servers and keep it that way. |
| about | | untouched: this is the page about the company and the founder |

The `"jobTitle": "Privacy and security researcher"` node in the JSON-LD of 45 pages is untouched. It is not visible copy and `tests/seo-contract` pins it.

## CSS

The four `.hero-by` rules in the inline block of index.html are removed with the markup that used them; nothing else on the page did. `.letter-sign .by-mark` is a separate rule and stays. No colour, token or shared stylesheet is touched, so this does not collide with the colour work in flight.

## Tests

Each change carries a line saying why.

- `first-screen` -- the `[data-home="out"] .hero-by` pin is gone.
- `pricing-fold` -- the founder pin becomes a company pin, still measured as a whole block and still required to end above 844px on a 390px screen. The block-measurement comment is rewritten around the new claim.
- `navigation-shell` -- the signed-in hero is checked on the workspace it opens on ("Your documents") instead of on the name.
- `ui-truthfulness` -- `FOUNDER_REQUIRED` is `['index']` only; pricing/parasign/parasend are pinned to the company line *and* to the absence of the name; /security keeps company, place and registration; parasend keeps the free-plan promise in the wording it now uses.

Green: `first-screen`, `pricing-fold`, `ui-truthfulness`, `site-claims`, `seo-contract`, `theme-contrast`, `frontend-loading-contract`, `static-sanity`.

`navigation-shell` has one failure, `mobile navigation is opaque before opening the menu`, reporting `rgba(21, 25, 28, 0.92)` with no backdrop filter. It fails identically on `origin/main` (checked on a clean checkout of the same commit), so it arrived with the night design in #404 and belongs to the colour work, not to this branch. The assertion this branch does own, the signed-in hero, passes.
