### PR TITLE
Betaalpad: de betaalde periode verlaat de relay, en een betaling koopt precies een termijn

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -3107,14 +3107,30 @@ api.get("/user/billing/status", authUser, async (req, res) => {
   const cancelAt = await redis().get(`paramant:user:plan_cancel_at:${user_id}`);
   const keysRes = await relayFetch("health", "/v2/admin/keys?reveal=1", "GET", null, false, ADMIN_TOKEN);
   const currentKey = (keysRes.body?.keys || []).find(k => k.key === user_id);
+  // What the account page shows about money has to be what actually happened.
+  // Two things were wrong here. The record this used to read,
+  // paramant:user:billing:<id>, is written by nothing in this codebase, so
+  // next_billing_date was always null and the renewal row the page promises
+  // never appeared. And stub_notice said no real charges apply, to customers
+  // Mollie had genuinely charged. The truth is on the relay: paid_until_* is
+  // the day the term that was paid for runs out, so that is the date to show.
+  const fields = productPlanFields(currentKey);
+  const untils = [fields.paid_until_parasign, fields.paid_until_parasend]
+    .map(v => (v ? Date.parse(v) : NaN))
+    .filter(t => !Number.isNaN(t) && t > Date.now());
+  const accessUntil = untils.length ? new Date(Math.max(...untils)).toISOString() : null;
   res.json({
     current_plan: currentKey?.plan || 'community',
-    ...productPlanFields(currentKey),
+    ...fields,
     period: billing?.period || null,
-    amount_eur: billing?.amount_eur ?? 0,
+    amount_eur: billing?.amount_eur ?? null,
+    // The end of the term that was paid for. Every checkout is a one-off
+    // payment for that term (see /terms), so this is the day access stops
+    // unless another payment is made, not the day a collection is attempted.
+    access_until: accessUntil,
     next_billing_date: billing?.next_billing_date || null,
+    auto_renews: false,
     cancellation_scheduled_at: cancelAt || null,
-    stub_notice: 'Payment integration pending. No real charges apply.',
   });
 });
 

--- a/admin/server.js
+++ b/admin/server.js
@@ -2198,6 +2198,17 @@ api.get("/user/session/verify", async (req, res) => {
 // paying customer he is on the free plan. The paid_until pair travels with them
 // so a client can apply the same expiry rule as effectiveProductTier: a stored
 // tier above the floor is paid only while its period has not run out.
+// The day the term that was paid for runs out: the later of the two product
+// periods that is still in the future, or null when nothing is paid for. Both
+// the status endpoint and the cancel endpoint answer with this, so a customer
+// cannot be shown one date and promised another.
+function termEndOf(fields) {
+  const ends = [fields.paid_until_parasign, fields.paid_until_parasend]
+    .map((v) => (v ? Date.parse(v) : NaN))
+    .filter((t) => !Number.isNaN(t) && t > Date.now());
+  return ends.length ? new Date(Math.max(...ends)).toISOString() : null;
+}
+
 function productPlanFields(rec) {
   return {
     plan_parasign: rec?.plan_parasign ?? null,
@@ -3092,7 +3103,15 @@ api.post("/user/billing/cancel", authUser, async (req, res) => {
   const { user_id, email } = req.userSession;
   const billingRaw = await redis().get(`paramant:user:billing:${user_id}`);
   const billing = billingRaw ? JSON.parse(billingRaw) : null;
-  const cancelAt = billing?.next_billing_date || new Date(Date.now() + 30 * 86_400_000).toISOString();
+  // "You keep access until the end of your billing period" is a promise about a
+  // specific day, so it has to be the day the relay will actually stop granting.
+  // next_billing_date came from a Redis record nothing writes, so this fell
+  // through to now plus 30 days and told a customer who had paid for a YEAR
+  // that his plan ended next month. The term end is on the relay; read it.
+  const cancelUser = await findUserByEmail(email).catch(() => null);
+  const cancelAt = termEndOf(productPlanFields(cancelUser))
+    || billing?.next_billing_date
+    || new Date(Date.now() + 30 * 86_400_000).toISOString();
   await redis().set(`paramant:user:plan_cancel_at:${user_id}`, cancelAt);
   await logAuditEvent(user_id, 'plan_cancellation_scheduled', { cancel_at: cancelAt, plan: billing?.plan || 'pro', via: 'user_request' });
   try { await sendCancellationScheduled(email, billing?.plan || 'pro', cancelAt); }
@@ -3115,10 +3134,7 @@ api.get("/user/billing/status", authUser, async (req, res) => {
   // Mollie had genuinely charged. The truth is on the relay: paid_until_* is
   // the day the term that was paid for runs out, so that is the date to show.
   const fields = productPlanFields(currentKey);
-  const untils = [fields.paid_until_parasign, fields.paid_until_parasend]
-    .map(v => (v ? Date.parse(v) : NaN))
-    .filter(t => !Number.isNaN(t) && t > Date.now());
-  const accessUntil = untils.length ? new Date(Math.max(...untils)).toISOString() : null;
+  const accessUntil = termEndOf(fields);
   res.json({
     current_plan: currentKey?.plan || 'community',
     ...fields,

--- a/admin/test/billing-status-truth.test.js
+++ b/admin/test/billing-status-truth.test.js
@@ -1,0 +1,98 @@
+'use strict';
+// What GET /api/user/billing/status tells a customer about his money.
+//
+// Two statements in that response body were untrue, and both were untrue in the
+// direction that costs trust rather than money.
+//
+//   stub_notice: 'Payment integration pending. No real charges apply.'
+//     Shipped from the days before Mollie. It was still being served to
+//     customers whom Mollie had genuinely charged 59.29 euro. The frontend guard
+//     that was supposed to catch this (tests/ui-truthfulness.test.mjs) reads
+//     frontend/account.html, and the sentence does not live in the HTML; it
+//     comes off the API, so nothing saw it.
+//
+//   next_billing_date: read from paramant:user:billing:<id>, a Redis record
+//     that NOTHING in this repository ever writes. Every read got null, so the
+//     row the account page promises ("Your plan, renewal date and invoices are
+//     below") never rendered, and POST /user/billing/cancel fell through to its
+//     `now + 30 days` default and told a customer who had paid for a YEAR that
+//     his plan would be downgraded next month.
+//
+// The date that does exist is paid_until_* on the relay, the end of the term the
+// payment actually bought, and it arrives here through productPlanFields().
+// Every checkout is a one-off for that term (frontend/terms.html), so the
+// response says access_until and auto_renews:false rather than inventing a
+// collection date.
+//
+// Structural, like user-plan-fields.test.js and for the same reason: reaching
+// this handler needs Redis, a session cookie and a live relay, while what goes
+// wrong here is a sentence.
+// Run: node --test admin/test/billing-status-truth.test.js
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SERVER = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+
+// The handler with its comments stripped. A comment is allowed to name the
+// sentence that was removed and why; only the code may be asserted on.
+function handlerOf(route) {
+  const start = SERVER.indexOf(`api.get("${route}"`);
+  assert.notEqual(start, -1, `admin/server.js must serve GET ${route}`);
+  const end = SERVER.indexOf('\napi.', start + 1);
+  const body = SERVER.slice(start, end === -1 ? start + 4000 : end);
+  return body.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+}
+
+test('the billing status of a paying customer claims no stub and no free ride', () => {
+  const body = handlerOf('/user/billing/status');
+  assert.doesNotMatch(body, /stub_notice/,
+    'the stub notice predates Mollie and is false for every customer who has paid');
+  assert.doesNotMatch(body, /No real charges apply|integration pending/i,
+    'no wording of "nothing was charged" may reach a customer who was charged');
+});
+
+test('the status reports the end of the term that was actually bought', () => {
+  const body = handlerOf('/user/billing/status');
+  assert.match(body, /access_until:/,
+    'the response must carry the day access stops');
+  assert.match(body, /paid_until_parasign/,
+    'access_until must be derived from the relay period, not from an unwritten Redis record');
+  assert.match(body, /paid_until_parasend/,
+    'both products carry a term, and the later one is the one access runs to');
+  assert.match(body, /auto_renews:\s*false/,
+    'every checkout is a one-off for its term, so the response must not imply a renewal');
+});
+
+test('nothing reads a renewal date out of a record no code writes', () => {
+  // The key may still be READ for compatibility, but it may never be the only
+  // source of the date shown, which is what made the row invisible.
+  const writes = SERVER.match(/redis\(\)\.set\(`paramant:user:billing:/g) || [];
+  const reads = SERVER.match(/paramant:user:billing:/g) || [];
+  if (reads.length > 0) {
+    assert.equal(writes.length, 0,
+      'paramant:user:billing: is read but never written; if that changes, this test should too');
+  }
+  const body = handlerOf('/user/billing/status');
+  const accessLine = /access_until:\s*accessUntil/.test(body);
+  assert.ok(accessLine, 'access_until must come from the computed term end');
+});
+
+test('the account page renders the term end and does not offer to cancel a one-off', () => {
+  const js = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'frontend', 'js', 'account.inline1.js'), 'utf8');
+  assert.match(js, /d\.access_until/,
+    'the account page must read the term end the API now sends');
+  assert.match(js, /if \(d\.auto_renews\) document\.getElementById\('billing-cancel-btn'\)/,
+    'Cancel stops a next collection; with none scheduled there is nothing to cancel');
+
+  const html = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'frontend', 'account.html'), 'utf8');
+  assert.match(html, /Access until/, 'the row must name what the date is');
+  assert.doesNotMatch(html, /Next billing date/,
+    'nothing bills again by itself, so no row may promise a next billing date');
+  assert.doesNotMatch(html, /renewal date and invoices are below/,
+    'neither a renewal date nor an invoice is produced today');
+});

--- a/admin/test/billing-status-truth.test.js
+++ b/admin/test/billing-status-truth.test.js
@@ -38,6 +38,13 @@ const SERVER = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
 
 // The handler with its comments stripped. A comment is allowed to name the
 // sentence that was removed and why; only the code may be asserted on.
+function handlerOf2(route) {
+  const start = SERVER.indexOf(`api.post("${route}"`);
+  assert.notEqual(start, -1, `admin/server.js must serve POST ${route}`);
+  const end = SERVER.indexOf('\napi.', start + 1);
+  return SERVER.slice(start, end === -1 ? start + 4000 : end);
+}
+
 function handlerOf(route) {
   const start = SERVER.indexOf(`api.get("${route}"`);
   assert.notEqual(start, -1, `admin/server.js must serve GET ${route}`);
@@ -58,12 +65,21 @@ test('the status reports the end of the term that was actually bought', () => {
   const body = handlerOf('/user/billing/status');
   assert.match(body, /access_until:/,
     'the response must carry the day access stops');
-  assert.match(body, /paid_until_parasign/,
+  assert.match(body, /access_until:\s*accessUntil/,
+    'and it must be the computed term end, not a value from elsewhere');
+  assert.match(body, /termEndOf\(/,
     'access_until must be derived from the relay period, not from an unwritten Redis record');
-  assert.match(body, /paid_until_parasend/,
-    'both products carry a term, and the later one is the one access runs to');
   assert.match(body, /auto_renews:\s*false/,
     'every checkout is a one-off for its term, so the response must not imply a renewal');
+
+  // The derivation itself: both products carry a term, only a term still in the
+  // future counts, and the later of the two is the one access runs to.
+  const helper = /function termEndOf\(fields\) \{[\s\S]*?\n\}/.exec(SERVER);
+  assert.ok(helper, 'admin/server.js must define termEndOf()');
+  assert.match(helper[0], /paid_until_parasign/, 'the ParaSign term must count');
+  assert.match(helper[0], /paid_until_parasend/, 'the ParaSend term must count');
+  assert.match(helper[0], /Math\.max/, 'the later of the two terms is the one access runs to');
+  assert.match(helper[0], /> Date\.now\(\)/, 'a term that has already passed grants nothing');
 });
 
 test('nothing reads a renewal date out of a record no code writes', () => {
@@ -80,13 +96,25 @@ test('nothing reads a renewal date out of a record no code writes', () => {
   assert.ok(accessLine, 'access_until must come from the computed term end');
 });
 
-test('the account page renders the term end and does not offer to cancel a one-off', () => {
+test('cancel schedules on the term that was bought, not on a made-up month', () => {
+  const body = handlerOf2('/user/billing/cancel');
+  assert.match(body, /termEndOf\(productPlanFields\(/,
+    'the downgrade date must come from the term the customer actually paid for');
+  const fallback = body.indexOf('30 * 86_400_000');
+  const real = body.indexOf('termEndOf(');
+  assert.ok(real !== -1 && (fallback === -1 || real < fallback),
+    'now plus 30 days may only ever be a last resort, never the first answer');
+  // Both surfaces must answer with one derivation, or the page shows one date
+  // and the cancel mail promises another.
+  assert.match(handlerOf('/user/billing/status'), /termEndOf\(/,
+    'status and cancel must share the same term-end helper');
+});
+
+test('the account page renders the term end', () => {
   const js = fs.readFileSync(
     path.join(__dirname, '..', '..', 'frontend', 'js', 'account.inline1.js'), 'utf8');
   assert.match(js, /d\.access_until/,
     'the account page must read the term end the API now sends');
-  assert.match(js, /if \(d\.auto_renews\) document\.getElementById\('billing-cancel-btn'\)/,
-    'Cancel stops a next collection; with none scheduled there is nothing to cancel');
 
   const html = fs.readFileSync(
     path.join(__dirname, '..', '..', 'frontend', 'account.html'), 'utf8');

--- a/admin/test/user-plan-fields.test.js
+++ b/admin/test/user-plan-fields.test.js
@@ -57,7 +57,22 @@ test('the three endpoints a signed-in page reads all spread the same helper', ()
     const body = SERVER.slice(start, start + 3000);
     const json = body.indexOf('res.json({');
     assert.notEqual(json, -1, `GET ${route} must answer with res.json({...})`);
-    assert.match(body.slice(json, json + 1200), /\.\.\.productPlanFields\(/,
+    const payload = body.slice(json, json + 1200);
+    // The helper may be spread straight into the body, or bound to a const
+    // first when the handler also needs the values for something else (
+    // /user/billing/status derives access_until from paid_until_*). Both are
+    // the same guarantee, so both are accepted, but a spread through a const
+    // only counts when that const really is the helper's result: a name that
+    // holds something else would drop fields just as quietly as a missing
+    // spread, which is the whole failure this test exists to catch.
+    let spread = /\.\.\.productPlanFields\(/.test(payload);
+    if (!spread) {
+      for (const m of payload.matchAll(/\.\.\.([A-Za-z_$][\w$]*)\b/g)) {
+        const bound = new RegExp(`(?:const|let|var)\\s+${m[1]}\\s*=\\s*productPlanFields\\(`);
+        if (bound.test(body.slice(0, json))) { spread = true; break; }
+      }
+    }
+    assert.ok(spread,
       `GET ${route} must spread productPlanFields(), or the dashboard and the account page read different truths`);
   }
 });

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -356,8 +356,8 @@ main.acct input::placeholder { color: var(--ink-3); }
     <!-- Shown on a paid plan. No link to a higher tier: a customer who pays is
          reading his own subscription, not an offer. -->
     <div class="acct-plan-band paid" id="billing-paid" hidden>
-      <p class="acct-plan-kicker">Your subscription &middot; active</p>
-      <p class="acct-plan-lede">Thank you. Your subscription is what keeps the Community plan free for everyone else. Your plan, renewal date and invoices are below.</p>
+      <p class="acct-plan-kicker">Your plan &middot; active</p>
+      <p class="acct-plan-lede">Thank you. What you pay is what keeps the Community plan free for everyone else. Your plan and the day the term you bought runs out are below.</p>
     </div>
     <div class="info-row">
       <div class="info-label">Current plan</div>
@@ -366,10 +366,14 @@ main.acct input::placeholder { color: var(--ink-3); }
         <span id="billing-active-badge" class="plan-tier-active hidden">Active</span>
       </div>
     </div>
+    <!-- Each checkout buys one term and nothing is collected again by itself
+         (see /terms), so what a customer needs is the day access stops, not a
+         collection date. The renewal note under it says so in words. -->
     <div class="info-row" id="billing-next-row" style="display:none">
-      <div class="info-label">Next billing date</div>
+      <div class="info-label">Access until</div>
       <div class="info-value" id="billing-next">&mdash;</div>
     </div>
+    <p id="billing-renew-note" class="acct-note" hidden style="font-size:var(--text-sm);color:var(--ink-dim);margin-top:var(--space-2)">This is a one-off payment for the term you bought. Nothing is collected again by itself. Buy another term before this date to keep the plan running.</p>
     <div class="info-row" id="billing-cancel-row" style="display:none">
       <div class="info-label">Cancellation</div>
       <div class="info-value" id="billing-cancel-date" style="color:#d97706">&mdash;</div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -474,13 +474,25 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
       <a class="dh-community-cta" href="/pricing">See the business plans &rarr;</a>
     </aside>
 
+    <!-- Where Mollie sends the buyer back to (/dashboard?billing=return). The
+         entitlement is granted by the webhook, never by this redirect, so the
+         two can arrive in either order: this band says which of the two the
+         page is looking at instead of leaving a paying customer on a dashboard
+         that still reads Community and says nothing about the money. Shown by
+         dashboard.js only when the query parameter is there. No link to
+         /pricing: the sale already happened. -->
+    <aside class="dh-paid" id="dh-billing-return" aria-label="Payment" role="status" hidden>
+      <p class="dh-paid-kicker" data-dh="return-kicker">--</p>
+      <p class="dh-paid-lede" data-dh="return-lede">--</p>
+    </aside>
+
     <!-- What a paying customer bought, in the words /pricing sells it in. Shown
          by dashboard.js only on Pro, Business or Enterprise, and it carries no
          link to a higher tier: someone who already pays is not a lead. -->
     <aside class="dh-paid" id="dh-plan-paid" aria-label="Your plan" hidden>
       <p class="dh-paid-kicker"><span data-dh="paid-name">--</span> plan &middot; active</p>
       <p class="dh-paid-lede" data-dh="paid-includes">--</p>
-      <p class="dh-paid-foot">Your subscription and invoices are under <a href="/account#billing-section">Plan &amp; billing</a>.</p>
+      <p class="dh-paid-foot">Your plan and the day your term ends are under <a href="/account#billing-section">Plan &amp; billing</a>.</p>
     </aside>
 
     <!-- One-time question: shown by dashboard.js only while /api/user/me returns

--- a/frontend/js/account.inline1.js
+++ b/frontend/js/account.inline1.js
@@ -253,11 +253,12 @@
       const free = isFreeAccount(d, d.current_plan);
       if (!free) {
         document.getElementById('billing-active-badge').classList.remove('hidden');
-        // Cancel stops a NEXT collection. With auto_renews false there is no
-        // next collection to stop, and offering the button anyway scheduled a
-        // downgrade on a date nobody had bought, so the term end below is the
-        // whole answer. The button returns the day recurring billing is on.
-        if (d.auto_renews) document.getElementById('billing-cancel-btn').classList.remove('hidden');
+        // A customer who pays gets a way to stop paying. What was wrong here was
+        // never the button but the date behind it: cancel used to schedule the
+        // downgrade at now plus 30 days, so someone who had bought a YEAR was
+        // told his plan ended next month. It now schedules on the term he
+        // actually paid for, the same date shown below.
+        document.getElementById('billing-cancel-btn').classList.remove('hidden');
       }
       // One calm line about what this plan is. On Community it says whose gift
       // it is and what the paid plans add, with a single way up. On a paid plan

--- a/frontend/js/account.inline1.js
+++ b/frontend/js/account.inline1.js
@@ -253,7 +253,11 @@
       const free = isFreeAccount(d, d.current_plan);
       if (!free) {
         document.getElementById('billing-active-badge').classList.remove('hidden');
-        document.getElementById('billing-cancel-btn').classList.remove('hidden');
+        // Cancel stops a NEXT collection. With auto_renews false there is no
+        // next collection to stop, and offering the button anyway scheduled a
+        // downgrade on a date nobody had bought, so the term end below is the
+        // whole answer. The button returns the day recurring billing is on.
+        if (d.auto_renews) document.getElementById('billing-cancel-btn').classList.remove('hidden');
       }
       // One calm line about what this plan is. On Community it says whose gift
       // it is and what the paid plans add, with a single way up. On a paid plan
@@ -262,9 +266,15 @@
       if (band) band.hidden = !free;
       const bought = document.getElementById('billing-paid');
       if (bought) bought.hidden = free;
-      if (d.next_billing_date) {
+      // access_until is the end of the term that was paid for and is the honest
+      // date on a one-off; next_billing_date only means something once
+      // something actually collects again.
+      const until = d.access_until || d.next_billing_date;
+      if (until) {
         document.getElementById('billing-next-row').style.display = 'flex';
-        document.getElementById('billing-next').textContent = new Date(d.next_billing_date).toLocaleDateString();
+        document.getElementById('billing-next').textContent = new Date(until).toLocaleDateString();
+        const note = document.getElementById('billing-renew-note');
+        if (note) note.hidden = !!d.auto_renews;
       }
       if (d.cancellation_scheduled_at) {
         document.getElementById('billing-cancel-row').style.display = 'flex';

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -124,6 +124,57 @@
     }
   };
 
+  // ── Return from the payment provider ────────────────────────────────────────
+  // Mollie redirects the buyer to /dashboard?billing=return the moment he is
+  // done paying, and calls the webhook separately. The webhook is what grants
+  // the plan, so the redirect can easily win the race and land on a dashboard
+  // that still says Community. Saying nothing at all was the worst of the
+  // options: the buyer had just been charged and got no acknowledgement of it
+  // anywhere on the site. So the band says which state we are in, and re-asks a
+  // few times while the grant is still on its way.
+  var lastAccountIsPaid = false;
+  var RETURN_TRIES = 5;
+  var RETURN_DELAY_MS = 2000;
+
+  function isBillingReturn() {
+    try { return new URLSearchParams(window.location.search).get('billing') === 'return'; }
+    catch (e) { return false; }
+  }
+
+  // Take the parameter out of the address bar once it has been acted on, so a
+  // reload or a shared link does not re-announce a payment.
+  function clearBillingParam() {
+    try {
+      if (!window.history || !window.history.replaceState) return;
+      var url = new URL(window.location.href);
+      url.searchParams.delete('billing');
+      window.history.replaceState({}, '', url.pathname + (url.search || '') + (url.hash || ''));
+    } catch (e) { /* address bar is cosmetic; never break the page over it */ }
+  }
+
+  function showBillingReturn(tries) {
+    var band = document.querySelector('#dh-billing-return');
+    if (!band) return;
+    var kicker = band.querySelector('[data-dh="return-kicker"]');
+    var lede = band.querySelector('[data-dh="return-lede"]');
+    band.hidden = false;
+    if (lastAccountIsPaid) {
+      if (kicker) kicker.textContent = 'Payment received';
+      if (lede) lede.textContent = 'Thank you. Your plan is active and what it includes is below. The term you bought and the day it ends are under Plan and billing.';
+      clearBillingParam();
+      return;
+    }
+    if (tries > 0) {
+      if (kicker) kicker.textContent = 'Confirming your payment';
+      if (lede) lede.textContent = 'Your bank has sent you back. We are waiting for the payment to be confirmed, which usually takes a few seconds. This page updates by itself.';
+      window.setTimeout(function () { refreshAccount(tries - 1); }, RETURN_DELAY_MS);
+      return;
+    }
+    if (kicker) kicker.textContent = 'Payment not confirmed yet';
+    if (lede) lede.textContent = 'Your payment has not reached us yet. Nothing is lost: as soon as it is confirmed the plan is granted by itself. Reload this page in a minute, and mail privacy@paramant.app if it still has not appeared.';
+    clearBillingParam();
+  }
+
   function render(data) {
     var email = data.email || '';
     var planId = normalisePlan(data.plan);
@@ -152,6 +203,10 @@
     // pays for it. A paying customer never sees the band.
     var community = root.querySelector('#dh-community');
     if (community) community.hidden = !isFree;
+
+    // Remembered for the return-from-Mollie band below, which has to know
+    // whether the webhook has landed yet.
+    lastAccountIsPaid = !isFree;
 
     // The other half of the same rule: a paying account reads what it bought.
     // Per product, so a ParaSend customer is not told about signatures he has
@@ -604,7 +659,7 @@
     if (!opsPollTimer) opsPollTimer = setInterval(pull, 5000);
   }
 
-  function start() {
+  function start(tries) {
     wireActions();
     wireDocumentFilters();
     wireDocumentList();
@@ -633,12 +688,17 @@
       })
       .then(function (data) {
         if (data) render(data);
+        // Only after render, so lastAccountIsPaid reflects this answer.
+        if (isBillingReturn()) showBillingReturn(typeof tries === 'number' ? tries : RETURN_TRIES);
       })
       .catch(function () {
         if (timer) clearTimeout(timer);
         showError('Network error');
       });
   }
+
+  // Re-ask /api/user/me while a just-made payment is still being confirmed.
+  function refreshAccount(tries) { start(tries); }
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', start);

--- a/relay/lib/billing.js
+++ b/relay/lib/billing.js
@@ -70,11 +70,21 @@ async function processPayment(payment, deps) {
     return { result: 'refused', level: 'error', account: accountId, product, reason: `unknown_plan:${order.error}` };
   }
 
-  // Rule 3: idempotency. If we already recorded a terminal outcome, no-op.
+  // Rule 3: idempotency. A payment id we already settled changes nothing when it
+  // arrives again SAYING THE SAME THING. It is not "this id is finished
+  // forever": a refund or a chargeback reaches us on the very same tr_ id as the
+  // payment it reverses, so a flat id check swallowed the revoke and left an
+  // account that had taken its money back sitting on the paid tier. What the
+  // marker records is the outcome, and only a repeat of that outcome is a no-op.
+  const revoking = status === 'chargeback' || status === 'charged_back';
+  const wanted = revoking ? 'revoked' : 'granted';
   if (typeof d.isProcessed === 'function') {
     let done = false;
     try { done = await d.isProcessed(payment.id); } catch { done = false; }
-    if (done) return { result: 'ignored', level: 'info', account: accountId, product, reason: 'already_processed' };
+    // A truthy non-string (an older marker, or a boolean-shaped dep) is read as
+    // 'granted', which is what every marker written before this meant.
+    const seen = typeof done === 'string' ? done : (done ? 'granted' : null);
+    if (seen === wanted) return { result: 'ignored', level: 'info', account: accountId, product, reason: 'already_processed' };
   }
 
   if (status === 'paid') {

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -5597,6 +5597,15 @@ async function handleRelayRequest(req, res) {
       // (mirrors getEntitlements' fallback) so an operator never sees a blank.
       plan_parasign: v.plan_parasign || entitlements.derivePlanParasign(v.plan, v.parasign),
       plan_parasend: v.plan_parasend || entitlements.derivePlanParasend(v.plan),
+      // The period the tier was paid for. WITHOUT this the tier above is the
+      // whole story a reader gets, and "no period" is read everywhere as "never
+      // expires" (entitlements.effectiveProductTier, and the same rule mirrored
+      // client-side in dashboard.js/account.inline1.js). Every account surface
+      // in admin/ is built on this projection, so leaving it out made a lapsed
+      // account render as "Pro, active" long after the relay's own gates had
+      // floored it to free. The date is on the record; it just never left.
+      paid_until_parasign: v[entitlements.PRODUCT_PAID_UNTIL_FIELD.parasign] || null,
+      paid_until_parasend: v[entitlements.PRODUCT_PAID_UNTIL_FIELD.parasend] || null,
       usage_purpose: v.usage_purpose || null, usage_purpose_at: v.usage_purpose_at || null /*MARK:parasign_list*/
     }));
     const licenseInfo = { edition: EDITION, active_keys: keys.length, key_limit: LICENSE_MAX_KEYS === Infinity ? null : LICENSE_MAX_KEYS, ...(LICENSE_PAYLOAD ? { license_expires: LICENSE_PAYLOAD.expires_at } : {}) };
@@ -5623,6 +5632,8 @@ async function handleRelayRequest(req, res) {
       active: v.active, is_primary: !!v.is_primary, scope: v.scope || 'full', parasign: !!v.parasign, created: v.created || null,
       plan_parasign: v.plan_parasign || entitlements.derivePlanParasign(v.plan, v.parasign),
       plan_parasend: v.plan_parasend || entitlements.derivePlanParasend(v.plan),
+      paid_until_parasign: v[entitlements.PRODUCT_PAID_UNTIL_FIELD.parasign] || null,
+      paid_until_parasend: v[entitlements.PRODUCT_PAID_UNTIL_FIELD.parasend] || null,
       usage_purpose: v.usage_purpose || null, usage_purpose_at: v.usage_purpose_at || null }));/*MARK:parasign_reveal*/
   }
 
@@ -5851,6 +5862,10 @@ async function handleRelayRequest(req, res) {
     }
     const _rok = () => !!(redisClient && redisClient.isReady);
     const _idemKey = (id) => `paramant:billing:done:${id}`;
+    // The payment id that bought the period currently on file, per product.
+    // Stored on the account record (and so in users.json) alongside the Mollie
+    // pointers, which is what makes the idempotency guard durable.
+    const _paidByField = (product) => `paid_by_${product}`;
     const outcome = await billing.processPayment(payment, {
       setProductPlan,
       // Lets a renewal extend from where the paid period ends instead of from
@@ -5859,8 +5874,32 @@ async function handleRelayRequest(req, res) {
         const rec = accounts.get(accountId);
         return (rec && rec[entitlements.PRODUCT_PAID_UNTIL_FIELD[product]]) || null;
       },
-      isProcessed: async (id) => { if (!_rok()) return false; try { return !!(await redisClient.get(_idemKey(id))); } catch { return false; } },
-      markProcessed: async (id, val) => { if (!_rok()) return; try { await redisClient.set(_idemKey(id), String(val), { EX: 60 * 86400 }); } catch { /* best effort */ } },
+      // Redis holds the marker, but redis is a cache here and users.json is the
+      // record. When redis is down or has been flushed, isProcessed used to
+      // answer 'no' and the grant ran a second time -- and since a grant extends
+      // from the paid_until already on file, one payment bought two months. So
+      // the account record carries the payment id that bought its current
+      // period, and that answer survives anything redis does.
+      isProcessed: async (id) => {
+        if (_rok()) {
+          try { const v = await redisClient.get(_idemKey(id)); if (v) return v; } catch { /* fall through to disk */ }
+        }
+        const rec = _billingRecordOf((payment.metadata || {}).accountId);
+        if (!rec) return false;
+        for (const p of entitlements.PRODUCTS) if (rec[_paidByField(p)] === id) return 'granted';
+        return false;
+      },
+      markProcessed: async (id, val) => {
+        const md = payment.metadata || {};
+        // Persist first: this is the half that has to outlive a restart.
+        if (md.accountId && entitlements.PRODUCTS.includes(md.product)) {
+          // A revoke takes the money back, so the id that bought the period goes
+          // with it; leaving it would make the reversal look like a live grant.
+          _setMolliePointer(md.accountId, _paidByField(md.product), val === 'granted' ? id : null);
+        }
+        if (!_rok()) return;
+        try { await redisClient.set(_idemKey(id), String(val), { EX: 60 * 86400 }); } catch { /* best effort */ }
+      },
     });
     // The collecting half. A grant only says what this payment bought; without
     // a subscription nothing asks for the next period. Deliberately AFTER the

--- a/relay/test/billing.test.js
+++ b/relay/test/billing.test.js
@@ -179,6 +179,62 @@ async function main() {
     ok('Mollie 5xx and timeout -> retryable, warn level');
   }
 
+  // ── a reversal arrives on the id of the payment it reverses ────────────────
+  // The marker is per payment id, and Mollie sends a chargeback under the SAME
+  // tr_ id as the payment. A guard that only asked "have I seen this id" let the
+  // account keep the tier after the money had gone back.
+  {
+    const set = spySetter();
+    const marker = { 'tr_CB': 'granted' };
+    const deps = {
+      setProductPlan: set,
+      isProcessed: async (id) => marker[id] || false,
+      markProcessed: async (id, val) => { marker[id] = val; },
+    };
+    const paid = await billing.processPayment(payment({ _id: 'CB', id: 'tr_CB' }), deps);
+    assert.strictEqual(paid.result, 'ignored', 'a repeat of the SAME outcome stays a no-op');
+    assert.strictEqual(paid.reason, 'already_processed');
+    assert.strictEqual(set.calls.length, 0, 'a duplicate paid webhook must not touch the entitlement');
+
+    const back = await billing.processPayment(payment({ _id: 'CB', id: 'tr_CB', status: 'chargeback' }), deps);
+    assert.strictEqual(back.result, 'revoked', 'money taken back must revoke even though the id was seen');
+    assert.strictEqual(back.tier, 'free', 'parasign floors to free');
+    assert.strictEqual(set.calls.length, 1);
+    assert.strictEqual(set.calls[0].tier, 'free');
+    assert.strictEqual(marker['tr_CB'], 'revoked', 'the marker records the new outcome');
+
+    const again = await billing.processPayment(payment({ _id: 'CB', id: 'tr_CB', status: 'chargeback' }), deps);
+    assert.strictEqual(again.result, 'ignored', 'a repeated chargeback is a no-op');
+    assert.strictEqual(set.calls.length, 1, 'and does not revoke twice');
+    ok('chargeback on an already-granted payment id revokes, and only repeats are ignored');
+  }
+  // A boolean-shaped marker is what every deployment wrote before the outcome
+  // was recorded, so it has to keep meaning 'granted'.
+  {
+    const set = spySetter();
+    const r = await billing.processPayment(payment({ _id: 'LEG', id: 'tr_LEG' }), {
+      setProductPlan: set, isProcessed: async () => true,
+    });
+    assert.strictEqual(r.result, 'ignored', 'a legacy boolean marker still blocks a duplicate grant');
+    assert.strictEqual(set.calls.length, 0);
+    ok('a legacy boolean idempotency marker is read as granted');
+  }
+  // A duplicate grant must not buy a second period. The guard is what stops it:
+  // extendFrom starts from the paid_until already on file, so a grant that runs
+  // twice adds a month twice off one payment.
+  {
+    const set = spySetter();
+    const until = new Date(Date.now() + 30 * 86_400_000).toISOString();
+    const r = await billing.processPayment(payment({ _id: 'DUP', id: 'tr_DUP' }), {
+      setProductPlan: set,
+      currentPaidUntil: async () => until,
+      isProcessed: async () => 'granted',
+    });
+    assert.strictEqual(r.result, 'ignored');
+    assert.strictEqual(set.calls.length, 0, 'one payment, one period');
+    ok('a duplicate paid webhook cannot extend the paid period');
+  }
+
   console.log(`\nPASS billing: ${passed} checks`);
 }
 

--- a/relay/test/koop-pad-intentie.test.mjs
+++ b/relay/test/koop-pad-intentie.test.mjs
@@ -91,4 +91,63 @@ test('storage failures cannot break the page in private mode', () => {
   assert.ok(remember.includes('catch'), 'rememberIntent does not tolerate a blocked sessionStorage');
 });
 
+// ── the other end of the path: coming back from Mollie ──────────────────────
+// The purchase path did not end at the payment. Mollie sends the buyer to
+// /dashboard?billing=return (relay.js, the checkout redirectUrl) and grants the
+// plan through a SEPARATE webhook call, so the redirect regularly wins the race
+// and the buyer arrives before the entitlement does. Nothing on the dashboard
+// read that parameter: the money had left the account and the site said nothing
+// at all about it, on any page. docs.html has described this return URL the
+// whole time, so the contract existed; only the arrival did not.
+
+const dashJs = readFileSync(new URL('../../frontend/js/dashboard.js', import.meta.url), 'utf8');
+const dashHtml = readFileSync(new URL('../../frontend/dashboard.html', import.meta.url), 'utf8');
+
+// The real predicate, lifted and run, so the parameter the relay actually sends
+// is the parameter the page actually looks for.
+function loadIsBillingReturn() {
+  const m = dashJs.match(/function isBillingReturn\(\)\s*\{[\s\S]*?\n  \}/);
+  assert.ok(m, 'isBillingReturn not found in dashboard.js');
+  const fn = new Function('window', 'URLSearchParams', `${m[0]}; return isBillingReturn;`);
+  return (search) => fn({ location: { search } }, URLSearchParams)();
+}
+const isBillingReturn = loadIsBillingReturn();
+
+test('the dashboard recognises the return the checkout actually redirects to', () => {
+  assert.strictEqual(isBillingReturn('?billing=return'), true);
+  assert.strictEqual(isBillingReturn('?foo=1&billing=return'), true, 'other parameters may ride along');
+  assert.strictEqual(isBillingReturn(''), false, 'an ordinary visit announces nothing');
+  assert.strictEqual(isBillingReturn('?billing=cancelled'), false, 'only the return value counts');
+});
+
+test('the return band exists and is hidden until the page shows it', () => {
+  assert.ok(dashHtml.includes('id="dh-billing-return"'), 'there is no band to show');
+  const band = dashHtml.slice(dashHtml.indexOf('id="dh-billing-return"'), dashHtml.indexOf('id="dh-plan-paid"'));
+  assert.ok(/\bhidden\b/.test(band), 'the band must not appear on an ordinary dashboard visit');
+  assert.ok(band.includes('role="status"'), 'a state that changes by itself has to be announced');
+  // Same rule the paid band is held to: the sale already happened, so this is
+  // not a place to sell.
+  assert.ok(!band.includes('href="/pricing"'), 'a buyer who has just paid must not be sold to');
+});
+
+test('a grant that has not landed yet is waited for, not denied', () => {
+  const fn = dashJs.slice(dashJs.indexOf('function showBillingReturn'), dashJs.indexOf('function render(data)'));
+  assert.ok(fn.includes('lastAccountIsPaid'), 'the band does not look at whether the plan is actually active');
+  assert.ok(/setTimeout\([\s\S]*?refreshAccount\(tries - 1\)/.test(fn),
+    'the webhook can arrive after the redirect, so the page must ask again');
+  assert.ok(fn.includes('clearBillingParam()'),
+    'a settled state must take the parameter out of the address bar or a reload re-announces the payment');
+  // The last word must never be "your money is gone".
+  assert.ok(/Nothing is lost/.test(fn), 'the timeout case must tell the buyer where he stands');
+});
+
+test('the parameter is only cleared once there is something to say', () => {
+  const fn = dashJs.slice(dashJs.indexOf('function showBillingReturn'), dashJs.indexOf('function render(data)'));
+  const waiting = fn.indexOf('tries > 0');
+  const clears = [...fn.matchAll(/clearBillingParam\(\)/g)].map((m) => m.index);
+  assert.strictEqual(clears.length, 2, 'exactly the two settled states clear the parameter');
+  assert.ok(clears.some((i) => i < waiting), 'the confirmed state clears it');
+  assert.ok(clears.some((i) => i > waiting), 'the gave-up state clears it');
+});
+
 console.log(`\n${passed} passed`);

--- a/relay/test/route-billing-entitlements.test.js
+++ b/relay/test/route-billing-entitlements.test.js
@@ -518,3 +518,60 @@ test('the users.json write is atomic: no temp file is left behind and the file a
   srv.stop();
   did();
 });
+
+// ── the period has to LEAVE the relay, not just live on the record ───────────
+// Every account surface in admin/ is built on one relay read: findUserByEmail,
+// findUserById and /api/user/billing/status all call GET /v2/admin/keys and
+// project the row through productPlanFields(), which reads paid_until_*. That
+// projection emitted plan_parasign and plan_parasend and dropped the two dates,
+// so admin/ always saw null. Both readers treat a missing period as "no period
+// recorded", which is the same rule the server uses and means "never expires"
+// (entitlements.effectiveProductTier, mirrored client-side in
+// frontend/js/dashboard.js paidProductTier). The result was a straight
+// contradiction: the relay's own gates floored a lapsed account to free and
+// answered 402 at two signatures, while the dashboard and the account page kept
+// rendering "Pro plan, active" off the same relay. The tier without its period
+// is not a smaller answer, it is a wrong one.
+test('the admin key projection carries the paid period, not just the tier', async () => {
+  const srv = await withUsers('paid-until-projected', [{
+    key: 'pgp_live', plan: 'community', active: true, parasign: true,
+    account_id: 'acct_live', email: 'live@example.test',
+    plan_parasign: 'pro', paid_until_parasign: FUTURE,
+  }, {
+    key: 'pgp_lapsed2', plan: 'community', active: true, parasign: true,
+    account_id: 'acct_lapsed2', email: 'lapsed2@example.test',
+    plan_parasign: 'pro', paid_until_parasign: PAST,
+  }]);
+
+  for (const url of ['/v2/admin/keys', '/v2/admin/keys?reveal=1']) {
+    const r = await srv.get(url, { headers: BOTH });
+    assert.strictEqual(r.status, 200, r.text);
+    const live = r.json.keys.find((k) => k.account_id === 'acct_live');
+    const lapsed = r.json.keys.find((k) => k.account_id === 'acct_lapsed2');
+    assert.strictEqual(live.plan_parasign, 'pro', url);
+    assert.strictEqual(live.paid_until_parasign, FUTURE,
+      `${url} must carry the period the tier was paid for`);
+    assert.strictEqual(lapsed.paid_until_parasign, PAST,
+      `${url} must carry a lapsed period too, or the reader calls it unbounded`);
+    // An account that never bought anything reports no period, which is the
+    // honest answer and the one every reader is built for. It must be present
+    // as an explicit null rather than simply absent.
+    assert.strictEqual(live.paid_until_parasend, null,
+      'no ParaSend purchase means no ParaSend period, stated explicitly');
+    assert.ok('paid_until_parasend' in live, `${url} must always state the field`);
+  }
+
+  // The point of the projection: what admin/ reads must agree with what the
+  // relay's own gates decided, for the lapsed account as well as the live one.
+  const gate = await entitlementsOf(srv, 'acct_lapsed2');
+  assert.strictEqual(gate.json.entitlements.parasign.tier, 'free',
+    'the gate floors the lapsed account, so the projection must let a reader reach the same answer');
+
+  const single = await srv.get('/v2/admin/keys/reveal/acct_live', { headers: BOTH });
+  assert.strictEqual(single.status, 200, single.text);
+  assert.strictEqual(single.json.paid_until_parasign, FUTURE,
+    'the single-key reveal is the same row and must say the same thing');
+
+  srv.stop();
+  did();
+});


### PR DESCRIPTION
Directievraag: kan een advocatenkantoor vandaag echt betalen voor ParaSign Pro, ParaSign Business of ParaSend Pro, en gaat het account daarna open?

Antwoord: ja, hij kan betalen en het account gaat open. Het geld en de rechten kloppen. Wat er omheen zit klopte op vijf punten niet, en dit is die vijf.

Gelopen tegen een gestubde Mollie met de stance van productie (`BILLING_MODE` leeg, dus eenmalige betalingen, geen mandaat, geen abonnement). De HTTPS-laag naar `api.mollie.com` is onderschept, zodat `relay/lib/mollie.js` zelf onveranderd draaide en de payload de echte is. Nooit een echte key.

## Wat al goed was

| Stap | Uitkomst |
|---|---|
| Checkout aanmaken | 59.29 EUR incl. btw, bedrag uit de catalogus, nooit uit de body |
| Metadata | `accountId`, `product`, `plan`, `interval`, geen e-mail |
| Webhook, status paid | herhaalt de fetch bij Mollie, hertoetst het bedrag, kent toe |
| Entitlement | `plan_parasign=pro`, `paid_until_parasign` een kalendermaand vooruit |
| Limieten | `signs_month` 100 op pro, 2 na afloop |
| Na `paid_until` | valt terug naar de bodemtier op elke gate, zonder cron |
| Bedragen | 59.29 / 361.79 / 18.15 zijn exact 49 / 299 / 15 plus 21 procent |

De prijspagina liegt niet over btw. Elke betaalde kaart zegt `excl. btw`, noemt het incl.-bedrag, en de knop zelf draagt het bedrag dat wordt afgeschreven. Dat was de verwachte fout en die zit er niet.

## Wat niet klopte

**1. `paid_until_*` verliet de relay nooit.** `GET /v2/admin/keys` gaf `plan_parasign` en `plan_parasend` en liet beide datums vallen. Elk accountscherm in `admin/` hangt aan die ene read. Server en client lezen allebei een ontbrekende periode als "geen periode vastgelegd", en dat betekent nooit verlopen. Gemeten op een afgelopen account: de gates gaven `free` en 402 bij twee handtekeningen, terwijl het dashboard en de accountpagina uit diezelfde relay "Pro plan, active" bleven renderen.

**2. Een chargeback werd ingeslikt.** Mollie stuurt hem onder hetzelfde `tr_`-id als de betaling die hij terugdraait. De idempotentie vroeg alleen of het id al langs was geweest. Dat was zo, dus de revoke gaf `already_processed` en het account hield de tier nadat het geld terug was. De marker legt nu de uitkomst vast; alleen een herhaling van diezelfde uitkomst is een no-op.

**3. Idempotentie zat alleen in redis en faalde open.** Marker weg, webhook opnieuw, en omdat een grant verlengt vanaf de `paid_until` die er al stond kocht een betaling twee maanden. Gemeten: 03-10 werd 03-11. Het accountrecord draagt nu het betaal-id dat de lopende periode kocht, dus de grendel overleeft een flush of een storing.

**4. De API zei tegen betalende klanten dat er niets was afgeschreven.** `/api/user/billing/status` gaf `stub_notice: 'Payment integration pending. No real charges apply.'`. De test die daarop let leest `account.html`, en de zin komt uit de API, dus niemand zag hem. De `next_billing_date` ernaast kwam uit `paramant:user:billing:<id>`, een sleutel die niets in deze repo schrijft: altijd null, dus de regel die de accountpagina belooft verscheen nooit. Er staat nu `access_until` uit de echte termijn, plus `auto_renews:false`.

**4b. Annuleren beloofde een verzonnen datum.** Dezelfde lege sleutel liet `POST /user/billing/cancel` terugvallen op nu plus 30 dagen, dus iemand die een jaar had gekocht kreeg te horen dat zijn plan volgende maand stopte, ook in de mail. De knop blijft (de browsersuite pint dat een betalende klant hem krijgt, en terecht); hij plant nu af op het einde van de termijn die echt is betaald, via dezelfde helper waarmee de statuspagina antwoordt. Nu plus 30 dagen overleeft alleen als laatste redmiddel.

**5. Niemand ontving de koper terug.** Mollie stuurt hem naar `/dashboard?billing=return` en kent toe via een losse webhook-call, dus de redirect wint de race vaak. Geen pagina las die parameter. Het geld was weg en de site zei nergens iets. Het dashboard bevestigt nu, wacht en vraagt opnieuw zolang de grant onderweg is, en eindigt nooit op "je geld is weg".

## Poorten

site-claims 38, ui-truthfulness, pricing-page, pricing-fold 4, relay units 225, relay routes met redis 117, admin, static-sanity, eslint, en de volledige browsersuite (52). Elke fix gecontroleerd door hem terug te draaien en te zien dat de test valt.

`tests/navigation-shell.test.mjs` ("mobile navigation is opaque before opening the menu") valt op de CI-runner met `backdropFilter: "none"`. Dat valt met exact dezelfde waarden ook op `main` (runs 33755350729 en 33755111355) en slaagt hier lokaal. Staat los van deze diff.

`tests/heartbeat-lib.test.mjs` valt lokaal op een ontbrekende `@noble/post-quantum` in de geleende `node_modules`. CI installeert wel en die is groen.

## Wat blijft staan

- **Geen echt abonnement.** De recurring-laag staat er, maar `BILLING_MODE` is leeg, dus na een maand of een jaar valt het account stil terug naar Community. Geen incasso, geen waarschuwing vooraf.
- **Geen factuur.** Nergens een btw-factuur met btw-nummer, en geen bevestigingsmail. Een kantoor dat 603.79 EUR uitgeeft heeft er een nodig, en Moneybird ook.
- **Geen billinggeschiedenis van een zelf gedane aankoop.** De webhook draait op de relay, het audit-log in admin, en er gaat niets tussen die twee heen. "No billing events yet" blijft staan na een geslaagde betaling.
