### PR TITLE
The vault page says what the code does, and locks at the OWASP number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,26 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Enterprise as before.
 
 ### Changed
+- **/vault says what it does, and it no longer says "quantum-resistant".** The
+  page sold AES-256-GCM as quantum-resistant. AES-256 does survive Grover with
+  room to spare, but the claim describes the construction, and this
+  construction hangs on a human-chosen passphrase run through PBKDF2, which is
+  where it would actually break. The word is gone from the page and from the
+  header comment in `frontend/vault.js`. In its place: one sentence in plain
+  language (nothing leaves your browser, so we cannot reset your passphrase and
+  a lost one means a lost file) and one technical line that names every
+  parameter, "AES-256-GCM, key from your passphrase with PBKDF2-SHA-256,
+  600,000 rounds, random 16-byte salt, random 12-byte nonce".
+- **Vault PBKDF2 goes from 210,000 to 600,000 rounds**, the OWASP Password
+  Storage Cheat Sheet figure for PBKDF2-HMAC-SHA256. Files locked before this
+  still open: the count is a `u32` field in the `.prmnt` header and
+  `decryptFile` derives with the count the file carries, never with the current
+  constant. `tests/vault-kdf.test.mjs` forges a container at the old 210,000
+  rounds and makes the real page open it, and pins the number on the page to
+  the number in the code so the two cannot drift.
+- **Locking a file is a third verb in the signed-in navigation.** `/vault` sits
+  next to Send and Sign as "Lock a file". It had no route in from anywhere in
+  the product.
 - **The ParaSend delivery receipt moved out of the response header.**
   `GET /v2/outbound/:hash` used to answer with `X-Paramant-Receipt`, the whole
   signed receipt inline: 18551 bytes for that header and 19560 for the block.

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -115,6 +115,6 @@
     </div>
   </div>
 </footer>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -291,6 +291,6 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -399,7 +399,7 @@ main.acct input::placeholder { color: var(--ink-3); }
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script src="/js/account.inline1.js?v=2"></script>
 
 <script type="module" src="/js/account.inline2.js?v=3"></script>

--- a/frontend/apply-nav.py
+++ b/frontend/apply-nav.py
@@ -92,7 +92,7 @@ LEGAL_STRIP = '''\
 DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=25">'
 NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=20">'
 NAV_JS    = '<script src="/nav.js?v=15" defer></script>'
-NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=7" defer></script>'
+NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=8" defer></script>'
 
 # Pages that don't have <nav class="nav"> yet but should — inject the canonical
 # nav after <body> (or after a skip-link if present). App shells (admin,

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -749,6 +749,6 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -251,6 +251,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -110,7 +110,7 @@
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script src="/js/auth-backup.js?v=2"></script>
 
 <footer class="legal-strip">

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -135,7 +135,7 @@
 
 <script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script src="/js/auth-login.js?v=3"></script>
 <script type="module" src="/js/passkey.js?v=4"></script>
 

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -99,7 +99,7 @@
 
 <script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script src="/js/auth-request-reset.js?v=2"></script>
 <footer class="legal-strip">
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -114,7 +114,7 @@
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script src="/js/auth-reset-confirm.js?v=3"></script>
 <footer class="legal-strip">
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -284,7 +284,7 @@
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script src="/js/auth-setup.js?v=2"></script>
 <script type="module" src="/js/passkey.js?v=4"></script>
 

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -295,6 +295,6 @@ footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;al
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -590,6 +590,6 @@ FLAGS    1 byte    reserved for future features</pre>
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -429,6 +429,6 @@ body { min-height:100vh; }
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -648,7 +648,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script src="/js/dashboard.js?v=9" defer></script>
 </body>
 </html>

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -156,7 +156,7 @@ curl -X POST https://paramant.app/v1/envelopes \
 </div>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script src="/js/developer.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -1041,7 +1041,7 @@ python3 scripts/paramant-admin.py sync</pre>
 
 <script src="/js/docs.inline1.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <footer>
   <div class="container-lg">
     <div class="footer-grid footer-slim">

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -271,7 +271,7 @@ sha256sum -c SHA256SUMS --ignore-missing</pre>
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 
 <footer>
   <div class="container-lg">

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -378,6 +378,6 @@ input:focus{border-color:var(--cobalt)}
 
 <script src="/js/dpa.inline1.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -297,7 +297,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/get.page.js?v=2" defer></script>

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -372,6 +372,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -306,6 +306,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -407,6 +407,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -379,6 +379,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -413,6 +413,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -363,6 +363,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -394,6 +394,6 @@ print(resp.json()["url"])</div>
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -365,6 +365,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -401,6 +401,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -368,6 +368,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -656,7 +656,7 @@ footer a{color:var(--fg)}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script src="/js/home-auth.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/js/nav-auth.js
+++ b/frontend/js/nav-auth.js
@@ -12,10 +12,16 @@
     ['Pricing', '/pricing'],
     ['Docs', '/docs']
   ];
+  // The workspace bar is verbs: what you came here to do, in the order you do
+  // it. Send and Sign were the two; locking a file with a passphrase is the
+  // third, so it sits beside them under the same kind of name. /vault is the
+  // route, "Lock a file" is what it does; the page keeps no product name of its
+  // own because there is not one to give it yet.
   var APP_NAV = [
     ['Documents', '/dashboard'],
     ['Send', '/parashare'],
     ['Sign', '/sign'],
+    ['Lock a file', '/vault'],
     ['Verify', '/verify'],
     ['Settings', '/account']
   ];
@@ -56,7 +62,7 @@
     // Support survives signing in. The tail used to be REMOVED here, on the
     // reasoning that the user menu carries Help from then on. On a phone that
     // left no Help at all: the bar sheds .nav-help below 700px, the drawer is
-    // pinned to the five workspace links, and the menu behind the email
+    // pinned to the workspace links, and the menu behind the email
     // address is not where anyone looks for support. A signed-in customer with
     // a stuck signature had to type the url.
     //

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -322,6 +322,6 @@ all other recipients of the licensed work to be provided by Licensor:
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -269,6 +269,6 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/ontvang.page.js?v=2" defer></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -447,6 +447,6 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -711,7 +711,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
      agree on the number. -->
 <script src="/js/parashare.page.js?v=7" defer></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <footer>
   <div class="container-lg">
     <div class="footer-grid footer-slim">

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -400,6 +400,6 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -205,6 +205,6 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -341,6 +341,6 @@ td{color:var(--cobalt)}
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -626,7 +626,7 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script src="/js/pricing-billing.js?v=1" defer></script>
 </body>
 </html>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -348,6 +348,6 @@ footer a{color:var(--ink);text-decoration:none}
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -171,6 +171,6 @@
 
 <script src="/nav.js?v=15"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -299,6 +299,6 @@ footer a{color:var(--ink);text-decoration:none}
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -515,6 +515,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -195,6 +195,6 @@
   </div>
 </footer>
 
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -906,7 +906,7 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script src="/js/parasign-pdf-ops.js?v=1"></script>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -289,7 +289,7 @@ main#main-content .btn { width: 100%; justify-content: center; }
 
 <script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script src="/js/signup.inline1.js?v=1"></script>
 
 <script src="/js/signup.inline2.js?v=2"></script>

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="/nav.css?v=20">
 <link rel="stylesheet" href="/relay-pulse.css?v=1">
   <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
   <style>
     /* Every colour here is a token from app-2026.css, so this page follows the
        theme instead of staying light inside a dark shell. Section 5 of

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -369,6 +369,6 @@ a:hover{opacity:.8}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -271,6 +271,6 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
 
 <script src="/js/status.inline1.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -340,6 +340,6 @@ a:hover{opacity:.8}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -439,6 +439,6 @@ docker compose build   # build locally instead of pulling the published image</c
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/vault.html
+++ b/frontend/vault.html
@@ -50,6 +50,7 @@
 .vt-status.ok{border-color:var(--lime);background:rgba(178,255,63,.14);color:var(--navy)}
 .vt-status.err{border-color:rgba(200,30,30,.5);background:rgba(255,80,80,.06);color:rgba(170,20,20,1)}
 .vt-note{margin-top:22px;font-size:12px;color:var(--ink-dim);line-height:1.6;text-align:center}
+.vt-tech{margin-top:8px;font-family:var(--mono);font-size:11px;color:var(--ink-dim);line-height:1.6;text-align:center}
 .vt-warn{margin:20px 0;padding:14px 16px;border:1px solid #d4a017;background:#fff4d6;border-radius:10px;color:#5a3f00;font-size:13px}
 </style>
 <script type="application/ld+json" data-paramant-seo="1">
@@ -123,7 +124,7 @@
 <main class="vt-wrap">
   <div class="vt-kicker">Paramant Vault</div>
   <h1 class="vt-title">Lock a file</h1>
-  <p class="vt-lede">Pick a file and a passphrase. Paramant turns it into a locked <code>.prmnt</code> file that only your passphrase can open. Everything happens on this device — the file and the passphrase never leave your browser.</p>
+  <p class="vt-lede">Pick a file and a passphrase. Paramant turns it into a locked <code>.prmnt</code> file that only your passphrase can open. Everything happens on this device; the file and the passphrase never leave your browser.</p>
 
   <div id="vt-unsupported" class="vt-warn" hidden>Your browser does not support the encryption this page needs. Try a recent Chrome, Edge, Safari or Firefox.</div>
 
@@ -168,9 +169,10 @@
     <div id="open-status" class="vt-status" hidden></div>
   </section>
 
-  <p class="vt-note">Locked with AES-256-GCM (quantum-resistant), key from your passphrase via PBKDF2. Lose the passphrase and the file cannot be recovered — that is the point.</p>
+  <p class="vt-note">Your file is encrypted here, in this browser, before anything is saved. Nothing leaves your browser, so we never receive your file or your passphrase and we cannot reset it for you. Lose the passphrase and the file is gone.</p>
+  <p class="vt-tech">AES-256-GCM, key from your passphrase with PBKDF2-SHA-256, 600,000 rounds, random 16-byte salt, random 12-byte nonce.</p>
 </main>
 
-<script src="/vault.js?v=1" defer></script>
+<script src="/vault.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/vault.js
+++ b/frontend/vault.js
@@ -1,16 +1,28 @@
-// Paramant Vault — client-side file encryption to a .prmnt container.
+// Paramant Vault - client-side file encryption to a .prmnt container.
 //
-// MVP = passphrase mode: PBKDF2-SHA256 -> AES-256-GCM, all in the browser via
+// MVP = passphrase mode: PBKDF2-SHA-256 -> AES-256-GCM, all in the browser via
 // WebCrypto. Nothing is uploaded; the server never sees the file or the key
-// (server-blind by design). AES-256 is quantum-resistant, so this is already
-// post-quantum-safe for confidentiality. The .prmnt header is versioned so the
-// public-key / passkey (ML-KEM) key-slots can be added later without breaking it.
+// (server-blind by design). The .prmnt header is versioned so public-key /
+// passkey (ML-KEM) key-slots can be added later without breaking it.
+//
+// No post-quantum claim is made here and none belongs on the page either. A
+// large quantum computer halves the effective strength of a symmetric cipher at
+// best (Grover), which leaves AES-256 comfortable, but "quantum-resistant" is a
+// property of the whole construction and this one hangs on a human-chosen
+// passphrase run through PBKDF2. The weak link is the passphrase, not the
+// cipher, so the page says what the code does and stops there.
 //
 // .prmnt container (binary):
 //   MAGIC "PRMNT" (5) | VERSION (1) | KDF id (1) | ITER u32-LE (4)
 //   | SALT (16) | NONCE (12) | CIPHERTEXT (AES-256-GCM)
 // Plaintext inside the ciphertext: [metaLen u32-LE (4)][meta JSON][file bytes],
 // so the original filename/type is encrypted too (not leaked in the container).
+//
+// The iteration count travels IN the header, which is what makes raising it
+// safe: decryptFile derives with the count the file was written with, never
+// with ITER. Containers locked at the old 210,000 rounds keep opening; only
+// newly locked files get the current number. tests/vault-kdf.test.mjs proves
+// both directions in a real browser.
 
 (function () {
   'use strict';
@@ -18,7 +30,10 @@
   const MAGIC = new Uint8Array([0x50, 0x52, 0x4d, 0x4e, 0x54]); // "PRMNT"
   const VERSION = 1;
   const KDF_PBKDF2 = 1;
-  const ITER = 210000;
+  // OWASP's Password Storage Cheat Sheet puts PBKDF2-HMAC-SHA256 at 600,000
+  // rounds. This carried the older 210,000 figure. Old files still open: the
+  // count is read back out of their own header, see decryptFile.
+  const ITER = 600000;
   const HDR_LEN = 5 + 1 + 1 + 4 + 16 + 12; // 39
   const LOCKED_CONTAINER_NAME = 'paramant-vault.prmnt';
 
@@ -161,7 +176,7 @@
         if (cfg.mode === 'lock') {
           const out = await encryptFile(file, pw);
           downloadBytes(out, LOCKED_CONTAINER_NAME, 'application/octet-stream');
-          setStatus(status, 'Locked. Your .prmnt file is downloading. Keep your passphrase safe — without it the file cannot be opened.', 'ok');
+          setStatus(status, 'Locked. Your .prmnt file is downloading. Keep your passphrase safe: without it the file cannot be opened, and we cannot reset it for you.', 'ok');
         } else {
           const { meta, bytes } = await decryptFile(file, pw);
           downloadBytes(bytes, meta.name || 'unlocked', meta.type);

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -192,7 +192,7 @@
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 <script type="module" src="/parasign-verify.js?v=6"></script>
 </body>
 </html>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -495,7 +495,7 @@
 </section>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=7" defer></script>
+<script src="/js/nav-auth.js?v=8" defer></script>
 
 <footer>
   <div class="container-lg">

--- a/tests/navigation-shell.test.mjs
+++ b/tests/navigation-shell.test.mjs
@@ -339,9 +339,16 @@ await appPage.route('**/api/user/me', (route) => route.fulfill({ status:200, con
 await appPage.route('**/api/user/documents', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"documents":[]}' }));
 await appPage.route('**/api/user/account/**', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{}' }));
 await appPage.goto(ORIGIN + '/dashboard', { waitUntil:'domcontentloaded' });
-await appPage.waitForFunction(() => Array.from(document.querySelectorAll('nav.nav .nav-links .nav-link')).map((node) => node.textContent).join(',') === 'Documents,Send,Sign,Verify,Settings');
+// The workspace bar is pinned item by item, in order, because the order is the
+// claim: Documents is where the work lands, then the three verbs you came to
+// do, then Verify and Settings. It went from five entries to six when /vault
+// joined Send and Sign as the third verb ("Lock a file"), so this list and
+// APP_NAV in frontend/js/nav-auth.js are updated together or not at all.
+const WORKSPACE_NAV = ['Documents','Send','Sign','Lock a file','Verify','Settings'];
+await appPage.waitForFunction((expected) => Array.from(document.querySelectorAll('nav.nav .nav-links .nav-link')).map((node) => node.textContent).join(',') === expected, WORKSPACE_NAV.join(','));
 const appDesktop = await appPage.locator('nav.nav .nav-links .nav-link').allInnerTexts();
-ok('signed-in navigation follows document work', JSON.stringify(appDesktop) === JSON.stringify(['Documents','Send','Sign','Verify','Settings']), appDesktop.join(', '));
+ok('signed-in navigation follows document work', JSON.stringify(appDesktop) === JSON.stringify(WORKSPACE_NAV), appDesktop.join(', '));
+ok('locking a file is a verb in the bar, next to the other two', appDesktop.indexOf('Lock a file') === appDesktop.indexOf('Sign') + 1 && await appPage.locator('nav.nav .nav-links a[href="/vault"]').count() === 1, appDesktop.join(', '));
 ok('dashboard removes its duplicate marketing drawer', await appPage.locator('#nav-mobile-marketing').count() === 0 && await appPage.locator('nav.nav .nav-links').count() === 1, await appPage.locator('nav.nav .nav-links').count());
 await appPage.locator('#nav-hamburger').click();
 const appMobile = await appPage.locator('#nav-mobile a').allInnerTexts();
@@ -354,7 +361,7 @@ ok('developer tools are settings, not a sixth product', await appPage.locator('.
 // under the drawer. Signed in, js/nav-auth.js used to delete that strip, on the
 // reasoning that the user menu carries Help from then on. What that left on a
 // 390px screen was no Help at all in the two places anyone looks: the bar sheds
-// .nav-help below 700px, and the drawer is pinned to the five workspace links
+// .nav-help below 700px, and the drawer is pinned to the workspace links
 // by the check above. The only route was the menu behind the email address,
 // which is where you go to sign out, not where you go when a signature is
 // stuck. A customer had to type the url.
@@ -490,9 +497,9 @@ const developerPage = await browser.newPage({ viewport:{ width:1280, height:900 
 await developerPage.route('**/api/user/session/verify', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"authenticated":true,"email":"demo@example.com"}' }));
 await developerPage.route('**/api/developer/**', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{}' }));
 await developerPage.goto(ORIGIN + '/developer', { waitUntil:'domcontentloaded' });
-await developerPage.waitForFunction(() => Array.from(document.querySelectorAll('nav.nav .nav-links .nav-link')).map((node) => node.textContent).join(',') === 'Documents,Send,Sign,Verify,Settings');
+await developerPage.waitForFunction((expected) => Array.from(document.querySelectorAll('nav.nav .nav-links .nav-link')).map((node) => node.textContent).join(',') === expected, WORKSPACE_NAV.join(','));
 const developerNav = await developerPage.locator('nav.nav .nav-links .nav-link').allInnerTexts();
-ok('developer page is presented as settings inside the same shell', await developerPage.title() === 'Developer settings · Paramant' && developerNav.map((item) => item.toLowerCase()).join(',') === 'documents,send,sign,verify,settings', await developerPage.title());
+ok('developer page is presented as settings inside the same shell', await developerPage.title() === 'Developer settings · Paramant' && developerNav.map((item) => item.toLowerCase()).join(',') === WORKSPACE_NAV.map((item) => item.toLowerCase()).join(','), await developerPage.title());
 ok('developer page shares the settings hierarchy', JSON.stringify(await developerPage.locator('.settings-tabs a').allInnerTexts()) === JSON.stringify(['Account & security','Plan & billing','Developer settings']) && await developerPage.locator('.settings-tabs a[aria-current="page"]').getAttribute('href') === '/developer', await developerPage.locator('.settings-tabs').innerText());
 await developerPage.close();
 

--- a/tests/vault-kdf.test.mjs
+++ b/tests/vault-kdf.test.mjs
@@ -1,0 +1,188 @@
+// Paramant Vault, the KDF contract of the .prmnt container.
+//
+// Two things have to stay true at the same time, and they pull against each
+// other:
+//
+//   1. NEW files are locked at the current iteration count. OWASP's Password
+//      Storage Cheat Sheet puts PBKDF2-HMAC-SHA256 at 600,000 rounds; the page
+//      prints that number in words, so the number in the header has to be the
+//      number on the page.
+//   2. OLD files still open. The count is written into the container header, so
+//      decryptFile derives with whatever the file was written with rather than
+//      with today's constant. This test forges a container at the previous
+//      210,000 rounds -- with Node's WebCrypto, byte for byte in the shipped
+//      layout -- and makes the real page open it.
+//
+// Without (2), raising the number would have silently bricked every file a user
+// already locked, and nothing else in the suite would have noticed: the browser
+// reports a wrong count as "wrong passphrase".
+//
+// Run:
+//   PLAYWRIGHT_CHROMIUM_PATH=/usr/bin/google-chrome node tests/vault-kdf.test.mjs
+
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { webcrypto } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const KDF_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const KDF_EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const KDF_MIME = { '.css':'text/css', '.html':'text/html', '.js':'text/javascript', '.svg':'image/svg+xml', '.png':'image/png' };
+
+// The container, as frontend/vault.js writes it:
+//   MAGIC "PRMNT" (5) | VERSION (1) | KDF id (1) | ITER u32-LE (4)
+//   | SALT (16) | NONCE (12) | CIPHERTEXT
+// and inside the ciphertext: [metaLen u32-LE][meta JSON][file bytes].
+const PRMNT_MAGIC = Buffer.from('PRMNT', 'latin1');
+const PRMNT_VERSION = 1;
+const PRMNT_KDF_PBKDF2 = 1;
+const PRMNT_HDR_LEN = 39;
+const OLD_ITERATIONS = 210000; // what shipped before the raise
+
+// The source of truth for the new number, read out of the file under test so
+// this suite cannot drift away from it.
+const vaultSource = fs.readFileSync(path.join(KDF_ROOT, 'vault.js'), 'utf8');
+const iterMatch = /const ITER = (\d+);/.exec(vaultSource);
+assert.ok(iterMatch, 'frontend/vault.js must declare a literal ITER');
+const CURRENT_ITERATIONS = Number(iterMatch[1]);
+
+async function forgeOldContainer(bytes, meta, passphrase) {
+  const salt = webcrypto.getRandomValues(new Uint8Array(16));
+  const nonce = webcrypto.getRandomValues(new Uint8Array(12));
+  const base = await webcrypto.subtle.importKey('raw', Buffer.from(passphrase, 'utf8'), 'PBKDF2', false, ['deriveKey']);
+  const key = await webcrypto.subtle.deriveKey(
+    { name:'PBKDF2', salt, iterations:OLD_ITERATIONS, hash:'SHA-256' },
+    base, { name:'AES-GCM', length:256 }, false, ['encrypt']
+  );
+  const metaBuf = Buffer.from(JSON.stringify(meta), 'utf8');
+  const plain = Buffer.alloc(4 + metaBuf.length + bytes.length);
+  plain.writeUInt32LE(metaBuf.length, 0);
+  metaBuf.copy(plain, 4);
+  bytes.copy(plain, 4 + metaBuf.length);
+  const ct = Buffer.from(await webcrypto.subtle.encrypt({ name:'AES-GCM', iv:nonce }, key, plain));
+  const out = Buffer.alloc(PRMNT_HDR_LEN + ct.length);
+  PRMNT_MAGIC.copy(out, 0);
+  out[5] = PRMNT_VERSION;
+  out[6] = PRMNT_KDF_PBKDF2;
+  out.writeUInt32LE(OLD_ITERATIONS, 7);
+  Buffer.from(salt).copy(out, 11);
+  Buffer.from(nonce).copy(out, 27);
+  ct.copy(out, PRMNT_HDR_LEN);
+  return out;
+}
+
+const kdfServer = http.createServer((req, res) => {
+  const pathname = new URL(req.url, 'http://localhost').pathname;
+  const wanted = pathname === '/vault' ? '/vault.html' : decodeURIComponent(pathname);
+  const file = path.join(KDF_ROOT, wanted);
+  if (!file.startsWith(KDF_ROOT)) { res.writeHead(403); return res.end(); }
+  fs.readFile(file, (err, body) => {
+    if (err) { res.writeHead(404); return res.end(); }
+    res.writeHead(200, { 'content-type': KDF_MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  });
+});
+await new Promise((resolve) => kdfServer.listen(0, '127.0.0.1', resolve));
+const KDF_ORIGIN = `http://localhost:${kdfServer.address().port}`;
+
+const kdfBrowser = await chromium.launch({ headless:true, ...(KDF_EXE ? { executablePath:KDF_EXE } : {}) });
+
+try {
+  // ── The number in the code is 600,000, and it is the number on the page ────
+  //
+  // OWASP's floor for PBKDF2-HMAC-SHA256. Pinned as a literal on purpose: a
+  // regression that reads the constant back out of the same file it is checking
+  // proves nothing.
+  assert.equal(CURRENT_ITERATIONS, 600000,
+    'PBKDF2-HMAC-SHA256 must run at the OWASP figure of 600,000 rounds');
+
+  const context = await kdfBrowser.newContext({ baseURL:KDF_ORIGIN, acceptDownloads:true });
+  const page = await context.newPage();
+  await page.goto(`${KDF_ORIGIN}/vault`);
+
+  const shown = (await page.locator('main').innerText()).replace(/\s+/g, ' ');
+  assert.ok(shown.includes(CURRENT_ITERATIONS.toLocaleString('en-US')),
+    `the page must print the iteration count the code uses (${CURRENT_ITERATIONS.toLocaleString('en-US')}); it says: ${shown}`);
+  assert.ok(shown.includes('PBKDF2-SHA-256') && shown.includes('AES-256-GCM'),
+    `the page must name the KDF and the cipher it actually uses; it says: ${shown}`);
+  // The claim the security review struck. AES-256 is not what makes this
+  // construction strong, a long passphrase is, so no page here may sell it as
+  // quantum anything.
+  assert.doesNotMatch(shown, /quantum/i,
+    `the vault page may not make a quantum claim; it says: ${shown}`);
+  // And the honest sentence: no recovery, because there is nothing to recover
+  // from.
+  assert.match(shown, /cannot reset it for you/i,
+    `the page must say that a lost passphrase cannot be recovered; it says: ${shown}`);
+
+  // ── A file locked TODAY carries the new count in its header ───────────────
+  const plaintext = Buffer.from('the quick brown fox jumps over the lazy dog\n', 'utf8');
+  const passphrase = 'correct horse battery staple';
+  await page.setInputFiles('#lock-input', { name:'report.txt', mimeType:'text/plain', buffer:plaintext });
+  await page.fill('#lock-pw', passphrase);
+  await page.fill('#lock-pw2', passphrase);
+  const [locked] = await Promise.all([page.waitForEvent('download'), page.click('#lock-run')]);
+  const lockedBytes = fs.readFileSync(await locked.path());
+
+  assert.equal(lockedBytes.subarray(0, 5).toString('latin1'), 'PRMNT', 'the container must start with its magic');
+  assert.equal(lockedBytes[5], PRMNT_VERSION, 'the container version changed without this test hearing about it');
+  assert.equal(lockedBytes[6], PRMNT_KDF_PBKDF2, 'the KDF id must still say PBKDF2');
+  assert.equal(lockedBytes.readUInt32LE(7), CURRENT_ITERATIONS,
+    'a newly locked container must record the current iteration count');
+  assert.ok(lockedBytes.length > PRMNT_HDR_LEN, 'the container must carry ciphertext after its 39-byte header');
+  // Salt and nonce are fixed-width fields, so "16-byte salt" on the page is a
+  // statement about these offsets. Two containers of the same file must differ
+  // in both, which is the only way to see that they are random and not reused.
+  const second = await (async () => {
+    await page.reload();
+    await page.setInputFiles('#lock-input', { name:'report.txt', mimeType:'text/plain', buffer:plaintext });
+    await page.fill('#lock-pw', passphrase);
+    await page.fill('#lock-pw2', passphrase);
+    const [again] = await Promise.all([page.waitForEvent('download'), page.click('#lock-run')]);
+    return fs.readFileSync(await again.path());
+  })();
+  assert.notEqual(lockedBytes.subarray(11, 27).toString('hex'), second.subarray(11, 27).toString('hex'),
+    'the 16-byte salt must be random per file');
+  assert.notEqual(lockedBytes.subarray(27, 39).toString('hex'), second.subarray(27, 39).toString('hex'),
+    'the 12-byte nonce must be random per file');
+
+  // ── A file locked at the OLD count still opens ────────────────────────────
+  //
+  // This is the whole point of raising the number in a header field. The
+  // container below was never touched by the page: it was built here, at
+  // 210,000 rounds, the way the shipped code built them yesterday.
+  const legacyName = 'Q3_board_minutes.pdf';
+  const legacyBody = Buffer.from('%PDF-1.7\nboard minutes, locked last year\n', 'utf8');
+  const legacy = await forgeOldContainer(legacyBody, { name:legacyName, type:'application/pdf', size:legacyBody.length }, passphrase);
+  assert.equal(legacy.readUInt32LE(7), OLD_ITERATIONS, 'the forged container must carry the old count');
+
+  await page.reload();
+  await page.click('.vt-tab[data-mode="open"]');
+  await page.setInputFiles('#open-input', { name:'paramant-vault.prmnt', mimeType:'application/octet-stream', buffer:legacy });
+  await page.fill('#open-pw', passphrase);
+  const [opened] = await Promise.all([page.waitForEvent('download'), page.click('#open-run')]);
+  assert.equal(opened.suggestedFilename(), legacyName,
+    'opening a container locked at the old iteration count must give the original file back');
+  assert.equal(fs.readFileSync(await opened.path()).toString('utf8'), legacyBody.toString('utf8'),
+    'the bytes that come back out of an old container must be the bytes that went in');
+  assert.match(await page.locator('#open-status').innerText(), /Opened/,
+    'the page must report success for a container written with the old parameters');
+
+  // ── And a wrong passphrase is still refused, at either count ──────────────
+  await page.reload();
+  await page.click('.vt-tab[data-mode="open"]');
+  await page.setInputFiles('#open-input', { name:'paramant-vault.prmnt', mimeType:'application/octet-stream', buffer:legacy });
+  await page.fill('#open-pw', 'not the passphrase');
+  await page.click('#open-run');
+  await page.locator('#open-status.err').waitFor();
+  assert.match(await page.locator('#open-status').innerText(), /Wrong passphrase/,
+    'a wrong passphrase must be refused, not silently accepted');
+
+  console.log('PASS: vault locks at 600,000 PBKDF2-SHA-256 rounds, still opens containers written at 210,000, and the page says so.');
+} finally {
+  await kdfBrowser.close();
+  await new Promise((resolve) => kdfServer.close(resolve));
+}


### PR DESCRIPTION
A security review of `/vault` made two points. Both hold, and both are fixed here.

## What the code actually does

Read out of `frontend/vault.js` rather than assumed:

| | before | after |
|---|---|---|
| cipher | AES-256-GCM | unchanged |
| KDF | PBKDF2-HMAC-SHA256 | unchanged |
| iterations | 210,000 | **600,000** |
| salt | 16 random bytes | unchanged |
| nonce | 12 random bytes | unchanged |
| container | `MAGIC "PRMNT"(5) VERSION(1) KDF-id(1) ITER u32-LE(4) SALT(16) NONCE(12) CIPHERTEXT` | unchanged |

Filename and MIME type are inside the ciphertext, not the header, and the download is always named `paramant-vault.prmnt`. That was already true and `tests/vault-filename.test.mjs` already pinned it.

## 1. The quantum claim is gone

The page read: *"Locked with AES-256-GCM (quantum-resistant), key from your passphrase via PBKDF2."*

AES-256 does survive Grover with room to spare. But "quantum-resistant" describes a construction, and this construction derives its key from a human-chosen passphrase through PBKDF2. That is where it would break. The claim was flattering the weakest part of the design by naming the strongest one. The word is gone from the page and from the header comment in `frontend/vault.js`, and `tests/vault-kdf.test.mjs` fails on any `/quantum/i` in the page's visible text.

## 2. The iteration count is stated, and it is the OWASP number

600,000 is the current OWASP Password Storage Cheat Sheet figure for PBKDF2-HMAC-SHA256. 210,000 was the 2023 figure, and it was printed nowhere.

New text on the page, in two registers:

> Your file is encrypted here, in this browser, before anything is saved. Nothing leaves your browser, so we never receive your file or your passphrase and we cannot reset it for you. Lose the passphrase and the file is gone.
>
> `AES-256-GCM, key from your passphrase with PBKDF2-SHA-256, 600,000 rounds, random 16-byte salt, random 12-byte nonce.`

## Backward compatibility, proved

Raising the count is safe because it travels **in** the container: `decryptFile` reads the `u32` at offset 7 and derives with the count the file was written with, never with `ITER`. So every file locked at 210,000 still opens.

That is not an argument in a comment, it is `tests/vault-kdf.test.mjs`. The test forges a container at 210,000 rounds with Node's WebCrypto, byte for byte in the shipped layout, hands it to the real page, and asserts the original file comes back with the original name and the original bytes. It also:

- reads `ITER` out of `frontend/vault.js` and asserts the page prints that same number, so page and code cannot drift apart again
- asserts a newly locked container records 600,000 in its header
- locks the same file twice and asserts the 16-byte salt and 12-byte nonce differ, which is what makes "random 16-byte salt" a statement about those offsets rather than a hope
- asserts a wrong passphrase is still refused

Without this test, raising the number would have silently bricked every file a user already locked, and nothing else in the suite would have noticed: the browser reports a wrong iteration count as "wrong passphrase".

## 3. `/vault` had no route in

Locking a file is a verb, like Send and Sign, so it joins them in the signed-in bar as **Lock a file** pointing at `/vault`. No new product name is introduced: that decision has not been made.

`APP_NAV` in `frontend/js/nav-auth.js` goes from five entries to six. `tests/navigation-shell.test.mjs` pins that bar item by item in three places, so the list is lifted into one `WORKSPACE_NAV` const with a comment saying it and `APP_NAV` are updated together or not at all, plus one new check that "Lock a file" sits directly after "Sign" and points at `/vault`. Geometry and tap targets are untouched and still measured: the desktop bar only exists above 1024px, and the phone bar and drawer strip pass unchanged.

`nav-auth.js` changed, so its cache key goes to `v=8` via `apply-nav.py` and by hand in `developer.html`, which keeps its own nav. `vault.js` goes to `v=2`. `scripts/check-cache-bust.sh` is clean.

`vault.html` keeps its own narrow bar rather than gaining the marketing nav, which is the rule `apply-nav.py` already states for app shells.

## Tests

Green: `apply-nav-idempotent`, `site-claims`, `ui-truthfulness`, `seo-contract`, `theme-contrast`, `frontend-loading-contract`, `vault-filename`, `vault-kdf` (new), `static-sanity.sh`, `check-cache-bust.sh`, `check-csp-inline.sh`, `check-test-declarations.sh`, and `node --test` over the non-browser `tests/*.mjs`.

`navigation-shell` reports 55 PASS and one FAIL, `mobile navigation is opaque before opening the menu` (measured `rgba(21, 25, 28, 0.92)`). That failure is **pre-existing on `origin/main`**, was measured there before any change in this branch, is a colour value, and belongs to the colour work running in parallel. Every navigation check this PR touches passes:

```
PASS signed-in navigation follows document work :: Documents, Send, Sign, Lock a file, Verify, Settings
PASS locking a file is a verb in the bar, next to the other two
PASS signed-in mobile menu matches the workspace
PASS developer page is presented as settings inside the same shell
```

## Not touched

`design-system.css`, `nav.css` colour values, and the founder line on pricing / account / dashboard, all of which are being worked on in parallel. Nothing was deployed and no nginx route was added: `location /` already resolves `/vault` through `try_files $uri $uri.html`.
