### PR TITLE
Een betaalde termijn zegt nu wanneer hij afloopt, op de site en per mail, voordat hij afloopt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,11 @@ x-relay-env: &relay-env
   RAM_LIMIT_MB: "${RAM_LIMIT_MB:-1024}"
   LOG_LEVEL: "${LOG_LEVEL:-info}"
   RESEND_API_KEY: "${RESEND_API_KEY:-}"
+  # The public base the paid-term reminder mails link to (/pricing). Those
+  # mails are sent by the relay itself (lib/plan-expiry.js) and only when
+  # RESEND_API_KEY is set; without SITE_URL the link falls back to
+  # https://paramant.app.
+  SITE_URL: "${SITE_URL:-https://paramant.app}"
   # Mollie billing (dormant until a key is set in .env)
   MOLLIE_API_KEY: "${MOLLIE_API_KEY:-}"
   MOLLIE_TEST_API_KEY: "${MOLLIE_TEST_API_KEY:-}"

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -371,6 +371,14 @@ main.acct input::placeholder { color: var(--ink-3); }
       <p class="acct-plan-kicker">Your plan &middot; active</p>
       <p class="acct-plan-lede">Thank you. What you pay is what keeps the Community plan free for everyone else. Your plan and the day the term you bought runs out are below.</p>
     </div>
+    <!-- Shown by js/account.inline1.js from seven days before the bought term
+         runs out. One-off payments mean there is nothing to cancel and nothing
+         to stop, so the only thing worth saying is the date and that no money
+         moves by itself. -->
+    <div class="plan-term-warn" id="billing-term-warn" role="status" hidden>
+      <p class="plan-term-warn-text" data-term="text">&mdash;</p>
+      <a class="plan-term-warn-cta" href="/pricing">Renew</a>
+    </div>
     <div class="info-row">
       <div class="info-label">Current plan</div>
       <div class="info-value">
@@ -378,6 +386,11 @@ main.acct input::placeholder { color: var(--ink-3); }
         <span id="billing-active-badge" class="plan-tier-active hidden">Active</span>
       </div>
     </div>
+    <!-- The same fact in one line, whenever a term end is on record: before it,
+         the day it stops; after it, the day it stopped and where the account
+         landed. Filled from paid_until_*, which the relay has emitted since the
+         betaalpad fixes. -->
+    <p class="plan-term-line" id="billing-term-line" hidden>&mdash;</p>
     <!-- Each checkout buys one term and nothing is collected again by itself
          (see /terms), so what a customer needs is the day access stops, not a
          collection date. The renewal note under it says so in words. -->
@@ -449,7 +462,7 @@ main.acct input::placeholder { color: var(--ink-3); }
 
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
-<script src="/js/account.inline1.js?v=3"></script>
+<script src="/js/account.inline1.js?v=4"></script>
 
 <script type="module" src="/js/account.inline2.js?v=3"></script>
 <script type="module" src="/js/passkey.js?v=4"></script>

--- a/frontend/app-2026.css
+++ b/frontend/app-2026.css
@@ -569,6 +569,32 @@ footer .logo .a { color: var(--ink-1); }
 .acct-plan-band.paid .acct-plan-kicker { color: var(--accent); }
 .acct-plan-band.paid .acct-plan-lede { color: var(--ink-1); }
 
+/* The term a one-off payment bought is running out. Amber and not red: nothing
+   is broken, nothing is going to be charged, a date is simply approaching, and
+   a scare here would be a lie about what happens next. Shared by /account and
+   /dashboard so the same fact reads the same on both. */
+.plan-term-warn {
+  display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between;
+  gap: var(--space-3);
+  padding: 14px 18px; margin: 0 0 20px;
+  background: var(--sig-wait-bg);
+  border: 1px solid var(--sig-wait);
+  border-radius: var(--r-2);
+}
+.plan-term-warn-text { flex: 1 1 320px; margin: 0; font: 14px/1.6 var(--sans); color: var(--ink-1); }
+a.plan-term-warn-cta {
+  flex: 0 0 auto;
+  min-height: var(--tap); display: inline-flex; align-items: center;
+  padding: 0 18px; border-radius: var(--r-1);
+  background: var(--surface-ink); color: var(--on-ink);
+  font-family: var(--mono); font-size: 12px; font-weight: 600;
+  letter-spacing: .08em; text-transform: uppercase; text-decoration: none;
+}
+a.plan-term-warn-cta:hover { background: var(--ink-1); }
+/* The plain one-line statement of the same fact, shown whenever a term end is
+   on record and not only while it is close. */
+.plan-term-line { margin: 6px 0 20px; font: 13px/1.6 var(--sans); color: var(--ink-dim); }
+
 /* ── the appearance switch on /account ───────────────────────────────────────
    Three ways to answer one question, so the answer is visible without opening
    anything. The radio itself is 0x0 and the <span> is the target: it carries

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -486,6 +486,20 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
       <p class="dh-paid-lede" data-dh="return-lede">--</p>
     </aside>
 
+    <!-- Shown by dashboard.js from seven days before the bought term runs out.
+         A one-off payment has nothing to cancel and nothing to collect, so the
+         band says the date, what happens after it, and offers the one action
+         that changes anything. -->
+    <div class="plan-term-warn" id="dh-term-warn" role="status" hidden>
+      <p class="plan-term-warn-text" data-dh="term-warn">--</p>
+      <a class="plan-term-warn-cta" href="/pricing">Renew</a>
+    </div>
+    <!-- The same fact in one line, shown whenever a term end is on record and
+         not only while it is close: before it, the day the plan stops; after
+         it, the day it stopped and where the account landed. Filled from
+         paid_until_*, which the relay has emitted since the betaalpad fixes. -->
+    <p class="plan-term-line" id="dh-term-line" hidden>--</p>
+
     <!-- What a paying customer bought, in the words /pricing sells it in. Shown
          by dashboard.js only on Pro, Business or Enterprise, and it carries no
          link to a higher tier: someone who already pays is not a lead. -->
@@ -661,6 +675,6 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
-<script src="/js/dashboard.js?v=10" defer></script>
+<script src="/js/dashboard.js?v=11" defer></script>
 </body>
 </html>

--- a/frontend/js/account.inline1.js
+++ b/frontend/js/account.inline1.js
@@ -301,6 +301,57 @@
   });
 
 
+  // ── The end of the term that was bought ────────────────────────────────────
+  // Every checkout here is a ONE-OFF payment for one month or one year, so the
+  // date in paid_until_<product> is the day access stops and there is no
+  // collection to announce or to cancel. Before this the account page said
+  // "active" and nothing else, and the first sign a customer had that his term
+  // was over was a refused signature.
+  //
+  // Two products can carry two different dates. The one that matters is the
+  // nearest one still ahead, because that is the one that needs acting on; once
+  // they have all passed it is the last one, because that is the day the
+  // account fell back.
+  var TERM_WARN_DAYS = 7;
+  function termState(d, nowMs) {
+    var now = typeof nowMs === 'number' ? nowMs : Date.now();
+    var ends = [d.paid_until_parasign, d.paid_until_parasend]
+      .map(function (v) { return v ? Date.parse(v) : NaN; })
+      .filter(function (t) { return !isNaN(t); });
+    if (!ends.length) return null;
+    var ahead = ends.filter(function (t) { return t > now; });
+    var at = ahead.length ? Math.min.apply(null, ahead) : Math.max.apply(null, ends);
+    var days = (at - now) / 86400000;
+    return { at: at, ended: at <= now, warn: days > 0 && days <= TERM_WARN_DAYS };
+  }
+
+  // en-GB and not the visitor's locale: the site is in English and the same
+  // date has to read the same here as it does in the reminder mail.
+  function termDate(at) {
+    return new Date(at).toLocaleDateString('en-GB', { day: 'numeric', month: 'long' });
+  }
+
+  function renderTerm(d) {
+    var term = termState(d);
+    var line = document.getElementById('billing-term-line');
+    var warn = document.getElementById('billing-term-warn');
+    if (line) line.hidden = true;
+    if (warn) warn.hidden = true;
+    if (!term) return;
+    var when = termDate(term.at);
+    if (line) {
+      line.textContent = term.ended
+        ? 'Ended on ' + when + ', now on Community.'
+        : 'Ends on ' + when + ', nothing renews automatically.';
+      line.hidden = false;
+    }
+    if (warn && term.warn) {
+      var text = warn.querySelector('[data-term="text"]');
+      if (text) text.textContent = 'Your plan ends on ' + when + '. Renew for another month or year, or let it fall back to Community. Nothing is charged automatically.';
+      warn.hidden = false;
+    }
+  }
+
   async function loadBilling() {
     try {
       const res = await fetch('/api/user/billing/status', { credentials: 'include' });
@@ -345,6 +396,7 @@
         const note = document.getElementById('billing-renew-note');
         if (note) note.hidden = !!d.auto_renews;
       }
+      renderTerm(d);
       if (d.cancellation_scheduled_at) {
         document.getElementById('billing-cancel-row').style.display = 'flex';
         document.getElementById('billing-cancel-date').textContent = 'Downgrade scheduled ' + new Date(d.cancellation_scheduled_at).toLocaleDateString();

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -108,6 +108,48 @@
     return t;
   }
 
+  // ── The end of the term that was bought ────────────────────────────────────
+  // Same rule and same words as /account: a checkout here buys one month or one
+  // year outright, so paid_until_<product> is the day access stops and there is
+  // no collection to announce. Two products can hold two dates; the one that
+  // matters is the nearest one still ahead, and once they have all passed it is
+  // the last one, because that is the day the account fell back to Community.
+  var TERM_WARN_DAYS = 7;
+  function termState(data, nowMs) {
+    var now = typeof nowMs === 'number' ? nowMs : Date.now();
+    var ends = [data.paid_until_parasign, data.paid_until_parasend]
+      .map(function (v) { return v ? Date.parse(v) : NaN; })
+      .filter(function (t) { return !isNaN(t); });
+    if (!ends.length) return null;
+    var ahead = ends.filter(function (t) { return t > now; });
+    var at = ahead.length ? Math.min.apply(null, ahead) : Math.max.apply(null, ends);
+    var days = (at - now) / 86400000;
+    return { at: at, ended: at <= now, warn: days > 0 && days <= TERM_WARN_DAYS };
+  }
+
+  // en-GB and not the visitor's locale: the site is in English and the same
+  // date has to read the same here, on /account and in the reminder mail.
+  function renderTerm(root, data) {
+    var line = root.querySelector('#dh-term-line');
+    var warn = root.querySelector('#dh-term-warn');
+    if (line) line.hidden = true;
+    if (warn) warn.hidden = true;
+    var term = termState(data);
+    if (!term) return;
+    var when = new Date(term.at).toLocaleDateString('en-GB', { day: 'numeric', month: 'long' });
+    if (line) {
+      line.textContent = term.ended
+        ? 'Ended on ' + when + ', now on Community.'
+        : 'Ends on ' + when + ', nothing renews automatically.';
+      line.hidden = false;
+    }
+    if (warn && term.warn) {
+      var text = warn.querySelector('[data-dh="term-warn"]');
+      if (text) text.textContent = 'Your plan ends on ' + when + '. Renew for another month or year, or let it fall back to Community. Nothing is charged automatically.';
+      warn.hidden = false;
+    }
+  }
+
   // What a paying customer already has, per product, quoted from /pricing. It
   // is per product because a self-serve purchase moves one ladder only: someone
   // who bought ParaSend Pro has no signature allowance to read about. Nothing
@@ -233,6 +275,11 @@
         txt('paid-includes', lines.join(' '));
       }
     }
+
+    // Outside the paid band on purpose. An expired term floors every product,
+    // which empties that band, and the one moment a customer most needs the
+    // date is the moment the band that would have carried it disappears.
+    renderTerm(root, data);
     txt('created',      fmtDate(data.created_at));
     txt('backup',       String(data.backup_codes_remaining != null ? data.backup_codes_remaining : '--'));
     txt('session',      fmtMinutesUntil(data.session_expires_at));

--- a/relay/lib/plan-expiry.js
+++ b/relay/lib/plan-expiry.js
@@ -1,0 +1,471 @@
+'use strict';
+// Telling a paying customer that his term is about to run out, before it does.
+//
+// WHY THIS FILE EXISTS. Every checkout is a ONE-OFF payment for one term
+// (BILLING_MODE empty, so Mollie is never asked for a mandate or a
+// subscription). `paid_until_<product>` is the end of that term, and
+// entitlements.effectiveProductTier floors the tier the moment it passes. That
+// is correct and it is silent: the customer's account drops to Community with
+// no warning, no mail, and nothing on the site that ever said a date was
+// coming. He finds out when a signature is refused.
+//
+// There is no cron on the server and no scheduler container, so the reminder
+// has to live inside the relay process. That brings two problems this module
+// exists to solve, and they are the two that a naive setInterval gets wrong.
+//
+//   1. FIVE CONTAINERS. relay-main, relay-health, relay-finance, relay-legal
+//      and relay-iot all run this same code against ONE redis. Without a lock
+//      a customer gets the same mail five times. The lock is redis SET NX PX,
+//      taken per sweep, so exactly one container does the work per window.
+//
+//   2. RESTARTS. The relay is restarted for every deploy, and a restart is
+//      exactly what killed the previous paid_until fix (see the 2026-09-01
+//      finding: the period was written to memory and not to disk, so every
+//      restart handed paying accounts an unbounded grant again). NOTHING here
+//      lives in process memory. The "already told him" marker is a redis key
+//      whose NAME carries the paid_until it belongs to, with a TTL longer than
+//      the longest term sold. A new process against the same redis therefore
+//      sends zero mails, and a renewal (which moves paid_until) gets a fresh
+//      marker on its own, without anybody having to delete the old one.
+//
+// THE INDEX. Accounts do not live in redis; they live in users.json, per
+// container, loaded into memory at boot. So a sweep that reads only its own
+// container would mail about the accounts that container happens to know. The
+// index below is the fix: the same write path that sets paid_until also writes
+// {account, product} into a redis ZSET scored by the period end, plus the
+// address to write to. Every container seeds it from what it knows at boot
+// (idempotent, a ZADD with the same score is a no-op), so the union of all
+// five is complete, and any one of them can then do the whole sweep from redis
+// alone. Reading the due set is one ZRANGEBYSCORE over a window, not a scan of
+// every account.
+//
+// The mailer is injected (relay.js passes sendResendEmail), on the pattern of
+// lib/transfer-notify.js, so the tests drive a spy and never touch the network.
+
+const entitlements = require('./entitlements');
+
+// ── Redis layout ─────────────────────────────────────────────────────────────
+// Member is "<accountId>|<product>". A pipe cannot occur in either half: an
+// account id is a key or a uuid, and a product is one of two literals.
+const INDEX_ZSET = 'paramant:billing:expiry';        // score = paid_until epoch ms
+const META_HASH = 'paramant:billing:expiry_meta';    // member -> JSON {email, tier, paid_until}
+const LOCK_KEY = 'paramant:billing:expiry_lock';
+const NOTICE_PREFIX = 'paramant:billing:expiry_notice';
+
+const DAY_MS = 86400000;
+
+// How far ahead the warning goes out. Seven days is long enough to act on and
+// short enough that the date in the mail is still the date the customer cares
+// about.
+const WARN_DAYS = 7;
+const WARN_WINDOW_MS = WARN_DAYS * DAY_MS;
+
+// How long after a period ended the "it has ended" mail may still go out. The
+// sweep runs every six hours, so the normal case is the same day; this is the
+// tail for a relay that was down. Past it the account has been on Community
+// long enough that a mail saying so is news about nothing.
+const ENDED_GRACE_MS = 7 * DAY_MS;
+
+// When a finished period is dropped from the index. Well past ENDED_GRACE_MS,
+// so a pruned entry is never one that still had a mail owing.
+const PRUNE_AFTER_MS = 30 * DAY_MS;
+
+// Longer than the longest term sold (one year), so a marker can NEVER expire
+// while the paid_until it names is still the current one. This is the whole
+// idempotency guarantee and the number is deliberately generous: a marker that
+// outlives its period costs nothing, one that dies inside it sends a second
+// mail to someone who already had one.
+const NOTICE_TTL_S = 400 * 86400;
+
+// Every six hours, plus once at boot. Six hours means a term that ends at
+// 02:00 still gets its "ended" mail that morning, and it survives a container
+// that is restarted twice a day without ever sending twice (the markers do
+// that, not the interval).
+const SWEEP_INTERVAL_MS = 6 * 3600000;
+
+// Held only for the length of one sweep. Long enough that a slow redis or a
+// large index cannot let a second container in halfway; far shorter than the
+// interval, so a container that is killed mid-sweep does not block the next
+// window.
+const LOCK_TTL_MS = 10 * 60000;
+
+const DEFAULT_SITE_URL = 'https://paramant.app';
+
+// ── Naming ───────────────────────────────────────────────────────────────────
+const PRODUCT_NAME = Object.freeze({ parasign: 'ParaSign', parasend: 'ParaSend' });
+const TIER_NAME = Object.freeze({ pro: 'Pro', business: 'Business', enterprise: 'Enterprise' });
+
+// The name the site gives the free plan, for both products. entitlements calls
+// the floors 'free' (ParaSign) and 'community' (ParaSend); /pricing, /account
+// and /dashboard all say Community, and the mail has to match what the reader
+// sees when he arrives.
+const FLOOR_NAME = 'Community';
+
+const MONTHS = Object.freeze(['January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December']);
+
+// "3 October". UTC and hand-built rather than toLocaleDateString: the same
+// date has to read the same in a mail from any container, and Intl data is not
+// something a slim container image is guaranteed to carry.
+function formatDate(value) {
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  return `${d.getUTCDate()} ${MONTHS[d.getUTCMonth()]}`;
+}
+
+function memberOf(accountId, product) {
+  return `${accountId}|${product}`;
+}
+
+function parseMember(member) {
+  const i = String(member).lastIndexOf('|');
+  if (i <= 0) return null;
+  const accountId = String(member).slice(0, i);
+  const product = String(member).slice(i + 1);
+  if (product !== 'parasign' && product !== 'parasend') return null;
+  return { accountId, product };
+}
+
+// The marker that says this exact mail already went out. paid_until is IN the
+// name, so a renewal is a different key and gets its own mail, and a restart
+// finds the old one still standing.
+function noticeKey(kind, accountId, product, paidUntilIso) {
+  return `${NOTICE_PREFIX}:${kind}:${accountId}:${product}:${paidUntilIso}`;
+}
+
+function floorTierOf(product) {
+  return product === 'parasign' ? 'free' : 'community';
+}
+
+function planLabel(product, tier) {
+  const p = PRODUCT_NAME[product] || product;
+  const t = TIER_NAME[tier] || tier;
+  return `${p} ${t}`;
+}
+
+// ── The two mails ────────────────────────────────────────────────────────────
+// Plain sentences, no urgency, no offer. The customer bought a term; he is
+// being told when it stops and that nothing happens to his card unless he says
+// so. That last half is the point: on a one-off payment "your plan ends" reads
+// as a threat of a charge unless it says otherwise.
+function expiryMail({ product, tier, paidUntil, kind, siteUrl }) {
+  const date = formatDate(paidUntil);
+  if (!date) return null;
+  const plan = planLabel(product, tier);
+  const pricing = `${String(siteUrl || DEFAULT_SITE_URL).replace(/\/+$/, '')}/pricing`;
+  if (kind === 'ended') {
+    const subject = `Your ${plan} has ended`;
+    const text = [
+      `Your ${plan} ended on ${date}, and your account is now on ${FLOOR_NAME}.`,
+      '',
+      'Nothing was charged. Every plan here is a one-off payment for the term you buy, so nothing renews by itself and nothing is collected without you.',
+      '',
+      `You can buy another month or another year at any time: ${pricing}`,
+      '',
+      'Paramant',
+    ].join('\n');
+    return { subject, text, html: htmlBody(subject, text, pricing) };
+  }
+  const subject = `Your ${plan} ends on ${date}`;
+  const text = [
+    `Your ${plan} ends on ${date}.`,
+    '',
+    `Renew for another month or year, or let it fall back to ${FLOOR_NAME}; nothing is charged automatically.`,
+    '',
+    `Your plans and prices are here: ${pricing}`,
+    '',
+    'Paramant',
+  ].join('\n');
+  return { subject, text, html: htmlBody(subject, text, pricing) };
+}
+
+const escHtml = (s) => String(s === null || s === undefined ? '' : s)
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+
+function htmlBody(subject, text, pricing) {
+  const paragraphs = text.split('\n\n')
+    .filter((p) => p && p !== 'Paramant')
+    .map((p) => `<p style="margin:0 0 16px;line-height:1.6">${escHtml(p)}</p>`)
+    .join('\n');
+  return [
+    '<div style="font-family:system-ui,-apple-system,\'Segoe UI\',sans-serif;color:#0B3A6A;max-width:520px">',
+    `<h1 style="font-size:18px;margin:0 0 16px">${escHtml(subject)}</h1>`,
+    paragraphs,
+    `<p style="margin:0"><a href="${escHtml(pricing)}" style="color:#0B3A6A">${escHtml(pricing)}</a></p>`,
+    '</div>',
+  ].join('\n');
+}
+
+// ── Index maintenance ────────────────────────────────────────────────────────
+// Called from the same place that writes paid_until, and once per container at
+// boot for what is already on file. Both are upserts, so running them twice
+// costs two round trips and changes nothing.
+//
+// A record on the floor tier, or without a period, is REMOVED rather than
+// skipped: that is the chargeback path (setProductPlan(..., floor, null)) and
+// an entry left behind would mail a customer about a plan he no longer has.
+async function upsertExpiry(redis, { accountId, product, tier, paidUntil, email }) {
+  if (!redis || !accountId || (product !== 'parasign' && product !== 'parasend')) {
+    return { indexed: false, reason: 'bad_args' };
+  }
+  const member = memberOf(accountId, product);
+  const norm = product === 'parasign'
+    ? entitlements.normaliseParasignTier(tier)
+    : entitlements.normaliseParasendTier(tier);
+  const at = paidUntil ? Date.parse(paidUntil) : NaN;
+  if (norm === floorTierOf(product) || Number.isNaN(at)) {
+    await redis.zRem(INDEX_ZSET, member);
+    await redis.hDel(META_HASH, member);
+    return { indexed: false, reason: 'not_paid' };
+  }
+  await redis.zAdd(INDEX_ZSET, { score: at, value: member });
+  await redis.hSet(META_HASH, member, JSON.stringify({
+    email: email || '',
+    tier: norm,
+    paid_until: new Date(at).toISOString(),
+  }));
+  return { indexed: true, member, score: at };
+}
+
+// Drop an account from the index entirely (both products). Used when a key is
+// erased or deactivated.
+async function forgetAccount(redis, accountId) {
+  if (!redis || !accountId) return { removed: 0 };
+  let removed = 0;
+  for (const product of entitlements.PRODUCTS) {
+    const member = memberOf(accountId, product);
+    removed += await redis.zRem(INDEX_ZSET, member);
+    await redis.hDel(META_HASH, member);
+  }
+  return { removed };
+}
+
+// One boot seed from whatever this container has on file. `records` is an
+// iterable of { accountId, record } where record carries plan_<product> and
+// paid_until_<product>. Never mails; only fills the index.
+async function seedIndex(redis, records) {
+  let indexed = 0;
+  let seen = 0;
+  for (const entry of records || []) {
+    const rec = entry && entry.record;
+    const accountId = entry && entry.accountId;
+    if (!rec || !accountId) continue;
+    seen++;
+    for (const product of entitlements.PRODUCTS) {
+      const tier = rec[entitlements.PRODUCT_PLAN_FIELD[product]];
+      const paidUntil = rec[entitlements.PRODUCT_PAID_UNTIL_FIELD[product]];
+      if (!paidUntil) continue;
+      const r = await upsertExpiry(redis, { accountId, product, tier, paidUntil, email: rec.email });
+      if (r.indexed) indexed++;
+    }
+  }
+  return { seen, indexed };
+}
+
+// ── The lock ─────────────────────────────────────────────────────────────────
+// SET NX PX. The token is checked before the release so a sweep that overran
+// its TTL cannot delete a lock a different container is now holding.
+function lockToken() {
+  return `${process.pid}:${Date.now()}:${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function acquireLock(redis, ttlMs, token) {
+  const ok = await redis.set(LOCK_KEY, token, { NX: true, PX: ttlMs || LOCK_TTL_MS });
+  return ok === 'OK' || ok === true;
+}
+
+async function releaseLock(redis, token) {
+  const held = await redis.get(LOCK_KEY);
+  if (held !== token) return false;
+  await redis.del(LOCK_KEY);
+  return true;
+}
+
+// ── The sweep ────────────────────────────────────────────────────────────────
+// deps:
+//   redis      node-redis v4 client (required)
+//   now        epoch ms, injectable so the tests can move the clock
+//   sendEmail  ({to, subject, text, html}) -> truthy when the mail was
+//              DISPATCHED. relay.js's sendResendEmail returns false when
+//              RESEND_API_KEY is unset, which is exactly the case that must not
+//              consume the marker.
+//   log        (level, event, fields)
+//   siteUrl    base for the /pricing link
+//
+// Returns { ran, warned, ended, skipped, missing, pruned, reason }.
+async function runSweep(deps) {
+  const d = deps || {};
+  const redis = d.redis;
+  const log = typeof d.log === 'function' ? d.log : () => {};
+  const now = typeof d.now === 'number' ? d.now : Date.now();
+  const sendEmail = d.sendEmail;
+  const siteUrl = d.siteUrl || DEFAULT_SITE_URL;
+  const out = { ran: false, warned: 0, ended: 0, skipped: 0, missing: 0, pruned: 0, reason: null };
+  if (!redis || !redis.isReady) { out.reason = 'no_redis'; return out; }
+
+  const token = lockToken();
+  let got = false;
+  try {
+    got = await acquireLock(redis, d.lockTtlMs || LOCK_TTL_MS, token);
+  } catch (e) {
+    out.reason = 'lock_error';
+    log('warn', 'plan_expiry_lock_failed', { err: e.message });
+    return out;
+  }
+  // Not an error and not worth a log line above debug: on five containers this
+  // is the expected answer four times out of five.
+  if (!got) { out.reason = 'locked'; return out; }
+  out.ran = true;
+
+  try {
+    // Everything that has already ended (back to the prune horizon) plus
+    // everything ending inside the warning window. One range read; the index
+    // holds only accounts with a paid period, and the window is a slice of it.
+    const due = await redis.zRangeByScore(INDEX_ZSET, now - PRUNE_AFTER_MS, now + WARN_WINDOW_MS);
+    // Anything older than the prune horizon is a finished period nobody owes a
+    // mail for. Dropping it keeps the index the size of the paying customers,
+    // not the size of everyone who ever paid.
+    const stale = await redis.zRangeByScore(INDEX_ZSET, 0, now - PRUNE_AFTER_MS - 1);
+    for (const member of stale) {
+      await redis.zRem(INDEX_ZSET, member);
+      await redis.hDel(META_HASH, member);
+      out.pruned++;
+    }
+
+    for (const member of due) {
+      const parsed = parseMember(member);
+      if (!parsed) { out.missing++; continue; }
+      const { accountId, product } = parsed;
+      let meta = null;
+      try { meta = JSON.parse(await redis.hGet(META_HASH, member) || 'null'); } catch { meta = null; }
+      if (!meta || !meta.paid_until) {
+        // Score without meta: the index and the hash drifted. Drop the entry
+        // rather than guess an address.
+        await redis.zRem(INDEX_ZSET, member);
+        out.missing++;
+        continue;
+      }
+      const at = Date.parse(meta.paid_until);
+      if (Number.isNaN(at)) { await redis.zRem(INDEX_ZSET, member); await redis.hDel(META_HASH, member); out.missing++; continue; }
+      const tier = meta.tier;
+      if (!tier || tier === floorTierOf(product)) { out.skipped++; continue; }
+
+      let kind = null;
+      if (now >= at) {
+        if (now - at <= ENDED_GRACE_MS) kind = 'ended';
+      } else if (at - now <= WARN_WINDOW_MS) {
+        kind = 'warn';
+      }
+      if (!kind) { out.skipped++; continue; }
+
+      const to = meta.email;
+      if (!to) {
+        log('warn', 'plan_expiry_no_address', { account: String(accountId).slice(0, 12), product, kind });
+        out.skipped++;
+        continue;
+      }
+
+      // Reserve BEFORE sending. Under the lock this only guards against a
+      // repeat inside one sweep, but it is also what makes a crash between the
+      // send and the write impossible to turn into a second mail. The
+      // reservation is given back below when the mail did not actually leave.
+      const key = noticeKey(kind, accountId, product, meta.paid_until);
+      const reserved = await redis.set(key, String(now), { NX: true, EX: NOTICE_TTL_S });
+      if (!(reserved === 'OK' || reserved === true)) { out.skipped++; continue; }
+
+      const msg = expiryMail({ product, tier, paidUntil: at, kind, siteUrl });
+      let sent = false;
+      try {
+        sent = !!(typeof sendEmail === 'function' && await sendEmail({
+          to, subject: msg.subject, text: msg.text, html: msg.html,
+        }));
+      } catch (e) {
+        sent = false;
+        log('warn', 'plan_expiry_mail_error', { account: String(accountId).slice(0, 12), product, kind, err: e.message });
+      }
+      if (!sent) {
+        // No mail went out, so no marker may stand. One line per missed mail,
+        // and the next sweep tries again: an unconfigured RESEND_API_KEY must
+        // not silently consume the only warning a customer gets.
+        await redis.del(key);
+        log('warn', 'plan_expiry_mail_skipped', {
+          account: String(accountId).slice(0, 12), product, kind,
+          paid_until: meta.paid_until, reason: 'not_dispatched',
+        });
+        continue;
+      }
+      if (kind === 'ended') out.ended++; else out.warned++;
+      log('info', 'plan_expiry_mail_sent', {
+        account: String(accountId).slice(0, 12), product, tier, kind, paid_until: meta.paid_until,
+      });
+    }
+  } catch (e) {
+    out.reason = 'sweep_error';
+    log('warn', 'plan_expiry_sweep_failed', { err: e.message });
+  } finally {
+    try { await releaseLock(redis, token); } catch { /* the PX expiry is the backstop */ }
+  }
+  return out;
+}
+
+// ── The planner ──────────────────────────────────────────────────────────────
+// One sweep shortly after boot (delayed so the relay finishes starting and so
+// five containers coming up together do not all reach the lock in the same
+// millisecond), then one every six hours. The timers are unref'd: this must
+// never be the reason a process refuses to exit.
+function startPlanExpiryPlanner(deps) {
+  const d = deps || {};
+  const log = typeof d.log === 'function' ? d.log : () => {};
+  const intervalMs = d.intervalMs || SWEEP_INTERVAL_MS;
+  const bootDelayMs = typeof d.bootDelayMs === 'number'
+    ? d.bootDelayMs
+    : 30000 + Math.floor(Math.random() * 30000);
+  let running = false;
+  let seeded = false;
+  const tick = async () => {
+    // A sweep still running when the next tick arrives is a redis that is very
+    // slow; a second one on top of it would only make that worse.
+    if (running) return;
+    running = true;
+    try {
+      // Once per process, and BEFORE the first sweep: whatever this container
+      // has on file goes into the shared index, so an account that was paid
+      // for before this code existed is still reachable. Idempotent, so the
+      // other four containers doing the same thing costs round trips and
+      // nothing else.
+      if (!seeded && typeof d.seed === 'function') {
+        seeded = true;
+        try {
+          const s = await d.seed();
+          if (s && s.indexed) log('info', 'plan_expiry_index_seeded', s);
+        } catch (e) {
+          seeded = false;
+          log('warn', 'plan_expiry_seed_failed', { err: e.message });
+        }
+      }
+      const r = await runSweep({ ...d, now: Date.now() });
+      if (r.ran && (r.warned || r.ended || r.pruned || r.missing)) {
+        log('info', 'plan_expiry_sweep', r);
+      }
+    } catch (e) {
+      log('warn', 'plan_expiry_sweep_failed', { err: e.message });
+    } finally {
+      running = false;
+    }
+  };
+  const boot = setTimeout(tick, bootDelayMs);
+  const timer = setInterval(tick, intervalMs);
+  if (boot.unref) boot.unref();
+  if (timer.unref) timer.unref();
+  return { tick, stop() { clearTimeout(boot); clearInterval(timer); } };
+}
+
+module.exports = {
+  INDEX_ZSET, META_HASH, LOCK_KEY, NOTICE_PREFIX,
+  WARN_DAYS, WARN_WINDOW_MS, ENDED_GRACE_MS, PRUNE_AFTER_MS,
+  NOTICE_TTL_S, SWEEP_INTERVAL_MS, LOCK_TTL_MS, DEFAULT_SITE_URL,
+  formatDate, memberOf, parseMember, noticeKey, planLabel, expiryMail,
+  upsertExpiry, forgetAccount, seedIndex,
+  acquireLock, releaseLock, runSweep, startPlanExpiryPlanner,
+};

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -143,6 +143,7 @@ const parasignAuditExport = require('./lib/parasign-audit-export'); // GET /v2/p
 const transferNotify   = require('./lib/transfer-notify');   // ParaSend Pro upload/download mail
 const invoiceMod       = require('./lib/invoice');            // invoice numbering, records and VAT split
 const invoicePdf       = require('./lib/invoice-pdf');        // one-page PDF writer, no dependency
+const planExpiry       = require('./lib/plan-expiry');      // paid-term warning + expiry mail (in-process planner)
 
 // Outbound wire format selector. Default 0 keeps the legacy on-the-wire format;
 // setting PARAMANT_WIRE_VERSION=1 activates the self-describing v1 header
@@ -1998,7 +1999,35 @@ function setProductPlan(accountId, product, tier, paidUntil) {
     ud.updated = new Date().toISOString();
   }).then(() => log('info', 'billing_entitlement_set', { account: String(accountId).slice(0, 12), product, tier: norm, keys: members.size, changed, persisted: true }))
     .catch(we => log('warn', 'billing_entitlement_persist_failed', { err: we.message }));
+  // Keep the shared expiry index in step with the period that was just written.
+  // This is the ONLY thing that lets a container which has never seen this
+  // account mail its owner: users.json is per container, redis is not.
+  _indexAccountExpiry(accountId, product);
   return { ok: true, product, tier: norm, keys: members.size, changed };
+}
+
+// Mirror one product's paid period into the redis expiry index (lib/plan-expiry).
+// Reads back the record it just wrote rather than trusting the argument, so an
+// admin grant that passed paidUntil undefined (leave whatever is on file) is
+// indexed with what is actually on file. Fire-and-forget: a redis outage may
+// delay a reminder, never a grant.
+function _indexAccountExpiry(accountId, product) {
+  if (!redisClient || !redisClient.isReady) return;
+  const rec = entitlementRecordOf(accountId);
+  if (!rec) return;
+  const members = accountKeys.get(accountId) || (apiKeys.has(accountId) ? new Set([accountId]) : new Set());
+  let email = (accounts.get(accountId) || {}).email || '';
+  for (const m of members) { const mv = apiKeys.get(m); if (mv && mv.email) { email = mv.email; break; } }
+  const products = product ? [product] : entitlements.PRODUCTS;
+  for (const prod of products) {
+    planExpiry.upsertExpiry(redisClient, {
+      accountId,
+      product: prod,
+      tier: rec[entitlements.PRODUCT_PLAN_FIELD[prod]],
+      paidUntil: rec[entitlements.PRODUCT_PAID_UNTIL_FIELD[prod]] || null,
+      email,
+    }).catch(e => log('warn', 'plan_expiry_index_failed', { product: prod, err: e.message }));
+  }
 }
 
 // ── Mollie pointers (customer + per-product subscription) ────────────────────
@@ -5895,6 +5924,13 @@ async function handleRelayRequest(req, res) {
       }
       const acct = accounts.get(target);
       if (acct) { for (const f of keysTable.PERSONAL_DATA_FIELDS) delete acct[f]; }
+      // The expiry index carries a copy of the address so any container can
+      // mail from it. An erasure that left that copy behind would be an
+      // erasure in name only, and the next sweep would write to it.
+      if (redisClient && redisClient.isReady) {
+        planExpiry.forgetAccount(redisClient, target)
+          .catch(e => log('warn', 'plan_expiry_forget_failed', { err: e.message }));
+      }
       log('info', 'account_erased', { target: String(target).slice(0, 16), ...result });
       res.writeHead(200); return res.end(J({ ok: true, erased: result }));
     } catch (e) { if (redisOutage503(e, res)) return; res.writeHead(400); return res.end(J({ error: e.message })); }
@@ -7449,6 +7485,43 @@ setInterval(() => {
   if (sthLog.length === 0 || !relayIdentity) return;
   broadcastSTH(sthLog[sthLog.length - 1]).catch(() => {});
 }, 10 * 60_000);
+
+// ── Paid-term reminders ──────────────────────────────────────────────────────
+// The one thing standing between a customer and a plan that stops without a
+// word. There is no cron on the server, so the schedule lives here: one sweep a
+// short random delay after boot, then every six hours. Five relay containers
+// run this same line against one redis, and a SET NX lock in lib/plan-expiry
+// means exactly one of them does the work each window. Nothing about "already
+// warned him" is held in this process: the markers are redis keys carrying the
+// paid_until they belong to, so a restart, a redeploy and a second container
+// all send zero extra mail.
+//
+// The seed is what makes the index complete. Accounts live in users.json, per
+// container; every container puts what it knows into the shared index once at
+// boot, so an account that paid before this existed is still warned.
+planExpiry.startPlanExpiryPlanner({
+  redis: redisClient,
+  sendEmail: ({ to, subject, text, html }) => sendResendEmail({ to, subject, text, html }),
+  log,
+  siteUrl: process.env.SITE_URL || planExpiry.DEFAULT_SITE_URL,
+  seed: () => planExpiry.seedIndex(redisClient, accountsWithTerms()),
+});
+
+// One entry per ACCOUNT, not per key: an account with three keys is one
+// customer with one address. A fresh generator per call, so a seed that failed
+// on an unreachable redis can be retried against a full list instead of an
+// exhausted one.
+function* accountsWithTerms() {
+  const seenAccounts = new Set();
+  for (const [key, rec] of apiKeys) {
+    const accountId = (rec && rec.account_id) || key;
+    if (seenAccounts.has(accountId)) continue;
+    seenAccounts.add(accountId);
+    const merged = entitlementRecordOf(accountId);
+    if (!merged) continue;
+    yield { accountId, record: { ...merged, email: rec.email || (accounts.get(accountId) || {}).email || '' } };
+  }
+}
 server.listen(PORT, process.env.HOST || '0.0.0.0', () => {
   log('info', 'relay_started', { port: PORT, version: VERSION, sector: SECTOR, mode: RELAY_MODE,
       dsa: !!mlDsa, protocol: 'ghost-pipe-v2',

--- a/relay/test/plan-expiry.test.js
+++ b/relay/test/plan-expiry.test.js
@@ -1,0 +1,334 @@
+'use strict';
+// The paid-term reminder: does it warn the right account, once, and only once.
+//
+// WHAT THIS SUITE IS FOR. Two failures would each be worse than sending
+// nothing. Mailing a customer twice about the same date makes the relay look
+// broken at the moment it is asking for money, and five containers against one
+// redis is five copies by default. And a reminder that a restart resets would
+// mail the whole book again after every deploy, which is exactly the shape of
+// the bug the 2026-09-01 finding recorded (a paid_until fix that lived in
+// process memory and did not survive the restart it was written to prevent).
+//
+// So the checks are about state, not about copy: three accounts at 10 days, 5
+// days and expired yesterday; a second sweep; a sweep from a freshly required
+// module (a "restart" against the same store); and two sweeps at once.
+//
+// The store is a fake, deliberately. It implements only the seven commands the
+// planner uses, and it implements SET NX as a check-and-write with no await in
+// the middle, which is what redis guarantees and what the lock rests on. Every
+// method is async, so two concurrent sweeps really do interleave at their await
+// points rather than running to completion one after the other.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const MODULE = require.resolve('../lib/plan-expiry');
+const planExpiry = require(MODULE);
+
+// A "restart": a brand-new module instance, as a new process would get, against
+// the store that is already there. Anything the planner remembered in module
+// scope would show up here as a second mail.
+function freshModule() {
+  delete require.cache[MODULE];
+  return require(MODULE);
+}
+
+// ── the fake store ───────────────────────────────────────────────────────────
+function fakeRedis() {
+  const strings = new Map();   // key -> { value, opts }
+  const zsets = new Map();     // key -> Map(member -> score)
+  const hashes = new Map();    // key -> Map(field -> value)
+  const zset = (k) => { if (!zsets.has(k)) zsets.set(k, new Map()); return zsets.get(k); };
+  const hash = (k) => { if (!hashes.has(k)) hashes.set(k, new Map()); return hashes.get(k); };
+  return {
+    isReady: true,
+    strings, zsets, hashes,
+    async set(k, v, opts) {
+      // Atomic check-and-write, as redis SET NX is. No await between the read
+      // and the write: that is the whole reason the lock works.
+      if (opts && opts.NX && strings.has(k)) return null;
+      strings.set(k, { value: String(v), opts: opts || {} });
+      return 'OK';
+    },
+    async get(k) { const e = strings.get(k); return e ? e.value : null; },
+    async del(k) { return strings.delete(k) ? 1 : 0; },
+    async zAdd(k, { score, value }) { const z = zset(k); const had = z.has(value); z.set(value, score); return had ? 0 : 1; },
+    async zRem(k, member) { return zset(k).delete(member) ? 1 : 0; },
+    async zRangeByScore(k, min, max) {
+      return [...zset(k).entries()]
+        .filter(([, s]) => s >= min && s <= max)
+        .sort((a, b) => a[1] - b[1])
+        .map(([m]) => m);
+    },
+    async hSet(k, f, v) { hash(k).set(f, String(v)); return 1; },
+    async hGet(k, f) { const v = hash(k).get(f); return v === undefined ? null : v; },
+    async hDel(k, f) { return hash(k).delete(f) ? 1 : 0; },
+  };
+}
+
+function mailbox() {
+  const sent = [];
+  const fn = async (msg) => { sent.push(msg); return true; };
+  fn.sent = sent;
+  return fn;
+}
+
+const DAY = 86400000;
+const NOW = Date.parse('2026-09-26T09:00:00.000Z');
+const SITE = 'https://paramant.app';
+
+// Three accounts, the three cases that matter. The dates are exact so the copy
+// assertions below can name the day.
+const ACCOUNTS = [
+  { accountId: 'acct_ten', product: 'parasign', tier: 'pro', email: 'ten@example.com', paidUntil: new Date(NOW + 10 * DAY).toISOString() },
+  { accountId: 'acct_five', product: 'parasign', tier: 'pro', email: 'five@example.com', paidUntil: new Date(NOW + 5 * DAY).toISOString() },
+  { accountId: 'acct_gone', product: 'parasend', tier: 'pro', email: 'gone@example.com', paidUntil: new Date(NOW - 1 * DAY).toISOString() },
+];
+
+async function seeded(mod) {
+  const redis = fakeRedis();
+  for (const a of ACCOUNTS) await mod.upsertExpiry(redis, a);
+  return redis;
+}
+
+test('one sweep warns the account inside the window, tells the lapsed one, and leaves the far one alone', async () => {
+  const redis = await seeded(planExpiry);
+  const send = mailbox();
+  const r = await planExpiry.runSweep({ redis, now: NOW, sendEmail: send, siteUrl: SITE });
+
+  assert.equal(r.ran, true, 'the sweep took the lock');
+  assert.equal(r.warned, 1, 'exactly one warning');
+  assert.equal(r.ended, 1, 'exactly one end notice');
+  assert.equal(send.sent.length, 2);
+
+  const to = send.sent.map((m) => m.to).sort();
+  assert.deepEqual(to, ['five@example.com', 'gone@example.com'],
+    'ten days out is not warned; five days out and expired yesterday are');
+
+  const warn = send.sent.find((m) => m.to === 'five@example.com');
+  assert.equal(warn.subject, 'Your ParaSign Pro ends on 1 October');
+  assert.match(warn.text, /Your ParaSign Pro ends on 1 October\./);
+  assert.match(warn.text, /Renew for another month or year, or let it fall back to Community; nothing is charged automatically\./);
+  assert.match(warn.text, /https:\/\/paramant\.app\/pricing/);
+
+  const ended = send.sent.find((m) => m.to === 'gone@example.com');
+  assert.equal(ended.subject, 'Your ParaSend Pro has ended');
+  assert.match(ended.text, /ended on 25 September, and your account is now on Community\./);
+  assert.match(ended.text, /Nothing was charged\./);
+
+  // No em-dash anywhere in what a customer reads.
+  const EM_DASH = '\u2014';
+  for (const m of send.sent) assert.equal(m.text.includes(EM_DASH), false, 'no em-dash in the mail');
+});
+
+test('a second sweep at the same clock sends nothing', async () => {
+  const redis = await seeded(planExpiry);
+  const first = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW, sendEmail: first, siteUrl: SITE });
+  assert.equal(first.sent.length, 2);
+
+  const second = mailbox();
+  const r = await planExpiry.runSweep({ redis, now: NOW, sendEmail: second, siteUrl: SITE });
+  assert.equal(r.ran, true, 'the lock was given back, so the second sweep runs');
+  assert.equal(second.sent.length, 0, 'and it has nothing left to say');
+});
+
+test('a sweep six hours later, and one a day later, still send nothing', async () => {
+  const redis = await seeded(planExpiry);
+  const first = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW, sendEmail: first, siteUrl: SITE });
+
+  const later = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW + 6 * 3600000, sendEmail: later, siteUrl: SITE });
+  await planExpiry.runSweep({ redis, now: NOW + DAY, sendEmail: later, siteUrl: SITE });
+  assert.equal(later.sent.length, 0);
+});
+
+test('a restart is a new process against the same store, and it sends nothing', async () => {
+  const redis = await seeded(planExpiry);
+  const first = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW, sendEmail: first, siteUrl: SITE });
+  assert.equal(first.sent.length, 2);
+
+  // Nothing about "already warned him" may live in module scope.
+  const restarted = freshModule();
+  const after = mailbox();
+  const r = await restarted.runSweep({ redis, now: NOW + 3600000, sendEmail: after, siteUrl: SITE });
+  assert.equal(r.ran, true);
+  assert.equal(after.sent.length, 0, 'the markers are in redis, not in the process');
+});
+
+test('two containers sweeping at the same time: one does the work, the other stands down', async () => {
+  const redis = await seeded(planExpiry);
+  const a = mailbox();
+  const b = mailbox();
+  const [ra, rb] = await Promise.all([
+    planExpiry.runSweep({ redis, now: NOW, sendEmail: a, siteUrl: SITE }),
+    planExpiry.runSweep({ redis, now: NOW, sendEmail: b, siteUrl: SITE }),
+  ]);
+  const ran = [ra, rb].filter((r) => r.ran);
+  const stood = [ra, rb].filter((r) => !r.ran);
+  assert.equal(ran.length, 1, 'exactly one sweep held the lock');
+  assert.equal(stood.length, 1);
+  assert.equal(stood[0].reason, 'locked');
+  assert.equal(a.sent.length + b.sent.length, 2, 'and the mail went out once, not twice');
+});
+
+test('a renewal moves the date, and the new period gets its own warning', async () => {
+  const redis = await seeded(planExpiry);
+  const first = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW, sendEmail: first, siteUrl: SITE });
+  assert.equal(first.sent.length, 2);
+
+  // The five-day account pays for another month. paid_until moves, so the old
+  // marker no longer names the current period and the next warning is due.
+  const renewed = new Date(NOW + 35 * DAY).toISOString();
+  await planExpiry.upsertExpiry(redis, {
+    accountId: 'acct_five', product: 'parasign', tier: 'pro',
+    email: 'five@example.com', paidUntil: renewed,
+  });
+
+  const quiet = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW + 6 * DAY, sendEmail: quiet, siteUrl: SITE });
+  assert.equal(quiet.sent.some((m) => m.to === 'five@example.com'), false,
+    'the renewed account is 29 days out, so there is nothing to say to it yet');
+
+  const due = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW + 30 * DAY, sendEmail: due, siteUrl: SITE });
+  assert.equal(due.sent.length, 1);
+  assert.equal(due.sent[0].to, 'five@example.com');
+  assert.equal(due.sent[0].subject, 'Your ParaSign Pro ends on 31 October');
+});
+
+test('without a mailer nothing is marked as sent, so the next sweep tries again', async () => {
+  const redis = await seeded(planExpiry);
+  const lines = [];
+  const log = (level, event, fields) => lines.push({ level, event, fields });
+  // What relay.js's sendResendEmail returns when RESEND_API_KEY is unset.
+  const dead = async () => false;
+
+  const r = await planExpiry.runSweep({ redis, now: NOW, sendEmail: dead, siteUrl: SITE, log });
+  assert.equal(r.warned, 0);
+  assert.equal(r.ended, 0);
+  const skipped = lines.filter((l) => l.event === 'plan_expiry_mail_skipped');
+  assert.equal(skipped.length, 2, 'one line per missed mail');
+
+  // No marker was left behind, so a configured relay still sends them later.
+  const send = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW + 3600000, sendEmail: send, siteUrl: SITE });
+  assert.equal(send.sent.length, 2, 'the mail that could not go out is not lost');
+});
+
+test('a mailer that throws is treated as a mail that did not go out', async () => {
+  const redis = await seeded(planExpiry);
+  const boom = async () => { throw new Error('resend down'); };
+  await planExpiry.runSweep({ redis, now: NOW, sendEmail: boom, siteUrl: SITE });
+
+  const send = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW + 60000, sendEmail: send, siteUrl: SITE });
+  assert.equal(send.sent.length, 2);
+});
+
+test('the marker outlives the longest term that is sold', async () => {
+  const redis = await seeded(planExpiry);
+  await planExpiry.runSweep({ redis, now: NOW, sendEmail: mailbox(), siteUrl: SITE });
+  const keys = [...redis.strings.keys()].filter((k) => k.startsWith(planExpiry.NOTICE_PREFIX));
+  assert.equal(keys.length, 2);
+  for (const k of keys) {
+    assert.equal(redis.strings.get(k).opts.EX, planExpiry.NOTICE_TTL_S);
+    assert.ok(planExpiry.NOTICE_TTL_S > 366 * 86400, 'a yearly term must not outlive its marker');
+    assert.match(k, /2026-1?0?-?/);
+  }
+  // The paid_until is IN the name. That is what makes a renewal a new mail and
+  // a restart a no-op, with nothing to clean up either way.
+  assert.ok(keys.some((k) => k.includes('acct_five') && k.includes(ACCOUNTS[1].paidUntil)));
+});
+
+test('a lapsed period is only news for a week, and is dropped from the index after a month', async () => {
+  const redis = await seeded(planExpiry);
+  const late = mailbox();
+  // Eight days after it ended: past the grace, so no mail. Silence is right
+  // here; the account has been on Community long enough that a note saying so
+  // would be news about nothing.
+  await planExpiry.runSweep({ redis, now: NOW + 8 * DAY, sendEmail: late, siteUrl: SITE });
+  assert.equal(late.sent.some((m) => m.to === 'gone@example.com'), false,
+    'nine days past the end is past the grace, and silence is the honest answer');
+
+  const pruned = await planExpiry.runSweep({ redis, now: NOW + 40 * DAY, sendEmail: mailbox(), siteUrl: SITE });
+  assert.equal(pruned.pruned, 2, 'both finished periods left the index');
+  assert.equal(await redis.hGet(planExpiry.META_HASH, 'acct_gone|parasend'), null);
+});
+
+test('landing on the floor tier takes the account out of the index', async () => {
+  const redis = await seeded(planExpiry);
+  // The chargeback path: setProductPlan(account, product, floor, null).
+  await planExpiry.upsertExpiry(redis, { accountId: 'acct_five', product: 'parasign', tier: 'free', paidUntil: null });
+  const send = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW, sendEmail: send, siteUrl: SITE });
+  assert.equal(send.sent.some((m) => m.to === 'five@example.com'), false,
+    'a revoked plan is not warned about');
+});
+
+test('an erased account is forgotten, address and all', async () => {
+  const redis = await seeded(planExpiry);
+  await planExpiry.forgetAccount(redis, 'acct_five');
+  assert.equal(await redis.hGet(planExpiry.META_HASH, 'acct_five|parasign'), null);
+  const send = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW, sendEmail: send, siteUrl: SITE });
+  assert.equal(send.sent.some((m) => m.to === 'five@example.com'), false);
+});
+
+test('the boot seed fills the index from what a container has on file, and repeats harmlessly', async () => {
+  const redis = fakeRedis();
+  const records = [
+    { accountId: 'acct_a', record: { plan_parasign: 'pro', paid_until_parasign: new Date(NOW + 3 * DAY).toISOString(), email: 'a@example.com' } },
+    { accountId: 'acct_b', record: { plan_parasend: 'community', email: 'b@example.com' } },
+    { accountId: 'acct_c', record: { plan_parasend: 'pro', paid_until_parasend: new Date(NOW + 200 * DAY).toISOString(), email: 'c@example.com' } },
+  ];
+  const first = await planExpiry.seedIndex(redis, records);
+  assert.equal(first.seen, 3);
+  assert.equal(first.indexed, 2, 'the account with no paid period is not indexed');
+  const again = await planExpiry.seedIndex(redis, records);
+  assert.equal(again.indexed, 2, 'seeding twice is an upsert, not a duplicate');
+
+  const send = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW, sendEmail: send, siteUrl: SITE });
+  assert.deepEqual(send.sent.map((m) => m.to), ['a@example.com'],
+    'only the account whose term is close');
+});
+
+test('an account with no address is logged, not mailed, and not marked', async () => {
+  const redis = fakeRedis();
+  await planExpiry.upsertExpiry(redis, {
+    accountId: 'acct_quiet', product: 'parasign', tier: 'pro',
+    paidUntil: new Date(NOW + 2 * DAY).toISOString(), email: '',
+  });
+  const lines = [];
+  const send = mailbox();
+  await planExpiry.runSweep({ redis, now: NOW, sendEmail: send, siteUrl: SITE, log: (l, e, f) => lines.push([l, e, f]) });
+  assert.equal(send.sent.length, 0);
+  assert.equal(lines.filter(([, e]) => e === 'plan_expiry_no_address').length, 1);
+  assert.equal([...redis.strings.keys()].filter((k) => k.startsWith(planExpiry.NOTICE_PREFIX)).length, 0);
+});
+
+test('no redis is a sweep that does not run, not a sweep that crashes', async () => {
+  const r = await planExpiry.runSweep({ redis: null, now: NOW, sendEmail: mailbox() });
+  assert.equal(r.ran, false);
+  assert.equal(r.reason, 'no_redis');
+});
+
+test('the date in the mail is the same date in every container', () => {
+  // Hand-built and UTC on purpose: toLocaleDateString needs Intl data a slim
+  // container image is not guaranteed to carry, and a mail that says a
+  // different day depending on which relay sent it is worse than no mail.
+  assert.equal(planExpiry.formatDate('2026-10-03T00:00:00.000Z'), '3 October');
+  assert.equal(planExpiry.formatDate('2026-01-01T23:59:59.000Z'), '1 January');
+  assert.equal(planExpiry.formatDate('not a date'), null);
+});
+
+test('the member encoding survives an account id that looks like a key', () => {
+  const m = planExpiry.memberOf('pgp_live_abc123', 'parasign');
+  assert.deepEqual(planExpiry.parseMember(m), { accountId: 'pgp_live_abc123', product: 'parasign' });
+  assert.equal(planExpiry.parseMember('nonsense'), null);
+  assert.equal(planExpiry.parseMember('acct|banana'), null);
+});

--- a/tests/plan-term-visible.test.mjs
+++ b/tests/plan-term-visible.test.mjs
@@ -1,0 +1,186 @@
+// Does the customer actually SEE when his term runs out.
+//
+// The relay has carried paid_until_<product> since the betaalpad fixes and the
+// entitlement layer has always floored an expired tier at read time, so the
+// account has been quietly dropping to Community on a date nothing on the site
+// ever mentioned. The reminder mail is one half of the fix; this is the other,
+// and it is the half a customer looks at on the day he wonders.
+//
+// Driven against the real pages with the two APIs mocked, in the shape
+// tests/navigation-shell.test.mjs uses: a static file server on a free port and
+// page.route() for every /api call. Nothing here needs a relay.
+//
+// Three moments per page, and the third is the one that used to be invisible:
+//   far    a term 40 days out    -> the date, no warning band
+//   close  a term 3 days out     -> the date AND the amber band with Renew
+//   ended  a term that has gone  -> "Ended on ..., now on Community"
+
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = { '.js': 'text/javascript', '.css': 'text/css', '.html': 'text/html', '.svg': 'image/svg+xml', '.png': 'image/png', '.woff2': 'font/woff2' };
+const aliases = { '/': '/index.html', '/dashboard': '/dashboard.html', '/account': '/account.html', '/pricing': '/pricing.html' };
+
+const server = http.createServer((req, res) => {
+  let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+  pathname = aliases[pathname] || pathname;
+  const file = path.join(ROOT, pathname);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+  fs.readFile(file, (error, body) => {
+    if (error) { res.writeHead(404); return res.end(); }
+    res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  });
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const ORIGIN = `http://localhost:${server.address().port}`;
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+
+const checks = [];
+function ok(name, condition, detail = '') { checks.push({ name, pass: !!condition, detail: String(detail) }); }
+
+const DAY = 86400000;
+const json = (route, body, status = 200) =>
+  route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+
+// The three terms under test, as an ISO paid_until the pages have to read.
+function term(days) { return new Date(Date.now() + days * DAY).toISOString(); }
+function readable(iso) {
+  return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', timeZone: 'UTC' });
+}
+
+// ── /account ─────────────────────────────────────────────────────────────────
+// Its billing block hangs on one call. Everything else on the page is stubbed
+// to something harmless so nothing else can fail the run.
+async function account(paidUntil) {
+  const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+  // Playwright tries the most recently added route first, so the catch-all is
+  // registered before the two that matter, not after.
+  await page.route('**/api/**', (route) => json(route, {}));
+  await page.route('**/api/user/billing/status', (route) => json(route, {
+    current_plan: 'pro',
+    plan_parasign: 'pro',
+    plan_parasend: 'community',
+    paid_until_parasign: paidUntil,
+    paid_until_parasend: null,
+    period: 'monthly',
+    amount_eur: null,
+    access_until: Date.parse(paidUntil) > Date.now() ? paidUntil : null,
+    next_billing_date: null,
+    auto_renews: false,
+    cancellation_scheduled_at: null,
+  }));
+  await page.route('**/api/user/billing/history', (route) => json(route, { history: [] }));
+  await page.route('**/api/user/account', (route) => json(route, {
+    email: 'demo@example.com', plan: 'pro', api_key_masked: 'pgp_demo...abcd',
+    created_at: '2026-01-01T00:00:00.000Z', sessions: [], backup_codes_remaining: 0,
+  }));
+  await page.goto(ORIGIN + '/account', { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => {
+    const el = document.getElementById('billing-content');
+    return el && !el.classList.contains('hidden');
+  }, null, { timeout: 10000 });
+  const state = await page.evaluate(() => {
+    const line = document.getElementById('billing-term-line');
+    const warn = document.getElementById('billing-term-warn');
+    const cta = warn && warn.querySelector('a.plan-term-warn-cta');
+    return {
+      line: line && !line.hidden ? line.textContent.trim() : null,
+      warn: warn && !warn.hidden ? warn.querySelector('[data-term="text"]').textContent.trim() : null,
+      cta: cta ? { text: cta.textContent.trim(), href: cta.getAttribute('href') } : null,
+      warnVisible: !!(warn && !warn.hidden && warn.getBoundingClientRect().height > 0),
+    };
+  });
+  await page.close();
+  return state;
+}
+
+// ── /dashboard ───────────────────────────────────────────────────────────────
+async function dashboard(paidUntil) {
+  const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+  await page.route('**/api/**', (route) => json(route, {}));
+  await page.route('**/api/user/me', (route) => json(route, {
+    email: 'demo@example.com',
+    label: null,
+    plan: 'pro',
+    plan_parasign: 'pro',
+    plan_parasend: 'community',
+    paid_until_parasign: paidUntil,
+    paid_until_parasend: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    api_key_masked: 'pgp_demo...abcd',
+    backup_codes_remaining: 3,
+    session_expires_at: new Date(Date.now() + 3600000).toISOString(),
+    usage_purpose: 'other',
+  }));
+  await page.route('**/api/user/documents**', (route) => json(route, { documents: [] }));
+  await page.route('**/api/user/dashboard/overview', (route) => json(route, {}));
+  await page.goto(ORIGIN + '/dashboard', { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => {
+    const el = document.getElementById('dh-term-line');
+    return el && !el.hidden;
+  }, null, { timeout: 10000 });
+  const state = await page.evaluate(() => {
+    const line = document.getElementById('dh-term-line');
+    const warn = document.getElementById('dh-term-warn');
+    const cta = warn && warn.querySelector('a.plan-term-warn-cta');
+    return {
+      line: line && !line.hidden ? line.textContent.trim() : null,
+      warn: warn && !warn.hidden ? warn.querySelector('[data-dh="term-warn"]').textContent.trim() : null,
+      cta: cta ? { text: cta.textContent.trim(), href: cta.getAttribute('href') } : null,
+      warnVisible: !!(warn && !warn.hidden && warn.getBoundingClientRect().height > 0),
+    };
+  });
+  await page.close();
+  return state;
+}
+
+for (const [name, run] of [['account', account], ['dashboard', dashboard]]) {
+  // Far out: the date is stated, and nothing shouts. A warning band on a term
+  // with six weeks left is noise, and noise is what makes the real one invisible.
+  const far = term(40);
+  const farState = await run(far);
+  ok(`${name}: a term far out shows the date and says nothing renews`,
+    farState.line === `Ends on ${readable(far)}, nothing renews automatically.`, JSON.stringify(farState));
+  ok(`${name}: a term far out carries no warning band`, farState.warn === null, JSON.stringify(farState));
+
+  // Inside the last seven days: the same date, plus one calm amber line with the
+  // one action that changes anything.
+  const close = term(3);
+  const closeState = await run(close);
+  ok(`${name}: a term inside seven days still states the date`,
+    closeState.line === `Ends on ${readable(close)}, nothing renews automatically.`, JSON.stringify(closeState));
+  ok(`${name}: a term inside seven days raises the warning`,
+    closeState.warnVisible && closeState.warn.includes(readable(close)), JSON.stringify(closeState));
+  ok(`${name}: the warning says nothing is charged automatically`,
+    /Nothing is charged automatically\./.test(closeState.warn || ''), closeState.warn || '');
+  ok(`${name}: the warning offers Renew, and it goes to /pricing`,
+    closeState.cta && closeState.cta.text === 'Renew' && closeState.cta.href === '/pricing',
+    JSON.stringify(closeState.cta));
+
+  // After the term. This is the case the page used to render as "Pro plan,
+  // active" while every gate answered 402.
+  const gone = term(-2);
+  const goneState = await run(gone);
+  ok(`${name}: an ended term says so, and says where the account landed`,
+    goneState.line === `Ended on ${readable(gone)}, now on Community.`, JSON.stringify(goneState));
+  ok(`${name}: an ended term drops the warning band`, goneState.warn === null, JSON.stringify(goneState));
+
+  // House style. An em-dash in customer copy is a style failure everywhere in
+  // this repo, and this text is generated rather than written into the HTML.
+  ok(`${name}: no em-dash in the term copy`,
+    ![farState.line, closeState.line, closeState.warn, goneState.line].some((s) => s && s.includes('\u2014')), '');
+}
+
+await browser.close();
+server.close();
+
+for (const c of checks) console.log(`${c.pass ? 'ok' : 'FAIL'} - ${c.name}${c.pass ? '' : ` :: ${c.detail}`}`);
+const failed = checks.filter((c) => !c.pass);
+console.log(`${checks.length} checks, ${failed.length} failed`);
+if (failed.length) process.exit(1);

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -396,8 +396,14 @@ for (const [file, html] of [['dashboard.html', dashboardHtml], ['account.html', 
 // The free band is the one upgrade path, so it gets exactly one link to
 // /pricing. Two was the old bridge sentence explaining that Community was
 // called Free over there; /pricing says Community now and the sentence is gone.
-for (const [file, html, id] of [['dashboard.html', dashboardHtml, 'dh-community'], ['account.html', accountHtml, 'billing-community']]) {
-  const band = (html.match(new RegExp(`id="${id}"[\\s\\S]*?<\\/(aside|div)>\\s*<\\/?(aside|div|p)`)) || [''])[0];
+// The cut is the band's OWN closing tag. It used to be "the first block close
+// followed by another block", which is not a boundary at all: on dashboard.html
+// that ran 4224 characters past the band and swallowed three sections that have
+// nothing to do with the upgrade path, so any link added anywhere below the
+// free band failed this check. Naming the tag per band bounds it to the element
+// the rule is about.
+for (const [file, html, id, close] of [['dashboard.html', dashboardHtml, 'dh-community', 'aside'], ['account.html', accountHtml, 'billing-community', 'div']]) {
+  const band = (html.match(new RegExp(`id="${id}"[\\s\\S]*?<\\/${close}>`)) || [''])[0];
   assert.ok(band, `${file} must carry the free-plan band`);
   assert.equal((band.match(/href="\/pricing"/g) || []).length, 1,
     `${file} must offer exactly one upgrade link in the free band`);


### PR DESCRIPTION
Directievraag: een kantoor betaalt vandaag voor ParaSign Pro. Over een maand valt dat account terug naar Community. Wie zegt dat, en wanneer?

Antwoord tot nu toe: niemand, nooit. `BILLING_MODE` is leeg, dus elke checkout is een eenmalige betaling voor een termijn. `paid_until_<product>` is het einde van die termijn en `entitlements.effectiveProductTier` vloert de tier op het moment dat hij passeert. Correct, en volledig stil: geen mail, geen datum op de site, en het eerste signaal voor de klant is een geweigerde handtekening.

Deze PR is die twee helften.

## Bovenop #411

#411 was open toen dit begon, dus zijn tak stond hier lokaal in gemerged. Inmiddels is hij gesquasht op main (c3c5d88), dus deze tak is opnieuw op main gezet en is nu een enkele commit met alleen het werk hieronder. Zonder #411 verlaat `paid_until_*` de relay niet en heeft de frontend niets om een datum uit te lezen; met #411 op main is die voorwaarde vervuld.

## De planner

`relay/lib/plan-expiry.js`. Er is geen cron op de server, dus het schema draait in de relay zelf: een sweep na een korte willekeurige vertraging na boot, daarna elke zes uur.

**Waarom hij vijf containers overleeft.** relay-main, relay-health, relay-finance, relay-legal en relay-iot draaien dezelfde regel tegen dezelfde redis. Zonder slot krijgt een klant zijn mail vijf keer. Een `SET NX PX` slot van tien minuten betekent dat er per venster precies een sweep werkt; de rest krijgt `reason: 'locked'` terug en doet niets. Het slot wordt teruggegeven met een token-check, zodat een sweep die zijn TTL overschrijdt niet het slot van een ander wist.

**Waarom hij een herstart overleeft.** Niets over "die heeft hem al gehad" staat in procesgeheugen. De markering is een redis-sleutel waarvan de NAAM de `paid_until` draagt waar hij bij hoort, met een TTL van 400 dagen, ruim langer dan de langste termijn die verkocht wordt. Een nieuw proces tegen dezelfde redis stuurt dus nul mails, en een verlenging (die `paid_until` verzet) krijgt vanzelf een nieuwe sleutel zonder dat iemand een oude hoeft te wissen. Dat is precies de faalvorm van 01-09, waar de paid_until-fix in geheugen leefde en de herstart niet overleefde die hij moest stoppen.

**Hoe hij alle accounts vindt.** Accounts staan niet in redis. Ze staan in `users.json`, per container, in `apiKeys`/`accounts` in het geheugen. Een sweep die alleen zijn eigen container leest mailt dus alleen de accounts die die container toevallig kent. Daarom schrijft `setProductPlan` nu `{account, product}` in een redis-ZSET met de periode-einde als score, plus het adres ernaast in een hash, en zaait elke container die index eenmalig bij boot vanuit wat hij op schijf heeft staan. ZADD met dezelfde score is een no-op, dus de vijf zaaiacties leveren een unie op en geen duplicaten. Het uitlezen is een `ZRANGEBYSCORE` over een venster, geen scan over alle accounts. Vloertier of ingetrokken periode haalt de regel er weer uit, en `/v2/admin/keys/erase` vergeet de kopie van het adres, anders was die wissing er geen.

## De mail

Zeven dagen vooraf, onderwerp `Your ParaSign Pro ends on 3 October`:

> Your ParaSign Pro ends on 3 October.
>
> Renew for another month or year, or let it fall back to Community; nothing is charged automatically.
>
> Your plans and prices are here: https://paramant.app/pricing

Op de dag van afloop, onderwerp `Your ParaSign Pro has ended`:

> Your ParaSign Pro ended on 3 October, and your account is now on Community.
>
> Nothing was charged. Every plan here is a one-off payment for the term you buy, so nothing renews by itself and nothing is collected without you.
>
> You can buy another month or another year at any time: https://paramant.app/pricing

Die tweede helft is niet decoratief. Op een eenmalige betaling leest "je plan loopt af" als een dreiging met een afschrijving tenzij er staat dat dat niet gebeurt.

Verstuurd via de bestaande weg in de relay, `sendResendEmail`. De datum is met de hand opgebouwd in UTC en niet via `toLocaleDateString`: een slim container-image draagt geen gegarandeerde Intl-data, en een mail die per container een andere dag noemt is erger dan geen mail.

Zonder `RESEND_API_KEY` geeft de mailer terug dat hij niets verstuurd heeft. De reservering wordt dan teruggegeven en er gaat een regel `plan_expiry_mail_skipped` per gemiste mail naar het log, dus een sleutel die later gezet wordt stuurt ze alsnog. `SITE_URL` staat nu ook in de relay-env in docker-compose, met `https://paramant.app` als val.

## Op de site

`/account` en `/dashboard` zeggen nu hetzelfde. Bij het plan: `Ends on 3 October, nothing renews automatically.` Vanaf zeven dagen vooraf een gele regel met een Renew-knop naar `/pricing`. Na afloop: `Ended on 3 October, now on Community.` De datum komt uit `paid_until_*`, die sinds #411 de relay verlaat.

De regel op het dashboard staat bewust BUITEN de betaalde band. Een verlopen termijn vloert elk product, waardoor die band leeg is en verdwijnt, en dat is precies het moment waarop een klant de datum het hardst nodig heeft.

## Poorten

| Suite | Uitkomst |
|---|---|
| `relay/test/plan-expiry.test.js` (nieuw) | 17 |
| `tests/plan-term-visible.test.mjs` (nieuw) | 18 checks |
| relay units | 242 |
| relay routes met redis | 117 |
| root-integratie (`tests/*.mjs` zonder browser) | 224, 1 bekende val, 2 aangekondigde skips |
| ui-truthfulness, site-claims, frontend-loading-contract, env-documented | 52 |
| `tests/static-sanity.sh` | PASS |
| cache-bust guard | OK, 364 links |
| eslint | schoon |

De nieuwe relay-suite doet de drie accounts uit de opdracht: 10 dagen, 5 dagen, gisteren verlopen. Precies een waarschuwing voor de tweede, een afloopmelding voor de derde, niets voor de eerste. Tweede sweep: nul. Sweep vanuit een vers ge-required module tegen dezelfde store, wat een herstart is: nul. Twee gelijktijdige sweeps: een werkt, een krijgt `locked`, en de mail gaat een keer. Verder een verlenging die een nieuwe mail verdient, een mailer die faalt en een die gooit, een ingetrokken plan, een gewist account, de zaai-actie en de TTL.

Alles daarin draait tegen een nagemaakte store. Los daarvan is dezelfde reeks eenmalig met de hand tegen een echte redis 7.4.8 en de echte node-redis-client gedraaid, om te bewijzen dat `zAdd`, `zRangeByScore`, `hSet` en `SET NX PX` zich gedragen zoals de nagemaakte store doet: sweep 1 twee mails, sweep 2 nul, gelijktijdig een van de twee, TTL 400 dagen.

`tests/heartbeat-lib.test.mjs` valt lokaal op een ontbrekende `@noble/post-quantum` in de geleende `node_modules`. Staat los van deze diff, zoals in #411, en CI installeert wel.

## Een test aangepast

`ui-truthfulness` sneed de gratis band af op "de eerste blok-sluiting gevolgd door een tweede blok". Dat is geen grens: op `dashboard.html` liep dat 4224 tekens voorbij de band en slokte drie secties op die niets met het upgrade-pad te maken hebben, dus elke link die daaronder ergens bijkwam liet die check vallen. Nu begrensd op de sluittag van de band zelf. De regel is strenger geworden, niet losser.

## Wat blijft staan

- **De mailer zegt "verstuurd" zodra het verzoek de deur uit is.** `sendResendEmail` kijkt niet naar de HTTP-status van Resend, alleen naar transportfouten. Een 4xx van Resend verbruikt dus de markering. Dat is het gedrag van de bestaande mailweg en geldt voor elke bestaande verzender in de relay; het rechttrekken raakt callers buiten deze diff.
- **Niets hiervan heeft tegen Resend gedraaid.** Alle tests drijven een spion. Voor dit live gaat moet er een echte mail uit met `RESEND_API_KEY` gezet.
- **Zeven dagen en zes uur staan vast in de code**, geen env-variabele. Bewust: nog een ongedocumenteerde knop is geen winst zolang niemand hem verzet.
- **De admin-suite is hier niet gedraaid**: `express` staat in geen enkele `node_modules` op deze machine. Er is geen bestand in `admin/` gewijzigd behalve wat #411 zelf meebracht.
