### PR TITLE
The night is the design system, on every page and every screen

### DIFF
--- a/docs/site-claims.md
+++ b/docs/site-claims.md
@@ -104,10 +104,10 @@ key is for, because it is the one a page makes a promise about.
 
 | Key | What it holds | Written by | Set where |
 |---|---|---|---|
-| `paramant.theme.v1` | The appearance choice: `auto`, `light` or `dark`. Absent means light, which is the default on every app screen. Applied before the first paint by `frontend/js/theme.js`; the dark tokens in `frontend/app-2026.css` are scoped to `[data-theme="auto"]` and `[data-theme="dark"]`, so a dark operating system alone never darkens the app | `frontend/js/theme.js` | The Appearance switch on /account |
+| `paramant.theme.v1` | The appearance choice: `auto`, `light` or `dark`. Absent means the night, which is the default on every page of the site and every app screen. Applied before the first paint by `frontend/js/theme.js`; the cream-paper tokens in `frontend/app-2026.css` are scoped to `[data-theme="light"]` and `[data-theme="auto"]`, so a light operating system alone never lifts the app off the night | `frontend/js/theme.js` | The Appearance switch on /account |
 
 /account tells the reader the choice is "kept in this browser only" and that the
-public pages stay light. `tests/ui-truthfulness.test.mjs` pins the key name, the
+public pages stay dark. `tests/ui-truthfulness.test.mjs` pins the key name, the
 three values, that `theme.js` contains no `fetch`, `XMLHttpRequest` or
 `sendBeacon`, and that /privacy names the key. What the sentence promises about
 colour is measured in a browser by `tests/app-theme.test.mjs`.

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+  <style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Page not found · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
@@ -10,25 +10,25 @@
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
   <link rel="manifest" href="/manifest.json">
-  <meta name="theme-color" content="#0B3A6A">
+  <meta name="theme-color" content="#15191C">
   <style>
     *{box-sizing:border-box;margin:0;padding:0}
-    body{font-family:system-ui,sans-serif;background:#F8FAFC;color:#1E293B;display:flex;flex-direction:column;min-height:100vh}
+    body{font-family:system-ui,sans-serif;background:var(--card);color:#1E293B;display:flex;flex-direction:column;min-height:100vh}
     main{flex:1;display:flex;align-items:center;justify-content:center;padding:40px 24px;text-align:center}
     .wrap{max-width:480px}
-    .code{font-size:80px;font-weight:700;color:#0B3A6A;letter-spacing:-.04em;line-height:1;margin-bottom:16px;font-family:ui-monospace,monospace}
+    .code{font-size:80px;font-weight:700;color:var(--ink);letter-spacing:-.04em;line-height:1;margin-bottom:16px;font-family:ui-monospace,monospace}
     h1{font-size:20px;font-weight:600;margin-bottom:12px}
-    p{color:#64748B;font-size:15px;line-height:1.7;margin-bottom:28px}
+    p{color:var(--ink-dim);font-size:15px;line-height:1.7;margin-bottom:28px}
     .links{display:flex;flex-wrap:wrap;gap:12px;justify-content:center}
-    .links a{color:#1D4ED8;text-decoration:none;font-size:14px;padding:8px 16px;border:1px solid #BFDBFE;border-radius:2px}
-    .links a:hover{background:#EFF6FF}
-    footer{padding:20px 24px;text-align:center;font-size:11px;color:#94A3B8;border-top:1px solid #E2E8F0}
+    .links a{color:var(--cobalt);text-decoration:none;font-size:14px;padding:8px 16px;border:1px solid #BFDBFE;border-radius:2px}
+    .links a:hover{background:var(--card)}
+    footer{padding:20px 24px;text-align:center;font-size:11px;color:var(--ink-dim);border-top:1px solid var(--ink-hair)}
   </style>
-<style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
-<link rel="stylesheet" href="/parapear.css?v=1">
+<style>.skip-link{position:absolute;top:-200px;left:0;background:var(--bone-2);color:var(--ink);padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid var(--ochre);transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:var(--ochre)}</style>
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
+<link rel="stylesheet" href="/parapear.css?v=4">
 <style>
   main .wrap .parapear-block { max-width: 560px; margin: 0 auto 28px; text-align: left; }
 </style>

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>About Paramant · Founded by Mick Beer</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -24,11 +24,11 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .about-band{padding:var(--space-8) 0;border-top:1px solid var(--ink-hair)}
 .about-band:first-of-type{border-top:none}
@@ -36,7 +36,7 @@
 .about-band .mono-eyebrow{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;color:var(--cobalt)}
 .about-lede{font-size:var(--text-md);color:var(--ink);line-height:1.7;max-width:680px;margin-top:var(--space-4)}
 .about-band p{font-size:var(--text-base);color:var(--ink);line-height:1.8;max-width:680px;margin-top:var(--space-4)}
-.about-band p a{color:var(--cobalt)}
+.about-band p a:not(.btn){color:var(--cobalt)}
 .about-band p strong{color:var(--navy)}
 .check-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1px;background:var(--ink-hair);border:1px solid var(--ink-hair);margin-top:var(--space-5)}
 .check-card{background:var(--bone);padding:var(--space-5) var(--space-5)}

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -2,15 +2,15 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">:root{color-scheme:light}html,body{background:#FBFAF7;color:#0C1B2A;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}@media(prefers-color-scheme:dark){:root[data-theme="auto"]{color-scheme:dark}html[data-theme="auto"],html[data-theme="auto"] body{background:#0A0F16;color:#EDF1F6}}html[data-theme="dark"],html[data-theme="dark"] body{background:#0A0F16;color:#EDF1F6}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}html[data-theme="light"],html[data-theme="light"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="light"]{color-scheme:light}@media (prefers-color-scheme:light){html[data-theme="auto"],html[data-theme="auto"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="auto"]{color-scheme:light}}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Your account · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <meta property="og:title" content="Your account · Paramant">
 <meta property="og:description" content="Your account · Paramant">
 <meta property="og:url" content="https://paramant.app/account">
@@ -39,9 +39,9 @@
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -52,26 +52,26 @@
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -80,13 +80,13 @@
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }
@@ -150,9 +150,9 @@ main.acct input::placeholder { color: var(--ink-3); }
 .acct-advanced-body { margin-top:var(--space-4); padding-top:var(--space-3); border-top:1px solid var(--line); }
 @media (max-width: 680px) { .acct-grid2 { grid-template-columns: 1fr; gap: var(--space-4); } main.acct { padding: var(--space-5) var(--space-3) var(--space-6); } }
 </style>
-<meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=4">
-<script src="/js/theme.js?v=1"></script>
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/app-2026.css?v=7">
+<script src="/js/theme.js?v=4"></script>
 </head>
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -285,7 +285,7 @@ main.acct input::placeholder { color: var(--ink-3); }
       <h3>Enrolled keys</h3>
       <p style="margin:0 0 12px" id="signing-empty" class="small">Checking your account...</p>
       <ul id="signing-list" style="margin:0;padding:0;list-style:none"></ul>
-      <div id="revoke-totp-wrap" hidden style="margin-top:10px;padding:12px 14px;border:1px solid var(--ink-hair,#E2E8F0);border-radius:6px">
+      <div id="revoke-totp-wrap" hidden style="margin-top:10px;padding:12px 14px;border:1px solid var(--ink-hair);border-radius:6px">
         <p class="small" style="margin:0 0 8px">Enter your 6-digit authenticator code to revoke this signing key.</p>
         <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
           <input type="text" id="revoke-totp" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code" placeholder="6-digit code" style="max-width:140px">
@@ -336,9 +336,9 @@ main.acct input::placeholder { color: var(--ink-3); }
   <div class="acct-kicker">Appearance &middot; light and dark</div>
   <h2>Appearance.</h2>
   <p class="acct-lead">
-    Light is the default and it stays light until you change it here. Your choice is kept in this
+    Dark is the default and it stays dark until you change it here. Your choice is kept in this
     browser only, and it applies to the pages behind your sign-in: your dashboard, signing,
-    sending, this page and the sign-in screens. The public pages stay light.
+    sending, this page and the sign-in screens. The public pages stay dark.
   </p>
   <fieldset class="theme-choice" id="theme-choice">
     <legend>Appearance</legend>
@@ -388,7 +388,7 @@ main.acct input::placeholder { color: var(--ink-3); }
     <p id="billing-renew-note" class="acct-note" hidden style="font-size:var(--text-sm);color:var(--ink-dim);margin-top:var(--space-2)">This is a one-off payment for the term you bought. Nothing is collected again by itself. Buy another term before this date to keep the plan running.</p>
     <div class="info-row" id="billing-cancel-row" style="display:none">
       <div class="info-label">Cancellation</div>
-      <div class="info-value" id="billing-cancel-date" style="color:#d97706">&mdash;</div>
+      <div class="info-value" id="billing-cancel-date" style="color:var(--warn-ink)">&mdash;</div>
     </div>
     <div class="acct-actions">
       <a href="/pricing" class="btn btn-secondary btn-small">View plans</a>
@@ -454,7 +454,7 @@ main.acct input::placeholder { color: var(--ink-3); }
 <script type="module" src="/js/account.inline2.js?v=3"></script>
 <script type="module" src="/js/passkey.js?v=4"></script>
 <script type="module" src="/js/signing-enrol.js?v=14"></script>
-<script src="/js/account-theme.js?v=1" defer></script>
+<script src="/js/account-theme.js?v=2" defer></script>
 
 <footer class="legal-strip">
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -2,167 +2,167 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,system-ui,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,system-ui,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Admin · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
-body{background:#F8FAFC;color:#0B3A6A;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,system-ui,sans-serif;font-size:14px;-webkit-font-smoothing:antialiased;min-height:100vh}
+body{background:var(--card);color:var(--ink);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,system-ui,sans-serif;font-size:14px;-webkit-font-smoothing:antialiased;min-height:100vh}
 button,input,select{font-family:inherit;font-size:inherit}
 /* Login */
 .lw{display:flex;align-items:center;justify-content:center;min-height:100vh;padding:24px}
 .lb{width:100%;max-width:340px}
-.l-brand{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.15em;text-transform:uppercase;color:#475569;margin-bottom:20px}
-.l-title{font-size:22px;font-weight:600;color:#0B3A6A;margin-bottom:6px}
-.l-sub{font-size:13px;color:#475569;margin-bottom:26px;line-height:1.5}
-.l-lbl{display:block;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:#475569;margin-bottom:6px}
-.l-inp{width:100%;background:#fff;border:1.5px solid rgba(11,58,106,.15);padding:10px 12px;color:#0B3A6A;font-size:13px;outline:none;margin-bottom:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;transition:border-color .15s}
-.l-inp:focus{border-color:#1D4ED8}
+.l-brand{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.15em;text-transform:uppercase;color:var(--ink-2);margin-bottom:20px}
+.l-title{font-size:22px;font-weight:600;color:var(--ink);margin-bottom:6px}
+.l-sub{font-size:13px;color:var(--ink-2);margin-bottom:26px;line-height:1.5}
+.l-lbl{display:block;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--ink-2);margin-bottom:6px}
+.l-inp{width:100%;background:var(--card);border:1.5px solid rgba(var(--tint), .15);padding:10px 12px;color:var(--ink);font-size:13px;outline:none;margin-bottom:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;transition:border-color .15s}
+.l-inp:focus{border-color:var(--ochre)}
 .l-totp{font-size:20px;letter-spacing:.2em;margin-bottom:18px}
-.l-btn{width:100%;background:#0B3A6A;color:#F8FAFC;border:none;padding:11px;font-size:12px;font-weight:700;cursor:pointer;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;letter-spacing:.1em;text-transform:uppercase;transition:background .15s}
-.l-btn:hover{background:#1D4ED8}
+.l-btn{width:100%;background:var(--bone-2);color:var(--ink);border:none;padding:11px;font-size:12px;font-weight:700;cursor:pointer;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;letter-spacing:.1em;text-transform:uppercase;transition:background .15s}
+.l-btn:hover{background:var(--ochre)}
 .l-btn:disabled{opacity:.5;cursor:default}
-.l-err{font-size:12px;color:#dc2626;margin-top:10px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;display:none}
-.l-note{font-size:11px;color:#94a3b8;margin-top:12px;text-align:center;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.l-err{font-size:12px;color:var(--brick-ink);margin-top:10px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;display:none}
+.l-note{font-size:11px;color:var(--ink-dim);margin-top:12px;text-align:center;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
 /* Shell */
 .shell{display:none;flex-direction:column;min-height:100vh}
-.hdr{display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:52px;border-bottom:1.5px solid rgba(11,58,106,.08);background:#F8FAFC;position:sticky;top:0;z-index:50}
-.hdr-brand{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.14em;font-weight:700;color:#0B3A6A;text-transform:uppercase;white-space:nowrap}
+.hdr{display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:52px;border-bottom:1.5px solid rgba(var(--tint), .08);background:var(--card);position:sticky;top:0;z-index:50}
+.hdr-brand{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.14em;font-weight:700;color:var(--ink);text-transform:uppercase;white-space:nowrap}
 .tabs{display:flex;gap:0;overflow-x:auto}
-.tabs button{background:transparent;border:none;border-bottom:2px solid transparent;padding:16px 16px 14px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,system-ui,sans-serif;font-size:13px;color:#475569;cursor:pointer;white-space:nowrap;transition:color .15s}
-.tabs button.on{color:#0B3A6A;border-bottom-color:#1D4ED8;font-weight:600}
-.tabs button:hover:not(.on){color:#0B3A6A}
+.tabs button{background:transparent;border:none;border-bottom:2px solid transparent;padding:16px 16px 14px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,system-ui,sans-serif;font-size:13px;color:var(--ink-2);cursor:pointer;white-space:nowrap;transition:color .15s}
+.tabs button.on{color:var(--ink);border-bottom-color:var(--ochre);font-weight:600}
+.tabs button:hover:not(.on){color:var(--ink)}
 .hdr-meta{display:flex;gap:10px;align-items:center;flex-shrink:0}
-.lic{background:rgba(178,255,63,.22);color:#0B3A6A;padding:4px 10px;font-size:11px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;white-space:nowrap}
-.lo-btn{padding:6px 12px;background:transparent;border:1.5px solid rgba(11,58,106,.2);color:#0B3A6A;cursor:pointer;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.08em;text-transform:uppercase;transition:border-color .15s}
-.lo-btn:hover{border-color:#0B3A6A}
+.lic{background:rgba(217, 164, 65, .22);color:var(--ink);padding:4px 10px;font-size:11px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;white-space:nowrap}
+.lo-btn{padding:6px 12px;background:transparent;border:1.5px solid rgba(var(--tint), .2);color:var(--ink);cursor:pointer;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.08em;text-transform:uppercase;transition:border-color .15s}
+.lo-btn:hover{border-color:var(--line-2)}
 .main{flex:1;padding:24px;max-width:1400px;width:100%;margin:0 auto}
 .panel{display:none}.panel.on{display:block}
 /* Stat cards */
 .sg{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:20px}
-.sc{background:#fff;border:1px solid rgba(11,58,106,.08);padding:20px}
-.sc-lbl{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:#475569;margin-bottom:10px}
-.sc-val{font-size:30px;font-weight:500;color:#0B3A6A;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;line-height:1}
+.sc{background:var(--card);border:1px solid rgba(var(--tint), .08);padding:20px}
+.sc-lbl{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-2);margin-bottom:10px}
+.sc-val{font-size:30px;font-weight:500;color:var(--ink);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;line-height:1}
 /* Cards */
-.card{background:#fff;border:1px solid rgba(11,58,106,.08);padding:20px;margin-bottom:16px}
-.card-hdr{font-size:12px;font-weight:600;color:#0B3A6A;margin-bottom:14px;display:flex;align-items:center;justify-content:space-between;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;letter-spacing:.06em;text-transform:uppercase}
-.card-hdr small{font-size:11px;font-weight:400;color:#475569;text-transform:none;letter-spacing:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,system-ui,sans-serif}
+.card{background:var(--card);border:1px solid rgba(var(--tint), .08);padding:20px;margin-bottom:16px}
+.card-hdr{font-size:12px;font-weight:600;color:var(--ink);margin-bottom:14px;display:flex;align-items:center;justify-content:space-between;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;letter-spacing:.06em;text-transform:uppercase}
+.card-hdr small{font-size:11px;font-weight:400;color:var(--ink-2);text-transform:none;letter-spacing:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,system-ui,sans-serif}
 .g2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
 .g3{display:grid;grid-template-columns:2fr 1fr 1fr;gap:16px}
 /* Table */
 .tbl{width:100%;border-collapse:collapse;font-size:13px}
-.tbl th{text-align:left;padding:9px 12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:#475569;border-bottom:1.5px solid rgba(11,58,106,.08)}
-.tbl td{padding:11px 12px;border-bottom:1px solid rgba(11,58,106,.04);color:#0B3A6A}
-.tbl tr:hover td{background:rgba(29,78,216,.02)}
+.tbl th{text-align:left;padding:9px 12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-2);border-bottom:1.5px solid rgba(var(--tint), .08)}
+.tbl td{padding:11px 12px;border-bottom:1px solid rgba(var(--tint), .04);color:var(--ink)}
+.tbl tr:hover td{background:rgba(217, 164, 65, .02)}
 .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px}
 /* Badges */
 .badge{display:inline-block;padding:2px 8px;font-size:11px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-transform:uppercase;letter-spacing:.06em}
-.badge.community{background:rgba(11,58,106,.08);color:#0B3A6A}
-.badge.pro{background:rgba(29,78,216,.1);color:#1D4ED8}
-.badge.enterprise{background:rgba(178,255,63,.35);color:#2d5a00;font-weight:700}
-.badge.trial{background:rgba(245,158,11,.1);color:#b45309}
+.badge.community{background:rgba(var(--tint), .08);color:var(--ink)}
+.badge.pro{background:rgba(217, 164, 65, .1);color:var(--cobalt)}
+.badge.enterprise{background:rgba(217, 164, 65, .35);color:#2d5a00;font-weight:700}
+.badge.trial{background:rgba(245,158,11,.1);color:var(--warn-ink)}
 .chip{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;text-transform:uppercase;letter-spacing:.06em}
-.chip.active{color:#059669}.chip.pending{color:#d97706}.chip.none{color:#94a3b8}.chip.revoked{color:#dc2626}
+.chip.active{color:var(--ok-ink)}.chip.pending{color:var(--warn-ink)}.chip.none{color:var(--ink-dim)}.chip.revoked{color:var(--brick-ink)}
 /* Filter bar */
 .fb{display:flex;gap:10px;margin-bottom:14px;flex-wrap:wrap;align-items:center}
-.fb input,.fb select{padding:7px 10px;border:1.5px solid rgba(11,58,106,.12);font-size:12px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,system-ui,sans-serif;background:#fff;color:#0B3A6A;outline:none}
-.fb input:focus,.fb select:focus{border-color:#1D4ED8}
+.fb input,.fb select{padding:7px 10px;border:1.5px solid rgba(var(--tint), .12);font-size:12px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,system-ui,sans-serif;background:var(--card);color:var(--ink);outline:none}
+.fb input:focus,.fb select:focus{border-color:var(--ochre)}
 .sp{flex:1}
-.btn{padding:7px 14px;background:#0B3A6A;color:#F8FAFC;border:none;font-size:11px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;letter-spacing:.08em;text-transform:uppercase;cursor:pointer;transition:background .15s}
-.btn:hover{background:#1D4ED8}
-.btn.out{background:transparent;border:1.5px solid rgba(11,58,106,.2);color:#0B3A6A}
-.btn.out:hover{border-color:#1D4ED8;color:#1D4ED8;background:transparent}
+.btn{padding:7px 14px;background:var(--bone-2);color:var(--ink);border:none;font-size:11px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;letter-spacing:.08em;text-transform:uppercase;cursor:pointer;transition:background .15s}
+.btn:hover{background:var(--ochre)}
+.btn.out{background:transparent;border:1.5px solid rgba(var(--tint), .2);color:var(--ink)}
+.btn.out:hover{border-color:var(--ochre);color:var(--cobalt);background:transparent}
 /* Relay strip */
 .rs{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-bottom:16px}
-.ri{padding:10px 12px;background:rgba(5,150,105,.08);border-left:3px solid #059669;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px;color:#065f46}
-.ri.offline{background:rgba(220,38,38,.06);border-left-color:#dc2626;color:#991b1b}
-.ri.loading{background:rgba(11,58,106,.04);border-left-color:#94a3b8;color:#475569}
+.ri{padding:10px 12px;background:rgba(5,150,105,.08);border-left:3px solid var(--ok-ink);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px;color:#065f46}
+.ri.offline{background:rgba(196, 96, 79, .06);border-left-color:var(--brick);color:var(--brick-ink)}
+.ri.loading{background:rgba(var(--tint), .04);border-left-color:var(--line-2);color:var(--ink-2)}
 .ri-name{font-weight:700;margin-bottom:2px}
 .ri-det{font-size:10px;opacity:.8}
 /* Activity */
 .al{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px}
-.ai{display:flex;gap:12px;padding:5px 0;border-bottom:1px solid rgba(11,58,106,.04)}
-.ai .t{color:#475569;flex-shrink:0;width:80px}
-.ai .e{color:#1D4ED8;flex-shrink:0;width:160px}
-.ai .u{color:#0B3A6A;opacity:.6;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.ai{display:flex;gap:12px;padding:5px 0;border-bottom:1px solid rgba(var(--tint), .04)}
+.ai .t{color:var(--ink-2);flex-shrink:0;width:80px}
+.ai .e{color:var(--cobalt);flex-shrink:0;width:160px}
+.ai .u{color:var(--ink);opacity:.6;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 /* Plan bars */
 .pb{display:flex;align-items:center;gap:10px;margin-bottom:8px}
-.pb .pl{width:90px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:#475569}
-.pb .tr{flex:1;height:6px;background:rgba(11,58,106,.06);overflow:hidden}
-.pb .fi{height:100%;background:#1D4ED8;transition:width .5s}
-.pb .cn{width:28px;text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;color:#475569}
+.pb .pl{width:90px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--ink-2)}
+.pb .tr{flex:1;height:6px;background:rgba(var(--tint), .06);overflow:hidden}
+.pb .fi{height:100%;background:var(--ochre);transition:width .5s}
+.pb .cn{width:28px;text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;color:var(--ink-2)}
 /* Action menu */
 .amw{position:relative;display:inline-block}
-.amb{background:transparent;border:1px solid rgba(11,58,106,.12);color:#0B3A6A;padding:4px 10px;font-size:11px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;cursor:pointer}
-.amb:hover{background:rgba(11,58,106,.04)}
-.am{display:none;position:absolute;right:0;top:calc(100% + 4px);background:#fff;border:1px solid rgba(11,58,106,.15);z-index:20;min-width:190px;box-shadow:0 4px 16px rgba(11,58,106,.1)}
+.amb{background:transparent;border:1px solid rgba(var(--tint), .12);color:var(--ink);padding:4px 10px;font-size:11px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;cursor:pointer}
+.amb:hover{background:rgba(var(--tint), .04)}
+.am{display:none;position:absolute;right:0;top:calc(100% + 4px);background:var(--card);border:1px solid rgba(var(--tint), .15);z-index:20;min-width:190px;box-shadow:0 4px 16px rgba(0, 0, 0, .1)}
 .am.open{display:block}
-.am button{display:block;width:100%;text-align:left;padding:9px 14px;background:transparent;border:none;font-size:13px;color:#0B3A6A;cursor:pointer}
-.am button:hover{background:rgba(29,78,216,.05)}
-.am button.danger{color:#dc2626}
-.am button.danger:hover{background:rgba(220,38,38,.05)}
-.am .sep{height:1px;background:rgba(11,58,106,.06);margin:4px 0}
+.am button{display:block;width:100%;text-align:left;padding:9px 14px;background:transparent;border:none;font-size:13px;color:var(--ink);cursor:pointer}
+.am button:hover{background:rgba(217, 164, 65, .05)}
+.am button.danger{color:var(--brick-ink)}
+.am button.danger:hover{background:rgba(196, 96, 79, .05)}
+.am .sep{height:1px;background:rgba(var(--tint), .06);margin:4px 0}
 /* Banner */
 .banner{padding:10px 14px;margin-bottom:14px;font-size:13px;line-height:1.5}
-.banner.stub{background:rgba(245,158,11,.08);border-left:3px solid #d97706;color:#92400e}
-.banner.info{background:rgba(29,78,216,.06);border-left:3px solid #1D4ED8;color:#1e3a8a}
+.banner.stub{background:rgba(245,158,11,.08);border-left:3px solid var(--ochre-2);color:var(--warn-ink)}
+.banner.info{background:rgba(217, 164, 65, .06);border-left:3px solid var(--ochre);color:#1e3a8a}
 /* Toast */
-.toast{position:fixed;bottom:20px;right:20px;background:#0B3A6A;color:#F8FAFC;padding:10px 16px;font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;z-index:999;max-width:320px}
-.toast.err{background:#dc2626}
-.toast.ok{background:#059669}
+.toast{position:fixed;bottom:20px;right:20px;background:var(--bone-2);color:var(--ink);padding:10px 16px;font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;z-index:999;max-width:320px}
+.toast.err{background:var(--brick)}
+.toast.ok{background:var(--ok-ink)}
 /* Loading */
-.sp-icon{display:inline-block;width:14px;height:14px;border:2px solid rgba(11,58,106,.12);border-top-color:#1D4ED8;border-radius:50%;animation:spin .6s linear infinite;vertical-align:middle;margin-right:6px}
+.sp-icon{display:inline-block;width:14px;height:14px;border:2px solid rgba(var(--tint), .12);border-top-color:var(--ochre);border-radius:50%;animation:spin .6s linear infinite;vertical-align:middle;margin-right:6px}
 @keyframes spin{to{transform:rotate(360deg)}}
-.empty{padding:32px;text-align:center;color:#94a3b8;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px}
+.empty{padding:32px;text-align:center;color:var(--ink-dim);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px}
 /* Accessibility */
-.skip-link{position:absolute;top:-40px;left:0;background:#0B3A6A;color:#F8FAFC;padding:8px 12px;text-decoration:none;z-index:200;font-size:13px}
+.skip-link{position:absolute;top:-40px;left:0;background:var(--bone-2);color:var(--ink);padding:8px 12px;text-decoration:none;z-index:200;font-size:13px}
 .skip-link:focus{top:0}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-*:focus-visible{outline:2px solid #1D4ED8;outline-offset:2px}
-button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{outline:2px solid #1D4ED8;outline-offset:2px}
+*:focus-visible{outline:2px solid var(--ochre);outline-offset:2px}
+button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{outline:2px solid var(--ochre);outline-offset:2px}
 /* Pagination */
-.pag{display:flex;align-items:center;gap:10px;padding:12px 0;border-top:1px solid rgba(11,58,106,.06);margin-top:4px}
-.pag button{padding:5px 12px;border:1.5px solid rgba(11,58,106,.15);background:#fff;color:#0B3A6A;cursor:pointer;font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
-.pag button:hover:not(:disabled){border-color:#1D4ED8;color:#1D4ED8}
+.pag{display:flex;align-items:center;gap:10px;padding:12px 0;border-top:1px solid rgba(var(--tint), .06);margin-top:4px}
+.pag button{padding:5px 12px;border:1.5px solid rgba(var(--tint), .15);background:var(--card);color:var(--ink);cursor:pointer;font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.pag button:hover:not(:disabled){border-color:var(--ochre);color:var(--cobalt)}
 .pag button:disabled{opacity:.4;cursor:default}
-.pag select{padding:5px 8px;border:1.5px solid rgba(11,58,106,.15);background:#fff;color:#0B3A6A;font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
-.pag-info{font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:#475569;flex:1;text-align:center}
+.pag select{padding:5px 8px;border:1.5px solid rgba(var(--tint), .15);background:var(--card);color:var(--ink);font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.pag-info{font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:var(--ink-2);flex:1;text-align:center}
 /* Responsive */
 @media(max-width:900px){.sg,.rs,.g2,.g3{grid-template-columns:1fr 1fr}.tabs{overflow-x:auto}}
 @media(max-width:600px){.sg,.rs{grid-template-columns:1fr}.hdr{padding:0 12px}.main{padding:14px}.hdr-meta .lic{display:none}}
 
 /* Action menu group labels */
-.ag-lbl{display:block;padding:4px 14px 2px;font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:#94a3b8;pointer-events:none;user-select:none}
+.ag-lbl{display:block;padding:4px 14px 2px;font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-dim);pointer-events:none;user-select:none}
 .am button:disabled{opacity:.35;cursor:default}
 /* Toast animation */
 .toast{opacity:0;transform:translateY(8px);transition:opacity .2s,transform .2s}
 .toast.show{opacity:1;transform:translateY(0)}
 /* Modal overlay */
-.mo{display:none;position:fixed;inset:0;background:rgba(11,58,106,.45);z-index:100;align-items:center;justify-content:center;padding:16px}
+.mo{display:none;position:fixed;inset:0;background:rgba(0, 0, 0, .62);z-index:100;align-items:center;justify-content:center;padding:16px}
 .mo[open],.mo.vis{display:flex}
-.mb{background:#fff;width:100%;max-width:540px;max-height:90vh;display:flex;flex-direction:column;overflow:hidden}
-.mh{display:flex;align-items:center;padding:14px 18px;border-bottom:1px solid rgba(11,58,106,.1);gap:8px}
-.mt{flex:1;font-weight:600;font-size:15px;color:#0B3A6A}
-.mh button.close-mo{border:none;background:transparent;font-size:20px;cursor:pointer;padding:0 4px;color:#64748b;line-height:1}
+.mb{background:var(--card);width:100%;max-width:540px;max-height:90vh;display:flex;flex-direction:column;overflow:hidden}
+.mh{display:flex;align-items:center;padding:14px 18px;border-bottom:1px solid rgba(var(--tint), .1);gap:8px}
+.mt{flex:1;font-weight:600;font-size:15px;color:var(--ink)}
+.mh button.close-mo{border:none;background:transparent;font-size:20px;cursor:pointer;padding:0 4px;color:var(--ink-dim);line-height:1}
 .mbody{padding:18px;overflow-y:auto;flex:1}
 .mc{margin-bottom:14px}
-.mc label{display:block;font-size:12px;color:#475569;margin-bottom:4px;font-weight:500}
-.mc select,.mc input[type=text]{width:100%;padding:7px 10px;border:1.5px solid rgba(11,58,106,.2);font-size:13px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:#0B3A6A;background:#fff;outline:none}
-.mc select:focus,.mc input[type=text]:focus{border-color:#1D4ED8}
-.mfoot{padding:12px 18px;border-top:1px solid rgba(11,58,106,.1);display:flex;justify-content:flex-end;gap:8px}
+.mc label{display:block;font-size:12px;color:var(--ink-2);margin-bottom:4px;font-weight:500}
+.mc select,.mc input[type=text]{width:100%;padding:7px 10px;border:1.5px solid rgba(var(--tint), .2);font-size:13px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:var(--ink);background:var(--card);outline:none}
+.mc select:focus,.mc input[type=text]:focus{border-color:var(--ochre)}
+.mfoot{padding:12px 18px;border-top:1px solid rgba(var(--tint), .1);display:flex;justify-content:flex-end;gap:8px}
 /* Email preview tabs */
-.ep-tabs{display:flex;gap:0;border-bottom:1px solid rgba(11,58,106,.1);margin-bottom:14px}
-.ep-tab{padding:7px 14px;border:none;background:transparent;font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;cursor:pointer;color:#64748b;border-bottom:2px solid transparent;margin-bottom:-1px}
-.ep-tab.on{color:#1D4ED8;border-bottom-color:#1D4ED8}
-.ep-subj{font-size:12px;color:#475569;margin-bottom:10px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.ep-tabs{display:flex;gap:0;border-bottom:1px solid rgba(var(--tint), .1);margin-bottom:14px}
+.ep-tab{padding:7px 14px;border:none;background:transparent;font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;cursor:pointer;color:var(--ink-dim);border-bottom:2px solid transparent;margin-bottom:-1px}
+.ep-tab.on{color:var(--cobalt);border-bottom-color:var(--ochre)}
+.ep-subj{font-size:12px;color:var(--ink-2);margin-bottom:10px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
 .ep-content{font-size:12px;line-height:1.6;max-height:320px;overflow-y:auto}
 .ep-content pre{white-space:pre-wrap;word-break:break-word;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
 .ep-content iframe{width:100%;border:none;height:340px}
 
 /* TOTP required badges */
-.chip.required-missing{background:rgba(220,38,38,.08);color:#dc2626;font-weight:600}
-.chip.required-ok{background:rgba(29,78,216,.08);color:#1D4ED8}
+.chip.required-missing{background:rgba(196, 96, 79, .08);color:var(--brick-ink);font-weight:600}
+.chip.required-ok{background:rgba(217, 164, 65, .08);color:var(--cobalt)}
 </style>
 <meta property="og:title" content="Admin · Paramant">
 <meta property="og:description" content="Admin · Paramant">
@@ -251,7 +251,7 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
       <button class="close-mo" data-click="closeModal" data-modal="mo-plan" aria-label="Close">&times;</button>
     </div>
     <div class="mbody">
-      <div class="mc"><label>Current plan</label><span id="cp-current" style="font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:#475569"></span></div>
+      <div class="mc"><label>Current plan</label><span id="cp-current" style="font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:var(--ink-2)"></span></div>
       <div class="mc">
         <label for="cp-plan">New plan</label>
         <select id="cp-plan">
@@ -279,7 +279,7 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
       <button class="close-mo" data-click="closeModal" data-modal="mo-disable" aria-label="Close">&times;</button>
     </div>
     <div class="mbody">
-      <p style="font-size:13px;color:#475569;margin:0 0 12px">Disabling this key will immediately block all API access. It can be re-enabled manually.</p>
+      <p style="font-size:13px;color:var(--ink-2);margin:0 0 12px">Disabling this key will immediately block all API access. It can be re-enabled manually.</p>
       <div class="mc"><label>Reason (optional)</label><input type="text" id="dk-reason" placeholder="e.g. abuse, non-payment"></div>
       <div class="mc" style="display:flex;align-items:center;gap:8px">
         <input type="checkbox" id="dk-notify">
@@ -300,15 +300,15 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
       <button class="close-mo" data-click="closeModal" data-modal="mo-delete" aria-label="Close">&times;</button>
     </div>
     <div class="mbody">
-      <p style="font-size:13px;color:#dc2626;font-weight:600;margin:0 0 10px">This blocks the account key and removes active sessions and TOTP.</p>
-      <div id="da-recent-warn" style="display:none;background:#FEF2F2;border-left:3px solid #DC2626;padding:10px 12px;margin:0 0 12px;font-size:12px;color:#991B1B;border-radius:3px"><strong>Heads up:</strong> this account is less than 24 hours old. Are you sure it isn't a real tester?</div>
-      <div style="background:#F8FAFC;border:1px solid rgba(11,58,106,.08);padding:12px 14px;margin:0 0 12px;border-radius:3px">
+      <p style="font-size:13px;color:var(--brick-ink);font-weight:600;margin:0 0 10px">This blocks the account key and removes active sessions and TOTP.</p>
+      <div id="da-recent-warn" style="display:none;background:var(--card);border-left:3px solid var(--brick);padding:10px 12px;margin:0 0 12px;font-size:12px;color:var(--brick-ink);border-radius:3px"><strong>Heads up:</strong> this account is less than 24 hours old. Are you sure it isn't a real tester?</div>
+      <div style="background:var(--card);border:1px solid rgba(var(--tint), .08);padding:12px 14px;margin:0 0 12px;border-radius:3px">
         <div style="display:grid;grid-template-columns:90px 1fr;gap:6px 12px;font-size:12px">
-          <div style="color:#64748B">Email</div><div id="da-email" style="font-weight:600;color:#0B3A6A;word-break:break-all">—</div>
-          <div style="color:#64748B">Label</div><div id="da-label" style="color:#334155">—</div>
-          <div style="color:#64748B">Plan</div><div><span id="da-plan" class="badge community">—</span></div>
-          <div style="color:#64748B">Created</div><div id="da-created" class="mono" style="font-size:11px;color:#475569">—</div>
-          <div style="color:#64748B">Key</div><div id="da-target" class="mono" style="font-size:11px;color:#475569;word-break:break-all">—</div>
+          <div style="color:var(--ink-dim)">Email</div><div id="da-email" style="font-weight:600;color:var(--ink);word-break:break-all">&mdash;</div>
+          <div style="color:var(--ink-dim)">Label</div><div id="da-label" style="color:var(--ink-2)">&mdash;</div>
+          <div style="color:var(--ink-dim)">Plan</div><div><span id="da-plan" class="badge community">&mdash;</span></div>
+          <div style="color:var(--ink-dim)">Created</div><div id="da-created" class="mono" style="font-size:11px;color:var(--ink-2)">&mdash;</div>
+          <div style="color:var(--ink-dim)">Key</div><div id="da-target" class="mono" style="font-size:11px;color:var(--ink-2);word-break:break-all">&mdash;</div>
         </div>
       </div>
       <div class="mc" style="display:flex;align-items:center;gap:8px">

--- a/frontend/all-systems-go.html
+++ b/frontend/all-systems-go.html
@@ -6,18 +6,18 @@
   <title>All systems · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/all-systems-go">
-  <link rel="stylesheet" href="/design-system.css?v=25">
-  <link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+  <link rel="stylesheet" href="/design-system.css?v=28">
+  <link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
     .asg { max-width: 560px; margin: 64px auto; padding: 0 24px; }
     .asg-hero { text-align: center; margin-bottom: 40px; }
     .asg-dot-lg { width: 56px; height: 56px; border-radius: 50%; margin: 0 auto 20px;
-      display: flex; align-items: center; justify-content: center; font-size: 28px; color: #fff; }
+      display: flex; align-items: center; justify-content: center; font-size: 28px; color: var(--ink); }
     .asg-overall-green  { background: #1a8f4c; }
     .asg-overall-yellow { background: #c08a00; }
     .asg-overall-red    { background: #b00020; }
-    .asg-overall-loading{ background: #cfd6df; }
+    .asg-overall-loading{ background: var(--card-2); }
     .asg-title { font-size: 22px; font-weight: 700; margin: 0 0 6px; letter-spacing: -0.01em; }
     .asg-sub { color: #667; margin: 0; font-size: 14px; }
     .asg-list { border: 1px solid #e6e9ee; border-radius: 12px; overflow: hidden; }
@@ -28,7 +28,7 @@
     .asg-green  { background: #1a8f4c; }
     .asg-yellow { background: #c08a00; }
     .asg-red    { background: #b00020; }
-    .asg-loading{ background: #cfd6df; }
+    .asg-loading{ background: var(--card-2); }
     .asg-name { font-weight: 600; text-transform: capitalize; flex: 1; }
     .asg-detail { color: #889; font-size: 13px; text-align: right; }
     .asg-actions { margin-top: 28px; text-align: center; }

--- a/frontend/app-2026.css
+++ b/frontend/app-2026.css
@@ -1,71 +1,84 @@
 /* PARAMANT app-2026.css
    The product surface: dashboard, sign, parashare, signup, account, auth.
 
-   This file implements docs/brand/design-direction.md for the APP screens only.
-   Marketing pages keep design-system.css v4 untouched. Two things happen here:
+   Since the night edition this file no longer carries a palette of its own. It
+   carries the SAME night as frontend/design-system.css, plus the second half a
+   marketing page does not have: the cream paper, for the reader who asks for it
+   on /account.
 
-   1. Tokens. The 2026 palette from the direction (section 2), written twice so
-      an explicit "dark" and an explicit "auto" under a dark system both win,
-      and so no colour exists only inside a media query. Light is the default
-      and the app stays light until a reader picks otherwise on /account.
-   2. An alias layer that points the v4 token names at the new values. Every
+   1. Tokens. The night is the default, written out here rather than inherited,
+      because this file loads last and has to win over the hard-coded hexes the
+      page style blocks still carry. The cream paper is written twice: once for
+      an explicit "light", once for the system preference under an explicit
+      "auto". No colour exists only inside a media query.
+   2. An alias layer that points the v4 token names at the same values, so every
       rule already written against --bone / --ink / --ink-hair follows the theme
-      without being rewritten, which is what makes a dark mode on these pages
-      affordable at all.
+      without being rewritten.
 
    Load order matters: this file is the LAST stylesheet in the head, after the
-   page's own <style> blocks, so the hard-coded hexes those blocks still carry
-   can be corrected here for dark mode.
+   page's own <style> blocks.
 
    Contrast: every pair below was computed with the WCAG 2.1 relative-luminance
-   formula against its own background. Values are in the direction document. */
+   formula against its own background, and tests/app-contrast.test.mjs walks
+   every text node on eleven screens, at two widths, in both themes. */
 
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   1. TOKENS, light
+   1. TOKENS, the night. This is the default: no attribute, no media query.
    ═══════════════════════════════════════════════════════════════════════════ */
 :root {
+  /* the cream, as channels: every rgba(var(--tint), a) in a page's own style
+     block is a hairline or a tint, and it has to flip with the theme. */
+  --tint: 234, 226, 206;
+
   /* surface */
-  --paper:        #FBFAF7;
-  --surface:      #FFFFFF;
-  --surface-sunk: #F4F4F1;
-  --surface-ink:  #0C1622;
+  --paper:        #15191C;
+  --surface:      #1B1F23;
+  --surface-sunk: #101316;
+  --surface-ink:  #0B0E10;
 
   /* ink */
-  --ink-1: #0C1B2A;   /* 16.68 on paper */
-  --ink-2: #40505F;   /*  7.95 on paper */
-  --ink-3: #5C6A78;   /*  5.31 on paper */
+  --ink-1: #EAE2CE;                    /* 13.70 on the night */
+  --ink-2: rgba(234, 226, 206, .80);   /*  9.11 */
+  --ink-3: rgba(234, 226, 206, .62);   /*  5.95 */
 
   /* the one accent */
-  --accent:      #1D4ED8;              /* 6.42 on paper */
-  --accent-hov:  #1A43BE;
-  --accent-ink:  #FFFFFF;              /* 6.70 on accent */
-  --accent-soft: rgba(29,78,216,.08);
-  --accent-ring: rgba(29,78,216,.32);
+  --accent:      #D9A441;              /* 7.86 on the night */
+  --accent-hov:  #C7912E;
+  --accent-ink:  #141414;              /* 8.61 on the ochre */
+  --accent-soft: rgba(217, 164, 65, .12);
+  --accent-ring: rgba(217, 164, 65, .45);
 
   /* hairlines: the main shape of the system */
-  --line:       rgba(12,27,42,.11);
-  --line-2:     rgba(12,27,42,.20);
-  --line-ghost: rgba(12,27,42,.05);
+  --line:       rgba(234, 226, 206, .16);
+  --line-2:     rgba(234, 226, 206, .32);
+  --line-ghost: rgba(234, 226, 206, .06);
 
-  /* lime is a line, never a text background (one exception, see --mark-on) */
-  --mark:     #B2FF3F;
-  --mark-ink: #5C7A12;                 /* 4.90 on paper, readable lime */
-  --mark-on:  #0A1626;                 /* 14.94 on #B2FF3F */
+  /* the mark. Lime was the old one; the night has one accent and it is ochre. */
+  --mark:     #D9A441;
+  --mark-ink: #D9A441;
+  --mark-on:  #141414;
 
   /* signature states: the four words dashboard.js renders */
-  --sig-wait: #79600F;
-  --sig-move: #1D4ED8;
-  --sig-done: #1B6B45;
-  --sig-stop: #8C3A34;
-  --sig-wait-bg: rgba(121,96,15,.09);
-  --sig-stop-line: rgba(140,58,52,.42);
-  --paper-blur: rgba(251,250,247,.92);
-  --sig-move-bg: rgba(29,78,216,.09);
-  --sig-done-bg: rgba(27,107,69,.09);
-  --sig-stop-bg: rgba(140,58,52,.09);
+  --sig-wait: #E3C169;                 /* 10.19 */
+  --sig-move: #8FB8C9;                 /*  8.31 */
+  --sig-done: #8FC7A4;                 /*  9.15 */
+  --sig-stop: #E08A78;                 /*  6.80 */
+  --sig-wait-bg: rgba(227, 193, 105, .12);
+  --sig-move-bg: rgba(143, 184, 201, .12);
+  --sig-done-bg: rgba(143, 199, 164, .12);
+  --sig-stop-bg: rgba(224, 138, 120, .12);
+  --sig-stop-line: rgba(224, 138, 120, .44);
+  --paper-blur: rgba(21, 25, 28, .92);
 
-  /* radius: nul is a choice, soft only where you touch */
+  /* the cream paper, for the panels that have to read as paper on a desk */
+  --leaf:      #F1EAD6;
+  --leaf-2:    #E7DDC4;
+  --leaf-ink:  #1B1F22;
+  --leaf-ink-2:#4A4A44;
+  --ochre-ink: #8A5E10;                /* the ochre as ink on the cream paper */
+
+  /* radius: the night rounds, soft where you touch */
   --r-0: 0;
   --r-1: 3px;
   --r-2: 10px;
@@ -73,9 +86,9 @@
   --r-pill: 999px;
 
   /* shadow: almost nothing, depth comes from hairlines */
-  --sh-1: 0 1px 2px rgba(12,27,42,.04);
-  --sh-2: 0 1px 2px rgba(12,27,42,.05), 0 8px 24px -12px rgba(12,27,42,.14);
-  --sh-3: 0 24px 64px -24px rgba(12,27,42,.28);
+  --sh-1: 0 1px 2px rgba(0, 0, 0, .40);
+  --sh-2: 0 1px 2px rgba(0, 0, 0, .44), 0 8px 24px -12px rgba(0, 0, 0, .66);
+  --sh-3: 0 24px 64px -24px rgba(0, 0, 0, .80);
   --ring: 0 0 0 2px var(--paper), 0 0 0 4px var(--accent-ring);
 
   /* motion: three durations, two curves, and every one of them confirms
@@ -88,147 +101,181 @@
 
   --tap: 44px;
 
-  /* ── alias layer: the v4 names now resolve to the 2026 values ───────────── */
+  /* ── alias layer: the v4 names now resolve to the night ────────────────── */
   --bone:   var(--paper);
   --bone-2: var(--surface-sunk);
   --navy:   var(--ink-1);
   --navy-2: var(--ink-1);
   --ink:       var(--ink-1);
-  --ink-dim:   var(--ink-2);
+  --ink-dim:   var(--ink-3);
   --ink-hair:  var(--line);
   --ink-ghost: var(--line-ghost);
   --cobalt:   var(--accent);
   --cobalt-2: var(--accent-hov);
   --lime:     var(--mark);
-  --bone-on-navy:      #F4F7FA;
-  --bone-on-navy-dim:  rgba(244,247,250,.74);
-  --bone-on-navy-hair: rgba(244,247,250,.18);
+  --ochre:    var(--accent);
+  --ochre-2:  var(--accent-hov);
+  --on-ochre: var(--accent-ink);
+  --card:      var(--surface);
+  --card-2:    var(--surface-sunk);
+  --card-line: var(--line);
+  --brick:     #C4604F;
+  --brick-ink: var(--sig-stop);
+  --ok-ink:    var(--sig-done);
+  --warn-ink:  var(--sig-wait);
+  --petrol:    #155E75;
+  --petrol-ink:var(--sig-move);
+  --bone-on-navy:      var(--ink-1);
+  --bone-on-navy-dim:  var(--ink-2);
+  --bone-on-navy-hair: var(--line-2);
   --black:       var(--ink-1);
-  --black-dim:   var(--ink-2);
+  --black-dim:   var(--ink-3);
   --black-hair:  var(--line);
   --black-ghost: var(--line-ghost);
-  --lime-dim:    var(--ink-2);
+  --lime-dim:    var(--ink-3);
   --lime-hair:   var(--line);
   --lime-ghost:  var(--line-ghost);
 
-  /* an inverted block keeps its own ink regardless of theme */
-  --on-ink:      #F4F7FA;
-  --on-ink-dim:  rgba(244,247,250,.74);
+  /* an inverted block keeps its own ink regardless of theme: it is the night
+     in the night and the night again under the paper, so the ochre on it is
+     the bright one both times. */
+  --on-ink:        var(--ink-1);
+  --on-ink-dim:    var(--ink-2);
+  --on-ink-accent: #D9A441;
+
+  color-scheme: dark;
 }
 
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   2. TOKENS, dark: an own set and not a filter
+   2. TOKENS, the cream paper: an own set and not a filter
 
-   Dark is a CHOICE, never a jump. Measured 2026-09-03 on the previous version
-   of this file: with a dark OS and no choice made, /index and /pricing stayed
-   light while /dashboard, /sign, /parashare, /account and /auth/login went to
-   rgb(10,15,22). Signing in threw a reader from creme to black. So the system
-   preference is honoured under ONE condition, [data-theme="auto"], which only
-   frontend/js/theme.js writes and only after someone picked "Follow my system"
-   on /account. Without a choice there is no attribute, nothing below matches,
-   and the app is light. That holds with JavaScript switched off too.
+   The night is where the whole site stands, so it is the default here and it
+   needs neither an attribute nor a media query. The paper is the CHOICE: the
+   reader picks Light on /account, or picks Follow my system and is on a light
+   one. Both are written out in full, so no colour lives only inside a media
+   query, and the gate is [data-theme] and nothing else. Without a choice there
+   is no attribute, neither block matches, and the app is the night. That holds
+   with JavaScript switched off too.
 
-   Written twice: once for the system preference under an explicit "auto", once
-   for an explicit "dark". No colour exists only inside a media query.
+   Measured on the paper #F1EAD6: ink 13.81, ink-2 7.43, ink-3 5.35, the ochre
+   as ink 4.74.
    ═══════════════════════════════════════════════════════════════════════════ */
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
   :root[data-theme="auto"] {
-    --paper:        #0A0F16;
-    --surface:      #10161F;
-    --surface-sunk: #151C26;
-    --surface-ink:  #060A0F;
+    --tint: 27, 31, 34;
 
-    --ink-1: #EDF1F6;   /* 16.94 on paper */
-    --ink-2: #B4C1D0;   /* 10.50 */
-    --ink-3: #8D9CAD;   /*  6.86 */
+    --paper:        #F1EAD6;
+    --surface:      #F7F2E4;
+    --surface-sunk: #E7DDC4;
+    --surface-ink:  #15191C;
 
-    --accent:      #7FA6FF;   /* 8.05 */
-    --accent-hov:  #9CBAFF;
-    --accent-ink:  #061020;
-    --accent-soft: rgba(127,166,255,.12);
-    --accent-ring: rgba(127,166,255,.40);
+    --ink-1: #1B1F22;   /* 13.81 on the paper */
+    --ink-2: #4A4A44;   /*  7.43 */
+    --ink-3: #5F5F57;   /*  5.35 */
 
-    --line:       rgba(237,241,246,.10);
-    --line-2:     rgba(237,241,246,.20);
-    --line-ghost: rgba(237,241,246,.05);
+    --accent:      #6E4A0B;   /* 6.60 on the paper, 5.87 on the sunk paper */
+    --accent-hov:  #56390A;
+    --accent-ink:  #F1EAD6;
+    --accent-soft: rgba(110, 74, 11, .09);
+    --accent-ring: rgba(110, 74, 11, .38);
 
-    --mark:     #B2FF3F;   /* 15.80 on paper */
-    --mark-ink: #C7F86E;
-    --mark-on:  #0A1626;
+    --line:       rgba(27, 31, 34, .14);
+    --line-2:     rgba(27, 31, 34, .26);
+    --line-ghost: rgba(27, 31, 34, .06);
 
-    --sig-wait: #E3C169;
-    --sig-move: #90AEFF;
-    --sig-done: #6FD3A2;
-    --sig-stop: #F09A92;
-    --sig-wait-bg: rgba(227,193,105,.12);
-    --sig-move-bg: rgba(144,174,255,.12);
-    --sig-done-bg: rgba(111,211,162,.12);
-    --sig-stop-bg: rgba(240,154,146,.12);
-    --sig-stop-line: rgba(240,154,146,.44);
-    --paper-blur: rgba(10,15,22,.92);
+    --mark:     #6E4A0B;
+    --mark-ink: #6E4A0B;
+    --mark-on:  #F1EAD6;
 
-    --sh-1: 0 1px 2px rgba(0,0,0,.40);
-    --sh-2: 0 1px 2px rgba(0,0,0,.44), 0 8px 24px -12px rgba(0,0,0,.66);
-    --sh-3: 0 24px 64px -24px rgba(0,0,0,.80);
+    --sig-wait: #79600F;
+    --sig-move: #155E75;
+    --sig-done: #1B6B45;
+    --sig-stop: #8C3A34;
+    --sig-wait-bg: rgba(121, 96, 15, .10);
+    --sig-move-bg: rgba(21, 94, 117, .10);
+    --sig-done-bg: rgba(27, 107, 69, .10);
+    --sig-stop-bg: rgba(140, 58, 52, .10);
+    --sig-stop-line: rgba(140, 58, 52, .42);
+    --paper-blur: rgba(241, 234, 214, .92);
 
-    --bone-on-navy:      #EDF1F6;
-    --bone-on-navy-dim:  rgba(237,241,246,.74);
-    --bone-on-navy-hair: rgba(237,241,246,.18);
-    --on-ink:      #EDF1F6;
-    --on-ink-dim:  rgba(237,241,246,.74);
+    --leaf:      #15191C;
+    --leaf-2:    #101316;
+    --leaf-ink:  #EAE2CE;
+    --leaf-ink-2:rgba(234, 226, 206, .80);
+    --ochre-ink: #D9A441;
+
+    --sh-1: 0 1px 2px rgba(27, 31, 34, .05);
+    --sh-2: 0 1px 2px rgba(27, 31, 34, .06), 0 8px 24px -12px rgba(27, 31, 34, .16);
+    --sh-3: 0 24px 64px -24px rgba(27, 31, 34, .30);
+
+    --brick:     #8C3A34;
+    --petrol:    #155E75;
+
+    --on-ink:        #EAE2CE;
+    --on-ink-dim:    rgba(234, 226, 206, .80);
+    --on-ink-accent: #D9A441;
+
+    color-scheme: light;
   }
 }
 
-:root[data-theme="dark"] {
-  --paper:        #0A0F16;
-  --surface:      #10161F;
-  --surface-sunk: #151C26;
-  --surface-ink:  #060A0F;
+:root[data-theme="light"] {
+  --tint: 27, 31, 34;
 
-  --ink-1: #EDF1F6;
-  --ink-2: #B4C1D0;
-  --ink-3: #8D9CAD;
+  --paper:        #F1EAD6;
+  --surface:      #F7F2E4;
+  --surface-sunk: #E7DDC4;
+  --surface-ink:  #15191C;
 
-  --accent:      #7FA6FF;
-  --accent-hov:  #9CBAFF;
-  --accent-ink:  #061020;
-  --accent-soft: rgba(127,166,255,.12);
-  --accent-ring: rgba(127,166,255,.40);
+  --ink-1: #1B1F22;
+  --ink-2: #4A4A44;
+  --ink-3: #5F5F57;
 
-  --line:       rgba(237,241,246,.10);
-  --line-2:     rgba(237,241,246,.20);
-  --line-ghost: rgba(237,241,246,.05);
+  --accent:      #6E4A0B;
+  --accent-hov:  #56390A;
+  --accent-ink:  #F1EAD6;
+  --accent-soft: rgba(110, 74, 11, .09);
+  --accent-ring: rgba(110, 74, 11, .38);
 
-  --mark:     #B2FF3F;
-  --mark-ink: #C7F86E;
-  --mark-on:  #0A1626;
+  --line:       rgba(27, 31, 34, .14);
+  --line-2:     rgba(27, 31, 34, .26);
+  --line-ghost: rgba(27, 31, 34, .06);
 
-  --sig-wait: #E3C169;
-  --sig-move: #90AEFF;
-  --sig-done: #6FD3A2;
-  --sig-stop: #F09A92;
-  --sig-wait-bg: rgba(227,193,105,.12);
-  --sig-move-bg: rgba(144,174,255,.12);
-  --sig-done-bg: rgba(111,211,162,.12);
-  --sig-stop-bg: rgba(240,154,146,.12);
-  --sig-stop-line: rgba(240,154,146,.44);
-  --paper-blur: rgba(10,15,22,.92);
+  --mark:     #6E4A0B;
+  --mark-ink: #6E4A0B;
+  --mark-on:  #F1EAD6;
 
-  --sh-1: 0 1px 2px rgba(0,0,0,.40);
-  --sh-2: 0 1px 2px rgba(0,0,0,.44), 0 8px 24px -12px rgba(0,0,0,.66);
-  --sh-3: 0 24px 64px -24px rgba(0,0,0,.80);
+  --sig-wait: #79600F;
+  --sig-move: #155E75;
+  --sig-done: #1B6B45;
+  --sig-stop: #8C3A34;
+  --sig-wait-bg: rgba(121, 96, 15, .10);
+  --sig-move-bg: rgba(21, 94, 117, .10);
+  --sig-done-bg: rgba(27, 107, 69, .10);
+  --sig-stop-bg: rgba(140, 58, 52, .10);
+  --sig-stop-line: rgba(140, 58, 52, .42);
+  --paper-blur: rgba(241, 234, 214, .92);
 
-  --bone-on-navy:      #EDF1F6;
-  --bone-on-navy-dim:  rgba(237,241,246,.74);
-  --bone-on-navy-hair: rgba(237,241,246,.18);
-  --on-ink:      #EDF1F6;
-  --on-ink-dim:  rgba(237,241,246,.74);
+  --leaf:      #15191C;
+  --leaf-2:    #101316;
+  --leaf-ink:  #EAE2CE;
+  --leaf-ink-2:rgba(234, 226, 206, .80);
+  --ochre-ink: #D9A441;
+
+  --sh-1: 0 1px 2px rgba(27, 31, 34, .05);
+  --sh-2: 0 1px 2px rgba(27, 31, 34, .06), 0 8px 24px -12px rgba(27, 31, 34, .16);
+  --sh-3: 0 24px 64px -24px rgba(27, 31, 34, .30);
+
+  --brick:     #8C3A34;
+  --petrol:    #155E75;
+
+  --on-ink:        #EAE2CE;
+  --on-ink-dim:    rgba(234, 226, 206, .80);
+  --on-ink-accent: #D9A441;
+
+  color-scheme: light;
 }
-
-:root { color-scheme: light; }
-@media (prefers-color-scheme: dark) { :root[data-theme="auto"] { color-scheme: dark; } }
-:root[data-theme="dark"] { color-scheme: dark; }
 
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -502,22 +549,22 @@ footer .logo .a { color: var(--ink-1); }
 /* The one inverted block per screen. It keeps its own ink in both themes. */
 .dh-community, .acct-plan-band.free {
   background: var(--surface-ink);
-  box-shadow: inset 0 0 0 1px rgba(178,255,63,.20);
+  box-shadow: inset 0 0 0 1px rgba(217, 164, 65, .28);
   border: 0;
   border-radius: var(--r-2);
 }
 .dh-community-lede, .acct-plan-band.free .acct-plan-lede { color: var(--on-ink); }
 .dh-community-adds, .acct-plan-band.free .acct-plan-adds { color: var(--on-ink-dim); }
-.dh-community-kicker, .acct-plan-band.free .acct-plan-kicker { color: var(--mark); }
+.dh-community-kicker, .acct-plan-band.free .acct-plan-kicker { color: var(--on-ink-accent); }
 .dh-community-cta, .acct-plan-band.free a.acct-plan-cta {
   min-height: var(--tap); display: inline-flex; align-items: center;
-  background: var(--mark); color: var(--mark-on); border-radius: var(--r-1);
+  background: var(--on-ink-accent); color: #141414; border-radius: var(--r-1);
   font-family: var(--mono); font-size: 12px; font-weight: 600;
   letter-spacing: .08em; text-transform: uppercase; text-decoration: none;
   padding: 0 18px;
 }
-.dh-community-cta:hover, .acct-plan-band.free a.acct-plan-cta:hover { background: #C7F86E; }
-.dh-community-lede a, .acct-plan-band.free .acct-plan-lede a { color: var(--mark); }
+.dh-community-cta:hover, .acct-plan-band.free a.acct-plan-cta:hover { background: #C7912E; }
+.dh-community-lede a, .acct-plan-band.free .acct-plan-lede a { color: var(--on-ink-accent); }
 .acct-plan-band.paid { background: var(--surface); border: 1px solid var(--line); border-radius: var(--r-2); }
 .acct-plan-band.paid .acct-plan-kicker { color: var(--accent); }
 .acct-plan-band.paid .acct-plan-lede { color: var(--ink-1); }
@@ -565,16 +612,15 @@ footer .logo .a { color: var(--ink-1); }
 .theme-choice input:focus-visible + span { box-shadow: var(--ring); border-radius: var(--r-1); }
 
 
-/* The signed-out nav CTA used to be the one allowed lime field, with #0A1626
-   on it. It is cobalt now, in the bar and on the homepage: lime is the
-   punctuation of this brand and not the colour of its primary action, and next
-   to a cobalt hero button a lime bar button read as a second, competing offer.
-   White on #1D4ED8 is 6.3:1. Kept at the same weight as before, so an app page
-   cannot drift back to the lime field it was corrected out of. */
+/* The signed-out nav CTA was a lime field once and a cobalt one after that.
+   The night has one accent, so it is the ochre, and it takes the ochre's own
+   ink rather than white: --accent-ink is 8.61:1 on --accent. Kept on the token
+   at the same weight as before, so an app page cannot drift back to a colour
+   the system no longer has. */
 .nav-cta, a.nav-cta, .nav .nav-cta {
-  color: #FFFFFF !important;
-  background: #1D4ED8 !important;
-  border-color: #1D4ED8 !important;
+  color: var(--accent-ink) !important;
+  background: var(--accent) !important;
+  border-color: var(--accent) !important;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -803,7 +849,7 @@ footer .logo .a { color: var(--ink-1); }
 /* The build bar is an inverted strip, so every part of it takes inverted ink. */
 .meta-bar, .meta-bar .sep, .meta-bar .right { color: var(--on-ink-dim); }
 .meta-bar b { color: var(--on-ink); }
-.meta-bar a.meta-link { color: var(--mark); text-decoration-color: rgba(178,255,63,.5); }
+.meta-bar a.meta-link { color: var(--mark); text-decoration-color: rgba(217, 164, 65, .5); }
 .meta-bar a.meta-link:hover, .meta-bar a.meta-link:focus-visible { color: var(--mark); text-decoration-color: var(--mark); }
 
 /* A failure sentence is a sentence in the fault colour of the current theme. */

--- a/frontend/apply-nav.py
+++ b/frontend/apply-nav.py
@@ -89,8 +89,8 @@ LEGAL_STRIP = '''\
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>
 </footer>'''
 
-DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=25">'
-NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=21">'
+DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=28">'
+NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=23">'
 NAV_JS    = '<script src="/nav.js?v=15" defer></script>'
 NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=8" defer></script>'
 

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Architecture · How Paramant works</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -24,11 +24,11 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
@@ -38,105 +38,110 @@ body{font-family:Inter,system-ui,-apple-system,sans-serif}
 
 /* ── layout primitives ── */
 .arch-section{padding:80px 0}
-.arch-section--navy{background:#0B3A6A;color:#F8FAFC}
-.arch-section--tint{background:#EFF6FF}
+.arch-section--navy{background:var(--bone-2);color:var(--ink)}
+.arch-section--tint{background:var(--card)}
 .arch-inner{max-width:900px;margin:0 auto;padding:0 48px}
 
 /* ── eyebrow pill ── */
-.eyebrow{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;background:#B2FF3F;color:#0B3A6A;padding:4px 12px;margin-bottom:20px}
+.eyebrow{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;background:var(--ochre);color: var(--on-ochre);padding:4px 12px;margin-bottom:20px}
 
 /* ── hero ── */
-.page-hero{padding:100px 0 80px;border-bottom:1px solid var(--ink-hair,#e2e8f0)}
+.page-hero{padding:100px 0 80px;border-bottom:1px solid var(--ink-hair)}
 .page-hero-inner{max-width:900px;margin:0 auto;padding:0 48px}
 .page-hero h1{font-size:42px;font-weight:700;letter-spacing:-.03em;margin-bottom:16px;line-height:1.1}
-.lede{font-size:18px;color:#475569;line-height:1.7;max-width:600px}
-.lede a{color:#1D4ED8;text-decoration:none}
+.lede{font-size:18px;color:var(--ink-2);line-height:1.7;max-width:600px}
+.lede a{color:var(--cobalt);text-decoration:none}
 .lede a:hover{opacity:.7}
 
 /* ── section headings ── */
-.section-num{font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:#B2FF3F;margin-bottom:8px}
-.section-num--dark{color:#94a3b8}
+.section-num{font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--lime);margin-bottom:8px}
+.section-num--dark{color:var(--ink-dim)}
 .section-title{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:16px}
-.section-desc{font-size:16px;line-height:1.75;color:#475569;max-width:640px;margin-bottom:40px}
-.arch-section--navy .section-desc{color:#cbd5e1}
-.arch-section--navy .section-title{color:#F8FAFC}
+.section-desc{font-size:16px;line-height:1.75;color:var(--ink-2);max-width:640px;margin-bottom:40px}
+.arch-section--navy .section-desc{color:var(--ink-dim)}
+.arch-section--navy .section-title{color:var(--ink)}
 
 /* ── diagram box ── */
-.arch-diagram{background:#fff;border:1px solid #e2e8f0;padding:40px;margin:32px 0;overflow-x:auto}
+.arch-diagram{background:var(--paper);border:1px solid var(--ink-hair);border-radius:var(--r);padding:40px;margin:32px 0;overflow-x:auto}
+/* The three diagrams below are drawn with fixed ink, the way a printed figure
+   is: their fills and strokes are SVG presentation attributes, not CSS, and
+   redrawing them for the night would be a redraw and not a recolour. So the
+   frame is the cream paper of the design system, and the figure sits on it
+   like a printed sheet on the night desk. */
 
 /* ── takeaway callout ── */
-.arch-takeaway{border-left:3px solid #B2FF3F;padding:16px 20px;background:#f0fdf4;margin-top:32px}
-.arch-takeaway--navy{border-left:3px solid #B2FF3F;padding:16px 20px;background:rgba(178,255,63,.07);margin-top:32px}
-.arch-takeaway p{font-size:14px;color:#374151;line-height:1.7;margin:0}
-.arch-takeaway--navy p{color:#cbd5e1}
-.arch-takeaway strong{color:#0B3A6A}
-.arch-takeaway--navy strong{color:#B2FF3F}
+.arch-takeaway{border-left:3px solid var(--ochre);padding:16px 20px;background:var(--card);margin-top:32px}
+.arch-takeaway--navy{border-left:3px solid var(--ochre);padding:16px 20px;background:rgba(217, 164, 65, .07);margin-top:32px}
+.arch-takeaway p{font-size:14px;color:var(--ink-2);line-height:1.7;margin:0}
+.arch-takeaway--navy p{color:var(--ink-dim)}
+.arch-takeaway strong{color:var(--ink)}
+.arch-takeaway--navy strong{color:var(--lime)}
 
 /* ── compare grid ── */
 .compare-grid{display:grid;grid-template-columns:1fr 1fr;gap:24px;margin-top:32px}
-.compare-col{padding:28px 32px;border:1px solid rgba(255,255,255,.12)}
-.compare-col--bad{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.1)}
-.compare-col--good{background:rgba(178,255,63,.08);border-color:rgba(178,255,63,.3)}
+.compare-col{padding:28px 32px;border:1px solid rgba(var(--tint), .12)}
+.compare-col--bad{background:rgba(var(--tint), .04);border-color:rgba(var(--tint), .1)}
+.compare-col--good{background:rgba(217, 164, 65, .08);border-color:rgba(217, 164, 65, .3)}
 .compare-col h3{font-size:13px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;margin-bottom:20px}
-.compare-col--bad h3{color:#f87171}
-.compare-col--good h3{color:#B2FF3F}
+.compare-col--bad h3{color:var(--brick-ink)}
+.compare-col--good h3{color:var(--lime)}
 .compare-col ul{list-style:none;display:flex;flex-direction:column;gap:10px}
-.compare-col li{font-size:14px;line-height:1.5;padding-left:22px;position:relative;color:#cbd5e1}
+.compare-col li{font-size:14px;line-height:1.5;padding-left:22px;position:relative;color:var(--ink-dim)}
 .compare-col li::before{position:absolute;left:0;font-weight:700}
-.compare-col--bad li::before{content:"✗";color:#f87171}
-.compare-col--good li::before{content:"✓";color:#B2FF3F}
+.compare-col--bad li::before{content:"✗";color:var(--brick-ink)}
+.compare-col--good li::before{content:"✓";color:var(--lime)}
 
 /* ── URL anatomy ── */
 .url-anatomy{margin:36px 0;position:relative}
-.url-display{font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:15px;line-height:1.6;word-break:break-all;background:#fff;border:1px solid #e2e8f0;padding:20px 24px;display:flex;flex-wrap:wrap;align-items:center;gap:0}
+.url-display{font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:15px;line-height:1.6;word-break:break-all;background:var(--card);border:1px solid var(--ink-hair);padding:20px 24px;display:flex;flex-wrap:wrap;align-items:center;gap:0}
 .url-part{display:inline}
-.url-sent{color:#1D4ED8}
-.url-not-sent{background:#B2FF3F;color:#0B3A6A;padding:2px 4px}
+.url-sent{color:var(--cobalt)}
+.url-not-sent{background:var(--ochre);color: var(--on-ochre);padding:2px 4px}
 .url-labels{display:flex;flex-wrap:wrap;gap:32px;margin-top:24px}
 .url-label-item{display:flex;flex-direction:column;gap:4px}
 .url-label-dot{width:10px;height:10px;display:inline-block;margin-right:6px;vertical-align:middle}
-.url-label-dot--blue{background:#1D4ED8}
-.url-label-dot--lime{background:#B2FF3F}
-.url-label-text{font-size:13px;color:#475569;line-height:1.6}
-.url-label-text strong{color:#0B3A6A;display:block;font-size:12px;letter-spacing:.04em;text-transform:uppercase;margin-bottom:2px}
+.url-label-dot--blue{background:var(--ochre)}
+.url-label-dot--lime{background:var(--ochre)}
+.url-label-text{font-size:13px;color:var(--ink-2);line-height:1.6}
+.url-label-text strong{color:var(--ink);display:block;font-size:12px;letter-spacing:.04em;text-transform:uppercase;margin-bottom:2px}
 
 /* ── lifecycle grid ── */
 .lifecycle-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;margin:32px 0}
-.lifecycle-state{padding:24px;border:1px solid #e2e8f0;background:#fff;position:relative}
-.lifecycle-state--active{border-color:#B2FF3F;border-width:2px}
+.lifecycle-state{padding:24px;border:1px solid var(--ink-hair);background:var(--card);position:relative}
+.lifecycle-state--active{border-color:var(--ochre);border-width:2px}
 .lifecycle-state--gone{opacity:.5}
-.lifecycle-num{font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:#94a3b8;margin-bottom:12px}
-.lifecycle-state--active .lifecycle-num{color:#B2FF3F}
-.lifecycle-heading{font-size:15px;font-weight:700;color:#0B3A6A;margin-bottom:10px}
-.lifecycle-body{font-size:13px;color:#475569;line-height:1.6}
-.lifecycle-gone-icon{position:absolute;top:16px;right:16px;width:20px;height:20px;color:#ef4444}
+.lifecycle-num{font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:12px}
+.lifecycle-state--active .lifecycle-num{color:var(--lime)}
+.lifecycle-heading{font-size:15px;font-weight:700;color:var(--ink);margin-bottom:10px}
+.lifecycle-body{font-size:13px;color:var(--ink-2);line-height:1.6}
+.lifecycle-gone-icon{position:absolute;top:16px;right:16px;width:20px;height:20px;color:var(--brick-ink)}
 
 /* ── modes table ── */
 .modes-table{width:100%;border-collapse:collapse;margin-top:32px}
-.modes-table th{text-align:left;padding:12px 16px;font-size:12px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:#64748b;border-bottom:2px solid #e2e8f0}
+.modes-table th{text-align:left;padding:12px 16px;font-size:12px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-dim);border-bottom:2px solid var(--ink-hair)}
 .modes-table th:not(:first-child){text-align:center}
-.modes-table td{padding:12px 16px;font-size:14px;color:#374151;border-bottom:1px solid #f1f5f9;vertical-align:top}
-.modes-table td:first-child{color:#0B3A6A;font-weight:600}
-.modes-table td:not(:first-child){text-align:center;color:#475569}
+.modes-table td{padding:12px 16px;font-size:14px;color:var(--ink-2);border-bottom:1px solid var(--ink-hair);vertical-align:top}
+.modes-table td:first-child{color:var(--ink);font-weight:600}
+.modes-table td:not(:first-child){text-align:center;color:var(--ink-2)}
 .modes-table tr:last-child td{border-bottom:none}
-.modes-table .mode-head{font-size:13px;font-weight:700;color:#1D4ED8;text-transform:uppercase;letter-spacing:.04em}
-.modes-table .mode-badge{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:2px 8px;background:#eff6ff;color:#1D4ED8}
-.modes-table .mode-badge--lime{background:#f0fdf4;color:#166534}
+.modes-table .mode-head{font-size:13px;font-weight:700;color:var(--cobalt);text-transform:uppercase;letter-spacing:.04em}
+.modes-table .mode-badge{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:2px 8px;background:var(--card);color:var(--cobalt)}
+.modes-table .mode-badge--lime{background:var(--card);color:var(--ok-ink)}
 
 /* ── going deeper ── */
 .going-deeper{text-align:center;padding:64px 48px}
-.going-deeper h2{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px;color:#0B3A6A}
-.going-deeper p{font-size:16px;color:#475569;margin-bottom:32px;max-width:480px;margin-left:auto;margin-right:auto;line-height:1.7}
-.btn-arch{display:inline-block;background:#0B3A6A;color:#F8FAFC;text-decoration:none;padding:14px 32px;font-size:14px;font-weight:600;letter-spacing:.02em;transition:opacity .15s}
+.going-deeper h2{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px;color:var(--ink)}
+.going-deeper p{font-size:16px;color:var(--ink-2);margin-bottom:32px;max-width:480px;margin-left:auto;margin-right:auto;line-height:1.7}
+.btn-arch{display:inline-block;background:var(--bone-2);color:var(--ink);text-decoration:none;padding:14px 32px;font-size:14px;font-weight:600;letter-spacing:.02em;transition:opacity .15s}
 .btn-arch:hover{opacity:.85}
 
 /* ── SVG helpers ── */
 .diagram-label{font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase}
 
-footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:16px}
+footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:16px}
 .footer-links{display:flex;gap:20px;flex-wrap:wrap}
-.footer-links a{font-size:var(--text-xs,12px);color:var(--cobalt,#1D4ED8)}
-.footer-meta{font-size:var(--text-xs,12px);color:var(--ink-dim,#64748b)}
+.footer-links a{font-size:var(--text-xs,12px);color:var(--cobalt)}
+.footer-meta{font-size:var(--text-xs,12px);color:var(--ink-dim)}
 
 @media(max-width:900px){
   .arch-inner,.page-hero-inner{padding:0 24px}
@@ -163,9 +168,9 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -176,26 +181,26 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -204,13 +209,13 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }
@@ -342,7 +347,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
         <rect x="250" y="76" width="140" height="52" rx="2" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
         <text x="320" y="98" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#dc2626">████████████</text>
         <text x="320" y="114" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#dc2626">opaque ciphertext</text>
-        <text x="320" y="146" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" fill="#475569">RAM only — no disk write</text>
+        <text x="320" y="146" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" fill="#475569">RAM only &mdash; no disk write</text>
         <text x="320" y="160" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" fill="#475569">no key, no plaintext</text>
 
         <!-- Arrow 2→3 -->
@@ -400,7 +405,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
           <li>Readable file contents (stored in plaintext or decryptable by the provider)</li>
           <li>Filename and metadata logged</li>
           <li>Preview thumbnail generated server-side</li>
-          <li>Written to disk — survives restarts, subpoenas, breaches</li>
+          <li>Written to disk &mdash; survives restarts, subpoenas, breaches</li>
           <li>Access logs tied to content</li>
           <li>Subject to legal disclosure orders</li>
         </ul>
@@ -408,11 +413,11 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
       <div class="compare-col compare-col--good">
         <h3>Paramant relay</h3>
         <ul>
-          <li>Ciphertext only — we cannot read it</li>
+          <li>Ciphertext only &mdash; we cannot read it</li>
           <li>No filename, no metadata</li>
-          <li>No preview possible — opaque bytes</li>
-          <li>RAM only — relay restart destroys everything</li>
-          <li>Nothing to disclose — we hold no plaintext</li>
+          <li>No preview possible &mdash; opaque bytes</li>
+          <li>RAM only &mdash; relay restart destroys everything</li>
+          <li>Nothing to disclose &mdash; we hold no plaintext</li>
           <li>GDPR jurisdiction, no US CLOUD Act</li>
         </ul>
       </div>
@@ -429,7 +434,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
   <div class="arch-inner">
     <div class="section-num">03</div>
     <h2 class="section-title">The # in the link</h2>
-    <p class="section-desc">Every Paramant link is split in two. The left half goes to the relay. The right half — the part after <code style="font-family:'IBM Plex Mono',monospace;font-size:14px;background:#eff6ff;padding:2px 6px;color:#1D4ED8">#</code> — never leaves your browser. This is not a Paramant policy. It is how browsers work.</p>
+    <p class="section-desc">Every Paramant link is split in two. The left half goes to the relay. The right half &mdash; the part after <code style="font-family:'IBM Plex Mono',monospace;font-size:14px;background:var(--card);padding:2px 6px;color:var(--cobalt)">#</code> &mdash; never leaves your browser. This is not a Paramant policy. It is how browsers work.</p>
 
     <div class="url-anatomy">
       <div class="url-display">
@@ -439,16 +444,16 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
         <div class="url-label-item">
           <div>
             <span class="url-label-dot url-label-dot--blue"></span>
-            <strong style="font-family:'IBM Plex Mono',monospace;font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:#1D4ED8">Sent to relay</strong>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--cobalt)">Sent to relay</strong>
           </div>
           <p class="url-label-text" style="margin-top:6px;padding-left:16px">The path <code style="font-family:'IBM Plex Mono',monospace;font-size:12px">/r/a8f3c92d</code> identifies which blob to retrieve. The relay sees this and serves the matching ciphertext.</p>
         </div>
         <div class="url-label-item">
           <div>
             <span class="url-label-dot url-label-dot--lime"></span>
-            <strong style="font-family:'IBM Plex Mono',monospace;font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:#166534">Never leaves the browser</strong>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--ok-ink)">Never leaves the browser</strong>
           </div>
-          <p class="url-label-text" style="margin-top:6px;padding-left:16px">The fragment <code style="font-family:'IBM Plex Mono',monospace;font-size:12px">#key=…</code> is the decryption key. Browsers strip the fragment before making any network request. It is never transmitted to any server — including ours.</p>
+          <p class="url-label-text" style="margin-top:6px;padding-left:16px">The fragment <code style="font-family:'IBM Plex Mono',monospace;font-size:12px">#key=…</code> is the decryption key. Browsers strip the fragment before making any network request. It is never transmitted to any server &mdash; including ours.</p>
         </div>
       </div>
     </div>
@@ -473,7 +478,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
         <div class="lifecycle-body">Ciphertext is held in relay RAM. The decryption key lives only in the URL fragment on the sender's clipboard. The relay is waiting.</div>
       </div>
       <div class="lifecycle-state lifecycle-state--active">
-        <div class="lifecycle-num">State 02 — active</div>
+        <div class="lifecycle-num">State 02 &mdash; active</div>
         <div class="lifecycle-heading">Link opened</div>
         <div class="lifecycle-body">Recipient's browser fetches the ciphertext. The relay flags the slot for immediate erasure. Decryption happens locally using the key from <code style="font-family:'IBM Plex Mono',monospace;font-size:12px">#key=…</code>. File appears in the browser.</div>
       </div>
@@ -482,7 +487,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
           <circle cx="10" cy="10" r="9" stroke="#ef4444" stroke-width="1.5"/>
           <path d="M6.5 6.5L13.5 13.5M13.5 6.5L6.5 13.5" stroke="#ef4444" stroke-width="1.75"/>
         </svg>
-        <div class="lifecycle-num">State 03 — gone</div>
+        <div class="lifecycle-num">State 03 &mdash; gone</div>
         <div class="lifecycle-heading">Erased</div>
         <div class="lifecycle-body">Memory slot zeroed. Any subsequent request for that ID returns HTTP 410 Gone. No recovery, no retry, no copy anywhere on disk.</div>
       </div>
@@ -499,7 +504,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
   <div class="arch-inner">
     <div class="section-num">05</div>
     <h2 class="section-title">Verifiable history</h2>
-    <p class="section-desc">Every transfer event is appended to a Merkle tree. The root fingerprint is published. Changing any historical entry would change the root — which is publicly visible and tamper-evident.</p>
+    <p class="section-desc">Every transfer event is appended to a Merkle tree. The root fingerprint is published. Changing any historical entry would change the root &mdash; which is publicly visible and tamper-evident.</p>
 
     <div class="arch-diagram" role="img" aria-label="Merkle tree diagram showing root hash derived from four leaf events">
       <svg viewBox="0 0 680 260" xmlns="http://www.w3.org/2000/svg" style="width:100%;height:auto">
@@ -551,7 +556,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
     </div>
 
     <div class="arch-takeaway">
-      <p><strong>The root fingerprints the whole tree.</strong> Edit any leaf event — even by one byte — and the root hash changes. Because the root is published in the CT log, any retroactive tampering is immediately detectable. This is the same principle used by certificate transparency in TLS.</p>
+      <p><strong>The root fingerprints the whole tree.</strong> Edit any leaf event &mdash; even by one byte &mdash; and the root hash changes. Because the root is published in the CT log, any retroactive tampering is immediately detectable. This is the same principle used by certificate transparency in TLS.</p>
     </div>
   </div>
 </section>
@@ -564,7 +569,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
     <p class="section-desc">One jurisdiction. One data center. No CDN caching your files. No US entity holds ciphertext or a key; the one American sub-processor sends transactional email under Standard Contractual Clauses.</p>
 
     <div style="text-align:center;margin:40px 0 32px">
-      <div style="font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:13px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:#B2FF3F;margin-bottom:24px">HETZNER · NUREMBERG · GERMANY · EU</div>
+      <div style="font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:13px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--lime);margin-bottom:24px">HETZNER · NUREMBERG · GERMANY · EU</div>
 
       <svg viewBox="0 0 360 280" xmlns="http://www.w3.org/2000/svg" style="width:100%;max-width:360px;margin:0 auto;display:block" aria-label="Concentric circles showing relay location in Nuremberg, Germany">
         <!-- Concentric circles -->
@@ -584,21 +589,21 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
         <text x="196" y="128" font-family="'IBM Plex Mono',monospace" font-size="8" fill="rgba(178,255,63,0.7)">49.45°N 11.08°E</text>
       </svg>
 
-      <div style="font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:11px;color:rgba(178,255,63,0.8);letter-spacing:.08em;margin-top:8px">paramant-relay · 49.45N · 11.08E</div>
+      <div style="font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:11px;color:rgba(217, 164, 65, 0.8);letter-spacing:.08em;margin-top:8px">paramant-relay · 49.45N · 11.08E</div>
     </div>
 
     <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:16px;margin-top:8px">
-      <div style="padding:20px;border:1px solid rgba(255,255,255,0.1)">
-        <div style="font-family:'IBM Plex Mono',monospace;font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#B2FF3F;margin-bottom:8px">Jurisdiction</div>
-        <div style="font-size:14px;color:#e2e8f0;line-height:1.6">EU / Germany<br><span style="font-size:12px;color:#94a3b8">GDPR · DSGVO</span></div>
+      <div style="padding:20px;border:1px solid rgba(var(--tint), 0.1)">
+        <div style="font-family:'IBM Plex Mono',monospace;font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--lime);margin-bottom:8px">Jurisdiction</div>
+        <div style="font-size:14px;color:var(--ink-2);line-height:1.6">EU / Germany<br><span style="font-size:12px;color:var(--ink-dim)">GDPR · DSGVO</span></div>
       </div>
-      <div style="padding:20px;border:1px solid rgba(255,255,255,0.1)">
-        <div style="font-family:'IBM Plex Mono',monospace;font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#B2FF3F;margin-bottom:8px">US Cloud Act</div>
-        <div style="font-size:14px;color:#e2e8f0;line-height:1.6">Not applicable<br><span style="font-size:12px;color:#94a3b8">no US entity</span></div>
+      <div style="padding:20px;border:1px solid rgba(var(--tint), 0.1)">
+        <div style="font-family:'IBM Plex Mono',monospace;font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--lime);margin-bottom:8px">US Cloud Act</div>
+        <div style="font-size:14px;color:var(--ink-2);line-height:1.6">Not applicable<br><span style="font-size:12px;color:var(--ink-dim)">no US entity</span></div>
       </div>
-      <div style="padding:20px;border:1px solid rgba(255,255,255,0.1)">
-        <div style="font-family:'IBM Plex Mono',monospace;font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#B2FF3F;margin-bottom:8px">Storage</div>
-        <div style="font-size:14px;color:#e2e8f0;line-height:1.6">RAM only<br><span style="font-size:12px;color:#94a3b8">no disk, no CDN</span></div>
+      <div style="padding:20px;border:1px solid rgba(var(--tint), 0.1)">
+        <div style="font-family:'IBM Plex Mono',monospace;font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--lime);margin-bottom:8px">Storage</div>
+        <div style="font-size:14px;color:var(--ink-2);line-height:1.6">RAM only<br><span style="font-size:12px;color:var(--ink-dim)">no disk, no CDN</span></div>
       </div>
     </div>
   </div>
@@ -702,7 +707,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
     </table>
 
     <div class="arch-takeaway">
-      <p><strong>The relay never sees plaintext for SDK and WebApp transfers.</strong> The two extensions currently take a server-side path while their client-side crypto is finished — that is called out openly here rather than papered over. See <a href="/crypto-agility#06">crypto-agility § 06</a> for the per-client wire format and migration table.</p>
+      <p><strong>The relay never sees plaintext for SDK and WebApp transfers.</strong> The two extensions currently take a server-side path while their client-side crypto is finished &mdash; that is called out openly here rather than papered over. See <a href="/crypto-agility#06">crypto-agility § 06</a> for the per-client wire format and migration table.</p>
     </div>
   </div>
 </section>
@@ -710,7 +715,7 @@ footer{border-top:1px solid var(--ink-hair,#e2e8f0);padding:40px 48px;display:fl
 <!-- ── GOING DEEPER ── -->
 <section class="arch-section arch-section--tint">
   <div class="going-deeper">
-    <span class="eyebrow" style="display:block;text-align:center;margin-bottom:20px">GOING DEEPER</span>
+    <span class="eyebrow" style="display:block;width:fit-content;margin:0 auto 20px;text-align:center">GOING DEEPER</span>
     <h2>Want the cryptographic specification?</h2>
     <p>The security page covers every algorithm, the independent audit results, key verification layers, authentication model, and responsible disclosure. Written for cryptographers and security engineers.</p>
     <a href="/security" class="btn-arch">Read the security spec &rarr;</a>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Send audit logs to a regulator without a second leak · Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -19,9 +19,9 @@
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="canonical" href="https://paramant.app/audit-log-export">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 a{color:var(--ink);text-decoration:none}
 a:hover{opacity:.7}
@@ -31,7 +31,7 @@ code{font-size:var(--text-xs);padding:2px 6px;border:1px solid var(--ink-ghost);
 .hero-label{font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--cobalt);margin-bottom:16px}
 .hero h1{font-size:32px;font-weight:600;letter-spacing:-.025em;line-height:1.2;margin-bottom:18px}
 .hero h1 em{font-style:italic;color:var(--cobalt);position:relative;display:inline}
-.hero h1 em::after{content:"";position:absolute;left:0;right:0;bottom:4%;height:22%;background:var(--lime);z-index:-1;pointer-events:none}
+.hero h1 em::after{content:"";position:absolute;left:0;right:0;bottom:4%;height:22%;background:var(--accent-soft);z-index:-1;pointer-events:none}
 .hero .lead{font-size:15px;color:var(--ink-dim);max-width:660px;line-height:1.75}
 
 main{max-width:860px;margin:0 auto;padding:0 48px 80px}
@@ -49,14 +49,14 @@ section p+p{margin-top:14px}
 .step-num{font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:700;color:var(--lime);min-width:28px;padding-top:2px;flex-shrink:0}
 .step-body{font-size:14px;color:var(--bone-on-navy-dim);line-height:1.75}
 .step-body strong{color:var(--bone-on-navy)}
-.workflow-block{background:var(--navy);padding:28px 32px;margin-top:24px}
+.workflow-block{background:var(--invert);padding:28px 32px;margin-top:24px}
 
 .compliance-table{width:100%;border-collapse:collapse;margin-top:20px;font-size:13px}
 .compliance-table th{text-align:left;font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim);padding:8px 12px;border-bottom:2px solid var(--ink-hair)}
 .compliance-table td{padding:10px 12px;border-bottom:1px solid var(--ink-hair);vertical-align:top;line-height:1.6;color:var(--ink-dim)}
 .compliance-table td:first-child{color:var(--ink);font-weight:500;white-space:nowrap}
 
-.btn-primary{display:inline-block;font-size:13px;font-weight:700;text-decoration:none;color:#0B3A6A;background:var(--lime);padding:10px 22px;margin-right:10px}
+.btn-primary{display:inline-block;font-size:13px;font-weight:700;text-decoration:none;color: var(--on-ochre);background:var(--lime);padding:10px 22px;margin-right:10px}
 .btn-primary:hover{opacity:.88}
 .btn-sec{display:inline-block;font-size:13px;text-decoration:none;color:var(--bone-on-navy);border:1px solid var(--bone-on-navy-hair);padding:10px 22px}
 .btn-sec:hover{border-color:var(--lime)}
@@ -68,11 +68,11 @@ section p+p{margin-top:14px}
 }
 </style>
 <style>
-.nav-help{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;font-family:IBM Plex Mono,monospace;font-size:12px;letter-spacing:0.1em;color:#475569;text-decoration:none;border:1px solid #E2E8F0;transition:all 140ms ease;margin-right:12px}
-.nav-help::before{content:"?";display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border:1.5px solid #64748b;border-radius:50%;font-size:11px;font-weight:700;color:#64748b;font-family:Inter,sans-serif;line-height:1}
-.nav-help:hover{color:#0B3A6A;border-color:#B2FF3F;background:rgba(178,255,63,0.08)}
-.nav-help:hover::before{border-color:#0B3A6A;color:#0B3A6A;background:#B2FF3F}
-.nav-help:focus-visible{outline:2px solid #B2FF3F;outline-offset:2px}
+.nav-help{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;font-family:IBM Plex Mono,monospace;font-size:12px;letter-spacing:0.1em;color:var(--ink-2);text-decoration:none;border:1px solid var(--ink-hair);transition:all 140ms ease;margin-right:12px}
+.nav-help::before{content:"?";display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border:1.5px solid var(--ink-dim);border-radius:50%;font-size:11px;font-weight:700;color:var(--ink-dim);font-family:Inter,sans-serif;line-height:1}
+.nav-help:hover{color:var(--ink);border-color:var(--ochre);background:rgba(217, 164, 65, 0.08)}
+.nav-help:hover::before{border-color:var(--line-2);color: var(--on-ochre);background:var(--ochre)}
+.nav-help:focus-visible{outline:2px solid var(--ochre);outline-offset:2px}
 @media(max-width:900px){.nav-help{display:none}}
 </style>
 <script type="application/ld+json" data-paramant-seo="1">
@@ -214,7 +214,7 @@ section p+p{margin-top:14px}
 
 </main>
 
-<div style="background:var(--cobalt);padding:52px 48px;text-align:center">
+<div style="background:var(--bone-2);border:1px solid var(--ink-hair);padding:52px 48px;text-align:center">
   <h2 style="font-size:24px;font-weight:600;letter-spacing:-.02em;margin-bottom:10px;color:var(--bone-on-navy)">Deliver evidence without creating new exposure.</h2>
   <p style="font-size:14px;color:var(--bone-on-navy-dim);margin-bottom:28px;max-width:520px;margin-left:auto;margin-right:auto">Community plan for individual DPOs. Business plan for teams with regular audit obligations.</p>
   <a href="/signup" class="btn-primary">Create free account &rarr;</a>

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -2,16 +2,16 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">:root{color-scheme:light}html,body{background:#FBFAF7;color:#0C1B2A;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}@media(prefers-color-scheme:dark){:root[data-theme="auto"]{color-scheme:dark}html[data-theme="auto"],html[data-theme="auto"] body{background:#0A0F16;color:#EDF1F6}}html[data-theme="dark"],html[data-theme="dark"] body{background:#0A0F16;color:#EDF1F6}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}html[data-theme="light"],html[data-theme="light"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="light"]{color-scheme:light}@media (prefers-color-scheme:light){html[data-theme="auto"],html[data-theme="auto"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="auto"]{color-scheme:light}}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Sign in with a backup code · Paramant</title>
 <link rel="canonical" href="https://paramant.app/auth/backup">
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 /* Een auth-scherm is op een telefoon één taak. Kop, één zin en de knop moeten
    samen in de eerste 844px bij 390px breed passen; met de standaard
@@ -22,9 +22,9 @@
   .section { padding: var(--space-5) 0; border-top: none; }
 }
 </style>
-<meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=4">
-<script src="/js/theme.js?v=1"></script>
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/app-2026.css?v=7">
+<script src="/js/theme.js?v=4"></script>
 </head>
 <body>
 

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">:root{color-scheme:light}html,body{background:#FBFAF7;color:#0C1B2A;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}@media(prefers-color-scheme:dark){:root[data-theme="auto"]{color-scheme:dark}html[data-theme="auto"],html[data-theme="auto"] body{background:#0A0F16;color:#EDF1F6}}html[data-theme="dark"],html[data-theme="dark"] body{background:#0A0F16;color:#EDF1F6}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}html[data-theme="light"],html[data-theme="light"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="light"]{color-scheme:light}@media (prefers-color-scheme:light){html[data-theme="auto"],html[data-theme="auto"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="auto"]{color-scheme:light}}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Sign in · Paramant</title>
 <link rel="canonical" href="https://paramant.app/auth/login">
@@ -21,9 +21,9 @@
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 /* Compact auth layout — existing design tokens only; design-system.css untouched. */
 .auth-wrap { max-width: 380px; margin: 0 auto; padding: var(--space-6) var(--space-4) var(--space-7); }
@@ -41,13 +41,13 @@
 .auth-link { background: none; border: none; color: var(--navy); font: inherit; font-size: 13px; cursor: pointer; text-decoration: underline; text-underline-offset: 3px; padding: 4px; }
 .auth-link:hover { opacity: .75; }
 #code-fields { margin-top: 4px; }
-.auth-note { max-width: 380px; margin: var(--space-3) auto 0; padding: 14px 18px; border: 1px solid var(--ink-hair, #E2E8F0); border-radius: 8px; background: #F8FAFC; color: #334155; font-size: 14px; line-height: 1.55; }
+.auth-note { max-width: 380px; margin: var(--space-3) auto 0; padding: 14px 18px; border: 1px solid var(--ink-hair); border-radius: 8px; background: var(--card); color: var(--ink-2); font-size: 14px; line-height: 1.55; }
 .auth-note p { margin: 0 0 10px; }
 .auth-note a { color: var(--navy); }
 </style>
-<meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=4">
-<script src="/js/theme.js?v=1"></script>
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/app-2026.css?v=7">
+<script src="/js/theme.js?v=4"></script>
 </head>
 <body>
 

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -2,16 +2,16 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">:root{color-scheme:light}html,body{background:#FBFAF7;color:#0C1B2A;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}@media(prefers-color-scheme:dark){:root[data-theme="auto"]{color-scheme:dark}html[data-theme="auto"],html[data-theme="auto"] body{background:#0A0F16;color:#EDF1F6}}html[data-theme="dark"],html[data-theme="dark"] body{background:#0A0F16;color:#EDF1F6}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}html[data-theme="light"],html[data-theme="light"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="light"]{color-scheme:light}@media (prefers-color-scheme:light){html[data-theme="auto"],html[data-theme="auto"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="auto"]{color-scheme:light}}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Reset authenticator · Paramant</title>
 <link rel="canonical" href="https://paramant.app/auth/request-reset">
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 /* Same compact phone rhythm as /auth/backup: existing tokens only,
    design-system.css untouched. */
@@ -20,9 +20,9 @@
   .section { padding: var(--space-5) 0; border-top: none; }
 }
 </style>
-<meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=4">
-<script src="/js/theme.js?v=1"></script>
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/app-2026.css?v=7">
+<script src="/js/theme.js?v=4"></script>
 </head>
 <body>
 

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -2,16 +2,16 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">:root{color-scheme:light}html,body{background:#FBFAF7;color:#0C1B2A;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}@media(prefers-color-scheme:dark){:root[data-theme="auto"]{color-scheme:dark}html[data-theme="auto"],html[data-theme="auto"] body{background:#0A0F16;color:#EDF1F6}}html[data-theme="dark"],html[data-theme="dark"] body{background:#0A0F16;color:#EDF1F6}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}html[data-theme="light"],html[data-theme="light"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="light"]{color-scheme:light}@media (prefers-color-scheme:light){html[data-theme="auto"],html[data-theme="auto"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="auto"]{color-scheme:light}}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Confirm authenticator reset · Paramant</title>
 <link rel="canonical" href="https://paramant.app/auth/reset-confirm">
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 /* Same compact phone rhythm as /auth/backup: existing tokens only,
    design-system.css untouched. */
@@ -24,16 +24,16 @@
   .warning-box {
     background: #fffbeb;
     border: 1px solid #fde68a;
-    color: #92400e;
+    color: var(--warn-ink);
     padding: 12px 16px;
     font-size: 14px;
     margin: 16px 0;
     border-radius: 4px;
   }
 </style>
-<meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=4">
-<script src="/js/theme.js?v=1"></script>
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/app-2026.css?v=7">
+<script src="/js/theme.js?v=4"></script>
 </head>
 <body>
 
@@ -92,7 +92,7 @@
   </div>
 
   <div id="success-view" style="display:none">
-    <p class="lede" style="color:#059669">Confirmed. The second email, the one with the setup link, is on its way.</p>
+    <p class="lede" style="color:var(--ok-ink)">Confirmed. The second email, the one with the setup link, is on its way.</p>
     <p>Look for a mail from noreply@paramant.app with a setup link. Open it, scan the QR code, and your new authenticator app is linked.</p>
     <p style="margin-top:8px">Delete the old Paramant entry in your authenticator app first. Its codes no longer work.</p>
     <p class="footer-text mt-4"><a href="/auth/login">Return to sign in</a></p>

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -2,16 +2,16 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">:root{color-scheme:light}html,body{background:#FBFAF7;color:#0C1B2A;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}@media(prefers-color-scheme:dark){:root[data-theme="auto"]{color-scheme:dark}html[data-theme="auto"],html[data-theme="auto"] body{background:#0A0F16;color:#EDF1F6}}html[data-theme="dark"],html[data-theme="dark"] body{background:#0A0F16;color:#EDF1F6}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}html[data-theme="light"],html[data-theme="light"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="light"]{color-scheme:light}@media (prefers-color-scheme:light){html[data-theme="auto"],html[data-theme="auto"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="auto"]{color-scheme:light}}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Set up your account · Paramant</title>
 <link rel="canonical" href="https://paramant.app/auth/setup">
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <script src="/js/qrcode.min.js?v=1"></script>
 <style>
 /* Een auth-scherm is op een telefoon één taak. Kop, één zin en de knop moeten
@@ -23,9 +23,9 @@
   .section { padding: var(--space-5) 0; border-top: none; }
 }
 </style>
-<meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=4">
-<script src="/js/theme.js?v=1"></script>
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/app-2026.css?v=7">
+<script src="/js/theme.js?v=4"></script>
 </head>
 <body>
 
@@ -73,7 +73,7 @@
 <!-- Step 3: pick a sign-in method. Passkey is recommended; the authenticator
      route stays scanner-safe (no POST until the user clicks "instead"). -->
 <section id="state-loading" class="section">
-  <div class="card" style="border-left:3px solid #B2FF3F">
+  <div class="card" style="border-left:3px solid var(--ochre)">
     <div style="font-weight:600;color:var(--navy);margin-bottom:6px">Use a passkey &middot; Recommended</div>
     <p style="margin:0 0 16px">
       A passkey lives on this device and nowhere else. You unlock it with your
@@ -160,7 +160,7 @@
     </div>
   </div>
 
-  <details class="mt-4" style="border:1px solid var(--ink-hair,#E2E8F0);border-radius:6px;padding:14px 18px">
+  <details class="mt-4" style="border:1px solid var(--ink-hair);border-radius:6px;padding:14px 18px">
     <summary style="cursor:pointer;font-weight:600;color:var(--navy)">Which apps work?</summary>
     <p class="small mt-2" style="margin-bottom:0">
       Every standard authenticator app works, including Google Authenticator and Microsoft Authenticator.
@@ -217,8 +217,8 @@
     <button type="button" class="btn btn-primary" id="download-codes">Download my codes</button>
   </div>
   <p class="small mt-2">
-    or <button type="button" id="copy-codes" style="background:none;border:none;color:#1D4ED8;font-weight:600;cursor:pointer;text-decoration:underline;padding:0;font:inherit">copy them</button>
-    &middot; <button type="button" id="print-codes" style="background:none;border:none;color:#1D4ED8;font-weight:600;cursor:pointer;text-decoration:underline;padding:0;font:inherit">print</button>
+    or <button type="button" id="copy-codes" style="background:none;border:none;color:var(--cobalt);font-weight:600;cursor:pointer;text-decoration:underline;padding:0;font:inherit">copy them</button>
+    &middot; <button type="button" id="print-codes" style="background:none;border:none;color:var(--cobalt);font-weight:600;cursor:pointer;text-decoration:underline;padding:0;font:inherit">print</button>
   </p>
 
   <div class="form-checkbox mt-4">
@@ -265,7 +265,7 @@
   <h2>You're all set.</h2>
   <p class="lede mt-3">Your account is active. Two things you can do right now.</p>
   <div class="grid2 mt-3">
-    <a href="/parashare" class="card" style="border-left:3px solid #B2FF3F;text-decoration:none;display:block">
+    <a href="/parashare" class="card" style="border-left:3px solid var(--ochre);text-decoration:none;display:block">
       <div style="font-weight:600;color:var(--navy);margin-bottom:6px">Send a file</div>
       <p class="small" style="margin:0">Encrypt a file in your browser and send a link that the web app burns on the first read, on every plan.</p>
     </a>

--- a/frontend/billing/checkout.html
+++ b/frontend/billing/checkout.html
@@ -8,8 +8,8 @@
 <meta http-equiv="refresh" content="0;url=/pricing">
 <link rel="canonical" href="https://paramant.app/pricing">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=25">
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/design-system.css?v=28">
 <style>
   body { background: var(--bone); }
   .checkout-wrap { max-width: 480px; margin: var(--space-10) auto; padding: 0 var(--space-5); text-align: center; }

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Changelog · Paramant release history</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -21,39 +21,39 @@
 <link rel="canonical" href="https://paramant.app/changelog">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
-body{background:var(--bone,#F8FAFC);color:var(--ink,#0B3A6A)}
+body{background:var(--bone);color:var(--ink)}
 main{max-width:780px;margin:0 auto;padding:80px 48px 120px}
 h1{font-size:36px;font-weight:600;letter-spacing:-.03em;margin-bottom:12px}
-.lead{font-size:16px;color:var(--ink-dim,#475569);line-height:1.7;margin-bottom:60px;max-width:560px}
-.release{margin-bottom:64px;border-top:2px solid var(--cobalt,#1D4ED8);padding-top:32px}
+.lead{font-size:16px;color:var(--ink-dim);line-height:1.7;margin-bottom:60px;max-width:560px}
+.release{margin-bottom:64px;border-top:2px solid var(--cobalt);padding-top:32px}
 .release:first-of-type{border-top:none;padding-top:0}
 .release-header{display:flex;align-items:baseline;gap:16px;flex-wrap:wrap;margin-bottom:8px}
-h2{font-size:20px;font-weight:600;letter-spacing:-.01em;color:var(--ink,#0B3A6A)}
-.release-date{font-size:12px;color:var(--ink-dim,#475569);font-family:monospace;letter-spacing:.06em;text-transform:uppercase}
-.release-summary{font-size:15px;color:var(--ink-dim,#475569);line-height:1.7;margin-bottom:28px;max-width:620px}
-h3{font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-dim,#475569);margin:28px 0 12px}
+h2{font-size:20px;font-weight:600;letter-spacing:-.01em;color:var(--ink)}
+.release-date{font-size:12px;color:var(--ink-dim);font-family:monospace;letter-spacing:.06em;text-transform:uppercase}
+.release-summary{font-size:15px;color:var(--ink-dim);line-height:1.7;margin-bottom:28px;max-width:620px}
+h3{font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-dim);margin:28px 0 12px}
 ul{padding-left:20px;margin-bottom:0}
-li{font-size:14px;color:var(--ink-dim,#475569);line-height:1.8;margin-bottom:4px}
-li strong{color:var(--ink,#0B3A6A)}
-code{background:rgba(11,58,106,.06);padding:2px 5px;font-size:12px;font-family:monospace}
+li{font-size:14px;color:var(--ink-dim);line-height:1.8;margin-bottom:4px}
+li strong{color:var(--ink)}
+code{background:rgba(var(--tint), .06);padding:2px 5px;font-size:12px;font-family:monospace}
 .badge{display:inline-block;font-size:11px;font-family:monospace;padding:2px 7px;letter-spacing:.06em;text-transform:uppercase;font-weight:600}
-.badge-added{background:rgba(178,255,63,.25);color:#166534}
-.badge-changed{background:rgba(29,78,216,.08);color:#1D4ED8}
-.badge-fixed{background:rgba(11,58,106,.06);color:#475569}
-.badge-security{background:#FEF3C7;color:#92400E}
+.badge-added{background:rgba(217, 164, 65, .25);color:var(--ok-ink)}
+.badge-changed{background:rgba(217, 164, 65, .08);color:var(--cobalt)}
+.badge-fixed{background:rgba(var(--tint), .06);color:var(--ink-2)}
+.badge-security{background:var(--card);color:var(--warn-ink)}
 .unreleased{opacity:.6}
-footer{border-top:1px solid rgba(11,58,106,.1);padding:40px 48px;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:16px}
+footer{border-top:1px solid rgba(var(--tint), .1);padding:40px 48px;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:16px}
 .footer-links{display:flex;gap:20px;flex-wrap:wrap}
-.footer-links a{font-size:12px;color:var(--cobalt,#1D4ED8);text-decoration:none}
-.footer-meta{font-size:12px;color:var(--ink-dim,#475569)}
+.footer-links a{font-size:12px;color:var(--cobalt);text-decoration:none}
+.footer-meta{font-size:12px;color:var(--ink-dim)}
 @media(max-width:640px){main{padding:48px 20px 80px}h1{font-size:26px}footer{padding:32px 20px;flex-direction:column}}
 </style>
 <script type="application/ld+json" data-paramant-seo="1">

--- a/frontend/claim.html
+++ b/frontend/claim.html
@@ -8,19 +8,19 @@
 <meta name="robots" content="noindex, nofollow">
 <meta name="referrer" content="no-referrer">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/design-system.css?v=25">
+<link rel="stylesheet" href="/design-system.css?v=28">
 <style>
   .claim-wrap{max-width:560px;margin:8vh auto;padding:0 20px}
-  .claim-card{background:#fff;border:1px solid #E2E8F0;border-radius:10px;padding:32px}
-  .claim-warn{background:#FEF3C7;border-left:3px solid #D97706;padding:12px 16px;margin:20px 0;color:#92400E;font-size:13px;line-height:1.5}
-  .claim-key{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:14px;word-break:break-all;background:#0B3A6A;color:#fff;padding:16px;border-radius:8px;margin:16px 0}
-  .claim-btn{display:inline-block;background:#0B3A6A;color:#fff;border:0;border-radius:8px;padding:12px 22px;font-size:15px;font-weight:600;cursor:pointer}
+  .claim-card{background:var(--card);border:1px solid var(--ink-hair);border-radius:10px;padding:32px}
+  .claim-warn{background:var(--card);border-left:3px solid var(--ochre-2);padding:12px 16px;margin:20px 0;color:var(--warn-ink);font-size:13px;line-height:1.5}
+  .claim-key{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:14px;word-break:break-all;background:var(--bone-2);color:var(--ink);padding:16px;border-radius:8px;margin:16px 0}
+  .claim-btn{display:inline-block;background:var(--bone-2);color:var(--ink);border:0;border-radius:8px;padding:12px 22px;font-size:15px;font-weight:600;cursor:pointer}
   .claim-btn:disabled{opacity:.5;cursor:default}
-  .claim-muted{color:#64748B;font-size:13px;line-height:1.6}
-  .claim-err{color:#B91C1C;font-size:14px}
-  .claim-next{margin-top:24px;padding-top:20px;border-top:1px solid #E2E8F0}
+  .claim-muted{color:var(--ink-dim);font-size:13px;line-height:1.6}
+  .claim-err{color:var(--brick-ink);font-size:14px}
+  .claim-next{margin-top:24px;padding-top:20px;border-top:1px solid var(--ink-hair)}
   .claim-next p{margin:0 0 10px}
-  .claim-link{display:inline-block;margin-right:16px;color:#0B3A6A;font-weight:600;font-size:14px;text-decoration:none}
+  .claim-link{display:inline-block;margin-right:16px;color:var(--ink);font-weight:600;font-size:14px;text-decoration:none}
   .claim-link:hover{text-decoration:underline}
   [hidden]{display:none !important}
 </style>

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -5,7 +5,7 @@
 <!-- Sticky readiness signals. Plain script in <head> on purpose: it must run
      before every module and deferred script that signals or awaits. -->
 <script src="/js/ready.js?v=1"></script>
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Co-sign this document · Paramant</title>
 <meta name="description" content="Review and sign a document someone sent you. The file and your signing key stay in your browser.">
@@ -24,10 +24,10 @@
 <meta name="robots" content="noindex,nofollow">
 <link rel="canonical" href="https://paramant.app/co-sign">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{background:var(--bone);color:var(--ink);font-family:var(--sans);min-height:100vh}
@@ -39,39 +39,39 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 .card-head-title{font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-dim)}
 .card-body{padding:18px}
 .dot{width:6px;height:6px;background:var(--lime);border:1px solid var(--navy)}
-.dot.amber{background:#f59e0b}
-.dot.red{background:rgba(255,80,80,1)}
+.dot.amber{background:var(--ochre)}
+.dot.red{background:rgba(196, 96, 79, 1)}
 .kv{display:grid;grid-template-columns:140px 1fr;gap:6px 12px;font-size:12px;line-height:1.6}
 .kv dt{font-family:var(--mono);font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-dim);padding-top:1px}
 .kv dd{font-family:var(--mono);font-size:11px;color:var(--ink);word-break:break-all}
 .party-row{display:grid;grid-template-columns:32px 1fr auto;gap:10px;padding:8px 0;border-bottom:1px solid var(--ink-hair);font-size:12px;align-items:center}
 .party-row:last-child{border-bottom:0}
-.party-row.me{background:rgba(178,255,63,0.08);margin:0 -8px;padding-left:8px;padding-right:8px}
+.party-row.me{background:rgba(217, 164, 65, 0.08);margin:0 -8px;padding-left:8px;padding-right:8px}
 .party-idx{font-family:var(--mono);font-size:10px;color:var(--ink-dim);text-align:center}
 .party-label{font-weight:600}
 .party-status{font-family:var(--mono);font-size:10px;letter-spacing:.06em;text-transform:uppercase}
 .party-status.signed{color:var(--cobalt)}
 .party-status.pending{color:#888}
-.party-status.viewed{color:#d4a017}
+.party-status.viewed{color:var(--warn-ink)}
 .field{margin-bottom:14px}
 .label{display:block;font-family:var(--mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:6px}
 .input,.select,.file-cta{width:100%;padding:10px;border:1px solid var(--ink-hair);background:var(--bone);color:var(--ink);font-family:var(--mono);font-size:12px}
 .file-cta{display:inline-block;text-align:center;cursor:pointer;border-style:dashed}
 .file-cta:hover{border-color:var(--cobalt);color:var(--cobalt)}
-.btn{display:inline-block;width:100%;padding:11px;background:var(--cobalt);color:var(--bone-on-navy);border:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.06em;cursor:pointer;text-decoration:none;text-align:center}
+.btn{display:inline-block;width:100%;padding:11px;background:var(--cobalt);color: var(--on-ochre);border:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.06em;cursor:pointer;text-decoration:none;text-align:center}
 .btn:hover{opacity:.85}
 .btn:disabled{opacity:.4;cursor:not-allowed}
 .btn-outline{background:transparent;color:var(--ink);border:1px solid var(--ink-hair)}
 .btn-outline:hover{color:var(--cobalt);border-color:var(--cobalt)}
 .banner{padding:10px 14px;font-size:12px;border:1px solid var(--ink-hair);background:var(--bone-2);margin-bottom:14px;line-height:1.5}
-.banner.ok{border-color:var(--cobalt);color:var(--cobalt);background:rgba(11,58,106,0.04)}
-.banner.err{border-color:rgba(200,30,30,0.6);color:rgba(180,20,20,1);background:rgba(255,80,80,0.06)}
-.banner.warn{border-color:#d4a017;background:#fff4d6;color:#5a3f00}
-.disclaimer{background:#fff4d6;border:1px solid #d4a017;padding:10px 14px;font-size:12px;color:#5a3f00;margin-bottom:14px;line-height:1.5}
+.banner.ok{border-color:var(--cobalt);color:var(--cobalt);background:rgba(var(--tint), 0.04)}
+.banner.err{border-color:rgba(196, 96, 79, 0.6);color:rgba(196, 96, 79, 1);background:rgba(196, 96, 79, 0.06)}
+.banner.warn{border-color:#d4a017;background:var(--card);color:var(--warn-ink)}
+.disclaimer{background:var(--card);border:1px solid #d4a017;padding:10px 14px;font-size:12px;color:var(--warn-ink);margin-bottom:14px;line-height:1.5}
 .disclaimer strong{display:block;font-size:11px;letter-spacing:.06em;text-transform:uppercase;margin-bottom:4px;color:#7a5300}
 .tag{display:inline-block;font-family:var(--mono);font-size:10px;padding:3px 8px;border:1px solid var(--ink-hair);color:var(--ink-dim);margin-right:4px}
 .tag.green{border-color:var(--cobalt);color:var(--cobalt)}
-.tag.red{border-color:rgba(200,30,30,0.6);color:rgba(180,20,20,1)}
+.tag.red{border-color:rgba(196, 96, 79, 0.6);color:rgba(196, 96, 79, 1)}
 .step{display:none;animation:fadeIn .2s ease}
 .step.active{display:block}
 @keyframes fadeIn{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
@@ -81,21 +81,21 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
    looking at a 343px render of the same page. The negative margin cancels the
    two paddings it is nested in, so the preview runs edge to edge inside the
    card and both sides see the document at the same scale. */
-.doc-preview{margin:12px -50px 0;border:1px solid var(--ink-hair);border-left:0;border-right:0;background:#fff;max-height:72vh;overflow:auto;padding:10px 8px}
+.doc-preview{margin:12px -50px 0;border:1px solid var(--ink-hair);border-left:0;border-right:0;background:var(--card);max-height:72vh;overflow:auto;padding:10px 8px}
 .doc-page{position:relative;width:100%;margin:0 auto 12px;max-width:100%}
 .doc-page:last-child{margin-bottom:0}
-.doc-page canvas,.doc-page img{display:block;width:100%;height:auto;border:1px solid var(--ink-hair);background:#fff}
+.doc-page canvas,.doc-page img{display:block;width:100%;height:auto;border:1px solid var(--ink-hair);background:#FFFFFF}
 .doc-page.appearance-page{position:relative;cursor:crosshair}
 .appearance-layer{position:absolute;inset:0;pointer-events:auto;cursor:crosshair}
-.appearance-field{position:absolute;display:flex;align-items:center;overflow:hidden;border:2px solid var(--cobalt);background:rgba(255,255,255,.94);color:var(--ink);padding:5px 8px;font:600 10px/1.25 var(--sans);box-shadow:0 3px 12px rgba(11,58,106,.16);pointer-events:auto}
-.appearance-field.date{border-color:#64748b;font-family:var(--mono);font-weight:500}
+.appearance-field{position:absolute;display:flex;align-items:center;overflow:hidden;border:2px solid #1D4ED8;background:rgba(255,255,255,.94);color:#0C1B2A;padding:5px 8px;font:600 10px/1.25 var(--sans);box-shadow:0 3px 12px rgba(0, 0, 0, .16);pointer-events:auto}
+.appearance-field.date{border-color:#5C6A78;font-family:var(--mono);font-weight:500}
 /* The box the SENDER asked for, before the signer has touched it. It must not
    look like a signature that already exists: no name, no date, no delete
    control, a dashed outline and its own words. It becomes a real placed field
    the moment the signer chooses Place my signature. */
-.appearance-field.requested{border:2px dashed var(--cobalt);background:rgba(11,58,106,.06);box-shadow:none;color:var(--cobalt);font-weight:600;justify-content:center;text-align:center;pointer-events:none}
+.appearance-field.requested{border:2px dashed #1D4ED8;background:rgba(29,78,216,.06);box-shadow:none;color:#1D4ED8;font-weight:600;justify-content:center;text-align:center;pointer-events:none}
 .appearance-field.prior{border-style:solid;background:rgba(239,246,255,.92);pointer-events:none}
-.appearance-remove{position:absolute;top:1px;right:2px;width:20px;height:20px;border:0;background:var(--cobalt);color:#fff;font:700 13px/1 var(--sans);cursor:pointer}
+.appearance-remove{position:absolute;top:1px;right:2px;width:20px;height:20px;border:0;background:#1D4ED8;color:#FFFFFF;font:700 13px/1 var(--sans);cursor:pointer}
 .appearance-tools{display:flex;gap:8px;flex-wrap:wrap;margin:12px 0}
 .appearance-tools .btn{width:auto;min-width:120px}
 /* 44px: a finger, not a mouse. These were 34-36px, under every touch-target
@@ -105,14 +105,14 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 /* The pointer to the requested spot. It sits ABOVE the preview because that is
    where the reader is when the document opens; the spot itself can be three
    pages down. */
-.requested-note{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap;margin-bottom:10px;padding:10px 14px;border:1px solid var(--cobalt);background:rgba(11,58,106,.04);font-size:12px;line-height:1.5;color:var(--cobalt)}
+.requested-note{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap;margin-bottom:10px;padding:10px 14px;border:1px solid var(--cobalt);background:rgba(var(--tint), .04);font-size:12px;line-height:1.5;color:var(--cobalt)}
 .requested-note .btn{width:auto;min-width:0;padding:11px 14px;flex:0 0 auto}
 .appearance-help{font-size:12px;line-height:1.55;color:var(--ink-dim)}
 .appearance-help.active{color:var(--cobalt);font-weight:600}
 .doc-preview-meta{font-family:var(--mono);font-size:10px;letter-spacing:.04em;color:var(--ink-dim);text-align:center;padding:8px 0;line-height:1.5}
 .review-gate{font-size:12px;color:var(--ink-dim);margin-top:10px;line-height:1.6}
 .blind-link{background:none;border:none;color:var(--ink-dim);text-decoration:underline;font-family:var(--mono);font-size:11px;cursor:pointer;padding:0}
-.blind-link:hover{color:#b91c1c}
+.blind-link:hover{color:var(--brick-ink)}
 @media(max-width:640px){main{padding:40px 16px}h1{font-size:19px}.kv{grid-template-columns:1fr}}
 </style>
 </head>
@@ -204,8 +204,8 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
            for this session — signing "like logging in again". -->
       <div class="banner" id="cs-pass-panel" hidden style="margin-top:12px">
         <p id="cs-pass-prompt" style="margin-bottom:10px"></p>
-        <input type="text" id="cs-pass-input" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code" autocapitalize="off" autocorrect="off" spellcheck="false" placeholder="6-digit code" aria-label="Authenticator code" style="width:100%;padding:10px;border:1px solid var(--ink-hair,#e2e8f0);border-radius:6px;margin-bottom:8px;font-size:14px">
-        <p id="cs-pass-err" hidden style="color:var(--danger,#b91c1c);font-size:13px;margin-bottom:8px"></p>
+        <input type="text" id="cs-pass-input" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code" autocapitalize="off" autocorrect="off" spellcheck="false" placeholder="6-digit code" aria-label="Authenticator code" style="width:100%;padding:10px;border:1px solid var(--ink-hair);border-radius:6px;margin-bottom:8px;font-size:14px">
+        <p id="cs-pass-err" hidden style="color:var(--danger);font-size:13px;margin-bottom:8px"></p>
         <div style="display:flex;gap:8px">
           <button class="btn btn-outline" id="cs-pass-cancel" type="button">Cancel</button>
           <button class="btn" id="cs-pass-confirm" type="button">Continue</button>

--- a/frontend/components-parasign.css
+++ b/frontend/components-parasign.css
@@ -16,7 +16,7 @@
 .ps-step {
   display: inline-flex; align-items: center; justify-content: center;
   width: 1.6rem; height: 1.6rem; flex: 0 0 1.6rem; border-radius: 50%;
-  background: var(--navy); color: var(--bone); font-family: var(--mono);
+  background: var(--invert); color: var(--invert-ink); font-family: var(--mono);
   font-size: var(--text-xs); font-weight: 700;
 }
 .ps-panel-title { font-size: var(--text-lg); margin: 0; }

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Crypto agility · Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -19,9 +19,9 @@
 <meta name="twitter:title" content="Crypto agility · Paramant">
 <meta name="twitter:description" content="Algorithms you can swap without rebuilding. Identifiers travel in the header, not in the code path. NIST FIPS 203, 204, 205 and 206 loaded in production.">
 <link rel="canonical" href="https://paramant.app/crypto-agility">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 a{color:var(--ink);text-decoration:none}
 a:hover{opacity:.7}
@@ -45,7 +45,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
 
 /* algo comparison */
 .algo-table{width:100%;border-collapse:collapse;margin-top:20px;font-size:13px}
-.algo-table th{text-align:left;padding:9px 14px;font-size:11px;font-weight:500;text-transform:uppercase;letter-spacing:.06em;color:var(--ink-dim);border-bottom:1px solid var(--ink-hair);background:rgba(178,255,63,.06)}
+.algo-table th{text-align:left;padding:9px 14px;font-size:11px;font-weight:500;text-transform:uppercase;letter-spacing:.06em;color:var(--ink-dim);border-bottom:1px solid var(--ink-hair);background:rgba(217, 164, 65, .06)}
 .algo-table td{padding:10px 14px;border-bottom:1px solid var(--ink-ghost);vertical-align:top;color:var(--ink-dim)}
 .algo-table td:first-child{font-size:11px;color:var(--ink);font-weight:600}
 .algo-table tr:last-child td{border-bottom:none}
@@ -73,7 +73,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
 .cta{background:var(--ink-ghost);border:1px solid var(--ink-hair);padding:26px 30px;margin-top:48px}
 .cta h3{font-size:15px;font-weight:600;margin-bottom:8px}
 .cta p{font-size:13px;color:var(--ink-dim);line-height:1.65;margin-bottom:14px}
-.btn-primary{display:inline-block;font-size:13px;font-weight:700;text-decoration:none;color:var(--bone-on-navy);background:var(--cobalt);padding:8px 18px;margin-right:10px}
+.btn-primary{display:inline-block;font-size:13px;font-weight:700;text-decoration:none;color: var(--on-ochre);background:var(--cobalt);padding:8px 18px;margin-right:10px}
 .btn-primary:hover{opacity:.88}
 .btn-sec{display:inline-block;font-size:13px;text-decoration:none;color:var(--ink);border:1px solid var(--ink-hair);padding:8px 18px}
 .btn-sec:hover{border-color:var(--cobalt)}
@@ -96,9 +96,9 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -109,26 +109,26 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -137,13 +137,13 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }
@@ -161,7 +161,7 @@ section .section-sub{font-size:13px;color:var(--ink-dim);margin-bottom:22px}
 .hero-stats b::before{content:"";width:8px;height:8px;background:var(--lime);flex:none}
 .hero-stats li span{display:block;font-size:11px;color:var(--ink-dim);line-height:1.45;margin-top:8px}
 section h2{display:flex;align-items:baseline;gap:11px}
-.s-num{flex:none;font-family:var(--mono);font-size:12px;font-weight:600;letter-spacing:.03em;color:var(--navy);background:var(--lime);padding:2px 7px;line-height:1.5}
+.s-num{flex:none;font-family:var(--mono);font-size:12px;font-weight:600;letter-spacing:.03em;color: var(--on-ochre);background:var(--lime);padding:2px 7px;line-height:1.5}
 .algo-table td.safe::before{content:"";display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--lime);margin-right:7px}
 @media(max-width:640px){.hero-stats li{min-width:100%;border-right:none;border-bottom:1px solid var(--ink-hair)}.hero-stats li:last-child{border-bottom:none}}
 </style>
@@ -283,7 +283,7 @@ section h2{display:flex;align-items:baseline;gap:11px}
   <section>
     <h2><span class="s-num">02</span>The wire format (v1)</h2>
     <p class="section-sub">A 10-byte fixed header, length-prefixed variable fields after.</p>
-    <pre style="background:var(--navy);color:#F8FAFC;border:1px solid var(--ink-hair);padding:18px 22px;font-size:12px;overflow-x:auto;line-height:1.75;font-family:'IBM Plex Mono',ui-monospace,monospace">MAGIC    4 bytes   PQHB
+    <pre style="background:var(--invert);color:var(--invert-ink);border:1px solid var(--ink-hair);padding:18px 22px;font-size:12px;overflow-x:auto;line-height:1.75;font-family:'IBM Plex Mono',ui-monospace,monospace">MAGIC    4 bytes   PQHB
 VERSION  1 byte    0x01
 KEM_ID   2 bytes   uint16 BE
 SIG_ID   2 bytes   uint16 BE (0x0000 = anonymous)
@@ -397,9 +397,9 @@ FLAGS    1 byte    reserved for future features</pre>
   <section>
     <h2><span class="s-num">05</span>See for yourself</h2>
     <p class="section-sub">The live capabilities endpoint is the source of truth.</p>
-    <pre style="background:var(--navy);color:#F8FAFC;border:1px solid var(--ink-hair);padding:14px 20px;font-size:12px;overflow-x:auto;font-family:'IBM Plex Mono',ui-monospace,monospace">curl https://paramant.app/v2/capabilities</pre>
+    <pre style="background:var(--invert);color:var(--invert-ink);border:1px solid var(--ink-hair);padding:14px 20px;font-size:12px;overflow-x:auto;font-family:'IBM Plex Mono',ui-monospace,monospace">curl https://paramant.app/v2/capabilities</pre>
     <p style="font-size:12px;color:var(--ink-dim);margin-top:12px;margin-bottom:10px">Excerpt (full response lists all 21 entries):</p>
-    <pre style="background:var(--navy);color:#F8FAFC;border:1px solid var(--ink-hair);padding:16px 20px;font-size:12px;overflow-x:auto;line-height:1.6;font-family:'IBM Plex Mono',ui-monospace,monospace">{
+    <pre style="background:var(--invert);color:var(--invert-ink);border:1px solid var(--ink-hair);padding:16px 20px;font-size:12px;overflow-x:auto;line-height:1.6;font-family:'IBM Plex Mono',ui-monospace,monospace">{
   "wire_version": 1,
   "kem": [
     { "id": 1, "name": "ML-KEM-512",  "loaded": true },

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Certificate transparency log · Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -15,11 +15,11 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <meta property="og:title" content="Certificate transparency log · Paramant">
 <meta property="og:description" content="Every public key registration is appended to a tamper-evident Merkle tree. Anyone can verify that a device was registered, without seeing the payload.">
 <meta property="og:url" content="https://paramant.app/ct-log">
@@ -60,7 +60,7 @@ body { min-height:100vh; }
   padding:12px 16px; font-family:inherit; font-size:var(--text-sm); outline:none; }
 .verify-bar input::placeholder { color:var(--ink-ghost); }
 .verify-bar input:focus { border-color:var(--ink); }
-.verify-bar button { background:var(--cobalt); color:var(--bone-on-navy); border:none; padding:12px 20px;
+.verify-bar button { background:var(--cobalt); color: var(--on-ochre); border:none; padding:12px 20px;
   font-family:inherit; font-size:var(--text-xs); font-weight:700; letter-spacing:.08em; cursor:pointer; white-space:nowrap; }
 .verify-bar button:hover { opacity:.88; }
 .verify-result { margin-top:10px; font-size:var(--text-sm); display:none; padding:14px 16px; }
@@ -73,7 +73,7 @@ body { min-height:100vh; }
   padding:12px 16px; font-family:inherit; font-size:var(--text-sm); outline:none; }
 .search-bar input::placeholder { color:var(--ink-ghost); }
 .search-bar input:focus { border-color:var(--ink); }
-.search-bar button { background:var(--cobalt); color:var(--bone-on-navy); border:none; padding:12px 20px;
+.search-bar button { background:var(--cobalt); color: var(--on-ochre); border:none; padding:12px 20px;
   font-family:inherit; font-size:var(--text-xs); font-weight:700; letter-spacing:.1em; cursor:pointer; }
 .search-bar button:hover { opacity:.88; }
 
@@ -157,9 +157,9 @@ body { min-height:100vh; }
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -170,26 +170,26 @@ body { min-height:100vh; }
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -198,13 +198,13 @@ body { min-height:100vh; }
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">:root{color-scheme:light}html,body{background:#FBFAF7;color:#0C1B2A;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}@media(prefers-color-scheme:dark){:root[data-theme="auto"]{color-scheme:dark}html[data-theme="auto"],html[data-theme="auto"] body{background:#0A0F16;color:#EDF1F6}}html[data-theme="dark"],html[data-theme="dark"] body{background:#0A0F16;color:#EDF1F6}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}html[data-theme="light"],html[data-theme="light"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="light"]{color-scheme:light}@media (prefers-color-scheme:light){html[data-theme="auto"],html[data-theme="auto"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="auto"]{color-scheme:light}}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Your dashboard · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
@@ -10,10 +10,10 @@
 <meta name="description" content="Sign in to your Paramant dashboard.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://relay.paramant.app">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
-<link rel="stylesheet" href="/parapear.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
+<link rel="stylesheet" href="/parapear.css?v=4">
 <noscript><meta http-equiv="refresh" content="0;url=/auth/login?next=/dashboard"></noscript>
 <style>
 /* Dashboard. Client-side rendered from /api/user/me JSON. Auth-gate stays
@@ -62,7 +62,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 /* The one filled accent on this screen. */
 .dh-start-card.primary { background: var(--accent); color: var(--accent-ink); border-color: var(--accent); box-shadow: var(--sh-2); }
 .dh-start-card.primary:hover { background: var(--accent-hov); border-color: var(--accent-hov); }
-.dh-start-card.primary .dh-start-icon { background: rgba(255,255,255,.16); color: var(--accent-ink); }
+.dh-start-card.primary .dh-start-icon { background: rgba(0, 0, 0, .14); color: var(--accent-ink); }
 .dh-start-card.primary .dh-start-kicker { color: var(--accent-ink); opacity: .8; }
 .dh-start-card.primary p { color: var(--accent-ink); opacity: .86; }
 
@@ -116,7 +116,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 .dh-filter [data-doc-count] { font-family: var(--mono); font-size: 11px; font-weight: 600; color: var(--ink-3); }
 .dh-filter[aria-pressed="true"] { background: var(--surface-ink); border-color: var(--surface-ink); color: var(--on-ink); }
 .dh-filter[aria-pressed="true"] + .dh-filter { border-left-color: var(--surface-ink); }
-.dh-filter[aria-pressed="true"] [data-doc-count] { color: var(--mark); }
+.dh-filter[aria-pressed="true"] [data-doc-count] { color: var(--on-ink-accent); }
 .dh-filter:focus-visible { outline: none; box-shadow: var(--ring); position: relative; z-index: 1; }
 
 .dh-documents { border-top: 1px solid var(--line); }
@@ -192,7 +192,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 .dh-invites span { display: block; font: 13px/1.55 var(--sans); color: var(--ink-2); }
 
 /* ── Document detail ───────────────────────────────────────────────────────── */
-.dh-doc-dialog { position: fixed; inset: 0; z-index: 1000; display: grid; place-items: center; padding: 14px; background: rgba(6,10,15,.62); animation: dh-veil var(--d-2) var(--e-standard) both; }
+.dh-doc-dialog { position: fixed; inset: 0; z-index: 1000; display: grid; place-items: center; padding: 14px; background: rgba(0, 0, 0, .62); animation: dh-veil var(--d-2) var(--e-standard) both; }
 @keyframes dh-veil { from { opacity: 0; } to { opacity: 1; } }
 .dh-doc-dialog-panel { width: min(620px, 100%); max-height: calc(100dvh - 28px); overflow: auto; border-radius: var(--r-3); color: var(--ink-1); background: var(--surface); border: 1px solid var(--line); box-shadow: var(--sh-3); animation: dh-panel-in var(--d-3) var(--e-enter) both; }
 @keyframes dh-panel-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
@@ -249,7 +249,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 .dh-btn[disabled] { opacity: .5; cursor: default; }
 
 /* ── Setup nudge ───────────────────────────────────────────────────────────── */
-.dh-modal { position: fixed; inset: 0; z-index: 1000; display: flex; align-items: center; justify-content: center; padding: var(--space-4); background: rgba(6,10,15,.62); animation: dh-veil var(--d-2) var(--e-standard) both; }
+.dh-modal { position: fixed; inset: 0; z-index: 1000; display: flex; align-items: center; justify-content: center; padding: var(--space-4); background: rgba(0, 0, 0, .62); animation: dh-veil var(--d-2) var(--e-standard) both; }
 .dh-modal-card { background: var(--surface); border: 1px solid var(--line); border-radius: var(--r-3); max-width: 460px; width: 100%; padding: var(--space-6) var(--space-5) var(--space-5); box-shadow: var(--sh-3); text-align: center; animation: dh-panel-in var(--d-3) var(--e-enter) both; }
 .dh-modal-img { display: block; margin: 0 auto var(--space-3); }
 .dh-modal-card h2 { font: 600 21px/1.2 var(--sans); letter-spacing: -.02em; color: var(--ink-1); margin: 0 0 var(--space-2); }
@@ -351,9 +351,9 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
   .dh-start-card:hover { transform: none; }
 }
 </style>
-<meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=4">
-<script src="/js/theme.js?v=1"></script>
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/app-2026.css?v=7">
+<script src="/js/theme.js?v=4"></script>
 </head>
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/frontend/design-system.css
+++ b/frontend/design-system.css
@@ -1,49 +1,103 @@
-/* PARAMANT design-system.css v4.1
-   Source of truth: PARAMANT-DESIGN-SYSTEM-v4.md (Denim Edit)
-   Four colors: bone / navy / cobalt / lime. Zero radius. Sans + mono split.
+/* PARAMANT design-system.css v5.0, night edition
+   Source of truth for colour: the homepage of PR #404, which put Paramant in
+   the same hand as BeerWeer (weer.mickbeer.com). That was one page. This file
+   moves it into the system, so every page of the site and every screen of the
+   app stands on the same ground.
 
-   v4.1 verandert precies een ding: --ink-dim, --lime-dim en --black-dim
-   wijzen naar --ink-2 (#40505F) in plaats van naar rgba(11,58,106,.65).
-   Dat is de enige gemeten wijziging; alle andere waarden staan zoals ze
-   stonden. Zie het blok bij --ink-2 voor de getallen. */
+   What the night is. A warm dark ground (#15191C into #101316), cream ink
+   (#EAE2CE) with a dim at 62% of it, hairlines at 16% of it, cards at 4.5% of
+   it with a 16px radius. ONE accent, ochre #D9A441, with #141414 as the ink on
+   top of it. Petrol #155E75 is the second accent and never carries text on the
+   night; #3FA3C4 is its readable ink. Brick #C4604F marks a fault; #E08A78 is
+   its readable ink. Cream paper #F1EAD6 with ink #1B1F22 is the one inverted
+   surface, for a panel that has to read as paper on a desk.
+
+   Cobalt and lime are gone from the UI. Their token names stay and point at
+   the ochre, so a rule written against --cobalt or --lime in a page's own
+   style block follows the system instead of breaking.
+
+   Measured against WCAG 2.1 on #15191C: cream 13.70, dim 5.95, ochre 7.86,
+   petrol-ink 6.10, brick-ink 6.80. On the cream paper #F1EAD6: ink 13.81,
+   ink-2 7.43, ochre-ink 4.74. tests/theme-contrast.test.mjs walks every text
+   node on sixteen pages and fails on anything under AA. */
 
 
 /* ═══════════════════════════════════════════════════
    TOKENS
    ═══════════════════════════════════════════════════ */
 :root {
+  /* the cream, as channels, so every tint of it is one number away */
+  --tint: 234, 226, 206;
+
+  /* the night, the cream, the one accent */
+  --night:     #15191C;
+  --night-2:   #101316;
+  --cream:     #EAE2CE;
+  --ochre:     #D9A441;
+  --ochre-2:   #C7912E;
+  --ochre-ink: #8A5E10;              /* the ochre as ink, for the cream paper */
+  --on-ochre:  #141414;              /* the ink that sits on a filled ochre */
+  --petrol:    #155E75;              /* second accent: fills and lines only */
+  --petrol-ink:#3FA3C4;              /* the petrol as ink on the night */
+  --brick:     #C4604F;              /* a fault, as a fill or a line */
+  --brick-ink: #E08A78;              /* a fault, as ink on the night */
+  --ok-ink:    #8FC7A4;
+  --warn-ink:  #E3C169;
+
+  /* the cream paper: the one inverted surface */
+  --paper:       #F1EAD6;
+  --paper-2:     #E7DDC4;
+  --paper-ink:   #1B1F22;
+  --paper-ink-2: #4A4A44;
+  --paper-line:  rgba(27, 31, 34, .18);
+
+  /* the corner. Zero was the old system's choice; the night rounds. */
+  --r: 16px;
+
   /* surface */
-  --bone:   #F8FAFC;
-  --bone-2: #EEF2F6;
+  --bone:   var(--night);
+  --bone-2: var(--night-2);
+  --card:      rgba(var(--tint), .045);
+  --card-2:    rgba(var(--tint), .075);
+  --card-line: rgba(var(--tint), .14);
+  --surface:   var(--card);
 
   /* ink */
-  --navy:      #0B3A6A;
-  --navy-2:    #0A2E55;
-  --ink:       #0B3A6A;
-  /* --ink-2 is de leeskleur voor alles wat niet de primaire tekst is: de
-     kleine letter, de prijsregel, de limietregel, de meta onder een kaart.
-     De oude waarde was rgba(11,58,106,.65) en die landt op 4.09:1 tegen het
-     papier, 3.96:1 tegen de voet en 4.18:1 op een witte kaart. Drie keer net
-     onder de 4.5 die WCAG AA vraagt, en drie keer onder de tekst die de prijs
-     en de kleine letter draagt. #40505F haalt 7.95:1 op het papier en 7.35:1
-     op de voet. Gemeten met de WCAG 2.1 relatieve-luminantieformule; de meting
-     staat in tests/theme-contrast.test.mjs en die faalt op elke nieuwe. */
-  --ink-2:     #40505F;
-  --ink-dim:   var(--ink-2);
-  --ink-hair:  rgba(11,58,106,.15);
-  --ink-ghost: rgba(11,58,106,.08);
+  --navy:      var(--cream);
+  --navy-2:    var(--cream);
+  --ink:       var(--cream);
+  --ink-2:     rgba(var(--tint), .80);
+  --ink-dim:   rgba(var(--tint), .62);
+  --ink-hair:  rgba(var(--tint), .16);
+  --ink-ghost: rgba(var(--tint), .06);
+  --line:      var(--ink-hair);
+  --line-2:    rgba(var(--tint), .32);
 
-  /* accent */
-  --cobalt:   #1D4ED8;
-  --cobalt-2: #1A43BE;
+  /* accent. One ochre. The old names survive as aliases so no page breaks. */
+  --cobalt:      var(--ochre);
+  --cobalt-2:    var(--ochre-2);
+  --accent:      var(--ochre);
+  --accent-hov:  var(--ochre-2);
+  --accent-ink:  var(--on-ochre);
+  --accent-soft: rgba(217, 164, 65, .10);
+  --accent-ring: rgba(217, 164, 65, .50);
 
-  /* punctuation */
-  --lime: #B2FF3F;
+  /* punctuation. Lime was the old one; it is the ochre now. */
+  --lime: var(--ochre);
 
-  /* inverted text */
-  --bone-on-navy:      #F8FAFC;
-  --bone-on-navy-dim:  rgba(248,250,252,.72);
-  --bone-on-navy-hair: rgba(248,250,252,.18);
+  /* the inverted block. On the old bone site this was a navy slab with bone
+     text. On the night it goes the other way: a slab cut deeper than the page,
+     with the same cream ink, and a hairline so it still reads as a block. */
+  --invert:      #0C0F11;
+  --invert-ink:  var(--cream);
+  --invert-dim:  var(--ink-2);
+  --invert-hair: var(--line-2);
+  --bone-on-navy:      var(--invert-ink);
+  --bone-on-navy-dim:  var(--invert-dim);
+  --bone-on-navy-hair: var(--invert-hair);
+
+  /* the bar, translucent over the night */
+  --bone-blur: rgba(21, 25, 28, .92);
 
   /* typography */
   --sans: ui-sans-serif, system-ui, -apple-system, "Inter",
@@ -94,16 +148,18 @@
   --ease-out:      cubic-bezier(0.16, 1, 0.3, 1);
 
   /* ─── v3 legacy token aliases (remove after Phase D HTML migration) ─── */
-  --black:       #0B3A6A;
-  --lime-dim:    var(--ink-2);
-  --lime-hair:   rgba(11,58,106,.15);
-  --lime-ghost:  rgba(11,58,106,.08);
-  --black-dim:   var(--ink-2);
-  --black-hair:  rgba(11,58,106,.15);
-  --black-ghost: rgba(11,58,106,.08);
+  --black:       var(--cream);
+  --lime-dim:    var(--ink-dim);
+  --lime-hair:   var(--ink-hair);
+  --lime-ghost:  var(--ink-ghost);
+  --black-dim:   var(--ink-dim);
+  --black-hair:  var(--ink-hair);
+  --black-ghost: var(--ink-ghost);
   --doc-bg:      var(--bone);
   --doc-ink:     var(--ink);
   --doc-ink-dim: var(--ink-dim);
+
+  color-scheme: dark;
 }
 
 
@@ -191,13 +247,13 @@ h1 em::after {
   content: "";
   position: absolute;
   left: 0; right: 0; bottom: 4%; height: 22%;
-  background: var(--lime);
+  background: rgba(217, 164, 65, .22);
   z-index: -1;
 }
 
 ::selection {
   background: var(--lime);
-  color: var(--navy);
+  color: var(--on-ochre);
 }
 
 
@@ -223,27 +279,27 @@ h1 em::after {
    SECTION WRAPPERS
    ═══════════════════════════════════════════════════ */
 .section-cobalt {
-  background: var(--cobalt);
-  color: var(--bone-on-navy);
+  background: var(--invert);
+  color: var(--invert-ink);
 }
 .section-navy {
-  background: var(--navy);
-  color: var(--bone-on-navy);
+  background: var(--invert);
+  color: var(--invert-ink);
 }
 .section-cobalt ::selection,
 .section-navy ::selection {
   background: var(--lime);
-  color: var(--navy);
+  color: var(--on-ochre);
 }
 
-/* v3 .invert — maps to cobalt during migration */
+/* v3 .invert: the inverted block, which on the night is the deeper night */
 .invert {
-  background: var(--cobalt);
-  color: var(--bone-on-navy);
+  background: var(--invert);
+  color: var(--invert-ink);
 }
 .invert ::selection {
   background: var(--lime);
-  color: var(--navy);
+  color: var(--on-ochre);
 }
 
 /* document mode — kept for Template B pages */
@@ -287,12 +343,12 @@ h1 em::after {
   display: flex;
   flex-direction: column;
 }
-.stack > * + * { margin-top: var(--stack-gap, var(--space-5)); }
+.stack > * + * { margin-top: var(--stack-gap); }
 
 .cluster {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--cluster-gap, var(--space-4));
+  gap: var(--cluster-gap);
   align-items: center;
 }
 
@@ -467,7 +523,7 @@ h1 em::after {
   display: block;
   width: 200px;
   height: 80px;
-  background: var(--lime);
+  background: var(--accent-soft);
   position: absolute;
   right: 0;
   top: -40px;
@@ -513,12 +569,12 @@ h1 em::after {
 .cta-stack button:first-child { border-top: none; }
 .cta-stack .primary {
   background: var(--cobalt);
-  color: var(--bone-on-navy);
+  color: var(--on-ochre);
 }
-.cta-stack .primary:hover { background: var(--navy); border-top-color: var(--navy); }
+.cta-stack .primary:hover { background: var(--invert); border-top-color: var(--invert); }
 .cta-stack a:not(.primary):hover,
 .cta-stack button:not(.primary):hover {
-  background: var(--navy);
+  background: var(--invert);
   color: var(--bone-on-navy);
 }
 
@@ -545,8 +601,8 @@ h1 em::after {
   animation: drop-breathe 3.6s var(--ease-soft) infinite;
 }
 @keyframes drop-breathe {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(178,255,63,0); }
-  50%      { box-shadow: 0 0 0 4px rgba(178,255,63,.18); }
+  0%, 100% { box-shadow: 0 0 0 0 rgba(217, 164, 65, 0); }
+  50%      { box-shadow: 0 0 0 4px rgba(217, 164, 65, .18); }
 }
 .drop:hover, .drop:focus-within,
 .dropzone:hover, .dropzone:focus-within {
@@ -557,7 +613,7 @@ h1 em::after {
 .dropzone.drag-over {
   background: var(--ink-ghost);
   border-color: var(--cobalt);
-  box-shadow: 0 0 0 4px rgba(29,78,216,.18);
+  box-shadow: 0 0 0 4px rgba(217, 164, 65, .18);
 }
 
 /* "01" bleeding label */
@@ -567,7 +623,7 @@ h1 em::after {
   top: -1px;
   left: -1px;
   background: var(--lime);
-  color: var(--navy);
+  color: var(--on-ochre);
   padding: var(--space-1) var(--space-3);
   font-family: var(--mono);
   font-size: var(--text-xs);
@@ -643,7 +699,7 @@ h1 em::after {
   width: 100%;
   padding: var(--space-4) var(--space-5);
   background: var(--cobalt);
-  color: var(--bone-on-navy);
+  color: var(--on-ochre);
   font-family: var(--mono);
   font-size: var(--text-sm);
   font-weight: 700;
@@ -656,7 +712,7 @@ h1 em::after {
   transition: background var(--duration-base) var(--ease-sharp);
   margin-top: var(--space-5);
 }
-.drop-btn:hover { background: var(--navy); }
+.drop-btn:hover { background: var(--invert); }
 
 
 /* ═══════════════════════════════════════════════════
@@ -677,7 +733,7 @@ h1 em::after {
   top: -1px;
   left: -1px;
   background: var(--lime);
-  color: var(--navy);
+  color: var(--on-ochre);
   padding: var(--space-1) var(--space-3);
   font-family: var(--mono);
   font-size: var(--text-xs);
@@ -771,7 +827,7 @@ h1 em::after {
   font-family: var(--mono);
   font-size: var(--text-4xl);
   font-weight: 700;
-  color: rgba(29,78,216,.2);
+  color: rgba(217, 164, 65, .2);
   line-height: 1;
   margin-bottom: var(--space-4);
 }
@@ -803,7 +859,7 @@ h1 em::after {
   display: block;
   padding: var(--space-7) var(--space-6);
   text-decoration: none;
-  color: var(--bone-on-navy);
+  color: var(--on-ochre);
   background: var(--cobalt);
   min-height: 340px;
   transition: background var(--duration-base) var(--ease-sharp);
@@ -1053,7 +1109,7 @@ h1 em::after {
   flex-direction: column;
   position: relative;
 }
-.tier.featured { background: var(--lime); }
+.tier.featured { background: var(--night-2); box-shadow: inset 3px 0 0 var(--ochre); }
 
 .pricing-tier,
 .tier-tag {
@@ -1087,7 +1143,7 @@ h1 em::after {
   margin-bottom: var(--space-5);
 }
 .tier.featured .tier-unit,
-.tier.featured .pricing-note { color: rgba(11,58,106,.65); }
+.tier.featured .pricing-note { color: rgba(var(--tint), .65); }
 
 .pricing-card > p,
 .tier > p {
@@ -1161,6 +1217,7 @@ h1 em::after {
   white-space: nowrap;
   line-height: 1;
   user-select: none;
+  border-radius: 12px;
 }
 .btn:active:not(:disabled) {
   transform: translateY(1px);
@@ -1173,22 +1230,23 @@ h1 em::after {
 
 .btn-primary {
   background: var(--cobalt);
-  color: var(--bone-on-navy);
+  color: var(--on-ochre);
   border-color: var(--cobalt);
 }
 .btn-primary:hover {
-  background: var(--navy);
-  border-color: var(--navy);
+  background: var(--ochre-2);
+  border-color: var(--ochre-2);
 }
 
 .btn-secondary {
-  background: transparent;
-  color: var(--navy);
-  border-color: var(--navy);
+  background: var(--card);
+  color: var(--ink);
+  border-color: var(--line-2);
 }
 .btn-secondary:hover {
-  background: var(--navy);
-  color: var(--bone-on-navy);
+  background: var(--card-2);
+  color: var(--ink);
+  border-color: var(--ink);
 }
 
 .btn-tertiary {
@@ -1212,7 +1270,7 @@ h1 em::after {
 .section-navy   .btn-primary,
 .invert         .btn-primary {
   background: var(--lime);
-  color: var(--navy);
+  color: var(--on-ochre);
   border-color: var(--lime);
 }
 .section-cobalt .btn-primary:hover,
@@ -1220,7 +1278,7 @@ h1 em::after {
 .invert         .btn-primary:hover {
   background: var(--bone);
   color: var(--navy);
-  border-color: var(--bone);
+  border-color: var(--invert-ink);
 }
 
 .section-cobalt .btn-secondary,
@@ -1328,7 +1386,7 @@ footer {
    actually for; everything else has a home in the navigation. */
 .footer-grid.footer-slim {
   grid-template-columns: minmax(260px, 2fr) 1fr;
-  gap: var(--space-10, var(--space-8));
+  gap: var(--space-10);
 }
 
 .footer-col-label,
@@ -1659,9 +1717,9 @@ pre code { background: none; padding: 0; }
   border-top: none;
 }
 .section-dark {
-  background: var(--navy);
+  background: var(--invert);
 }
-.section-dark h2 { color: var(--bone); }
+.section-dark h2 { color: var(--invert-ink); }
 .section-dark p  { color: var(--bone-on-navy-dim); }
 
 /* Eyebrow label above hero heading */
@@ -1707,7 +1765,7 @@ pre code { background: none; padding: 0; }
 .dim.mono    { margin-top: 12px; margin-bottom: 40px; }
 .cobalt-text { color: var(--cobalt); font-weight: 600; }
 .strong      { font-weight: 600; color: var(--ink); }
-.warn-text   { color: #C2410C; font-weight: 600; }
+.warn-text   { color: var(--warn-ink); font-weight: 600; }
 
 /* Two-column layout */
 .two-col {
@@ -1720,7 +1778,7 @@ pre code { background: none; padding: 0; }
 
 /* Callout box */
 .callout {
-  background: rgba(11, 58, 106, 0.04);
+  background: rgba(var(--tint), 0.04);
   border-left: 3px solid var(--cobalt);
   padding: 20px 24px;
   margin: 32px 0;
@@ -1742,10 +1800,10 @@ pre code { background: none; padding: 0; }
   margin: 0;
 }
 .callout.warn {
-  background: rgba(178, 255, 63, 0.08);
-  border-left-color: #B2FF3F;
+  background: rgba(217, 164, 65, 0.08);
+  border-left-color: var(--ochre);
 }
-.callout.warn h4 { color: #C2410C; }
+.callout.warn h4 { color: var(--warn-ink); }
 
 /* Pull quote */
 .pull {
@@ -1805,11 +1863,11 @@ pre code { background: none; padding: 0; }
 
 /* Table cell states */
 .compare-table td.yes,
-.ownership-table td.yes   { color: #166534; font-weight: 600; }
+.ownership-table td.yes   { color: var(--ok-ink); font-weight: 600; }
 .compare-table td.no,
-.ownership-table td.no    { color: #991B1B; font-weight: 600; }
+.ownership-table td.no    { color: var(--brick-ink); font-weight: 600; }
 .compare-table td.partial,
-.ownership-table td.partial { color: #92400E; font-weight: 600; }
+.ownership-table td.partial { color: var(--warn-ink); font-weight: 600; }
 
 /* Responsive */
 @media (max-width: 768px) {
@@ -1882,7 +1940,7 @@ pre code { background: none; padding: 0; }
 
 .section-cobalt h3,
 .section-dark h3 {
-  color: var(--bone);
+  color: var(--invert-ink);
   margin-top: 32px;
   margin-bottom: 12px;
 }
@@ -1895,8 +1953,8 @@ pre code { background: none; padding: 0; }
 
 .section-cobalt a,
 .section-dark a {
-  color: var(--bone);
-  border-bottom: 1px solid rgba(248,250,252,0.3);
+  color: var(--invert-ink);
+  border-bottom: 1px solid rgba(var(--tint), 0.3);
 }
 
 /* Marker z-index inside colored sections */
@@ -1909,13 +1967,13 @@ pre code { background: none; padding: 0; }
 /* Callout inside dark sections */
 .section-cobalt .callout,
 .section-dark .callout {
-  background: rgba(248, 250, 252, 0.08);
+  background: rgba(var(--tint), 0.08);
   border-left-color: var(--lime);
 }
 .section-cobalt .callout h4,
 .section-dark .callout h4 { color: var(--lime); }
 .section-cobalt .callout p,
-.section-dark .callout p  { color: var(--bone); }
+.section-dark .callout p  { color: var(--invert-ink); }
 
 @media (max-width: 900px) {
   .section-cobalt .container,
@@ -1981,7 +2039,7 @@ pre code { background: none; padding: 0; }
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 1px;
-  background: rgba(248,250,252,0.15);
+  background: rgba(var(--tint), 0.15);
   margin: 32px 0;
 }
 @media (max-width: 640px) {
@@ -1989,7 +2047,7 @@ pre code { background: none; padding: 0; }
 }
 
 .auth-lane {
-  background: rgba(11,58,106,0.35);
+  background: rgba(var(--tint), 0.35);
   padding: 32px 28px;
   display: flex;
   flex-direction: column;
@@ -2005,7 +2063,7 @@ pre code { background: none; padding: 0; }
 .auth-lane h3 {
   font-size: var(--text-md);
   font-weight: 600;
-  color: var(--bone);
+  color: var(--invert-ink);
   margin: 0;
 }
 .auth-lane p {
@@ -2094,7 +2152,7 @@ pre code { background: none; padding: 0; }
   align-items: center;
   gap: 6px;
   background: var(--lime);
-  color: var(--navy);
+  color: var(--on-ochre);
   font-family: var(--mono);
   font-size: var(--text-xs);
   font-weight: 700;
@@ -2182,13 +2240,13 @@ pre code { background: none; padding: 0; }
 
 /* Button additions */
 .btn-danger {
-  background: #dc2626;
-  color: var(--bone);
-  border-color: #dc2626;
+  background: var(--brick);
+  color: var(--invert-ink);
+  border-color: var(--brick);
 }
 .btn-danger:hover {
-  background: #991b1b;
-  border-color: #991b1b;
+  background: var(--brick);
+  border-color: var(--brick);
 }
 .btn-small {
   padding: 6px 10px;
@@ -2264,9 +2322,9 @@ pre code { background: none; padding: 0; }
   font-family: var(--mono);
   font-size: var(--text-sm);
   line-height: 1.5;
-  background: rgba(220,38,38,.06);
-  border-left: 3px solid #dc2626;
-  color: #991b1b;
+  background: rgba(196, 96, 79, .06);
+  border-left: 3px solid var(--brick);
+  color: var(--brick-ink);
 }
 .msg-success {
   display: none;
@@ -2275,7 +2333,7 @@ pre code { background: none; padding: 0; }
   font-family: var(--mono);
   font-size: var(--text-sm);
   line-height: 1.5;
-  background: rgba(178,255,63,.10);
+  background: rgba(217, 164, 65, .10);
   border-left: 3px solid var(--lime);
   color: var(--navy);
 }
@@ -2338,7 +2396,7 @@ pre code { background: none; padding: 0; }
 .secret-display {
   font-family: var(--mono);
   font-size: var(--text-sm);
-  background: rgba(11,58,106,0.04);
+  background: rgba(var(--tint), 0.04);
   padding: 6px 10px;
   letter-spacing: 0.1em;
   color: var(--navy);
@@ -2393,7 +2451,7 @@ pre code { background: none; padding: 0; }
 /* Warning / highlight box */
 .warning-box {
   padding: 16px 20px;
-  background: rgba(178,255,63,.10);
+  background: rgba(217, 164, 65, .10);
   border-left: 3px solid var(--lime);
   margin: 24px 0;
 }
@@ -2420,7 +2478,7 @@ pre code { background: none; padding: 0; }
   border-left: 3px solid;
 }
 .banner-cobalt {
-  background: rgba(29,78,216,.06);
+  background: rgba(217, 164, 65, .06);
   border-left-color: var(--cobalt);
 }
 .banner-label {
@@ -2443,9 +2501,9 @@ pre code { background: none; padding: 0; }
 /* ── Billing ─────────────────────────────────────────────────────────────── */
 .billing-card { border: 1.5px solid var(--ink-hair); padding: var(--space-6); background: var(--bone); }
 .billing-card + .billing-card { margin-top: var(--space-4); }
-.plan-tier-active { display: inline-block; background: var(--cobalt); color: #fff; font-family: var(--mono); font-size: 10px; letter-spacing: .12em; text-transform: uppercase; font-weight: 700; padding: 3px 8px; margin-left: 8px; vertical-align: middle; }
-.stub-banner { background: #fef3c7; border: 1.5px solid #d97706; padding: var(--space-4) var(--space-5); }
-.stub-banner strong { color: #92400e; }
+.plan-tier-active { display: inline-block; background: var(--cobalt); color: var(--on-ochre); font-family: var(--mono); font-size: 10px; letter-spacing: .12em; text-transform: uppercase; font-weight: 700; padding: 3px 8px; margin-left: 8px; vertical-align: middle; }
+.stub-banner { background: var(--card); border: 1.5px solid var(--ochre-2); padding: var(--space-4) var(--space-5); }
+.stub-banner strong { color: var(--warn-ink); }
 
 /* De navigatiebalk staat in frontend/nav.css. Die had hier een tweede huis:
    .nav-auth, .nav-signin, .nav-cta, .nav-user en .nav-help stonden in dit
@@ -2479,13 +2537,13 @@ pre code { background: none; padding: 0; }
 }
 .pick-card:hover {
   border-color: var(--cobalt);
-  background: rgba(11,58,106,.03);
+  background: rgba(var(--tint), .03);
 }
 .pick-card-featured {
   border: 2px solid var(--cobalt);
-  background: rgba(11,58,106,.02);
+  background: rgba(var(--tint), .02);
 }
-.pick-card-featured:hover { background: rgba(11,58,106,.06); }
+.pick-card-featured:hover { background: rgba(var(--tint), .06); }
 .pick-label {
   font-family: var(--mono);
   font-size: var(--text-xs);
@@ -2548,7 +2606,7 @@ pre code { background: none; padding: 0; }
   padding-top: var(--space-4);
   margin-top: auto;
 }
-.pick-card-featured .pick-cta { border-top-color: rgba(29,78,216,.2); }
+.pick-card-featured .pick-cta { border-top-color: rgba(217, 164, 65, .2); }
 @media (max-width: 900px) {
   .pick-grid { grid-template-columns: 1fr; }
 }
@@ -2560,44 +2618,44 @@ pre code { background: none; padding: 0; }
 
 /* Text link lime underline on hover */
 a:not(.btn):not(.skip-link):not(.nav-link):not(.nav-logo):not(.footer-link):hover {
-  text-decoration-color: #B2FF3F;
+  text-decoration-color: var(--lime);
   text-underline-offset: 3px;
   text-decoration-thickness: 2px;
 }
 
 /* Secondary button: lime on hover */
 .btn-secondary:hover {
-  background: #B2FF3F !important;
-  color: #0B3A6A !important;
-  border-color: #B2FF3F !important;
+  background: var(--ochre) !important;
+  color: var(--on-ochre) !important;
+  border-color: var(--ochre) !important;
 }
 
 /* Tertiary button: lime on hover */
 .btn-tertiary:hover {
-  color: #0B3A6A !important;
-  text-decoration-color: #B2FF3F !important;
+  color: var(--ink) !important;
+  text-decoration-color: var(--lime) !important;
 }
 
 /* Product picker cards: lime border on hover */
 .pick-card:hover {
-  border-color: #B2FF3F !important;
+  border-color: var(--ochre) !important;
 }
 .pick-card-featured:hover {
-  border-color: #B2FF3F !important;
+  border-color: var(--ochre) !important;
 }
 
 /* Pricing cards: lime border on hover */
 .pricing-card:hover {
-  border-color: #B2FF3F !important;
-  outline: 2px solid #B2FF3F;
+  border-color: var(--ochre) !important;
+  outline: 2px solid var(--ochre);
 }
 
 /* ─── PAGE HERO — reusable gradient band ─────────────────── */
 /* lime-hover-accents (sentinel) */
 .page-hero {
-  background: linear-gradient(180deg, #F0F4F8 0%, rgba(11,58,106,0.04) 100%);
-  border-top: 1px solid rgba(11,58,106,0.08);
-  border-bottom: 1px solid rgba(11,58,106,0.08);
+  background: linear-gradient(180deg, var(--card) 0%, rgba(var(--tint), 0.04) 100%);
+  border-top: 1px solid rgba(var(--tint), 0.08);
+  border-bottom: 1px solid rgba(var(--tint), 0.08);
   padding: 48px 24px;
   margin-bottom: 0;
 }
@@ -2607,8 +2665,8 @@ a:not(.btn):not(.skip-link):not(.nav-link):not(.nav-logo):not(.footer-link):hove
 }
 .page-hero .eyebrow {
   display: inline-block;
-  background: #B2FF3F;
-  color: #0B3A6A;
+  background: var(--ochre);
+  color: var(--on-ochre);
   padding: 2px 10px;
   font-family: 'IBM Plex Mono', monospace;
   font-size: 10px;
@@ -2618,7 +2676,7 @@ a:not(.btn):not(.skip-link):not(.nav-link):not(.nav-logo):not(.footer-link):hove
 }
 .page-hero h1 {
   margin: 0 0 12px;
-  color: #0B3A6A;
+  color: var(--ink);
 }
 .page-hero .lede {
   font-size: var(--text-md);
@@ -2630,23 +2688,23 @@ a:not(.btn):not(.skip-link):not(.nav-link):not(.nav-logo):not(.footer-link):hove
 
 /* ─── DARK BAND — reusable navy section ──────────────────── */
 .dark-band {
-  background: #0B3A6A;
-  color: #F8FAFC;
+  background: var(--bone-2);
+  color: var(--ink);
   padding: 48px 24px;
   margin: 48px 0;
 }
-.dark-band h2, .dark-band h3 { color: #F8FAFC; }
-.dark-band a { color: #B2FF3F; }
+.dark-band h2, .dark-band h3 { color: var(--ink); }
+.dark-band a { color: var(--lime); }
 .dark-band code, .dark-band .tag {
-  background: #B2FF3F;
-  color: #0B3A6A;
+  background: var(--ochre);
+  color: var(--on-ochre);
   padding: 2px 8px;
 }
 
 /* ── SECTION TINT — subtle off-white background for visual rhythm ── */
 /* visual-reset-v3 (sentinel) */
 .section-tint {
-  background: #F8FAFC;
+  background: var(--card);
 }
 
 /* ── Skip to main content — WCAG 2.4.1 ─────────────────── */
@@ -2655,15 +2713,15 @@ a.skip-link,
   position: absolute !important;
   top: -200px !important;
   left: 0 !important;
-  background: #0B3A6A;
-  color: #F8FAFC;
+  background: var(--bone-2);
+  color: var(--ink);
   padding: 12px 20px;
   z-index: 10000;
   text-decoration: none;
   font-family: system-ui, -apple-system, sans-serif;
   font-size: 14px;
   font-weight: 500;
-  border: 2px solid #B2FF3F;
+  border: 2px solid var(--ochre);
   transition: top 120ms ease;
 }
 a.skip-link:focus,
@@ -2682,7 +2740,7 @@ a.skip-link:focus-visible,
   font-family: "IBM Plex Mono", monospace;
   font-size: 11px;
   letter-spacing: 0.18em;
-  color: #64748b;
+  color: var(--ink-dim);
   text-transform: uppercase;
   margin-bottom: 28px;
   display: flex;
@@ -2691,7 +2749,7 @@ a.skip-link:focus-visible,
   gap: 2px;
 }
 .hero-split-eyebrow .eyebrow-dot {
-  color: #B2FF3F;
+  color: var(--lime);
   font-weight: 700;
   margin: 0 10px;
 }
@@ -2699,7 +2757,7 @@ a.skip-link:focus-visible,
   font-size: clamp(40px, 6vw, 80px);
   font-weight: 600;
   line-height: 1.05;
-  color: #0B3A6A;
+  color: var(--ink);
   margin: 0;
   letter-spacing: -0.02em;
 }
@@ -2713,7 +2771,7 @@ a.skip-link:focus-visible,
 }
 .hero-split-divider {
   width: 1px;
-  background: linear-gradient(180deg, transparent 0%, rgba(11,58,106,0.15) 20%, rgba(11,58,106,0.15) 80%, transparent 100%);
+  background: linear-gradient(180deg, transparent 0%, rgba(var(--tint), 0.15) 20%, rgba(var(--tint), 0.15) 80%, transparent 100%);
 }
 .hero-col {
   display: flex;
@@ -2722,8 +2780,8 @@ a.skip-link:focus-visible,
 }
 .hero-col-label {
   display: inline-block;
-  background: #B2FF3F;
-  color: #0B3A6A;
+  background: var(--ochre);
+  color: var(--on-ochre);
   padding: 4px 14px;
   font-family: "IBM Plex Mono", monospace;
   font-size: 12px;
@@ -2735,7 +2793,7 @@ a.skip-link:focus-visible,
 .hero-col-title {
   font-size: 28px;
   font-weight: 600;
-  color: #0B3A6A;
+  color: var(--ink);
   line-height: 1.2;
   margin: 0 0 16px 0;
   letter-spacing: -0.01em;
@@ -2743,7 +2801,7 @@ a.skip-link:focus-visible,
 .hero-col-lede {
   font-size: 16px;
   line-height: 1.6;
-  color: #475569;
+  color: var(--ink-2);
   margin: 0 0 28px 0;
   flex-grow: 1;
 }
@@ -2755,12 +2813,12 @@ a.skip-link:focus-visible,
   list-style: none;
   padding: 20px 0 0 0;
   margin: 0;
-  border-top: 1px solid rgba(11,58,106,0.08);
+  border-top: 1px solid rgba(var(--tint), 0.08);
 }
 .hero-col-specs li {
   font-family: "IBM Plex Mono", monospace;
   font-size: 12px;
-  color: #475569;
+  color: var(--ink-2);
   padding: 4px 0 4px 16px;
   position: relative;
 }
@@ -2768,14 +2826,14 @@ a.skip-link:focus-visible,
   content: "\25B8";
   position: absolute;
   left: 0;
-  color: #B2FF3F;
+  color: var(--lime);
 }
 .hero-trust-strip {
   max-width: 1200px;
   margin: 80px auto 0 auto;
   padding: 24px;
-  background: #0B3A6A;
-  color: #F8FAFC;
+  background: var(--bone-2);
+  color: var(--ink);
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 24px;
@@ -2785,18 +2843,18 @@ a.skip-link:focus-visible,
   font-family: "IBM Plex Mono", monospace;
   font-size: 10px;
   letter-spacing: 0.15em;
-  color: #B2FF3F;
+  color: var(--lime);
   text-transform: uppercase;
 }
 .trust-value {
   font-family: "IBM Plex Mono", monospace;
   font-size: 12px;
-  color: #F8FAFC;
+  color: var(--ink);
   line-height: 1.4;
 }
 @media (max-width: 900px) {
   .hero-split-grid { grid-template-columns: 1fr; gap: 48px; }
-  .hero-split-divider { width: 100%; height: 1px; background: linear-gradient(90deg, transparent, rgba(11,58,106,0.15), transparent); }
+  .hero-split-divider { width: 100%; height: 1px; background: linear-gradient(90deg, transparent, rgba(var(--tint), 0.15), transparent); }
   .hero-trust-strip { grid-template-columns: 1fr 1fr; gap: 16px; }
   .hero-col-title { font-size: 22px; }
   .hero-split-title { letter-spacing: -0.01em; }
@@ -2812,7 +2870,7 @@ a.skip-link:focus-visible,
 
 .product-tag--lime {
   background: var(--lime);
-  color: var(--navy);
+  color: var(--on-ochre);
   padding: 2px 8px;
   border-radius: 2px;
   font-family: "IBM Plex Mono", monospace;
@@ -2823,7 +2881,7 @@ a.skip-link:focus-visible,
 }
 .product-tag--cobalt {
   background: var(--cobalt);
-  color: #fff;
+  color: var(--on-ochre);
   padding: 2px 8px;
   border-radius: 2px;
   font-family: "IBM Plex Mono", monospace;
@@ -2833,7 +2891,7 @@ a.skip-link:focus-visible,
   white-space: nowrap;
 }
 .product-card-light {
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: border-color 150ms ease, transform 150ms ease;
 }
 .product-card-light:hover {
@@ -2843,8 +2901,8 @@ a.skip-link:focus-visible,
 
 /* § app-warning — SHA-256 authenticator hard blocker ───────────────────────── */
 .app-warning {
-  background: #FEF2F2;
-  border: 2px solid #DC2626;
+  background: var(--card);
+  border: 2px solid var(--brick);
   padding: 20px 24px;
   margin: 0 0 36px 0;
   font-family: 'Inter', sans-serif;
@@ -2852,13 +2910,13 @@ a.skip-link:focus-visible,
 .app-warning__title {
   font-size: 17px;
   font-weight: 700;
-  color: #B91C1C;
+  color: var(--brick-ink);
   line-height: 1.35;
   margin-bottom: 10px;
 }
 .app-warning__body {
   font-size: 14px;
-  color: #7F1D1D;
+  color: var(--brick-ink);
   line-height: 1.6;
   margin: 0 0 16px 0;
 }
@@ -2879,8 +2937,8 @@ a.skip-link:focus-visible,
   align-items: center;
   gap: 7px;
 }
-.app-warning__no  { color: #B91C1C; }
-.app-warning__yes { color: #166534; }
+.app-warning__no  { color: var(--brick-ink); }
+.app-warning__yes { color: var(--ok-ink); }
 .app-warning__no::before  { content: "✕"; font-size: 12px; }
 .app-warning__yes::before { content: "✓"; font-size: 12px; }
 .app-warning__link {
@@ -2888,11 +2946,11 @@ a.skip-link:focus-visible,
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #B91C1C;
+  color: var(--brick-ink);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
-.app-warning__link:hover { color: #7F1D1D; }
+.app-warning__link:hover { color: var(--brick-ink); }
 
 /* ── Quota upgrade notice ─────────────────────────────────────────────────────
    Rendered by js/quota-upgrade.js when the relay answers 402
@@ -2904,23 +2962,23 @@ a.skip-link:focus-visible,
   gap: 8px;
   max-width: 480px;
   padding: var(--space-4, 16px) var(--space-5, 20px);
-  border: 1px solid rgba(11, 58, 106, 0.14);
+  border: 1px solid rgba(var(--tint), 0.14);
   border-radius: 14px;
   background: var(--bone, #FAF7F0);
-  box-shadow: 0 4px 14px rgba(11, 58, 106, 0.06);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
   text-align: left;
 }
 .pa-quota-upsell strong {
   font-family: var(--sans);
   font-size: 15px;
   font-weight: 600;
-  color: var(--ink, #0B1622);
+  color: var(--ink);
 }
 .pa-quota-upsell span {
   font-family: var(--sans);
   font-size: 13px;
   line-height: 1.55;
-  color: var(--ink-dim, #5A6B7A);
+  color: var(--ink-dim);
 }
 .pa-quota-upsell .btn { margin-top: 4px; }
 
@@ -2939,8 +2997,8 @@ a.skip-link:focus-visible,
   margin: 12px 0;
   padding: 10px 14px;
   max-width: 560px;
-  border: 1px solid rgba(11, 58, 106, 0.14);
-  border-left: 3px solid var(--lime, #B2FF3F);
+  border: 1px solid rgba(var(--tint), 0.14);
+  border-left: 3px solid var(--lime);
   background: var(--bone, #FAF7F0);
   text-align: left;
 }
@@ -2948,9 +3006,9 @@ a.skip-link:focus-visible,
   font-family: var(--sans);
   font-size: 13px;
   line-height: 1.55;
-  color: var(--ink, #0B1622);
+  color: var(--ink);
 }
-.pa-sign-note a { color: var(--cobalt, #1D4ED8); }
+.pa-sign-note a { color: var(--cobalt); }
 
 /* Heading LEVEL vs heading SIZE. A page needs exactly one h1 for search engines
    and screen readers, but the visual hierarchy does not always match the
@@ -2964,21 +3022,21 @@ h1.paramant-h2 { font-size: var(--text-3xl); font-weight: inherit; letter-spacin
    visitor the three legal documents, so apply-nav.py stamps this one line
    there instead of a second navigation. */
 .legal-strip {
-  border-top: 1px solid var(--ink-hair, #E2E8F0);
+  border-top: 1px solid var(--ink-hair);
   margin-top: var(--space-6, 48px);
   padding: 16px 24px;
   text-align: center;
   font-family: var(--mono);
   font-size: 11px;
   letter-spacing: 0.06em;
-  color: var(--ink-dim, #64748b);
+  color: var(--ink-dim);
 }
 .legal-strip a {
-  color: var(--ink-dim, #64748b);
+  color: var(--ink-dim);
   text-decoration: none;
   border-bottom: 1px solid transparent;
   padding: 2px 0;
 }
-.legal-strip a:hover { color: var(--navy, #0B3A6A); border-bottom-color: var(--lime, #B2FF3F); }
-.legal-strip a:focus-visible { outline: 2px solid var(--lime, #B2FF3F); outline-offset: 2px; }
+.legal-strip a:hover { color: var(--navy); border-bottom-color: var(--lime); }
+.legal-strip a:focus-visible { outline: 2px solid var(--lime); outline-offset: 2px; }
 .legal-strip .legal-sep { padding: 0 8px; opacity: 0.5; }

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -2,51 +2,51 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#f5f7fb;color:#0b3a6a;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none!important}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none!important}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Developer settings · Paramant</title>
 <link rel="canonical" href="https://paramant.app/developer">
 <meta name="robots" content="noindex,nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<meta name="theme-color" content="#0b3a6a">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
 <style>
 *{box-sizing:border-box}
-body{background:linear-gradient(180deg,#f8faff 0,#f5f7fb 460px)}
+body{background:linear-gradient(180deg,#f8faff 0,var(--card) 460px)}
 .dev{max-width:1120px;margin:0 auto;padding:52px 24px 80px}
 .hero{display:flex;justify-content:space-between;align-items:flex-end;gap:24px;margin-bottom:28px}
-.eyebrow{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:#607896;margin:0 0 10px}
-h1{font-size:clamp(30px,5vw,48px);letter-spacing:-.035em;line-height:1.05;color:#0b3a6a;margin:0 0 12px}
-.lede{max-width:690px;color:#587391;font-size:15px;line-height:1.65;margin:0}
-.lede a{color:#1d4ed8;text-decoration:underline;text-underline-offset:2px}
-.account{display:flex;align-items:center;gap:9px;padding:9px 13px;background:#fff;border:1px solid #dfe7f2;border-radius:999px;font-family:var(--mono);font-size:11px;color:#587391;white-space:nowrap;box-shadow:0 5px 18px rgba(11,58,106,.05)}
+.eyebrow{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-2);margin:0 0 10px}
+h1{font-size:clamp(30px,5vw,48px);letter-spacing:-.035em;line-height:1.05;color:var(--ink);margin:0 0 12px}
+.lede{max-width:690px;color:var(--ink-2);font-size:15px;line-height:1.65;margin:0}
+.lede a{color:var(--cobalt);text-decoration:underline;text-underline-offset:2px}
+.account{display:flex;align-items:center;gap:9px;padding:9px 13px;background:var(--card);border:1px solid #dfe7f2;border-radius:999px;font-family:var(--mono);font-size:11px;color:var(--ink-2);white-space:nowrap;box-shadow:0 5px 18px rgba(0, 0, 0, .05)}
 .status-dot{width:8px;height:8px;border-radius:50%;background:#a7b4c5}.status-dot.ok{background:#20a66a}.status-dot.err{background:#d94b4b}
 .grid{display:grid;grid-template-columns:minmax(0,1.35fr) minmax(300px,.65fr);gap:20px;margin-top:20px}
 .stack{display:grid;gap:20px}
-.card{background:#fff;border:1px solid #e0e7f1;border-radius:18px;padding:24px;box-shadow:0 10px 35px rgba(11,58,106,.055)}
+.card{background:var(--card);border:1px solid var(--ink-hair);border-radius:18px;padding:24px;box-shadow:0 10px 35px rgba(0, 0, 0, .055)}
 .card-head{display:flex;justify-content:space-between;align-items:flex-start;gap:16px;margin-bottom:18px}
-.card h2{font-size:18px;letter-spacing:-.015em;color:#0b3a6a;margin:0 0 5px}
-.card-sub{font-size:12px;color:#6b819b;line-height:1.5;margin:0}
+.card h2{font-size:18px;letter-spacing:-.015em;color:var(--ink);margin:0 0 5px}
+.card-sub{font-size:12px;color:var(--ink-2);line-height:1.5;margin:0}
 .btn{display:inline-flex;align-items:center;justify-content:center;gap:7px;border-radius:10px;padding:10px 14px;font-family:var(--mono);font-size:11px;font-weight:700;text-decoration:none;cursor:pointer;border:1px solid transparent}
-.btn-primary{background:#1457d9;color:#fff}.btn-primary:hover{background:#0f48b8}
-.btn-secondary{background:#fff;color:#0b3a6a;border-color:#d4dfec}.btn-secondary:hover{border-color:#1457d9}
+.btn-primary{background:var(--ochre);color: var(--on-ochre)}.btn-primary:hover{background:#0f48b8}
+.btn-secondary{background:var(--card);color:var(--ink);border-color:var(--ink-hair)}.btn-secondary:hover{border-color:var(--ochre)}
 .key-list{display:grid;gap:10px}
-.key-row{display:grid;grid-template-columns:1fr auto;gap:14px;align-items:center;border:1px solid #e3eaf3;background:#f9fbfe;border-radius:12px;padding:13px 14px}
+.key-row{display:grid;grid-template-columns:1fr auto;gap:14px;align-items:center;border:1px solid #e3eaf3;background:var(--card);border-radius:12px;padding:13px 14px}
 .key-main{min-width:0}.key-value{font-family:var(--mono);font-size:12px;color:#173f6f;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .key-meta{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-top:5px;font-size:11px;color:#73869c}
 .pill{display:inline-flex;padding:3px 7px;border-radius:999px;background:#e8f7ef;color:#087443;font-family:var(--mono);font-size:9px;text-transform:uppercase;letter-spacing:.08em}.pill.off{background:#f3f4f6;color:#6b7280}
 .key-revoke{border:0;background:transparent;color:#a33b3b;font-size:11px;cursor:pointer;padding:6px}.key-revoke:hover{text-decoration:underline}
-.empty{border:1px dashed #ccd8e7;border-radius:12px;padding:20px;text-align:center;color:#6b819b;font-size:13px;line-height:1.55}
-.usage-number{display:flex;justify-content:space-between;align-items:baseline;margin:9px 0 8px;font-family:var(--mono);font-size:12px;color:#6b819b}.usage-number strong{font-size:25px;color:#0b3a6a;letter-spacing:-.03em}
-.bar{height:9px;background:#e6edf5;border-radius:999px;overflow:hidden}.bar span{display:block;height:100%;width:0;background:#1457d9;border-radius:inherit;transition:width .35s ease}.bar span.warn{background:#ea9d24}
+.empty{border:1px dashed #ccd8e7;border-radius:12px;padding:20px;text-align:center;color:var(--ink-2);font-size:13px;line-height:1.55}
+.usage-number{display:flex;justify-content:space-between;align-items:baseline;margin:9px 0 8px;font-family:var(--mono);font-size:12px;color:var(--ink-2)}.usage-number strong{font-size:25px;color:var(--ink);letter-spacing:-.03em}
+.bar{height:9px;background:#e6edf5;border-radius:999px;overflow:hidden}.bar span{display:block;height:100%;width:0;background:var(--ochre);border-radius:inherit;transition:width .35s ease}.bar span.warn{background:#ea9d24}
 .usage-note{font-size:11px;color:#73869c;margin:9px 0 0}
-.code-card{padding:0;overflow:hidden}.code-head{display:flex;justify-content:space-between;align-items:center;padding:16px 18px;border-bottom:1px solid #e2e9f2;background:#f9fbfe}.code-head strong{font-size:13px}.copy{border:1px solid #d4dfec;background:#fff;border-radius:8px;padding:6px 10px;color:#1457d9;font-family:var(--mono);font-size:10px;cursor:pointer}
+.code-card{padding:0;overflow:hidden}.code-head{display:flex;justify-content:space-between;align-items:center;padding:16px 18px;border-bottom:1px solid #e2e9f2;background:var(--card)}.code-head strong{font-size:13px}.copy{border:1px solid var(--ink-hair);background:var(--card);border-radius:8px;padding:6px 10px;color:var(--cobalt);font-family:var(--mono);font-size:10px;cursor:pointer}
 pre{margin:0;padding:20px;background:#0d1d33;color:#d7e7f8;overflow:auto;font-family:var(--mono);font-size:11px;line-height:1.65;white-space:pre-wrap;word-break:break-word}
-.steps{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:20px}.step{background:#fff;border:1px solid #e0e7f1;border-radius:14px;padding:17px}.step b{display:block;font-family:var(--mono);font-size:10px;color:#1457d9;margin-bottom:7px}.step span{font-size:12px;line-height:1.5;color:#5f7691}
-.links{display:grid;gap:8px}.link{display:flex;justify-content:space-between;gap:12px;padding:12px 0;border-bottom:1px solid #e6ecf3;color:#0b3a6a;text-decoration:none;font-size:13px}.link:last-child{border-bottom:0}.link span{color:#1457d9}
+.steps{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:20px}.step{background:var(--card);border:1px solid var(--ink-hair);border-radius:14px;padding:17px}.step b{display:block;font-family:var(--mono);font-size:10px;color:var(--cobalt);margin-bottom:7px}.step span{font-size:12px;line-height:1.5;color:#5f7691}
+.links{display:grid;gap:8px}.link{display:flex;justify-content:space-between;gap:12px;padding:12px 0;border-bottom:1px solid #e6ecf3;color:var(--ink);text-decoration:none;font-size:13px}.link:last-child{border-bottom:0}.link span{color:var(--cobalt)}
 .activity{max-height:290px;overflow:auto}.event{display:grid;grid-template-columns:76px 1fr;gap:10px;padding:9px 0;border-bottom:1px solid #e8edf4;font-family:var(--mono);font-size:10px}.event time{color:#8393a7}.event span{color:#294d76;word-break:break-word}
-.modal{position:fixed;inset:0;background:rgba(8,28,54,.55);display:flex;align-items:center;justify-content:center;padding:20px;z-index:1000}.modal-card{width:min(520px,100%);max-height:90vh;overflow:auto;background:#fff;border-radius:18px;padding:26px;box-shadow:0 24px 80px rgba(8,28,54,.3);position:relative}.modal-x{position:absolute;top:14px;right:16px;border:0;background:transparent;font-size:24px;color:#6b819b;cursor:pointer}.modal h2{font-size:19px;margin:0 32px 8px 0}.field{display:grid;gap:6px;margin:18px 0}.field label{font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.09em;color:#607896}.field input{width:100%;border:1px solid #ccd8e7;border-radius:10px;padding:11px 12px;font:inherit}.field input:focus{outline:3px solid rgba(20,87,217,.15);border-color:#1457d9}.notice{padding:12px 14px;border-radius:10px;background:#f1f6ff;color:#31567e;font-size:12px;line-height:1.55}.secret{margin:15px 0;background:#0d1d33;color:#d7e7f8;border-radius:10px;padding:14px;font-family:var(--mono);font-size:11px;word-break:break-all}.actions{display:flex;gap:9px;flex-wrap:wrap;margin-top:18px}.error{color:#a33b3b;font-size:12px;margin:12px 0 0}
+.modal{position:fixed;inset:0;background:rgba(8,28,54,.55);display:flex;align-items:center;justify-content:center;padding:20px;z-index:1000}.modal-card{width:min(520px,100%);max-height:90vh;overflow:auto;background:var(--card);border-radius:18px;padding:26px;box-shadow:0 24px 80px rgba(8,28,54,.3);position:relative}.modal-x{position:absolute;top:14px;right:16px;border:0;background:transparent;font-size:24px;color:var(--ink-2);cursor:pointer}.modal h2{font-size:19px;margin:0 32px 8px 0}.field{display:grid;gap:6px;margin:18px 0}.field label{font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.09em;color:var(--ink-2)}.field input{width:100%;border:1px solid #ccd8e7;border-radius:10px;padding:11px 12px;font:inherit}.field input:focus{outline:3px solid rgba(20,87,217,.15);border-color:var(--ochre)}.notice{padding:12px 14px;border-radius:10px;background:#f1f6ff;color:#31567e;font-size:12px;line-height:1.55}.secret{margin:15px 0;background:#0d1d33;color:#d7e7f8;border-radius:10px;padding:14px;font-family:var(--mono);font-size:11px;word-break:break-all}.actions{display:flex;gap:9px;flex-wrap:wrap;margin-top:18px}.error{color:#a33b3b;font-size:12px;margin:12px 0 0}
 @media(max-width:820px){.hero{align-items:flex-start;flex-direction:column}.grid{grid-template-columns:1fr}.steps{grid-template-columns:1fr}.account{white-space:normal}.card{padding:20px}}
 @media(max-width:520px){.dev{padding:34px 16px 64px}.card-head{flex-direction:column}.card-head .btn{width:100%}.key-row{grid-template-columns:1fr}.key-revoke{justify-self:start}.actions .btn{width:100%}}
 @media(prefers-reduced-motion:reduce){*{transition:none!important}}

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Documentation · Paramant API and self-hosting</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -20,24 +20,24 @@
 <meta name="twitter:description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
 <link rel="canonical" href="https://paramant.app/docs">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}
 a{color:var(--ink);text-decoration:none}
 .layout{display:flex;min-height:calc(100vh - 52px)}
 .sidebar{width:224px;flex-shrink:0;padding:28px 16px 40px;border-right:1px solid var(--ink-hair);position:sticky;top:52px;height:calc(100vh - 52px);overflow-y:auto}
 .sidebar::-webkit-scrollbar{width:3px}.sidebar::-webkit-scrollbar-track{background:transparent}.sidebar::-webkit-scrollbar-thumb{background:var(--ink-hair)}
-.sidebar h3{font-size:10px;color:#64748b;letter-spacing:.12em;text-transform:uppercase;margin:22px 0 6px;padding:6px 0 4px 10px;font-family:var(--mono);border-left:2px solid #B2FF3F}
+.sidebar h3{font-size:10px;color:var(--ink-dim);letter-spacing:.12em;text-transform:uppercase;margin:22px 0 6px;padding:6px 0 4px 10px;font-family:var(--mono);border-left:2px solid var(--ochre)}
 .sidebar h3:first-child{margin-top:0}
 .sidebar a{display:block;font-size:12px;color:var(--ink-dim);padding:3px 8px 3px 10px;line-height:1.8;transition:color .12s,background .12s,border-left-color .12s;border-left:2px solid transparent}
-.sidebar a:hover{color:#0B3A6A;background:rgba(178,255,63,0.08);border-left-color:#B2FF3F}
-.sidebar a.active{color:#0B3A6A;font-weight:500;background:rgba(29,78,216,0.06);border-left-color:#1D4ED8}
+.sidebar a:hover{color:var(--ink);background:rgba(217, 164, 65, 0.08);border-left-color:var(--ochre)}
+.sidebar a.active{color:var(--ink);font-weight:500;background:rgba(217, 164, 65, 0.06);border-left-color:var(--ochre)}
 .content{flex:1;min-width:0;padding:52px 72px 80px;max-width:840px}
 .content h1{font-size:26px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 .subtitle{font-size:14px;color:var(--ink-dim);margin-bottom:52px;line-height:1.8}
-.content h2{font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:#0B3A6A;margin:56px 0 18px;padding-top:56px;border-top:2px solid #B2FF3F}
+.content h2{font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--ink);margin:56px 0 18px;padding-top:56px;border-top:2px solid var(--ochre)}
 .content h2:first-of-type{border-top:none;padding-top:0;margin-top:0}
 .content h3{font-size:13px;font-weight:600;color:var(--ink);margin:28px 0 10px}
 .content p{font-size:13px;color:var(--ink-dim);line-height:1.85;margin-bottom:14px}
@@ -45,13 +45,13 @@ a{color:var(--ink);text-decoration:none}
 .content ul{margin:10px 0 18px 0;padding-left:0;list-style:none}
 .content ul li{font-size:13px;color:var(--ink-dim);padding:3px 0 3px 16px;position:relative}
 .content ul li::before{content:'·';position:absolute;left:4px;color:var(--ink-dim)}
-code{background:rgba(178,255,63,0.14);border:none;padding:2px 7px;font-size:12px;color:#0B3A6A;font-family:var(--mono)}
+code{background:rgba(217, 164, 65, 0.14);border:none;padding:2px 7px;font-size:12px;color:var(--ink);font-family:var(--mono)}
 pre{background:var(--black-hair);border:1px solid var(--ink-hair);padding:20px 24px;margin:14px 0 22px;overflow-x:auto;font-size:12px;color:var(--ink-dim);line-height:1.9;font-family:var(--mono)}
 pre .cm{color:var(--ink-dim)}.pre .kw{color:var(--cobalt)}.pre .st{color:var(--ink-dim)}
 .cb{background:var(--black-hair);border:1px solid var(--ink-hair);overflow:hidden;margin:14px 0 22px}
-.cb-header{padding:8px 16px;border-bottom:none;background:#0B3A6A;display:flex;align-items:center;gap:6px}
-.cb-dots{display:flex;gap:5px}.cb-dot{width:7px;height:7px;background:#B2FF3F}
-.cb-lang{margin-left:auto;font-size:10px;color:#B2FF3F;font-family:var(--mono);letter-spacing:.08em;font-weight:600;text-transform:uppercase}
+.cb-header{padding:8px 16px;border-bottom:none;background:var(--bone-2);display:flex;align-items:center;gap:6px}
+.cb-dots{display:flex;gap:5px}.cb-dot{width:7px;height:7px;background:var(--ochre)}
+.cb-lang{margin-left:auto;font-size:10px;color:var(--lime);font-family:var(--mono);letter-spacing:.08em;font-weight:600;text-transform:uppercase}
 .cb pre{margin:0;border:none;background:transparent;padding:18px 24px}
 table{width:100%;border-collapse:collapse;margin:14px 0 26px;font-size:12px}
 th{text-align:left;font-size:10px;color:var(--ink-dim);letter-spacing:.1em;text-transform:uppercase;padding:9px 14px;border-bottom:1px solid var(--ink-hair);font-family:var(--mono)}
@@ -62,12 +62,12 @@ tr:last-child td{border-bottom:none}
 .get{background:var(--ink-ghost);color:var(--ink);border:1px solid var(--ink-hair)}
 .post{background:var(--black-hair);color:var(--ink-dim);border:1px solid var(--ink-hair)}
 .badge{display:inline-block;padding:2px 8px;border:1px solid var(--ink-hair);font-size:11px;color:var(--ink-dim);margin-right:4px;font-family:var(--mono)}
-.callout{border:none;border-left:4px solid #B2FF3F;background:#0B3A6A;padding:14px 18px;margin:16px 0 22px}
-.callout.warn{border-left-color:#FCA5A5;background:#7F1D1D}
-.callout p{margin:0;color:#F8FAFC;font-size:12.5px;line-height:1.75}
-.callout.warn p{color:#FECACA}.callout-label{display:inline-block;background:#B2FF3F;color:#0B3A6A;padding:2px 8px;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;margin-bottom:8px}.callout.warn .callout-label{background:#FCA5A5;color:#7F1D1D}
+.callout{border:none;border-left:4px solid var(--ochre);background:var(--bone-2);padding:14px 18px;margin:16px 0 22px}
+.callout.warn{border-left-color:var(--brick);background:rgba(196, 96, 79, .12)}
+.callout p{margin:0;color:var(--ink);font-size:12.5px;line-height:1.75}
+.callout.warn p{color:var(--ink)}.callout-label{display:inline-block;background:var(--ochre);color: var(--on-ochre);padding:2px 8px;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;margin-bottom:8px}.callout.warn .callout-label{background:var(--brick);color:#141414}
 .step-row{display:flex;gap:16px;align-items:flex-start;margin:8px 0}
-.step-num{width:28px;height:28px;background:#B2FF3F;border:none;font-size:13px;font-family:var(--mono);font-weight:700;color:#0B3A6A;display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:1px}
+.step-num{width:28px;height:28px;background:var(--ochre);border:none;font-size:13px;font-family:var(--mono);font-weight:700;color: var(--on-ochre);display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:1px}
 .step-body{flex:1}
 .step-body p{margin-bottom:8px}
 .faq-item{border-bottom:1px solid var(--ink-hair);padding:18px 0}
@@ -78,24 +78,24 @@ tr:last-child td{border-bottom:none}
 @media(max-width:900px){.sidebar{display:none}.content{padding:32px 24px 60px}.content table{display:block;overflow-x:auto;max-width:100%}}
 
 /* docs-hero */
-.docs-hero{background:linear-gradient(180deg,#F8FAFC 0%,rgba(11,58,106,0.04) 100%);border-bottom:1px solid rgba(11,58,106,0.08);padding:36px 24px 28px;margin-bottom:0}
+.docs-hero{background:linear-gradient(180deg,var(--card) 0%,rgba(var(--tint), 0.04) 100%);border-bottom:1px solid rgba(var(--tint), 0.08);padding:36px 24px 28px;margin-bottom:0}
 .docs-hero-inner{max-width:840px;margin:0 auto;padding:0 72px}
-.docs-hero .eyebrow{display:inline-block;background:#B2FF3F;color:#0B3A6A;padding:2px 10px;font-family:var(--mono);font-size:10px;letter-spacing:.15em;text-transform:uppercase;margin-bottom:10px}
-.docs-hero h1{font-size:32px;font-weight:700;color:#0B3A6A;margin:0 0 10px;line-height:1.15;letter-spacing:-.02em}
-.docs-hero .lede{font-size:13px;line-height:1.75;color:#475569;margin:0 0 14px;max-width:640px}
-.docs-hero-cta{display:inline-block;font-family:var(--mono);font-size:12px;color:#1D4ED8;text-decoration:underline;text-decoration-color:#B2FF3F;text-decoration-thickness:2px;padding:4px 0}
-.docs-hero .docs-buyer{font-size:13px;line-height:1.7;color:#0B3A6A;margin:0 0 12px;max-width:640px;padding-left:10px;border-left:2px solid #B2FF3F}
-.docs-hero .docs-buyer a{color:#1D4ED8;text-decoration:underline;text-decoration-color:#B2FF3F;text-decoration-thickness:2px}
-.docs-hero .lede a{color:#1D4ED8;text-decoration:underline;text-decoration-color:#B2FF3F;text-decoration-thickness:2px}
+.docs-hero .eyebrow{display:inline-block;background:var(--ochre);color: var(--on-ochre);padding:2px 10px;font-family:var(--mono);font-size:10px;letter-spacing:.15em;text-transform:uppercase;margin-bottom:10px}
+.docs-hero h1{font-size:32px;font-weight:700;color:var(--ink);margin:0 0 10px;line-height:1.15;letter-spacing:-.02em}
+.docs-hero .lede{font-size:13px;line-height:1.75;color:var(--ink-2);margin:0 0 14px;max-width:640px}
+.docs-hero-cta{display:inline-block;font-family:var(--mono);font-size:12px;color:var(--cobalt);text-decoration:underline;text-decoration-color:var(--lime);text-decoration-thickness:2px;padding:4px 0}
+.docs-hero .docs-buyer{font-size:13px;line-height:1.7;color:var(--ink);margin:0 0 12px;max-width:640px;padding-left:10px;border-left:2px solid var(--ochre)}
+.docs-hero .docs-buyer a{color:var(--cobalt);text-decoration:underline;text-decoration-color:var(--lime);text-decoration-thickness:2px}
+.docs-hero .lede a{color:var(--cobalt);text-decoration:underline;text-decoration-color:var(--lime);text-decoration-thickness:2px}
 .docs-hero-actions{display:flex;flex-wrap:wrap;align-items:center;gap:12px;margin-top:4px}
-.docs-hero-btn{display:inline-flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:12px;line-height:1;padding:12px 20px;border:1px solid #1D4ED8;border-radius:2px;text-decoration:none;transition:background .12s,color .12s,border-color .12s}
-.docs-hero-btn-primary{background:#1D4ED8;color:#fff}
-.docs-hero-btn-primary:hover{background:#0B3A6A;border-color:#0B3A6A;color:#fff}
-.docs-hero-btn-secondary{background:#fff;color:#1D4ED8}
-.docs-hero-btn-secondary:hover{background:rgba(29,78,216,0.07);color:#0B3A6A}
+.docs-hero-btn{display:inline-flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:12px;line-height:1;padding:12px 20px;border:1px solid var(--ochre);border-radius:2px;text-decoration:none;transition:background .12s,color .12s,border-color .12s}
+.docs-hero-btn-primary{background:var(--ochre);color: var(--on-ochre)}
+.docs-hero-btn-primary:hover{background:var(--bone-2);border-color:var(--line-2);color:var(--ink)}
+.docs-hero-btn-secondary{background:var(--card);color:var(--cobalt)}
+.docs-hero-btn-secondary:hover{background:rgba(217, 164, 65, 0.07);color:var(--ink)}
 .docs-hero-actions .docs-hero-cta{margin-left:6px}
 @media(max-width:640px){.docs-hero-btn{flex:1 1 100%}.docs-hero-actions .docs-hero-cta{margin-left:0;width:100%}}
-.docs-hero-cta:hover{color:#0B3A6A}
+.docs-hero-cta:hover{color:var(--ink)}
 @media(max-width:900px){.docs-hero-inner{padding:0 24px}}
 </style>
 <style>
@@ -107,9 +107,9 @@ tr:last-child td{border-bottom:none}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -120,26 +120,26 @@ tr:last-child td{border-bottom:none}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -148,13 +148,13 @@ tr:last-child td{border-bottom:none}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }
@@ -681,7 +681,7 @@ id=tr_XXXX
     <p>Community Edition is free forever for up to 5 users. One <code>docker compose up</code> starts 6 containers: five sector relays and an admin panel.</p>
 
     <div class="callout"><span class="callout-label">Requirements</span>
-      <p><strong style="color:#B2FF3F">Requirements:</strong> Ubuntu 22.04+ / Debian 12+ · Docker 24+ · 1 GB RAM min · swap disabled · a domain with wildcard DNS</p>
+      <p><strong style="color:var(--lime)">Requirements:</strong> Ubuntu 22.04+ / Debian 12+ · Docker 24+ · 1 GB RAM min · swap disabled · a domain with wildcard DNS</p>
     </div>
 
     <div class="callout"><span class="callout-label">Where to start</span>
@@ -791,10 +791,10 @@ open https://your-domain.com/admin/</pre>
     </div>
     <p>Community Edition enforces a hard cap of 5 users: the 6th <code>add</code> returns HTTP 402. Add a <code>PLK_KEY</code> to <code>.env</code> to unlock unlimited users.</p>
     <div class="callout"><span class="callout-label">New in 3.0.0</span>
-      <p><strong style="color:#B2FF3F">Guided setup:</strong> a first-run web wizard at <code>/setup</code> replaces hand-run admin scripts for first-time operators: generating the admin token, enrolling TOTP and minting the first key from the browser. The wizard is gated to first boot (no keys yet) or an explicit <code>SETUP_MODE</code> flag, and runs deeper <code>/v2/health/deep</code> and DNS checks before declaring all-systems-go (design: ADR R005). Once running, <code>/admin/settings</code> exposes relay configuration visually: no more editing <code>.env</code> by hand: and <code>/admin/cli</code> gives admins a browser terminal for debugging without SSH.</p>
+      <p><strong style="color:var(--lime)">Guided setup:</strong> a first-run web wizard at <code>/setup</code> replaces hand-run admin scripts for first-time operators: generating the admin token, enrolling TOTP and minting the first key from the browser. The wizard is gated to first boot (no keys yet) or an explicit <code>SETUP_MODE</code> flag, and runs deeper <code>/v2/health/deep</code> and DNS checks before declaring all-systems-go (design: ADR R005). Once running, <code>/admin/settings</code> exposes relay configuration visually: no more editing <code>.env</code> by hand: and <code>/admin/cli</code> gives admins a browser terminal for debugging without SSH.</p>
     </div>
     <div class="callout"><span class="callout-label">New in 3.0.0</span>
-      <p><strong style="color:#B2FF3F">Plug-and-play serving:</strong> set <code>SERVE_FRONTEND=1</code> to have a single relay serve its own UI from a read-only static handler, so a fresh self-host needs no separate web server (opt-in, default off; ADR R011). Set <code>CRYPTO_MODE</code> to choose the algorithm set the relay advertises on <code>/v2/capabilities</code>: <code>core</code> (the default: ML-KEM-768 + ML-DSA-65) or <code>extended</code> for the full opt-in set (ADR R006).</p>
+      <p><strong style="color:var(--lime)">Plug-and-play serving:</strong> set <code>SERVE_FRONTEND=1</code> to have a single relay serve its own UI from a read-only static handler, so a fresh self-host needs no separate web server (opt-in, default off; ADR R011). Set <code>CRYPTO_MODE</code> to choose the algorithm set the relay advertises on <code>/v2/capabilities</code>: <code>core</code> (the default: ML-KEM-768 + ML-DSA-65) or <code>extended</code> for the full opt-in set (ADR R006).</p>
     </div>
 
     <h2 id="selfhost-upgrade">Upgrade</h2>
@@ -806,14 +806,14 @@ docker compose up -d --build
 <span class="cm"># Named volumes (users.json, CT log, relay identity) are preserved</span></pre>
     </div>
     <div class="callout warn"><span class="callout-label">Important</span>
-      <p><strong style="color:#FECACA">Note:</strong> User data and the CT log persist in Docker named volumes across upgrades. The relay identity keypair (ML-DSA-65) is generated once on first boot and stored at <code>/data/relay-identity.json</code>: do not delete this volume or the relay will lose its registered identity. Since v3.0.0 the ML-DSA-65 signing that backs this identity comes from <a href="https://github.com/Apolloccrypt/paramant-core" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">paramant-core</a>, the relay's audit-ready Rust crypto dependency (consumed via the <code>@paramant/core</code> NAPI binding): it ships inside the Docker image, so no extra install step is needed.</p>
+      <p><strong style="color:var(--brick-ink)">Note:</strong> User data and the CT log persist in Docker named volumes across upgrades. The relay identity keypair (ML-DSA-65) is generated once on first boot and stored at <code>/data/relay-identity.json</code>: do not delete this volume or the relay will lose its registered identity. Since v3.0.0 the ML-DSA-65 signing that backs this identity comes from <a href="https://github.com/Apolloccrypt/paramant-core" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)">paramant-core</a>, the relay's audit-ready Rust crypto dependency (consumed via the <code>@paramant/core</code> NAPI binding): it ships inside the Docker image, so no extra install step is needed.</p>
     </div>
 
     <!-- ── Admin scripts ─────────────────────────────────────────── -->
     <h2 id="client-deb">Admin scripts</h2>
     <p>Admin scripts ship with the relay repository. After cloning <a href="https://github.com/Apolloccrypt/paramant-relay">paramant-relay</a>, the server-side admin tool lives under <code>deploy/</code>: run <code>python3 deploy/paramant-admin.py [command]</code> directly. Operator helpers (key add/revoke, first-boot setup) live under <code>scripts/</code>. No system-wide install package is currently provided: the SDK packages on PyPI (<code>paramant-sdk</code>) and npm (<code>paramant-sdk</code>) are the canonical client integrations.</p>
     <div class="callout"><span class="callout-label">Coming soon</span>
-      <p><strong style="color:#B2FF3F">Add-ons:</strong> an add-on architecture is specified for integrations that live just beyond the relay core: storage mirrors, notification bridges, SIEM exporters, OIDC/SAML SSO. Container-isolated, manifest-declared capabilities, HomeAssistant-style, working on ciphertext and metadata only (never plaintext or keys). Specification: ADR R007, draft.</p>
+      <p><strong style="color:var(--lime)">Add-ons:</strong> an add-on architecture is specified for integrations that live just beyond the relay core: storage mirrors, notification bridges, SIEM exporters, OIDC/SAML SSO. Container-isolated, manifest-declared capabilities, HomeAssistant-style, working on ciphertext and metadata only (never plaintext or keys). Specification: ADR R007, draft.</p>
     </div>
 
     <h2 id="client-cli">CLI reference</h2>
@@ -925,7 +925,7 @@ python3 scripts/paramant-admin.py sync</pre>
     <p>The threat model assumes network-level attackers, compromised relay operators, and post-quantum adversaries. Encryption uses a hybrid scheme (ML-KEM-768 + ECDH P-256) so that breaking <em>either</em> primitive is not sufficient: both must be broken simultaneously.</p>
 
     <div class="callout"><span class="callout-label">Key insight</span>
-      <p><strong style="color:#B2FF3F">Key insight:</strong> The relay stores encrypted blobs it cannot decrypt and Merkle hashes it cannot forge. A warrant served on the relay operator yields ciphertext and metadata: not plaintext.</p>
+      <p><strong style="color:var(--lime)">Key insight:</strong> The relay stores encrypted blobs it cannot decrypt and Merkle hashes it cannot forge. A warrant served on the relay operator yields ciphertext and metadata: not plaintext.</p>
     </div>
 
     <h3>Jurisdiction</h3>

--- a/frontend/docs/paramant-ot-brief.html
+++ b/frontend/docs/paramant-ot-brief.html
@@ -57,7 +57,7 @@ h2 {
   color: var(--doc-ink-dim);
   margin-bottom: 7px;
   margin-top: 18px;
-  border-bottom: 1px solid rgba(10,10,10,.2);
+  border-bottom: 1px solid rgba(var(--tint), .2);
   padding-bottom: 3px;
 }
 h3 { font-size: 9.5pt; font-weight: 700; margin: 12px 0 5px; }
@@ -65,7 +65,7 @@ p { font-size: 9.5pt; color: var(--doc-ink); line-height: 1.6; margin-bottom: 6p
 ul { padding-left: 14px; margin-bottom: 8px; }
 li { font-size: 9.5pt; color: var(--doc-ink); line-height: 1.55; margin-bottom: 2px; }
 .intro-block {
-  background: rgba(10,10,10,.05);
+  background: rgba(var(--tint), .05);
   border-left: 3px solid var(--doc-ink);
   padding: 10px 14px;
   margin-bottom: 16px;
@@ -75,11 +75,11 @@ li { font-size: 9.5pt; color: var(--doc-ink); line-height: 1.55; margin-bottom: 
 .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; margin-bottom: 8px; }
 .three-col { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; margin-bottom: 8px; }
 .prop-list { list-style: none; padding: 0; }
-.prop-list li { font-size: 9.5pt; padding: 3px 0; border-bottom: 1px solid rgba(10,10,10,.1); display: flex; gap: 6px; }
+.prop-list li { font-size: 9.5pt; padding: 3px 0; border-bottom: 1px solid rgba(var(--tint), .1); display: flex; gap: 6px; }
 .prop-list li::before { content: "✓"; color: var(--doc-accent); font-weight: 700; flex-shrink: 0; }
 .arch-box {
-  background: rgba(10,10,10,.05);
-  border: 1px solid rgba(10,10,10,.2);
+  background: rgba(var(--tint), .05);
+  border: 1px solid rgba(var(--tint), .2);
   padding: 12px 14px;
   font-family: var(--mono);
   font-size: 8.5pt;
@@ -90,14 +90,14 @@ li { font-size: 9.5pt; color: var(--doc-ink); line-height: 1.55; margin-bottom: 
 code {
   font-family: var(--mono);
   font-size: 8.5pt;
-  background: rgba(10,10,10,.07);
+  background: rgba(var(--tint), .07);
   padding: 1px 5px;
 }
 .code-block {
   font-family: var(--mono);
   font-size: 8pt;
-  background: rgba(10,10,10,.05);
-  border: 1px solid rgba(10,10,10,.2);
+  background: rgba(var(--tint), .05);
+  border: 1px solid rgba(var(--tint), .2);
   padding: 10px 12px;
   line-height: 1.65;
   color: var(--doc-ink);
@@ -106,11 +106,11 @@ code {
 }
 table { width: 100%; border-collapse: collapse; margin: 8px 0; font-size: 9pt; }
 th { background: var(--doc-ink); color: var(--doc-bg); text-align: left; padding: 6px 10px; font-size: 8pt; font-weight: 600; letter-spacing: 0.4px; }
-td { padding: 6px 10px; border-bottom: 1px solid rgba(10,10,10,.1); vertical-align: top; color: var(--doc-ink); }
-tr:nth-child(even) td { background: rgba(10,10,10,.03); }
+td { padding: 6px 10px; border-bottom: 1px solid rgba(var(--tint), .1); vertical-align: top; color: var(--doc-ink); }
+tr:nth-child(even) td { background: rgba(var(--tint), .03); }
 .sr-ref { font-family: var(--mono); font-weight: 700; color: var(--doc-accent); white-space: nowrap; }
 .check-col { color: var(--doc-accent); font-weight: 700; text-align: center; }
-.tier-row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1px; background: rgba(10,10,10,.2); margin: 8px 0; }
+.tier-row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1px; background: rgba(var(--tint), .2); margin: 8px 0; }
 .tier { background: var(--doc-bg); padding: 10px 12px; }
 .tier.hl { background: rgba(26,122,60,.07); }
 .tier-name { font-size: 8pt; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 3px; }

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>The Paramant desktop app is no longer maintained</title>
 <meta property="og:site_name" content="Paramant">
@@ -65,10 +65,10 @@ pre{font-family:var(--mono);font-size:12px;line-height:1.7;color:var(--ink);back
 
 @media(max-width:600px){h1{font-size:25px}.dl-sub{font-size:15px}main{padding:0 18px 60px}.dl-lead{padding:28px 0 30px}}
 </style>
-<style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<style>.skip-link{position:absolute;top:-200px;left:0;background:var(--bone-2);color:var(--ink);padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid var(--ochre);transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:var(--ochre)}</style>
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <script type="application/ld+json" data-paramant-seo="1">
 {
   "@context": "https://schema.org",

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Data processing agreement · Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -19,9 +19,9 @@
 <meta name="twitter:title" content="Data processing agreement · Paramant">
 <meta name="twitter:description" content="The GDPR Article 28 agreement between Paramantis Solutions B.V. as processor and your organisation as controller. Sign it electronically, EU and German law.">
 <link rel="canonical" href="https://paramant.app/dpa">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 a{color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-hair)}
 a:hover{opacity:.7}
@@ -39,7 +39,7 @@ th{text-align:left;padding:10px 16px;font-size:var(--text-xs);letter-spacing:.06
 td{padding:12px 16px;color:var(--ink-dim);border-bottom:1px solid var(--ink-ghost)}
 tr:last-child td{border-bottom:none}
 td:first-child{color:var(--ink);font-weight:500;width:38%}
-.note-box{background:rgba(178,255,63,.08);border:1px solid var(--ink-hair);padding:20px 24px;margin-bottom:32px;font-size:13px;color:var(--ink-dim);line-height:1.7}
+.note-box{background:rgba(217, 164, 65, .08);border:1px solid var(--ink-hair);padding:20px 24px;margin-bottom:32px;font-size:13px;color:var(--ink-dim);line-height:1.7}
 .note-box strong{color:var(--ink)}
 .divider{border:none;border-top:1px solid var(--ink-hair);margin:48px 0}
 .sign-box{background:var(--bone-2);border:1px solid var(--ink-hair);padding:40px;margin-top:56px}
@@ -53,13 +53,13 @@ input:focus{border-color:var(--cobalt)}
 .checkbox-row{display:flex;align-items:flex-start;gap:12px;margin-bottom:24px}
 .checkbox-row input[type=checkbox]{width:16px;height:16px;margin-top:3px;flex-shrink:0;accent-color:var(--cobalt)}
 .checkbox-row label{font-size:13px;text-transform:none;letter-spacing:0;color:var(--ink-dim);line-height:1.6}
-.btn{background:var(--cobalt);color:var(--bone-on-navy);border:none;padding:12px 28px;font-size:14px;font-weight:600;font-family:var(--mono);letter-spacing:.04em;cursor:pointer;transition:opacity .15s}
+.btn{background:var(--cobalt);color: var(--on-ochre);border:none;padding:12px 28px;font-size:14px;font-weight:600;font-family:var(--mono);letter-spacing:.04em;cursor:pointer;transition:opacity .15s}
 .btn:hover{opacity:.88}
 .btn:disabled{opacity:.4;cursor:not-allowed}
-.success-box{display:none;background:rgba(178,255,63,.12);border:1px solid var(--navy);color:var(--navy);padding:24px;margin-top:24px}
+.success-box{display:none;background:rgba(217, 164, 65, .12);border:1px solid var(--navy);color:var(--navy);padding:24px;margin-top:24px}
 .ref{font-family:var(--mono);font-size:15px;color:var(--ink);margin:8px 0;font-weight:600}
 .error-box{display:none;background:rgba(200,50,50,.12);border:1px solid rgba(200,50,50,.4);padding:16px;margin-top:16px;font-size:13px;color:rgba(238,136,136,.9)}
-.spinner{display:inline-block;width:14px;height:14px;border:2px solid rgba(11,58,106,.2);border-top-color:var(--cobalt);animation:spin .7s linear infinite;vertical-align:middle;margin-right:8px}
+.spinner{display:inline-block;width:14px;height:14px;border:2px solid rgba(var(--tint), .2);border-top-color:var(--cobalt);animation:spin .7s linear infinite;vertical-align:middle;margin-right:8px}
 @keyframes spin{to{transform:rotate(360deg)}}
 @media(max-width:640px){.wrap{padding:48px 24px 80px}.form-grid{grid-template-columns:1fr}.sign-box{padding:24px}}
 </style>
@@ -72,9 +72,9 @@ input:focus{border-color:var(--cobalt)}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -85,26 +85,26 @@ input:focus{border-color:var(--cobalt)}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -113,13 +113,13 @@ input:focus{border-color:var(--cobalt)}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -5,7 +5,7 @@
 <!-- Sticky readiness signals. Plain script in <head> on purpose: it must run
      before every module and deferred script that signals or awaits. -->
 <script src="/js/ready.js?v=1"></script>
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Receive a file · Paramant</title>
 <meta name="description" content="Secure file waiting for you. Decrypts in your browser. Burns after one download.">
@@ -27,17 +27,17 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{background:var(--bone);color:var(--ink);font-family:var(--sans);min-height:100vh}
 main{max-width:520px;margin:0 auto;padding:80px 24px}
 main:has(#step-preview.active){max-width:880px}
-#preview-canvas-list canvas{width:100%;height:auto;display:block;border:1px solid var(--ink-hair);margin-bottom:12px;background:#fff}
+#preview-canvas-list canvas{width:100%;height:auto;display:block;border:1px solid var(--ink-hair);margin-bottom:12px;background:var(--card)}
 .page-wrap{position:relative;margin-bottom:12px}
 .btn-row{display:flex;gap:10px;flex-wrap:wrap}
 .btn-row .btn{flex:1;margin:0}
@@ -50,20 +50,20 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 .card-head{padding:14px 18px;border-bottom:1px solid var(--ink-hair);display:flex;align-items:center;gap:10px}
 .card-head-title{font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-dim)}
 .dot{width:6px;height:6px;background:var(--lime);border:1px solid var(--navy)}
-.dot.amber{background:#f59e0b}
-.dot.red{background:rgba(255,80,80,1)}
+.dot.amber{background:var(--ochre)}
+.dot.red{background:rgba(196, 96, 79, 1)}
 .card-body{padding:20px 18px}
 .progress-wrap{background:var(--bone-2);border:1px solid var(--ink-hair);height:3px;overflow:hidden;margin:14px 0 8px}
 .progress-bar{height:100%;background:var(--cobalt);width:0%;transition:width .4s}
 .status-line{font-family:var(--mono);font-size:11px;color:var(--ink-dim);padding:2px 0;line-height:1.7}
 .status-line.ok{color:var(--cobalt)}
-.status-line.err{color:rgba(200,30,30,1)}
+.status-line.err{color:rgba(196, 96, 79, 1)}
 .file-name{font-family:var(--mono);font-size:15px;font-weight:700;color:var(--navy);margin:8px 0 4px;word-break:break-all}
 .file-size{font-family:var(--mono);font-size:11px;color:var(--ink-dim)}
 .burned-icon{font-size:36px;margin-bottom:16px;display:block;text-align:center}
 .burned-msg{font-size:14px;color:var(--ink);text-align:center;line-height:1.7;margin-bottom:8px}
 .burned-sub{font-size:11px;color:var(--ink-dim);text-align:center;line-height:1.7}
-.btn{display:block;width:100%;padding:11px;background:var(--cobalt);color:var(--bone-on-navy);border:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.06em;cursor:pointer;margin-top:16px;text-decoration:none;text-align:center}
+.btn{display:block;width:100%;padding:11px;background:var(--cobalt);color: var(--on-ochre);border:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.06em;cursor:pointer;margin-top:16px;text-decoration:none;text-align:center}
 .btn:hover{opacity:.85}
 .btn-outline{background:transparent;color:var(--ink);border:1px solid var(--ink-hair)}
 .btn-outline:hover{color:var(--cobalt);border-color:var(--cobalt)}
@@ -80,9 +80,9 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -93,26 +93,26 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -121,13 +121,13 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -23,7 +23,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
@@ -72,9 +72,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {
   display: inline-flex;
@@ -84,9 +84,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -97,26 +97,26 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -125,13 +125,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -23,7 +23,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
@@ -58,9 +58,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {
   display: inline-flex;
@@ -70,9 +70,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -83,26 +83,26 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -111,13 +111,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -23,7 +23,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
@@ -43,14 +43,14 @@ a:hover{opacity:.7}
 em{color:var(--cobalt)}
 .step{display:flex;gap:20px;margin-bottom:32px;padding-bottom:32px;border-bottom:1px solid var(--ink-ghost)}
 .step:last-of-type{border-bottom:none}
-.step-num{width:32px;height:32px;background:var(--cobalt);color:#fff;font-size:14px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:2px}
+.step-num{width:32px;height:32px;background:var(--cobalt);color: var(--on-ochre);font-size:14px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:2px}
 .step-body{flex:1}
 .step-body h2{margin-top:0}
 .app-list{list-style:none;margin:16px 0;display:flex;flex-direction:column;gap:8px}
 .app-list li{padding:10px 14px;border:1px solid var(--ink-hair);font-size:var(--text-sm);color:var(--ink-dim)}
 .app-list li strong{color:var(--ink)}
 .app-list li .tag{font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--cobalt);margin-left:8px;font-weight:600}
-.code-block{background:var(--ink);color:var(--bone);padding:14px 18px;font-family:var(--mono,ui-monospace);font-size:var(--text-sm);line-height:1.6;margin:16px 0;word-break:break-all}
+.code-block{background:var(--invert);color:var(--invert-ink);padding:14px 18px;font-family:var(--mono,ui-monospace);font-size:var(--text-sm);line-height:1.6;margin:16px 0;word-break:break-all}
 .tip{border-left:3px solid var(--cobalt);padding:12px 16px;margin:16px 0;background:var(--ink-ghost)}
 .tip p{margin:0;font-size:var(--text-sm)}
 .warn{border-left:3px solid var(--lime);padding:12px 16px;margin:16px 0;background:var(--ink-ghost)}
@@ -72,9 +72,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {
   display: inline-flex;
@@ -84,9 +84,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -97,26 +97,26 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -125,13 +125,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -23,7 +23,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
@@ -43,7 +43,7 @@ a:hover{opacity:.7}
 em{color:var(--cobalt)}
 .step{display:flex;gap:20px;margin-bottom:32px;padding-bottom:32px;border-bottom:1px solid var(--ink-ghost)}
 .step:last-of-type{border-bottom:none}
-.step-num{width:32px;height:32px;background:var(--cobalt);color:#fff;font-size:14px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:2px}
+.step-num{width:32px;height:32px;background:var(--cobalt);color: var(--on-ochre);font-size:14px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:2px}
 .step-body{flex:1}
 .step-body h2{margin-top:0}
 .app-list{list-style:none;margin:16px 0;display:flex;flex-direction:column;gap:8px}
@@ -74,9 +74,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {
   display: inline-flex;
@@ -86,9 +86,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -99,26 +99,26 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -127,13 +127,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -23,7 +23,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
@@ -43,7 +43,7 @@ a:hover{opacity:.7}
 em{color:var(--cobalt)}
 .step{display:flex;gap:20px;margin-bottom:32px;padding-bottom:32px;border-bottom:1px solid var(--ink-ghost)}
 .step:last-of-type{border-bottom:none}
-.step-num{width:32px;height:32px;background:var(--cobalt);color:#fff;font-size:14px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:2px}
+.step-num{width:32px;height:32px;background:var(--cobalt);color: var(--on-ochre);font-size:14px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:2px}
 .step-body{flex:1}
 .step-body h2{margin-top:0}
 .tip{border-left:3px solid var(--cobalt);padding:12px 16px;margin:16px 0;background:var(--ink-ghost)}
@@ -76,9 +76,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {
   display: inline-flex;
@@ -88,9 +88,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -101,26 +101,26 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -129,13 +129,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -23,7 +23,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
@@ -31,13 +31,13 @@ main{max-width:860px;margin:0 auto;padding:80px 48px 120px}
 h1{font-size:36px;font-weight:600;letter-spacing:-.03em;margin-bottom:12px}
 .lead{font-size:var(--text-base);color:var(--ink-dim);line-height:1.7;margin-bottom:48px;max-width:560px}
 h2{font-size:18px;font-weight:600;letter-spacing:-.01em;margin-bottom:20px;margin-top:56px;color:var(--ink)}
-.buyer-qa{border:1px solid var(--ink-hair);border-left:3px solid #B2FF3F;padding:24px 24px 8px;margin:0 0 48px}
-.buyer-qa .buyer-qa-title{margin:0 0 18px;font-family:IBM Plex Mono,monospace;font-size:11px;font-weight:600;letter-spacing:.14em;text-transform:uppercase;color:#64748b}
+.buyer-qa{border:1px solid var(--ink-hair);border-left:3px solid var(--ochre);padding:24px 24px 8px;margin:0 0 48px}
+.buyer-qa .buyer-qa-title{margin:0 0 18px;font-family:IBM Plex Mono,monospace;font-size:11px;font-weight:600;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-dim)}
 .buyer-qa-item{margin-bottom:20px}
 .buyer-qa-q{font-size:15px;font-weight:600;color:var(--ink);margin-bottom:6px}
 .buyer-qa-a{font-size:var(--text-sm);color:var(--ink-dim);line-height:1.7;margin-bottom:6px}
 .buyer-qa-a a.buyer-qa-inline{color:var(--cobalt);text-decoration:underline;text-underline-offset:2px}
-.buyer-qa-link{font-family:IBM Plex Mono,monospace;font-size:12px;color:var(--cobalt);text-decoration:underline;text-decoration-color:#B2FF3F;text-decoration-thickness:2px;text-underline-offset:3px}
+.buyer-qa-link{font-family:IBM Plex Mono,monospace;font-size:12px;color:var(--cobalt);text-decoration:underline;text-decoration-color:var(--lime);text-decoration-thickness:2px;text-underline-offset:3px}
 .buyer-qa-link:hover{color:var(--ink)}
 /* Three questions, three answers, and on a 390x844 phone the third answer ended
    at y=860: the line that says the documents sit at Hetzner Nuremberg under EU
@@ -56,10 +56,10 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
-<link rel="stylesheet" href="/parapear.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
+<link rel="stylesheet" href="/parapear.css?v=4">
 <style>
 .nav-help {
   display: inline-flex;
@@ -69,9 +69,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -82,26 +82,26 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -110,13 +110,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -23,7 +23,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
@@ -41,7 +41,7 @@ p strong{color:var(--ink)}
 a{color:var(--cobalt);text-decoration:none}
 a:hover{opacity:.7}
 em{color:var(--cobalt)}
-.code-block{background:var(--ink);color:var(--bone);padding:14px 18px;font-family:var(--mono,ui-monospace);font-size:var(--text-sm);line-height:1.6;margin:16px 0;word-break:break-all;white-space:pre-wrap}
+.code-block{background:var(--invert);color:var(--invert-ink);padding:14px 18px;font-family:var(--mono,ui-monospace);font-size:var(--text-sm);line-height:1.6;margin:16px 0;word-break:break-all;white-space:pre-wrap}
 .tip{border-left:3px solid var(--cobalt);padding:12px 16px;margin:16px 0;background:var(--ink-ghost)}
 .tip p{margin:0;font-size:var(--text-sm)}
 .warn{border-left:3px solid var(--lime);padding:12px 16px;margin:16px 0;background:var(--ink-ghost)}
@@ -71,9 +71,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {
   display: inline-flex;
@@ -83,9 +83,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -96,26 +96,26 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -124,13 +124,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -23,7 +23,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
@@ -43,7 +43,7 @@ a:hover{opacity:.7}
 em{color:var(--cobalt)}
 .step{display:flex;gap:20px;margin-bottom:32px;padding-bottom:32px;border-bottom:1px solid var(--ink-ghost)}
 .step:last-of-type{border-bottom:none}
-.step-num{width:32px;height:32px;background:var(--cobalt);color:#fff;font-size:14px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:2px}
+.step-num{width:32px;height:32px;background:var(--cobalt);color: var(--on-ochre);font-size:14px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:2px}
 .step-body{flex:1}
 .step-body h2{margin-top:0}
 .tip{border-left:3px solid var(--cobalt);padding:12px 16px;margin:16px 0;background:var(--ink-ghost)}
@@ -70,9 +70,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {
   display: inline-flex;
@@ -82,9 +82,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -95,26 +95,26 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -123,13 +123,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -23,7 +23,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
@@ -43,7 +43,7 @@ a:hover{opacity:.7}
 em{color:var(--cobalt)}
 .step{display:flex;gap:20px;margin-bottom:32px;padding-bottom:32px;border-bottom:1px solid var(--ink-ghost)}
 .step:last-of-type{border-bottom:none}
-.step-num{width:32px;height:32px;background:var(--cobalt);color:#fff;font-size:14px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:2px}
+.step-num{width:32px;height:32px;background:var(--cobalt);color: var(--on-ochre);font-size:14px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:2px}
 .step-body{flex:1}
 .step-body h2{margin-top:0}
 .tip{border-left:3px solid var(--cobalt);padding:12px 16px;margin:16px 0;background:var(--ink-ghost)}
@@ -76,9 +76,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {
   display: inline-flex;
@@ -88,9 +88,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -101,26 +101,26 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -129,13 +129,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -23,7 +23,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
@@ -70,9 +70,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {
   display: inline-flex;
@@ -82,9 +82,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -95,26 +95,26 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -123,13 +123,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 <title>ParaSign by Paramant &middot; sign and send documents in the EU</title>
 <meta property="og:site_name" content="Paramant">
 <meta name="description" content="Get documents signed and send files safely, straight from your browser. Built and hosted in the EU by Paramantis Solutions B.V. The Community plan is free, forever.">
@@ -22,35 +22,26 @@
 <link rel="canonical" href="https://paramant.app/">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="manifest" href="/manifest.json">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
 <style>
-/* Homepage 2026, night edition: the same hand as BeerWeer. Warm night ground,
-   cream ink, one ochre accent, mono for the small facts, a drawn band at the
-   top. One column, 780px, so nothing has to shout. */
+/* Homepage 2026, night edition: the same hand as BeerWeer. The night itself is
+   no longer here: frontend/design-system.css carries it for the whole site, so
+   this block is only what the homepage owns on top of it. The band, the letter,
+   the drawn document and the receipt live nowhere else. */
 :root{
-  --tint:234,226,206; --cream:#EAE2CE; --night:#15191C; --night-2:#101316;
-  --fg:var(--cream); --fg-mid:rgba(var(--tint),.8); --fg-dim:rgba(var(--tint),.62);
-  --line:rgba(var(--tint),.16); --line-2:rgba(var(--tint),.32); --card:rgba(var(--tint),.045); --card-line:rgba(var(--tint),.14);
-  --ochre:#D9A441; --ochre-2:#C7912E; --petrol:#155E75; --teal:#8FB3C4; --brick:#C4604F;
-  --paper:#F1EAD6; --paper-2:#E7DDC4; --paper-ink:#1B1F22; --paper-ink-2:#4A4A44;
-  --r:16px; --pad:clamp(16px,4vw,28px); --maxw:780px;
-  /* the design system's tokens, re-pointed so the nav, the menu and the footer follow the page */
-  --bone:var(--night); --bone-2:var(--night-2); --ink:var(--cream); --ink-2:var(--fg-mid); --ink-dim:var(--fg-dim);
-  --ink-hair:var(--line); --ink-ghost:rgba(var(--tint),.06); --cobalt:var(--ochre); --cobalt-2:var(--ochre-2); --lime:var(--ochre); --navy:var(--cream); --navy-2:var(--cream); --ochre-ink:#8A5E10;
+  --fg:var(--ink); --fg-mid:var(--ink-2); --fg-dim:var(--ink-dim);
+  --teal:#8FB3C4;   /* the band at first light, and nowhere else */
+  --pad:clamp(16px,4vw,28px); --maxw:780px;
   --hp-paper:var(--night); --hp-paper-2:var(--night-2); --hp-ink:var(--cream); --hp-ink-2:var(--fg-mid); --hp-ink-3:var(--fg-dim);
   --hp-line:var(--line); --hp-line-2:var(--line-2); --hp-night:var(--paper); --hp-night-2:var(--paper-2);
   --hp-cobalt:var(--ochre); --hp-cobalt-2:var(--ochre-2); --hp-lime:var(--ochre); --hp-lime-ink:var(--ochre);
   --hp-sans:var(--sans, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif);
   --hp-mono:var(--mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
 }
-html{background:var(--night)}
-body{background:linear-gradient(180deg,var(--night) 0,var(--night-2) 100%);color:var(--fg);font-family:var(--hp-sans);-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
+body{background:linear-gradient(180deg,var(--night) 0,var(--night-2) 100%);font-family:var(--hp-sans);text-rendering:optimizeLegibility}
 main{display:block;overflow:hidden}
-nav.nav{background:var(--night);border-bottom-color:var(--line)}
-nav.nav .nav-logo .logo-para{color:var(--cream)}
-nav.nav .nav-logo .logo-mant{color:var(--ochre)}
-.btn,.btn-primary,nav.nav a.nav-cta,.nav-mobile-cta .btn{color:#141414}
+
 .hp-wrap{width:min(100% - 2*var(--pad), var(--maxw));margin-inline:auto}
 .hp-kicker{font-family:var(--hp-mono);font-size:12px;letter-spacing:.12em;text-transform:uppercase;color:var(--fg-dim);margin:0 0 14px;display:flex;align-items:center;gap:10px}
 .hp-kicker::before{content:"";width:10px;height:10px;border-radius:50%;background:var(--fg-dim)}

--- a/frontend/iot.html
+++ b/frontend/iot.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta http-equiv="refresh" content="0; url=/docs#compliance-iec62443">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <link rel="canonical" href="https://paramant.app/docs">
 <title>Paramant IoT / OT · redirecting…</title>
 <meta property="og:site_name" content="Paramant">
@@ -16,7 +16,7 @@
 <meta name="twitter:title" content="Paramant IoT / OT · redirecting…">
 <meta name="twitter:description" content="Paramant IoT / OT · redirecting…">
 
-<style>.skip-link{position:absolute;top:-200px;left:0;background:#0B3A6A;color:#F8FAFC;padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid #B2FF3F;transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:#1D4ED8}</style>
+<style>.skip-link{position:absolute;top:-200px;left:0;background:var(--bone-2);color:var(--ink);padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid var(--ochre);transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:var(--ochre)}</style>
 <script type="application/ld+json" data-paramant-seo="1">
 {
   "@context": "https://schema.org",

--- a/frontend/js/account-theme.js
+++ b/frontend/js/account-theme.js
@@ -10,7 +10,8 @@
   var group = document.getElementById('theme-choice');
   if (!api || !group) return;
 
-  var current = api.read() || 'light';
+  // No stored choice is the night, the same default /js/theme.js applies.
+  var current = api.read() || 'dark';
   var inputs = group.querySelectorAll('input[name="appearance"]');
 
   for (var i = 0; i < inputs.length; i++) {

--- a/frontend/js/theme.js
+++ b/frontend/js/theme.js
@@ -1,23 +1,22 @@
 // The appearance choice, applied before the first paint.
 //
-// Why this file exists. Dark mode on the app screens used to follow
-// prefers-color-scheme on its own. Measured on 2026-09-03 with a dark OS and no
-// choice made: /index and /pricing stayed light, while /dashboard, /sign,
-// /parashare, /account and /auth/login came up on rgb(10,15,22). Signing in was
-// a jump from creme to black in one click. Dark is now something a reader picks
-// on /account, never something the operating system decides for them.
+// Why this file exists. The site stands on the night: warm dark ground, cream
+// ink, one ochre accent, on every page and on every app screen. That is the
+// default and it needs no script. What a reader can do on /account is ask for
+// the cream paper instead, or hand the decision to their operating system.
 //
 // How the default holds. Without a stored choice this script sets NOTHING, so
-// <html> carries no data-theme, the media block in /app-2026.css is scoped to
-// [data-theme="auto"] and does not match, and the app is light. That is also
-// what happens with JavaScript off: the light default does not depend on this
-// file running. What this file does is apply a choice that was made.
+// <html> carries no data-theme, the two paper blocks in /app-2026.css are
+// scoped to [data-theme="light"] and [data-theme="auto"] and neither matches,
+// and the app is the night. That is also what happens with JavaScript off: the
+// default does not depend on this file running. What this file does is apply a
+// choice that was made.
 //
 // Why it is external and why it blocks. The site runs under script-src 'self',
 // so an inline script is dead in the browser (scripts/check-csp-inline.sh). It
 // is a plain <script> at the end of the <head> of every app page: it runs while
 // the head is being parsed, before the body exists and before the first paint,
-// so a reader who chose dark never sees a light flash.
+// so a reader who chose the paper never sees a night flash.
 //
 // Storage. localStorage['paramant.theme.v1'], one of 'auto', 'light', 'dark'.
 // Anything else, and a browser that refuses storage, reads as no choice. The
@@ -29,8 +28,8 @@
   var CHOICES = ['auto', 'light', 'dark'];
   // The two page grounds, kept in step with --paper in /app-2026.css. This is
   // the browser chrome, not the page: leaving it on a media query would tint
-  // the address bar dark above a light page.
-  var CHROME = { light: '#FBFAF7', dark: '#0A0F16' };
+  // the address bar light above the night.
+  var CHROME = { light: '#F1EAD6', dark: '#15191C' };
 
   function read() {
     try {
@@ -50,10 +49,11 @@
   }
 
   // What the reader actually sees, after the choice and the system are both in.
+  // No choice is the night, because the night is what the whole site stands on.
   function resolved(choice) {
-    if (choice === 'dark') return 'dark';
+    if (choice === 'light') return 'light';
     if (choice === 'auto') return systemIsDark() ? 'dark' : 'light';
-    return 'light';
+    return 'dark';
   }
 
   function apply(choice) {

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>License · Paramant Business Source License 1.1</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -24,11 +24,11 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 main{max-width:760px;margin:64px auto;padding:0 24px 80px}
@@ -52,9 +52,9 @@ footer a{color:var(--cobalt)}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -65,26 +65,26 @@ footer a{color:var(--cobalt)}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -93,13 +93,13 @@ footer a{color:var(--cobalt)}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -5,8 +5,8 @@
   "start_url": "/",
   "scope": "/",
   "display": "standalone",
-  "background_color": "#F8FAFC",
-  "theme_color": "#0B3A6A",
+  "background_color": "#15191C",
+  "theme_color": "#15191C",
   "icons": [
     { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
     { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }

--- a/frontend/nav.css
+++ b/frontend/nav.css
@@ -18,13 +18,7 @@ nav.nav {
   gap: var(--space-4);
   padding: 0 40px;
   height: 56px;
-  /* The bar paints the paper of the page it sits on, not a fixed hex. The
-     homepage runs on warm paper (#FAF8F3) while the bar was pinned to the cool
-     bone (#F8FAFC), and the two met in a visible band under the bar as soon as
-     the page scrolled. app-2026.css already does this for the app screens
-     (var(--paper)); --nav-paper is the same idea for the marketing pages. Any
-     page that sets no token keeps the exact value it had. */
-  background: var(--nav-paper-blur, rgba(248,250,252,.92));
+  background: var(--bone-blur);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border-bottom: 1px solid var(--ink-hair);
@@ -173,9 +167,9 @@ nav.nav .nav-dropdown-menu li a {
 }
 nav.nav .nav-dropdown-menu li a:hover,
 nav.nav .nav-dropdown-menu li a:focus {
-  color: #0B3A6A;
-  background: rgba(178,255,63,0.15);
-  border-left: 2px solid #B2FF3F;
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.15);
+  border-left: 2px solid var(--ochre);
   padding-left: calc(var(--space-5) - 2px);
   outline: none;
 }
@@ -231,7 +225,7 @@ nav.nav .nav-link.active::after { transform: scaleX(1); }
   padding: 4px;
   border: 1px solid var(--ink-hair);
   border-radius: 12px;
-  background: rgba(255,255,255,.62);
+  background: var(--card);
 }
 .settings-tabs a {
   flex: 0 0 auto;
@@ -242,8 +236,8 @@ nav.nav .nav-link.active::after { transform: scaleX(1); }
   text-decoration: none;
   white-space: nowrap;
 }
-.settings-tabs a:hover { color: var(--cobalt); background: rgba(35,80,216,.05); }
-.settings-tabs a[aria-current="page"] { color: var(--cobalt); background: rgba(35,80,216,.1); }
+.settings-tabs a:hover { color: var(--cobalt); background: rgba(217, 164, 65, .05); }
+.settings-tabs a[aria-current="page"] { color: var(--cobalt); background: rgba(217, 164, 65, .1); }
 .settings-tabs a:focus-visible { outline: 2px solid var(--lime); outline-offset: 2px; }
 @media (max-width:520px) {
   .settings-tabs { gap:2px; padding:3px; }
@@ -272,17 +266,17 @@ nav.nav .nav-hamburger {
 }
 nav.nav .nav-hamburger:hover {
   border-color: var(--cobalt);
-  background: rgba(29,78,216,.05);
+  background: rgba(217, 164, 65, .05);
 }
 nav.nav .nav-hamburger:focus-visible {
-  outline: 3px solid rgba(29,78,216,.35);
+  outline: 3px solid rgba(217, 164, 65, .35);
   outline-offset: 2px;
 }
 nav.nav .nav-hamburger span {
   display: block;
   width: 22px;
   height: 2px;
-  background: var(--ink);
+  background: var(--invert);
   transition: transform var(--duration-base) var(--ease-out),
               opacity var(--duration-fast) var(--ease-out);
   pointer-events: none;
@@ -357,11 +351,11 @@ nav.nav .nav-hamburger[aria-expanded="true"] span:nth-child(3) {
   transition: color var(--duration-base) var(--ease-sharp);
 }
 .nav-mobile-group-btn:hover {
-  background: rgba(178,255,63,0.08);
-  color: #0B3A6A;
+  background: rgba(217, 164, 65, 0.08);
+  color: var(--ink);
 }
-.nav-mobile-group.open .nav-mobile-group-btn { color: #0B3A6A; }
-.nav-mobile-group.open .nav-mobile-group-btn::after { content: '\2212'; color: #B2FF3F; }
+.nav-mobile-group.open .nav-mobile-group-btn { color: var(--ink); }
+.nav-mobile-group.open .nav-mobile-group-btn::after { content: '\2212'; color: var(--lime); }
 
 /* Group items — animated reveal using max-height + opacity */
 .nav-mobile-group-items {
@@ -394,15 +388,15 @@ nav.nav .nav-hamburger[aria-expanded="true"] span:nth-child(3) {
 }
 .nav-mobile-group-items a:hover,
 .nav-mobile-group-items a:focus-visible {
-  color: #0B3A6A;
-  border-left-color: #B2FF3F;
-  background: rgba(178,255,63,0.1);
+  color: var(--ink);
+  border-left-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.1);
   outline: none;
 }
 .nav-mobile-group-items a[aria-current="page"] {
-  color: #0B3A6A;
-  border-left-color: #B2FF3F;
-  background: rgba(178,255,63,0.12);
+  color: var(--ink);
+  border-left-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.12);
   font-weight: 600;
 }
 
@@ -433,13 +427,13 @@ nav.nav .nav-hamburger[aria-expanded="true"] span:nth-child(3) {
 .nav-mobile-standalone:focus-visible {
   color: var(--cobalt);
   border-left-color: var(--cobalt);
-  background: rgba(29,78,216,.04);
+  background: rgba(217, 164, 65, .04);
   outline: none;
 }
 .nav-mobile-standalone[aria-current="page"] {
   color: var(--cobalt);
   border-left-color: var(--cobalt);
-  background: rgba(29,78,216,.06);
+  background: rgba(217, 164, 65, .06);
   font-weight: 600;
 }
 
@@ -528,7 +522,7 @@ body.nav-locked .nav {
   color: var(--ink-dim);
   line-height: 1.35;
 }
-.nmpl-featured { border-left-color: rgba(29,78,216,.25); }
+.nmpl-featured { border-left-color: rgba(217, 164, 65, .25); }
 .nmpl-featured .nmpl-title { color: var(--cobalt); }
 
 /* Desktop Products dropdown — title + tagline */
@@ -556,7 +550,7 @@ body.nav-locked .nav {
   letter-spacing: 0;
   font-weight: 400;
 }
-.nav-product-item:hover .npi-title { color: #0B3A6A; }
+.nav-product-item:hover .npi-title { color: var(--ink); }
 
 /* Plain-link "buttons" — Compare and Pricing */
 nav.nav .nav-link-btn {
@@ -578,20 +572,20 @@ nav.nav .nav-link-btn:hover {
   position: absolute;
   top: -200px;
   left: 0;
-  background: var(--navy, #0B3A6A);
-  color: #F8FAFC;
+  background: var(--navy);
+  color: var(--ink);
   padding: 12px 20px;
   z-index: 10000;
   text-decoration: none;
   font-family: var(--mono);
   font-size: var(--text-xs);
   letter-spacing: .04em;
-  border: 2px solid #B2FF3F;
+  border: 2px solid var(--ochre);
   transition: top 120ms ease;
 }
 .skip-link:focus,
 .skip-link:focus-visible { top: 0; outline: none; }
-.skip-link:focus:hover { background: #1D4ED8; }
+.skip-link:focus:hover { background: var(--ochre); }
 
 /* ════════════════════════════════════════
    MOBILE NAV CTA + META
@@ -627,8 +621,8 @@ nav.nav .nav-link-btn:hover {
               color var(--duration-base) var(--ease-sharp);
 }
 .btn-ghost-dark:hover {
-  background: var(--ink);
-  color: #F8FAFC;
+  background: var(--invert);
+  color: var(--ink);
 }
 .nav-mobile-meta {
   padding: var(--space-3) var(--space-5) var(--space-5);
@@ -640,7 +634,7 @@ nav.nav .nav-link-btn:hover {
   gap: var(--space-2);
   letter-spacing: .04em;
 }
-.nav-mobile-meta .meta-sep { color: #B2FF3F; }
+.nav-mobile-meta .meta-sep { color: var(--lime); }
 
 /* Beeldmerk-logo: de blauwe P met lime stip als de P van Paramant. */
 nav.nav .nav-logo { display: inline-flex; align-items: center; gap: 0; color: var(--ink); font-weight: 600; }
@@ -683,7 +677,7 @@ nav.nav .nav-help:hover,
 nav.nav .nav-signin:hover { color: var(--cobalt); }
 nav.nav .nav-help:focus-visible,
 nav.nav .nav-signin:focus-visible {
-  outline: 3px solid rgba(29,78,216,.35);
+  outline: 3px solid rgba(217, 164, 65, .35);
   outline-offset: 2px;
 }
 
@@ -698,7 +692,7 @@ nav.nav .nav-cta {
   min-height: 40px;
   padding: 0 var(--space-4);
   background: var(--cobalt);
-  color: #FFFFFF;
+  color: var(--on-ochre);
   border: 1px solid var(--cobalt);
   border-radius: 3px;
   font-family: var(--sans);
@@ -715,10 +709,10 @@ nav.nav .nav-cta {
 nav.nav .nav-cta:hover {
   background: var(--cobalt-2);
   border-color: var(--cobalt-2);
-  color: #FFFFFF;
+  color: var(--ink);
 }
 nav.nav .nav-cta:focus-visible {
-  outline: 3px solid rgba(29,78,216,.35);
+  outline: 3px solid rgba(217, 164, 65, .35);
   outline-offset: 2px;
 }
 
@@ -744,7 +738,7 @@ nav.nav .nav-user-trigger {
 }
 nav.nav .nav-user-trigger:hover { border-color: var(--cobalt); }
 nav.nav .nav-user-trigger:focus-visible {
-  outline: 3px solid rgba(29,78,216,.35);
+  outline: 3px solid rgba(217, 164, 65, .35);
   outline-offset: 2px;
 }
 nav.nav .nav-user-email {
@@ -763,7 +757,7 @@ nav.nav .nav-user-menu {
   background: var(--bone);
   border: 1px solid var(--ink-hair);
   border-radius: 3px;
-  box-shadow: 0 6px 24px rgba(15,23,42,.08);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, .08);
   padding: var(--space-1) 0;
   z-index: 400;
 }
@@ -783,9 +777,9 @@ nav.nav .nav-menu-item {
   cursor: pointer;
   text-align: left;
 }
-nav.nav .nav-menu-item:hover { background: rgba(29,78,216,.06); color: var(--cobalt); }
-nav.nav .nav-menu-signout { color: #991B1B; }
-nav.nav .nav-menu-signout:hover { background: rgba(220,38,38,.06); color: #991B1B; }
+nav.nav .nav-menu-item:hover { background: rgba(217, 164, 65, .06); color: var(--cobalt); }
+nav.nav .nav-menu-signout { color: var(--brick-ink); }
+nav.nav .nav-menu-signout:hover { background: rgba(196, 96, 79, .06); color: var(--brick-ink); }
 nav.nav .nav-menu-divider { height: 1px; background: var(--ink-hair); margin: var(--space-1) 0; }
 
 @media (max-width: 420px) {
@@ -842,7 +836,7 @@ nav.nav .nav-menu-divider { height: 1px; background: var(--ink-hair); margin: va
 }
 .nav-mobile-tail .nav-tail-link:hover { color: var(--cobalt); }
 .nav-mobile-tail a:focus-visible {
-  outline: 3px solid rgba(29,78,216,.35);
+  outline: 3px solid rgba(217, 164, 65, .35);
   outline-offset: 2px;
 }
 

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -5,13 +5,13 @@
 <!-- Sticky readiness signals. Plain script in <head> on purpose: it must run
      before every module and deferred script that signals or awaits. -->
 <script src="/js/ready.js?v=1"></script>
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Receive a file · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <meta name="description" content="A secure file is waiting for you. It decrypts in your browser and burns after one download.">
 <meta property="og:title" content="A secure file is waiting · Paramant">
 <meta property="og:description" content="A secure file is waiting for you. It decrypts in your browser and burns after one download. Nothing is stored on the server.">
@@ -42,10 +42,10 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 .card-body{padding:20px 18px}
 .status-line{font-size:11px;color:var(--ink-dim);padding:4px 0;display:flex;align-items:center;gap:8px;line-height:1.7}
 .status-line.ok{color:var(--cobalt)}
-.status-line.err{color:rgba(255,80,80,1)}
+.status-line.err{color:rgba(196, 96, 79, 1)}
 .fingerprint{font-size:28px;font-weight:700;letter-spacing:.18em;color:var(--ink);text-align:center;padding:24px;background:var(--bone);border:1px solid var(--ink-hair);margin:16px 0}
 .fingerprint-label{font-size:11px;color:var(--ink-dim);text-align:center;margin-bottom:8px}
-.btn{width:100%;padding:11px;background:var(--cobalt);color:var(--bone-on-navy);border:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.06em;cursor:pointer;margin-top:8px}
+.btn{width:100%;padding:11px;background:var(--cobalt);color: var(--on-ochre);border:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.06em;cursor:pointer;margin-top:8px}
 .btn:hover{opacity:.85}
 .btn:disabled{background:var(--ink-ghost);cursor:not-allowed}
 .progress-bar-wrap{background:var(--bone);border:1px solid var(--ink-hair);height:4px;overflow:hidden;margin:12px 0}
@@ -67,9 +67,9 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -80,26 +80,26 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -108,13 +108,13 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }
@@ -225,7 +225,7 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 <div class="step" id="step-error">
   <h1>Transfer failed</h1>
   <div class="card">
-    <div class="card-head"><div class="dot" style="background:rgba(255,80,80,1)"></div><div class="card-head-title">Error</div></div>
+    <div class="card-head"><div class="dot" style="background:rgba(196, 96, 79, 1)"></div><div class="card-head-title">Error</div></div>
     <div class="card-body">
       <div class="status-line err" id="error-msg">Unknown error</div>
     </div>

--- a/frontend/parapear.css
+++ b/frontend/parapear.css
@@ -27,15 +27,15 @@
   font-family: var(--sans, Inter, system-ui, sans-serif);
   font-size: var(--text-base, 15px);
   line-height: 1.55;
-  color: var(--ink, #0B3A6A);
+  color: var(--ink);
   background: transparent;
-  border: 1px solid var(--ink-hair, rgba(11,58,106,0.18));
+  border: 1px solid var(--ink-hair, rgba(var(--tint), 0.18));
   border-radius: 12px;
   padding: var(--space-3, 12px) var(--space-4, 16px);
 }
 
 .parapear-bubble strong {
-  color: var(--ink, #0B3A6A);
+  color: var(--ink);
   font-weight: 600;
 }
 
@@ -45,31 +45,31 @@
   font-size: 11px;
   letter-spacing: .08em;
   text-transform: uppercase;
-  color: var(--ink-dim, #64748B);
+  color: var(--ink-dim);
   margin-bottom: 4px;
 }
 
 .parapear-bubble a {
-  color: var(--cobalt, #1D4ED8);
+  color: var(--cobalt);
 }
 
 .parapear-dismiss {
   align-self: flex-start;
   margin-left: var(--space-2, 8px);
   background: transparent;
-  border: 1px solid var(--ink-hair, rgba(11,58,106,0.18));
+  border: 1px solid var(--ink-hair, rgba(var(--tint), 0.18));
   border-radius: 8px;
   font-family: var(--sans, Inter, system-ui, sans-serif);
   font-size: 12px;
-  color: var(--ink-dim, #64748B);
+  color: var(--ink-dim);
   padding: 6px 10px;
   cursor: pointer;
   line-height: 1;
 }
 
 .parapear-dismiss:hover {
-  border-color: var(--ink, #0B3A6A);
-  color: var(--ink, #0B3A6A);
+  border-color: var(--ink);
+  color: var(--ink);
 }
 
 /* Accent variant: warm green dot before the kicker, reuses --lime. */
@@ -79,7 +79,7 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--lime, #B2FF3F);
+  background: var(--lime);
   margin-right: 8px;
   vertical-align: 1px;
 }

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>ParaSend &middot; Encrypted file transfer by Paramant</title>
 <meta property="og:site_name" content="Paramant">
@@ -21,11 +21,11 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .ps-hero{padding:var(--space-10) 0 var(--space-6)}
 .ps-band{padding:var(--space-8) 0;border-top:1px solid var(--ink-hair)}
@@ -52,7 +52,7 @@
 .tier-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--ink-hair);border:1px solid var(--ink-hair);margin-top:var(--space-3)}
 .tier-grid.one{grid-template-columns:1fr;max-width:420px}
 .tier-card{background:var(--bone);padding:var(--space-5);display:flex;flex-direction:column}
-.tier-card.featured{background:var(--lime)}
+.tier-card.featured{background:var(--night-2);box-shadow:inset 3px 0 0 var(--ochre)}
 .tier-name{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;font-weight:700;color:var(--cobalt)}
 .tier-price{font-family:var(--mono);font-size:var(--text-2xl);font-weight:700;color:var(--navy);margin-top:var(--space-2)}
 .tier-price span{font-size:var(--text-sm);color:var(--ink-dim);font-weight:400}

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">:root{color-scheme:light}html,body{background:#FBFAF7;color:#0C1B2A;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}@media(prefers-color-scheme:dark){:root[data-theme="auto"]{color-scheme:dark}html[data-theme="auto"],html[data-theme="auto"] body{background:#0A0F16;color:#EDF1F6}}html[data-theme="dark"],html[data-theme="dark"] body{background:#0A0F16;color:#EDF1F6}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}html[data-theme="light"],html[data-theme="light"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="light"]{color-scheme:light}@media (prefers-color-scheme:light){html[data-theme="auto"],html[data-theme="auto"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="auto"]{color-scheme:light}}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Encrypted file transfer · Paramant</title>
 <meta property="og:site_name" content="Paramant">
@@ -11,10 +11,10 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
-<link rel="stylesheet" href="/parapear.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
+<link rel="stylesheet" href="/parapear.css?v=4">
 <style>
 /* Page: parashare — transfer UI */
 
@@ -195,7 +195,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 
 #globe-overlay::before{content:'';position:absolute;inset:0;pointer-events:none;z-index:20;
   background:repeating-linear-gradient(0deg,transparent,transparent 3px,
-  rgba(178,255,63,.018) 3px,rgba(178,255,63,.018) 4px)}
+  rgba(217, 164, 65, .018) 3px,rgba(217, 164, 65, .018) 4px)}
 #globe-overlay::after{content:'';position:absolute;inset:0;pointer-events:none;z-index:19;
   background:radial-gradient(ellipse 80% 80% at 50% 50%,transparent 35%,#000 100%)}
 
@@ -216,18 +216,18 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
   border-bottom:1px solid var(--ink-ghost);
   background:linear-gradient(to bottom,rgba(0,0,0,.9),transparent)}
 .hud-logo{font-size:12px;font-weight:700;letter-spacing:.14em;color:var(--lime)}
-.hud-center{font-size:10px;letter-spacing:.22em;color:rgba(178,255,63,.5);text-transform:uppercase}
-.hud-close-btn{background:none;border:1px solid rgba(178,255,63,.3);color:rgba(178,255,63,.8);
+.hud-center{font-size:10px;letter-spacing:.22em;color:rgba(217, 164, 65, .5);text-transform:uppercase}
+.hud-close-btn{background:none;border:1px solid rgba(217, 164, 65, .3);color:rgba(217, 164, 65, .8);
   padding:5px 14px;font-family:inherit;font-size:10px;letter-spacing:.1em;cursor:pointer;
   text-transform:uppercase;transition:all .2s}
 .hud-close-btn:hover{border-color:var(--lime);color:var(--lime)}
 
 .hud-bot{position:absolute;bottom:0;left:0;right:0;height:48px;z-index:30;
   display:flex;align-items:center;justify-content:center;gap:40px;padding:0 24px;
-  border-top:1px solid rgba(178,255,63,.12);
+  border-top:1px solid rgba(217, 164, 65, .12);
   background:linear-gradient(to top,rgba(0,0,0,.9),transparent)}
 .hud-stat{display:flex;flex-direction:column;align-items:center;gap:2px}
-.hud-stat-lbl{font-size:8px;letter-spacing:.16em;color:rgba(178,255,63,.4);text-transform:uppercase}
+.hud-stat-lbl{font-size:8px;letter-spacing:.16em;color:rgba(217, 164, 65, .4);text-transform:uppercase}
 .hud-stat-val{font-size:11px;color:var(--lime);letter-spacing:.06em}
 .hud-stat-val.amber{color:var(--lime)}
 
@@ -236,8 +236,8 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
   backdrop-filter:blur(6px)}
 .hud-panel-title{font-size:8px;letter-spacing:.2em;color:var(--ink-dim);
   text-transform:uppercase;margin-bottom:10px;padding-bottom:6px;
-  border-bottom:1px solid rgba(178,255,63,.12)}
-.hud-panel-row{font-size:10px;color:rgba(178,255,63,.8);padding:4px 0;
+  border-bottom:1px solid rgba(217, 164, 65, .12)}
+.hud-panel-row{font-size:10px;color:rgba(217, 164, 65, .8);padding:4px 0;
   display:flex;justify-content:space-between;gap:16px;letter-spacing:.04em}
 .hud-panel-row .val{color:var(--lime)}
 
@@ -245,7 +245,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 #hud-right{right:20px;top:50%;transform:translateY(-50%)}
 
 .hud-session{font-size:10px;color:var(--ink);padding:5px 0;
-  border-bottom:1px solid rgba(178,255,63,.08);display:flex;align-items:center;gap:8px}
+  border-bottom:1px solid rgba(217, 164, 65, .08);display:flex;align-items:center;gap:8px}
 .hud-session:last-child{border:none}
 .hud-dot{width:5px;height:5px;background:var(--lime);flex-shrink:0;
   animation:blink 2s ease-in-out infinite}
@@ -254,7 +254,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 
 @keyframes globeSpin{to{transform:rotate(360deg)}}
 #globe-loading{position:absolute;inset:0;z-index:5;display:flex;align-items:center;
-  justify-content:center;flex-direction:column;gap:16px;color:rgba(178,255,63,.6);
+  justify-content:center;flex-direction:column;gap:16px;color:rgba(217, 164, 65, .6);
   font-size:11px;letter-spacing:.14em;text-transform:uppercase}
 #globe-loading-ring{width:64px;height:64px;border:2px solid var(--ink-ghost);
   border-top-color:var(--lime);animation:globeSpin .8s linear infinite}
@@ -293,9 +293,9 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -306,26 +306,26 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -334,13 +334,13 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }
@@ -378,9 +378,9 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
   ]
 }
 </script>
-<meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=4">
-<script src="/js/theme.js?v=1"></script>
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/app-2026.css?v=7">
+<script src="/js/theme.js?v=4"></script>
 </head>
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -562,7 +562,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
       <div id="fp-seen-before" style="display:none;font-size:10px;color:var(--cobalt);margin:-4px 0 10px;text-align:center;font-family:var(--mono)">✓ Same code as the last time you sent to this person</div>
       <div id="fp-new-device" style="display:none;font-size:10px;color:var(--cobalt);margin:-4px 0 10px;text-align:center">◈ First time with this receiver. Compare with extra care.</div>
       <div style="display:flex;justify-content:center;margin:12px 0 4px">
-        <canvas id="fp-qr" style="display:none;border:4px solid #fff"></canvas>
+        <canvas id="fp-qr" style="display:none;border:4px solid var(--line-2)"></canvas>
       </div>
       <p style="font-size:10px;color:var(--ink-dim);text-align:center;margin-bottom:10px" id="fp-qr-label">Your receiver can scan this instead of reading it out</p>
       <label style="display:flex;align-items:center;gap:8px;margin:12px 0 4px;font-size:11px;cursor:pointer;user-select:none">

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>ParaSign &middot; get documents signed, by Paramant</title>
 <meta property="og:site_name" content="Paramant">
@@ -21,11 +21,11 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .ps-hero{padding:var(--space-10) 0 var(--space-6)}
 .ps-band{padding:var(--space-8) 0;border-top:1px solid var(--ink-hair)}
@@ -44,11 +44,11 @@
 .check-card a{color:var(--cobalt)}
 .tier-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--ink-hair);border:1px solid var(--ink-hair);margin-top:var(--space-5)}
 .tier-card{background:var(--bone);padding:var(--space-5);display:flex;flex-direction:column}
-.community{background:var(--lime);border:1px solid var(--ink-hair);padding:var(--space-6);margin-top:var(--space-5);display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1.3fr);gap:var(--space-6)}
+.community{background:var(--night-2);border:1px solid var(--ink-hair);padding:var(--space-6);margin-top:var(--space-5);display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1.3fr);gap:var(--space-6)}
 .community h3{font-size:var(--text-xl);letter-spacing:-.01em;color:var(--navy);margin:var(--space-2) 0 0}
 .community p{max-width:none;margin-top:var(--space-3);font-size:var(--text-sm);line-height:1.75}
 .community ul{list-style:none;margin:var(--space-4) 0 0;padding:0}
-.community li{font-family:var(--mono);font-size:var(--text-xs);color:var(--navy);padding:var(--space-2) 0;border-bottom:1px solid rgba(11,58,106,.18);line-height:1.5}
+.community li{font-family:var(--mono);font-size:var(--text-xs);color:var(--navy);padding:var(--space-2) 0;border-bottom:1px solid rgba(var(--tint), .18);line-height:1.5}
 .community li:last-child{border-bottom:none}
 .community li::before{content:'+ ';font-weight:700}
 .tier-name{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;font-weight:700;color:var(--cobalt)}

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>In the wild · Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -20,9 +20,9 @@
 <meta name="twitter:description" content="Organisations that publicly confirm they run Paramant in production will be listed here. For case studies or references, get in touch.">
 <link rel="canonical" href="https://paramant.app/partners">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 
 <style>
 *{margin:0;padding:0;box-sizing:border-box}

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Press kit · Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -24,11 +24,11 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 :root{
@@ -47,7 +47,7 @@ p{color:var(--ink-dim);margin-bottom:12px;line-height:1.7}
 .blurb{background:var(--ink-ghost);border-left:3px solid var(--lime);padding:16px 20px;margin:0 0 16px}
 .blurb strong{font-family:var(--mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink);display:block;margin-bottom:8px}
 .blurb p{margin:0;color:var(--ink);font-size:14px;line-height:1.75}
-.card{background:rgba(178,255,63,.06);border:1px solid var(--ink-hair);padding:20px 24px;margin-bottom:16px}
+.card{background:rgba(217, 164, 65, .06);border:1px solid var(--ink-hair);padding:20px 24px;margin-bottom:16px}
 .facts{display:grid;grid-template-columns:auto 1fr;gap:.4rem 1.5rem}
 .facts dt{color:var(--ink-dim);white-space:nowrap;font-family:var(--mono);font-size:12px}
 .facts dd{margin:0;color:var(--ink);font-size:13px}
@@ -57,13 +57,13 @@ p{color:var(--ink-dim);margin-bottom:12px;line-height:1.7}
 .bullet-list li::before{content:"▸";color:var(--ink);position:absolute;left:0}
 .download-row{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}
 .dl-btn{background:var(--ink-ghost);border:1px solid var(--ink-hair);color:var(--ink);padding:.5rem 1rem;text-decoration:none;font-size:13px;font-family:var(--mono);transition:background .15s}
-.dl-btn:hover{background:var(--cobalt);color:var(--bone-on-navy);text-decoration:none}
-.contact{background:rgba(178,255,63,.06);border:1px solid var(--ink-hair);padding:20px 24px}
+.dl-btn:hover{background:var(--cobalt);color: var(--on-ochre);text-decoration:none}
+.contact{background:rgba(217, 164, 65, .06);border:1px solid var(--ink-hair);padding:20px 24px}
 .contact p{margin-bottom:8px;color:var(--ink-dim);font-size:14px}
 .contact strong{color:var(--cobalt)}
 table{width:100%;border-collapse:collapse;margin-top:8px;font-size:13px}
 td,th{border:1px solid var(--ink-hair);padding:.55rem .9rem;text-align:left}
-th{background:rgba(178,255,63,.06);color:var(--ink-dim);font-family:var(--mono);font-size:11px;letter-spacing:.05em}
+th{background:rgba(217, 164, 65, .06);color:var(--ink-dim);font-family:var(--mono);font-size:11px;letter-spacing:.05em}
 td{color:var(--cobalt)}
 @media(max-width:600px){.grid{grid-template-columns:1fr}}
 </style>
@@ -76,9 +76,9 @@ td{color:var(--cobalt)}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -89,26 +89,26 @@ td{color:var(--cobalt)}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -117,13 +117,13 @@ td{color:var(--cobalt)}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Pricing · What is free, and what businesses pay · Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -19,13 +19,13 @@
 <meta name="twitter:title" content="Pricing · What is free, and what businesses pay · Paramant">
 <meta name="twitter:description" content="The Community plan is free, forever. Organisations pay for higher limits: sending from 15 euro a month, signing from 49, excl. btw. From Paramantis Solutions B.V.">
 <link rel="canonical" href="https://paramant.app/pricing">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .tier-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--ink-hair)}
 .tier-card{padding:var(--space-7) var(--space-6);background:var(--bone);min-height:440px;display:flex;flex-direction:column}
-.tier-card.featured{background:var(--lime)}
+.tier-card.featured{background:var(--night-2);box-shadow:inset 3px 0 0 var(--ochre)}
 .tier-name{font-family:var(--mono);font-size:var(--text-xs);letter-spacing:.18em;text-transform:uppercase;font-weight:700;color:var(--cobalt);margin-bottom:var(--space-4)}
 .tier-price{font-family:var(--mono);font-size:var(--text-3xl);font-weight:700;color:var(--navy);margin-bottom:var(--space-2)}
 .tier-price-note{font-size:var(--text-sm);color:var(--ink-dim);margin-bottom:var(--space-6)}
@@ -84,9 +84,9 @@
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -97,26 +97,26 @@
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -125,13 +125,13 @@
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Privacy policy · Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -24,11 +24,11 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 .content{max-width:800px;margin:80px auto;padding:0 48px}
@@ -60,9 +60,9 @@ footer a{color:var(--ink);text-decoration:none}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -73,26 +73,26 @@ footer a{color:var(--ink);text-decoration:none}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -101,13 +101,13 @@ footer a{color:var(--ink);text-decoration:none}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }
@@ -264,7 +264,7 @@ footer a{color:var(--ink);text-decoration:none}
 <li><strong>Signature placement template</strong> (<code>parasign.placement.tpl.v1</code>): where you last put a seal on a page, so the next document opens the same way</li>
 <li><strong>Seen signing fingerprints</strong> (<code>paramant_fp_&hellip;</code>): a marker per signing key you have already been shown, so a known key is not flagged as new</li>
 <li><strong>Dismissed key-setup notice</strong> (<code>paramant.keysetup.dismissed.v1</code>): that you closed the signing-key banner on your dashboard</li>
-<li><strong>Appearance</strong> (<code>paramant.theme.v1</code>): whether you asked the app screens to follow your system, stay light or go dark. Light without it. Nothing is sent to us; the choice lives in this browser and on this device only.</li>
+<li><strong>Appearance</strong> (<code>paramant.theme.v1</code>): whether you asked the app screens to follow your system, go light or stay dark. Dark without it. Nothing is sent to us; the choice lives in this browser and on this device only.</li>
 <li><strong>Passkey / WebAuthn credentials</strong>: your passkey&rsquo;s private key is created and held by your device or password manager. PARAMANT only ever stores its <em>public</em> key, server-side; the private key never leaves your device.</li>
 <li><strong>ParaSign signing vault</strong> (IndexedDB): if you sign documents, your post-quantum signing key (ML-DSA-65) is generated and kept in your browser&rsquo;s IndexedDB, encrypted either with your passkey (WebAuthn-PRF &rarr; HKDF &rarr; AES-256-GCM) or, if your passkey provider cannot do that, with a passphrase (PBKDF2 &rarr; AES-256-GCM). The private key never leaves your device; only its public half is registered to your account.</li>
 </ul>

--- a/frontend/relay-pulse.css
+++ b/frontend/relay-pulse.css
@@ -1,6 +1,6 @@
 /* relay-pulse.css  ·  site-wide "relay signal"
  *
- * One lime pulse glides across the very top edge of every page on a slow loop:
+ * One ochre pulse glides across the very top edge of every page on a slow loop:
  * the signal passing through the relay, tying the whole site together. It is the
  * connective motif that echoes the lime beats in the homepage panel animations.
  *
@@ -11,7 +11,7 @@
  * --rp-* custom properties below.
  */
 :root {
-  --rp-lime: #B2FF3F;   /* brand lime */
+  --rp-lime: var(--ochre, #D9A441);   /* the one accent */
   --rp-width: 280px;    /* length of the travelling pulse */
   --rp-period: 7s;      /* one pulse every N seconds */
   --rp-thickness: 2px;
@@ -27,9 +27,9 @@ body::after {
   z-index: 100;
   pointer-events: none;
   background: linear-gradient(90deg,
-    rgba(178, 255, 63, 0) 0%,
+    rgba(217, 164, 65, 0) 0%,
     var(--rp-lime) 50%,
-    rgba(178, 255, 63, 0) 100%);
+    rgba(217, 164, 65, 0) 100%);
   transform: translateX(-320px);
   animation: relay-pulse var(--rp-period) ease-in-out 0.5s infinite;
   will-change: transform, opacity;

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -2,16 +2,16 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Create an account · Paramant</title>
 <meta name="description" content="Paramant API keys are now issued through account signup with TOTP protection. Create a free account to get started.">
 <meta name="robots" content="noindex">
 <meta http-equiv="refresh" content="8;url=/signup">
 <link rel="canonical" href="https://paramant.app/signup">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>
 .nav-help {
@@ -22,9 +22,9 @@
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -35,26 +35,26 @@
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -63,13 +63,13 @@
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }
@@ -114,25 +114,25 @@
   <section class="section section--light" style="padding: 80px 24px;">
     <div style="max-width: 600px; margin: 0 auto; text-align: center;">
 
-      <span style="display:inline-block;background:#B2FF3F;color:#0B3A6A;padding:3px 14px;font-family:&quot;IBM Plex Mono&quot;,monospace;font-size:11px;font-weight:700;letter-spacing:0.15em;text-transform:uppercase;margin-bottom:28px;">UPDATED FLOW</span>
+      <span style="display:inline-block;background:var(--ochre);color:var(--ink);padding:3px 14px;font-family:&quot;IBM Plex Mono&quot;,monospace;font-size:11px;font-weight:700;letter-spacing:0.15em;text-transform:uppercase;margin-bottom:28px;">UPDATED FLOW</span>
 
-      <h1 style="font-size:clamp(32px,5vw,52px);color:#0B3A6A;margin:0 0 20px 0;letter-spacing:-0.02em;line-height:1.1;font-weight:600;">
+      <h1 style="font-size:clamp(32px,5vw,52px);color:var(--ink);margin:0 0 20px 0;letter-spacing:-0.02em;line-height:1.1;font-weight:600;">
         API keys now come with accounts.
       </h1>
 
-      <p style="font-size:17px;color:#475569;line-height:1.7;margin:0 0 36px 0;">
+      <p style="font-size:17px;color:var(--ink-2);line-height:1.7;margin:0 0 36px 0;">
         We replaced the trial-key-by-email flow with a proper signup. You still get a free key — but now it comes with TOTP protection, an admin dashboard, and no plaintext key sitting in your inbox.
       </p>
 
-      <a href="/signup" style="display:inline-block;padding:16px 36px;background:#B2FF3F;color:#0B3A6A;text-decoration:none;font-family:&quot;IBM Plex Mono&quot;,monospace;font-size:14px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;">
+      <a href="/signup" style="display:inline-block;padding:16px 36px;background:var(--ochre);color:var(--ink);text-decoration:none;font-family:&quot;IBM Plex Mono&quot;,monospace;font-size:14px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;">
         Create account →
       </a>
 
-      <p style="font-size:14px;color:#64748b;margin:32px 0 0 0;line-height:1.6;">
-        Already had a trial key? It still works until it expires. <a href="/signup" style="color:#1D4ED8;text-decoration:underline;">Upgrade to a full account</a> to keep access after the trial.
+      <p style="font-size:14px;color:var(--ink-dim);margin:32px 0 0 0;line-height:1.6;">
+        Already had a trial key? It still works until it expires. <a href="/signup" style="color:var(--cobalt);text-decoration:underline;">Upgrade to a full account</a> to keep access after the trial.
       </p>
 
-      <p style="font-size:12px;color:#94A3B8;margin:24px 0 0 0;font-family:&quot;IBM Plex Mono&quot;,monospace;">
+      <p style="font-size:12px;color:var(--ink-dim);margin:24px 0 0 0;font-family:&quot;IBM Plex Mono&quot;,monospace;">
         Redirecting automatically in 8 seconds&hellip;
       </p>
 

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Our rules · What Paramant stands for</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -24,11 +24,11 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 .content{max-width:800px;margin:80px auto;padding:0 48px}
@@ -61,9 +61,9 @@ footer a{color:var(--ink);text-decoration:none}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -74,26 +74,26 @@ footer a{color:var(--ink);text-decoration:none}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -102,13 +102,13 @@ footer a{color:var(--ink);text-decoration:none}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Security · How to check Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -24,22 +24,22 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
-.page-hero--navy{background:var(--navy);border-color:transparent}
-.page-hero--navy .eyebrow{background:var(--lime);color:var(--navy)}
-.page-hero--navy h1{color:var(--bone)}
-.page-hero--navy .lede{color:rgba(248,250,252,.8)}
+.page-hero--navy{background:var(--invert);border-color:transparent}
+.page-hero--navy .eyebrow{background:var(--lime);color: var(--on-ochre)}
+.page-hero--navy h1{color:var(--invert-ink)}
+.page-hero--navy .lede{color:rgba(var(--tint), .8)}
 .hero-cta{display:flex;flex-wrap:wrap;gap:14px;margin-top:20px}
-.page-hero--navy .btn-secondary{color:var(--bone);border-color:rgba(248,250,252,.45)}
-.page-hero--navy .btn-secondary:hover{background:var(--bone);color:var(--navy);border-color:var(--bone)}
-.hero-by{color:rgba(248,250,252,.7);font-size:var(--text-sm);line-height:1.7;margin-top:16px;max-width:620px}
+.page-hero--navy .btn-secondary{color:var(--invert-ink);border-color:rgba(var(--tint), .45)}
+.page-hero--navy .btn-secondary:hover{background:var(--bone);color:var(--navy);border-color:var(--invert-ink)}
+.hero-by{color:rgba(var(--tint), .7);font-size:var(--text-sm);line-height:1.7;margin-top:16px;max-width:620px}
 main{max-width:780px;margin:0 auto;padding:48px 48px 120px}
 h1{font-size:36px;font-weight:600;letter-spacing:-.03em;margin-bottom:12px}
 .lead{font-size:var(--text-base);color:var(--ink-dim);line-height:1.7;margin-bottom:48px;max-width:580px}
@@ -88,9 +88,9 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -101,26 +101,26 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -129,13 +129,13 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -22,7 +22,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="manifest" href="/manifest.json">
-  <meta name="theme-color" content="#0B3A6A">
+  <meta name="theme-color" content="#15191C">
   <meta name="description" content="Paramant thanks the researchers who responsibly disclosed security issues. Good-faith research makes Paramant better for everyone.">
   <style>
     *{box-sizing:border-box;margin:0;padding:0}
@@ -39,9 +39,9 @@
     .divider{border:none;border-top:1px solid var(--ink-hair);margin:48px 0}
     footer{border-top:1px solid var(--ink-hair);padding:32px 48px}
   </style>
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <script type="application/ld+json" data-paramant-seo="1">
 {
   "@context": "https://schema.org",

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -6,9 +6,9 @@
   <title>First-time setup · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/setup">
-  <link rel="stylesheet" href="/design-system.css?v=25">
-  <link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+  <link rel="stylesheet" href="/design-system.css?v=28">
+  <link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 </head>
 <body>
   <main class="setup-wizard" style="max-width:640px;margin:48px auto;padding:0 20px">

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -5,7 +5,7 @@
 <!-- Sticky readiness signals. Plain script in <head> on purpose: it must run
      before every module and deferred script that signals or awaits. -->
 <script src="/js/ready.js?v=1"></script>
-<style id="critical-css">:root{color-scheme:light}html,body{background:#FBFAF7;color:#0C1B2A;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}@media(prefers-color-scheme:dark){:root[data-theme="auto"]{color-scheme:dark}html[data-theme="auto"],html[data-theme="auto"] body{background:#0A0F16;color:#EDF1F6}}html[data-theme="dark"],html[data-theme="dark"] body{background:#0A0F16;color:#EDF1F6}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}html[data-theme="light"],html[data-theme="light"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="light"]{color-scheme:light}@media (prefers-color-scheme:light){html[data-theme="auto"],html[data-theme="auto"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="auto"]{color-scheme:light}}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Sign a PDF in your browser · Paramant</title>
 <meta property="og:site_name" content="Paramant">
@@ -23,10 +23,10 @@
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="canonical" href="https://paramant.app/sign">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
-<link rel="stylesheet" href="/components-parasign.css?v=3">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
+<link rel="stylesheet" href="/components-parasign.css?v=6">
 <style>
 .ds-note{margin:12px 0 0;padding:13px 16px;border:1px solid var(--line);border-left:2px solid var(--mark);border-radius:var(--r-1);background:var(--surface-sunk);color:var(--ink-2);font-size:14px;line-height:1.6}
 .ds-note p{margin:0 0 8px}
@@ -89,14 +89,14 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 /* The document stays white in both themes. A PDF page IS white paper; the
    signed result has to look like what the other side will print. Only the
    chrome around it follows the theme. */
-.ds-page-wrap canvas{width:100%;height:auto;display:block;border:1px solid var(--line-2);background:#fff}
-.ds-stamp-marker{position:absolute;border:1px solid var(--cobalt);background:#fff;pointer-events:auto;cursor:grab;touch-action:none;z-index:5;box-sizing:border-box;overflow:hidden;display:flex;flex-direction:column;font-family:Inter,sans-serif;color:var(--navy)}
+.ds-page-wrap canvas{width:100%;height:auto;display:block;border:1px solid var(--line-2);background:var(--card)}
+.ds-stamp-marker{position:absolute;border:1px solid var(--cobalt);background:var(--card);pointer-events:auto;cursor:grab;touch-action:none;z-index:5;box-sizing:border-box;overflow:hidden;display:flex;flex-direction:column;font-family:Inter,sans-serif;color:var(--navy)}
 .ds-stamp-marker.dragging{will-change:transform}
-.ds-stamp-resize{position:absolute;right:0;bottom:0;width:28px;height:28px;padding:0;background:var(--cobalt);border:0;border-top:2px solid #fff;border-left:2px solid #fff;cursor:nwse-resize;touch-action:none;z-index:6;box-shadow:-1px -1px 3px rgba(0,0,0,.2)}
-.ds-stamp-resize::after{content:'';position:absolute;right:2px;bottom:2px;width:4px;height:4px;border-right:1.5px solid #fff;border-bottom:1.5px solid #fff}
+.ds-stamp-resize{position:absolute;right:0;bottom:0;width:28px;height:28px;padding:0;background:var(--cobalt);border:0;border-top:2px solid var(--line-2);border-left:2px solid var(--line-2);cursor:nwse-resize;touch-action:none;z-index:6;box-shadow:-1px -1px 3px rgba(0,0,0,.2)}
+.ds-stamp-resize::after{content:'';position:absolute;right:2px;bottom:2px;width:4px;height:4px;border-right:1.5px solid var(--line-2);border-bottom:1.5px solid var(--line-2)}
 /* Seal delete handle (matches the annotation × handle) */
-.ds-stamp-del{position:absolute;top:4px;left:4px;width:28px;height:28px;border-radius:50%;background:#b00020;color:#fff;border:2px solid #fff;font-size:18px;line-height:1;cursor:pointer;display:flex;align-items:center;justify-content:center;z-index:7;padding:0;box-shadow:0 1px 4px rgba(0,0,0,.35)}
-.ds-stamp-del:focus-visible,.ds-stamp-resize:focus-visible{outline:3px solid #fff;outline-offset:1px;box-shadow:0 0 0 5px var(--cobalt)}
+.ds-stamp-del{position:absolute;top:4px;left:4px;width:28px;height:28px;border-radius:50%;background:#b00020;color:var(--ink);border:2px solid var(--line-2);font-size:18px;line-height:1;cursor:pointer;display:flex;align-items:center;justify-content:center;z-index:7;padding:0;box-shadow:0 1px 4px rgba(0,0,0,.35)}
+.ds-stamp-del:focus-visible,.ds-stamp-resize:focus-visible{outline:3px solid var(--line-2);outline-offset:1px;box-shadow:0 0 0 5px var(--cobalt)}
 /* Repeated-seal ghosts (sign-every-page preview): faint + non-interactive */
 .ds-stamp-ghost{opacity:.42;pointer-events:none !important;cursor:default;border-style:dashed}
 .ds-stamp-ghost .ds-stamp-del,.ds-stamp-ghost .ds-stamp-resize{display:none}
@@ -106,16 +106,16 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 .ds-seal-check{display:inline-flex;align-items:center;gap:7px;font-size:13px;font-weight:600;color:var(--navy);cursor:pointer;user-select:none}
 .ds-seal-check input{width:16px;height:16px;accent-color:var(--cobalt);cursor:pointer}
 .ds-seal-choice{display:flex;gap:12px;flex-wrap:wrap;width:100%}
-.ds-seal-choice .ds-seal-check{padding:8px 10px;border:1px solid var(--ink-hair);border-radius:8px;background:#fff}
-.ds-signature-sheet-preview{width:100%;max-width:820px;min-height:420px;aspect-ratio:210/297;background:#fff;border:2px solid var(--cobalt);box-shadow:0 8px 24px rgba(11,58,106,.1);margin:18px auto 22px;padding:7% 8%;box-sizing:border-box;cursor:default;position:relative;color:var(--navy)}
-.ds-sheet-page-tag{position:absolute;right:18px;top:16px;font-family:var(--mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--cobalt);background:rgba(29,78,216,.07);padding:5px 8px}
+.ds-seal-choice .ds-seal-check{padding:8px 10px;border:1px solid var(--ink-hair);border-radius:8px;background:var(--card)}
+.ds-signature-sheet-preview{width:100%;max-width:820px;min-height:420px;aspect-ratio:210/297;background:var(--card);border:2px solid var(--cobalt);box-shadow:0 8px 24px rgba(0, 0, 0, .1);margin:18px auto 22px;padding:7% 8%;box-sizing:border-box;cursor:default;position:relative;color:var(--navy)}
+.ds-sheet-page-tag{position:absolute;right:18px;top:16px;font-family:var(--mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--cobalt);background:rgba(217, 164, 65, .07);padding:5px 8px}
 .ds-sheet-title{font-size:clamp(18px,3vw,28px);font-weight:700;margin:18px 0 6px}
 .ds-sheet-sub{font-size:12px;color:var(--ink-dim);line-height:1.5;padding-bottom:16px;border-bottom:1px solid var(--ink-hair)}
 .ds-sheet-fields{display:grid;grid-template-columns:120px 1fr;gap:8px 14px;margin:22px 0;font-family:var(--mono);font-size:11px;text-align:left}
 .ds-sheet-fields dt{text-transform:uppercase;letter-spacing:.05em;color:var(--ink-dim)}
 .ds-sheet-fields dd{margin:0;word-break:break-all;color:var(--navy)}
 .ds-sheet-seal-label{font-family:var(--mono);font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-dim);margin:18px 0 8px}
-.ds-sheet-seal{width:min(390px,78%);height:135px;border:1px solid var(--cobalt);background:#fff;display:flex;flex-direction:column;overflow:hidden}
+.ds-sheet-seal{width:min(390px,78%);height:135px;border:1px solid var(--cobalt);background:var(--card);display:flex;flex-direction:column;overflow:hidden}
 @media(max-width:640px){.ds-signature-sheet-preview{min-height:360px;padding:12% 7%}.ds-sheet-fields{grid-template-columns:1fr;gap:3px}.ds-sheet-fields dd{margin-bottom:8px}.ds-sheet-seal{width:100%;height:110px}}
 /* Sticky action bar (Back / Continue) so it stays reachable on long documents */
 /* Sticky action bar so Back and Continue stay reachable on a long document.
@@ -152,11 +152,11 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 .ds-edit-btn:focus-visible{outline:none;box-shadow:var(--ring)}
 .ds-edit-tip{font-size:11px;color:var(--ink-dim)}
 .ds-edit-hint{font-size:12px;color:var(--ink-dim);margin:0 0 10px;padding:6px 10px;border:1px dashed #cdd9e8;border-radius:4px;max-width:64ch}
-.ds-anno{position:absolute;box-sizing:border-box;z-index:5;border:1px dashed var(--cobalt);background:rgba(255,255,255,.88);color:var(--navy);font-family:'Times New Roman',Times,serif;display:flex;align-items:center;padding:2px 4px;cursor:grab;touch-action:none;overflow:visible;white-space:pre;line-height:1.15}
-.ds-anno.editing{cursor:text;background:#fff;outline:2px solid var(--cobalt);border-style:solid}
-.ds-anno[data-type="date"]{font-family:var(--mono);border:2px solid var(--cobalt);background:#fff;box-shadow:0 2px 7px rgba(11,58,106,.18)}
-.ds-anno-del{position:absolute;top:-14px;left:-14px;width:28px;height:28px;border-radius:50%;background:#b00020;color:#fff;border:2px solid #fff;font-size:17px;line-height:1;cursor:pointer;display:flex;align-items:center;justify-content:center;z-index:7;padding:0;box-shadow:0 1px 4px rgba(0,0,0,.3)}
-.ds-anno-resize{position:absolute;right:-8px;bottom:-8px;width:24px;height:24px;background:var(--cobalt);border:2px solid #fff;cursor:nwse-resize;touch-action:none;z-index:7;box-shadow:0 1px 4px rgba(0,0,0,.25)}
+.ds-anno{position:absolute;box-sizing:border-box;z-index:5;border:1px dashed var(--cobalt);background:rgba(var(--tint), .88);color:var(--navy);font-family:'Times New Roman',Times,serif;display:flex;align-items:center;padding:2px 4px;cursor:grab;touch-action:none;overflow:visible;white-space:pre;line-height:1.15}
+.ds-anno.editing{cursor:text;background:var(--card);outline:2px solid var(--cobalt);border-style:solid}
+.ds-anno[data-type="date"]{font-family:var(--mono);border:2px solid var(--cobalt);background:var(--card);box-shadow:0 2px 7px rgba(0, 0, 0, .18)}
+.ds-anno-del{position:absolute;top:-14px;left:-14px;width:28px;height:28px;border-radius:50%;background:#b00020;color:var(--ink);border:2px solid var(--line-2);font-size:17px;line-height:1;cursor:pointer;display:flex;align-items:center;justify-content:center;z-index:7;padding:0;box-shadow:0 1px 4px rgba(0,0,0,.3)}
+.ds-anno-resize{position:absolute;right:-8px;bottom:-8px;width:24px;height:24px;background:var(--cobalt);border:2px solid var(--line-2);cursor:nwse-resize;touch-action:none;z-index:7;box-shadow:0 1px 4px rgba(0,0,0,.25)}
 /* Annotation types: highlight (translucent bar), note (sticky, wrapping), draw (pen stroke) */
 .ds-anno[data-type="highlight"]{background:rgba(255,214,61,.42);border:1px dashed rgba(191,146,7,.85);padding:0}
 .ds-anno[data-type="note"]{background:#fff7c9;border:1px solid #d3b334;white-space:normal;line-height:1.35;align-items:flex-start;font-family:inherit;box-shadow:0 1px 4px rgba(0,0,0,.18);padding:4px 6px}
@@ -173,7 +173,7 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 /* Touch / a11y (QA cluster E): touch has no hover, so per-page controls must be
    always visible; the sticky page-nav must clear the fixed header; and pointer
    handles need a bigger hit area than the mouse defaults. */
-.ds-anno-edit{position:absolute;top:-9px;left:14px;width:18px;height:18px;border-radius:50%;background:var(--cobalt);color:#fff;border:2px solid #fff;font-size:11px;line-height:1;cursor:pointer;display:flex;align-items:center;justify-content:center;z-index:7;padding:0}
+.ds-anno-edit{position:absolute;top:-9px;left:14px;width:18px;height:18px;border-radius:50%;background:var(--cobalt);color: var(--on-ochre);border:2px solid var(--line-2);font-size:11px;line-height:1;cursor:pointer;display:flex;align-items:center;justify-content:center;z-index:7;padding:0}
 @media (hover: none), (pointer: coarse){
   .ds-page-bar{opacity:1}
   .ds-page-nav{top:64px}
@@ -186,16 +186,16 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
   .ds-page-nav button{padding:6px 12px}
   .ds-page-nav input{width:54px;padding:6px 4px}
 }
-.ds-page-bar button{font:inherit;font-size:12px;width:26px;height:24px;padding:0;border:1px solid var(--ink-hair);background:#fff;color:var(--navy);border-radius:4px;cursor:pointer;line-height:1}
-.ds-page-bar button:hover{background:var(--cobalt);border-color:var(--cobalt);color:#fff}
-.ds-sm-band{background:var(--cobalt);color:#fff;display:flex;justify-content:space-between;align-items:center;padding:2px 5px;line-height:1;flex:0 0 auto}
+.ds-page-bar button{font:inherit;font-size:12px;width:26px;height:24px;padding:0;border:1px solid var(--ink-hair);background:var(--card);color:var(--navy);border-radius:4px;cursor:pointer;line-height:1}
+.ds-page-bar button:hover{background:var(--cobalt);border-color:var(--cobalt);color: var(--on-ochre)}
+.ds-sm-band{background:var(--cobalt);color: var(--on-ochre);display:flex;justify-content:space-between;align-items:center;padding:2px 5px;line-height:1;flex:0 0 auto}
 .ds-sm-logo{font-family:var(--mono);font-weight:700;letter-spacing:.04em;font-size:8px}
 .ds-sm-logo span{color:var(--lime)}
 .ds-sm-badge{font-family:var(--mono);font-weight:700;font-size:6px;letter-spacing:.08em}
 .ds-sm-mid{flex:1 1 auto;display:flex;align-items:center;justify-content:center;padding:2px 4px;overflow:hidden;min-height:0}
 .ds-sm-mid .ds-sm-sig-img{max-height:100%;max-width:100%;object-fit:contain}
 .ds-sm-mid .ds-sm-sig-typed{font-family:'Times New Roman',Times,serif;font-style:italic;font-size:clamp(11px,1.6vw,20px);text-align:center;line-height:1.1}
-.ds-sm-foot{display:flex;justify-content:space-between;padding:1px 5px;border-top:.5px solid rgba(11,58,106,.25);font-size:7px;line-height:1.15;flex:0 0 auto}
+.ds-sm-foot{display:flex;justify-content:space-between;padding:1px 5px;border-top:.5px solid rgba(var(--tint), .25);font-size:7px;line-height:1.15;flex:0 0 auto}
 .ds-sm-foot .ds-sm-name{font-weight:700;color:var(--navy)}
 .ds-sm-foot .ds-sm-date{color:var(--ink-dim);font-family:var(--mono)}
 .ds-sm-crypto{padding:0 5px 2px;font-family:var(--mono);font-size:6px;color:var(--ink-dim);line-height:1.1;flex:0 0 auto}
@@ -227,21 +227,21 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 .ds-success strong{display:block;margin-bottom:2px;font-size:14px}
 .ds-success span{color:var(--ink-2);font-size:12.5px}
 .ds-success-icon{flex:0 0 26px;height:26px;width:26px;background:var(--mark);color:var(--mark-on);border:0;display:flex;align-items:center;justify-content:center;font-size:15px;font-weight:700;border-radius:50%}
-#ds-signed-preview canvas{width:100%;height:auto;display:block;border:1px solid var(--ink-hair);margin-bottom:12px;background:#fff}
+#ds-signed-preview canvas{width:100%;height:auto;display:block;border:1px solid var(--ink-hair);margin-bottom:12px;background:var(--card)}
 .ds-sig-tabs{display:flex;gap:0;margin-bottom:14px;border-bottom:1px solid var(--line)}
 .ds-tab{min-height:var(--tap);padding:13px 18px;border:0;background:transparent;color:var(--ink-3);font-family:var(--mono);font-size:11px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px}
 .ds-tab:hover{color:var(--ink-1)}
 .ds-tab:focus-visible{outline:none;box-shadow:var(--ring)}
 .ds-tab.active{color:var(--ink-1);border-bottom-color:var(--accent)}
 .ds-sig-panel{padding:6px 0 0}
-#ds-sig-canvas{border:1px solid var(--ink-hair);background:#fff;width:100%;max-width:500px;height:auto;cursor:crosshair;touch-action:none;display:block}
+#ds-sig-canvas{border:1px solid var(--ink-hair);background:var(--card);width:100%;max-width:500px;height:auto;cursor:crosshair;touch-action:none;display:block}
 .ds-review-grid{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-bottom:18px}
 .ds-review-h{font-family:var(--mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-dim);font-weight:700;margin:0 0 8px}
 .ds-review-pane{background:var(--bone);border:1px solid var(--ink-hair);min-height:140px;padding:10px;display:flex;align-items:center;justify-content:center;text-align:center;position:relative;overflow:hidden}
-.ds-review-pane.has-pdf{padding:0;background:#fff;align-items:flex-start;max-height:380px;overflow-y:auto}
+.ds-review-pane.has-pdf{padding:0;background:var(--card);align-items:flex-start;max-height:380px;overflow-y:auto}
 .ds-review-pane canvas{width:100%;height:auto;display:block}
 .ds-review-pane img{max-width:100%;max-height:120px}
-.ds-review-pane .ds-mockup-stamp{position:absolute;border:1px solid var(--cobalt);background:#fff;pointer-events:none;box-sizing:border-box;overflow:hidden;display:flex;flex-direction:column;font-family:Inter,sans-serif;color:var(--navy)}
+.ds-review-pane .ds-mockup-stamp{position:absolute;border:1px solid var(--cobalt);background:var(--card);pointer-events:none;box-sizing:border-box;overflow:hidden;display:flex;flex-direction:column;font-family:Inter,sans-serif;color:var(--navy)}
 .ds-review-pane .ds-pane-meta{font-family:var(--mono);font-size:11px;color:var(--ink-dim);line-height:1.6;word-break:break-all;text-align:left;padding:6px}
 .ds-typed-preview{font-family:'Brush Script MT', cursive, sans-serif;font-size:32px;color:var(--navy);font-weight:400}
 .ds-review-cap{font-size:11px;color:var(--ink-dim);margin:0 0 8px;line-height:1.5}
@@ -319,21 +319,21 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 .ds-mode-t{font-size:17px;font-weight:600;color:var(--ink-1);letter-spacing:-.014em}
 .ds-mode-d{font-size:13.5px;color:var(--ink-2);line-height:1.55}
 .ds-mode-go{font-size:20px;color:var(--accent);transition:transform var(--d-1) var(--e-standard)}.ds-mode-card:hover .ds-mode-go{transform:translateX(3px)}
-.ds-mode-badge{display:inline-flex;width:max-content;margin-bottom:4px;padding:4px 9px;border-radius:var(--r-pill);background:var(--sig-done-bg);color:var(--sig-done);font-family:var(--mono);font-size:10px;font-weight:600;letter-spacing:.1em;text-transform:uppercase}
+.ds-mode-badge{display:inline-flex;width:max-content;margin-bottom:4px;padding:4px 9px;border-radius:var(--r-pill);background:var(--accent-soft);color:var(--accent);font-family:var(--mono);font-size:10px;font-weight:600;letter-spacing:.1em;text-transform:uppercase}
 @media(max-width:640px){.ds-mode-intro{align-items:flex-start;flex-direction:column}.ds-modes{grid-template-columns:1fr}.ds-mode-card.primary{grid-column:auto}.ds-mode-safe{white-space:normal}.ds-mode-card{padding:18px;grid-template-columns:40px 1fr auto}.ds-mode-icon{width:40px;height:40px}.ds-head{margin-bottom:24px}}
 /* PDF placement: zoom toolbar + page-nav (the stamp marker stays pointer-events:none) */
 .ds-zoom{display:flex;align-items:center;gap:8px;margin-bottom:10px}
-.ds-zoom button{font:inherit;padding:2px 10px;border:1px solid var(--ink-hair);background:#fff;border-radius:4px;cursor:pointer;line-height:1.4}
+.ds-zoom button{font:inherit;padding:2px 10px;border:1px solid var(--ink-hair);background:var(--card);border-radius:4px;cursor:pointer;line-height:1.4}
 .ds-zoom #ds-zoom-pct{font-family:var(--mono);font-size:11px;color:var(--ink-dim);min-width:42px;text-align:center}
 #ds-pdf-canvas-list{overflow:auto}
 #ds-pdf-canvas-list .ds-page-wrap{max-width:none;margin-left:auto;margin-right:auto}
-.ds-page-nav{position:sticky;top:8px;z-index:5;display:flex;align-items:center;gap:8px;width:fit-content;margin:0 auto 10px;padding:5px 12px;border:1px solid var(--ink-hair);border-radius:999px;background:rgba(255,255,255,.92);backdrop-filter:saturate(1.2) blur(2px);font:600 12px/1 Inter,sans-serif;color:var(--navy);pointer-events:none}
+.ds-page-nav{position:sticky;top:8px;z-index:5;display:flex;align-items:center;gap:8px;width:fit-content;margin:0 auto 10px;padding:5px 12px;border:1px solid var(--ink-hair);border-radius:999px;background:rgba(var(--tint), .92);backdrop-filter:saturate(1.2) blur(2px);font:600 12px/1 Inter,sans-serif;color:var(--navy);pointer-events:none}
 .ds-page-nav>*{pointer-events:auto}
 .ds-page-nav input{width:46px;text-align:center;font:inherit;border:1px solid var(--ink-hair);border-radius:6px;padding:2px 4px}
-.ds-page-nav button{border:1px solid var(--ink-hair);background:#fff;border-radius:6px;cursor:pointer;padding:2px 8px;font:inherit}
+.ds-page-nav button{border:1px solid var(--ink-hair);background:var(--card);border-radius:6px;cursor:pointer;padding:2px 8px;font:inherit}
 /* Review-step document preview: sticky zoom bar + scroll the (CSS-)zoomed content */
 .ds-review-pane.has-pdf{overflow:auto}
-.ds-rv-zoom{position:sticky;top:0;z-index:6;background:#fff;margin:0;padding:6px 4px;width:100%}
+.ds-rv-zoom{position:sticky;top:0;z-index:6;background:var(--card);margin:0;padding:6px 4px;width:100%}
 .ds-rv-zoom .ds-rv-pct{font-family:var(--mono);font-size:11px;color:var(--ink-dim);min-width:42px;text-align:center}
 
 /* ── The document layer ──────────────────────────────────────────────────────
@@ -344,7 +344,10 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
    resolves to a light blue, and a white-on-light-blue seal would preview a
    stamp that no printer will ever produce. So the document layer is pinned to
    fixed values here, on purpose, and it is the one place in the app where a
-   token is deliberately not used. */
+   token is deliberately not used, and it is why the night edition left it
+   alone: frontend/js/sign-flow.js draws the seal into the PDF with these exact
+   values, so a preview in cream on a warm dark ground would be a preview of a
+   document that does not exist. */
 .ds-page-wrap canvas,
 .ds-review-pane.has-pdf,
 .ds-signature-sheet-preview,
@@ -455,9 +458,9 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
   ]
 }
 </script>
-<meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=4">
-<script src="/js/theme.js?v=1"></script>
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/app-2026.css?v=7">
+<script src="/js/theme.js?v=4"></script>
 </head>
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -746,7 +749,7 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
         <label class="ds-dropzone" id="ds-sig-image-drop" style="padding:20px;text-align:center;display:block">
           <input type="file" id="ds-sig-image-input" accept="image/png,image/jpeg" hidden>
           <p class="big" style="font-size:13px">Click to choose a PNG/JPG (max 1 MB)</p>
-          <img id="ds-sig-image-preview" alt="" style="max-height:80px;display:none;margin:10px auto 0;background:#fff;padding:4px;border:1px solid var(--ink-hair)">
+          <img id="ds-sig-image-preview" alt="" style="max-height:80px;display:none;margin:10px auto 0;background:var(--card);padding:4px;border:1px solid var(--ink-hair)">
         </label>
       </div>
     </div>
@@ -824,7 +827,7 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
     <div class="ds-banner" id="ds-pass-panel" hidden>
       <p id="ds-pass-prompt" style="margin-bottom:10px"></p>
       <input class="ds-input" type="text" id="ds-pass-input" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code" autocapitalize="off" autocorrect="off" spellcheck="false" style="margin-bottom:8px" aria-label="Authenticator code">
-      <p id="ds-pass-err" class="ds-hint" hidden style="color:var(--danger,#b91c1c);margin-bottom:8px"></p>
+      <p id="ds-pass-err" class="ds-hint" hidden style="color:var(--danger);margin-bottom:8px"></p>
       <div class="ds-actions">
         <button class="btn btn-tertiary" id="ds-pass-cancel" type="button">Cancel</button>
         <button class="btn btn-primary" id="ds-pass-confirm" type="button">Continue</button>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">:root{color-scheme:light}html,body{background:#FBFAF7;color:#0C1B2A;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}@media(prefers-color-scheme:dark){:root[data-theme="auto"]{color-scheme:dark}html[data-theme="auto"],html[data-theme="auto"] body{background:#0A0F16;color:#EDF1F6}}html[data-theme="dark"],html[data-theme="dark"] body{background:#0A0F16;color:#EDF1F6}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}html[data-theme="light"],html[data-theme="light"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="light"]{color-scheme:light}@media (prefers-color-scheme:light){html[data-theme="auto"],html[data-theme="auto"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="auto"]{color-scheme:light}}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Create a free Paramant account</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -24,9 +24,9 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {
   display: inline-flex;
@@ -36,9 +36,9 @@
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -49,26 +49,26 @@
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -77,13 +77,13 @@
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }
@@ -174,9 +174,9 @@ main#main-content .btn { width: 100%; justify-content: center; }
   ]
 }
 </script>
-<meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=4">
-<script src="/js/theme.js?v=1"></script>
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/app-2026.css?v=7">
+<script src="/js/theme.js?v=4"></script>
 </head>
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -2,14 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-<style id="critical-css">:root{color-scheme:light}html,body{background:#FBFAF7;color:#0C1B2A;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}@media(prefers-color-scheme:dark){:root[data-theme="auto"]{color-scheme:dark}html[data-theme="auto"],html[data-theme="auto"] body{background:#0A0F16;color:#EDF1F6}}html[data-theme="dark"],html[data-theme="dark"] body{background:#0A0F16;color:#EDF1F6}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}html[data-theme="light"],html[data-theme="light"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="light"]{color-scheme:light}@media (prefers-color-scheme:light){html[data-theme="auto"],html[data-theme="auto"] body{background:#F1EAD6;color:#1B1F22}html[data-theme="auto"]{color-scheme:light}}</style>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Email verified, one step left · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/signup/verified">
-  <link rel="stylesheet" href="/design-system.css?v=25">
-  <link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+  <link rel="stylesheet" href="/design-system.css?v=28">
+  <link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
   <style>
@@ -96,9 +96,9 @@
       .faq summary { min-height: var(--tap); }
     }
   </style>
-<meta name="theme-color" content="#FBFAF7">
-<link rel="stylesheet" href="/app-2026.css?v=4">
-<script src="/js/theme.js?v=1"></script>
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/app-2026.css?v=7">
+<script src="/js/theme.js?v=4"></script>
 </head>
 <body>
 <nav class="nav">

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Service level agreement · Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -20,9 +20,9 @@
 <meta name="twitter:description" content="Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise.">
 <link rel="canonical" href="https://paramant.app/sla">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{
@@ -71,9 +71,9 @@ a:hover{opacity:.8}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -84,26 +84,26 @@ a:hover{opacity:.8}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -112,13 +112,13 @@ a:hover{opacity:.8}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>System status · Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -24,10 +24,10 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{background:var(--bone);color:var(--ink);font-family:var(--mono);font-size:15px;line-height:1.6;min-height:100vh}
@@ -39,7 +39,7 @@ a:hover{color:var(--cobalt)}
 h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
 .overall{display:flex;align-items:center;gap:10px;padding:14px 20px;font-size:14px;border:1px solid var(--ink-hair);margin-bottom:8px;transition:background .3s,border-color .3s}
 .overall.ok{background:var(--ink-ghost);border-color:var(--ink-hair)}
-.overall.degraded{background:rgba(29,78,216,.08);border-color:rgba(29,78,216,.3)}
+.overall.degraded{background:rgba(217, 164, 65, .08);border-color:rgba(217, 164, 65, .3)}
 .overall.checking{background:var(--bone-2)}
 .dot-large{width:10px;height:10px;flex-shrink:0;transition:background .3s}
 .dot-large.ok{background:var(--lime)}
@@ -50,7 +50,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
 .sector-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:12px}
 .sector-card{background:var(--bone-2);border:1px solid var(--ink-hair);padding:20px 22px;transition:border-color .3s}
 .sector-card.ok{border-color:var(--ink-hair)}
-.sector-card.degraded{border-color:rgba(29,78,216,.4)}
+.sector-card.degraded{border-color:rgba(217, 164, 65, .4)}
 .card-top{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px}
 .sector-name{font-family:var(--mono);font-size:13px;font-weight:700;letter-spacing:.06em;text-transform:uppercase}
 .dot{width:8px;height:8px;flex-shrink:0;transition:background .3s}
@@ -84,9 +84,9 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -97,26 +97,26 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -125,13 +125,13 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Terms of service · Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -20,9 +20,9 @@
 <meta name="twitter:description" content="The agreement between you and Paramantis Solutions B.V. for the use of Paramant. Plans, payment, cancellation, acceptable use, liability and Dutch law.">
 <link rel="canonical" href="https://paramant.app/terms">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{
@@ -71,9 +71,9 @@ a:hover{opacity:.8}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -84,26 +84,26 @@ a:hover{opacity:.8}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -112,13 +112,13 @@ a:hover{opacity:.8}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Trust and verification · Paramant</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -24,22 +24,22 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#0B3A6A">
+<meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
-.page-hero--navy{background:var(--navy);border-color:transparent}
-.page-hero--navy .eyebrow{background:var(--lime);color:var(--navy)}
-.page-hero--navy h1{color:var(--bone)}
-.page-hero--navy .lede{color:rgba(248,250,252,.8)}
+.page-hero--navy{background:var(--invert);border-color:transparent}
+.page-hero--navy .eyebrow{background:var(--lime);color: var(--on-ochre)}
+.page-hero--navy h1{color:var(--invert-ink)}
+.page-hero--navy .lede{color:rgba(var(--tint), .8)}
 .page-hero--navy .lede a{color:var(--lime);text-decoration:underline}
 .hero-cta{display:flex;flex-wrap:wrap;gap:14px;margin-top:20px}
-.page-hero--navy .btn-secondary{color:var(--bone);border-color:rgba(248,250,252,.45)}
-.page-hero--navy .btn-secondary:hover{background:var(--bone);color:var(--navy);border-color:var(--bone)}
+.page-hero--navy .btn-secondary{color:var(--invert-ink);border-color:rgba(var(--tint), .45)}
+.page-hero--navy .btn-secondary:hover{background:var(--bone);color:var(--navy);border-color:var(--invert-ink)}
 main{max-width:780px;margin:0 auto;padding:48px 48px 120px}
 h1{font-size:36px;font-weight:600;letter-spacing:-.03em;margin-bottom:12px}
 .lead{font-size:var(--text-base);color:var(--ink-dim);line-height:1.7;margin-bottom:48px;max-width:580px}
@@ -102,9 +102,9 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -115,26 +115,26 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -143,13 +143,13 @@ code{font-family:var(--mono);font-size:.92em;color:var(--cobalt)}
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }

--- a/frontend/vault.html
+++ b/frontend/vault.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}[hidden]{display:none !important}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}[hidden]{display:none !important}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Lock a file with a passphrase · Paramant</title>
 <meta name="twitter:description" content="Lock any file with a passphrase before you store or share it. Everything happens on this device; the file and the passphrase never leave your browser.">
@@ -20,8 +20,8 @@
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="canonical" href="https://paramant.app/vault">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=25">
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/design-system.css?v=28">
 <style>
 .vt-bar{display:flex;align-items:center;justify-content:space-between;padding:14px 24px;border-bottom:1px solid var(--ink-hair)}
 .vt-brand{font-family:var(--mono);font-size:13px;font-weight:700;letter-spacing:.04em;color:var(--navy);text-decoration:none}
@@ -34,24 +34,23 @@
 .vt-lede{font-size:14px;color:var(--ink-dim);line-height:1.7;margin:0 0 26px}
 .vt-tabs{display:flex;gap:8px;margin-bottom:22px}
 .vt-tab{flex:1;padding:14px;border:1px solid var(--ink-hair);background:var(--bone);color:var(--ink-dim);font-family:var(--mono);font-size:13px;font-weight:600;letter-spacing:.02em;cursor:pointer;border-radius:12px;text-align:center;transition:all .14s}
-.vt-tab.on{border-color:var(--cobalt);color:var(--navy);background:rgba(11,58,106,.05)}
-.vt-card{background:#fff;border:1px solid var(--ink-hair);border-radius:16px;padding:24px}
+.vt-tab.on{border-color:var(--cobalt);color:var(--navy);background:rgba(var(--tint), .05)}
+.vt-card{background:var(--card);border:1px solid var(--ink-hair);border-radius:16px;padding:24px}
 .vt-drop{border:2px dashed var(--ink-hair);background:var(--bone);border-radius:14px;padding:36px 20px;text-align:center;cursor:pointer;transition:all .14s;outline:none}
-.vt-drop:hover,.vt-drop:focus-visible,.vt-drop.drag{border-color:var(--cobalt);background:rgba(11,58,106,.04)}
+.vt-drop:hover,.vt-drop:focus-visible,.vt-drop.drag{border-color:var(--cobalt);background:rgba(var(--tint), .04)}
 .vt-drop .big{font-size:16px;font-weight:600;color:var(--navy);margin:0 0 4px}
 .vt-drop .small{font-size:12px;color:var(--ink-dim);margin:0}
-.vt-info{margin-top:12px;font-family:var(--mono);font-size:12px;color:var(--navy);background:var(--bone-2,rgba(11,58,106,.04));border:1px solid var(--ink-hair);border-radius:10px;padding:10px 12px;word-break:break-all}
+.vt-info{margin-top:12px;font-family:var(--mono);font-size:12px;color:var(--navy);background:var(--bone-2,rgba(var(--tint), .04));border:1px solid var(--ink-hair);border-radius:10px;padding:10px 12px;word-break:break-all}
 .vt-field{margin-top:16px}
 .vt-label{display:block;font-family:var(--mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:6px}
 .vt-input{width:100%;box-sizing:border-box;padding:12px 14px;border:1px solid var(--ink-hair);border-radius:10px;background:var(--bone);color:var(--ink);font-family:var(--mono);font-size:14px}
 .vt-input:focus{outline:none;border-color:var(--cobalt)}
 .vt-run{width:100%;margin-top:20px;min-height:48px;font-size:15px}
 .vt-status{margin-top:16px;padding:12px 14px;border-radius:10px;font-size:13px;line-height:1.5;border:1px solid var(--ink-hair);background:var(--bone)}
-.vt-status.ok{border-color:var(--lime);background:rgba(178,255,63,.14);color:var(--navy)}
-.vt-status.err{border-color:rgba(200,30,30,.5);background:rgba(255,80,80,.06);color:rgba(170,20,20,1)}
+.vt-status.ok{border-color:var(--lime);background:rgba(217, 164, 65, .14);color:var(--navy)}
+.vt-status.err{border-color:rgba(196, 96, 79, .5);background:rgba(196, 96, 79, .06);color:rgba(170,20,20,1)}
 .vt-note{margin-top:22px;font-size:12px;color:var(--ink-dim);line-height:1.6;text-align:center}
-.vt-tech{margin-top:8px;font-family:var(--mono);font-size:11px;color:var(--ink-dim);line-height:1.6;text-align:center}
-.vt-warn{margin:20px 0;padding:14px 16px;border:1px solid #d4a017;background:#fff4d6;border-radius:10px;color:#5a3f00;font-size:13px}
+.vt-warn{margin:20px 0;padding:14px 16px;border:1px solid #d4a017;background:var(--card);border-radius:10px;color:var(--warn-ink);font-size:13px}
 </style>
 <script type="application/ld+json" data-paramant-seo="1">
 {

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Check a signed document or a delivery receipt · Paramant</title>
 <meta property="og:site_name" content="Paramant">
@@ -20,12 +20,11 @@
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="canonical" href="https://paramant.app/verify">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<meta name="theme-color" content="#0B3A6A">
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
-<link rel="stylesheet" href="/components-parasign.css?v=3">
-<link rel="stylesheet" href="/receipt-verify.css?v=1">
+<meta name="theme-color" content="#15191C">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
+<link rel="stylesheet" href="/components-parasign.css?v=6">
 <script type="application/ld+json" data-paramant-seo="1">
 {
   "@context": "https://schema.org",

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<style id="critical-css">html,body{background:#F8FAFC;color:#0B3A6A;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}</style>
+<style id="critical-css">html,body{background:#15191C;color:#EAE2CE;margin:0;padding:0;font-family:Inter,system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased}body{min-height:100vh}.skip-link{position:absolute;top:-200px;left:0;z-index:10000}.skip-link:focus{top:0}[hidden]{display:none !important}img,svg{max-width:100%;display:block}html{color-scheme:dark}</style>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Paramant compared to Zivver, Tresorit and WeTransfer</title>
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
@@ -20,9 +20,9 @@
 <meta name="twitter:description" content="How Paramant compares to Zivver, Tresorit, WeTransfer and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting.">
 <link rel="canonical" href="https://paramant.app/vs">
 
-<link rel="stylesheet" href="/design-system.css?v=25">
-<link rel="stylesheet" href="/nav.css?v=21">
-<link rel="stylesheet" href="/relay-pulse.css?v=1">
+<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>
 .nav-help {
@@ -33,9 +33,9 @@
   font-family: IBM Plex Mono, monospace;
   font-size: 12px;
   letter-spacing: 0.1em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border: 1px solid #E2E8F0;
+  border: 1px solid var(--ink-hair);
   transition: all 140ms ease;
   margin-right: 12px;
 }
@@ -46,26 +46,26 @@
   justify-content: center;
   width: 16px;
   height: 16px;
-  border: 1.5px solid #64748b;
+  border: 1.5px solid var(--ink-dim);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
-  color: #64748b;
+  color: var(--ink-dim);
   font-family: Inter, sans-serif;
   line-height: 1;
 }
 .nav-help:hover {
-  color: #0B3A6A;
-  border-color: #B2FF3F;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  border-color: var(--ochre);
+  background: rgba(217, 164, 65, 0.08);
 }
 .nav-help:hover::before {
-  border-color: #0B3A6A;
-  color: #0B3A6A;
-  background: #B2FF3F;
+  border-color: var(--line-2);
+  color: var(--on-ochre);
+  background: var(--ochre);
 }
 .nav-help:focus-visible {
-  outline: 2px solid #B2FF3F;
+  outline: 2px solid var(--ochre);
   outline-offset: 2px;
 }
 .nav-help-mobile {
@@ -74,13 +74,13 @@
   font-family: IBM Plex Mono, monospace;
   font-size: 13px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ink-hair);
 }
 .nav-help-mobile:hover {
-  color: #0B3A6A;
-  background: rgba(178, 255, 63, 0.08);
+  color: var(--ink);
+  background: rgba(217, 164, 65, 0.08);
 }
 @media (max-width: 900px) {
   .nav-help { display: none; }
@@ -355,9 +355,9 @@
     </table>
 
     <div style="margin-top:24px;display:flex;gap:24px;font-family:var(--mono);font-size:11px;color:var(--ink-dim);letter-spacing:0.1em;text-transform:uppercase">
-      <span><strong style="color:#1D4ED8">✓</strong> supported / available</span>
-      <span><strong style="color:rgba(11,58,106,.65)">~</strong> partial / limited</span>
-      <span><strong style="color:rgba(11,58,106,.45)">✗</strong> not available</span>
+      <span><strong style="color:var(--cobalt)">✓</strong> supported / available</span>
+      <span><strong style="color:rgba(var(--tint), .65)">~</strong> partial / limited</span>
+      <span><strong style="color:rgba(var(--tint), .45)">✗</strong> not available</span>
     </div>
   </div>
 </section>
@@ -476,15 +476,15 @@
   <div class="container">
     <div class="marker">
       <div class="num">04</div>
-      <h2 style="color:var(--bone)">Where Paramant is genuinely different.</h2>
-      <div class="tag" style="color:rgba(248,250,252,.72)">architecture<br/>matters</div>
+      <h2 style="color:var(--invert-ink)">Where Paramant is genuinely different.</h2>
+      <div class="tag" style="color:rgba(var(--tint), .72)">architecture<br/>matters</div>
     </div>
 
-    <p style="color:var(--bone);max-width:720px">Paramant occupies a specific position. It is a post-quantum encrypted file relay and document-signing service, with RAM-only storage, burn-on-read delivery, and public cryptographic transparency. It is not a cloud storage product, not an email plugin, and not a DLP platform.</p>
+    <p style="color:var(--invert-ink);max-width:720px">Paramant occupies a specific position. It is a post-quantum encrypted file relay and document-signing service, with RAM-only storage, burn-on-read delivery, and public cryptographic transparency. It is not a cloud storage product, not an email plugin, and not a DLP platform.</p>
 
-    <p style="color:var(--bone);max-width:720px;margin-top:16px">For organizations that need the combination of EU data sovereignty (without US ownership), post-quantum cryptography (today, not roadmap), zero-knowledge architecture (mathematically, not by policy), and the option to self-host, Paramant is presently the only option in this category.</p>
+    <p style="color:var(--invert-ink);max-width:720px;margin-top:16px">For organizations that need the combination of EU data sovereignty (without US ownership), post-quantum cryptography (today, not roadmap), zero-knowledge architecture (mathematically, not by policy), and the option to self-host, Paramant is presently the only option in this category.</p>
 
-    <p style="color:var(--bone);max-width:720px;margin-top:16px">For any other use case, one of the alternatives above is likely a better fit. That honesty is the point.</p>
+    <p style="color:var(--invert-ink);max-width:720px;margin-top:16px">For any other use case, one of the alternatives above is likely a better fit. That honesty is the point.</p>
 
     <div style="margin-top:48px;display:flex;gap:16px;flex-wrap:wrap">
       <a href="/dashboard" class="btn btn-primary">Open your dashboard</a>

--- a/tests/access-log-visitors.test.mjs
+++ b/tests/access-log-visitors.test.mjs
@@ -36,7 +36,7 @@ test('a client that renders is not excluded for lacking a referer', () => {
   // exclude every genuine visitor on this site.
   const r = analyse([
     line({ ip: '8.8.8.8', path: '/sign' }),
-    line({ ip: '8.8.8.8', path: '/design-system.css?v=25' }),
+    line({ ip: '8.8.8.8', path: '/design-system.css?v=28' }),
     line({ ip: '8.8.8.8', path: '/sign-flow.js?v=51' }),
   ]);
   assert.equal(r.atMostVisitors, 1);
@@ -49,7 +49,7 @@ test('a crawler that really renders is reported apart, not as a person', () => {
   const ua = 'Mozilla/5.0 (compatible; heritrix/3.14.2-SNAPSHOT-20250101 +http://archive.org)';
   const r = analyse([
     line({ ip: '7.7.7.7', path: '/', ua }),
-    line({ ip: '7.7.7.7', path: '/nav.css?v=21', ua }),
+    line({ ip: '7.7.7.7', path: '/nav.css?v=23', ua }),
   ]);
   assert.equal(r.atMostVisitors, 0, 'a named crawler was counted as a possible visitor');
   assert.equal(r.verdicts.declared_automation, 1);

--- a/tests/app-theme.test.mjs
+++ b/tests/app-theme.test.mjs
@@ -1,29 +1,31 @@
-// Dark is a choice, never a jump.
+// The night is the ground. The paper is a choice, never a jump.
 //
-// What was measured on 2026-09-03, before this gate existed: with
-// prefers-color-scheme: dark and nobody having chosen anything, /index and
-// /pricing stayed light while /dashboard, /sign, /parashare, /account and
-// /auth/login came up on rgb(10, 15, 22). A reader on a dark operating system
-// went from creme to black by signing in, and had no way to say no. That is the
-// one thing this suite exists to keep from coming back.
+// What this file measured before the night edition was the opposite case: with
+// prefers-color-scheme: dark and nobody having chosen anything, the app screens
+// went to rgb(10, 15, 22) while the marketing pages stayed creme, so signing in
+// threw a reader from creme to black. The site now stands on one ground on
+// every page, so that jump cannot happen at all: /index, /pricing, /dashboard,
+// /sign, /parashare, /account and /auth/login all come up on the same warm
+// night. What is left to guard is the mirror image of the old rule, and the
+// switch on /account that carries it.
 //
 // The rule it measures:
 //
-//   no choice   -> light, whatever the operating system says
-//   'light'     -> light, whatever the operating system says
-//   'dark'      -> dark,  whatever the operating system says
+//   no choice   -> the night, whatever the operating system says
+//   'dark'      -> the night, whatever the operating system says
+//   'light'     -> the cream paper, whatever the operating system says
 //   'auto'      -> the operating system decides, because someone asked it to
 //
-// and the marketing pages stay light in every one of those cases, which is what
-// the text next to the switch on /account promises.
+// and the marketing pages stay on the night in every one of those cases, which
+// is what the text next to the switch on /account says.
 //
 // It has to be a browser. The gate is a media query scoped to an attribute that
 // a script writes during head parsing, so the answer is a cascade over a DOM
 // state, and only the browser can flatten those into one background colour.
 //
-// The last test in the file takes the gate out and checks the screens go dark
-// again. Without that, a suite like this one passes just as happily against a
-// site that has no dark mode at all.
+// The last test in the file takes the gate out and checks the screens go light
+// again on a light system. Without that, a suite like this one passes just as
+// happily against a site that has no second theme at all.
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -38,8 +40,8 @@ const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
 const THEME_KEY = 'paramant.theme.v1';
 
 // The two page grounds, from --paper in frontend/app-2026.css.
-const LIGHT = 'rgb(251, 250, 247)';
-const DARK = 'rgb(10, 15, 22)';
+const LIGHT = 'rgb(241, 234, 214)';
+const DARK = 'rgb(21, 25, 28)';
 
 const TYPES = { '.js':'text/javascript','.mjs':'text/javascript','.css':'text/css','.html':'text/html','.svg':'image/svg+xml','.png':'image/png','.json':'application/json','.woff2':'font/woff2' };
 const ROUTES = {
@@ -83,16 +85,16 @@ async function stubApi(page) {
   await page.route('**/api/user/documents**', (r) => r.fulfill({ status:200, contentType:'application/json', body:'{"documents":[]}' }));
 }
 
-// Serve the pages back with the gate taken out: [data-theme="auto"] becomes the
-// :not([data-theme="light"]) it replaced, in the stylesheet and in every page's
-// critical <style>. That is the code as it stood before this change, and under
-// a dark system with no choice made it must go dark again.
+// Serve the pages back with the gate taken out: [data-theme="auto"] becomes a
+// :not([data-theme="dark"]), in the stylesheet and in every page's critical
+// <style>. That is a site whose second theme follows the operating system on
+// its own, and under a light system with no choice made it must go light.
 async function withoutTheGate(page) {
   await page.route('**/*', async (route) => {
     const response = await route.fetch();
     const type = response.headers()['content-type'] || '';
     if (!/html|css/.test(type)) return route.fulfill({ response });
-    const body = (await response.text()).split('[data-theme="auto"]').join(':not([data-theme="light"])');
+    const body = (await response.text()).split('[data-theme="auto"]').join(':not([data-theme="dark"])');
     return route.fulfill({ response, body });
   });
 }
@@ -129,17 +131,17 @@ const MARKETING = ['/', '/pricing'];
 
 const browser = await chromium.launch({ headless:true, ...(EXE ? { executablePath:EXE } : {}) });
 
-test('a dark system with no choice made leaves every app screen light', async () => {
+test('a light system with no choice made leaves every app screen on the night', async () => {
   const wrong = [];
   for (const url of APP) {
-    const seen = await ground(browser, { url, system:'dark', choice:null });
-    if (seen.body !== LIGHT) wrong.push(`${url}: body is ${seen.body}, expected ${LIGHT}`);
+    const seen = await ground(browser, { url, system:'light', choice:null });
+    if (seen.body !== DARK) wrong.push(`${url}: body is ${seen.body}, expected ${DARK}`);
     if (seen.attribute !== null) wrong.push(`${url}: <html data-theme="${seen.attribute}"> without anyone choosing it`);
-    if (seen.chrome !== '#FBFAF7') wrong.push(`${url}: theme-color is ${seen.chrome}, expected #FBFAF7`);
+    if (seen.chrome !== '#15191C') wrong.push(`${url}: theme-color is ${seen.chrome}, expected #15191C`);
   }
   assert.deepEqual(wrong, [],
-    '\n  A dark operating system must not darken the app on its own. That is the\n' +
-    '  jump from creme to black at sign-in this gate exists to prevent.\n\n  ' +
+    '\n  A light operating system must not lift the app off the night on its own.\n' +
+    '  The night is the ground of the whole site; the paper is asked for.\n\n  ' +
     wrong.join('\n  ') + '\n');
 });
 
@@ -159,10 +161,10 @@ test('the choice "dark" darkens every app screen, on a light system too', async 
     const seen = await ground(browser, { url, system:'light', choice:'dark' });
     if (seen.body !== DARK) wrong.push(`${url}: body is ${seen.body}, expected ${DARK}`);
     if (seen.attribute !== 'dark') wrong.push(`${url}: <html data-theme="${seen.attribute}">, expected "dark"`);
-    if (seen.chrome !== '#0A0F16') wrong.push(`${url}: theme-color is ${seen.chrome}, expected #0A0F16`);
+    if (seen.chrome !== '#15191C') wrong.push(`${url}: theme-color is ${seen.chrome}, expected #15191C`);
   }
   assert.deepEqual(wrong, [],
-    '\n  A dark mode nobody can switch on is not a dark mode.\n\n  ' + wrong.join('\n  ') + '\n');
+    '\n  A choice nobody can make is not a choice.\n\n  ' + wrong.join('\n  ') + '\n');
 });
 
 test('the choice "auto" hands the decision back to the operating system', async () => {
@@ -176,17 +178,20 @@ test('the choice "auto" hands the decision back to the operating system', async 
   assert.deepEqual(wrong, [], '\n  ' + wrong.join('\n  ') + '\n');
 });
 
-test('the marketing pages stay light in every case, which is what /account promises', async () => {
+test('the marketing pages stay on the night in every case, which is what /account promises', async () => {
   const wrong = [];
   for (const url of MARKETING) {
-    for (const choice of [null, 'auto', 'dark']) {
-      const seen = await ground(browser, { url, system:'dark', choice });
-      if (seen.body === DARK) wrong.push(`${url} with choice ${choice}: body is ${seen.body}`);
+    for (const choice of [null, 'auto', 'light']) {
+      const seen = await ground(browser, { url, system:'light', choice });
+      // The homepage paints its ground with a gradient, so its computed
+      // backgroundColor is transparent and never equals a hex. What matters is
+      // that it never becomes the paper.
+      if (seen.body === LIGHT) wrong.push(`${url} with choice ${choice}: body is ${seen.body}, which is the paper`);
     }
   }
   assert.deepEqual(wrong, [],
-    '\n  The switch on /account says the public pages stay light. Either the pages\n' +
-    '  changed or the sentence has to.\n\n  ' + wrong.join('\n  ') + '\n');
+    '\n  The switch on /account says the public pages stay on the night. Either the\n' +
+    '  pages changed or the sentence has to.\n\n  ' + wrong.join('\n  ') + '\n');
 });
 
 // ── the switch itself ────────────────────────────────────────────────────────
@@ -202,24 +207,24 @@ test('/account offers the three choices and picking one repaints the page', asyn
     (nodes) => nodes.map((node) => node.value));
   assert.deepEqual(values, ['auto', 'light', 'dark'], 'the switch must offer exactly Systeem / Licht / Donker');
 
-  assert.equal(await page.evaluate(() => getComputedStyle(document.body).backgroundColor), LIGHT,
-    'a fresh browser starts light');
+  assert.equal(await page.evaluate(() => getComputedStyle(document.body).backgroundColor), DARK,
+    'a fresh browser starts on the night');
 
   // Click the label, the way a reader does: the radio itself is 0x0 by design
   // and the <span> is the 44px target (see .theme-choice in app-2026.css).
-  await page.locator('#theme-choice input[value="dark"] + span').click();
+  await page.locator('#theme-choice input[value="light"] + span').click();
   await page.waitForTimeout(120);
-  assert.equal(await page.locator('#theme-choice input[value="dark"]').isChecked(), true,
+  assert.equal(await page.locator('#theme-choice input[value="light"]').isChecked(), true,
     'clicking the label must select the radio it belongs to');
-  assert.equal(await page.evaluate(() => getComputedStyle(document.body).backgroundColor), DARK,
-    'picking Dark must darken the page you are standing on');
-  assert.equal(await page.evaluate((key) => window.localStorage.getItem(key), THEME_KEY), 'dark',
+  assert.equal(await page.evaluate(() => getComputedStyle(document.body).backgroundColor), LIGHT,
+    'picking Light must repaint the page you are standing on');
+  assert.equal(await page.evaluate((key) => window.localStorage.getItem(key), THEME_KEY), 'light',
     'the choice must survive the next page load');
 
   // And it comes back on the next screen, not just this one.
   await page.goto(ORIGIN + '/dashboard', { waitUntil:'load' });
   await page.waitForTimeout(120);
-  assert.equal(await page.evaluate(() => getComputedStyle(document.body).backgroundColor), DARK,
+  assert.equal(await page.evaluate(() => getComputedStyle(document.body).backgroundColor), LIGHT,
     'the choice must carry to the other app screens');
 
   await context.close();
@@ -254,17 +259,17 @@ test('every page that loads app-2026.css also loads the theme script', () => {
 
 // ── the sabotage ─────────────────────────────────────────────────────────────
 
-test('sabotage: with the [data-theme="auto"] gate removed the screens go dark again', async () => {
-  const stillLight = [];
+test('sabotage: with the [data-theme="auto"] gate removed the screens go light again', async () => {
+  const stillNight = [];
   for (const url of APP) {
-    const seen = await ground(browser, { url, system:'dark', choice:null, sabotage:true });
-    if (seen.body !== DARK) stillLight.push(`${url}: body is ${seen.body}, expected ${DARK} without the gate`);
+    const seen = await ground(browser, { url, system:'light', choice:null, sabotage:true });
+    if (seen.body !== LIGHT) stillNight.push(`${url}: body is ${seen.body}, expected ${LIGHT} without the gate`);
   }
-  assert.deepEqual(stillLight, [],
-    '\n  The gate was taken out and the screens stayed light anyway, so the four\n' +
-    '  tests above are not measuring the thing they claim to measure. Either the\n' +
-    '  dark tokens moved somewhere this rewrite no longer reaches, or the dark\n' +
-    '  mode is gone.\n\n  ' + stillLight.join('\n  ') + '\n');
+  assert.deepEqual(stillNight, [],
+    '\n  The gate was taken out and the screens stayed on the night anyway, so the\n' +
+    '  four tests above are not measuring the thing they claim to measure. Either\n' +
+    '  the paper tokens moved somewhere this rewrite no longer reaches, or the\n' +
+    '  second theme is gone.\n\n  ' + stillNight.join('\n  ') + '\n');
 });
 
 test.after(async () => { await browser.close(); host.close(); });

--- a/tests/navigation-shell.test.mjs
+++ b/tests/navigation-shell.test.mjs
@@ -54,8 +54,11 @@ const publicMobilePaint = await publicPage.locator('nav.nav').evaluate((node) =>
   webkitBackdropFilter: getComputedStyle(node).getPropertyValue('-webkit-backdrop-filter'),
   paper: getComputedStyle(document.body).backgroundColor,
 }));
-// Pinned to the bone hex until 4 September 2026; the homepage now paints the bar in the night colour, so the pin is what it always guarded: fully opaque, no blur.
-ok('mobile navigation is opaque before opening the menu', /^rgb\(/.test(publicMobilePaint.background) && publicMobilePaint.backdropFilter === 'none' && (!publicMobilePaint.webkitBackdropFilter || publicMobilePaint.webkitBackdropFilter === 'none'), JSON.stringify(publicMobilePaint));
+// The pin was loosened to "any opaque rgb" while the homepage painted the bar
+// itself and the rest of the site was still bone. The night is the design
+// system now, so the bar has one colour on every page again and the hex can be
+// named: nav.css paints it with --bone under 1024px, and --bone is the night.
+ok('mobile navigation is opaque before opening the menu', publicMobilePaint.background === 'rgb(21, 25, 28)' && publicMobilePaint.backdropFilter === 'none' && (!publicMobilePaint.webkitBackdropFilter || publicMobilePaint.webkitBackdropFilter === 'none'), JSON.stringify(publicMobilePaint));
 await publicPage.locator('#nav-hamburger').click();
 await publicPage.waitForFunction(() => {
   const nav = document.querySelector('nav.nav')?.getBoundingClientRect();

--- a/tests/theme-contrast.test.mjs
+++ b/tests/theme-contrast.test.mjs
@@ -9,25 +9,28 @@
 // prijs, de limiet en de kleine letter draagt. Dat is niet te zien met het
 // blote oog en het is wel het verschil tussen voldoen en niet voldoen.
 //
-// design-system.css v4.1 zet --ink-dim (en de v3-aliassen --lime-dim en
-// --black-dim) op --ink-2, #40505F, 7.95:1 op het papier. Wat er van die 336
-// overblijft staat hieronder met naam en toenaam in KNOWN_LIGHT, en alle
-// overgebleven gevallen zitten in het style-blok van een pagina en niet in het
-// ontwerpsysteem. Die lijst mag korter worden en nooit langer: een nieuwe regel
-// eronder is een regressie, ook als niemand hem ziet.
+// design-system.css v4.1 zette --ink-dim op #40505F en bracht dat terug tot
+// vier bekende gevallen. design-system.css v5.0, de nachtronde, zet de hele
+// site op de nacht en heeft die laatste vier ook opgelost, in de kleur. De
+// KNOWN_LIGHT-lijst hieronder is daarom leeg. Hij mag korter worden en nooit
+// langer: een nieuwe regel eronder is een regressie, ook als niemand hem ziet.
 //
 // De meting zelf. Voor elk tekstknooppunt wordt de tekstkleur afgevlakt tegen
 // de eerste ondoorzichtige achtergrond erboven, precies zoals een browser hem
 // samenstelt, en dan door de WCAG 2.1 relatieve-luminantie formule gehaald.
 // 4.5:1 voor gewone tekst, 3:1 voor groot (>=24px, of >=18.66px vetgedrukt).
 //
-// GEEN DONKERE MODUS. Een eerdere versie van dit bestand mat ook donker, tegen
-// een donkere tokenset die achter [data-theme] stond zonder schakelaar in de
-// nav. Die laag is uit de tak gehaald: hij was op /security, /pricing en het
-// dashboard onleesbaar (wit op lime, 1.07:1) en kostte 31 KB op elke pagina.
-// Wat hier overblijft is de meting die wel iets bewaakt wat een bezoeker
-// vandaag ziet. Komt donker terug, dan komt de tweede helft van dit bestand
-// mee terug, met een schakelaar en met nul open gevallen.
+// WAT "LIGHT" HIER NOG BETEKENT. De pagina's staan sinds de nachtronde alle
+// zestien op de nacht: warme donkere grond, creme inkt, een okeren accent. De
+// browser wordt hier nog steeds op colorScheme 'light' gezet, en dat is met
+// opzet: het bewijst dat een bezoeker met een licht besturingssysteem exact
+// dezelfde pagina krijgt, want de marketingpagina's laden de schakelaar niet
+// en kennen dus maar een grond. De meting zelf is niet veranderd; alleen de
+// kleuren eronder zijn dat.
+//
+// De schakelaar met drie standen zit op de app-schermen en wordt gemeten door
+// tests/app-theme.test.mjs (welke grond) en tests/app-contrast.test.mjs (of
+// beide gronden leesbaar zijn).
 //
 // Run: node --test tests/theme-contrast.test.mjs
 import { chromium } from 'playwright';
@@ -55,35 +58,20 @@ const aliases = {
 const PAGES = Object.keys(aliases);
 const SIZES = [[390, 844], [1440, 900]];
 
-// Wat er na de tokenfix overbleef, elk met de reden dat hij er nog staat.
-// Alles wat hier niet in staat is een regressie. Het formaat is pagina +
-// selector, want de kleurwaarden veranderen mee met het merk en de plek niet.
+// Wat er na de tokenfix overbleef. Alles wat hier niet in staat is een
+// regressie. Het formaat is pagina + selector, want de kleurwaarden veranderen
+// mee met het merk en de plek niet.
 //
-// Geen van de vier komt uit het ontwerpsysteem: alle vier staan als letterlijke
-// kleur in het style-blok van de pagina zelf, en alle vier stonden er al voor
-// deze tak. Ze horen bij de groep die zo'n scherm onder handen neemt, niet bij
-// een tokenronde die geen woord tekst en geen pagina-CSS aanraakt.
+// Deze lijst is leeg. Hij stond op vier: de primaire knop van /about in cobalt
+// op cobalt, het lime vinkje van /security op papier, en twee gevallen in het
+// style-blok van /docs. De nachtronde heeft alle vier opgelost in de kleur en
+// niet in de lijst. De knop van /about was het enige geval dat de nacht niet
+// vanzelf meenam: `.about-band p a{color:var(--cobalt)}` pakte ook de knop in
+// die alinea, en dat is nu `a:not(.btn)`.
 //
-// De statusregel van /parashare stond hier ook, op rgba(248,250,252,.65),
-// bijna-wit op bijna-wit. #381 heeft hem opgelost, dus hij is hier weg. De
-// mono-kicker van de homepage stond hier ook, op 4.31:1 tegen het tweede
-// papier (#F3F0E8). #389 heeft --hp-ink-3 van #66727F naar #5F6B78 gezet en
-// daarmee haalt hij 4.78:1 tegen dat papier en 5.12:1 tegen #FAF8F3, dus hij
-// is hier weg. Zo hoort deze lijst te bewegen: korter, nooit langer.
-const KNOWN_LIGHT = [
-  // about.html geeft de primaire knop cobalt tekst op een cobalt vlak.
-  { slug: '/about', sel: 'a.btn.btn-primary' },
-  // security.html zet het vinkje in lime op papier: 1.16:1. Lime is 1.17 op
-  // papier en dus per definitie nooit tekst. Het vinkje is hier bullet en geen
-  // inhoud: de zin ernaast draagt de betekenis volledig. Lime hier vervangen is
-  // een merkbesluit en geen herstel, dus het staat hier met naam in plaats van
-  // dat het stil wordt weggepoetst.
-  { slug: '/security', sel: 'span.check' },
-  // docs.html zet inline code en links op gekleurde blokken zonder de
-  // tekstkleur mee te kantelen. Vier gevallen, alle vier in dat style-blok.
-  { slug: '/docs', sel: 'code' },
-  { slug: '/docs', sel: 'a' },
-];
+// De lijst mag korter worden en nooit langer: een nieuwe regel eronder is een
+// regressie, ook als niemand hem ziet.
+const KNOWN_LIGHT = [];
 
 const server = http.createServer((req, res) => {
   let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
@@ -181,12 +169,13 @@ test('every page clears WCAG AA in light, and the known page defects do not grow
     measured += result.measured;
     for (const hit of result.uniq) {
       const known = KNOWN_LIGHT.find((k) => k.slug === slug && k.sel === hit.sel);
-      if (known) { stillThere.add(`${slug} ${hit.sel}`); continue; }
+      if (known) { stillThere.add(`${slug} ${hit.sel}: ${hit.c}:1 (needs ${hit.need}), ${hit.color} on ${hit.bg}, "${hit.text}"`); continue; }
       unexpected.push(`${slug} ${hit.sel}: ${hit.c}:1 (needs ${hit.need}), ${hit.color} on ${hit.bg}, "${hit.text}"`);
     }
   }
   t.diagnostic(`light: ${measured} text pairs measured across ${PAGES.length} pages at 390 and 1440`);
   t.diagnostic(`light: ${stillThere.size} of the ${KNOWN_LIGHT.length} known page defects still present`);
+  for (const one of stillThere) t.diagnostic(`light: still on the known list: ${one}`);
   assert.deepEqual(unexpected, [],
     `New contrast failures in light mode. Every one of these is below WCAG AA and none of them is on the known list:\n  ${unexpected.join('\n  ')}\n`
     + 'Fix the colour, or, if it is a deliberate page-owned defect that predates this run, add it to KNOWN_LIGHT with the reason. Do not loosen the ratio.');

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -1853,12 +1853,12 @@ console.log('ui-truthfulness: the rules page is Our rules on /rules, with /parar
   assert.doesNotMatch(themeJs, /fetch\(|XMLHttpRequest|navigator\.sendBeacon/,
     'theme.js must not send the choice anywhere; /account and /privacy both say it stays in the browser');
 
-  assert.match(account, /Light is the default and it stays light until you change it here/,
-    '/account must say that light is the default, because app-2026.css makes it so');
+  assert.match(account, /Dark is the default and it stays dark until you change it here/,
+    '/account must say that the night is the default, because app-2026.css makes it so');
   assert.match(account, /kept in this\s+browser only/,
     '/account must say the choice never leaves the browser');
-  assert.match(account, /The public pages stay light\./,
-    '/account promises the marketing pages stay light; tests/app-theme.test.mjs measures that');
+  assert.match(account, /The public pages stay dark\./,
+    '/account promises the marketing pages stay on the night; tests/app-theme.test.mjs measures that');
 })();
 
 console.log('ui-truthfulness: the appearance switch says only what theme.js and app-2026.css do');


### PR DESCRIPTION
PR #404 put the homepage in the same hand as BeerWeer. It did that in a `<style>`
block on /index that re-pointed the design-system tokens for that one page.
Everything a visitor opened after it was still the old bone-and-cobalt site, so
the homepage read as a different product than the thing it sells. This moves the
night into the system, where it belongs.

## What changed

**frontend/design-system.css v5.0** carries the palette instead of /index:
`--night` #15191C into #101316, `--cream` #EAE2CE with a dim at 62% and
hairlines at 16%, cards at 4.5% with a 16px radius, `--ochre` #D9A441 with
`--on-ochre` #141414 as the ink on it, `--petrol` as the second accent,
`--brick` for a fault, and the cream paper #F1EAD6 with ink #1B1F22 for the one
inverted surface. Every old name survives as an alias: `--bone`, `--bone-2`,
`--navy`, `--ink`, `--ink-2`, `--ink-dim`, `--ink-hair`, `--cobalt`, `--lime`,
`--black`, `--doc-bg`. No page had to be rewritten to follow.

Cobalt and lime are gone as colours; their tokens point at the ochre. Focus rings
are ochre. A filled button is ochre with #141414 on it; an outlined one is a
cream hairline on the card tint. A block that used to be a navy slab with bone
text is now `--invert`, a slab cut deeper than the night with the same cream ink.

**frontend/app-2026.css** carries the same night as its default and the cream
paper as the second half. The three-way switch on /account keeps working and
keeps holding, with the rule mirrored:

| choice | result |
|---|---|
| no choice | the night, whatever the operating system says |
| `dark` | the night, whatever the operating system says |
| `light` | the cream paper, whatever the operating system says |
| `auto` | the operating system decides, because someone asked it to |

`js/theme.js` still applies the choice before the first paint, still writes
nothing but `localStorage['paramant.theme.v1']`, and the paper tokens are scoped
to `[data-theme="light"]` and `[data-theme="auto"]` so a light operating system
never lifts the app off the night on its own.

**The critical inline CSS** at the top of all 45 pages paints the night straight
away, with the paper half inlined on the eleven app pages, so neither ground
flashes the other.

**frontend/index.html** keeps only what the homepage owns: the band, the letter,
the drawn document, the receipt, the panels. The token re-point is gone.

**frontend/nav.css**: colour values only. No structure, no geometry.

## Colour literals

Literals of the old palette in components, counted over every `.css` under
frontend/ and every `<style>` block and `style=""` attribute in every `.html`:

| | before | after |
|---|---|---|
| old-palette literals | 1273 | 41 |
| all colour literals | 1594 | 641 |

All 41 remaining are the document layer of /sign and /co-sign. That block is
pinned to fixed values on purpose and says so: `js/sign-flow.js` draws the seal
into the PDF with those exact values, so previewing it in cream on a warm dark
ground would preview a document that does not exist. The 641 figure counts the
token definitions themselves, which are literals by definition.

## Gates

| gate | result |
|---|---|
| `tests/theme-contrast.test.mjs` | pass, 4446 pairs over 16 pages at 390 and 1440 |
| `tests/app-theme.test.mjs` | pass, 8 tests including the sabotage |
| `tests/app-contrast.test.mjs` | pass, 11 screens x 2 widths x 2 themes |
| `tests/first-screen.test.mjs` | pass |
| `tests/navigation-shell.test.mjs` | pass |
| `tests/motion-safety.test.mjs` | pass |
| `tests/apply-nav-idempotent.test.mjs` | pass |
| `tests/ui-truthfulness.test.mjs` | pass |
| `tests/site-claims.test.mjs` | pass |
| `tests/seo-contract.test.mjs` | pass |
| `tests/frontend-loading-contract.test.mjs` | pass |
| `tests/links.test.mjs` | pass |
| `tests/pricing-fold.test.mjs` | pass |
| `tests/access-log-visitors.test.mjs` | pass |
| `bash tests/static-sanity.sh` | pass |
| `scripts/check-cache-bust.sh` | pass, 364 links, one version each |
| `scripts/check-csp-inline.sh` | pass, no inline JS |

`KNOWN_LIGHT` in theme-contrast was four entries and is now empty. All four were
fixed in the colour, not in the list. The last one needed a real fix:
`.about-band p a{color:var(--cobalt)}` also caught the primary button inside that
paragraph, and is now `a:not(.btn)`.

`navigation-shell` pinned the mobile bar to "any opaque rgb" while the homepage
painted the bar itself. The night is the system now, so the hex is named again.

## The two sentences that had to change

/account said "Light is the default and it stays light until you change it here"
and "The public pages stay light", and /privacy said "Light without it". Those
are claims about the code, and the code changed, so they now say dark. The pins
in `ui-truthfulness` and the row in `docs/site-claims.md` moved with them. No
other word of UI text was touched.

## Not done

The three SVG diagrams on /architecture are drawn with fixed ink in SVG
presentation attributes, not CSS. Recolouring them is a redraw, not a recolour,
so the frame is now the cream paper of the design system and the figure sits on
it like a printed sheet on the night desk.
