### PR TITLE
/sign says out loud that you are not signed in, and takes PDFs only

### DIFF
--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -1,7 +1,9 @@
 // DocuSign-style sign flow on /sign. Doc-first state machine.
 //
-// Steps: pick document -> (PDF: place stamp) -> identity -> review & sign -> done.
-// Non-PDF inputs go through a hash-only path that skips the placement step.
+// Steps: pick document -> place stamp -> identity -> review & sign -> done.
+// The document must be a PDF, checked on the magic bytes. The hash-only path
+// below is the fallback for a file that CLAIMS to be a PDF and then will not
+// parse; it is no longer something a visitor can select on purpose.
 //
 // Reuses /vendor/parasign-bridge.js (ml_dsa65 + sha3_256 + vault helpers),
 // /vendor/pdfjs (preview render) and /vendor/pdf-lib (stamp baking). All
@@ -234,6 +236,9 @@ function enterRecipients() {
     const subject = $('ds-invite-subject'); if (subject) subject.value = state.inviteSubject;
   }
   renderRecipients();
+  // Last, so it wins over the label and the hint this function just set: with
+  // no session, Send is a sign-in.
+  applySessionToSendButton();
 }
 
 function commitInviteDeliveryFromDom() {
@@ -417,6 +422,44 @@ function clearDocError() {
   const el = $('ds-doc-error'); if (el) el.hidden = true;
 }
 
+// What the first bytes actually are, in the word a person uses for them.
+//
+// accept="application/pdf,.pdf" is a hint the file picker MAY honour, and iOS
+// Safari does not: the photo library is offered whatever the attribute says. A
+// 6.5MB camera JPEG walked in as a "document" and got as far as Co-signers. The
+// MIME type on the File object is no better, because it comes from the same
+// place. Magic bytes are the one check that cannot be talked out of it.
+//
+// Returns a phrase to drop into "This is ___, not a PDF.", or null when the
+// bytes are not something we can name.
+function describeFileType(bytes, name) {
+  const b = bytes;
+  const at = (offset, ...sig) => sig.every((v, i) => b[offset + i] === v);
+  if (b.length >= 4 && at(0, 0x89, 0x50, 0x4E, 0x47)) return 'a PNG image';
+  if (b.length >= 3 && at(0, 0xFF, 0xD8, 0xFF)) return 'a JPEG image';
+  if (b.length >= 3 && at(0, 0x47, 0x49, 0x46)) return 'a GIF image';
+  if (b.length >= 12 && at(0, 0x52, 0x49, 0x46, 0x46) && at(8, 0x57, 0x45, 0x42, 0x50)) return 'a WebP image';
+  // ISO base media: the brand at offset 8 says which flavour. HEIC is what an
+  // iPhone hands over when the camera roll is not set to "most compatible".
+  if (b.length >= 12 && at(4, 0x66, 0x74, 0x79, 0x70)) {
+    const brand = String.fromCharCode(b[8], b[9], b[10], b[11]);
+    if (['heic', 'heix', 'heim', 'heis', 'hevc', 'mif1', 'msf1'].includes(brand)) return 'a HEIC photo';
+    return 'a video or media file';
+  }
+  // A zip container. Word, Excel, PowerPoint and OpenDocument are all zips, and
+  // only the extension separates them from a plain archive at this depth.
+  if (b.length >= 4 && at(0, 0x50, 0x4B, 0x03, 0x04)) {
+    const ext = String(name || '').toLowerCase().split('.').pop();
+    if (ext === 'docx' || ext === 'doc' || ext === 'odt') return 'a Word document';
+    if (ext === 'xlsx' || ext === 'ods') return 'a spreadsheet';
+    if (ext === 'pptx' || ext === 'odp') return 'a presentation';
+    return 'a ZIP archive';
+  }
+  // The old Office compound-document container (.doc, .xls, .ppt).
+  if (b.length >= 8 && at(0, 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1)) return 'a Word document';
+  return null;
+}
+
 async function onDocChosen(file) {
   clearDocError();
   const bytes = new Uint8Array(await file.arrayBuffer());
@@ -424,6 +467,18 @@ async function onDocChosen(file) {
   // of silently enabling Continue on a 0-byte document (QA).
   if (!bytes.length) {
     showDocError('That file is empty (0 bytes). Pick a file that has content.');
+    return;
+  }
+  // PDF or nothing, decided on the bytes. A refused file does not become
+  // state.doc, does not get named on screen and does not advance the step: the
+  // visitor stays on the picker with the reason in front of him, instead of
+  // three steps deep into a flow that cannot end.
+  const looksPdf = bytes.length >= 5
+    && bytes[0] === 0x25 && bytes[1] === 0x50 && bytes[2] === 0x44 && bytes[3] === 0x46 && bytes[4] === 0x2D;
+  if (!looksPdf) {
+    const what = describeFileType(bytes, file.name);
+    showDocError((what ? 'This is ' + what + ', not a PDF. ' : 'This file is not a PDF. ')
+      + 'ParaSign signs PDF documents. Export or print your file to PDF first.');
     return;
   }
   state.doc = { bytes, name: file.name, size: file.size };
@@ -3251,6 +3306,13 @@ function wireNav() {
     else setActive(state.mode === 'pdf' ? 'step-place' : 'step-hash-only');
   });
   $('ds-recipients-continue').addEventListener('click', () => {
+    // Signed out: this button is the sign-in, and nothing below it should run.
+    // Whatever was typed here is lost by the navigation; applySessionToSendButton
+    // has already said so on screen, above the button.
+    if ($('ds-recipients-continue').dataset.signInFirst === '1') {
+      location.href = '/auth/login?next=/sign';
+      return;
+    }
     commitRecipientsFromDom();
     commitInviteDeliveryFromDom();
     // Audit 1.1: every envelope is email-bound, so every co-signer needs a
@@ -3388,57 +3450,109 @@ function init() {
   showSessionRequirement();
 }
 
-// The page is now served to everyone (nginx no longer gates /sign), so a
-// visitor without a session can reach it. Signing still needs an account,
-// because a Paramant signature is made with a key bound to a passkey on the
-// device and that key has to be enrolled first.
+// What the probe answered, kept so every later step can ask the same question
+// without a second round trip. 'unknown' until it has answered at all: nothing
+// on this page may claim "you are not signed in" before it has.
+let sessionState = 'unknown';   // 'unknown' | 'in' | 'out'
+
+function showServiceNote() {
+  const note = $('ds-service-note');
+  const errors = (typeof self !== 'undefined') && self.paramantErrors;
+  if (note && errors) { note.textContent = errors.SUPPORT_FAILURE_MESSAGE; note.hidden = false; }
+}
+
+// Everything that changes when the visitor has no session. Called from the
+// probe, so it may land after the flow has already moved a step or two; each
+// piece is therefore written to be safe at any point in the flow.
+function applySignedOut() {
+  const bar = $('ds-signedout');
+  if (bar) bar.hidden = false;
+  const el = $('step-anon');
+  // The mode picker stays visible underneath: a visitor should still see what
+  // the three workflows are before deciding whether the account is worth it.
+  if (el) el.hidden = false;
+  applySessionToSendButton();
+}
+
+// The one irreversible action in the invite flow is "Send for signature": it
+// creates the envelope, uploads the capsule and mails the links, and all three
+// need a session. Offering that button to a signed-out visitor is offering a
+// button whose only possible answer is 401, three steps after the moment we
+// already knew. So it becomes the sign-in.
+//
+// The prepared state does NOT survive it, and the button says so rather than
+// pretending. The document lives in this page as raw bytes; a scanned contract
+// or a phone photo is megabytes and sessionStorage is about 5MB per origin, so
+// stashing it would fail on exactly the files people bring. The recipients and
+// the message are small enough to keep, but keeping half a flow and silently
+// dropping the other half is worse than one honest sentence.
+function applySessionToSendButton() {
+  const cont = $('ds-recipients-continue');
+  if (!cont) return;
+  const gate = sessionState === 'out' && state.signingMode === 'invite';
+  cont.dataset.signInFirst = gate ? '1' : '';
+  if (!gate) return;
+  cont.textContent = 'Sign in to send';
+  cont.disabled = false;
+  if (!$('step-recipients').hidden) {
+    showRecipientsHint('Your document has not been uploaded and stays in this browser. Signing in reloads this page, so you pick the file and the recipients again afterwards.', false);
+  }
+}
+
+// The page is served to everyone (nginx no longer gates /sign), so a visitor
+// without a session can reach it. Signing still needs an account, because a
+// Paramant signature is made with a key bound to a passkey on the device and
+// that key has to be enrolled first.
 //
 // Where the message goes matters more than what it says. Failing at the last
 // step with "please sign in" would move the dead end to a worse place: after
 // the visitor has chosen a file, placed a stamp and pressed Sign. So the
-// requirement is stated up front, next to what the product does.
+// requirement is stated up front, and #ds-signedout keeps stating it for every
+// step after that.
+//
+// One probe, /api/user/session/verify, the same endpoint the nav bar and the
+// homepage read. /api/user/check answered the same question in a different
+// shape and made /sign the only page in the app with its own idea of what a
+// session is.
 //
 // Someone arriving on an invitation link is NOT stopped: that path carries its
-// own invite token and does not need a session, so the notice stays hidden
-// whenever the URL names an envelope. A network failure also leaves it hidden,
-// because guessing "not signed in" from a failed fetch would show the notice to
-// exactly the paying customer whose connection blipped.
+// own invite token and does not need a session, so nothing is shown whenever
+// the URL names an envelope. A network failure also shows nothing, because
+// guessing "not signed in" from a failed fetch would show the notice to exactly
+// the paying customer whose connection blipped.
 async function showSessionRequirement() {
-  const el = $('step-anon');
-  if (!el) return;
   const q = new URLSearchParams(location.search);
   if (q.get('envelope') || q.get('e') || q.get('invite') || q.get('token') || location.hash.length > 1) return;
-  let status = 0;
+  let res;
   try {
-    const r = await fetch('/api/user/check', { credentials: 'same-origin', cache: 'no-store' });
-    status = r.status;
+    res = await fetch('/api/user/session/verify', { credentials: 'include', cache: 'no-store' });
   } catch {
     // A thrown fetch is the browser being offline, and the browser says so
-    // better than we can. Silence, as before: guessing "not signed in" from a
-    // dead connection would show the account notice to the paying customer
-    // whose wifi dropped.
+    // better than we can. Silence: guessing "not signed in" from a dead
+    // connection would show the account notice to the paying customer whose
+    // wifi dropped.
     return;
   }
-  // The probe answered, but it answered that IT is broken. authUser returns 503
-  // session_store_unavailable when redis is unreachable, and a proxy in front
-  // can return any 5xx of its own. None of those mean "no account": a koper
-  // review found a signed-in user reading "Signing a document needs an account"
-  // because the answer was a failure rather than a refusal. Say what actually
-  // happened, in the shared sentence, and leave the account notice hidden.
-  if (status >= 500) {
-    const note = $('ds-service-note');
-    const errors = (typeof self !== 'undefined') && self.paramantErrors;
-    if (note && errors) { note.textContent = errors.SUPPORT_FAILURE_MESSAGE; note.hidden = false; }
-    try { console.error('[paramant] session probe', status); } catch { /* no console is never why a flow dies */ }
+  // The probe answered, but it answered that IT is broken. The endpoint reads
+  // redis, and a proxy in front can return any 5xx of its own. None of those
+  // mean "no account": a koper review found a signed-in user reading "Signing a
+  // document needs an account" because the answer was a failure rather than a
+  // refusal. Say what actually happened, and leave the account notice hidden.
+  if (res.status >= 500) {
+    showServiceNote();
+    try { console.error('[paramant] session probe', res.status); } catch { /* no console is never why a flow dies */ }
     return;
   }
-  // 401/403 is the one answer that means what the notice says: this browser has
-  // no session. Anything else (200, and any 4xx that is not a refusal) leaves
-  // both the notice and the service line hidden.
-  if (status !== 401 && status !== 403) return;
-  el.hidden = false;
-  // The mode picker stays visible underneath: a visitor should still see what
-  // the three workflows are before deciding whether the account is worth it.
+  // 401/403 is a refusal: this browser has no session. A healthy answer is 200
+  // with an authenticated flag. Anything else (a 404 from a static host, a
+  // gateway's own 4xx) leaves both the bar and the service line hidden.
+  if (res.status === 401 || res.status === 403) { sessionState = 'out'; applySignedOut(); return; }
+  if (!res.ok) return;
+  let data = null;
+  try { data = await res.json(); } catch { return; }
+  if (!data || typeof data.authenticated !== 'boolean') return;
+  sessionState = data.authenticated ? 'in' : 'out';
+  if (sessionState === 'out') applySignedOut();
 }
 
 // What the finished proof does and does not say. An open-mode envelope has no

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -45,6 +45,15 @@
 .ds-headlink a{color:var(--accent);text-decoration:underline;text-underline-offset:3px}
 .ds-anon-actions{display:flex;flex-wrap:wrap;gap:10px;margin:20px 0 0}
 .ds-service-note{margin:0 0 16px;padding:10px 14px;border:1px solid var(--line-2);border-left:2px solid var(--mark);border-radius:var(--r-1);background:var(--surface-sunk);font-size:13px;line-height:1.6;color:var(--ink-2)}
+/* Not signed in. This belongs to the whole flow, not to one step: #step-anon
+   is a .ds-step, so setActive() hides it the second a workflow is chosen, and a
+   visitor could pick a file and reach Co-signers with nothing on screen saying
+   he had no session. This bar sits outside the steps and stays put. It borrows
+   the service note's paint, so it introduces no colour of its own. */
+.ds-signedout{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:10px 16px;margin:0 0 20px;padding:11px 14px;border:1px solid var(--line-2);border-left:2px solid var(--mark);border-radius:var(--r-1);background:var(--surface-sunk)}
+.ds-signedout-text{margin:0;font-size:13px;line-height:1.6;color:var(--ink-2);max-width:62ch}
+.ds-signedout-actions{display:flex;flex-wrap:wrap;gap:8px;margin:0}
+.ds-signedout-actions .btn{font-size:13px;padding:8px 14px}
 /* The hero is the pitch for a visitor who has not started yet. From the step
    after the document is chosen it is only in the way: at 390px it held the
    whole uploaded PDF below the fold. sign-flow.js stamps the active step on
@@ -516,6 +525,20 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
        js/error-message.js, so both products apologise in the same words. -->
   <p class="ds-service-note" id="ds-service-note" role="status" hidden></p>
 
+  <!-- No session, said once and said for every step. Revealed by sign-flow.js
+       only after /api/user/session/verify has answered, so it never flashes at
+       a signed-in customer, and never dismissible: the requirement does not go
+       away by being closed. Both links carry ?next=/sign, which auth-login.js
+       honours on the way back; signup still finishes through the emailed
+       verification link and does not carry it yet. -->
+  <div class="ds-signedout" id="ds-signedout" role="status" hidden>
+    <p class="ds-signedout-text">You are not signed in. You can prepare a document here; sending it needs a free Community account.</p>
+    <p class="ds-signedout-actions">
+      <a class="btn btn-secondary" href="/auth/login?next=/sign">Sign in</a>
+      <a class="btn btn-primary" href="/signup?next=/sign">Create account</a>
+    </p>
+  </div>
+
   <ol class="ds-stepper" id="ds-stepper" aria-label="Sign progress" hidden>
     <li data-step="doc" class="active">Document</li>
     <li data-step="place">Place</li>
@@ -593,11 +616,11 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
   <!-- Step 1: pick document -->
   <section class="ds-step" id="step-doc" hidden>
     <h2>Pick the document you want to sign</h2>
-    <p class="ds-sub">PDFs get a visual signature stamp you can place on any page. Other file types get a hash-only attestation that recipients verify by re-hashing the file.</p>
+    <p class="ds-sub">ParaSign signs PDF files. Pick a PDF and place your signature stamp on any page. The file stays in this browser.</p>
     <div class="ds-dropzone" id="ds-dropzone" role="button" tabindex="0" aria-label="Pick or drop a file">
       <p class="big">Drop a file here, or click to choose</p>
       <p class="small">Stays in your browser. Nothing is uploaded yet.</p>
-      <input type="file" id="ds-doc-input" hidden>
+      <input type="file" id="ds-doc-input" accept="application/pdf,.pdf" hidden>
     </div>
     <p class="ds-doc-error" id="ds-doc-error" role="alert" hidden></p>
   </section>
@@ -936,6 +959,6 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script src="/js/parasign-pdf-ops.js?v=1"></script>
 <script src="/js/quota-upgrade.js?v=4" defer></script>
-<script type="module" src="/sign-flow.js?v=51"></script>
+<script type="module" src="/sign-flow.js?v=52"></script>
 </body>
 </html>

--- a/tests/access-log-visitors.test.mjs
+++ b/tests/access-log-visitors.test.mjs
@@ -37,7 +37,7 @@ test('a client that renders is not excluded for lacking a referer', () => {
   const r = analyse([
     line({ ip: '8.8.8.8', path: '/sign' }),
     line({ ip: '8.8.8.8', path: '/design-system.css?v=28' }),
-    line({ ip: '8.8.8.8', path: '/sign-flow.js?v=51' }),
+    line({ ip: '8.8.8.8', path: '/sign-flow.js?v=52' }),
   ]);
   assert.equal(r.atMostVisitors, 1);
   assert.equal(r.verdicts.possible_visitor, 1);

--- a/tests/sign-full.test.mjs
+++ b/tests/sign-full.test.mjs
@@ -61,6 +61,10 @@ await page.route('**/api/**', (route) => {
     return j({ flowId: 'f', options: { challenge: CHAL, allowCredentials: CRED_ID ? [{ id: CRED_ID, transports: ['internal'] }] : [], userVerification: 'required', timeout: 20000, rpId: 'localhost' } });
   }
   if (u.pathname.endsWith('/signing-key/step-up/bind')) return j({ ok: true });
+  // /sign reads the same session probe the nav reads. This suite is the signed-in
+  // signer, so answer it as one: a bare {ok:true} reads as no session and puts
+  // the signed-out bar on every screenshot below.
+  if (u.pathname.endsWith('/user/session/verify')) return j({ authenticated: true, email: 'demo@example.com' });
   // TOTP-gated ephemeral enrol route — response controlled by totpResp.
   if (u.pathname.endsWith('/account/signing-key')) return j(totpResp.body, totpResp.status);
   return j({ ok: true });

--- a/tests/sign-invite-delivery.test.mjs
+++ b/tests/sign-invite-delivery.test.mjs
@@ -73,7 +73,7 @@ await directPage.close();
 // a healthy answer gets neither.
 async function probeSays(status, body) {
   const probe = await browser.newPage({ viewport: { width: 390, height: 844 } });
-  await probe.route('**/api/user/check', (route) => route.fulfill({
+  await probe.route('**/api/user/session/verify', (route) => route.fulfill({
     status, contentType: 'application/json', body: body || '{}',
   }));
   await probe.goto(ORIGIN + '/sign', { waitUntil: 'domcontentloaded' });
@@ -81,6 +81,7 @@ async function probeSays(status, body) {
   await probe.waitForTimeout(300);
   const seen = await probe.evaluate(() => ({
     anon: !document.getElementById('step-anon').hidden,
+    bar: !document.getElementById('ds-signedout').hidden,
     service: !document.getElementById('ds-service-note').hidden,
     serviceText: document.getElementById('ds-service-note').textContent,
     support: self.paramantErrors.SUPPORT_FAILURE_MESSAGE,
@@ -88,14 +89,14 @@ async function probeSays(status, body) {
   await probe.close();
   return seen;
 }
-const probe401 = await probeSays(401, '{"error":"unauthenticated"}');
-ok('no session still gets the account notice', probe401.anon === true && probe401.service === false, JSON.stringify(probe401));
+const probeOut = await probeSays(200, '{"authenticated":false}');
+ok('no session gets the account notice and the bar', probeOut.anon === true && probeOut.bar === true && probeOut.service === false, JSON.stringify(probeOut));
 const probe503 = await probeSays(503, '{"error":"session_store_unavailable"}');
 ok('a broken probe is a service failure, not a missing account',
-  probe503.anon === false && probe503.service === true && probe503.serviceText === probe503.support,
+  probe503.anon === false && probe503.bar === false && probe503.service === true && probe503.serviceText === probe503.support,
   JSON.stringify(probe503));
-const probe200 = await probeSays(200, '');
-ok('a signed-in visitor is told nothing at all', probe200.anon === false && probe200.service === false, JSON.stringify(probe200));
+const probeIn = await probeSays(200, '{"authenticated":true,"email":"owner@example.com"}');
+ok('a signed-in visitor is told nothing at all', probeIn.anon === false && probeIn.bar === false && probeIn.service === false, JSON.stringify(probeIn));
 
 await page.goto(ORIGIN + '/sign', { waitUntil: 'domcontentloaded' });
 ok('landing leads with the request-signatures workflow', await page.locator('.ds-mode-card').first().getAttribute('data-mode') === 'invite' && await page.locator('.ds-mode-card').first().getAttribute('class').then((value) => value.includes('primary')), await page.locator('.ds-mode-card').first().innerText());
@@ -103,7 +104,24 @@ ok('technical stepper stays hidden until a workflow is chosen', await page.locat
 ok('landing has no phone-width overflow', await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth) <= 1, await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth));
 if (process.env.PARAMANT_SIGN_SCREENSHOT_PATH) await stableScreenshot(page, { path:process.env.PARAMANT_SIGN_SCREENSHOT_PATH, fullPage:true });
 await page.locator('.ds-mode-card[data-mode="invite"]').click();
-await page.locator('#ds-doc-input').setInputFiles({ name: 'agreement-demo.txt', mimeType: 'text/plain', buffer: Buffer.from('agreement document for invite delivery') });
+// A .txt used to go straight to the recipients through the hash-only path.
+// /sign refuses anything that is not a PDF now (tests/sign-signed-out.test.mjs
+// covers the refusal), so the delivery run takes the road a customer takes.
+await page.evaluate(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  while (!window.PDFLib) await sleep(20);
+  const source = await window.PDFLib.PDFDocument.create();
+  source.addPage([300, 400]).drawText('Agreement', { x: 30, y: 350, size: 14 });
+  const transfer = new DataTransfer();
+  transfer.items.add(new File([await source.save()], 'agreement-demo.pdf', { type: 'application/pdf' }));
+  const input = document.getElementById('ds-doc-input');
+  input.files = transfer.files;
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+});
+await page.locator('#step-place:not([hidden])').waitFor({ timeout: 15000 });
+await page.locator('#ds-pdf-canvas-list .ds-page-wrap[data-page-index="0"] canvas').waitFor();
+await page.locator('#ds-pdf-canvas-list .ds-page-wrap[data-page-index="0"]').click({ position: { x: 150, y: 120 } });
+await page.locator('#ds-place-continue').click();
 await page.locator('#step-recipients:not([hidden])').waitFor();
 await page.locator('#ds-add-recipient').click();
 await page.locator('[data-field="label"]').fill('Signer Demo');
@@ -130,11 +148,10 @@ ok('successful retry clears the warning', /all email invitations/i.test(await pa
 ok('phone viewport has no horizontal overflow', await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth) <= 1, await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth));
 
 // ── PDF variant: the requester points at the spot where the other party signs ──
-// The .txt run above is the hash-only half of the invite flow: nothing can be
-// pointed at, so it must still go straight to the recipients. Everything below
-// is the PDF half, which is where /sign's promise ("show them where to sign")
-// either exists or does not.
-ok('a hash-only invite asks for no position', envelopeCreates.length === 1 && envelopeCreates[0].requested_appearance === undefined, JSON.stringify(Object.keys(envelopeCreates[0] || {})));
+// The run above is the delivery half: what the email does, what a partial
+// failure says, what a retry sends. Everything below is /sign's promise ("show
+// them where to sign"), measured on the bytes that leave the browser.
+ok('the delivery run created exactly one signing request', envelopeCreates.length === 1, JSON.stringify(envelopeCreates.map((e) => e.recipients?.length)));
 
 const pdfCreates = [];
 const pdfPage = await browser.newPage({ viewport: { width: 390, height: 844 } });

--- a/tests/sign-place-toolbar.test.mjs
+++ b/tests/sign-place-toolbar.test.mjs
@@ -60,6 +60,9 @@ for (const [width, height] of [[320, 844], [360, 844], [390, 844], [1440, 900]])
   const context = await browser.newContext({ viewport: { width, height } });
   const page = await context.newPage();
   await page.route('**/api/**', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' }));
+  // Signed in: this measures the signer's toolbar, not the signed-out bar. Last
+  // registered wins in Playwright, so this sits under the catch-all above.
+  await page.route('**/api/user/session/verify', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '{"authenticated":true,"email":"demo@example.com"}' }));
   await page.goto(`${ORIGIN}/sign.html`, { waitUntil: 'domcontentloaded' });
 
   const reached = await page.evaluate(async () => {

--- a/tests/sign-signed-out.test.mjs
+++ b/tests/sign-signed-out.test.mjs
@@ -1,0 +1,180 @@
+// /sign told the truth about two things it used to be quiet about.
+//
+// 1. A visitor with no session. The page is public, and the notice that says
+//    so was a .ds-step, so setActive() hid it the moment a workflow was chosen.
+//    The owner reached step 3 (Co-signers) on an iPhone with the nav still
+//    reading "Create account / Sign in" and nothing on screen disagreeing.
+//    #ds-signedout lives outside the steps and stays for every step, and the
+//    send button becomes the sign-in rather than a guaranteed 401.
+//
+// 2. The file. accept="application/pdf,.pdf" is a hint iOS Safari ignores, and
+//    the File object's MIME type comes from the same place, so a 6.5MB camera
+//    JPEG was accepted as a "document". The check is on the magic bytes now.
+//
+// Real Chromium, the real page, same-origin APIs stubbed the way
+// tests/navigation-shell.test.mjs stubs them.
+
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = { '.js':'text/javascript','.mjs':'text/javascript','.css':'text/css','.html':'text/html','.svg':'image/svg+xml','.json':'application/json','.wasm':'application/wasm','.png':'image/png','.woff2':'font/woff2' };
+const server = http.createServer((req, res) => {
+  let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+  if (pathname === '/sign') pathname = '/sign.html';
+  const file = path.join(ROOT, pathname);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+  fs.readFile(file, (error, body) => {
+    if (error) { res.writeHead(404); return res.end(); }
+    res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  });
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const ORIGIN = `http://localhost:${server.address().port}`;
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+
+const checks = [];
+function ok(name, condition, detail = '') { checks.push({ name, pass: !!condition, detail: String(detail) }); }
+
+// The session answer, in the shape /api/user/session/verify actually returns:
+// 200 with authenticated true or false. Everything else on the page is stubbed
+// to a bland 200 so nothing else in the flow reaches the network.
+async function openSign(authenticated, url = '/sign') {
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  // Playwright matches routes last-registered-first, so the catch-all goes down
+  // before the specific one or it swallows it.
+  await page.route('**/api/**', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' }));
+  await page.route('**/api/user/session/verify', (route) => route.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify(authenticated ? { authenticated: true, email: 'owner@example.com' } : { authenticated: false }),
+  }));
+  await page.goto(ORIGIN + url, { waitUntil: 'domcontentloaded' });
+  return page;
+}
+
+// A real PDF, built in the page with the pdf-lib the page already loads, so the
+// bytes that reach the picker are the bytes a browser would hand it.
+async function pickPdf(page) {
+  await page.evaluate(async () => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    for (let i = 0; i < 400 && !(window.PDFLib && window.pdfjsLib); i++) await sleep(20);
+    const doc = await window.PDFLib.PDFDocument.create();
+    doc.addPage([300, 400]).drawText('Lease agreement', { x: 30, y: 350, size: 14 });
+    const transfer = new DataTransfer();
+    transfer.items.add(new File([await doc.save()], 'lease.pdf', { type: 'application/pdf' }));
+    const input = document.getElementById('ds-doc-input');
+    input.files = transfer.files;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
+// The exact shape of the file the owner picked on his phone: JPEG magic bytes,
+// and a MIME type that says image/jpeg. The page used to take it anyway.
+async function pickJpeg(page) {
+  await page.locator('#ds-doc-input').setInputFiles({
+    name: 'IMG_4445.jpeg',
+    mimeType: 'image/jpeg',
+    buffer: Buffer.concat([Buffer.from([0xFF, 0xD8, 0xFF, 0xE0]), Buffer.alloc(4096, 7)]),
+  });
+}
+
+// ── signed out: the bar, and what it does not do ─────────────────────────────
+const out = await openSign(false);
+await out.locator('#ds-signedout:not([hidden])').waitFor({ timeout: 15000 });
+ok('signed out, the flow carries a bar that says so',
+  /You are not signed in\. You can prepare a document here; sending it needs a free Community account\./.test(await out.locator('#ds-signedout').innerText()),
+  await out.locator('#ds-signedout').innerText());
+const barLinks = await out.locator('#ds-signedout a').evaluateAll((nodes) => nodes.map((n) => [n.textContent.trim(), n.getAttribute('href')]));
+ok('the bar comes back to /sign afterwards',
+  JSON.stringify(barLinks) === JSON.stringify([['Sign in', '/auth/login?next=/sign'], ['Create account', '/signup?next=/sign']]),
+  JSON.stringify(barLinks));
+ok('the bar cannot be dismissed', await out.locator('#ds-signedout button').count() === 0, String(await out.locator('#ds-signedout button').count()));
+
+// The bug itself: it has to survive the steps, because the notice it replaces
+// did not. Walk the same route the owner walked.
+await out.locator('.ds-mode-card[data-mode="invite"]').click();
+ok('the bar survives choosing a workflow', await out.locator('#ds-signedout').isVisible(), 'step-doc');
+ok('the account notice is gone by then, as it always was', await out.locator('#step-anon').isHidden(), 'step-anon');
+await pickPdf(out);
+await out.locator('#step-place:not([hidden])').waitFor({ timeout: 15000 });
+ok('the bar survives picking a document', await out.locator('#ds-signedout').isVisible(), 'step-place');
+await out.locator('#ds-pdf-canvas-list .ds-page-wrap[data-page-index="0"]').click({ position: { x: 150, y: 100 } });
+await out.locator('#ds-place-continue').click();
+await out.locator('#step-recipients:not([hidden])').waitFor({ timeout: 15000 });
+ok('the bar is still there on Co-signers, where it was missing', await out.locator('#ds-signedout').isVisible(), 'step-recipients');
+ok('the send button asks for the session instead of promising to send',
+  (await out.locator('#ds-recipients-continue').innerText()).trim() === 'Sign in to send',
+  await out.locator('#ds-recipients-continue').innerText());
+ok('and it says the prepared document does not survive signing in',
+  /has not been uploaded/i.test(await out.locator('#ds-recipients-hint').innerText()),
+  await out.locator('#ds-recipients-hint').innerText());
+await out.locator('#ds-recipients-continue').click();
+await out.waitForURL(/\/auth\/login\?next=%2Fsign|\/auth\/login\?next=\/sign/, { timeout: 15000 }).catch(() => {});
+ok('pressing it goes to the sign-in and back to /sign', /\/auth\/login\?next=(\/|%2F)sign$/.test(out.url()), out.url());
+await out.close();
+
+// ── signed in: nothing of the above ──────────────────────────────────────────
+const inn = await openSign(true);
+await inn.waitForTimeout(600);
+ok('signed in, there is no bar', await inn.locator('#ds-signedout').isHidden(), 'hidden');
+ok('signed in, there is no account notice either', await inn.locator('#step-anon').isHidden(), 'hidden');
+await inn.locator('.ds-mode-card[data-mode="invite"]').click();
+await pickPdf(inn);
+await inn.locator('#step-place:not([hidden])').waitFor({ timeout: 15000 });
+await inn.locator('#ds-pdf-canvas-list .ds-page-wrap[data-page-index="0"]').click({ position: { x: 150, y: 100 } });
+await inn.locator('#ds-place-continue').click();
+await inn.locator('#step-recipients:not([hidden])').waitFor({ timeout: 15000 });
+ok('signed in, the send button is the send button',
+  (await inn.locator('#ds-recipients-continue').innerText()).trim() === 'Send for signature',
+  await inn.locator('#ds-recipients-continue').innerText());
+await inn.close();
+
+// ── the file: a JPEG is not a document ───────────────────────────────────────
+const jpeg = await openSign(true);
+await jpeg.locator('.ds-mode-card[data-mode="invite"]').click();
+await pickJpeg(jpeg);
+await jpeg.locator('#ds-doc-error:not([hidden])').waitFor({ timeout: 15000 });
+ok('a JPEG is refused, and named',
+  (await jpeg.locator('#ds-doc-error').innerText()).trim()
+    === 'This is a JPEG image, not a PDF. ParaSign signs PDF documents. Export or print your file to PDF first.',
+  await jpeg.locator('#ds-doc-error').innerText());
+ok('a refused file does not move the flow on',
+  await jpeg.locator('#step-doc').isVisible()
+  && await jpeg.locator('#step-place').isHidden()
+  && await jpeg.locator('#step-hash-only').isHidden()
+  && await jpeg.locator('#step-recipients').isHidden(),
+  await jpeg.locator('main').innerText());
+ok('a refused file is not named as the document under the flow',
+  await jpeg.locator('#ds-doc-meta').isHidden(), 'ds-doc-meta');
+
+// The picker also stops asking for a file it cannot use.
+ok('the picker asks for a PDF',
+  await jpeg.locator('#ds-doc-input').getAttribute('accept') === 'application/pdf,.pdf',
+  await jpeg.locator('#ds-doc-input').getAttribute('accept'));
+// The signature IMAGE is a different field and keeps taking images.
+await jpeg.close();
+const sig = await openSign(true, '/sign?mode=alone');
+ok('the signature image field is untouched',
+  await sig.locator('#ds-sig-image-input').getAttribute('accept') === 'image/png,image/jpeg',
+  await sig.locator('#ds-sig-image-input').getAttribute('accept'));
+
+// A real PDF still walks straight through the same door.
+await pickPdf(sig);
+await sig.locator('#step-place:not([hidden])').waitFor({ timeout: 15000 });
+ok('a real PDF reaches the placement step', await sig.locator('#step-place').isVisible(), 'step-place');
+ok('and it is named under the flow',
+  /lease\.pdf/.test(await sig.locator('#ds-doc-meta').innerText()),
+  await sig.locator('#ds-doc-meta').innerText());
+ok('with no error left on screen', await sig.locator('#ds-doc-error').isHidden(), 'ds-doc-error');
+await sig.close();
+
+for (const check of checks) console.log(`${check.pass ? 'PASS' : 'FAIL'} ${check.name}${check.detail ? ' :: ' + check.detail : ''}`);
+await browser.close();
+server.close();
+if (checks.some((check) => !check.pass)) process.exit(1);
+console.log(`\nsign-signed-out: ${checks.length} checks passed`);


### PR DESCRIPTION
Found on an iPhone, at night, signed out, on https://paramant.app/sign: a photo
(IMG_4445.jpeg, 6.5 MB) could be picked as the "document" and the flow ran on to
step 3, Co-signers, while the navigation still read "Create account / Sign in".

## 1. Signed out is visible, and stays visible

The account notice on /sign is `#step-anon`, and `#step-anon` has the class
`.ds-step`. `setActive()` hides every `.ds-step` that is not the current one, so
the notice vanished the second a workflow was chosen. Everything after that ran
as if there were a session. The dead end had not been removed, only moved.

The requirement now lives outside the steps:

- `#ds-signedout`, a quiet bar above the stepper. Not dismissible, revealed only
  after the session probe answers, so it never flashes at a signed-in customer.
  "You are not signed in. You can prepare a document here; sending it needs a
  free Community account", with **Sign in** and **Create account** next to it.
  Both carry `?next=/sign`; `auth-login.js` honours it on the way back.
- On the Co-signers step, "Send for signature" becomes **"Sign in to send"** and
  goes to the sign-in instead of the API. Without a session that button had one
  possible answer, 401, three steps after we already knew.
- It says out loud that the prepared document does not survive. The bytes live
  in the page; a scanned contract or a phone photo is megabytes and
  sessionStorage is about 5MB per origin, so stashing it would fail on exactly
  the files people bring. Keeping the recipients and silently dropping the file
  is worse than one honest sentence.

The probe is `/api/user/session/verify`, what the navigation bar and the
homepage already read. `/api/user/check` answered the same question in a
different shape and left /sign the only page in the app with its own idea of
what a session is. The three answers stay three different things: a refusal
shows the bar, a 5xx shows the shared service sentence and no bar, an invitation
link shows neither.

## 2. PDF only, decided on the bytes

`accept="application/pdf,.pdf"` is a hint iOS Safari ignores, and the MIME type
on the File object comes from the same place. The check is the first five bytes
now. No `%PDF-` and the file is refused, by name where the bytes say what it is:

> This is a JPEG image, not a PDF. ParaSign signs PDF documents. Export or print
> your file to PDF first.

JPEG, PNG, GIF, WebP, HEIC, Word, spreadsheets, presentations and plain archives
are recognised; anything else is refused without a name. A refused file does not
become the document, is not named under the flow, and does not advance the step.

This closes the hash-only route for files a visitor picks on purpose. It remains
the fallback for a file that claims to be a PDF and then will not parse. The
signature image field is a different field and is untouched: still PNG and JPEG.

## Tests

`tests/sign-signed-out.test.mjs`, 21 checks in real Chromium with the API
stubbed the way `tests/navigation-shell.test.mjs` stubs it: the bar and its two
return links signed out, the bar surviving every step to Co-signers, the button
that becomes a sign-in and where it goes, none of it signed in, a JPEG refused
with the step unmoved and no document named, and a real PDF through the same
door.

`tests/sign-invite-delivery.test.mjs` used a .txt to reach the recipients in one
hop; it takes the road a customer takes now, and its probe scenarios move to
session/verify. `sign-full` and `sign-place-toolbar` answer the probe as the
signed-in signers they are.

Green: sign-signed-out (21), sign-invite-delivery (28), sign-full (33),
sign-document-identity (5), sign-place-toolbar (40), navigation-shell (55),
first-screen, frontend-loading-contract (`/sign-flow.js` bumped to `?v=52`),
static-sanity, check-csp-inline.

## Not in here

- Colours, the night styling and the sticky action bar on /sign are untouched,
  so #417 and the already merged #407 do not collide with this.
- `/signup?next=/sign` does not actually return to /sign: signup finishes
  through the emailed verification link and does not carry the parameter yet.
  The link matches what `#step-anon` already shipped; carrying it through signup
  is its own change.
- The final Sign button in the sign-alone and sign-together flows is not
  relabelled. It already fails with a readable 401 message, and the bar now
  stands above it on every step.
