### PR TITLE
A chargeback gets a credit note, and the billing history says what happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,37 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the message goes to the log.
 
 ### Added
+- **A credit note for money that goes back.** A chargeback used to stamp
+  `reversed_at` on the invoice and stop there, which keeps our own records from
+  lying and is all it does: Dutch VAT law does not let an issued invoice be
+  withdrawn, so the document for a reversal is a SECOND document with its own
+  sequential number that refers to the first (Wet OB art. 35a in full, art. 29
+  for the VAT). `relay/lib/credit-note.js` issues it in its own series,
+  `CN-2026-0001` per calendar year, carrying the number and the date of the
+  invoice it credits, the same description, VAT rate, seller and buyer as that
+  invoice stated, and negative net, VAT and total. It is a PDF on the same
+  renderer, it is mailed, and it appears on /account beside the invoice. One per
+  reversal: the reversal is claimed before a number is drawn, exactly as a
+  payment is, so a Mollie retry finds the document instead of writing a second
+  one. A partial refund gets a credit note for the amount that went back, its
+  VAT pro rata in whole cents; because the split is computed against Mollie's
+  CUMULATIVE counter and issued as the difference, a series of partial credits
+  adds back up to the invoice to the cent, remainder and all, and can never give
+  back more than came in. The invoice is only stamped reversed when the whole of
+  it has been credited.
+- **The billing history on /account is a real history.** It said "No billing
+  events yet" to a customer who had paid, been invoiced and watched his term run
+  out, because the only feed behind it was the admin audit log, which records
+  what an ADMIN did to a plan and knows nothing about a self-serve Mollie
+  payment. `relay/lib/billing-history.js` derives one chronological list from
+  records that already exist: the invoice and credit-note records for the money,
+  and the paid periods on those same records, cross-read against the plan-expiry
+  index and its notice markers (#415), for the terms that ended. No new storage,
+  so nothing can drift from the documents it is derived from. A period end that
+  a renewal extended is not listed as an ending, because the customer never lost
+  a day; a lapse and a later restart are two real endings and both are listed.
+  The admin panel merges its audit events into the same list, so a plan change
+  still shows up in the one place the customer reads.
 - **`admin/test/ratelimit-ttl.test.js`**, which boots a real admin behind a proxy
   that delivers commands and drops replies, and then reads the TTL on its own
   connection. That is the only shape that reproduces a counter stranded without

--- a/admin/server.js
+++ b/admin/server.js
@@ -3204,7 +3204,10 @@ api.get("/user/billing/status", authUser, async (req, res) => {
 // SECTORS.main and not health, because nginx routes public /v2/ to relay-main
 // (deploy/nginx-paramant-public.conf), so that is the relay the Mollie webhook
 // reaches and the one whose logs a billing question is read out of.
-const INVOICE_NUMBER_RE = /^PS-\d{4}-\d{4,}$/;
+// Two series share the route: PS for an invoice, CN for the credit note that
+// reverses one. Both are served by the relay from the same document keyspace,
+// which checks the number belongs to this account.
+const INVOICE_NUMBER_RE = /^(?:PS|CN)-\d{4}-\d{4,}$/;
 
 api.get("/user/billing/invoices", authUser, async (req, res) => {
   try {
@@ -3277,13 +3280,70 @@ async function billingProfileProxy(req, res, method) {
 api.get("/user/billing/profile", authUser, (req, res) => billingProfileProxy(req, res, "GET"));
 api.post("/user/billing/profile", authUser, (req, res) => billingProfileProxy(req, res, "POST"));
 
+// The customer's billing history, and it used to be only half of one: the audit
+// log records what an ADMIN did to a plan and knows nothing about a self-serve
+// Mollie payment, so a customer who had paid, been invoiced and seen his term
+// run out was shown "No billing events yet".
+//
+// The relay half is what the money did: invoices, credit notes, and the terms
+// that ended, all derived from records it already holds (relay/lib/
+// billing-history.js). The audit half stays, mapped into the same row shape, so
+// an admin plan change still appears in the one list the customer reads. A
+// relay that cannot be reached costs the money rows and keeps the rest, because
+// half a history beats an empty one.
+const AUDIT_LABEL = {
+  plan_changed: (m) => `Plan changed from ${m.from || 'unknown'} to ${m.to || 'unknown'}`,
+  plan_cancellation_scheduled: () => 'Cancellation scheduled',
+  plan_downgraded: (m) => `Plan downgraded to ${m.to || 'Community'}`,
+};
+
 api.get("/user/billing/history", authUser, async (req, res) => {
   const { user_id } = req.userSession;
-  const events = await getAuditEvents(user_id, {
-    limit: 10,
-    event_types: ['plan_changed', 'plan_cancellation_scheduled', 'plan_downgraded'],
+  let events = [];
+  try {
+    events = await getAuditEvents(user_id, {
+      limit: 10,
+      event_types: ['plan_changed', 'plan_cancellation_scheduled', 'plan_downgraded'],
+    });
+  } catch (err) {
+    console.error("[user/billing/history audit]", err.message);
+  }
+  const audit = (events || []).map((e) => {
+    const meta = e.metadata || {};
+    const label = AUDIT_LABEL[e.event_type];
+    return {
+      ts: e.ts,
+      type: e.event_type,
+      label: label ? label(meta) : e.event_type,
+      detail: null,
+      amount: null,
+      currency: null,
+      document: null,
+      // The raw event, so a page that has not been updated still renders.
+      event_type: e.event_type,
+      metadata: meta,
+    };
   });
-  res.json({ history: events });
+
+  let documents = [];
+  try {
+    const r = await fetch(`${SECTORS.main}/v2/billing/history`, {
+      headers: { "X-Api-Key": proxyApiKey(req.userSession) },
+      signal: AbortSignal.timeout(10000),
+    });
+    if (r.ok) {
+      const body = await r.json().catch(() => ({}));
+      if (Array.isArray(body.history)) documents = body.history;
+    }
+  } catch (err) {
+    console.error("[user/billing/history relay]", err.message);
+  }
+
+  const history = documents.concat(audit)
+    .filter((row) => row && row.ts)
+    .sort((a, b) => Date.parse(b.ts) - Date.parse(a.ts))
+    .slice(0, 50);
+  res.json({ history });
 });
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -974,7 +974,16 @@ Returns current plan and subscription state: `current_plan`, `period`, `amount_e
 
 ### GET /api/user/billing/history
 
-Returns the most recent billing events (plan changes, scheduled cancellations, downgrades).
+Returns one chronological list, newest first: the payments and credit notes the
+relay has documents for, the plan terms that ended, and the admin plan changes
+from the audit log (plan changes, scheduled cancellations, downgrades). Rows
+carry `ts`, `type`, `label`, `detail`, `amount`, `currency` and `document`; a row
+with a `document` is downloadable at
+`/api/user/billing/invoices/<number>.pdf`.
+
+### GET /api/user/billing/invoices
+
+Returns this account's invoices and credit notes, proxied from the relay.
 
 ---
 
@@ -1009,6 +1018,35 @@ Errors: `401 unauthorized` (missing or invalid API key), `400 bad_json` / `unkno
 Called by Mollie with `id=tr_…` (form-encoded). The relay ignores everything else in the webhook body, re-fetches the payment from the Mollie API as the only source of truth, verifies the amount actually paid against the catalog, and grants the product tier idempotently. Responds `200` on every handled event, `400 bad_payment_id` for a malformed id, and `503` on a transient Mollie fetch failure (so Mollie retries).
 
 Not intended to be called by clients.
+
+A refund or a chargeback arrives on the same `tr_` id as the payment. The relay
+issues a **credit note** for it: its own sequential number in its own series
+(`CN-2026-0001`, per calendar year), referring to the invoice it credits by
+number and date, with negative net, VAT and total. One per reversal, idempotent
+against a Mollie retry. A partial refund is credited for the amount that went
+back, with VAT pro rata in whole cents; the invoice itself is only marked
+reversed once the whole of it has been credited.
+
+### GET /v2/billing/invoices: this account's documents
+
+Requires `X-Api-Key`. Returns every document issued to the account, newest
+first: invoices (`PS-…`), payment receipts, and credit notes (`CN-…`, `kind`
+`credit_note`, with `credit_for` naming the invoice and `partial` saying whether
+the rest of it still stands). Each row carries `pdf_url`.
+
+### GET /v2/billing/invoices/:number.pdf: one document
+
+Requires `X-Api-Key`. Serves the PDF for one `PS-` or `CN-` number, rendered on
+demand from the stored record. `400 bad_invoice_number` for a malformed number,
+`404` for a number that does not belong to this account.
+
+### GET /v2/billing/history: one chronological list
+
+Requires `X-Api-Key`. Derived, never stored: the invoice and credit-note records
+for the money, and the paid periods on those same records for the terms that
+ended. Rows carry `ts`, `type` (`invoice`, `credit_note`, `term_ended`), `label`,
+`detail`, `amount`, `currency`, `document` and `pdf_url`. A period end that a
+renewal extended is not an ending and is not listed.
 
 ---
 

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -410,9 +410,10 @@ main.acct input::placeholder { color: var(--ink-3); }
 
     <hr class="acct-divider">
     <!-- Every payment gets a numbered document, issued by the relay the moment
-         Mollie confirms the money. The list is read-only here: a document is
-         never edited after it is issued. -->
-    <h3 style="font-size:var(--text-sm);font-family:var(--mono);letter-spacing:.1em;text-transform:uppercase;color:var(--cobalt);margin-bottom:var(--space-3)">Invoices</h3>
+         Mollie confirms the money, and every refund or chargeback gets a credit
+         note with its own number that refers back to it. The list is read-only
+         here: a document is never edited after it is issued. -->
+    <h3 style="font-size:var(--text-sm);font-family:var(--mono);letter-spacing:.1em;text-transform:uppercase;color:var(--cobalt);margin-bottom:var(--space-3)">Invoices and credit notes</h3>
     <div id="billing-invoices" style="font-size:var(--text-sm);color:var(--ink-dim)">Loading invoices&hellip;</div>
 
     <hr class="acct-divider">
@@ -443,7 +444,10 @@ main.acct input::placeholder { color: var(--ink-3); }
 
     <hr class="acct-divider">
     <h3 style="font-size:var(--text-sm);font-family:var(--mono);letter-spacing:.1em;text-transform:uppercase;color:var(--cobalt);margin-bottom:var(--space-3)">Billing history</h3>
-    <div id="billing-history" style="font-size:var(--text-sm);color:var(--ink-dim)">No billing events yet.</div>
+    <!-- Payments, credit notes, the terms that ended and any plan change, in one
+         list, newest first. Derived from the documents themselves, so it can
+         never disagree with them. -->
+    <div id="billing-history" style="font-size:var(--text-sm);color:var(--ink-dim)">Loading billing history&hellip;</div>
   </div>
 </section>
 
@@ -462,7 +466,7 @@ main.acct input::placeholder { color: var(--ink-3); }
 
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
-<script src="/js/account.inline1.js?v=4"></script>
+<script src="/js/account.inline1.js?v=5"></script>
 
 <script type="module" src="/js/account.inline2.js?v=3"></script>
 <script type="module" src="/js/passkey.js?v=4"></script>

--- a/frontend/js/account.inline1.js
+++ b/frontend/js/account.inline1.js
@@ -407,23 +407,78 @@
     }
   }
 
+  // ── Billing history ────────────────────────────────────────────────────────
+  // One chronological list: every payment, every credit note, every term that
+  // ended, and the admin plan changes that used to be the only thing here. The
+  // API derives it from the invoice and credit-note records and from the paid
+  // periods on them, so this renders what it is given and invents nothing.
+  //
+  // Built with DOM nodes rather than a string of markup: these rows carry a
+  // document number, a description and an amount that all come from the server,
+  // and this page has no business putting any of them through innerHTML.
+  function historyLabel(e) {
+    if (e.label) return e.label;
+    // A row from an older API, or an event this page does not know by name. The
+    // event name is not pretty, and it is at least true.
+    if (e.event_type === 'plan_changed') {
+      var m = e.metadata || {};
+      return 'Plan changed from ' + (m.from || 'unknown') + ' to ' + (m.to || 'unknown');
+    }
+    if (e.event_type === 'plan_cancellation_scheduled') return 'Cancellation scheduled';
+    return e.event_type || 'Billing event';
+  }
+
+  function historyRow(e) {
+    const row = document.createElement('div');
+    row.className = 'info-row';
+
+    const left = document.createElement('div');
+    left.className = 'info-label';
+    left.appendChild(document.createTextNode(new Date(e.ts).toLocaleDateString()));
+    left.appendChild(document.createTextNode(' · ' + historyLabel(e)));
+    if (e.document) {
+      const num = document.createElement('span');
+      num.style.fontFamily = 'var(--mono)';
+      num.textContent = ' ' + e.document;
+      left.appendChild(num);
+    }
+
+    const right = document.createElement('div');
+    right.className = 'info-value';
+    if (e.amount) {
+      const amount = document.createElement('span');
+      amount.style.fontFamily = 'var(--mono)';
+      amount.textContent = (e.currency || 'EUR') + ' ' + e.amount;
+      right.appendChild(amount);
+    } else if (e.detail) {
+      right.appendChild(document.createTextNode(e.detail));
+    }
+    if (e.document) {
+      right.appendChild(document.createTextNode(' '));
+      const link = document.createElement('a');
+      link.href = '/api/user/billing/invoices/' + encodeURIComponent(e.document) + '.pdf';
+      link.textContent = 'Download PDF';
+      right.appendChild(link);
+    }
+    row.appendChild(left);
+    row.appendChild(right);
+    return row;
+  }
+
   async function loadBillingHistory() {
+    const histEl = document.getElementById('billing-history');
+    if (!histEl) return;
     try {
       const res = await fetch('/api/user/billing/history', { credentials: 'include' });
-      if (!res.ok) return;
+      if (!res.ok) { histEl.textContent = 'Billing history unavailable right now.'; return; }
       const d = await res.json();
-      const histEl = document.getElementById('billing-history');
-      if (!d.history || d.history.length === 0) { histEl.textContent = 'No billing events yet.'; return; }
-      histEl.innerHTML = d.history.map(function(e) {
-        const date = new Date(e.ts).toLocaleString();
-        const label = e.event_type === 'plan_changed'
-          ? 'Plan changed: ' + (e.metadata.from || '?') + ' → ' + (e.metadata.to || '?')
-          : e.event_type === 'plan_cancellation_scheduled'
-          ? 'Cancellation scheduled'
-          : e.event_type;
-        return '<div class="info-row"><div class="info-label">' + date + '</div><div class="info-value">' + label + '</div></div>';
-      }).join('');
-    } catch(err) {}
+      const rows = (d && d.history) || [];
+      if (rows.length === 0) { histEl.textContent = 'No billing events yet.'; return; }
+      histEl.textContent = '';
+      rows.forEach(function(e) { histEl.appendChild(historyRow(e)); });
+    } catch(err) {
+      histEl.textContent = 'Could not load billing history.';
+    }
   }
 
   document.getElementById('billing-cancel-btn').addEventListener('click', async function() {
@@ -460,7 +515,15 @@
         num.textContent = inv.number;
         left.appendChild(num);
         left.appendChild(document.createTextNode(' · ' + new Date(inv.date).toLocaleDateString()));
-        if (inv.kind !== 'invoice') left.appendChild(document.createTextNode(' · receipt'));
+        // Three shapes in one list. A credit note is not a receipt and must not
+        // be labelled as one: it is the document that gives money back, and it
+        // says which invoice it belongs to.
+        if (inv.kind === 'credit_note') {
+          left.appendChild(document.createTextNode(
+            ' · ' + (inv.partial ? 'partial credit for ' : 'credit for ') + inv.credit_for));
+        } else if (inv.kind !== 'invoice') {
+          left.appendChild(document.createTextNode(' · receipt'));
+        }
         if (inv.reversed_at) left.appendChild(document.createTextNode(' · reversed'));
         const right = document.createElement('div');
         right.className = 'info-value';

--- a/relay/lib/billing-history.js
+++ b/relay/lib/billing-history.js
@@ -1,0 +1,186 @@
+'use strict';
+// One chronological list of everything that has happened to a customer's money
+// and to his term, built from records that already exist.
+//
+// WHAT WAS WRONG. /account has a "Billing history" block, and it said "No
+// billing events yet" to a customer who had paid, been invoiced, and watched
+// his term run out. The only feed behind it was the admin audit log, which
+// records plan_changed for an ADMIN action and knows nothing about a
+// self-serve Mollie payment. So the one page a paying customer looks at when he
+// wonders what he was charged showed him nothing at all.
+//
+// NO NEW STORAGE. Everything below is derived:
+//   - payments and refunds  -> the invoice and credit-note records
+//                              (lib/invoice.js, lib/credit-note.js)
+//   - a term that ended     -> the paid period on those same records, cross-read
+//                              against the plan-expiry index and its "already
+//                              told him" markers (lib/plan-expiry.js)
+// Adding a third store for "billing events" would mean a fourth thing that can
+// disagree with the other three. A derived list cannot drift from the documents
+// it is derived from.
+//
+// WHY A TERM END IS NOT SIMPLY "service_period_end IS IN THE PAST".
+// A renewal bought before the period ran out EXTENDS it (lib/billing.js
+// extendFrom), so the earlier period end is not a moment anything ended: the
+// customer never lost access and never saw a mail. A period end is a real end
+// only when no later period was bought on or before it. Renew late, after a
+// lapse, and both ends are real, and both belong in the list, which is exactly
+// what a customer reading his own history needs to see.
+//
+// The plan-expiry marker is read but never required. It says a mail went out
+// (and when), which is worth showing; a term that ended while the mailer was
+// unconfigured still ended, and still gets its line.
+
+const invoice = require('./invoice');
+const planExpiry = require('./plan-expiry');
+const entitlements = require('./entitlements');
+
+const PRODUCT_NAME = Object.freeze({ parasign: 'ParaSign', parasend: 'ParaSend' });
+
+function productName(product) {
+  return PRODUCT_NAME[product] || product || 'plan';
+}
+
+function tierName(tier) {
+  const t = String(tier || '');
+  return t ? t.charAt(0).toUpperCase() + t.slice(1) : '';
+}
+
+// ── the money rows ───────────────────────────────────────────────────────────
+// One row per document, in both series. The amount is the document's own total,
+// so a credit note is negative and the column adds up to what the customer
+// actually paid over the whole list.
+function documentRow(rec) {
+  const isCredit = rec.kind === 'credit_note';
+  const label = isCredit
+    ? `${rec.title || 'Credit note'} for invoice ${rec.credit_for}${rec.partial ? ' (partial)' : ''}`
+    : rec.description || rec.title || 'Payment';
+  return {
+    ts: rec.issued_at,
+    type: isCredit ? 'credit_note' : 'invoice',
+    label,
+    detail: isCredit
+      ? (rec.reason === 'chargeback' ? 'Charged back' : 'Refunded')
+      : (rec.kind === 'invoice' ? 'Paid' : 'Paid, receipt issued'),
+    amount: rec.amount_gross,
+    currency: rec.currency || 'EUR',
+    document: rec.number,
+    document_kind: rec.kind,
+    credit_for: isCredit ? rec.credit_for : null,
+    reversed_at: (!isCredit && rec.reversed_at) || null,
+    pdf_url: `/v2/billing/invoices/${rec.number}.pdf`,
+  };
+}
+
+// ── the term rows ────────────────────────────────────────────────────────────
+// Candidate ends per product, from the documents that bought them. Sorted by
+// the period end so "was this one renewed" is a scan and not a nested search.
+function termEndsFromDocuments(records, nowMs) {
+  const byProduct = new Map();
+  for (const rec of records) {
+    if (!rec || rec.kind === 'credit_note') continue;
+    if (!rec.product || !rec.service_period_end) continue;
+    // A fully reversed payment bought no term. Leaving it in would tell a
+    // customer his plan ended on a date it never started.
+    if (rec.reversed_at) continue;
+    const end = Date.parse(rec.service_period_end);
+    const issued = Date.parse(rec.issued_at);
+    if (Number.isNaN(end)) continue;
+    const list = byProduct.get(rec.product) || [];
+    list.push({ end, issued: Number.isNaN(issued) ? end : issued, plan: rec.plan, iso: rec.service_period_end });
+    byProduct.set(rec.product, list);
+  }
+  const out = [];
+  for (const [product, list] of byProduct) {
+    list.sort((a, b) => a.end - b.end);
+    for (const term of list) {
+      // Renewed: some other period reaches further AND was bought before this
+      // one ran out, so nothing ended here.
+      const renewed = list.some((other) => other.end > term.end && other.issued <= term.end);
+      if (renewed) continue;
+      if (term.end > nowMs) continue;
+      out.push({ product, endsAt: term.end, iso: term.iso, tier: term.plan });
+    }
+  }
+  return out;
+}
+
+// The plan-expiry index knows about periods that no document did: a plan set by
+// an admin, or one granted before the invoice module existed. Two keyed reads,
+// one per product, never a scan.
+async function termEndFromIndex(accountId, redis, nowMs) {
+  const out = [];
+  for (const product of entitlements.PRODUCTS) {
+    let meta = null;
+    try { meta = JSON.parse(await redis.hGet(planExpiry.META_HASH, planExpiry.memberOf(accountId, product)) || 'null'); }
+    catch { meta = null; }
+    if (!meta || !meta.paid_until) continue;
+    const at = Date.parse(meta.paid_until);
+    if (Number.isNaN(at) || at > nowMs) continue;
+    out.push({ product, endsAt: at, iso: meta.paid_until, tier: meta.tier });
+  }
+  return out;
+}
+
+// Did the customer get the "your plan has ended" mail for this exact period,
+// and when. The marker name carries the period, so it is constructed and read
+// by key; nothing is scanned.
+async function endedNoticeAt(accountId, product, iso, redis) {
+  try {
+    const raw = await redis.get(planExpiry.noticeKey('ended', accountId, product, iso));
+    const ms = parseInt(String(raw || ''), 10);
+    return Number.isFinite(ms) && ms > 0 ? new Date(ms).toISOString() : null;
+  } catch { return null; }
+}
+
+function termRow({ product, endsAt, tier, notifiedAt }) {
+  const plan = `${productName(product)} ${tierName(tier)}`.trim();
+  return {
+    ts: new Date(endsAt).toISOString(),
+    type: 'term_ended',
+    label: `${plan} term ended`,
+    detail: 'Account back on Community',
+    amount: null,
+    currency: null,
+    document: null,
+    notified_at: notifiedAt || null,
+  };
+}
+
+// ── the list ─────────────────────────────────────────────────────────────────
+// Never throws and never half-answers: a redis that drops out mid-read costs
+// the rows it had not reached, and the customer still sees the rest. `limit`
+// caps what goes over the wire; the documents themselves stay complete in the
+// invoice list beside it.
+async function build({ accountId, redis, now, limit = 100 } = {}) {
+  if (!accountId || !redis) return [];
+  const nowMs = (now instanceof Date ? now : new Date()).getTime();
+  let records = [];
+  try { records = await invoice.listFor(accountId, redis); } catch { records = []; }
+
+  const rows = [];
+  for (const rec of records) {
+    try { rows.push(documentRow(rec)); } catch { /* one bad record must not empty the list */ }
+  }
+
+  // Both sources of a term end, deduplicated on the period itself: the index
+  // holds the CURRENT period, which is usually the same one the last document
+  // bought, and showing it twice would read as two lapses.
+  const ends = termEndsFromDocuments(records, nowMs);
+  let indexed = [];
+  try { indexed = await termEndFromIndex(accountId, redis, nowMs); } catch { indexed = []; }
+  const seen = new Set(ends.map((e) => `${e.product}|${e.endsAt}`));
+  for (const e of indexed) {
+    if (seen.has(`${e.product}|${e.endsAt}`)) continue;
+    seen.add(`${e.product}|${e.endsAt}`);
+    ends.push(e);
+  }
+  for (const e of ends) {
+    rows.push(termRow({ ...e, notifiedAt: await endedNoticeAt(accountId, e.product, e.iso, redis) }));
+  }
+
+  rows.sort((a, b) => Date.parse(b.ts) - Date.parse(a.ts));
+  return rows.slice(0, limit);
+}
+
+module.exports = { build, documentRow, termRow, termEndsFromDocuments, termEndFromIndex, productName, tierName };

--- a/relay/lib/credit-note.js
+++ b/relay/lib/credit-note.js
@@ -1,0 +1,354 @@
+'use strict';
+// The document a customer gets when money goes back: a credit note.
+//
+// WHY A MARKER WAS NOT ENOUGH. lib/invoice.js issues a numbered invoice for
+// every payment and, when a chargeback arrived, stamped `reversed_at` on it.
+// That keeps our own records from lying, and it is all it does. Dutch VAT law
+// does not let an issued invoice be withdrawn: an invoice that has gone out
+// stays out, and the money that goes back is documented by a SECOND document
+// with its own sequential number that refers to the first (Wet OB art. 35a
+// applies to it in full, and art. 29 is what makes the VAT correctable at all).
+// A bookkeeper who is handed PS-2026-0001 and told "ignore that one" has
+// nothing to book. Handed CN-2026-0001 he books a reversal, and the VAT return
+// closes.
+//
+// WHAT A CREDIT NOTE HERE CARRIES:
+//   - its own number from its own series, CN-2026-0001, per calendar year
+//   - the number AND the date of the invoice it credits
+//   - the same description, the same VAT rate, the same seller and buyer as
+//     they stood on the original document
+//   - negative net, negative VAT and a negative total
+//   - the reason: a chargeback, or a refund we sent
+//
+// THE THREE RULES ARE lib/invoice.js's, and for the same reasons:
+//
+// 1. ONE DOCUMENT PER REVERSAL. Mollie retries a webhook for about a day and
+//    the relay re-runs the handler; a second credit note for one chargeback
+//    would hand the customer twice his money back on paper. The reversal is
+//    claimed BEFORE a number is drawn, exactly as a payment is.
+//
+// 2. A NUMBER IS NEVER REUSED AND NEVER SKIPPED. INCR on one key per year, and
+//    the number drawn is written back onto the claim, so a crash between the
+//    draw and the record hands the SAME number to the retry.
+//
+// 3. AMOUNTS COME FROM THE ORIGINAL DOCUMENT AND FROM THE PAYMENT, never from
+//    a request. What may be credited is capped by what was invoiced, and what
+//    is already credited is tracked, so no series of partial refunds can ever
+//    give back more than came in.
+//
+// PARTIAL REFUNDS, AND WHY THE SPLIT IS DONE AGAINST THE RUNNING TOTAL.
+// Mollie reports `amountRefunded` and `amountChargedBack` as CUMULATIVE totals
+// on the payment, not as the delta of one event. So this module computes the
+// split for the cumulative amount and issues the DIFFERENCE against what it has
+// already credited. Two consequences, both wanted:
+//   - each note is the VAT of its own amount, pro rata, in whole cents;
+//   - when the running total reaches the invoiced amount, the target split IS
+//     the original split (same gross, same rate, same rounding), so the last
+//     note absorbs every rounding remainder and the credit notes together add
+//     back up to the invoice, to the cent.
+
+const invoice = require('./invoice');
+
+// ── redis key shapes ─────────────────────────────────────────────────────────
+// No TTL, for the reason invoice.js gives: seven years of retention (AWR art.
+// 52), and a credit note that expires is one that was never kept. Documents
+// themselves live in invoice.K.doc and in the same per-account list, so the
+// account page and the PDF route serve both series without a second index.
+const CK = {
+  claim:    (reversalId) => `paramant:billing:credit:for:${reversalId}`,
+  seq:      (year)       => `paramant:billing:credit:seq:${year}`,
+  against:  (number)     => `paramant:billing:credit:against:${number}`,
+};
+
+const PENDING_TAKEOVER_MS = invoice.PENDING_TAKEOVER_MS;
+
+// The wording on a credit note against a document that could not call itself an
+// invoice (no seller VAT id on file). Same honesty as RECEIPT_NOTE: the money
+// really did go back, and the VAT document follows.
+const CREDIT_RECEIPT_NOTE = 'Credit note with VAT number follows.';
+
+// ── numbering ────────────────────────────────────────────────────────────────
+// CN-2026-0001. A SEPARATE series from PS: mixing credit notes into the invoice
+// series makes the invoice numbering non-consecutive for anyone reading only
+// the invoices, which is the thing the sequence exists to prevent. Two series
+// is explicitly allowed ("uit een of meer reeksen", art. 35a lid 1 sub b).
+function formatNumber(year, seq) {
+  return `CN-${year}-${String(seq).padStart(4, '0')}`;
+}
+
+function parseNumber(number) {
+  const m = /^CN-(\d{4})-(\d{4,})$/.exec(String(number || '').trim());
+  return m ? { year: parseInt(m[1], 10), seq: parseInt(m[2], 10) } : null;
+}
+
+// ── how much went back ───────────────────────────────────────────────────────
+// Reads only the payment object the caller re-fetched from Mollie, never a
+// webhook body. Both cumulative counters are added: a payment can be partly
+// refunded by us and then charged back for the rest, and both halves are money
+// the customer no longer paid. Capped at what was invoiced, because a credit
+// note for more than the invoice is a document nobody can book.
+//
+// The fallback matters. A chargeback event does not always carry a populated
+// amountChargedBack on the payment (it is settled asynchronously), and a
+// `refunded` status without counters means the whole thing went back. Answering
+// zero there would leave the customer with an invoice for money he does not
+// have, which is the state this module exists to end.
+function reversedCentsOf(payment, record) {
+  const p = payment || {};
+  const status = String(p.status || '');
+  const cap = invoice.centsOf(record && record.amount_gross);
+  const capped = Number.isFinite(cap) ? cap : 0;
+  const read = (amount) => {
+    const c = invoice.centsOf(amount && amount.value);
+    return Number.isFinite(c) ? c : 0;
+  };
+  let cents = read(p.amountRefunded) + read(p.amountChargedBack);
+  const full = status === 'chargeback' || status === 'charged_back' || status === 'refunded';
+  if (cents <= 0 && full) cents = capped;
+  return Math.max(0, Math.min(cents, capped));
+}
+
+// Is there anything here that asks for a credit note at all. Kept next to the
+// amount so the relay has one place to ask, rather than repeating a list of
+// Mollie statuses at the call site.
+function isReversal(payment) {
+  const p = payment || {};
+  const status = String(p.status || '');
+  if (status === 'chargeback' || status === 'charged_back' || status === 'refunded') return true;
+  const refunded = invoice.centsOf(p.amountRefunded && p.amountRefunded.value);
+  const back = invoice.centsOf(p.amountChargedBack && p.amountChargedBack.value);
+  return (Number.isFinite(refunded) && refunded > 0) || (Number.isFinite(back) && back > 0);
+}
+
+function reasonOf(payment) {
+  const status = String((payment || {}).status || '');
+  if (status === 'chargeback' || status === 'charged_back') return 'chargeback';
+  const back = invoice.centsOf((payment || {}).amountChargedBack && payment.amountChargedBack.value);
+  if (Number.isFinite(back) && back > 0) return 'chargeback';
+  return 'refund';
+}
+
+// ── the record ───────────────────────────────────────────────────────────────
+// Seller and buyer are COPIED FROM THE ORIGINAL DOCUMENT, not rebuilt from
+// today's configuration. A credit note reverses a specific invoice, and it has
+// to state the same parties that invoice stated even if the customer has since
+// changed his company address.
+function describe(original) {
+  return `Credit for ${original.description || 'a paid plan'} (invoice ${original.number})`;
+}
+
+function buildRecord({ number, original, amounts, reason, payment, now, partial }) {
+  const issued = now instanceof Date ? now : new Date();
+  const forInvoice = original.kind === 'invoice';
+  return {
+    number,
+    kind: 'credit_note',
+    series: 'CN',
+    title: forInvoice ? 'Credit note' : 'Refund receipt',
+    note: forInvoice ? '' : CREDIT_RECEIPT_NOTE,
+    credits_kind: original.kind,
+    issued_at: issued.toISOString(),
+    invoice_date: issued.toISOString().slice(0, 10),
+    account_id: original.account_id,
+    payment_id: (payment && payment.id) || original.payment_id,
+    payment_method: original.payment_method || null,
+    credit_for: original.number,
+    credit_for_date: original.invoice_date,
+    reason,
+    partial: !!partial,
+    product: original.product,
+    plan: original.plan,
+    interval: original.interval,
+    description: describe(original),
+    service_period_end: original.service_period_end || null,
+    currency: original.currency || 'EUR',
+    vat_rate: original.vat_rate,
+    amount_net: invoice.money(-amounts.net_cents),
+    amount_vat: invoice.money(-amounts.vat_cents),
+    amount_gross: invoice.money(-amounts.gross_cents),
+    seller: Object.assign({}, original.seller),
+    buyer: Object.assign({}, original.buyer),
+  };
+}
+
+// ── what has already been given back ─────────────────────────────────────────
+// One small JSON blob per invoice: the running totals and the numbers of the
+// notes that produced them. It is what makes a second partial refund credit the
+// delta instead of the whole amount again, and it is the only place a reader
+// has to look to answer "is this invoice fully credited".
+async function creditedAgainst(number, redis) {
+  const empty = { gross_cents: 0, net_cents: 0, vat_cents: 0, notes: [] };
+  if (!redis || !number) return empty;
+  try {
+    const raw = await redis.get(CK.against(number));
+    if (!raw) return empty;
+    const parsed = JSON.parse(raw);
+    return {
+      gross_cents: parsed.gross_cents || 0,
+      net_cents: parsed.net_cents || 0,
+      vat_cents: parsed.vat_cents || 0,
+      notes: Array.isArray(parsed.notes) ? parsed.notes : [],
+    };
+  } catch { return empty; }
+}
+
+// ── issuing ──────────────────────────────────────────────────────────────────
+// `redis` is anything with get / set / incr / rPush / lRange, so the unit tests
+// drive a Map and the route tests drive a real server, exactly as invoice.js
+// does. Never throws and never blocks the webhook: a customer whose money went
+// back must not see the webhook fail over paperwork either.
+//
+// Returns { result, number, record, fully_credited }:
+//   'issued'      a credit note exists for this reversal
+//   'existing'    this reversal already has one; record is that one
+//   'none'        nothing to credit (no invoice, or already credited in full)
+//   'deferred'    another attempt holds the claim right now; try again later
+//   'unavailable' no redis, or nothing could be written
+async function issueCreditNote({ payment, original, now }, redis) {
+  if (!redis) return { result: 'unavailable', reason: 'no_redis' };
+  if (!payment || !payment.id) return { result: 'unavailable', reason: 'no_payment' };
+
+  // The invoice being credited. Passed in by the tests, looked up from the
+  // payment id in production: a chargeback arrives on the same tr_ id as the
+  // payment it reverses, and the claim key is the index from one to the other.
+  const invoiceRecord = original || await invoice.recordForPayment(payment.id, redis);
+  if (!invoiceRecord || !invoiceRecord.number) return { result: 'none', reason: 'no_invoice' };
+
+  const issued = now instanceof Date ? now : new Date();
+  const grossCents = invoice.centsOf(invoiceRecord.amount_gross);
+  if (!Number.isFinite(grossCents) || grossCents <= 0) return { result: 'none', reason: 'bad_invoice_amount' };
+
+  const targetGross = reversedCentsOf(payment, invoiceRecord);
+  if (targetGross <= 0) return { result: 'none', reason: 'nothing_reversed' };
+
+  // Step 1: claim the reversal. The id is the payment PLUS the cumulative
+  // amount, which is what makes this both idempotent and able to follow a
+  // second partial refund: a repeat webhook reports the same total and hits the
+  // same claim, a further refund reports a higher total and is a new one.
+  const reversalId = `${payment.id}:${targetGross}`;
+  const claimKey = CK.claim(reversalId);
+  const pendingValue = `pending:${issued.getTime()}`;
+  let claimed = false;
+  try {
+    claimed = !!(await redis.set(claimKey, pendingValue, { NX: true }));
+  } catch (e) {
+    return { result: 'unavailable', reason: `claim_failed:${e.message}` };
+  }
+  if (!claimed) {
+    let held = null;
+    try { held = await redis.get(claimKey); } catch { held = null; }
+    if (held && held.startsWith('CN-')) {
+      let record = null;
+      try { record = JSON.parse((await redis.get(invoice.K.doc(held))) || 'null'); } catch { record = null; }
+      return { result: 'existing', number: held, record };
+    }
+    const started = parseInt(String(held || '').split(':')[1] || '0', 10);
+    if (!(started && issued.getTime() - started > PENDING_TAKEOVER_MS)) {
+      return { result: 'deferred', reason: 'claim_pending' };
+    }
+    // Older than the takeover window: the previous attempt is not coming back.
+  }
+
+  // Step 2: how much of that total is new. Read under the claim, so two
+  // reversals of the same payment cannot both read the same starting point.
+  const already = await creditedAgainst(invoiceRecord.number, redis);
+  const target = invoice.splitVat(invoice.money(targetGross), invoiceRecord.vat_rate);
+  if (!target) return { result: 'unavailable', reason: 'bad_amount' };
+  const amounts = {
+    gross_cents: target.gross_cents - already.gross_cents,
+    net_cents: target.net_cents - already.net_cents,
+    vat_cents: target.vat_cents - already.vat_cents,
+  };
+  if (amounts.gross_cents <= 0) {
+    // Everything this reversal asks for is already on a credit note. Release
+    // the claim so a LATER, larger reversal of the same payment is not blocked
+    // by a claim that produced nothing.
+    try { await redis.set(claimKey, 'none'); } catch { /* best effort */ }
+    return { result: 'none', reason: 'already_credited', fully_credited: already.gross_cents >= grossCents };
+  }
+
+  // Step 3: draw the number. Only ever reached for a reversal that has no
+  // document yet, which is what keeps the CN series gapless.
+  const year = issued.getUTCFullYear();
+  let seq;
+  try { seq = await redis.incr(CK.seq(year)); }
+  catch (e) { return { result: 'unavailable', reason: `seq_failed:${e.message}` }; }
+  const number = formatNumber(year, seq);
+
+  const record = buildRecord({
+    number,
+    original: invoiceRecord,
+    amounts,
+    reason: reasonOf(payment),
+    payment,
+    now: issued,
+    partial: targetGross < grossCents,
+  });
+
+  // Step 4: the record first, then the claim, then the running total, then the
+  // lists. A crash leaves at worst a document nobody has indexed yet, never a
+  // claim pointing at a number that has no document, and never a running total
+  // counting a note that was never written.
+  try {
+    await redis.set(invoice.K.doc(number), JSON.stringify(record));
+    await redis.set(claimKey, number);
+    await redis.set(CK.against(invoiceRecord.number), JSON.stringify({
+      invoice: invoiceRecord.number,
+      gross_cents: target.gross_cents,
+      net_cents: target.net_cents,
+      vat_cents: target.vat_cents,
+      notes: already.notes.concat([number]),
+      updated_at: issued.toISOString(),
+    }));
+    if (invoiceRecord.account_id) await redis.rPush(invoice.K.byAcct(invoiceRecord.account_id), number);
+    await redis.rPush(invoice.K.all, number);
+  } catch (e) {
+    return { result: 'unavailable', reason: `store_failed:${e.message}`, number };
+  }
+
+  // Back-reference on the invoice, best effort. Not the record of the credit
+  // (that is CK.against and the note itself); it is so that anyone who opens
+  // only the invoice, PDF included, is told which document reversed it and for
+  // how much. A failure here must never undo a credit note that exists.
+  try {
+    const raw = await redis.get(invoice.K.doc(invoiceRecord.number));
+    if (raw) {
+      const rec = JSON.parse(raw);
+      const notes = Array.isArray(rec.credit_notes) ? rec.credit_notes : [];
+      if (!notes.includes(number)) notes.push(number);
+      rec.credit_notes = notes;
+      rec.credited_gross = invoice.money(target.gross_cents);
+      await redis.set(invoice.K.doc(invoiceRecord.number), JSON.stringify(rec));
+    }
+  } catch { /* the credit note stands on its own */ }
+
+  return {
+    result: 'issued',
+    number,
+    record,
+    credited: invoiceRecord.number,
+    fully_credited: target.gross_cents >= grossCents,
+  };
+}
+
+// Every credit note issued against one invoice, oldest first. Reading is by
+// number through the shared document keyspace, so nothing here can serve a
+// document belonging to another account that the caller has not already checked.
+async function notesAgainst(number, redis) {
+  const state = await creditedAgainst(number, redis);
+  const out = [];
+  for (const n of state.notes) {
+    try {
+      const raw = await redis.get(invoice.K.doc(n));
+      if (raw) out.push(JSON.parse(raw));
+    } catch { /* one unreadable note must not hide the rest */ }
+  }
+  return out;
+}
+
+module.exports = {
+  CK, CREDIT_RECEIPT_NOTE, PENDING_TAKEOVER_MS,
+  formatNumber, parseNumber, describe, buildRecord,
+  reversedCentsOf, isReversal, reasonOf,
+  creditedAgainst, issueCreditNote, notesAgainst,
+};

--- a/relay/lib/invoice-pdf.js
+++ b/relay/lib/invoice-pdf.js
@@ -174,7 +174,14 @@ function render(record, opts = {}) {
   const right = PAGE.width - MARGIN;
   const seller = record.seller || {};
   const buyer = record.buyer || {};
-  const isInvoice = record.kind === 'invoice';
+  // Three shapes off one layout. A credit note is the same document with the
+  // amounts negative, its own series, and a line naming the invoice it credits
+  // (art. 35a applies to it in full, and without that reference a bookkeeper
+  // cannot match the reversal to anything). `isInvoice` stays what it always
+  // meant: this document may call itself a VAT invoice. A credit note against a
+  // receipt is a refund receipt and says so, on the same footing.
+  const isCredit = record.kind === 'credit_note';
+  const isInvoice = isCredit ? record.credits_kind === 'invoice' : record.kind === 'invoice';
   let y = MARGIN + 6;
 
   // Header: who is sending this, and what it is.
@@ -205,8 +212,16 @@ function render(record, opts = {}) {
     doc.text(k, MARGIN, yy, { size: 9, grey: 0.4 });
     doc.text(v, MARGIN + 110, yy, { font: FONTS.mono, size: 9.5 });
   };
-  label(isInvoice ? 'Invoice date' : 'Receipt date', record.invoice_date || '', y); y += 14;
-  label(isInvoice ? 'Invoice number' : 'Document number', record.number || '', y); y += 14;
+  const dateLabel = isCredit ? (isInvoice ? 'Credit note date' : 'Refund date') : (isInvoice ? 'Invoice date' : 'Receipt date');
+  const numberLabel = isCredit ? (isInvoice ? 'Credit note number' : 'Document number') : (isInvoice ? 'Invoice number' : 'Document number');
+  label(dateLabel, record.invoice_date || '', y); y += 14;
+  label(numberLabel, record.number || '', y); y += 14;
+  // The reference that makes a credit note bookable at all: which invoice, and
+  // of what date. Both, because a number alone sends the reader hunting.
+  if (isCredit) {
+    label('Credit for invoice', record.credit_for || '', y); y += 14;
+    if (record.credit_for_date) { label('Invoice date', String(record.credit_for_date).slice(0, 10), y); y += 14; }
+  }
   label('Payment reference', record.payment_id || '', y); y += 14;
   if (record.service_period_end) { label('Service until', String(record.service_period_end).slice(0, 10), y); y += 14; }
   y += 10;
@@ -255,10 +270,26 @@ function render(record, opts = {}) {
   };
   total('Subtotal excl. VAT', `${cur} ${record.amount_net}`, false);
   total(`VAT ${record.vat_rate}%`, `${cur} ${record.amount_vat}`, false);
-  total('Total', `${cur} ${record.amount_gross}`, true);
+  total(isCredit ? 'Total credited' : 'Total', `${cur} ${record.amount_gross}`, true);
   y += 6;
-  doc.text('Paid in full. No payment is due.', right, y, { size: 9, align: 'right', grey: 0.4 });
+  // What the reader owes, in one line, and it is never "nothing to do here".
+  // On a credit note the money has already moved back, by the same route it
+  // came in, and saying so is what stops a support mail.
+  doc.text(isCredit
+    ? (record.reason === 'chargeback'
+      ? 'This amount was charged back and is no longer due. Nothing is payable.'
+      : 'This amount has been refunded to you. Nothing is payable.')
+    : 'Paid in full. No payment is due.',
+  right, y, { size: 9, align: 'right', grey: 0.4 });
   y += 26;
+
+  // A partial credit note has to say what is left standing, or it reads as a
+  // full reversal of an invoice that is still partly owed and partly booked.
+  if (isCredit && record.partial) {
+    doc.text('Partial credit. The remainder of the invoice named above still stands.',
+      MARGIN, y, { size: 9, grey: 0.35 });
+    y += 18;
+  }
 
   // What the document is not, when it is not an invoice yet.
   if (!isInvoice) {
@@ -266,15 +297,26 @@ function render(record, opts = {}) {
     y += 16;
     doc.text(record.note || '', MARGIN, y, { font: FONTS.bold, size: 10 });
     y += 14;
-    doc.text('This receipt confirms your payment. It is not a VAT invoice: our VAT identification', MARGIN, y, { size: 9, grey: 0.35 }); y += 12;
-    doc.text('number is not yet on file. You will receive the invoice for this payment as soon as it is.', MARGIN, y, { size: 9, grey: 0.35 }); y += 12;
+    if (isCredit) {
+      doc.text('This receipt confirms the refund. It is not a VAT credit note: our VAT identification', MARGIN, y, { size: 9, grey: 0.35 }); y += 12;
+      doc.text('number is not yet on file. You will receive the credit note for this refund as soon as it is.', MARGIN, y, { size: 9, grey: 0.35 }); y += 12;
+    } else {
+      doc.text('This receipt confirms your payment. It is not a VAT invoice: our VAT identification', MARGIN, y, { size: 9, grey: 0.35 }); y += 12;
+      doc.text('number is not yet on file. You will receive the invoice for this payment as soon as it is.', MARGIN, y, { size: 9, grey: 0.35 }); y += 12;
+    }
     y += 10;
   }
 
-  if (record.reversed_at) {
+  // Only on an invoice: a credit note is the document that reverses, and can
+  // never itself be reversed.
+  if (!isCredit && record.reversed_at) {
     doc.text(`Reversed on ${String(record.reversed_at).slice(0, 10)} (chargeback). This document no longer represents money received.`,
       MARGIN, y, { font: FONTS.bold, size: 9 });
     y += 18;
+    if (record.credit_notes && record.credit_notes.length) {
+      doc.text(`Credited by ${record.credit_notes.join(', ')}.`, MARGIN, y, { size: 9, grey: 0.35 });
+      y += 14;
+    }
   }
 
   // Footer, on the last line of the page rather than after the content, so it

--- a/relay/lib/invoice.js
+++ b/relay/lib/invoice.js
@@ -44,9 +44,11 @@
 //    here, in integer cents.
 //
 // NOT HERE, ON PURPOSE:
-//   - a credit note for a chargeback. A reversal writes a marker (see
-//     recordReversal) so the record is not silently wrong, but a numbered
-//     credit note with its own series is a separate piece of work.
+//   - the credit note itself. Money that goes back gets its own numbered
+//     document in its own series (CN-2026-0001), and that lives in
+//     lib/credit-note.js. What stays here is recordReversal, the marker that
+//     says an invoice was credited IN FULL, so a reader of the invoice alone
+//     is not misled.
 //   - reverse charge / VAT-MOSS. Every catalog price is 21% Dutch VAT and that
 //     is what was actually charged, so that is what the document states. An
 //     EU customer outside NL with a VAT number is charged the same 21% today;
@@ -144,6 +146,16 @@ function formatNumber(year, seq) {
 function parseNumber(number) {
   const m = /^PS-(\d{4})-(\d{4,})$/.exec(String(number || '').trim());
   return m ? { year: parseInt(m[1], 10), seq: parseInt(m[2], 10) } : null;
+}
+
+// Two series share one document keyspace and one per-account list: PS for what
+// was charged, CN for what was given back (lib/credit-note.js). A reader that
+// only knew PS answered 404 for a credit note it had itself just written into
+// the customer's list, so anything that looks up a stored document goes through
+// this and not through parseNumber.
+function parseDocumentNumber(number) {
+  const m = /^(PS|CN)-(\d{4})-(\d{4,})$/.exec(String(number || '').trim());
+  return m ? { series: m[1], year: parseInt(m[2], 10), seq: parseInt(m[3], 10) } : null;
 }
 
 // ── the record ───────────────────────────────────────────────────────────────
@@ -275,10 +287,12 @@ async function issueDocument({ payment, order, seller, buyer, now, periodEnd }, 
   return { result: 'issued', number, record };
 }
 
-// A chargeback takes the money back on the SAME tr_ id as the payment. There is
-// no credit note yet (see the header), so the least dishonest thing available
-// is a marker on the invoice that was reversed: the document keeps its number
-// and its place in the series, and every reader can see the money went back.
+// A chargeback takes the money back on the SAME tr_ id as the payment. The
+// document that reverses it is a credit note (lib/credit-note.js); this is the
+// marker on the invoice itself, so the invoice keeps its number and its place
+// in the series while every reader can see the money went back. Only ever set
+// when the whole invoice went back: a partial refund leaves an invoice that is
+// still partly true, and stamping it reversed would be the opposite of honest.
 // Never issues a new number.
 async function recordReversal({ payment, now }, redis) {
   if (!redis || !payment || !payment.id) return { result: 'unavailable' };
@@ -322,7 +336,7 @@ async function listFor(accountId, redis, limit = 200) {
 }
 
 async function getFor(accountId, number, redis) {
-  if (!redis || !accountId || !parseNumber(number)) return null;
+  if (!redis || !accountId || !parseDocumentNumber(number)) return null;
   try {
     const raw = await redis.get(K.doc(number));
     if (!raw) return null;
@@ -331,9 +345,22 @@ async function getFor(accountId, number, redis) {
   } catch { return null; }
 }
 
+// The document a payment produced, found from the payment id alone. The claim
+// key is the index: it holds the number once the document exists. Used by the
+// credit-note path, which is handed a chargeback carrying nothing but the tr_
+// id of the payment it reverses.
+async function recordForPayment(paymentId, redis) {
+  if (!redis || !paymentId) return null;
+  let number = null;
+  try { number = await redis.get(K.claim(paymentId)); } catch { return null; }
+  if (!number || !number.startsWith('PS-')) return null;
+  try { return JSON.parse((await redis.get(K.doc(number))) || 'null'); } catch { return null; }
+}
+
 module.exports = {
   CATALOG_VAT_RATE, K, BUYER_HINT, RECEIPT_NOTE, PENDING_TAKEOVER_MS,
   sellerFromEnv, documentKind, documentTitle, buyerIsComplete,
-  centsOf, money, splitVat, formatNumber, parseNumber, describe, buildRecord,
-  issueDocument, recordReversal, listFor, getFor,
+  centsOf, money, splitVat, formatNumber, parseNumber, parseDocumentNumber,
+  describe, buildRecord,
+  issueDocument, recordReversal, recordForPayment, listFor, getFor,
 };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -143,6 +143,8 @@ const parasignAuditExport = require('./lib/parasign-audit-export'); // GET /v2/p
 const transferNotify   = require('./lib/transfer-notify');   // ParaSend Pro upload/download mail
 const invoiceMod       = require('./lib/invoice');            // invoice numbering, records and VAT split
 const invoicePdf       = require('./lib/invoice-pdf');        // one-page PDF writer, no dependency
+const creditNote       = require('./lib/credit-note');        // credit notes (CN series) for money that goes back
+const billingHistory   = require('./lib/billing-history');    // one chronological list, derived from the records
 const planExpiry       = require('./lib/plan-expiry');      // paid-term warning + expiry mail (in-process planner)
 
 // Outbound wire format selector. Default 0 keeps the legacy on-the-wire format;
@@ -2184,6 +2186,80 @@ function _mailInvoice(record) {
     ``,
     isInvoice ? '' : `${invoiceMod.RECEIPT_NOTE}`,
     invoiceMod.buyerIsComplete(record.buyer) ? '' : `${invoiceMod.BUYER_HINT}.`,
+    ``,
+    `The document is attached, and every document stays available on your account page.`,
+    ``,
+    record.seller.name,
+  ].filter((l, i, a) => !(l === '' && a[i - 1] === ''));
+  return sendResendEmail({
+    to: record.buyer.email,
+    from: 'PARAMANT <billing@paramant.app>',
+    subject,
+    text: lines.join('\n'),
+    attachments: [{ filename: `${record.number}.pdf`, content: pdf.toString('base64') }],
+  });
+}
+
+// The document for money that goes back. A chargeback or a refund reaches us on
+// the SAME tr_ id as the payment, so the invoice it reverses is found from that
+// id alone; the credit note gets its own number in its own series and refers to
+// the invoice by number and date, because an issued invoice may not be
+// withdrawn (see lib/credit-note.js).
+//
+// Runs for a repeat webhook too, and for a partial refund, on the same
+// reasoning as _issueInvoiceForPayment: issueCreditNote is idempotent per
+// reversal, so a retry can only ever repair. Never throws: paperwork must not
+// be able to fail a webhook.
+async function _creditNoteForPayment(payment) {
+  try {
+    const redis = (redisClient && redisClient.isReady) ? redisClient : null;
+    if (!redis) return;
+    const out = await creditNote.issueCreditNote({ payment }, redis);
+    if (out.result !== 'issued') {
+      // 'none' is the ordinary answer for a payment that has no invoice (money
+      // taken before the invoice module existed) and for a repeat of a reversal
+      // already credited in full. Neither is a fault, and neither is silent.
+      log(out.result === 'existing' || out.result === 'none' ? 'info' : 'warn', 'billing_credit_note', {
+        payment_id: payment.id, result: out.result, reason: out.reason, number: out.number,
+      });
+      return out;
+    }
+    log('warn', 'billing_credit_note', {
+      payment_id: payment.id, result: 'issued', number: out.number, credits: out.credited,
+      account: String(out.record.account_id || '').slice(0, 12),
+      total: out.record.amount_gross, reason: out.record.reason, partial: out.record.partial,
+    });
+    _mailCreditNote(out.record);
+    return out;
+  } catch (e) {
+    log('error', 'billing_credit_note_failed', { payment_id: payment && payment.id, err: e.message });
+    return { result: 'unavailable', reason: e.message };
+  }
+}
+
+// The credit note as mail, with the PDF attached. Same shape and same
+// no-mail-path-is-not-an-error rule as _mailInvoice: the record exists and
+// /v2/billing/invoices serves it either way.
+function _mailCreditNote(record) {
+  if (!record || !record.buyer || !record.buyer.email) return false;
+  let pdf;
+  try { pdf = invoicePdf.render(record, { buyerHint: invoiceMod.BUYER_HINT }); }
+  catch (e) { log('warn', 'billing_credit_pdf_failed', { number: record.number, err: e.message }); return false; }
+  const chargedBack = record.reason === 'chargeback';
+  const subject = `${record.title} ${record.number} - ${record.seller.name}`;
+  const lines = [
+    chargedBack
+      ? `Your payment was charged back, so the invoice below has been credited.`
+      : `Your payment has been refunded, so the invoice below has been credited.`,
+    ``,
+    `${record.title} ${record.number}`,
+    `Date: ${record.invoice_date}`,
+    `Credit for invoice ${record.credit_for} of ${record.credit_for_date}`,
+    `${record.description}`,
+    `Total credited: ${record.currency} ${record.amount_gross} (incl. ${record.vat_rate}% VAT, ${record.currency} ${record.amount_vat})`,
+    ``,
+    record.partial ? 'This is a partial credit. The remainder of that invoice still stands.' : '',
+    record.note || '',
     ``,
     `The document is attached, and every document stays available on your account page.`,
     ``,
@@ -6138,11 +6214,26 @@ async function handleRelayRequest(req, res) {
          (outcome.result === 'ignored' && outcome.reason === 'already_processed'))) {
       await _issueInvoiceForPayment(payment, outcome);
     }
-    // A chargeback leaves the invoice standing with its number, and marks it as
-    // reversed. There is no numbered credit note yet (see lib/invoice.js), so a
-    // marker is the honest minimum: the record must not keep claiming money the
-    // customer took back.
-    if (outcome.result === 'revoked' && redisClient && redisClient.isReady) {
+    // Money going back. An issued invoice may not be withdrawn, so the document
+    // for it is a CREDIT NOTE with its own number in its own series, referring
+    // to the invoice it credits (lib/credit-note.js).
+    //
+    // Not gated on outcome.result. A chargeback revokes the entitlement and a
+    // refund does not, but both are money the customer no longer paid, and both
+    // need the document. A partial refund arrives as a still-'paid' payment
+    // with amountRefunded set, which no outcome would ever have caught.
+    if (creditNote.isReversal(payment) && redisClient && redisClient.isReady) {
+      const credit = await _creditNoteForPayment(payment);
+      // The marker on the invoice, and only when the WHOLE invoice went back: a
+      // partly refunded invoice is still partly true, and stamping it reversed
+      // would say the opposite. The credit note is the record either way.
+      if (credit && credit.fully_credited) {
+        const rev = await invoiceMod.recordReversal({ payment }, redisClient);
+        if (rev.result === 'reversed') log('warn', 'billing_invoice_reversed', { payment_id: paymentId, number: rev.number });
+      }
+    } else if (outcome.result === 'revoked' && redisClient && redisClient.isReady) {
+      // A revoke we could not read an amount for. The marker is still the
+      // honest minimum: the record must not keep claiming money that went back.
       const rev = await invoiceMod.recordReversal({ payment }, redisClient);
       if (rev.result === 'reversed') log('warn', 'billing_invoice_reversed', { payment_id: paymentId, number: rev.number });
     }
@@ -6180,9 +6271,31 @@ async function handleRelayRequest(req, res) {
         currency: r.currency, amount_net: r.amount_net, amount_vat: r.amount_vat,
         amount_gross: r.amount_gross, vat_rate: r.vat_rate,
         reversed_at: r.reversed_at || null,
+        // Credit notes ride in the same list, in the same order the customer's
+        // documents happened. These four fields are what tells the page a row
+        // is money going back and which invoice it belongs to.
+        credit_for: r.credit_for || null,
+        reason: r.kind === 'credit_note' ? (r.reason || null) : null,
+        partial: r.kind === 'credit_note' ? !!r.partial : false,
+        credit_notes: r.credit_notes || null,
         pdf_url: `/v2/billing/invoices/${r.number}.pdf`,
       })),
     }));
+  }
+
+  // ── GET /v2/billing/history: one chronological list (authenticated) ──────
+  // Derived, never stored: the invoice and credit-note records for the money,
+  // and the paid periods on those same records (cross-read against the
+  // plan-expiry index) for the terms that ended. See lib/billing-history.js for
+  // why a period end is not simply a date in the past.
+  if (path === '/v2/billing/history' && req.method === 'GET') {
+    if (!keyData) { res.writeHead(401, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'unauthorized' })); }
+    if (!redisClient || !redisClient.isReady) {
+      res.writeHead(503, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'history_unavailable' }));
+    }
+    const history = await billingHistory.build({ accountId: acctOf(apiKey), redis: redisClient, now: new Date() });
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    return res.end(J({ ok: true, history }));
   }
 
   // ── GET /v2/billing/invoices/:number.pdf: one document (authenticated) ────
@@ -6192,7 +6305,10 @@ async function handleRelayRequest(req, res) {
   if (path.startsWith('/v2/billing/invoices/') && req.method === 'GET') {
     if (!keyData) { res.writeHead(401, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'unauthorized' })); }
     const number = decodeURIComponent(path.slice('/v2/billing/invoices/'.length)).replace(/\.pdf$/i, '');
-    if (!invoiceMod.parseNumber(number)) {
+    // Both series: PS for what was charged, CN for what was credited back. They
+    // share one document keyspace and one per-account list, so a credit note is
+    // downloaded by the same route that serves the invoice it credits.
+    if (!invoiceMod.parseDocumentNumber(number)) {
       res.writeHead(400, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'bad_invoice_number' }));
     }
     if (!redisClient || !redisClient.isReady) {

--- a/relay/test/billing-history.test.js
+++ b/relay/test/billing-history.test.js
@@ -1,0 +1,291 @@
+'use strict';
+// The one list a customer reads when he wonders what he was charged.
+//
+// /account carried a "Billing history" block that said "No billing events yet"
+// to an account that had paid, been invoiced and watched its term run out. This
+// suite drives the module that fills it, and the assertion that matters most is
+// the one about renewals: a period end that was extended by a renewal is NOT a
+// moment anything ended, and putting it in the list would tell a paying customer
+// he had lapsed on a day he never lost access.
+//
+// No redis and no network: the same Map stand-in the invoice and credit-note
+// suites use, plus the two hash reads lib/plan-expiry.js's index needs.
+//
+// Run: node --test relay/test/billing-history.test.js
+
+const { test, after } = require('node:test');
+const assert = require('assert');
+const invoice = require('../lib/invoice');
+const credit = require('../lib/credit-note');
+const planExpiry = require('../lib/plan-expiry');
+const history = require('../lib/billing-history');
+const catalog = require('../lib/billing-catalog');
+const { summary } = require('./_requires');
+
+let checks = 0;
+const did = () => { checks++; };
+after(() => summary('billing-history', checks));
+
+function fakeRedis() {
+  const kv = new Map();
+  const lists = new Map();
+  const hashes = new Map();
+  return {
+    kv, lists, hashes,
+    async get(k) { return kv.has(k) ? kv.get(k) : null; },
+    async set(k, v, opts) {
+      if (opts && opts.NX && kv.has(k)) return null;
+      kv.set(k, String(v));
+      return 'OK';
+    },
+    async incr(k) { const n = (parseInt(kv.get(k) || '0', 10) || 0) + 1; kv.set(k, String(n)); return n; },
+    async rPush(k, v) { const l = lists.get(k) || []; l.push(v); lists.set(k, l); return l.length; },
+    async lRange(k, start, stop) {
+      const l = lists.get(k) || [];
+      const a = start < 0 ? Math.max(0, l.length + start) : start;
+      const b = stop < 0 ? l.length + stop : stop;
+      return l.slice(a, b + 1);
+    },
+    async hSet(h, f, v) { const m = hashes.get(h) || new Map(); m.set(f, String(v)); hashes.set(h, m); return 1; },
+    async hGet(h, f) { const m = hashes.get(h); return m && m.has(f) ? m.get(f) : null; },
+  };
+}
+
+const SELLER = {
+  name: 'Paramantis Solutions B.V.',
+  address: 'Example Street 1\n1234 AB Example City\nNetherlands',
+  kvk: '42115132',
+  vat: 'NL863456789B01',
+};
+const BUYER = { email: 'office@example.test', company: 'Acme B.V.', address: 'Example Road 12', vat: '' };
+const ACCT = 'acct_demo';
+const NOW = new Date('2027-03-01T00:00:00Z');
+
+function payment(id, plan = 'pro', interval = 'yearly') {
+  const order = catalog.resolveOrder({ product: 'parasign', plan, interval });
+  return {
+    id, status: 'paid', method: 'ideal',
+    amount: { value: order.amount, currency: order.currency },
+    metadata: { accountId: ACCT, product: 'parasign', plan, interval },
+  };
+}
+
+// One payment, on a date, buying a term that runs to another date. Both are
+// injected, because everything this module decides is a comparison of those two
+// against each other and against now.
+async function pay(redis, id, { at, until, plan = 'pro', interval = 'yearly' }) {
+  const p = payment(id, plan, interval);
+  return invoice.issueDocument({
+    payment: p,
+    order: Object.assign({ accountId: ACCT }, catalog.resolveOrder(p.metadata)),
+    seller: SELLER, buyer: BUYER,
+    now: new Date(at),
+    periodEnd: until,
+  }, redis);
+}
+
+const build = (redis) => history.build({ accountId: ACCT, redis, now: NOW });
+const typesOf = (rows) => rows.map((r) => r.type);
+
+// ── 1. the money ─────────────────────────────────────────────────────────────
+
+test('a paid invoice becomes a row with its number, its total and a download', async () => {
+  const redis = fakeRedis();
+  await pay(redis, 'tr_one', { at: '2026-09-03T12:00:00Z', until: '2027-09-03T12:00:00Z' });
+  const rows = await build(redis);
+  assert.strictEqual(rows.length, 1, 'a paid account is not "no billing events yet"');
+  const row = rows[0];
+  assert.strictEqual(row.type, 'invoice');
+  assert.strictEqual(row.document, 'PS-2026-0001');
+  assert.strictEqual(row.amount, '603.79');
+  assert.strictEqual(row.currency, 'EUR');
+  assert.strictEqual(row.label, 'Paramant ParaSign Pro, yearly plan');
+  assert.strictEqual(row.detail, 'Paid');
+  assert.strictEqual(row.pdf_url, '/v2/billing/invoices/PS-2026-0001.pdf');
+  assert.strictEqual(row.ts, '2026-09-03T12:00:00.000Z');
+  did();
+});
+
+test('a credit note is its own row, negative, naming the invoice it credits', async () => {
+  const redis = fakeRedis();
+  const paid = await pay(redis, 'tr_back', { at: '2026-09-03T12:00:00Z', until: '2027-09-03T12:00:00Z' });
+  assert.strictEqual(paid.result, 'issued');
+  await credit.issueCreditNote({
+    payment: Object.assign(payment('tr_back'), { status: 'chargeback', amountChargedBack: { value: '603.79', currency: 'EUR' } }),
+    now: new Date('2026-09-20T09:00:00Z'),
+  }, redis);
+  const rows = await build(redis);
+  assert.deepStrictEqual(typesOf(rows), ['credit_note', 'invoice'], 'newest first');
+  assert.strictEqual(rows[0].document, 'CN-2026-0001');
+  assert.strictEqual(rows[0].amount, '-603.79');
+  assert.strictEqual(rows[0].credit_for, 'PS-2026-0001');
+  assert.strictEqual(rows[0].label, 'Credit note for invoice PS-2026-0001');
+  assert.strictEqual(rows[0].detail, 'Charged back');
+  assert.strictEqual(rows[0].pdf_url, '/v2/billing/invoices/CN-2026-0001.pdf');
+  did();
+});
+
+test('a partial credit says it is partial, and the invoice row stays', async () => {
+  const redis = fakeRedis();
+  await pay(redis, 'tr_part', { at: '2026-09-03T12:00:00Z', until: '2027-09-03T12:00:00Z' });
+  await credit.issueCreditNote({
+    payment: Object.assign(payment('tr_part'), { amountRefunded: { value: '100.00', currency: 'EUR' } }),
+    now: new Date('2026-10-01T09:00:00Z'),
+  }, redis);
+  const rows = await build(redis);
+  assert.strictEqual(rows[0].label, 'Credit note for invoice PS-2026-0001 (partial)');
+  assert.strictEqual(rows[0].detail, 'Refunded');
+  assert.strictEqual(rows[0].amount, '-100.00');
+  assert.strictEqual(rows[1].amount, '603.79', 'the invoice still says what was charged');
+  did();
+});
+
+// ── 2. the terms ─────────────────────────────────────────────────────────────
+
+test('a term that has run out is a row of its own, on the day it ended', async () => {
+  const redis = fakeRedis();
+  await pay(redis, 'tr_gone', { at: '2026-01-10T12:00:00Z', until: '2026-02-10T12:00:00Z', interval: 'monthly' });
+  const rows = await build(redis);
+  assert.deepStrictEqual(typesOf(rows), ['term_ended', 'invoice']);
+  assert.strictEqual(rows[0].ts, '2026-02-10T12:00:00.000Z');
+  assert.strictEqual(rows[0].label, 'ParaSign Pro term ended');
+  assert.strictEqual(rows[0].detail, 'Account back on Community');
+  assert.strictEqual(rows[0].amount, null, 'nothing was charged for it ending');
+  assert.strictEqual(rows[0].notified_at, null, 'and no mail is claimed that never went out');
+  did();
+});
+
+test('a term still running is not in the list at all', async () => {
+  const redis = fakeRedis();
+  await pay(redis, 'tr_live', { at: '2027-02-01T12:00:00Z', until: '2028-02-01T12:00:00Z' });
+  const rows = await build(redis);
+  assert.deepStrictEqual(typesOf(rows), ['invoice'], 'a plan that has not ended has not ended');
+  did();
+});
+
+test('a renewal bought in time is one term, not two', async () => {
+  // The whole point. The first period ends on 2026-09-03, and a renewal bought
+  // in August extends it (lib/billing.js extendFrom) rather than starting a
+  // second one. Listing that first end would tell a customer who never lost a
+  // day of access that his plan had lapsed.
+  const redis = fakeRedis();
+  await pay(redis, 'tr_r1', { at: '2025-09-03T12:00:00Z', until: '2026-09-03T12:00:00Z' });
+  await pay(redis, 'tr_r2', { at: '2026-08-20T12:00:00Z', until: '2027-09-03T12:00:00Z' });
+  const rows = await build(redis);
+  assert.deepStrictEqual(typesOf(rows), ['invoice', 'invoice'], 'two payments, no lapse');
+  did();
+});
+
+test('a lapse and a later restart are two real term ends', async () => {
+  // Paid a month, let it go, came back four months later, let that go too.
+  // Both ends really happened and the customer really was on Community in
+  // between, so both belong in his own history.
+  const redis = fakeRedis();
+  await pay(redis, 'tr_l1', { at: '2026-01-10T12:00:00Z', until: '2026-02-10T12:00:00Z', interval: 'monthly' });
+  await pay(redis, 'tr_l2', { at: '2026-06-10T12:00:00Z', until: '2026-07-10T12:00:00Z', interval: 'monthly' });
+  const rows = await build(redis);
+  assert.deepStrictEqual(typesOf(rows), ['term_ended', 'invoice', 'term_ended', 'invoice']);
+  assert.deepStrictEqual(rows.filter((r) => r.type === 'term_ended').map((r) => r.ts),
+    ['2026-07-10T12:00:00.000Z', '2026-02-10T12:00:00.000Z']);
+  did();
+});
+
+test('a term the customer was mailed about carries when he was told', async () => {
+  const redis = fakeRedis();
+  await pay(redis, 'tr_told', { at: '2026-01-10T12:00:00Z', until: '2026-02-10T12:00:00Z', interval: 'monthly' });
+  // The marker lib/plan-expiry.js writes when the "your plan has ended" mail
+  // really went out. Its name carries the period, so it is read by key.
+  await redis.set(
+    planExpiry.noticeKey('ended', ACCT, 'parasign', '2026-02-10T12:00:00Z'),
+    String(Date.parse('2026-02-10T18:00:00Z')));
+  const rows = await build(redis);
+  assert.strictEqual(rows[0].type, 'term_ended');
+  assert.strictEqual(rows[0].notified_at, '2026-02-10T18:00:00.000Z');
+  did();
+});
+
+test('a period no invoice ever bought still ends, via the plan-expiry index', async () => {
+  // An admin-set plan, or one granted before the invoice module existed. The
+  // expiry index is the only record of it, and it is two keyed reads away.
+  const redis = fakeRedis();
+  await redis.hSet(planExpiry.META_HASH, planExpiry.memberOf(ACCT, 'parasend'), JSON.stringify({
+    email: 'office@example.test', tier: 'business', paid_until: '2026-05-01T00:00:00.000Z',
+  }));
+  const rows = await build(redis);
+  assert.deepStrictEqual(typesOf(rows), ['term_ended']);
+  assert.strictEqual(rows[0].label, 'ParaSend Business term ended');
+  assert.strictEqual(rows[0].ts, '2026-05-01T00:00:00.000Z');
+  did();
+});
+
+test('the index and the invoice do not produce the same ending twice', async () => {
+  const redis = fakeRedis();
+  await pay(redis, 'tr_dup', { at: '2026-01-10T12:00:00Z', until: '2026-02-10T12:00:00Z', interval: 'monthly' });
+  await redis.hSet(planExpiry.META_HASH, planExpiry.memberOf(ACCT, 'parasign'), JSON.stringify({
+    email: 'office@example.test', tier: 'pro', paid_until: '2026-02-10T12:00:00.000Z',
+  }));
+  const rows = await build(redis);
+  assert.strictEqual(rows.filter((r) => r.type === 'term_ended').length, 1, 'one ending, one row');
+  did();
+});
+
+test('a fully reversed payment bought no term, so none ended', async () => {
+  const redis = fakeRedis();
+  await pay(redis, 'tr_rev', { at: '2026-01-10T12:00:00Z', until: '2026-02-10T12:00:00Z', interval: 'monthly' });
+  await invoice.recordReversal({ payment: { id: 'tr_rev' }, now: new Date('2026-01-15T00:00:00Z') }, redis);
+  const rows = await build(redis);
+  assert.strictEqual(rows.filter((r) => r.type === 'term_ended').length, 0,
+    'a plan that was charged back never ran to a term end');
+  assert.strictEqual(rows[0].reversed_at, '2026-01-15T00:00:00.000Z', 'and the invoice row says it was reversed');
+  did();
+});
+
+// ── 3. the empty and broken cases ────────────────────────────────────────────
+
+test('an account that never paid gets an empty list, not an error', async () => {
+  const rows = await build(fakeRedis());
+  assert.deepStrictEqual(rows, []);
+  did();
+});
+
+test('no account and no redis answer empty rather than throw', async () => {
+  assert.deepStrictEqual(await history.build({ accountId: ACCT, redis: null }), []);
+  assert.deepStrictEqual(await history.build({ accountId: '', redis: fakeRedis() }), []);
+  assert.deepStrictEqual(await history.build({}), []);
+  did();
+});
+
+test('the whole list is one chronology, newest first', async () => {
+  const redis = fakeRedis();
+  await pay(redis, 'tr_c1', { at: '2026-01-10T12:00:00Z', until: '2026-02-10T12:00:00Z', interval: 'monthly' });
+  await pay(redis, 'tr_c2', { at: '2026-06-10T12:00:00Z', until: '2026-07-10T12:00:00Z', interval: 'monthly' });
+  await credit.issueCreditNote({
+    payment: Object.assign(payment('tr_c2', 'pro', 'monthly'), { status: 'chargeback' }),
+    now: new Date('2026-06-15T09:00:00Z'),
+  }, redis);
+  const rows = await build(redis);
+  const stamps = rows.map((r) => Date.parse(r.ts));
+  for (let i = 1; i < stamps.length; i++) {
+    assert.ok(stamps[i - 1] >= stamps[i], `row ${i} is not out of order`);
+  }
+  assert.ok(rows.some((r) => r.type === 'credit_note'), 'the credit note is in the same list');
+  assert.ok(rows.some((r) => r.type === 'invoice'), 'so are the payments');
+  did();
+});
+
+test('no em-dash reaches the customer from anything this module writes', async () => {
+  const redis = fakeRedis();
+  await pay(redis, 'tr_style', { at: '2026-01-10T12:00:00Z', until: '2026-02-10T12:00:00Z', interval: 'monthly' });
+  await credit.issueCreditNote({
+    payment: Object.assign(payment('tr_style', 'pro', 'monthly'), { status: 'chargeback' }),
+    now: new Date('2026-01-20T09:00:00Z'),
+  }, redis);
+  const rows = await build(redis);
+  assert.ok(rows.length >= 3);
+  for (const row of rows) {
+    for (const field of ['label', 'detail']) {
+      assert.ok(!String(row[field] || '').includes('\u2014'), `${row.type}.${field} has no em-dash`);
+    }
+  }
+  did();
+});

--- a/relay/test/credit-note.test.js
+++ b/relay/test/credit-note.test.js
@@ -1,0 +1,409 @@
+'use strict';
+// The document money gets when it goes back: its own number, its reference to
+// the invoice it credits, its VAT split, and the one rule that matters more
+// than any of them, that a chargeback can only ever produce ONE of it.
+//
+// No redis and no network. The store is the same Map stand-in test/invoice.test.js
+// uses, behind the five commands lib/credit-note.js calls, which is enough to
+// drive the exact ordering a real client would see. The route half (auth, the
+// listing, the PDF download) lives in test/route-billing-invoices.test.js.
+//
+// Run: node --test relay/test/credit-note.test.js
+
+const { test, after } = require('node:test');
+const assert = require('assert');
+const invoice = require('../lib/invoice');
+const credit = require('../lib/credit-note');
+const invoicePdf = require('../lib/invoice-pdf');
+const catalog = require('../lib/billing-catalog');
+const { summary } = require('./_requires');
+
+let checks = 0;
+const did = () => { checks++; };
+after(() => summary('credit-note', checks));
+
+function fakeRedis() {
+  const kv = new Map();
+  const lists = new Map();
+  return {
+    kv, lists,
+    async get(k) { return kv.has(k) ? kv.get(k) : null; },
+    async set(k, v, opts) {
+      if (opts && opts.NX && kv.has(k)) return null;
+      kv.set(k, String(v));
+      return 'OK';
+    },
+    async incr(k) { const n = (parseInt(kv.get(k) || '0', 10) || 0) + 1; kv.set(k, String(n)); return n; },
+    async rPush(k, v) { const l = lists.get(k) || []; l.push(v); lists.set(k, l); return l.length; },
+    async lRange(k, start, stop) {
+      const l = lists.get(k) || [];
+      const a = start < 0 ? Math.max(0, l.length + start) : start;
+      const b = stop < 0 ? l.length + stop : stop;
+      return l.slice(a, b + 1);
+    },
+    async hGet() { return null; },
+  };
+}
+
+const SELLER = {
+  name: 'Paramantis Solutions B.V.',
+  address: 'Example Street 1\n1234 AB Example City\nNetherlands',
+  kvk: '42115132',
+  vat: 'NL863456789B01',
+};
+
+const BUYER = {
+  email: 'office@example.test',
+  company: 'Acme B.V.',
+  address: 'Example Road 12\n1015 BR Example City',
+  vat: 'NL812345678B01',
+};
+
+const PAID_AT = new Date('2026-09-03T12:00:00Z');
+const BACK_AT = new Date('2026-09-20T09:00:00Z');
+
+function payment(id, value = '603.79', extra = {}) {
+  return Object.assign({
+    id, status: 'paid', method: 'ideal',
+    amount: { value, currency: 'EUR' },
+    metadata: { accountId: 'acct_demo', product: 'parasign', plan: 'pro', interval: 'yearly' },
+  }, extra);
+}
+
+// A payment that has come back, in the two shapes Mollie sends: a chargeback
+// (status flips, the counter follows later) and a refund (status stays 'paid'
+// until the whole amount is back, and only the counter moves).
+function chargedBack(p, value) {
+  return Object.assign({}, p, {
+    status: 'chargeback',
+    amountChargedBack: value ? { value, currency: 'EUR' } : undefined,
+  });
+}
+function refunded(p, value) {
+  return Object.assign({}, p, { amountRefunded: { value, currency: 'EUR' } });
+}
+
+async function issueInvoice(redis, p) {
+  const md = p.metadata;
+  return invoice.issueDocument({
+    payment: p,
+    order: Object.assign({ accountId: md.accountId }, catalog.resolveOrder(md)),
+    seller: SELLER,
+    buyer: BUYER,
+    now: PAID_AT,
+    periodEnd: '2027-09-03T12:00:00Z',
+  }, redis);
+}
+
+async function paidAndBack(reversal, value, redis = fakeRedis(), id = 'tr_back') {
+  const p = payment(id);
+  await issueInvoice(redis, p);
+  const back = reversal(p, value);
+  const out = await credit.issueCreditNote({ payment: back, now: BACK_AT }, redis);
+  return { redis, invoicePayment: p, back, out };
+}
+
+// ── 1. one credit note per chargeback ────────────────────────────────────────
+
+test('a chargeback produces exactly one credit note, numbered CN-2026-0001', async () => {
+  const { out, redis } = await paidAndBack(chargedBack, '603.79');
+  assert.strictEqual(out.result, 'issued');
+  assert.strictEqual(out.number, 'CN-2026-0001', 'its own series, starting at one');
+  assert.strictEqual(out.record.kind, 'credit_note');
+  assert.strictEqual(out.record.title, 'Credit note');
+  assert.strictEqual(out.record.credit_for, 'PS-2026-0001', 'it names the invoice it credits');
+  assert.strictEqual(out.record.credit_for_date, '2026-09-03', 'and the date of that invoice');
+  assert.strictEqual(out.record.reason, 'chargeback');
+  assert.strictEqual(out.record.partial, false);
+  assert.strictEqual(out.fully_credited, true);
+  // Stored under the SAME document keyspace and in the same per-account list as
+  // the invoice, so /account and the PDF route serve it without a second index.
+  assert.ok(await redis.get(invoice.K.doc('CN-2026-0001')), 'the record is stored');
+  assert.deepStrictEqual(await redis.lRange(invoice.K.byAcct('acct_demo'), 0, -1),
+    ['PS-2026-0001', 'CN-2026-0001']);
+  did();
+});
+
+test('the amounts are the invoice, negated, to the cent', async () => {
+  const { out } = await paidAndBack(chargedBack, '603.79');
+  assert.strictEqual(out.record.amount_gross, '-603.79');
+  assert.strictEqual(out.record.amount_net, '-499.00');
+  assert.strictEqual(out.record.amount_vat, '-104.79');
+  assert.strictEqual(out.record.vat_rate, 21);
+  assert.strictEqual(out.record.currency, 'EUR');
+  did();
+});
+
+test('the seller and the buyer are the ones the invoice stated', async () => {
+  const { out } = await paidAndBack(chargedBack, '603.79');
+  assert.deepStrictEqual(out.record.seller, SELLER);
+  assert.deepStrictEqual(out.record.buyer, BUYER);
+  assert.strictEqual(out.record.account_id, 'acct_demo');
+  assert.strictEqual(out.record.payment_id, 'tr_back');
+  did();
+});
+
+test('the same chargeback webhook twice issues exactly one credit note', async () => {
+  const { redis, back } = await paidAndBack(chargedBack, '603.79');
+  const second = await credit.issueCreditNote({ payment: back, now: BACK_AT }, redis);
+  assert.strictEqual(second.result, 'existing', 'the retry finds the document, it does not write one');
+  assert.strictEqual(second.number, 'CN-2026-0001');
+  const third = await credit.issueCreditNote({ payment: back, now: BACK_AT }, redis);
+  assert.strictEqual(third.result, 'existing');
+  assert.strictEqual(parseInt(await redis.get(credit.CK.seq(2026)), 10), 1,
+    'and the counter was never drawn a second time');
+  const list = await redis.lRange(invoice.K.byAcct('acct_demo'), 0, -1);
+  assert.strictEqual(list.filter((n) => n.startsWith('CN-')).length, 1, 'one row on the account, not three');
+  did();
+});
+
+test('a chargeback that reports no counter yet still credits the whole invoice', async () => {
+  // Mollie flips the status before amountChargedBack is settled. Answering
+  // "nothing was reversed" there would leave the customer holding an invoice
+  // for money he no longer paid.
+  const { out } = await paidAndBack(chargedBack, undefined);
+  assert.strictEqual(out.result, 'issued');
+  assert.strictEqual(out.record.amount_gross, '-603.79');
+  assert.strictEqual(out.record.partial, false);
+  did();
+});
+
+test('a payment with no invoice gets no credit note, and no error', async () => {
+  const redis = fakeRedis();
+  const out = await credit.issueCreditNote({ payment: chargedBack(payment('tr_orphan'), '10.00'), now: BACK_AT }, redis);
+  assert.strictEqual(out.result, 'none');
+  assert.strictEqual(out.reason, 'no_invoice');
+  assert.strictEqual(await redis.get(credit.CK.seq(2026)), null, 'and no number was burned');
+  did();
+});
+
+test('without redis nothing is written and nothing throws', async () => {
+  const out = await credit.issueCreditNote({ payment: chargedBack(payment('tr_none'), '1.00') }, null);
+  assert.strictEqual(out.result, 'unavailable');
+  assert.strictEqual(out.reason, 'no_redis');
+  did();
+});
+
+// ── 2. partial refunds ───────────────────────────────────────────────────────
+// The half that has to be right to the cent, because a partial credit is the
+// only case where the VAT is not simply copied off the invoice.
+
+test('a partial refund credits the refunded amount, with VAT pro rata', async () => {
+  const { out } = await paidAndBack(refunded, '100.00');
+  assert.strictEqual(out.result, 'issued');
+  assert.strictEqual(out.record.partial, true, 'and it says on its face that it is partial');
+  assert.strictEqual(out.record.reason, 'refund');
+  assert.strictEqual(out.record.amount_gross, '-100.00');
+  // 100.00 gross at 21%: net 82.64, VAT 17.36, and the two halves add back up
+  // to exactly what went back.
+  assert.strictEqual(out.record.amount_net, '-82.64');
+  assert.strictEqual(out.record.amount_vat, '-17.36');
+  assert.strictEqual(
+    invoice.centsOf(out.record.amount_net.slice(1)) + invoice.centsOf(out.record.amount_vat.slice(1)),
+    invoice.centsOf(out.record.amount_gross.slice(1)),
+    'net plus VAT is exactly the amount refunded');
+  assert.strictEqual(out.fully_credited, false, 'the invoice is not reversed by a partial refund');
+  did();
+});
+
+test('a partial refund is idempotent, and a further refund credits only the difference', async () => {
+  const { redis, invoicePayment, out: first } = await paidAndBack(refunded, '100.00');
+  assert.strictEqual(first.number, 'CN-2026-0001');
+
+  // The same webhook again: Mollie reports the same cumulative total.
+  const repeat = await credit.issueCreditNote(
+    { payment: refunded(invoicePayment, '100.00'), now: BACK_AT }, redis);
+  assert.strictEqual(repeat.result, 'existing');
+  assert.strictEqual(repeat.number, 'CN-2026-0001');
+
+  // A second refund. Mollie's counter is cumulative, so this says 250.00 in
+  // total, of which 150.00 is new.
+  const second = await credit.issueCreditNote(
+    { payment: refunded(invoicePayment, '250.00'), now: BACK_AT }, redis);
+  assert.strictEqual(second.result, 'issued');
+  assert.strictEqual(second.number, 'CN-2026-0002');
+  assert.strictEqual(second.record.amount_gross, '-150.00');
+  assert.strictEqual(second.record.partial, true);
+  did();
+});
+
+test('partial credits add back up to the invoice exactly, remainder and all', async () => {
+  // 603.79 is not divisible by 1.21, and neither are the parts. Each note
+  // carries the VAT of its own amount; the LAST one has to absorb whatever the
+  // rounding left over, or the books do not close.
+  const redis = fakeRedis();
+  const p = payment('tr_thirds');
+  await issueInvoice(redis, p);
+  const notes = [];
+  for (const cumulative of ['200.00', '400.00', '603.79']) {
+    const out = await credit.issueCreditNote({ payment: refunded(p, cumulative), now: BACK_AT }, redis);
+    assert.strictEqual(out.result, 'issued', `${cumulative} produced a note`);
+    notes.push(out.record);
+  }
+  const sum = (field) => notes.reduce((t, r) => t + invoice.centsOf(String(r[field]).replace('-', '')), 0);
+  assert.strictEqual(sum('amount_gross'), 60379, 'the totals add back up to the invoice');
+  assert.strictEqual(sum('amount_net'), 49900, 'the net amounts add back up to the invoice net');
+  assert.strictEqual(sum('amount_vat'), 10479, 'the VAT amounts add back up to the invoice VAT');
+  assert.strictEqual(notes[2].partial, false, 'the note that closes it is not marked partial');
+  const state = await credit.creditedAgainst('PS-2026-0001', redis);
+  assert.deepStrictEqual(state.notes, ['CN-2026-0001', 'CN-2026-0002', 'CN-2026-0003']);
+  assert.strictEqual(state.gross_cents, 60379);
+  did();
+});
+
+test('a refund can never give back more than the invoice', async () => {
+  const redis = fakeRedis();
+  const p = payment('tr_over');
+  await issueInvoice(redis, p);
+  const out = await credit.issueCreditNote({ payment: refunded(p, '9999.00'), now: BACK_AT }, redis);
+  assert.strictEqual(out.record.amount_gross, '-603.79', 'capped at what was invoiced');
+  assert.strictEqual(out.fully_credited, true);
+  // A chargeback on top of a refund that already took everything back reports
+  // the same total, so it is the same reversal and finds the same document.
+  const again = await credit.issueCreditNote({ payment: chargedBack(p, '603.79'), now: BACK_AT }, redis);
+  assert.strictEqual(again.result, 'existing');
+  assert.strictEqual(again.number, 'CN-2026-0001');
+  did();
+});
+
+test('a claim that was lost still cannot produce a second credit note', async () => {
+  // The claim key is what makes a retry cheap; the running total is what makes
+  // it SAFE. Delete the claim (a redis eviction, or an attempt that timed out
+  // past the takeover window) and the second pass must still find that there is
+  // nothing left to credit, without drawing a number for it.
+  const { redis, invoicePayment } = await paidAndBack(chargedBack, '603.79');
+  redis.kv.delete(credit.CK.claim(`${invoicePayment.id}:60379`));
+  const again = await credit.issueCreditNote(
+    { payment: chargedBack(invoicePayment, '603.79'), now: BACK_AT }, redis);
+  assert.strictEqual(again.result, 'none');
+  assert.strictEqual(again.reason, 'already_credited');
+  assert.strictEqual(again.fully_credited, true);
+  assert.strictEqual(parseInt(await redis.get(credit.CK.seq(2026)), 10), 1, 'no number was burned');
+  const list = await redis.lRange(invoice.K.byAcct('acct_demo'), 0, -1);
+  assert.strictEqual(list.filter((n) => n.startsWith('CN-')).length, 1);
+  did();
+});
+
+// ── 3. what counts as a reversal at all ──────────────────────────────────────
+
+test('isReversal recognises a chargeback, a refunded status and a partial refund', () => {
+  assert.strictEqual(credit.isReversal(payment('tr_a')), false, 'a plain paid payment is not one');
+  assert.strictEqual(credit.isReversal(chargedBack(payment('tr_b'))), true);
+  assert.strictEqual(credit.isReversal(Object.assign(payment('tr_c'), { status: 'charged_back' })), true);
+  assert.strictEqual(credit.isReversal(Object.assign(payment('tr_d'), { status: 'refunded' })), true);
+  assert.strictEqual(credit.isReversal(refunded(payment('tr_e'), '0.01')), true, 'one cent back is a reversal');
+  assert.strictEqual(credit.isReversal(refunded(payment('tr_f'), '0.00')), false);
+  assert.strictEqual(credit.isReversal(null), false);
+  did();
+});
+
+test('the reason distinguishes a chargeback from a refund we sent', () => {
+  assert.strictEqual(credit.reasonOf(chargedBack(payment('tr_g'), '1.00')), 'chargeback');
+  assert.strictEqual(credit.reasonOf(refunded(payment('tr_h'), '1.00')), 'refund');
+  did();
+});
+
+// ── 4. the PDF carries what a credit note must carry ─────────────────────────
+// Same reasoning as the invoice suite: the content stream is uncompressed on
+// purpose, so the text is readable straight out of the bytes.
+
+test('the credit note PDF carries every field, and the invoice it credits', async () => {
+  const { out } = await paidAndBack(chargedBack, '603.79');
+  const pdf = invoicePdf.render(out.record, { buyerHint: invoice.BUYER_HINT });
+  const text = pdf.toString('latin1');
+
+  assert.ok(text.startsWith('%PDF-1.4'), 'it is a PDF');
+  assert.ok(text.trimEnd().endsWith('%%EOF'), 'with a complete trailer');
+
+  const required = {
+    'a: issue date':                '2026-09-20',
+    'b: sequential number':         'CN-2026-0001',
+    'b: its own series':            'Credit note number',
+    'c: supplier name':             'Paramantis Solutions B.V.',
+    'c: supplier address':          '1234 AB Example City',
+    'd: supplier VAT number':       'NL863456789B01',
+    'e: customer name':             'Acme B.V.',
+    'e: customer address':          '1015 BR Example City',
+    'f: description':               'Paramant ParaSign Pro, yearly plan',
+    'g: amount excluding VAT':      '-499.00',
+    'h: VAT rate':                  '21%',
+    'h: VAT amount':                '-104.79',
+    'i: total':                     '-603.79',
+    'the invoice it credits':       'PS-2026-0001',
+    'the date of that invoice':     '2026-09-03',
+    'extra: KvK number':            '42115132',
+  };
+  for (const [what, value] of Object.entries(required)) {
+    assert.ok(text.includes(value), `${what} is on the document (${value})`);
+  }
+  for (const label of ['Credit note', 'Credit for invoice', 'Billed to', 'Subtotal excl. VAT', 'Total credited']) {
+    assert.ok(text.includes(label), `the document is labelled: ${label}`);
+  }
+  assert.ok(text.includes('charged back'), 'it says why the money went back');
+  assert.ok(!text.includes('Paid in full'), 'and never claims the customer paid it');
+  did();
+});
+
+test('a partial credit note says so on the page', async () => {
+  const { out } = await paidAndBack(refunded, '100.00');
+  const text = invoicePdf.render(out.record, { buyerHint: invoice.BUYER_HINT }).toString('latin1');
+  assert.ok(text.includes('Partial credit'), 'a partial credit is labelled as one');
+  assert.ok(text.includes('refunded to you'), 'and says the money was refunded, not charged back');
+  assert.ok(text.includes('-100.00'));
+  did();
+});
+
+test('crediting a receipt produces a refund receipt, not a VAT credit note', async () => {
+  // No seller VAT id: the original could not call itself an invoice, so the
+  // document that reverses it may not call itself a credit note either.
+  const redis = fakeRedis();
+  const p = payment('tr_no_vat');
+  const md = p.metadata;
+  await invoice.issueDocument({
+    payment: p,
+    order: Object.assign({ accountId: md.accountId }, catalog.resolveOrder(md)),
+    seller: Object.assign({}, SELLER, { vat: '' }),
+    buyer: BUYER,
+    now: PAID_AT,
+    periodEnd: '2027-09-03T12:00:00Z',
+  }, redis);
+  const out = await credit.issueCreditNote({ payment: chargedBack(p, '603.79'), now: BACK_AT }, redis);
+  assert.strictEqual(out.result, 'issued');
+  assert.strictEqual(out.record.title, 'Refund receipt');
+  assert.strictEqual(out.record.note, credit.CREDIT_RECEIPT_NOTE);
+  const text = invoicePdf.render(out.record, { buyerHint: invoice.BUYER_HINT }).toString('latin1');
+  assert.ok(text.includes('Refund receipt'));
+  assert.ok(!/\(Credit note\) Tj/.test(text), 'and never calls itself a credit note');
+  did();
+});
+
+// ── 5. what the invoice itself now says ──────────────────────────────────────
+
+test('the invoice keeps its number and points at the note that credited it', async () => {
+  const { redis } = await paidAndBack(chargedBack, '603.79');
+  const original = JSON.parse(await redis.get(invoice.K.doc('PS-2026-0001')));
+  assert.strictEqual(original.number, 'PS-2026-0001', 'the invoice is never renumbered');
+  assert.deepStrictEqual(original.credit_notes, ['CN-2026-0001']);
+  assert.strictEqual(original.credited_gross, '603.79');
+  // The reversal marker is the relay's to set, on a FULL credit only, so the
+  // record here is still unstamped: this suite drives the module, not the route.
+  const withMarker = Object.assign({}, original, { reversed_at: '2026-09-20T09:00:00.000Z' });
+  const text = invoicePdf.render(withMarker, { buyerHint: invoice.BUYER_HINT }).toString('latin1');
+  assert.ok(text.includes('Reversed on 2026-09-20'), 'the invoice PDF says it was reversed');
+  assert.ok(text.includes('Credited by CN-2026-0001'), 'and names the document that did it');
+  did();
+});
+
+test('a credit note is served by the same document lookup as an invoice', async () => {
+  const { redis } = await paidAndBack(chargedBack, '603.79');
+  assert.ok(invoice.parseDocumentNumber('CN-2026-0001'), 'the number parses');
+  assert.ok(invoice.parseDocumentNumber('PS-2026-0001'));
+  assert.strictEqual(invoice.parseDocumentNumber('XX-2026-0001'), null);
+  const fetched = await invoice.getFor('acct_demo', 'CN-2026-0001', redis);
+  assert.ok(fetched && fetched.number === 'CN-2026-0001');
+  assert.strictEqual(await invoice.getFor('acct_other', 'CN-2026-0001', redis), null,
+    'and never to another account');
+  const listed = (await invoice.listFor('acct_demo', redis)).map((r) => r.number);
+  assert.deepStrictEqual(listed, ['CN-2026-0001', 'PS-2026-0001'], 'newest first, both series');
+  did();
+});

--- a/relay/test/route-billing-invoices.test.js
+++ b/relay/test/route-billing-invoices.test.js
@@ -28,6 +28,7 @@ const assert = require('assert');
 const { boot, killAll } = require('./_relay-server');
 const { requireRedis, summary } = require('./_requires');
 const invoice = require('../lib/invoice');
+const creditNote = require('../lib/credit-note');
 
 const KEY_A = 'pgp_invoice_account_a';
 const KEY_B = 'pgp_invoice_account_b';
@@ -234,5 +235,77 @@ test('numbers issued through the relay redis run consecutively', async (t) => {
   const list = await srv.get('/v2/billing/invoices', asA);
   const numbers = list.json.invoices.map((i) => i.number).filter((n) => n.startsWith('PS-2031-'));
   assert.deepStrictEqual(numbers, ['PS-2031-0002', 'PS-2031-0001'], 'newest first, no duplicate');
+  did();
+});
+
+// ── credit notes and the history, on the wire ────────────────────────────────
+// The document half is proved against a Map in test/credit-note.test.js and
+// test/billing-history.test.js. What can only be wrong here is the routing: that
+// a CN number is not rejected as malformed before it is looked up, that it comes
+// back as a PDF, that it is not readable by the neighbour, and that the history
+// route derives a list from documents this same redis holds.
+
+test('a credit note is listed, downloadable, and still only the owner its own', async (t) => {
+  if (!srv) return t.skip('no redis');
+  const paymentId = `tr_credit_${RUN}`;
+  const paid = await issueFor(acct(ACCT_A), paymentId, '603.79', {
+    buyer: { email: 'one@example.test', company: 'Acme One B.V.', address: 'Example Road 12\n1015 BR Example City', vat: '' },
+  });
+  assert.strictEqual(paid.result, 'issued');
+  const note = await creditNote.issueCreditNote({
+    payment: {
+      id: paymentId, status: 'chargeback',
+      amount: { value: '603.79', currency: 'EUR' },
+      amountChargedBack: { value: '603.79', currency: 'EUR' },
+      metadata: { accountId: acct(ACCT_A), product: 'parasign', plan: 'pro', interval: 'yearly' },
+    },
+  }, redis);
+  assert.strictEqual(note.result, 'issued', note.reason);
+  assert.ok(/^CN-\d{4}-\d{4,}$/.test(note.number), `its own series: ${note.number}`);
+
+  const list = await srv.get('/v2/billing/invoices', asA);
+  const row = list.json.invoices.find((i) => i.number === note.number);
+  assert.ok(row, 'the credit note is in the account listing');
+  assert.strictEqual(row.kind, 'credit_note');
+  assert.strictEqual(row.amount_gross, '-603.79');
+  assert.strictEqual(row.credit_for, paid.number);
+  assert.strictEqual(row.reason, 'chargeback');
+  assert.strictEqual(row.partial, false);
+
+  const pdf = await srv.get(row.pdf_url, asA);
+  assert.strictEqual(pdf.status, 200, 'a CN number is not rejected as malformed');
+  assert.strictEqual(pdf.headers['content-type'], 'application/pdf');
+  const text = pdf.buf.toString('latin1');
+  assert.ok(text.includes(note.number), 'the document carries its own number');
+  assert.ok(text.includes(paid.number), 'and the number of the invoice it credits');
+  assert.ok(text.includes('-603.79'), 'with a negative total');
+
+  const stolen = await srv.get(row.pdf_url, asB);
+  assert.strictEqual(stolen.status, 404, 'the neighbour still gets nothing');
+  did();
+});
+
+test('the history route builds one chronological list from the documents', async (t) => {
+  if (!srv) return t.skip('no redis');
+  const unauth = await srv.get('/v2/billing/history');
+  assert.strictEqual(unauth.status, 401, 'it needs a key');
+
+  const r = await srv.get('/v2/billing/history', asA);
+  assert.strictEqual(r.status, 200);
+  assert.ok(Array.isArray(r.json.history), 'it answers a list');
+  assert.ok(r.json.history.length > 0, 'an account that has paid is not "no billing events yet"');
+
+  const stamps = r.json.history.map((row) => Date.parse(row.ts));
+  for (let i = 1; i < stamps.length; i++) {
+    assert.ok(stamps[i - 1] >= stamps[i], `row ${i} is in order`);
+  }
+  assert.ok(r.json.history.some((row) => row.type === 'invoice' && row.amount && row.document),
+    'the payments are in it, with their document numbers');
+  assert.ok(r.json.history.some((row) => row.type === 'credit_note' && String(row.amount).startsWith('-')),
+    'and so is the money that went back');
+
+  const empty = await srv.get('/v2/billing/history', asB);
+  assert.strictEqual(empty.status, 200);
+  assert.ok(Array.isArray(empty.json.history), 'an account with nothing gets a list, not an error');
   did();
 });

--- a/tests/billing-history-visible.test.mjs
+++ b/tests/billing-history-visible.test.mjs
@@ -1,0 +1,183 @@
+// Does the customer actually SEE his billing history.
+//
+// /account has had a "Billing history" block since the account page existed and
+// it said "No billing events yet" to a customer who had paid, been invoiced and
+// watched his term run out: the only feed behind it was the admin audit log,
+// which knows nothing about a self-serve Mollie payment. The relay now derives
+// the list from the invoice and credit-note records it already holds; this is
+// the half a customer looks at.
+//
+// Driven against the real page with the APIs mocked, in the shape
+// tests/navigation-shell.test.mjs and tests/plan-term-visible.test.mjs use: a
+// static file server on a free port and page.route() for every /api call.
+// Nothing here needs a relay.
+//
+// Three states, and the first is the bug this replaces:
+//   empty     nothing has happened      -> "No billing events yet."
+//   paid      an invoice, a credit note, a term that ended
+//   unreachable  the API is down        -> says so, does not lie about nothing
+
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = { '.js': 'text/javascript', '.css': 'text/css', '.html': 'text/html', '.svg': 'image/svg+xml', '.png': 'image/png', '.woff2': 'font/woff2' };
+const aliases = { '/': '/index.html', '/account': '/account.html' };
+
+const server = http.createServer((req, res) => {
+  let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+  pathname = aliases[pathname] || pathname;
+  const file = path.join(ROOT, pathname);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+  fs.readFile(file, (error, body) => {
+    if (error) { res.writeHead(404); return res.end(); }
+    res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  });
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const ORIGIN = `http://localhost:${server.address().port}`;
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+
+const checks = [];
+function ok(name, condition, detail = '') { checks.push({ name, pass: !!condition, detail: String(detail) }); }
+
+const json = (route, body, status = 200) =>
+  route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+
+// Exactly the rows /api/user/billing/history answers for an account that paid,
+// was partly refunded, and then let the term run out.
+const HISTORY = [
+  {
+    ts: '2027-09-03T12:00:00.000Z', type: 'term_ended',
+    label: 'ParaSign Pro term ended', detail: 'Account back on Community',
+    amount: null, currency: null, document: null, notified_at: '2027-09-03T18:00:00.000Z',
+  },
+  {
+    ts: '2026-10-01T09:00:00.000Z', type: 'credit_note',
+    label: 'Credit note for invoice PS-2026-0001 (partial)', detail: 'Refunded',
+    amount: '-100.00', currency: 'EUR', document: 'CN-2026-0001',
+    credit_for: 'PS-2026-0001', pdf_url: '/v2/billing/invoices/CN-2026-0001.pdf',
+  },
+  {
+    ts: '2026-09-03T12:00:00.000Z', type: 'invoice',
+    label: 'Paramant ParaSign Pro, yearly plan', detail: 'Paid',
+    amount: '603.79', currency: 'EUR', document: 'PS-2026-0001',
+    pdf_url: '/v2/billing/invoices/PS-2026-0001.pdf',
+  },
+  {
+    ts: '2026-08-01T08:00:00.000Z', type: 'plan_changed',
+    label: 'Plan changed from community to pro', detail: null,
+    amount: null, currency: null, document: null,
+    event_type: 'plan_changed', metadata: { from: 'community', to: 'pro' },
+  },
+];
+
+async function account({ history, status = 200 }) {
+  const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+  await page.route('**/api/**', (route) => json(route, {}));
+  await page.route('**/api/user/billing/status', (route) => json(route, {
+    current_plan: 'pro', plan_parasign: 'pro', plan_parasend: 'community',
+    access_until: null, next_billing_date: null, auto_renews: false,
+    cancellation_scheduled_at: null,
+  }));
+  await page.route('**/api/user/billing/invoices', (route) => json(route, { invoices: [] }));
+  await page.route('**/api/user/billing/history', (route) =>
+    (status === 200 ? json(route, { history }) : json(route, { error: 'relay_unreachable' }, status)));
+  await page.route('**/api/user/account', (route) => json(route, {
+    email: 'demo@example.com', plan: 'pro', api_key_masked: 'pgp_demo...abcd',
+    created_at: '2026-01-01T00:00:00.000Z', sessions: [], backup_codes_remaining: 0,
+  }));
+  await page.goto(ORIGIN + '/account', { waitUntil: 'domcontentloaded' });
+  // The block starts on a loading line, so "done" is when that line is gone.
+  await page.waitForFunction(() => {
+    const el = document.getElementById('billing-history');
+    return el && !/Loading/i.test(el.textContent || '');
+  }, null, { timeout: 10000 });
+  const state = await page.evaluate(() => {
+    const el = document.getElementById('billing-history');
+    const rows = Array.from(el.querySelectorAll('.info-row')).map((row) => ({
+      left: (row.querySelector('.info-label') || {}).textContent || '',
+      right: (row.querySelector('.info-value') || {}).textContent || '',
+      href: (row.querySelector('a') || {}).getAttribute ? row.querySelector('a').getAttribute('href') : null,
+    }));
+    return { text: (el.textContent || '').trim(), rows, html: el.innerHTML };
+  });
+  await page.close();
+  return state;
+}
+
+// ── an account that has never paid ───────────────────────────────────────────
+const empty = await account({ history: [] });
+ok('nothing has happened: the block says so and says nothing else',
+  empty.text === 'No billing events yet.', empty.text);
+
+// ── an account that paid, was refunded, and ran out ──────────────────────────
+const full = await account({ history: HISTORY });
+ok('every event is a row', full.rows.length === HISTORY.length, `${full.rows.length} rows`);
+ok('the block is no longer empty', !full.text.includes('No billing events yet'), full.text);
+
+ok('the payment is there, with its invoice number and its total',
+  full.rows.some((r) => r.left.includes('PS-2026-0001')
+    && r.left.includes('Paramant ParaSign Pro, yearly plan')
+    && r.right.includes('EUR 603.79')),
+  JSON.stringify(full.rows[2]));
+
+ok('the credit note is there, negative, naming the invoice it credits',
+  full.rows.some((r) => r.left.includes('CN-2026-0001')
+    && r.left.includes('Credit note for invoice PS-2026-0001')
+    && r.right.includes('EUR -100.00')),
+  JSON.stringify(full.rows[1]));
+
+ok('the term that ended is there, and says where the account landed',
+  full.rows.some((r) => r.left.includes('ParaSign Pro term ended')
+    && r.right.includes('Account back on Community')),
+  JSON.stringify(full.rows[0]));
+
+ok('the plan change from the audit log is in the same list',
+  full.rows.some((r) => r.left.includes('Plan changed from community to pro')),
+  JSON.stringify(full.rows[3]));
+
+ok('every document row offers its PDF, and only document rows do',
+  full.rows.filter((r) => r.href).length === 2
+  && full.rows.filter((r) => r.href).every((r) => /\/api\/user\/billing\/invoices\/(PS|CN)-2026-0001\.pdf$/.test(r.href)),
+  JSON.stringify(full.rows.map((r) => r.href)));
+
+ok('the newest event is first',
+  full.rows[0].left.includes('term ended') && full.rows[3].left.includes('Plan changed'),
+  `${full.rows[0].left} | ${full.rows[3].left}`);
+
+// House style, on copy this page generates rather than carries.
+ok('no em-dash anywhere in the history',
+  !full.text.includes('\u2014'), full.text);
+
+// The server sends text; the page must put it in the document as text. A label
+// that arrived as markup and rendered as markup would be a hole straight into
+// the account page.
+const injected = await account({
+  history: [{
+    ts: '2026-09-03T12:00:00.000Z', type: 'invoice',
+    label: '<img src=x onerror=1>', detail: 'Paid', amount: '1.00',
+    currency: 'EUR', document: 'PS-2026-0001',
+  }],
+});
+ok('a label is rendered as text and never as markup',
+  !injected.html.includes('<img') && injected.text.includes('<img src=x onerror=1>'),
+  injected.html.slice(0, 200));
+
+// ── the API is down ──────────────────────────────────────────────────────────
+const down = await account({ history: [], status: 502 });
+ok('an unreachable API says so rather than claiming nothing ever happened',
+  down.text.includes('unavailable') && !down.text.includes('No billing events yet'), down.text);
+
+await browser.close();
+server.close();
+
+for (const c of checks) console.log(`${c.pass ? 'ok' : 'FAIL'} - ${c.name}${c.pass ? '' : ` :: ${c.detail}`}`);
+const failed = checks.filter((c) => !c.pass);
+console.log(`${checks.length} checks, ${failed.length} failed`);
+if (failed.length) process.exit(1);


### PR DESCRIPTION
Two gaps the invoice work (#416) left open, named by its own author.

## 1. The credit note

A chargeback stamped `reversed_at` on the invoice and stopped there. That keeps our own records from lying and it is all it does: Dutch VAT law does not let an issued invoice be withdrawn, so what documents a reversal is a **second** document with its own sequential number that refers to the first (art. 35a applies to it in full, art. 29 is what makes the VAT correctable). A bookkeeper handed `PS-2026-0001` and told to ignore it has nothing to book.

`relay/lib/credit-note.js` issues it, in its own series, `CN-2026-0001` per calendar year. A credit note carries:

- its own sequential number, from its own series
- the number **and** the date of the invoice it credits
- the same description, VAT rate, seller and buyer as that invoice stated, copied from the record and not rebuilt from today's configuration
- negative net, negative VAT and a negative total
- the reason: a chargeback, or a refund we sent

It is rendered by the same PDF writer (no new dependency), it is mailed with the PDF attached, and it appears on /account beside the invoice it credits. The invoice keeps its number and its place in the series and now names the note that credited it.

**One per reversal.** The reversal is claimed before a number is drawn, exactly as a payment is, so a Mollie retry finds the existing document instead of writing a second one and the CN series stays gapless. The claim id is the payment id plus the cumulative amount reversed, which makes it both idempotent for a retry and able to follow a second, larger refund.

**Partial refunds.** Mollie reports `amountRefunded` and `amountChargedBack` as cumulative totals, not as the delta of one event. So the split is computed for the cumulative amount and the note is issued as the difference from what is already credited. Two consequences, both wanted: each note carries the VAT of its own amount, pro rata in whole cents, and when the running total reaches the invoiced amount the target split **is** the original split, so the last note absorbs every rounding remainder and the credit notes add back up to the invoice to the cent. Nothing can credit back more than came in. The invoice is only marked reversed once the whole of it has been credited; a partly refunded invoice is still partly true.

The webhook branch is no longer gated on `outcome.result`. A chargeback revokes the entitlement and a refund does not, but both are money the customer no longer paid, and a partial refund arrives as a still-`paid` payment with `amountRefunded` set, which no outcome would ever have caught.

## 2. The billing history

/account said "No billing events yet" to a customer who had paid, been invoiced and watched his term run out. The only feed behind it was the admin audit log, which records what an **admin** did to a plan and knows nothing about a self-serve Mollie payment.

`relay/lib/billing-history.js` derives one chronological list from records that already exist:

- **payments and refunds** from the invoice and credit-note records
- **terms that ended** from the paid period on those same records, cross-read against the plan-expiry index (#415) and its notice markers, which say whether and when the customer was actually mailed

No new storage, so nothing can drift from the documents it is derived from. A period end that a renewal extended is **not** listed as an ending, because the customer never lost a day of access; a lapse and a later restart are two real endings and both are listed. A period no invoice ever bought (an admin-set plan) still shows up, through two keyed reads on the expiry index, never a scan.

The admin panel merges its audit events into the same list, so a plan change still shows up in the one place the customer reads, and a relay it cannot reach costs the money rows and keeps the rest.

## Tests

- `relay/test/credit-note.test.js`, 19 checks: the number and the series, the reference to the invoice, one note per chargeback and none for a retry, a lost claim that still cannot produce a second, the partial split closing to the cent over three refunds, the cap, and every field the PDF must carry including the invoice it credits
- `relay/test/billing-history.test.js`, 15 checks: the rows, the renewal that is not an ending, the lapse and restart that are two, the expiry index, the notice marker, and the empty and broken cases
- `relay/test/route-billing-invoices.test.js`, two more on a really booted relay against a real redis: a `CN-` number is not rejected as malformed, comes back as a PDF, is not readable by the neighbour, and the history route answers one ordered list
- `tests/billing-history-visible.test.mjs`, 12 checks on the page itself with the API mocked, including that a server-sent label is rendered as text and never as markup

Green here: relay units (298), relay routes against redis (130), the root integration suites, the browser suites that touch /account, `tests/ui-truthfulness`, `tests/site-claims`, `tests/frontend-loading-contract`, `bash tests/static-sanity.sh`, eslint. `?v` bumped on `account.inline1.js`.

No deploy, no migration. Existing invoices are untouched; the credit series starts at one.
