### PR TITLE
A qualified signature can sit next to the ParaSign receipt, proved behind a flag

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,6 +1,6 @@
 # PARAMANT: complete environment reference
 #
-# 91 variables. Copy to deploy/.env and fill in what the "required" blocks ask
+# 97 variables. Copy to deploy/.env and fill in what the "required" blocks ask
 # for. .env is NEVER committed to git.
 #
 # This file is the reference: every name the relay or the admin panel reads is
@@ -292,6 +292,69 @@ PARAMANT_TOTP_MASTER_KEY=
 # optional · default: false
 # read in: relay/relay.js
 # PARASIGN_ACCEPT_LEGACY_V1=false
+
+
+# ==============================================================================
+# PARASIGN: qualified electronic signature (prototype)
+# ==============================================================================
+#
+# All of this is off by default. With PARASIGN_QES_PROVIDER empty, POST
+# /v2/qes/sign does not exist, /v2/auth/capabilities reports an empty provider,
+# the /sign page shows no extra option, and the .psign receipt is unchanged.
+#
+# The provider signs a SHA-256 digest of the CAdES signed attributes and returns
+# a signature value. The document never leaves the relay: there is no upload
+# path in the Cleverbase Signing API and none here either.
+
+# Which qualified trust service provider signs. Empty means the whole layer is
+# off. "cleverbase-sandbox" targets the Cleverbase pre-production host;
+# "cleverbase" targets production and refuses to start without a registered
+# client, because client registration there is a manual step with an account
+# manager and there is no contract yet.
+# optional · default: none (feature off)
+# read in: relay/lib/qes/index.js, relay/relay.js
+# PARASIGN_QES_PROVIDER=
+
+# Cleverbase Signing API host. Defaults follow PARASIGN_QES_PROVIDER:
+# https://connect.acc.cleverbase.com for the sandbox, https://connect.cleverbase.com
+# for production. Set this only to point at something else.
+# optional · default: derived from PARASIGN_QES_PROVIDER
+# read in: relay/lib/qes/cleverbase.js, relay/lib/qes/index.js
+# CLEVERBASE_BASE_URL=
+
+# OAuth 2.0 client identifier issued by Cleverbase, a UUID. Cleverbase publishes
+# a client id and secret for its development and test stubs at
+# https://cleverbase.com/en/dev-docs/client-registration/ ; that pair is not
+# repeated here, and it would not get you far anyway: the signing host rejects
+# it with invalid_client, as docs/qes-prototype.md records. A real client id and
+# secret are issued per integration and belong in .env, never in git.
+# optional · default: none
+# read in: relay/lib/qes/cleverbase.js, relay/lib/qes/index.js
+# CLEVERBASE_CLIENT_ID=
+
+# OAuth 2.0 client secret matching CLEVERBASE_CLIENT_ID. Never in git, not even
+# a sandbox one: see the client registration page linked above for the vendor's
+# published stub pair.
+# optional · default: none
+# read in: relay/lib/qes/cleverbase.js
+# CLEVERBASE_CLIENT_SECRET=
+
+# Redirect URI registered with the OAuth client. The signer returns here with
+# the authorisation code after authorising in the provider app.
+# optional · default: none
+# read in: relay/lib/qes/cleverbase.js
+# CLEVERBASE_REDIRECT_URI=
+
+# RFC 3161 timestamp authority, used to lift the signature from PAdES-B-B to
+# PAdES-B-T. The default is DigiCert's free public timestamp service, which
+# needs no account and answers over plain HTTP as RFC 3161 specifies. It is NOT
+# an EU-qualified TSA: it is a code-signing timestamp service and appears on no
+# member state's eIDAS trusted list. Production needs a qualified TSA, from a
+# provider with a granted TSA/QTST service. Set this to an empty string to skip
+# timestamping and stay honestly at PAdES-B-B.
+# optional · default: http://timestamp.digicert.com
+# read in: relay/lib/qes/index.js, relay/lib/qes/tsa.js
+# QES_TSA_URL=http://timestamp.digicert.com
 
 
 # ==============================================================================

--- a/docs/qes-prototype.md
+++ b/docs/qes-prototype.md
@@ -1,0 +1,144 @@
+# Qualified electronic signature: a prototype, behind a flag
+
+This is a working prototype of a QES layer for ParaSign. It is off by default and
+it changes nothing about signing until `PARASIGN_QES_PROVIDER` names a provider.
+It exists to answer one question without a contract: does a qualified signature
+fit next to what ParaSign already does, or does it need the product rebuilt?
+
+The answer is that it fits. This document records what was proved, against what,
+and what is still missing.
+
+## The shape
+
+Three layers that do not touch each other:
+
+1. **The PAdES signature inside the PDF.** A qualified trust service provider
+   signs a SHA-256 digest and returns a signature value. The container is built
+   here. The document never leaves.
+2. **The `.psign` receipt.** Unchanged, with one extra top-level field pointing
+   at the qualified signature. It is a separate file next to the PDF, so it
+   cannot break a PAdES signature and a PAdES signature cannot break it.
+3. **The public log.** Untouched.
+
+"Verifiable without us" holds for both halves separately: the receipt through
+the existing verify page, the PAdES signature through Adobe Acrobat or the EU
+DSS validator, neither of which has to ask Paramant anything.
+
+## The modules
+
+| File | What it is |
+|---|---|
+| `relay/lib/qes/asn1.js` | Minimal DER encoder and decoder. No new dependency. |
+| `relay/lib/qes/cms.js` | CMS SignedData for a detached CAdES-BES signature, plus the signed attributes and the one digest that goes out. |
+| `relay/lib/qes/pades.js` | The PDF incremental-update writer: signature dictionary, ByteRange, signature field, cross-reference section. |
+| `relay/lib/qes/tsa.js` | RFC 3161 timestamping, for PAdES-B-T. |
+| `relay/lib/qes/cleverbase.js` | Cleverbase Signing API client (CSC API v1.0.4). |
+| `relay/lib/qes/index.js` | The flag, and the two phases either side of the provider call. |
+| `scripts/qes-verify.mjs` | Independent verification of the result. |
+
+`pdf-lib` is used only as the object model. It cannot write an incremental
+update: `PDFDocument.save()` rewrites the whole file, which would break any
+signature already present and makes "the original bytes are untouched"
+impossible to assert. So pdf-lib parses the catalogue, the page tree and the
+AcroForm, and `pades.js` writes the bytes.
+
+## What the sandbox allowed, and what it did not
+
+Checked on 3 September 2026 against `https://connect.acc.cleverbase.com`.
+
+**Reachable without any credentials.** `POST /csc/v1/info` answers 200 with the
+CSC discovery document: `specs 1.0.4.0`, `region NL`, `authType ["oauth2code"]`,
+and the method list `auth/revoke, credentials/info, credentials/list, info,
+oauth2/authorize, oauth2/revoke, oauth2/token, signatures/signHash`. Production
+answers identically on `https://connect.cleverbase.com`.
+
+**Hash-only signing is confirmed by absence.** There is no `signatures/signDoc`
+in the method list. The only way to get a signature out of this API is to hand
+it a digest. That is the finding the whole architecture rests on, and it holds.
+
+**No qualified timestamp.** There is no `signatures/timestamp` method either.
+Cleverbase has no TSA/QTST service, so the timestamp has to be bought elsewhere.
+
+**No signature is reachable from a test.** `authType` is `oauth2code` and
+nothing else. Every signature needs a natural person to authorise it in the
+Cleverbase app, having identified himself there with an NFC chip read plus
+biometrics. There is no `client_credentials` grant: asking for one returns
+`invalid_request: Invalid parameter grant_type`. This is not a sandbox
+limitation to be worked around; it is what makes the signature qualified.
+
+**The published test credentials do not work here.** The client id
+`6dd5f48d-bcd9-4a98-8a4c-5c82182f5be4` and secret published on
+`https://cleverbase.com/en/dev-docs/client-registration/` are for the *trust
+driver stub* services, of which only the identification stub
+(`trust-driver-stub-idf.cleverbase.com`) is publicly reachable. Against the
+signing host they are rejected: `/csc/v1/oauth2/authorize` redirects to
+`error=invalid_client`. There is no self-service OAuth client for the Signing
+API. Client registration is a manual step with an account manager, in
+pre-production as well as in production.
+
+So the honest state of the integration is: the client speaks the protocol, the
+request and response shapes are pinned by unit tests against recorded payloads,
+the discovery call runs live in CI when asked, and the one call that produces a
+signature has never been made because it cannot be made without a registered
+client and an identified person.
+
+## The timestamp
+
+`QES_TSA_URL` defaults to `http://timestamp.digicert.com`. It is free, needs no
+account, answers over plain HTTP as RFC 3161 specifies, and it works: a request
+made on 3 September 2026 came back `Status: Granted` with a SHA-256 token whose
+imprint matched.
+
+It is **not** an EU-qualified TSA. It is a code-signing timestamp service and it
+appears on no member state's eIDAS trusted list. With it the signature is
+PAdES-B-T in shape only. For a signature that counts, the URL has to point at a
+qualified TSA, which means a provider with a granted TSA/QTST service: DigiCert
+Europe Netherlands has nine on the Dutch list, Zetes ten on the Belgian one.
+Setting `QES_TSA_URL=` (empty) skips timestamping and stays honestly at
+PAdES-B-B.
+
+## Verification
+
+```
+node scripts/qes-verify.mjs signed.pdf [--json]
+```
+
+It recomputes the ByteRange digest, checks it against the message-digest
+attribute, checks that `signing-certificate-v2` names the certificate that is
+actually in the CMS, verifies the RSA signature over the signed attributes,
+walks the certificate chain link by link, and checks that any timestamp covers
+this signature value.
+
+It does not check trust. No trusted list is consulted, so nothing it prints
+proves the issuer is a qualified trust service provider. It does not check
+revocation: no CRL, no OCSP. It does not do full RFC 5280 path validation. Use
+Adobe Acrobat or the EU DSS demo validator for the real verdict.
+
+## What is still needed for production
+
+1. **A contract with Cleverbase.** Client registration is manual. The API tariff
+   per `signHash` at low volume is not published anywhere.
+2. **A qualified timestamp authority.** Cleverbase has none. Without one there
+   is no B-T, and therefore no B-LT and no B-LTA.
+3. **Long term validation.** B-LTA needs a DSS dictionary with the certificates,
+   OCSP responses and CRLs, plus a document timestamp. None of that is built
+   here. Without it the signature stops being verifiable once the signer
+   certificate expires.
+4. **The Belgian gap.** A Belgian can identify at Cleverbase only with a
+   passport. The Belgian eID card is not accepted.
+5. **The public wording.** `about.html`, `security.html` and `parasign.html`
+   currently state that a ParaSign signature is not qualified, and the tests pin
+   that sentence. Those pages describe the ParaSign signature and stay correct
+   while the QES sits next to it as a separate, optional artefact. They will
+   need a deliberate rewrite before any of this is offered to customers.
+
+## Running the tests
+
+```
+# no network
+node --test relay/test/qes-pades.test.js relay/test/qes-cms.test.js
+node --test tests/qes-pdf-readable.test.mjs
+
+# real calls to the Cleverbase pre-production host and a public TSA
+CLEVERBASE_SANDBOX=1 node --test tests/qes-cleverbase-live.test.mjs
+```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,7 +20,7 @@ export default [
     // Hand-written server code only. The vendored bundles (pqc, wasm glue) are
     // generated, single-line, and full of browser globals: linting them says
     // nothing about code anyone edits.
-    files: ['relay/*.js', 'relay/lib/*.js', 'admin/*.js', 'admin/lib/*.js'],
+    files: ['relay/*.js', 'relay/lib/**/*.js', 'admin/*.js', 'admin/lib/*.js'],
     ignores: ['**/node_modules/**', 'relay/lib/paramant-pqc.js', '**/*.min.js'],
     languageOptions: {
       ecmaVersion: 2023,

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -2967,6 +2967,83 @@ async function doSign() {
   }
 }
 
+// ── qualified signature (optional, off unless the relay says otherwise) ──────
+// The relay reports the configured provider on /v2/auth/capabilities. With no
+// provider the checkbox is never revealed and nothing on this page changes.
+async function revealQesOption() {
+  const box = $('ds-qes-option');
+  if (!box) return;
+  let res;
+  try {
+    res = await fetch('/v2/auth/capabilities', { cache: 'no-store' });
+  } catch {
+    return;   // offline is not a reason to show a half-working option
+  }
+  if (!res.ok) return;
+  let caps;
+  try { caps = await res.json(); } catch { return; }
+  if (caps && caps.parasign_qes) box.hidden = false;
+}
+
+// Hand the signed PDF to the server QES step. Everything here is additive: the
+// ParaSign signature and its .psign are already made and downloadable, and a
+// failure below never takes them away.
+async function addQualifiedSignature(pdfBytes) {
+  const note = document.createElement('div');
+  note.id = 'ds-qes-note';
+  note.className = 'ds-note';
+  note.setAttribute('role', 'note');
+  const line = document.createElement('p');
+  line.textContent = 'Requesting a qualified signature...';
+  note.appendChild(line);
+  const dl = $('ds-dl-pdf');
+  if (dl && dl.parentNode) dl.parentNode.insertBefore(note, dl.nextSibling);
+
+  let bin = '';
+  for (let i = 0; i < pdfBytes.length; i++) bin += String.fromCharCode(pdfBytes[i]);
+  let res;
+  try {
+    res = await fetch('/v2/qes/sign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ document: btoa(bin), signer_name: state.signer.name || null }),
+    });
+  } catch {
+    line.textContent = 'The qualified signature could not be requested. Your ParaSign signature is unaffected.';
+    return;
+  }
+  let body = null;
+  try { body = await res.json(); } catch { /* handled by the status below */ }
+
+  if (res.status === 409 && body) {
+    line.textContent = 'A qualified signature needs the signer to authorise it in the provider app first. '
+      + (body.reason || '');
+    if (body.authorize_url) {
+      const a = document.createElement('a');
+      a.href = body.authorize_url;
+      a.textContent = 'Open the provider authorisation';
+      a.rel = 'noopener';
+      note.appendChild(a);
+    }
+    return;
+  }
+  if (!res.ok || !body || !body.document) {
+    line.textContent = 'The provider did not return a qualified signature. Your ParaSign signature is unaffected.';
+    return;
+  }
+
+  const raw = atob(body.document);
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  line.textContent = 'Qualified signature added (' + (body.level || 'PAdES') + ').';
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'btn btn-secondary';
+  btn.textContent = 'Download the qualified PDF';
+  btn.addEventListener('click', () => downloadBytes(out, 'qualified-' + signedDocName(), 'application/pdf'));
+  note.appendChild(btn);
+}
+
 function downloadBytes(bytes, name, mime) {
   const blob = new Blob([bytes], { type: mime || 'application/octet-stream' });
   const url = URL.createObjectURL(blob);
@@ -3061,6 +3138,10 @@ function showDone() {
     $('ds-dl-pdf').hidden = false;
     $('ds-dl-pdf').textContent = state.mode === 'pdf' ? 'Download signed PDF' : 'Download signed image';
     $('ds-dl-pdf').onclick = () => downloadBytes(r.stampedBytes, signedDocName(), signedDocMime());
+    const optIn = $('ds-qes-optin');
+    if (state.mode === 'pdf' && optIn && optIn.checked) {
+      addQualifiedSignature(r.stampedBytes).catch(() => { /* additive only */ });
+    }
   } else {
     $('ds-dl-pdf').hidden = true;
   }
@@ -3429,6 +3510,7 @@ function wireLiveStampUpdates() {
 }
 
 function init() {
+  revealQesOption().catch(() => { /* the option simply stays hidden */ });
   initStepMode();
   initStepDoc();
   initStepIdentity();

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -837,6 +837,10 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
       <strong>Post-quantum, zero-knowledge. Not eIDAS-qualified.</strong>
       A ParaSign signature is a Simple Electronic Signature (SES): an ML-DSA-65 (FIPS 204) cryptographic attestation, produced in your browser. It is not a notarised legal signature under eIDAS or any qualified-trust regime (QES).
     </div>
+    <div class="ds-info-card" id="ds-qes-option" hidden>
+      <label class="ds-seal-check"><input type="checkbox" id="ds-qes-optin"> Also add a qualified signature (sandbox)</label>
+      <p class="ds-sub">A qualified trust service provider signs a hash of this document and returns a PAdES signature carrying its own certificate. The document itself never leaves this page. Sandbox only: this is a prototype against a test environment, not a production service.</p>
+    </div>
     <div class="ds-actions">
       <button class="btn btn-tertiary" id="ds-sign-back" type="button">Back</button>
       <button class="btn btn-primary" id="ds-sign-now" type="button">Sign this document</button>
@@ -959,6 +963,6 @@ body[data-ds-step="step-done"] #ds-doc-meta{display:none}
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script src="/js/parasign-pdf-ops.js?v=1"></script>
 <script src="/js/quota-upgrade.js?v=4" defer></script>
-<script type="module" src="/sign-flow.js?v=52"></script>
+<script type="module" src="/sign-flow.js?v=53"></script>
 </body>
 </html>

--- a/relay/lib/parasign-open-api.js
+++ b/relay/lib/parasign-open-api.js
@@ -668,6 +668,20 @@ function buildEnvelopePsign({ env, meta, canonicalJSON, sigEngine, relayIdentity
   // signed .psign, so the test nature travels with the evidence itself, not
   // only the create-response note. A live envelope carries NO such marker.
   if (m.mode === 'test') { psign.mode = 'test'; psign.sandbox = true; }
+  // Qualified-signature marker (PARASIGN_QES_PROVIDER). The QES itself lives in
+  // the PDF as a PAdES signature and is validated by Adobe or DSS without us;
+  // this is only a pointer to it, so a reader of the receipt knows a second,
+  // independent signature exists and which certificate carries it. Added BEFORE
+  // the notary signature, like mode/sandbox above, or the counter-signature
+  // over the canonical JSON would no longer verify.
+  const qes = env.qes && typeof env.qes === 'object' ? env.qes : null;
+  if (qes && qes.provider && qes.certificate_fingerprint) {
+    psign.qes = {
+      provider: String(qes.provider),
+      certificate_fingerprint: String(qes.certificate_fingerprint),
+      signed_at: qes.signed_at || null,
+    };
+  }
 
   const notarySig = Buffer.from(
     sigEngine.sign(Buffer.from(canonicalJSON(psign), 'utf8'), relayIdentity.sk)

--- a/relay/lib/qes/asn1.js
+++ b/relay/lib/qes/asn1.js
@@ -1,0 +1,146 @@
+'use strict';
+// Minimal DER encoder/decoder, just enough for CMS SignedData and RFC 3161.
+//
+// Deliberately dependency-free: the relay already ships without an ASN.1
+// library and a QES prototype is not a good reason to add one. Everything here
+// is definite-length DER, which is all that CMS and PKIX allow anyway.
+
+// ── encoding ────────────────────────────────────────────────────────────────
+
+function encodeLength(n) {
+  if (n < 0x80) return Buffer.from([n]);
+  const bytes = [];
+  let v = n;
+  while (v > 0) { bytes.unshift(v & 0xff); v >>>= 8; }
+  return Buffer.from([0x80 | bytes.length, ...bytes]);
+}
+
+// One tag-length-value. `tag` is the full identifier octet.
+function tlv(tag, content) {
+  const body = Buffer.isBuffer(content) ? content : Buffer.concat(content);
+  return Buffer.concat([Buffer.from([tag]), encodeLength(body.length), body]);
+}
+
+const seq = (...parts) => tlv(0x30, parts.flat());
+const set = (...parts) => tlv(0x31, parts.flat());
+const octetString = (buf) => tlv(0x04, buf);
+const bitString = (buf, unused = 0) => tlv(0x03, Buffer.concat([Buffer.from([unused]), buf]));
+const nullValue = () => Buffer.from([0x05, 0x00]);
+// Context-specific constructed [n].
+const explicit = (n, ...parts) => tlv(0xa0 | n, parts.flat());
+// Context-specific constructed [n] IMPLICIT over a SET/SEQUENCE body.
+const implicitSet = (n, ...parts) => tlv(0xa0 | n, parts.flat());
+
+function integer(value) {
+  let buf;
+  if (Buffer.isBuffer(value)) {
+    buf = value;
+  } else {
+    const n = BigInt(value);
+    if (n === 0n) buf = Buffer.from([0]);
+    else {
+      let hex = n.toString(16);
+      if (hex.length % 2) hex = '0' + hex;
+      buf = Buffer.from(hex, 'hex');
+    }
+  }
+  // Strip redundant leading zeros, then re-add one if the top bit is set.
+  let i = 0;
+  while (i + 1 < buf.length && buf[i] === 0 && (buf[i + 1] & 0x80) === 0) i++;
+  buf = buf.subarray(i);
+  if (buf.length && (buf[0] & 0x80)) buf = Buffer.concat([Buffer.from([0]), buf]);
+  if (!buf.length) buf = Buffer.from([0]);
+  return tlv(0x02, buf);
+}
+
+function oid(dotted) {
+  const parts = String(dotted).split('.').map((p) => parseInt(p, 10));
+  if (parts.length < 2 || parts.some((p) => !Number.isInteger(p) || p < 0)) {
+    throw new Error('invalid OID: ' + dotted);
+  }
+  const out = [40 * parts[0] + parts[1]];
+  for (const part of parts.slice(2)) {
+    const chunk = [];
+    let v = part;
+    do { chunk.unshift(v & 0x7f); v = Math.floor(v / 128); } while (v > 0);
+    for (let i = 0; i < chunk.length - 1; i++) chunk[i] |= 0x80;
+    out.push(...chunk);
+  }
+  return tlv(0x06, Buffer.from(out));
+}
+
+// UTCTime, the CMS default for dates before 2050.
+function utcTime(date) {
+  const d = new Date(date);
+  const p = (n, w = 2) => String(n).padStart(w, '0');
+  const s = p(d.getUTCFullYear() % 100) + p(d.getUTCMonth() + 1) + p(d.getUTCDate()) +
+    p(d.getUTCHours()) + p(d.getUTCMinutes()) + p(d.getUTCSeconds()) + 'Z';
+  return tlv(0x17, Buffer.from(s, 'ascii'));
+}
+
+// AlgorithmIdentifier with an absent-or-NULL parameter, the only two shapes we emit.
+function algorithmIdentifier(algOid, { withNull = true } = {}) {
+  return withNull ? seq(oid(algOid), nullValue()) : seq(oid(algOid));
+}
+
+// ── decoding ────────────────────────────────────────────────────────────────
+
+// Read one TLV at `offset`. Returns { tag, headerLength, length, content, end }
+// where `content` is a view into `buf` (no copy).
+function readTlv(buf, offset = 0) {
+  if (offset >= buf.length) throw new Error('DER: read past end');
+  const tag = buf[offset];
+  if ((tag & 0x1f) === 0x1f) throw new Error('DER: multi-byte tags unsupported');
+  let pos = offset + 1;
+  if (pos >= buf.length) throw new Error('DER: truncated length');
+  let length = buf[pos++];
+  if (length === 0x80) throw new Error('DER: indefinite length is not DER');
+  if (length & 0x80) {
+    const count = length & 0x7f;
+    if (count > 4) throw new Error('DER: length too large');
+    length = 0;
+    for (let i = 0; i < count; i++) {
+      if (pos >= buf.length) throw new Error('DER: truncated length');
+      length = (length << 8) | buf[pos++];
+    }
+  }
+  const end = pos + length;
+  if (end > buf.length) throw new Error('DER: content past end');
+  return { tag, headerLength: pos - offset, length, content: buf.subarray(pos, end), start: offset, end };
+}
+
+// Every direct child of a constructed TLV's content.
+function readChildren(content) {
+  const out = [];
+  let pos = 0;
+  while (pos < content.length) {
+    const node = readTlv(content, pos);
+    out.push(node);
+    pos = node.end;
+  }
+  return out;
+}
+
+function decodeOid(content) {
+  if (!content.length) throw new Error('DER: empty OID');
+  const first = content[0];
+  const parts = [Math.floor(first / 40), first % 40];
+  let value = 0;
+  for (let i = 1; i < content.length; i++) {
+    value = value * 128 + (content[i] & 0x7f);
+    if (!(content[i] & 0x80)) { parts.push(value); value = 0; }
+  }
+  return parts.join('.');
+}
+
+// The full encoding of a node, header included. Used where a signature covers
+// the bytes as they appear on the wire.
+function rawOf(buf, node) {
+  return buf.subarray(node.start, node.end);
+}
+
+module.exports = {
+  encodeLength, tlv, seq, set, octetString, bitString, nullValue,
+  explicit, implicitSet, integer, oid, utcTime, algorithmIdentifier,
+  readTlv, readChildren, decodeOid, rawOf,
+};

--- a/relay/lib/qes/cleverbase.js
+++ b/relay/lib/qes/cleverbase.js
@@ -1,0 +1,193 @@
+'use strict';
+// Cleverbase Signing API client (Cloud Signature Consortium API v1.0.4).
+//
+// Hosts, per https://cleverbase.com/en/dev-docs/signing/ :
+//   pre-production  https://connect.acc.cleverbase.com
+//   production      https://connect.cleverbase.com
+// Endpoint paths come from POST /csc/v1/info, which is public and unauthenticated.
+//
+// What this does and does not do:
+//   - It only ever sends a 32-byte SHA-256 digest. There is no signDoc in this
+//     API and there is no upload path here either. The PDF never leaves.
+//   - It cannot identify a signer on its own. authType is "oauth2code" only, so
+//     a natural person has to authorise in the Cleverbase app; there is no
+//     client_credentials shortcut, in sandbox or in production. The identity in
+//     the certificate is Cleverbase's, established with NFC chip reading plus
+//     biometrics, not ours.
+//   - Credentials come from the environment (CLEVERBASE_*) and nowhere else.
+//
+// Every secret stays out of the repository. deploy/.env.example carries only the
+// client id and secret that Cleverbase itself publishes for its development
+// stubs, marked as such.
+
+const crypto = require('node:crypto');
+
+const SANDBOX_BASE_URL = 'https://connect.acc.cleverbase.com';
+const PRODUCTION_BASE_URL = 'https://connect.cleverbase.com';
+
+// Both fixed by the API: SHA-256 digests, RSA PKCS#1 v1.5 signatures.
+const HASH_ALGO_OID = '2.16.840.1.101.3.4.2.1';
+const SIGN_ALGO_OID = '1.2.840.113549.1.1.1';
+const MAX_SIGNATURES_PER_AUTHORISATION = 50;
+
+function configFromEnv(env = process.env) {
+  return {
+    baseUrl: env.CLEVERBASE_BASE_URL || SANDBOX_BASE_URL,
+    clientId: env.CLEVERBASE_CLIENT_ID || '',
+    clientSecret: env.CLEVERBASE_CLIENT_SECRET || '',
+    redirectUri: env.CLEVERBASE_REDIRECT_URI || '',
+  };
+}
+
+function b64url(buf) {
+  return Buffer.from(buf).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+class CleverbaseError extends Error {
+  constructor(message, { status = 0, body = null } = {}) {
+    super(message);
+    this.name = 'CleverbaseError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+class CleverbaseClient {
+  constructor(options = {}) {
+    const cfg = { ...configFromEnv(options.env), ...options };
+    this.baseUrl = String(cfg.baseUrl).replace(/\/+$/, '');
+    this.clientId = cfg.clientId;
+    this.clientSecret = cfg.clientSecret;
+    this.redirectUri = cfg.redirectUri;
+    this.timeoutMs = Number(cfg.timeoutMs) || 20000;
+    this.fetchImpl = cfg.fetchImpl || fetch;
+  }
+
+  get isSandbox() { return this.baseUrl === SANDBOX_BASE_URL; }
+  url(path) { return this.baseUrl + '/csc/v1/' + String(path).replace(/^\/+/, ''); }
+
+  async request(path, { body = null, bearer = null, form = null } = {}) {
+    const headers = {};
+    let payload;
+    if (form) {
+      headers['Content-Type'] = 'application/x-www-form-urlencoded';
+      headers['Authorization'] = 'Basic ' + Buffer.from(this.clientId + ':' + this.clientSecret).toString('base64');
+      payload = new URLSearchParams(form).toString();
+    } else {
+      headers['Content-Type'] = 'application/json';
+      payload = JSON.stringify(body || {});
+    }
+    if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
+
+    const res = await this.fetchImpl(this.url(path), {
+      method: 'POST', headers, body: payload,
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+    const text = await res.text();
+    let parsed = null;
+    try { parsed = text ? JSON.parse(text) : null; } catch { /* keep the raw text below */ }
+    if (!res.ok) {
+      const detail = (parsed && (parsed.error_description || parsed.error)) || text.slice(0, 300);
+      throw new CleverbaseError('Cleverbase ' + path + ' failed: ' + res.status + ' ' + detail,
+        { status: res.status, body: parsed || text });
+    }
+    return parsed;
+  }
+
+  // Public discovery document. Needs no credentials, which makes it the one
+  // call an integration test can always make against the sandbox.
+  info(lang = 'en-US') { return this.request('info', { body: { lang } }); }
+
+  // Step 1: where the signer's browser goes. `scope` is "service" for an API
+  // token, "credential" for a Signature Activation Data token bound to exactly
+  // the hashes handed in here.
+  authorizeUrl({ scope, state, credentialID = null, hashes = null, numSignatures = null,
+    redirectUri = this.redirectUri, lang = 'en-US', accountToken = null }) {
+    if (scope !== 'service' && scope !== 'credential') throw new Error('scope must be service or credential');
+    if (!this.clientId) throw new Error('CLEVERBASE_CLIENT_ID is not set');
+    if (!redirectUri) throw new Error('CLEVERBASE_REDIRECT_URI is not set');
+    const q = new URLSearchParams({
+      response_type: 'code', client_id: this.clientId, redirect_uri: redirectUri, scope, lang,
+      state: String(state || ''),
+    });
+    if (scope === 'credential') {
+      if (!credentialID) throw new Error('credential scope needs a credentialID');
+      if (!Array.isArray(hashes) || !hashes.length) throw new Error('credential scope needs hashes');
+      const count = numSignatures || hashes.length;
+      if (count > MAX_SIGNATURES_PER_AUTHORISATION) {
+        throw new Error('at most ' + MAX_SIGNATURES_PER_AUTHORISATION + ' signatures per authorisation');
+      }
+      q.set('credentialID', credentialID);
+      q.set('numSignatures', String(count));
+      q.set('hash', hashes.map((h) => b64url(h)).join(','));
+    }
+    if (accountToken) q.set('account_token', accountToken);
+    return this.url('oauth2/authorize') + '?' + q.toString();
+  }
+
+  // Step 2: authorisation code to token. A "service" scope code yields a Bearer
+  // token; a "credential" scope code yields the SAD, which lives 300 seconds.
+  async exchangeCode(code, redirectUri = this.redirectUri) {
+    if (!this.clientSecret) throw new Error('CLEVERBASE_CLIENT_SECRET is not set');
+    return this.request('oauth2/token', {
+      form: { grant_type: 'authorization_code', code, client_id: this.clientId, redirect_uri: redirectUri },
+    });
+  }
+
+  listCredentials(serviceToken, maxResults = 10) {
+    return this.request('credentials/list', { bearer: serviceToken, body: { maxResults } });
+  }
+
+  // Returns the CSC payload plus the certificate chain as DER buffers, signer
+  // certificate first, which is the order CMS wants.
+  async credentialInfo(serviceToken, credentialID) {
+    const out = await this.request('credentials/info', { bearer: serviceToken, body: { credentialID } });
+    const chain = ((out && out.cert && out.cert.certificates) || []).map((b64) => Buffer.from(b64, 'base64'));
+    return { ...out, chain };
+  }
+
+  // Step 3: the only call that produces a signature. `hashes` are raw digests;
+  // they go out base64-encoded and come back as raw signature values.
+  async signHash({ serviceToken, credentialID, sad, hashes }) {
+    if (!Array.isArray(hashes) || !hashes.length) throw new Error('signHash needs at least one hash');
+    for (const h of hashes) {
+      if (!Buffer.isBuffer(h) || h.length !== 32) throw new Error('signHash takes 32-byte SHA-256 digests');
+    }
+    const out = await this.request('signatures/signHash', {
+      bearer: serviceToken,
+      body: {
+        credentialID,
+        SAD: sad,
+        hash: hashes.map((h) => h.toString('base64')),
+        hashAlgo: HASH_ALGO_OID,
+        signAlgo: SIGN_ALGO_OID,
+      },
+    });
+    const signatures = (out && out.signatures) || [];
+    if (signatures.length !== hashes.length) throw new CleverbaseError('signHash returned ' + signatures.length + ' signatures for ' + hashes.length + ' hashes');
+    return signatures.map((b64) => Buffer.from(b64, 'base64'));
+  }
+
+  // Cleverbase asks a signature application serving several customers to
+  // identify the account it is signing for. HS256 over the client secret's
+  // SHA-256, per https://cleverbase.com/en/dev-docs/signing/account-tokens/ .
+  accountToken(accountId) {
+    if (!this.clientSecret) throw new Error('CLEVERBASE_CLIENT_SECRET is not set');
+    const header = b64url(JSON.stringify({ typ: 'JWT', alg: 'HS256' }));
+    const payload = b64url(JSON.stringify({
+      sub: String(accountId),
+      iat: Math.floor(Date.now() / 1000),
+      jti: crypto.randomUUID(),
+      azp: this.clientId,
+    }));
+    const key = crypto.createHash('sha256').update(this.clientSecret).digest();
+    const mac = crypto.createHmac('sha256', key).update(header + '.' + payload).digest();
+    return header + '.' + payload + '.' + b64url(mac);
+  }
+}
+
+module.exports = {
+  CleverbaseClient, CleverbaseError, configFromEnv,
+  SANDBOX_BASE_URL, PRODUCTION_BASE_URL,
+  HASH_ALGO_OID, SIGN_ALGO_OID, MAX_SIGNATURES_PER_AUTHORISATION,
+};

--- a/relay/lib/qes/cms.js
+++ b/relay/lib/qes/cms.js
@@ -1,0 +1,211 @@
+'use strict';
+// CMS SignedData (RFC 5652) for a detached CAdES-BES signature, plus the two
+// helpers a remote hash-signing QTSP needs: the DER of the signed attributes
+// and the SHA-256 over them. The QTSP only ever sees that 32-byte digest.
+//
+// Scope is deliberately narrow and matches what Cleverbase's Signing API
+// accepts: SHA-256 digests, RSA PKCS#1 v1.5 signatures, one signer.
+
+const crypto = require('node:crypto');
+const a = require('./asn1');
+
+const OID = {
+  data: '1.2.840.113549.1.7.1',
+  signedData: '1.2.840.113549.1.7.2',
+  contentType: '1.2.840.113549.1.9.3',
+  messageDigest: '1.2.840.113549.1.9.4',
+  signingTime: '1.2.840.113549.1.9.5',
+  signingCertificateV2: '1.2.840.113549.1.9.16.2.47',
+  signatureTimeStampToken: '1.2.840.113549.1.9.16.2.14',
+  sha256: '2.16.840.1.101.3.4.2.1',
+  rsaEncryption: '1.2.840.113549.1.1.1',
+};
+
+const sha256 = (buf) => crypto.createHash('sha256').update(buf).digest();
+
+// ── certificate field extraction ────────────────────────────────────────────
+
+// Pull issuer (raw Name DER) and serialNumber (raw INTEGER content) straight
+// out of the TBSCertificate. node:crypto exposes these only as display strings,
+// and IssuerAndSerialNumber needs the original encoding byte for byte.
+function certIssuerAndSerial(certDer) {
+  const cert = a.readTlv(certDer);
+  const tbs = a.readChildren(cert.content)[0];
+  const fields = a.readChildren(tbs.content);
+  let i = 0;
+  if (fields[i] && fields[i].tag === 0xa0) i++; // [0] EXPLICIT Version
+  const serial = fields[i++];
+  if (!serial || serial.tag !== 0x02) throw new Error('certificate: no serialNumber');
+  i++; // signature AlgorithmIdentifier
+  const issuer = fields[i];
+  if (!issuer || issuer.tag !== 0x30) throw new Error('certificate: no issuer Name');
+  return {
+    issuerDer: Buffer.from(a.rawOf(tbs.content, issuer)),
+    serialDer: Buffer.from(a.rawOf(tbs.content, serial)),
+  };
+}
+
+function issuerAndSerialNumber(certDer) {
+  const { issuerDer, serialDer } = certIssuerAndSerial(certDer);
+  return a.seq(issuerDer, serialDer);
+}
+
+// ── signed attributes ───────────────────────────────────────────────────────
+
+function attribute(typeOid, ...values) {
+  return a.seq(a.oid(typeOid), a.set(values.flat()));
+}
+
+// ESSCertIDv2 with the default SHA-256 hash algorithm omitted, as RFC 5035 allows.
+function signingCertificateV2(certDer) {
+  const essCertId = a.seq(a.octetString(sha256(certDer)));
+  return a.seq(a.seq(essCertId));
+}
+
+// The SET OF Attribute, DER-sorted. Returned with tag 0x31 (SET OF): this is
+// the encoding the signature is computed over, per RFC 5652 5.4. Inside
+// SignerInfo the same content bytes are re-tagged [0] IMPLICIT.
+function buildSignedAttributes({ messageDigest, signerCertDer, signingTime = null }) {
+  if (!Buffer.isBuffer(messageDigest) || messageDigest.length !== 32) {
+    throw new Error('messageDigest must be a 32-byte SHA-256 digest');
+  }
+  const attrs = [
+    attribute(OID.contentType, a.oid(OID.data)),
+    attribute(OID.messageDigest, a.octetString(messageDigest)),
+    attribute(OID.signingCertificateV2, signingCertificateV2(signerCertDer)),
+  ];
+  // ETSI EN 319 142-1 takes the claimed signing time from the /M entry of the
+  // signature dictionary, so the CAdES signing-time attribute stays off by
+  // default. Kept as an option for verifiers that still want it.
+  if (signingTime) attrs.push(attribute(OID.signingTime, a.utcTime(signingTime)));
+  attrs.sort(Buffer.compare);
+  return a.set(attrs);
+}
+
+// What the QTSP signs. Never the document, never the ByteRange digest: the
+// SHA-256 of the signed attributes, which in turn commit to both.
+function signedAttributesDigest(signedAttrsDer) {
+  return sha256(signedAttrsDer);
+}
+
+// ── SignedData ──────────────────────────────────────────────────────────────
+
+// certificates: [signerCertDer, ...chainDer]; signerCertDer must be first.
+// signatureValue: the raw RSA PKCS#1 v1.5 signature returned by the QTSP.
+// timeStampToken: an RFC 3161 TimeStampToken (a full ContentInfo DER), or null.
+function buildSignedData({ certificates, signedAttrsDer, signatureValue, timeStampToken = null }) {
+  if (!Array.isArray(certificates) || !certificates.length) throw new Error('certificates required');
+  const signerCertDer = certificates[0];
+
+  // Re-tag the SET OF as [0] IMPLICIT without touching the content.
+  const attrsNode = a.readTlv(signedAttrsDer);
+  const signedAttrsImplicit = a.implicitSet(0, Buffer.from(attrsNode.content));
+
+  const parts = [
+    a.integer(1),                                    // version (issuerAndSerialNumber)
+    issuerAndSerialNumber(signerCertDer),            // sid
+    a.algorithmIdentifier(OID.sha256),               // digestAlgorithm
+    signedAttrsImplicit,
+    a.algorithmIdentifier(OID.rsaEncryption),        // signatureAlgorithm
+    a.octetString(signatureValue),
+  ];
+  if (timeStampToken) {
+    parts.push(a.implicitSet(1, attribute(OID.signatureTimeStampToken, timeStampToken)));
+  }
+  const signerInfo = a.seq(parts);
+
+  const signedData = a.seq(
+    a.integer(1),                                    // version
+    a.set(a.algorithmIdentifier(OID.sha256)),        // digestAlgorithms
+    a.seq(a.oid(OID.data)),                          // encapContentInfo, detached
+    a.implicitSet(0, certificates.map((c) => Buffer.from(c))),
+    a.set(signerInfo)
+  );
+
+  return a.seq(a.oid(OID.signedData), a.explicit(0, signedData));
+}
+
+// ── reading a CMS back ──────────────────────────────────────────────────────
+
+// Everything scripts/qes-verify.mjs needs to check a signature without a
+// second ASN.1 library. Returns raw DER for the pieces that must be verified
+// byte for byte.
+function parseSignedData(cmsDer) {
+  const contentInfo = a.readTlv(cmsDer);
+  const ciChildren = a.readChildren(contentInfo.content);
+  if (a.decodeOid(ciChildren[0].content) !== OID.signedData) throw new Error('not a CMS SignedData');
+  const sd = a.readChildren(ciChildren[1].content)[0];
+  const sdChildren = a.readChildren(sd.content);
+
+  const certificates = [];
+  let signerInfosNode = null;
+  for (const node of sdChildren) {
+    if (node.tag === 0xa0) {
+      for (const c of a.readChildren(node.content)) certificates.push(Buffer.from(a.rawOf(node.content, c)));
+    } else if (node.tag === 0x31 && node !== sdChildren[1]) {
+      signerInfosNode = node;
+    }
+  }
+  if (!signerInfosNode) throw new Error('CMS: no signerInfos');
+  const si = a.readChildren(signerInfosNode.content)[0];
+  if (!si) throw new Error('CMS: empty signerInfos');
+  const siChildren = a.readChildren(si.content);
+
+  let signedAttrsDer = null;
+  let signatureValue = null;
+  let timeStampToken = null;
+  let digestAlgorithm = null;
+  let signatureAlgorithm = null;
+  const sid = siChildren[1];
+
+  for (let i = 2; i < siChildren.length; i++) {
+    const node = siChildren[i];
+    if (node.tag === 0x30 && !digestAlgorithm) {
+      digestAlgorithm = a.decodeOid(a.readChildren(node.content)[0].content);
+    } else if (node.tag === 0xa0) {
+      // [0] IMPLICIT SET OF Attribute; hash it as a real SET OF (tag 0x31).
+      signedAttrsDer = a.set(Buffer.from(node.content));
+    } else if (node.tag === 0x30 && digestAlgorithm && !signatureAlgorithm) {
+      signatureAlgorithm = a.decodeOid(a.readChildren(node.content)[0].content);
+    } else if (node.tag === 0x04) {
+      signatureValue = Buffer.from(node.content);
+    } else if (node.tag === 0xa1) {
+      for (const attr of a.readChildren(node.content)) {
+        const kids = a.readChildren(attr.content);
+        if (a.decodeOid(kids[0].content) === OID.signatureTimeStampToken) {
+          const val = a.readChildren(kids[1].content)[0];
+          timeStampToken = Buffer.from(a.rawOf(kids[1].content, val));
+        }
+      }
+    }
+  }
+
+  const attrs = {};
+  if (signedAttrsDer) {
+    for (const attr of a.readChildren(a.readTlv(signedAttrsDer).content)) {
+      const kids = a.readChildren(attr.content);
+      attrs[a.decodeOid(kids[0].content)] = a.readChildren(kids[1].content)[0];
+    }
+  }
+
+  return {
+    certificates,
+    signedAttrsDer,
+    signatureValue,
+    timeStampToken,
+    digestAlgorithm,
+    signatureAlgorithm,
+    sidDer: sid ? Buffer.from(a.rawOf(si.content, sid)) : null,
+    messageDigest: attrs[OID.messageDigest] ? Buffer.from(attrs[OID.messageDigest].content) : null,
+    contentType: attrs[OID.contentType] ? a.decodeOid(attrs[OID.contentType].content) : null,
+    signingCertificateV2Hash: attrs[OID.signingCertificateV2]
+      ? Buffer.from(a.readChildren(a.readChildren(a.readChildren(attrs[OID.signingCertificateV2].content)[0].content)[0].content)[0].content)
+      : null,
+  };
+}
+
+module.exports = {
+  OID, sha256,
+  certIssuerAndSerial, issuerAndSerialNumber,
+  buildSignedAttributes, signedAttributesDigest, buildSignedData, parseSignedData,
+};

--- a/relay/lib/qes/index.js
+++ b/relay/lib/qes/index.js
@@ -1,0 +1,146 @@
+'use strict';
+// The QES layer, in one place, behind one flag.
+//
+// PARASIGN_QES_PROVIDER is empty by default. Empty means this module does
+// nothing at all: no route, no UI, no outbound call, and the .psign receipt
+// comes out byte for byte as it does today. The only supported value today is
+// "cleverbase-sandbox"; "cleverbase" is reserved for a production client and
+// refuses to start without one, because production onboarding at Cleverbase is
+// a manual client registration and there is no contract yet.
+//
+// The three layers stay separate, exactly as designed:
+//   1. the PAdES signature inside the PDF, made by a QTSP over a hash,
+//   2. the ParaSign .psign receipt with its ML-DSA-65 signatures, unchanged,
+//   3. the public log, untouched.
+// A verifier can check either one without the other and without contacting us.
+
+const crypto = require('node:crypto');
+const pades = require('./pades');
+const cms = require('./cms');
+const tsa = require('./tsa');
+const { CleverbaseClient, SANDBOX_BASE_URL, PRODUCTION_BASE_URL } = require('./cleverbase');
+
+const PROVIDERS = ['cleverbase-sandbox', 'cleverbase'];
+
+function provider(env = process.env) {
+  const value = String(env.PARASIGN_QES_PROVIDER || '').trim();
+  return PROVIDERS.includes(value) ? value : '';
+}
+
+function enabled(env = process.env) { return provider(env) !== ''; }
+
+// A client wired for whichever provider the flag selects. Throws when the flag
+// is off, so a caller can never fall through to a live call by accident.
+function clientFor(env = process.env, overrides = {}) {
+  const name = provider(env);
+  if (!name) throw new Error('QES is disabled: PARASIGN_QES_PROVIDER is not set');
+  const baseUrl = env.CLEVERBASE_BASE_URL ||
+    (name === 'cleverbase-sandbox' ? SANDBOX_BASE_URL : PRODUCTION_BASE_URL);
+  if (name === 'cleverbase' && !env.CLEVERBASE_CLIENT_ID) {
+    throw new Error('PARASIGN_QES_PROVIDER=cleverbase needs a registered CLEVERBASE_CLIENT_ID');
+  }
+  return new CleverbaseClient({ env, baseUrl, ...overrides });
+}
+
+const fingerprint = (certDer) => crypto.createHash('sha256').update(certDer).digest('hex');
+
+// ── phase 1: everything up to the hash ──────────────────────────────────────
+
+// Reserves the signature in the PDF and works out the one digest the QTSP is
+// allowed to see. Returns the digest twice over: `documentDigest` is the
+// ByteRange hash, `hashToSign` is the SHA-256 of the signed attributes, and it
+// is only the second one that ever goes out.
+async function prepareSignature({ pdf, certificateChain, signerName = null, reason = null,
+  location = null, signingTime = new Date(), contentsBytes }) {
+  if (!Array.isArray(certificateChain) || !certificateChain.length) {
+    throw new Error('a signer certificate is required before the document can be prepared');
+  }
+  const prepared = await pades.prepare(pdf, {
+    signerName, reason, location, signingTime, contentsBytes,
+    fieldName: 'ParaSign QES',
+  });
+  const signedAttrsDer = cms.buildSignedAttributes({
+    messageDigest: prepared.digest,
+    signerCertDer: certificateChain[0],
+  });
+  return {
+    prepared,
+    certificateChain,
+    signedAttrsDer,
+    documentDigest: prepared.digest,
+    hashToSign: cms.signedAttributesDigest(signedAttrsDer),
+    certificateFingerprint: fingerprint(certificateChain[0]),
+  };
+}
+
+// ── phase 2: the QTSP has signed ────────────────────────────────────────────
+
+// Assembles the CMS, optionally timestamps it, writes it into the reserved
+// space and reports what was actually achieved. `tsaUrl` empty means B-B.
+async function finishSignature(session, signatureValue, { tsaUrl = tsa.DEFAULT_TSA_URL,
+  providerName = 'cleverbase-sandbox', fetchImpl } = {}) {
+  if (!Buffer.isBuffer(signatureValue) || !signatureValue.length) {
+    throw new Error('the provider returned no signature value');
+  }
+  let timeStampToken = null;
+  let timestamp = null;
+  if (tsaUrl) {
+    timeStampToken = await tsa.stamp(cms.sha256(signatureValue), { url: tsaUrl, ...(fetchImpl ? { fetchImpl } : {}) });
+    timestamp = tsa.parseTimeStampToken(timeStampToken);
+  }
+  const der = cms.buildSignedData({
+    certificates: session.certificateChain,
+    signedAttrsDer: session.signedAttrsDer,
+    signatureValue,
+    timeStampToken,
+  });
+  const signed = pades.embed(session.prepared, der);
+  return {
+    pdf: signed,
+    cms: der,
+    level: timeStampToken ? 'PAdES-B-T' : 'PAdES-B-B',
+    tsaUrl: timeStampToken ? tsaUrl : null,
+    timestampedAt: timestamp ? timestamp.genTime : null,
+    qes: receiptField({
+      providerName,
+      certificateFingerprint: session.certificateFingerprint,
+      signedAt: timestamp ? timestamp.genTime : session.prepared.signingTime,
+    }),
+  };
+}
+
+// The single extra top-level field the .psign receipt gains. Kept to three
+// keys on purpose: the receipt stays a ParaSign artefact, and the QES is
+// validated separately by Adobe or DSS against the PDF itself.
+function receiptField({ providerName, certificateFingerprint, signedAt }) {
+  return {
+    provider: providerName,
+    certificate_fingerprint: certificateFingerprint,
+    signed_at: signedAt,
+  };
+}
+
+// ── the whole run, for a caller that already holds the tokens ───────────────
+
+// `authorise` is handed the hash and must return { serviceToken, credentialID,
+// sad }. That callback is where the signer's browser trip to the Cleverbase app
+// happens; there is no way around it, because the API only speaks oauth2code.
+async function signPdf({ pdf, client, credentialID, serviceToken, authorise,
+  signerName, reason, location, tsaUrl = process.env.QES_TSA_URL !== undefined
+    ? process.env.QES_TSA_URL : tsa.DEFAULT_TSA_URL, providerName = 'cleverbase-sandbox' }) {
+  const info = await client.credentialInfo(serviceToken, credentialID);
+  if (!info.chain.length) throw new Error('the credential carries no certificate');
+  const session = await prepareSignature({ pdf, certificateChain: info.chain, signerName, reason, location });
+  const sad = await authorise({ hashToSign: session.hashToSign, credentialID });
+  const [signatureValue] = await client.signHash({
+    serviceToken, credentialID, sad, hashes: [session.hashToSign],
+  });
+  const out = await finishSignature(session, signatureValue, { tsaUrl, providerName });
+  return { ...out, credentialInfo: { status: info.key && info.key.status, keyLength: info.key && info.key.len } };
+}
+
+module.exports = {
+  PROVIDERS, provider, enabled, clientFor, fingerprint,
+  prepareSignature, finishSignature, receiptField, signPdf,
+  pades, cms, tsa,
+};

--- a/relay/lib/qes/pades.js
+++ b/relay/lib/qes/pades.js
@@ -1,0 +1,364 @@
+'use strict';
+// PAdES signature embedding through a real PDF incremental update.
+//
+// pdf-lib cannot do this: PDFDocument.save() rewrites the whole file, which
+// would break any signature already in the document and makes "the original
+// bytes are untouched" impossible to assert. So pdf-lib is used only as the
+// object model (it parses the catalogue, the page tree and the AcroForm for
+// us), and the bytes are written here: the original file, verbatim, followed
+// by an update section holding the signature dictionary, the signature field,
+// the objects that had to change, and a fresh cross-reference section.
+//
+// Two calls, because a QTSP sits between them:
+//   prepare(pdf, opts) -> { pdf, byteRange, digest, contents: {start,end} }
+//   embed(prepared, cmsDer)  -> the signed PDF
+// Everything between the two is hash-only: the document never leaves.
+
+const crypto = require('node:crypto');
+const zlib = require('node:zlib');
+
+let _PDFLib = null;
+function loadPdfLib() {
+  if (_PDFLib) return _PDFLib;
+  // Same candidate order as relay/lib/parasign-stamp.js: the vendored browser
+  // bundle first (it is bind-mounted into the container), the npm package last.
+  const candidates = [
+    '../../../frontend/vendor/pdf-lib/pdf-lib.min.js',
+    '../../frontend/vendor/pdf-lib/pdf-lib.min.js',
+    'pdf-lib',
+  ];
+  const tried = [];
+  for (const c of candidates) {
+    try { _PDFLib = require(c); return _PDFLib; } catch (e) { tried.push(c + ': ' + e.code); }
+  }
+  throw new Error('pdf-lib not available: ' + tried.join('; '));
+}
+
+const BYTE_RANGE_FIELD = 10; // decimal digits reserved per ByteRange entry
+const DEFAULT_CONTENTS_BYTES = 16384;
+
+function pdfLiteral(value) {
+  return '(' + String(value == null ? '' : value).replace(/[\\()]/g, (c) => '\\' + c) + ')';
+}
+
+function pdfDate(date) {
+  const d = new Date(date);
+  const p = (n, w = 2) => String(n).padStart(w, '0');
+  return "D:" + d.getUTCFullYear() + p(d.getUTCMonth() + 1) + p(d.getUTCDate()) +
+    p(d.getUTCHours()) + p(d.getUTCMinutes()) + p(d.getUTCSeconds()) + "+00'00'";
+}
+
+// The offset of the last cross-reference section, and whether it is a classic
+// table or a cross-reference stream. An update has to match the original: a
+// classic table gets a classic table, a stream gets a stream.
+function readLastXref(bytes) {
+  const tailStart = Math.max(0, bytes.length - 4096);
+  const tail = bytes.subarray(tailStart).toString('latin1');
+  const idx = tail.lastIndexOf('startxref');
+  if (idx < 0) throw new Error('PDF: no startxref');
+  const m = /startxref\s+(\d+)/.exec(tail.slice(idx));
+  if (!m) throw new Error('PDF: malformed startxref');
+  const offset = parseInt(m[1], 10);
+  if (!(offset >= 0 && offset < bytes.length)) throw new Error('PDF: startxref out of range');
+  const classic = bytes.subarray(offset, offset + 4).toString('latin1') === 'xref';
+  return { offset, classic };
+}
+
+// The highest object number the file already uses. pdf-lib's
+// largestObjectNumber only counts objects it materialised, so it misses the
+// object streams and cross-reference streams that hold everything else in a
+// PDF 1.5+ file. Handing out a number that is already taken silently clobbers
+// the object stream the page tree lives in, so all three sources are combined:
+// what pdf-lib saw, the /Size in the last trailer, and every "N 0 obj" header.
+function highestObjectNumber(bytes, xref, fromPdfLib) {
+  let max = fromPdfLib || 0;
+
+  const searchFrom = xref.classic ? bytes.indexOf(Buffer.from('trailer', 'latin1'), xref.offset) : xref.offset;
+  if (searchFrom >= 0) {
+    const window = bytes.subarray(searchFrom, Math.min(bytes.length, searchFrom + 8192)).toString('latin1');
+    const m = /\/Size\s+(\d+)/.exec(window);
+    if (m) max = Math.max(max, parseInt(m[1], 10) - 1);
+  }
+
+  const text = bytes.toString('latin1');
+  const re = /(?:^|[\r\n\s])(\d{1,9})\s+\d{1,5}\s+obj\b/g;
+  let hit;
+  while ((hit = re.exec(text)) !== null) max = Math.max(max, parseInt(hit[1], 10));
+  return max;
+}
+
+// Group object numbers into the contiguous runs a cross-reference section wants.
+function subsections(numbers) {
+  const sorted = [...new Set(numbers)].sort((x, y) => x - y);
+  const out = [];
+  for (const n of sorted) {
+    const last = out[out.length - 1];
+    if (last && n === last.start + last.count) last.count++;
+    else out.push({ start: n, count: 1 });
+  }
+  return out;
+}
+
+function classicXref(entries, trailer) {
+  let s = 'xref\n';
+  for (const sub of subsections(entries.map((e) => e.num))) {
+    s += sub.start + ' ' + sub.count + '\n';
+    for (let n = sub.start; n < sub.start + sub.count; n++) {
+      const e = entries.find((x) => x.num === n);
+      s += String(e.offset).padStart(10, '0') + ' ' + String(e.gen || 0).padStart(5, '0') + ' n \n';
+    }
+  }
+  s += 'trailer\n' + trailer + '\n';
+  return Buffer.from(s, 'latin1');
+}
+
+function xrefStream(entries, dictEntries, selfNum, selfOffset) {
+  const all = [...entries, { num: selfNum, offset: selfOffset, gen: 0 }]
+    .sort((x, y) => x.num - y.num);
+  const rows = [];
+  for (const e of all) {
+    const row = Buffer.alloc(7);
+    row[0] = 1;
+    row.writeUInt32BE(e.offset, 1);
+    row.writeUInt16BE(e.gen || 0, 5);
+    rows.push(row);
+  }
+  const data = zlib.deflateSync(Buffer.concat(rows));
+  const index = subsections(all.map((e) => e.num)).map((s) => s.start + ' ' + s.count).join(' ');
+  const dict = '<< /Type /XRef /W [1 4 2] /Index [' + index + '] ' + dictEntries +
+    ' /Filter /FlateDecode /Length ' + data.length + ' >>';
+  return Buffer.concat([
+    Buffer.from(selfNum + ' 0 obj\n' + dict + '\nstream\n', 'latin1'),
+    data,
+    Buffer.from('\nendstream\nendobj\n', 'latin1'),
+  ]);
+}
+
+// ── step 1: reserve the signature ───────────────────────────────────────────
+
+// Appends an incremental update carrying a /Sig dictionary with a zero-filled
+// /Contents placeholder, wires an invisible signature field into the AcroForm
+// and onto the first page, and fills in the real /ByteRange. The returned
+// digest is SHA-256 over exactly the bytes that ByteRange covers.
+async function prepare(pdfBytes, opts = {}) {
+  const PDFLib = loadPdfLib();
+  const { PDFName, PDFRef, PDFArray, PDFNumber } = PDFLib;
+  const original = Buffer.isBuffer(pdfBytes) ? pdfBytes : Buffer.from(pdfBytes);
+  if (original.subarray(0, 5).toString('latin1') !== '%PDF-') throw new Error('not a PDF');
+
+  const contentsBytes = Math.max(2048, Number(opts.contentsBytes) || DEFAULT_CONTENTS_BYTES);
+  const signingTime = opts.signingTime ? new Date(opts.signingTime) : new Date();
+
+  const doc = await PDFLib.PDFDocument.load(original, { ignoreEncryption: false });
+  const ctx = doc.context;
+  if (ctx.trailerInfo && ctx.trailerInfo.Encrypt) throw new Error('encrypted PDFs are not supported');
+
+  const { offset: prevOffset, classic } = readLastXref(original);
+
+  let next = highestObjectNumber(original, { offset: prevOffset, classic }, ctx.largestObjectNumber);
+  const sigRef = PDFRef.of(++next);
+  const fieldRef = PDFRef.of(++next);
+
+  // Objects whose serialisation changes and therefore has to be re-emitted.
+  const changed = new Map(); // objectNumber -> PDFObject
+  const catalogRef = ctx.trailerInfo.Root;
+  const catalog = doc.catalog;
+  const page = doc.getPage(0);
+
+  // AcroForm: reuse the document's own if it has one, otherwise add one.
+  const acroRaw = catalog.get(PDFName.of('AcroForm'));
+  if (acroRaw instanceof PDFRef) {
+    const acro = ctx.lookup(acroRaw);
+    const fieldsRaw = acro.get(PDFName.of('Fields'));
+    if (fieldsRaw instanceof PDFRef) {
+      ctx.lookup(fieldsRaw).push(fieldRef);
+      changed.set(fieldsRaw.objectNumber, ctx.lookup(fieldsRaw));
+    } else if (fieldsRaw instanceof PDFArray) {
+      fieldsRaw.push(fieldRef);
+    } else {
+      acro.set(PDFName.of('Fields'), ctx.obj([fieldRef]));
+    }
+    acro.set(PDFName.of('SigFlags'), PDFNumber.of(3));
+    changed.set(acroRaw.objectNumber, acro);
+  } else if (acroRaw) {
+    const fieldsRaw = acroRaw.get(PDFName.of('Fields'));
+    if (fieldsRaw instanceof PDFArray) fieldsRaw.push(fieldRef);
+    else acroRaw.set(PDFName.of('Fields'), ctx.obj([fieldRef]));
+    acroRaw.set(PDFName.of('SigFlags'), PDFNumber.of(3));
+    changed.set(catalogRef.objectNumber, catalog);
+  } else {
+    const acroRef = PDFRef.of(++next);
+    const acro = ctx.obj({ Fields: [fieldRef], SigFlags: 3 });
+    changed.set(acroRef.objectNumber, acro);
+    catalog.set(PDFName.of('AcroForm'), acroRef);
+    changed.set(catalogRef.objectNumber, catalog);
+  }
+
+  // The widget has to hang off a page, or the field is not reachable.
+  const annotsRaw = page.node.get(PDFName.of('Annots'));
+  if (annotsRaw instanceof PDFRef) {
+    ctx.lookup(annotsRaw).push(fieldRef);
+    changed.set(annotsRaw.objectNumber, ctx.lookup(annotsRaw));
+  } else if (annotsRaw instanceof PDFArray) {
+    annotsRaw.push(fieldRef);
+    changed.set(page.ref.objectNumber, page.node);
+  } else {
+    page.node.set(PDFName.of('Annots'), ctx.obj([fieldRef]));
+    changed.set(page.ref.objectNumber, page.node);
+  }
+
+  // The signature dictionary is written by hand: the placeholders have to sit
+  // at byte positions we control, which no object model will promise.
+  const zeroRange = Array(4).fill('0'.repeat(BYTE_RANGE_FIELD)).join(' ');
+  let sigDict = '<< /Type /Sig /Filter /Adobe.PPKLite /SubFilter /ETSI.CAdES.detached\n' +
+    '/ByteRange [' + zeroRange + ']\n' +
+    '/Contents <' + '0'.repeat(contentsBytes * 2) + '>\n' +
+    '/M ' + pdfLiteral(pdfDate(signingTime)) + '\n';
+  if (opts.signerName) sigDict += '/Name ' + pdfLiteral(opts.signerName) + '\n';
+  if (opts.reason) sigDict += '/Reason ' + pdfLiteral(opts.reason) + '\n';
+  if (opts.location) sigDict += '/Location ' + pdfLiteral(opts.location) + '\n';
+  if (opts.contactInfo) sigDict += '/ContactInfo ' + pdfLiteral(opts.contactInfo) + '\n';
+  sigDict += '>>';
+
+  const fieldDict = '<< /Type /Annot /Subtype /Widget /FT /Sig /Rect [0 0 0 0] /F 132\n' +
+    '/T ' + pdfLiteral(opts.fieldName || 'ParaSign QES') + '\n' +
+    '/V ' + sigRef.objectNumber + ' 0 R /P ' + page.ref.objectNumber + ' 0 R >>';
+
+  // ── assemble the update section ───────────────────────────────────────────
+  const chunks = [original];
+  let cursor = original.length;
+  if (original[original.length - 1] !== 0x0a) { chunks.push(Buffer.from('\n')); cursor += 1; }
+
+  const entries = [];
+  const pushObject = (num, body) => {
+    const buf = Buffer.from(num + ' 0 obj\n' + body + '\nendobj\n', 'latin1');
+    entries.push({ num, offset: cursor, gen: 0 });
+    chunks.push(buf);
+    cursor += buf.length;
+    return buf;
+  };
+
+  const sigOffsetInFile = cursor;
+  pushObject(sigRef.objectNumber, sigDict);
+  pushObject(fieldRef.objectNumber, fieldDict);
+  for (const [num, obj] of changed) pushObject(num, obj.toString());
+
+  const trailerCommon =
+    '/Size ' + (next + 1) +
+    ' /Root ' + catalogRef.objectNumber + ' 0 R' +
+    (ctx.trailerInfo.Info ? ' /Info ' + ctx.trailerInfo.Info.objectNumber + ' 0 R' : '') +
+    ' /Prev ' + prevOffset +
+    ' /ID [' + docId(ctx, PDFLib) + ']';
+
+  const xrefOffset = cursor;
+  if (classic) {
+    const xref = classicXref(entries, '<< ' + trailerCommon + ' >>');
+    chunks.push(xref);
+    cursor += xref.length;
+  } else {
+    const selfNum = ++next;
+    const xref = xrefStream(entries, '/Size ' + (next + 1) +
+      ' /Root ' + catalogRef.objectNumber + ' 0 R' +
+      (ctx.trailerInfo.Info ? ' /Info ' + ctx.trailerInfo.Info.objectNumber + ' 0 R' : '') +
+      ' /Prev ' + prevOffset +
+      ' /ID [' + docId(ctx, PDFLib) + ']', selfNum, xrefOffset);
+    chunks.push(xref);
+    cursor += xref.length;
+  }
+  const tail = Buffer.from('startxref\n' + xrefOffset + '\n%%EOF\n', 'latin1');
+  chunks.push(tail);
+
+  const out = Buffer.concat(chunks);
+
+  // Locate the placeholder and fill in the real ByteRange. Both edits keep the
+  // file length identical, so the offsets stay valid.
+  const contentsMarker = Buffer.from('/Contents <', 'latin1');
+  const markerAt = out.indexOf(contentsMarker, sigOffsetInFile);
+  if (markerAt < 0) throw new Error('signature placeholder lost');
+  const start = markerAt + contentsMarker.length - 1;      // the '<'
+  const end = start + 1 + contentsBytes * 2;               // the '>'
+  const byteRange = [0, start, end + 1, out.length - (end + 1)];
+
+  const rangeMarker = Buffer.from('/ByteRange [', 'latin1');
+  const rangeAt = out.indexOf(rangeMarker, sigOffsetInFile);
+  if (rangeAt < 0) throw new Error('ByteRange placeholder lost');
+  const rangeText = byteRange.map((n) => String(n).padEnd(BYTE_RANGE_FIELD, ' ')).join(' ');
+  if (rangeText.length !== BYTE_RANGE_FIELD * 4 + 3) throw new Error('ByteRange does not fit');
+  out.write(rangeText, rangeAt + rangeMarker.length, 'latin1');
+
+  return {
+    pdf: out,
+    byteRange,
+    contents: { start, end },
+    contentsBytes,
+    digest: digestByteRange(out, byteRange),
+    signingTime: signingTime.toISOString(),
+  };
+}
+
+function docId(ctx, PDFLib) {
+  const fresh = crypto.randomBytes(16).toString('hex');
+  const existing = ctx.trailerInfo && ctx.trailerInfo.ID;
+  let first = fresh;
+  if (existing && existing.get && existing.get(0) && existing.get(0) instanceof PDFLib.PDFHexString) {
+    first = existing.get(0).toString().replace(/^<|>$/g, '');
+  }
+  return '<' + first + '> <' + fresh + '>';
+}
+
+// SHA-256 over the two ByteRange spans, in order. This is the only thing the
+// QTSP ever gets to see of the document.
+function digestByteRange(pdfBytes, byteRange) {
+  const [a, b, c, d] = byteRange;
+  const h = crypto.createHash('sha256');
+  h.update(pdfBytes.subarray(a, a + b));
+  h.update(pdfBytes.subarray(c, c + d));
+  return h.digest();
+}
+
+// Read the ByteRange out of a signed PDF, for verification.
+function readByteRange(pdfBytes) {
+  const text = pdfBytes.toString('latin1');
+  const m = /\/ByteRange\s*\[\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s*\]/.exec(text);
+  if (!m) return null;
+  return [1, 2, 3, 4].map((i) => parseInt(m[i], 10));
+}
+
+// Read the hex /Contents blob, stripping the zero padding, and return the DER.
+function readContents(pdfBytes, byteRange) {
+  const start = byteRange[1];
+  const end = byteRange[2] - 1;
+  if (pdfBytes[start] !== 0x3c || pdfBytes[end] !== 0x3e) return null; // '<' and '>'
+  const hex = pdfBytes.subarray(start + 1, end).toString('latin1').replace(/[^0-9a-fA-F]/g, '');
+  const der = Buffer.from(hex, 'hex');
+  // Trim the reserved tail: read the outer DER length and cut there.
+  if (der.length < 2 || der[0] !== 0x30) return der;
+  let pos = 1;
+  let len = der[pos++];
+  if (len & 0x80) {
+    const count = len & 0x7f;
+    len = 0;
+    for (let i = 0; i < count; i++) len = (len << 8) | der[pos++];
+  }
+  return der.subarray(0, Math.min(der.length, pos + len));
+}
+
+// ── step 2: put the signature in ────────────────────────────────────────────
+
+// Writes the DER into the reserved /Contents span. Everything outside that span
+// stays byte-identical, so the digest computed in prepare() still holds.
+function embed(prepared, cmsDer) {
+  const { pdf, contents, contentsBytes } = prepared;
+  if (cmsDer.length > contentsBytes) {
+    throw new Error('signature is ' + cmsDer.length + ' bytes, only ' + contentsBytes + ' reserved');
+  }
+  const out = Buffer.from(pdf); // copy: prepare()'s buffer stays reusable
+  const hex = Buffer.concat([cmsDer, Buffer.alloc(contentsBytes - cmsDer.length)]).toString('hex');
+  out.write(hex, contents.start + 1, 'latin1');
+  return out;
+}
+
+module.exports = {
+  prepare, embed, digestByteRange, readByteRange, readContents,
+  loadPdfLib, readLastXref, DEFAULT_CONTENTS_BYTES,
+};

--- a/relay/lib/qes/tsa.js
+++ b/relay/lib/qes/tsa.js
@@ -1,0 +1,90 @@
+'use strict';
+// RFC 3161 timestamping, enough to lift a PAdES-B-B signature to B-T.
+//
+// The default TSA is DigiCert's public timestamp service. It is free, needs no
+// account and answers over plain HTTP, which is what RFC 3161 specifies. It is
+// NOT an EU-qualified timestamp authority: it sits on the CA/Browser-forum
+// code-signing side, not on any member state's eIDAS trusted list. A production
+// deployment must point QES_TSA_URL at a qualified TSA (a TSA/QTST service on a
+// trusted list) before the timestamp counts for anything under eIDAS. Set
+// QES_TSA_URL to an empty string to skip timestamping and stay at PAdES-B-B.
+
+const crypto = require('node:crypto');
+const a = require('./asn1');
+
+const DEFAULT_TSA_URL = 'http://timestamp.digicert.com';
+
+const OID = {
+  sha256: '2.16.840.1.101.3.4.2.1',
+  ctTSTInfo: '1.2.840.113549.1.9.16.1.4',
+};
+
+function buildRequest(digest, { certReq = true, nonce = true } = {}) {
+  if (!Buffer.isBuffer(digest) || digest.length !== 32) throw new Error('TSA: need a 32-byte SHA-256 digest');
+  const parts = [
+    a.integer(1),
+    a.seq(a.algorithmIdentifier(OID.sha256), a.octetString(digest)),
+  ];
+  if (nonce) parts.push(a.integer(crypto.randomBytes(8)));
+  if (certReq) parts.push(Buffer.from([0x01, 0x01, 0xff]));
+  return a.seq(parts);
+}
+
+// Returns the TimeStampToken (a full CMS ContentInfo, DER) or throws with the
+// PKIStatus the TSA reported.
+function parseResponse(responseDer) {
+  const resp = a.readTlv(responseDer);
+  const children = a.readChildren(resp.content);
+  const statusInfo = a.readChildren(children[0].content);
+  const status = statusInfo[0].content.length ? statusInfo[0].content[statusInfo[0].content.length - 1] : 0;
+  if (status !== 0 && status !== 1) throw new Error('TSA rejected the request, PKIStatus ' + status);
+  if (!children[1]) throw new Error('TSA returned no timestamp token');
+  return Buffer.from(a.rawOf(resp.content, children[1]));
+}
+
+// The genTime and message imprint out of a TimeStampToken, so a verifier can
+// say when the signature existed and confirm the token covers this signature.
+function parseTimeStampToken(tokenDer) {
+  const ci = a.readChildren(a.readTlv(tokenDer).content);
+  const sd = a.readChildren(ci[1].content)[0];
+  const sdChildren = a.readChildren(sd.content);
+  const encap = sdChildren[2];
+  const encapChildren = a.readChildren(encap.content);
+  if (a.decodeOid(encapChildren[0].content) !== OID.ctTSTInfo) throw new Error('not a TimeStampToken');
+  const eContent = a.readChildren(encapChildren[1].content)[0];
+  const info = a.readChildren(a.readTlv(eContent.content).content);
+  // TSTInfo ::= SEQUENCE { version, policy, messageImprint, serialNumber, genTime, ... }
+  const imprint = a.readChildren(info[2].content);
+  const genTimeRaw = info[4].content.toString('ascii');
+  const m = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(genTimeRaw);
+  const genTime = m ? new Date(Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6])).toISOString() : null;
+
+  const certificates = [];
+  for (const node of sdChildren) {
+    if (node.tag === 0xa0) {
+      for (const c of a.readChildren(node.content)) certificates.push(Buffer.from(a.rawOf(node.content, c)));
+    }
+  }
+  return {
+    genTime,
+    hashAlgorithm: a.decodeOid(a.readChildren(imprint[0].content)[0].content),
+    hashedMessage: Buffer.from(imprint[1].content),
+    certificates,
+  };
+}
+
+// Ask a TSA to timestamp `digest`. `url` empty or null means "do not timestamp".
+async function stamp(digest, { url = DEFAULT_TSA_URL, timeoutMs = 15000, fetchImpl = fetch } = {}) {
+  if (!url) return null;
+  const body = buildRequest(digest);
+  const res = await fetchImpl(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/timestamp-query', 'Content-Length': String(body.length) },
+    body,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) throw new Error('TSA HTTP ' + res.status);
+  return parseResponse(Buffer.from(await res.arrayBuffer()));
+}
+
+module.exports = { DEFAULT_TSA_URL, buildRequest, parseResponse, parseTimeStampToken, stamp };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -136,6 +136,7 @@ const billing         = require('./lib/billing');           // Mollie webhook de
 const billingRecurring = require('./lib/billing-recurring'); // subscription + mandate layer
 const parasignStoreMod = require('./lib/parasign-store');    // durable encrypted /v1 side-store
 const parasignStamp = require('./lib/parasign-stamp');       // server-side PDF stamp-worker
+const qes           = require('./lib/qes');                   // qualified-signature layer, off unless flagged
 const tierGate         = require('./lib/tier-gate');         // per-tier feature gate (billing hardening)
 const userHistory      = require('./lib/user-history');      // GET /v2/user/history (Pro+)
 const usagePurpose     = require('./lib/usage-purpose');     // POST /v2/user/usage-purpose (internal)
@@ -222,7 +223,7 @@ const ALLOWED = {
                '/v2/key-sector','/v2/team','/v2/reload-users','/v2/session','/v2/session-token',
                '/v2/ws-ticket','/v2/fingerprint','/v2/relays','/v2/sign-dpa',
                '/v2/sth','/v2/verify-receipt','/v2/transfers','/v2/capabilities','/v2/health','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
-               '/v2/sign','/v2/verify','/v2/lookup-signer','/v2/envelopes','/v2/billing','/v2/claim','/v2/parasign','/v1'],
+               '/v2/sign','/v2/verify','/v2/lookup-signer','/v2/envelopes','/v2/billing','/v2/claim','/v2/parasign','/v2/qes','/v1'],
   iot:        ['/health','/v2/pubkey','/v2/inbound','/v2/anon-inbound','/v2/outbound','/v2/status',
                '/v2/webhook','/v2/audit','/v2/check-key','/v2/stream','/v2/stream-next',
                '/v2/ack','/v2/monitor',
@@ -230,7 +231,7 @@ const ALLOWED = {
                '/v2/key-sector','/v2/team','/v2/reload-users','/v2/session','/v2/session-token',
                '/v2/relays','/v2/sign-dpa','/v2/sth','/v2/verify-receipt','/v2/transfers',
                '/v2/capabilities','/v2/health','/ct','/ct/feed','/v2/auth','/v2/user','/v2/setup',
-               '/v2/sign','/v2/verify','/v2/lookup-signer','/v2/envelopes','/v2/billing','/v2/claim','/v2/parasign','/v1'],
+               '/v2/sign','/v2/verify','/v2/lookup-signer','/v2/envelopes','/v2/billing','/v2/claim','/v2/parasign','/v2/qes','/v1'],
   full:       null,
 };
 
@@ -3007,6 +3008,66 @@ async function handleRelayRequest(req, res) {
     return res.end(J(registry.listSupported()));
   }
 
+  // ── POST /v2/qes/sign, a qualified signature over a hash (flag-gated) ────
+  // Off unless PARASIGN_QES_PROVIDER names a provider: without the flag this
+  // path does not exist and /sign shows no option for it.
+  //
+  // The document is prepared here (signature dictionary plus ByteRange), the
+  // SHA-256 of the CAdES signed attributes goes to the QTSP, and the signature
+  // comes back. Only that digest leaves the relay; the PDF does not.
+  //
+  // Without a service token and a SAD there is nothing to sign with, so the
+  // route answers 409 and hands back the authorisation URL. That is not a
+  // shortcut we chose: the Cleverbase Signing API only offers authType
+  // "oauth2code", so a natural person has to authorise in the Cleverbase app
+  // for every batch of signatures. There is no machine-to-machine route.
+  if (path === '/v2/qes/sign' && req.method === 'POST') {
+    if (!qes.enabled()) { res.writeHead(404, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'not_found' })); }
+    try {
+      const d = JSON.parse((await readBody(req, 32 * 1024 * 1024)).toString());
+      const pdf = Buffer.from(String(d.document || ''), 'base64');
+      if (pdf.subarray(0, 5).toString('latin1') !== '%PDF-') {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        return res.end(J({ error: 'document must be a base64 PDF' }));
+      }
+      const client = qes.clientFor();
+      if (!d.service_token || !d.sad || !d.credential_id) {
+        let authorizeUrl = null;
+        let reason = 'A qualified signature needs the signer to authorise it in the provider app.';
+        try {
+          authorizeUrl = client.authorizeUrl({ scope: 'service', state: crypto.randomBytes(16).toString('hex') });
+        } catch (e) { reason = e.message; }
+        res.writeHead(409, { 'Content-Type': 'application/json' });
+        return res.end(J({
+          error: 'qes_authorisation_required',
+          provider: qes.provider(),
+          authorize_url: authorizeUrl,
+          reason,
+        }));
+      }
+      const out = await qes.signPdf({
+        pdf, client,
+        credentialID: String(d.credential_id),
+        serviceToken: String(d.service_token),
+        authorise: () => String(d.sad),
+        signerName: d.signer_name ? String(d.signer_name).slice(0, 120) : null,
+        reason: d.reason ? String(d.reason).slice(0, 200) : null,
+        providerName: qes.provider(),
+      });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(J({
+        document: out.pdf.toString('base64'),
+        level: out.level,
+        tsa_url: out.tsaUrl,
+        qes: out.qes,
+      }));
+    } catch (e) {
+      log('warn', 'qes_sign_failed', { error: e.message });
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      return res.end(J({ error: e.message }));
+    }
+  }
+
   // ── GET /v2/auth/capabilities — public, no auth ─────────────────────────────
   if (req.method === 'GET' && path === '/v2/auth/capabilities') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -3016,6 +3077,10 @@ async function handleRelayRequest(req, res) {
       user_totp_status: process.env.ENABLE_USER_TOTP === 'true'
         ? 'live'
         : 'rolling_out_q2_2026',
+      // Qualified electronic signature layer. Empty string means off, which is
+      // the default: with no provider configured nothing about signing changes
+      // and the /sign page shows no extra option at all.
+      parasign_qes: qes.provider(),
       capabilities_version: 1,
     }));
   }

--- a/relay/test/_qes-fixture.js
+++ b/relay/test/_qes-fixture.js
@@ -1,0 +1,80 @@
+'use strict';
+// Test fixtures for the QES layer: a throwaway RSA key with a matching
+// self-signed X.509 certificate, and a stand-in for the qualified trust service
+// provider that signs the way the real one does.
+//
+// The certificate is built here rather than committed, because a committed
+// certificate needs a committed private key next to it and a repository is the
+// wrong place for one. Building it also exercises relay/lib/qes/asn1.js against
+// a structure that openssl and node:crypto both have to accept.
+
+const crypto = require('node:crypto');
+const a = require('../lib/qes/asn1');
+
+const SHA256_WITH_RSA = '1.2.840.113549.1.1.11';
+const DIGEST_INFO_SHA256 = Buffer.from('3031300d060960864801650304020105000420', 'hex');
+
+// RelativeDistinguishedName with a single attribute, PrintableString valued.
+function rdn(typeOid, value) {
+  return a.set(a.seq(a.oid(typeOid), a.tlv(0x13, Buffer.from(value, 'ascii'))));
+}
+
+function name({ country = 'NL', organisation = 'Acme', commonName = 'Demo Signer' }) {
+  return a.seq(rdn('2.5.4.6', country), rdn('2.5.4.10', organisation), rdn('2.5.4.3', commonName));
+}
+
+// A self-signed certificate. Not a qualified certificate and not pretending to
+// be one: no QcStatements, no policy OIDs, no trusted list anywhere near it.
+function selfSignedCertificate(options = {}) {
+  const { privateKey, publicKey } = options.keyPair || crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const subject = name(options);
+  const now = Date.now();
+  const notBefore = new Date(now - 3600 * 1000);
+  const notAfter = new Date(now + 30 * 24 * 3600 * 1000);
+
+  const spki = crypto.createPublicKey(privateKey).export({ type: 'spki', format: 'der' });
+
+  const extensions = a.explicit(3, a.seq(
+    // basicConstraints, critical, CA:FALSE
+    a.seq(a.oid('2.5.29.19'), Buffer.from([0x01, 0x01, 0xff]), a.octetString(a.seq())),
+    // keyUsage, critical, nonRepudiation only (bit 1)
+    a.seq(a.oid('2.5.29.15'), Buffer.from([0x01, 0x01, 0xff]),
+      a.octetString(a.bitString(Buffer.from([0x40]), 6)))
+  ));
+
+  const tbs = a.seq(
+    a.explicit(0, a.integer(2)),                       // v3
+    a.integer(crypto.randomBytes(8)),
+    a.algorithmIdentifier(SHA256_WITH_RSA),
+    subject,                                            // issuer, self-signed
+    a.seq(a.utcTime(notBefore), a.utcTime(notAfter)),
+    subject,
+    spki,
+    extensions
+  );
+
+  const signature = crypto.sign('sha256', tbs, privateKey);
+  const der = a.seq(tbs, a.algorithmIdentifier(SHA256_WITH_RSA), a.bitString(signature));
+  return { der, privateKey, publicKey, notBefore, notAfter };
+}
+
+// What a CSC signHash call does: RSASSA-PKCS1-v1_5 over the digest the caller
+// hands in. Nothing about the document reaches this function, by construction.
+function signHashLikeQtsp(privateKey, digest) {
+  if (!Buffer.isBuffer(digest) || digest.length !== 32) throw new Error('expected a SHA-256 digest');
+  return crypto.privateEncrypt(
+    { key: privateKey, padding: crypto.constants.RSA_PKCS1_PADDING },
+    Buffer.concat([DIGEST_INFO_SHA256, digest])
+  );
+}
+
+// A one-page PDF to sign, built with the same pdf-lib the browser uses.
+async function samplePdf(text = 'Demo contract for Acme', { useObjectStreams = true } = {}) {
+  const PDFLib = require('../lib/qes/pades').loadPdfLib();
+  const doc = await PDFLib.PDFDocument.create();
+  const font = await doc.embedFont(PDFLib.StandardFonts.Helvetica);
+  doc.addPage([595.28, 841.89]).drawText(text, { x: 60, y: 760, size: 14, font });
+  return Buffer.from(await doc.save({ useObjectStreams }));
+}
+
+module.exports = { selfSignedCertificate, signHashLikeQtsp, samplePdf, name, SHA256_WITH_RSA };

--- a/relay/test/qes-cms.test.js
+++ b/relay/test/qes-cms.test.js
@@ -1,0 +1,215 @@
+'use strict';
+// The ASN.1 and CMS layer, plus the flag that keeps all of it switched off.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const crypto = require('node:crypto');
+
+const a = require('../lib/qes/asn1');
+const cms = require('../lib/qes/cms');
+const tsa = require('../lib/qes/tsa');
+const qes = require('../lib/qes');
+const cleverbase = require('../lib/qes/cleverbase');
+const fixture = require('./_qes-fixture');
+
+const signer = fixture.selfSignedCertificate({ commonName: 'Demo Signer' });
+
+test('DER encoding matches the well known encodings', () => {
+  assert.strictEqual(a.oid('1.2.840.113549.1.1.1').toString('hex'), '06092a864886f70d010101');
+  assert.strictEqual(a.oid('2.16.840.1.101.3.4.2.1').toString('hex'), '0609608648016503040201');
+  assert.strictEqual(a.integer(0).toString('hex'), '020100');
+  assert.strictEqual(a.integer(255).toString('hex'), '020200ff', 'a leading zero keeps the value positive');
+  assert.strictEqual(a.integer(127).toString('hex'), '02017f');
+  assert.strictEqual(a.utcTime(new Date('2026-09-03T18:00:00Z')).toString('hex'), '170d3236303930333138303030305a');
+});
+
+test('lengths above 127 use the long form', () => {
+  const body = Buffer.alloc(300, 7);
+  const encoded = a.tlv(0x04, body);
+  assert.strictEqual(encoded.subarray(0, 4).toString('hex'), '0482012c');
+  assert.deepStrictEqual(a.readTlv(encoded).content, body);
+});
+
+test('the decoder round-trips what the encoder writes', () => {
+  const der = a.seq(a.oid('1.2.3.4'), a.integer(42), a.octetString(Buffer.from('hi')));
+  const children = a.readChildren(a.readTlv(der).content);
+  assert.strictEqual(children.length, 3);
+  assert.strictEqual(a.decodeOid(children[0].content), '1.2.3.4');
+  assert.strictEqual(children[1].content[0], 42);
+  assert.strictEqual(children[2].content.toString(), 'hi');
+});
+
+test('the decoder refuses indefinite lengths, which are not DER', () => {
+  assert.throws(() => a.readTlv(Buffer.from([0x30, 0x80, 0x00, 0x00])), /indefinite/);
+});
+
+test('signed attributes carry the three CAdES-BES attributes and are DER-sorted', () => {
+  const digest = crypto.createHash('sha256').update('document').digest();
+  const attrs = cms.buildSignedAttributes({ messageDigest: digest, signerCertDer: signer.der });
+  assert.strictEqual(a.readTlv(attrs).tag, 0x31, 'the hashed form is a SET OF');
+  const oids = a.readChildren(a.readTlv(attrs).content)
+    .map((n) => a.decodeOid(a.readChildren(n.content)[0].content));
+  assert.deepStrictEqual(new Set(oids), new Set([cms.OID.contentType, cms.OID.messageDigest, cms.OID.signingCertificateV2]));
+  const encoded = a.readChildren(a.readTlv(attrs).content).map((n) => a.rawOf(a.readTlv(attrs).content, n));
+  for (let i = 1; i < encoded.length; i++) {
+    assert.ok(Buffer.compare(encoded[i - 1], encoded[i]) <= 0, 'SET OF members must be in DER order');
+  }
+});
+
+test('the message digest has to be a SHA-256 digest', () => {
+  assert.throws(() => cms.buildSignedAttributes({ messageDigest: Buffer.alloc(20), signerCertDer: signer.der }),
+    /32-byte SHA-256/);
+});
+
+test('the provider only ever sees a 32-byte digest', () => {
+  const digest = crypto.createHash('sha256').update('document').digest();
+  const attrs = cms.buildSignedAttributes({ messageDigest: digest, signerCertDer: signer.der });
+  const toSign = cms.signedAttributesDigest(attrs);
+  assert.strictEqual(toSign.length, 32);
+  assert.notDeepStrictEqual(toSign, digest, 'what goes out is the attribute hash, not the document hash');
+});
+
+test('SignedData round-trips and the signature verifies', () => {
+  const digest = crypto.createHash('sha256').update('document').digest();
+  const attrs = cms.buildSignedAttributes({ messageDigest: digest, signerCertDer: signer.der });
+  const signature = fixture.signHashLikeQtsp(signer.privateKey, cms.signedAttributesDigest(attrs));
+  const der = cms.buildSignedData({ certificates: [signer.der], signedAttrsDer: attrs, signatureValue: signature });
+
+  const parsed = cms.parseSignedData(der);
+  assert.strictEqual(parsed.certificates.length, 1);
+  assert.deepStrictEqual(parsed.certificates[0], signer.der);
+  assert.deepStrictEqual(parsed.signedAttrsDer, attrs);
+  assert.deepStrictEqual(parsed.messageDigest, digest);
+  assert.strictEqual(parsed.contentType, cms.OID.data);
+  assert.strictEqual(parsed.digestAlgorithm, cms.OID.sha256);
+  assert.strictEqual(parsed.signatureAlgorithm, cms.OID.rsaEncryption);
+  assert.strictEqual(parsed.timeStampToken, null);
+
+  const cert = new crypto.X509Certificate(parsed.certificates[0]);
+  assert.ok(crypto.verify('sha256', parsed.signedAttrsDer, cert.publicKey, parsed.signatureValue));
+});
+
+test('IssuerAndSerialNumber is taken from the certificate byte for byte', () => {
+  const { issuerDer, serialDer } = cms.certIssuerAndSerial(signer.der);
+  const tbs = a.readChildren(a.readTlv(signer.der).content)[0];
+  assert.ok(a.rawOf(a.readTlv(signer.der).content, tbs).includes(issuerDer));
+  assert.strictEqual(serialDer[0], 0x02, 'the serial keeps its INTEGER tag');
+});
+
+test('an unsigned attribute carries the timestamp token through', () => {
+  const digest = crypto.createHash('sha256').update('document').digest();
+  const attrs = cms.buildSignedAttributes({ messageDigest: digest, signerCertDer: signer.der });
+  const signature = fixture.signHashLikeQtsp(signer.privateKey, cms.signedAttributesDigest(attrs));
+  // A stand-in token: parseSignedData only has to find and return it intact.
+  const token = a.seq(a.oid('1.2.840.113549.1.7.2'), a.explicit(0, a.seq(a.integer(3))));
+  const der = cms.buildSignedData({
+    certificates: [signer.der], signedAttrsDer: attrs, signatureValue: signature, timeStampToken: token,
+  });
+  assert.deepStrictEqual(cms.parseSignedData(der).timeStampToken, token);
+});
+
+test('an RFC 3161 request says what it should say', () => {
+  const digest = crypto.createHash('sha256').update('signature value').digest();
+  const req = tsa.buildRequest(digest, { nonce: false });
+  const children = a.readChildren(a.readTlv(req).content);
+  assert.strictEqual(children[0].content[0], 1, 'version 1');
+  const imprint = a.readChildren(children[1].content);
+  assert.strictEqual(a.decodeOid(a.readChildren(imprint[0].content)[0].content), '2.16.840.1.101.3.4.2.1');
+  assert.deepStrictEqual(imprint[1].content, digest);
+  assert.deepStrictEqual(children[2].content, Buffer.from([0xff]), 'certReq is TRUE');
+});
+
+test('a TSA that refuses is reported as a refusal, not as a token', () => {
+  const rejected = a.seq(a.seq(a.integer(2)));
+  assert.throws(() => tsa.parseResponse(rejected), /PKIStatus 2/);
+});
+
+test('the feature is off unless the flag names a known provider', () => {
+  assert.strictEqual(qes.provider({}), '');
+  assert.strictEqual(qes.provider({ PARASIGN_QES_PROVIDER: '' }), '');
+  assert.strictEqual(qes.provider({ PARASIGN_QES_PROVIDER: 'true' }), '');
+  assert.strictEqual(qes.provider({ PARASIGN_QES_PROVIDER: 'some-other-qtsp' }), '');
+  assert.strictEqual(qes.enabled({}), false);
+  assert.strictEqual(qes.provider({ PARASIGN_QES_PROVIDER: 'cleverbase-sandbox' }), 'cleverbase-sandbox');
+  assert.strictEqual(qes.enabled({ PARASIGN_QES_PROVIDER: 'cleverbase-sandbox' }), true);
+});
+
+test('a disabled flag cannot produce a client, and production needs a registered one', () => {
+  assert.throws(() => qes.clientFor({}), /QES is disabled/);
+  assert.throws(() => qes.clientFor({ PARASIGN_QES_PROVIDER: 'cleverbase' }), /registered CLEVERBASE_CLIENT_ID/);
+  const sandbox = qes.clientFor({ PARASIGN_QES_PROVIDER: 'cleverbase-sandbox' });
+  assert.strictEqual(sandbox.baseUrl, cleverbase.SANDBOX_BASE_URL);
+  assert.ok(sandbox.isSandbox);
+});
+
+test('the receipt field is exactly three keys', () => {
+  const field = qes.receiptField({
+    providerName: 'cleverbase-sandbox',
+    certificateFingerprint: 'ab'.repeat(32),
+    signedAt: '2026-09-03T18:00:00.000Z',
+  });
+  assert.deepStrictEqual(Object.keys(field).sort(), ['certificate_fingerprint', 'provider', 'signed_at']);
+});
+
+test('the Cleverbase client refuses anything that is not a SHA-256 digest', async () => {
+  const client = new cleverbase.CleverbaseClient({ env: {}, fetchImpl: () => { throw new Error('no call expected'); } });
+  await assert.rejects(() => client.signHash({ serviceToken: 't', credentialID: 'c', sad: 's', hashes: [] }),
+    /at least one hash/);
+  await assert.rejects(() => client.signHash({ serviceToken: 't', credentialID: 'c', sad: 's', hashes: [Buffer.alloc(20)] }),
+    /32-byte SHA-256/);
+});
+
+test('signHash sends only the digest, base64, with the fixed algorithm OIDs', async () => {
+  const digest = crypto.createHash('sha256').update('attributes').digest();
+  let seen = null;
+  const client = new cleverbase.CleverbaseClient({
+    env: {},
+    fetchImpl: async (url, init) => {
+      seen = { url, body: JSON.parse(init.body), headers: init.headers };
+      return { ok: true, status: 200, text: async () => JSON.stringify({ signatures: ['AAEC'] }) };
+    },
+  });
+  const [signature] = await client.signHash({ serviceToken: 'svc', credentialID: 'GX0112348', sad: 'SAD', hashes: [digest] });
+  assert.strictEqual(seen.url, 'https://connect.acc.cleverbase.com/csc/v1/signatures/signHash');
+  assert.strictEqual(seen.headers.Authorization, 'Bearer svc');
+  assert.deepStrictEqual(seen.body, {
+    credentialID: 'GX0112348',
+    SAD: 'SAD',
+    hash: [digest.toString('base64')],
+    hashAlgo: cleverbase.HASH_ALGO_OID,
+    signAlgo: cleverbase.SIGN_ALGO_OID,
+  });
+  assert.deepStrictEqual(signature, Buffer.from('AAEC', 'base64'));
+});
+
+test('the credential authorisation URL binds the exact hashes', () => {
+  const client = new cleverbase.CleverbaseClient({
+    env: {}, clientId: 'client-1', redirectUri: 'https://example.com/return',
+  });
+  const digest = crypto.createHash('sha256').update('attributes').digest();
+  const url = new URL(client.authorizeUrl({ scope: 'credential', state: 's', credentialID: 'GX0112348', hashes: [digest] }));
+  assert.strictEqual(url.searchParams.get('scope'), 'credential');
+  assert.strictEqual(url.searchParams.get('numSignatures'), '1');
+  assert.strictEqual(url.searchParams.get('hash'),
+    digest.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, ''));
+  assert.throws(() => client.authorizeUrl({ scope: 'credential', state: 's', credentialID: 'c', hashes: [] }), /needs hashes/);
+  assert.throws(() => client.authorizeUrl({ scope: 'anything', state: 's' }), /service or credential/);
+});
+
+test('no more than fifty signatures per authorisation, as the API states', () => {
+  const client = new cleverbase.CleverbaseClient({ env: {}, clientId: 'c', redirectUri: 'https://example.com/r' });
+  const hashes = Array.from({ length: 51 }, (_, i) => crypto.createHash('sha256').update(String(i)).digest());
+  assert.throws(() => client.authorizeUrl({ scope: 'credential', state: 's', credentialID: 'c', hashes }), /at most 50/);
+});
+
+test('the account token is an HS256 JWT over the hashed client secret', () => {
+  const client = new cleverbase.CleverbaseClient({ env: {}, clientId: 'client-1', clientSecret: 'secret-1' });
+  const [header, payload, mac] = client.accountToken('acct_demo').split('.');
+  assert.deepStrictEqual(JSON.parse(Buffer.from(header, 'base64url').toString()), { typ: 'JWT', alg: 'HS256' });
+  const claims = JSON.parse(Buffer.from(payload, 'base64url').toString());
+  assert.strictEqual(claims.sub, 'acct_demo');
+  assert.strictEqual(claims.azp, 'client-1');
+  const key = crypto.createHash('sha256').update('secret-1').digest();
+  const expected = crypto.createHmac('sha256', key).update(header + '.' + payload).digest('base64url');
+  assert.strictEqual(mac, expected);
+});

--- a/relay/test/qes-pades.test.js
+++ b/relay/test/qes-pades.test.js
@@ -1,0 +1,136 @@
+'use strict';
+// The PAdES writer, at byte level. Three things have to hold or the whole idea
+// falls over: the update is genuinely incremental, the ByteRange describes what
+// it claims to describe, and the result is still a readable PDF.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const crypto = require('node:crypto');
+
+const pades = require('../lib/qes/pades');
+const cms = require('../lib/qes/cms');
+const fixture = require('./_qes-fixture');
+
+// One certificate and one key for the whole file: generating RSA keys is the
+// slow part and nothing here depends on them being distinct.
+const signer = fixture.selfSignedCertificate({ commonName: 'Demo Signer' });
+
+async function signed(pdf, opts = {}) {
+  const prepared = await pades.prepare(pdf, opts);
+  const signedAttrsDer = cms.buildSignedAttributes({
+    messageDigest: prepared.digest,
+    signerCertDer: signer.der,
+  });
+  const signature = fixture.signHashLikeQtsp(signer.privateKey, cms.signedAttributesDigest(signedAttrsDer));
+  const der = cms.buildSignedData({ certificates: [signer.der], signedAttrsDer, signatureValue: signature });
+  return { prepared, signedAttrsDer, der, pdf: pades.embed(prepared, der) };
+}
+
+for (const useObjectStreams of [true, false]) {
+  const label = useObjectStreams ? 'cross-reference stream' : 'classic cross-reference table';
+
+  test('incremental update leaves the original bytes untouched, ' + label, async () => {
+    const original = await fixture.samplePdf('Demo contract for Acme', { useObjectStreams });
+    const out = await signed(original);
+    assert.ok(out.pdf.length > original.length, 'the update has to add bytes');
+    assert.deepStrictEqual(
+      out.pdf.subarray(0, original.length), original,
+      'every byte of the original document must survive the signature verbatim'
+    );
+    assert.strictEqual(out.pdf.subarray(-6).toString('latin1'), '%%EOF\n');
+  });
+
+  test('the update points back at the previous cross-reference section, ' + label, async () => {
+    const original = await fixture.samplePdf('Demo contract for Acme', { useObjectStreams });
+    const before = pades.readLastXref(original);
+    const out = await signed(original);
+    const after = pades.readLastXref(out.pdf);
+    assert.ok(after.offset > original.length, 'the new section sits in the appended part');
+    assert.strictEqual(after.classic, before.classic, 'the update matches the original section type');
+    assert.match(out.pdf.toString('latin1').slice(original.length), new RegExp('/Prev\\s+' + before.offset));
+  });
+
+  test('ByteRange covers the whole file except the signature blob, ' + label, async () => {
+    const original = await fixture.samplePdf('Demo contract for Acme', { useObjectStreams });
+    const out = await signed(original);
+    const range = pades.readByteRange(out.pdf);
+    assert.ok(range, 'the signed PDF must declare a ByteRange');
+    const [a, b, c, d] = range;
+    assert.strictEqual(a, 0, 'the first span starts at the first byte');
+    assert.strictEqual(c + d, out.pdf.length, 'the second span runs to the last byte');
+    assert.strictEqual(out.pdf[b], 0x3c, 'the gap opens on the < of /Contents');
+    assert.strictEqual(out.pdf[c - 1], 0x3e, 'the gap closes on the > of /Contents');
+    assert.deepStrictEqual(range, out.prepared.byteRange, 'the written range is the one prepare() reported');
+    // Nothing but hex digits inside the gap: no structure hides in there.
+    assert.match(out.pdf.subarray(b + 1, c - 1).toString('latin1'), /^[0-9a-f]+$/);
+  });
+}
+
+test('the digest handed to the provider is the digest of the ByteRange', async () => {
+  const original = await fixture.samplePdf();
+  const out = await signed(original);
+  const recomputed = pades.digestByteRange(out.pdf, pades.readByteRange(out.pdf));
+  assert.deepStrictEqual(recomputed, out.prepared.digest);
+  const parsed = cms.parseSignedData(pades.readContents(out.pdf, pades.readByteRange(out.pdf)));
+  assert.deepStrictEqual(parsed.messageDigest, recomputed,
+    'the message-digest attribute must equal the ByteRange hash');
+});
+
+test('embedding the signature changes only the reserved span', async () => {
+  const original = await fixture.samplePdf();
+  const out = await signed(original);
+  assert.strictEqual(out.pdf.length, out.prepared.pdf.length, 'embedding never resizes the file');
+  const { start, end } = out.prepared.contents;
+  assert.deepStrictEqual(out.pdf.subarray(0, start + 1), out.prepared.pdf.subarray(0, start + 1));
+  assert.deepStrictEqual(out.pdf.subarray(end), out.prepared.pdf.subarray(end));
+});
+
+test('the signature verifies against the certificate in the CMS', async () => {
+  const original = await fixture.samplePdf();
+  const out = await signed(original);
+  const parsed = cms.parseSignedData(pades.readContents(out.pdf, pades.readByteRange(out.pdf)));
+  const cert = new crypto.X509Certificate(parsed.certificates[0]);
+  assert.ok(crypto.verify('sha256', parsed.signedAttrsDer, cert.publicKey, parsed.signatureValue));
+  assert.deepStrictEqual(parsed.signingCertificateV2Hash, cms.sha256(signer.der),
+    'signing-certificate-v2 must name the certificate that is actually in the CMS');
+});
+
+test('a single changed byte in the document breaks the signature', async () => {
+  const original = await fixture.samplePdf();
+  const out = await signed(original);
+  const tampered = Buffer.from(out.pdf);
+  tampered[100] = tampered[100] ^ 0xff;
+  const range = pades.readByteRange(tampered);
+  const parsed = cms.parseSignedData(pades.readContents(tampered, range));
+  assert.notDeepStrictEqual(pades.digestByteRange(tampered, range), parsed.messageDigest);
+});
+
+test('the reserved space is honoured', async () => {
+  const original = await fixture.samplePdf();
+  const prepared = await pades.prepare(original, { contentsBytes: 2048 });
+  assert.throws(() => pades.embed(prepared, Buffer.alloc(4096)), /only 2048 reserved/);
+});
+
+test('a signature field reaches the AcroForm and the first page', async () => {
+  const PDFLib = pades.loadPdfLib();
+  const original = await fixture.samplePdf();
+  const out = await signed(original, { fieldName: 'ParaSign QES' });
+  const reloaded = await PDFLib.PDFDocument.load(out.pdf);
+  const names = reloaded.getForm().getFields().map((f) => f.getName());
+  assert.ok(names.includes('ParaSign QES'), 'expected the signature field, found ' + names.join(','));
+  assert.strictEqual(reloaded.getPageCount(), 1, 'signing must not add or drop a page');
+});
+
+test('an already signed document can be signed again without breaking the first signature', async () => {
+  const original = await fixture.samplePdf();
+  const first = await signed(original);
+  const firstRange = pades.readByteRange(first.pdf);
+  const firstDigest = pades.digestByteRange(first.pdf, firstRange);
+
+  const second = await signed(first.pdf, { fieldName: 'ParaSign QES 2' });
+  assert.deepStrictEqual(second.pdf.subarray(0, first.pdf.length), first.pdf,
+    'the second signature must be an incremental update over the first');
+  // The first signature still hashes to the same value, because its ByteRange
+  // still describes the same bytes.
+  assert.deepStrictEqual(pades.digestByteRange(second.pdf, firstRange), firstDigest);
+});

--- a/relay/test/qes-receipt.test.js
+++ b/relay/test/qes-receipt.test.js
@@ -1,0 +1,97 @@
+'use strict';
+// The .psign receipt gains exactly one field and loses nothing.
+//
+// The trap this guards against: the relay counter-signs the canonical JSON of
+// the whole receipt minus notary_signature. A field added anywhere after that
+// signature, in a route or a proxy or a client, silently invalidates every
+// receipt. So the marker has to go in before the signature, and this test is
+// what says it did.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const crypto = require('node:crypto');
+
+const openApi = require('../lib/parasign-open-api');
+
+// Byte-identical to relay/parasign.js canonicalJSON: sorted keys, all the way down.
+function canonicalJSON(value) {
+  if (Array.isArray(value)) return '[' + value.map(canonicalJSON).join(',') + ']';
+  if (value && typeof value === 'object') {
+    return '{' + Object.keys(value).sort().map((k) => JSON.stringify(k) + ':' + canonicalJSON(value[k])).join(',') + '}';
+  }
+  return JSON.stringify(value === undefined ? null : value);
+}
+
+// A stand-in notary: an HMAC over the same canonical bytes the real ML-DSA-65
+// signer covers. What matters here is which bytes get signed, not the algorithm.
+const notaryKey = crypto.randomBytes(32);
+const sigEngine = {
+  sign: (message) => crypto.createHmac('sha256', notaryKey).update(message).digest(),
+};
+const relayIdentity = { pk_hash: 'relay-pk-hash', pk: Buffer.from('relay-public-key'), sk: Buffer.alloc(32) };
+
+function envelope(extra = {}) {
+  return {
+    id: 'envCompleted0000000001',
+    doc_hash: 'a'.repeat(64),
+    binding_mode: 'open',
+    recipe_version: 4,
+    effective_recipe: 4,
+    created_at: '2026-09-03T10:00:00Z',
+    completed_at: '2026-09-03T10:05:00Z',
+    expires_at: '2026-10-03T10:00:00Z',
+    parties: [{
+      index: 0, label: 'Signer', email_hash: 'b'.repeat(64), status: 'signed',
+      signed_at: '2026-09-03T10:05:00Z', pk_b64: 'UEs=', sig_b64: 'U0lH', signer_pk_hash: 'c'.repeat(64),
+    }],
+    ...extra,
+  };
+}
+
+function build(env) {
+  return openApi.buildEnvelopePsign({
+    env, meta: null, canonicalJSON, sigEngine, relayIdentity, publicOrigin: 'https://example.com',
+  });
+}
+
+function notaryVerifies(psign) {
+  const unsigned = { ...psign };
+  delete unsigned.notary_signature;
+  const expected = crypto.createHmac('sha256', notaryKey).update(Buffer.from(canonicalJSON(unsigned), 'utf8')).digest();
+  return expected.toString('base64') === psign.notary_signature;
+}
+
+test('without a qualified signature the receipt has no qes field at all', () => {
+  const psign = build(envelope());
+  assert.strictEqual('qes' in psign, false, 'the default receipt must be unchanged');
+  assert.ok(notaryVerifies(psign));
+});
+
+test('with one, the receipt carries a three-key pointer and still counter-verifies', () => {
+  const qes = {
+    provider: 'cleverbase-sandbox',
+    certificate_fingerprint: 'd'.repeat(64),
+    signed_at: '2026-09-03T10:05:30Z',
+  };
+  const psign = build(envelope({ qes }));
+  assert.deepStrictEqual(psign.qes, qes);
+  assert.deepStrictEqual(Object.keys(psign.qes).sort(), ['certificate_fingerprint', 'provider', 'signed_at']);
+  assert.ok(notaryVerifies(psign), 'the marker must be inside the notary signature, not bolted on after it');
+  // Nothing else moved.
+  assert.strictEqual(psign.type, 'parasign-envelope-receipt');
+  assert.strictEqual(psign.version, '2');
+  assert.strictEqual(psign.algorithm, 'ML-DSA-65');
+  assert.strictEqual(psign.parties[0].signature, 'U0lH');
+});
+
+test('adding the marker after signing breaks the counter-signature, which is the point', () => {
+  const psign = build(envelope());
+  psign.qes = { provider: 'cleverbase-sandbox', certificate_fingerprint: 'e'.repeat(64), signed_at: null };
+  assert.strictEqual(notaryVerifies(psign), false);
+});
+
+test('a half-filled marker is ignored rather than written half-true', () => {
+  assert.strictEqual('qes' in build(envelope({ qes: { provider: 'cleverbase-sandbox' } })), false);
+  assert.strictEqual('qes' in build(envelope({ qes: { certificate_fingerprint: 'f'.repeat(64) } })), false);
+  assert.strictEqual('qes' in build(envelope({ qes: 'yes' })), false);
+});

--- a/scripts/qes-verify.mjs
+++ b/scripts/qes-verify.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+// Verify the qualified signature inside a PDF produced by the ParaSign QES
+// prototype, without trusting anything ParaSign says about it.
+//
+//   node scripts/qes-verify.mjs signed.pdf [--json]
+//
+// What it checks:
+//   1. the /ByteRange really covers the whole file except the signature blob,
+//   2. the SHA-256 over that ByteRange matches the message-digest attribute,
+//   3. the signing-certificate-v2 attribute names the certificate that is in
+//      the CMS, so the attributes cannot be replayed under another certificate,
+//   4. the RSA signature over the signed attributes verifies against that
+//      certificate's public key,
+//   5. each certificate in the chain is signed by the next one,
+//   6. if there is an RFC 3161 timestamp, that it covers this signature value.
+//
+// What it does NOT check, and what a real validator would add:
+//   - trust. No EU trusted list is consulted, so nothing here proves the issuer
+//     is a qualified trust service provider or that the certificate is a
+//     qualified certificate with a QSCD.
+//   - revocation. No CRL, no OCSP, so a revoked certificate still passes.
+//   - full PKIX path validation (RFC 5280): no name constraints, no policy
+//     mapping, no basicConstraints path length, no key usage enforcement.
+//   - long term validation material. There is no DSS dictionary and no
+//     document timestamp, so this is not PAdES-B-LT or B-LTA.
+// Use Adobe Acrobat or the EU DSS demo validator for the real verdict.
+
+import { readFileSync } from 'node:fs';
+import crypto from 'node:crypto';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const pades = require('../relay/lib/qes/pades.js');
+const cms = require('../relay/lib/qes/cms.js');
+const tsa = require('../relay/lib/qes/tsa.js');
+
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+const file = args.find((a) => !a.startsWith('--'));
+
+if (!file) {
+  console.error('usage: node scripts/qes-verify.mjs <signed.pdf> [--json]');
+  process.exit(2);
+}
+
+const checks = [];
+const add = (ok, name, detail) => { checks.push({ ok, name, detail }); return ok; };
+const info = {};
+
+const pdf = readFileSync(file);
+info.file = file;
+info.bytes = pdf.length;
+
+const byteRange = pades.readByteRange(pdf);
+if (!byteRange) {
+  add(false, 'byterange_present', 'no /ByteRange found; this PDF carries no signature');
+} else {
+  info.byte_range = byteRange;
+  const [a, b, c, d] = byteRange;
+  add(a === 0, 'byterange_starts_at_zero', 'first span starts at ' + a);
+  add(c + d === pdf.length, 'byterange_covers_to_eof',
+    'covered end is ' + (c + d) + ', file is ' + pdf.length + ' bytes');
+  add(pdf[b] === 0x3c && pdf[c - 1] === 0x3e, 'byterange_gap_is_the_signature',
+    'the excluded span must be exactly the hex /Contents blob including its angle brackets');
+
+  const digest = pades.digestByteRange(pdf, byteRange);
+  info.document_digest_sha256 = digest.toString('hex');
+
+  let parsed = null;
+  try {
+    parsed = cms.parseSignedData(pades.readContents(pdf, byteRange));
+    add(true, 'cms_parses', 'CMS SignedData, ' + parsed.certificates.length + ' certificate(s)');
+  } catch (e) {
+    add(false, 'cms_parses', e.message);
+  }
+
+  if (parsed) {
+    info.digest_algorithm = parsed.digestAlgorithm;
+    info.signature_algorithm = parsed.signatureAlgorithm;
+    add(parsed.digestAlgorithm === cms.OID.sha256, 'digest_algorithm_is_sha256', parsed.digestAlgorithm);
+    add(parsed.contentType === cms.OID.data, 'content_type_is_id_data', String(parsed.contentType));
+
+    add(!!parsed.messageDigest && parsed.messageDigest.equals(digest), 'message_digest_matches_document',
+      parsed.messageDigest ? parsed.messageDigest.toString('hex') : 'attribute missing');
+
+    const signerDer = parsed.certificates[0];
+    let signer = null;
+    try { signer = new crypto.X509Certificate(signerDer); } catch (e) { add(false, 'signer_certificate_parses', e.message); }
+
+    if (signer) {
+      info.signer = {
+        subject: signer.subject.replace(/\n/g, ', '),
+        issuer: signer.issuer.replace(/\n/g, ', '),
+        serial: signer.serialNumber,
+        valid_from: signer.validFrom,
+        valid_to: signer.validTo,
+        sha256_fingerprint: crypto.createHash('sha256').update(signerDer).digest('hex'),
+      };
+      add(!!parsed.signingCertificateV2Hash &&
+        parsed.signingCertificateV2Hash.equals(cms.sha256(signerDer)),
+      'signing_certificate_v2_binds_this_certificate',
+      parsed.signingCertificateV2Hash ? parsed.signingCertificateV2Hash.toString('hex') : 'attribute missing');
+
+      let sigOk = false;
+      try {
+        sigOk = crypto.verify('sha256', parsed.signedAttrsDer, signer.publicKey, parsed.signatureValue);
+      } catch (e) { sigOk = false; info.signature_error = e.message; }
+      add(sigOk, 'signature_verifies_against_signer_key',
+        'RSASSA-PKCS1-v1_5 over ' + parsed.signedAttrsDer.length + ' bytes of signed attributes');
+
+      const now = new Date();
+      add(now >= new Date(signer.validFrom) && now <= new Date(signer.validTo),
+        'signer_certificate_in_validity_window', signer.validFrom + ' .. ' + signer.validTo);
+    }
+
+    // Chain links only. This says the certificates form a chain, not that the
+    // chain ends somewhere trustworthy.
+    info.chain = [];
+    for (let i = 0; i < parsed.certificates.length; i++) {
+      const c = new crypto.X509Certificate(parsed.certificates[i]);
+      const next = parsed.certificates[i + 1] ? new crypto.X509Certificate(parsed.certificates[i + 1]) : null;
+      info.chain.push({ subject: c.subject.replace(/\n/g, ', '), issuer: c.issuer.replace(/\n/g, ', ') });
+      if (next) {
+        // The cryptographic link is what counts here. checkIssued() also wants
+        // matching key identifiers, which not every chain carries, so it is
+        // reported rather than required.
+        let linked = false;
+        try { linked = c.verify(next.publicKey); } catch { linked = false; }
+        add(linked, 'chain_link_' + i + '_signed_by_' + (i + 1), c.subject.replace(/\n/g, ', '));
+      } else if (parsed.certificates.length > 1 || c.issuer === c.subject) {
+        info.chain_ends_at = c.subject.replace(/\n/g, ', ');
+      }
+    }
+
+    if (parsed.timeStampToken) {
+      try {
+        const t = tsa.parseTimeStampToken(parsed.timeStampToken);
+        info.timestamp = { gen_time: t.genTime, hash_algorithm: t.hashAlgorithm };
+        add(t.hashedMessage.equals(cms.sha256(parsed.signatureValue)),
+          'timestamp_covers_this_signature', 'imprint ' + t.hashedMessage.toString('hex'));
+        const inner = cms.parseSignedData(parsed.timeStampToken);
+        if (inner.certificates.length) {
+          const tsaCert = new crypto.X509Certificate(inner.certificates[0]);
+          info.timestamp.authority = tsaCert.subject.replace(/\n/g, ', ');
+          let ok = false;
+          try { ok = crypto.verify('sha256', inner.signedAttrsDer, tsaCert.publicKey, inner.signatureValue); } catch { ok = false; }
+          add(ok, 'timestamp_token_signature_verifies', info.timestamp.authority);
+        }
+        info.level = 'PAdES-B-T (claimed; the TSA is not checked against any trusted list)';
+      } catch (e) {
+        add(false, 'timestamp_parses', e.message);
+      }
+    } else {
+      info.level = 'PAdES-B-B (no timestamp present)';
+    }
+  }
+}
+
+const failed = checks.filter((c) => !c.ok);
+
+if (asJson) {
+  console.log(JSON.stringify({ ok: failed.length === 0, info, checks }, null, 2));
+} else {
+  console.log('QES verification of ' + file);
+  console.log('');
+  for (const c of checks) console.log('  ' + (c.ok ? 'PASS' : 'FAIL') + '  ' + c.name + (c.detail ? '  (' + c.detail + ')' : ''));
+  console.log('');
+  if (info.signer) {
+    console.log('  signer      ' + info.signer.subject);
+    console.log('  issuer      ' + info.signer.issuer);
+    console.log('  fingerprint ' + info.signer.sha256_fingerprint);
+    console.log('  valid       ' + info.signer.valid_from + ' .. ' + info.signer.valid_to);
+  }
+  if (info.timestamp) console.log('  timestamp   ' + info.timestamp.gen_time + ' by ' + (info.timestamp.authority || 'unknown TSA'));
+  if (info.level) console.log('  level       ' + info.level);
+  console.log('');
+  console.log('  Not checked: trusted list membership, revocation (CRL/OCSP), full RFC 5280');
+  console.log('  path validation, and long term validation material. This tool proves the');
+  console.log('  bytes hang together, not that the signature is legally qualified.');
+  console.log('');
+  console.log(failed.length === 0 ? 'RESULT: all ' + checks.length + ' checks passed'
+    : 'RESULT: ' + failed.length + ' of ' + checks.length + ' checks failed');
+}
+
+process.exit(failed.length === 0 ? 0 : 1);

--- a/tests/access-log-visitors.test.mjs
+++ b/tests/access-log-visitors.test.mjs
@@ -37,7 +37,7 @@ test('a client that renders is not excluded for lacking a referer', () => {
   const r = analyse([
     line({ ip: '8.8.8.8', path: '/sign' }),
     line({ ip: '8.8.8.8', path: '/design-system.css?v=28' }),
-    line({ ip: '8.8.8.8', path: '/sign-flow.js?v=52' }),
+    line({ ip: '8.8.8.8', path: '/sign-flow.js?v=53' }),
   ]);
   assert.equal(r.atMostVisitors, 1);
   assert.equal(r.verdicts.possible_visitor, 1);

--- a/tests/qes-cleverbase-live.test.mjs
+++ b/tests/qes-cleverbase-live.test.mjs
@@ -1,0 +1,103 @@
+// Live checks against the Cleverbase pre-production Signing API.
+//
+// Off by default. It only runs with CLEVERBASE_SANDBOX=1, because it makes real
+// outbound calls and a test suite that needs the internet to be green is a test
+// suite nobody trusts. Run it with:
+//
+//   CLEVERBASE_SANDBOX=1 node --test tests/qes-cleverbase-live.test.mjs
+//
+// What it can and cannot prove is the point of the whole prototype, so it is
+// written to say so out loud:
+//   - POST /csc/v1/info needs no credentials and confirms the host, the CSC
+//     version and the method list. That part always runs.
+//   - Anything past that needs an OAuth client, and client registration at
+//     Cleverbase is a manual step with an account manager. Set
+//     CLEVERBASE_CLIENT_ID and CLEVERBASE_CLIENT_SECRET to exercise it.
+//   - A signature can never be produced by a test. The API offers authType
+//     "oauth2code" only: a natural person has to authorise in the Cleverbase
+//     app, having identified himself there with an NFC chip read plus
+//     biometrics. There is no client_credentials path, in sandbox or in
+//     production, and that is by design for a qualified signature.
+
+import test from 'node:test';
+import assert from 'node:assert';
+import crypto from 'node:crypto';
+import { createRequire } from 'node:module';
+
+const liveRequire = createRequire(import.meta.url);
+const liveCleverbase = liveRequire('../relay/lib/qes/cleverbase.js');
+const liveTsa = liveRequire('../relay/lib/qes/tsa.js');
+
+const LIVE = process.env.CLEVERBASE_SANDBOX === '1';
+const SKIP_REASON = 'set CLEVERBASE_SANDBOX=1 to run this; it makes real calls to '
+  + liveCleverbase.SANDBOX_BASE_URL;
+const liveOpts = LIVE ? {} : { skip: SKIP_REASON };
+
+const HAS_CLIENT = LIVE && !!process.env.CLEVERBASE_CLIENT_ID && !!process.env.CLEVERBASE_CLIENT_SECRET;
+const CLIENT_SKIP = 'needs CLEVERBASE_CLIENT_ID and CLEVERBASE_CLIENT_SECRET; '
+  + 'Cleverbase registers OAuth clients by hand, so there is no self-service pair for the signing host';
+const clientOpts = HAS_CLIENT ? {} : { skip: LIVE ? CLIENT_SKIP : SKIP_REASON };
+
+function liveClient() {
+  return new liveCleverbase.CleverbaseClient({
+    env: process.env,
+    baseUrl: process.env.CLEVERBASE_BASE_URL || liveCleverbase.SANDBOX_BASE_URL,
+    redirectUri: process.env.CLEVERBASE_REDIRECT_URI || 'https://example.com/qes/return',
+  });
+}
+
+test('the sandbox announces a CSC v1.0.4 signing service', liveOpts, async () => {
+  const info = await liveClient().info();
+  assert.strictEqual(info.specs, '1.0.4.0');
+  assert.deepStrictEqual(info.authType, ['oauth2code'],
+    'oauth2code only: every signature needs a person authorising it in the provider app');
+  for (const method of ['oauth2/authorize', 'oauth2/token', 'credentials/list', 'credentials/info', 'signatures/signHash']) {
+    assert.ok(info.methods.includes(method), 'expected method ' + method + ', got ' + info.methods.join(', '));
+  }
+  assert.ok(!info.methods.includes('signatures/signDoc'),
+    'there is no document-signing method, which is exactly why the document can stay here');
+  assert.ok(!info.methods.some((m) => m.includes('timestamp')),
+    'no timestamp method: a qualified timestamp has to come from somewhere else');
+});
+
+test('credentials/list refuses an unauthenticated caller', liveOpts, async () => {
+  const client = liveClient();
+  await assert.rejects(() => client.listCredentials('not-a-token'), (e) => {
+    assert.ok(e.status >= 400 && e.status < 500, 'expected a 4xx, got ' + e.status);
+    return true;
+  });
+});
+
+test('the OAuth client is recognised by the signing host', clientOpts, async () => {
+  const client = liveClient();
+  const url = client.authorizeUrl({ scope: 'service', state: crypto.randomBytes(8).toString('hex') });
+  const res = await fetch(url, { redirect: 'manual', signal: AbortSignal.timeout(20000) });
+  const location = res.headers.get('location') || '';
+  assert.ok(!location.includes('invalid_client'),
+    'the signing host rejected this client id: ' + location);
+});
+
+test('a signature cannot be produced without a person, and the API says so', clientOpts, async () => {
+  const client = liveClient();
+  const digest = crypto.createHash('sha256').update('signed attributes').digest();
+  await assert.rejects(
+    () => client.signHash({ serviceToken: 'not-a-token', credentialID: 'GX0112348', sad: 'not-a-sad', hashes: [digest] }),
+    (e) => {
+      assert.ok(e.status >= 400 && e.status < 500,
+        'signHash without a real service token and SAD must be refused, got ' + e.status);
+      return true;
+    }
+  );
+});
+
+test('the timestamp authority answers an RFC 3161 request', liveOpts, async () => {
+  const url = process.env.QES_TSA_URL || liveTsa.DEFAULT_TSA_URL;
+  const digest = crypto.createHash('sha256').update('signature value').digest();
+  const token = await liveTsa.stamp(digest, { url });
+  assert.ok(token && token.length > 500, 'expected a timestamp token, got ' + (token && token.length));
+  const parsed = liveTsa.parseTimeStampToken(token);
+  assert.deepStrictEqual(parsed.hashedMessage, digest, 'the token must cover the digest we sent');
+  assert.strictEqual(parsed.hashAlgorithm, '2.16.840.1.101.3.4.2.1');
+  const age = Math.abs(Date.now() - Date.parse(parsed.genTime));
+  assert.ok(age < 10 * 60 * 1000, 'the timestamp should be current, it reads ' + parsed.genTime);
+});

--- a/tests/qes-pdf-readable.test.mjs
+++ b/tests/qes-pdf-readable.test.mjs
@@ -1,0 +1,100 @@
+// A signed PDF has to stay a PDF. pdf-lib is what ParaSign edits with and
+// pdf.js is what it renders with, so if either one chokes on the incremental
+// update the feature is broken no matter how correct the CMS is. The verifier
+// script runs here too, because a verification tool that only its author can
+// run proves nothing.
+
+import test from 'node:test';
+import assert from 'node:assert';
+import crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+
+const qesRequire = createRequire(import.meta.url);
+const qesRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const qesPades = qesRequire('../relay/lib/qes/pades.js');
+const qesCms = qesRequire('../relay/lib/qes/cms.js');
+const qesFixture = qesRequire('../relay/test/_qes-fixture.js');
+
+const qesSigner = qesFixture.selfSignedCertificate({ commonName: 'Demo Signer' });
+
+async function qesSignedPdf(text) {
+  const original = await qesFixture.samplePdf(text);
+  const prepared = await qesPades.prepare(original, { signerName: 'Demo Signer', reason: 'Prototype' });
+  const attrs = qesCms.buildSignedAttributes({ messageDigest: prepared.digest, signerCertDer: qesSigner.der });
+  const signature = qesFixture.signHashLikeQtsp(qesSigner.privateKey, qesCms.signedAttributesDigest(attrs));
+  const der = qesCms.buildSignedData({ certificates: [qesSigner.der], signedAttrsDer: attrs, signatureValue: signature });
+  return { original, pdf: qesPades.embed(prepared, der) };
+}
+
+test('pdf-lib still reads a signed document', async () => {
+  const PDFLib = qesPades.loadPdfLib();
+  const { pdf } = await qesSignedPdf('Demo contract for Acme');
+  const doc = await PDFLib.PDFDocument.load(pdf);
+  assert.strictEqual(doc.getPageCount(), 1);
+  assert.deepStrictEqual(doc.getPage(0).getSize(), { width: 595.28, height: 841.89 });
+});
+
+test('pdf.js still renders the text of a signed document', async () => {
+  const pdfjs = await import(pathToFileURL(join(qesRoot, 'frontend/vendor/pdfjs/pdf.min.js')).href);
+  pdfjs.GlobalWorkerOptions.workerSrc = pathToFileURL(join(qesRoot, 'frontend/vendor/pdfjs/pdf.worker.min.js')).href;
+  const { pdf } = await qesSignedPdf('Demo contract for Acme');
+  const doc = await pdfjs.getDocument({ data: new Uint8Array(pdf), isEvalSupported: false }).promise;
+  try {
+    assert.strictEqual(doc.numPages, 1);
+    const content = await (await doc.getPage(1)).getTextContent();
+    assert.strictEqual(content.items.map((i) => i.str).join(''), 'Demo contract for Acme');
+  } finally {
+    await doc.destroy();
+  }
+});
+
+test('scripts/qes-verify.mjs passes on a good signature and fails on a tampered one', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'qes-verify-'));
+  try {
+    const { pdf } = await qesSignedPdf('Demo contract for Acme');
+    const good = join(dir, 'good.pdf');
+    writeFileSync(good, pdf);
+
+    const report = JSON.parse(execFileSync(process.execPath, [join(qesRoot, 'scripts/qes-verify.mjs'), good, '--json'],
+      { encoding: 'utf8' }));
+    assert.strictEqual(report.ok, true, JSON.stringify(report.checks.filter((c) => !c.ok)));
+    assert.ok(report.checks.some((c) => c.name === 'message_digest_matches_document' && c.ok));
+    assert.ok(report.checks.some((c) => c.name === 'signature_verifies_against_signer_key' && c.ok));
+    assert.match(report.info.level, /PAdES-B-B/, 'no timestamp was requested, so B-B is the honest answer');
+
+    // Flip a byte inside the signed range: the digest must stop matching.
+    const tampered = Buffer.from(pdf);
+    tampered[200] = tampered[200] ^ 0xff;
+    const bad = join(dir, 'bad.pdf');
+    writeFileSync(bad, tampered);
+    let failed = null;
+    try {
+      execFileSync(process.execPath, [join(qesRoot, 'scripts/qes-verify.mjs'), bad, '--json'], { encoding: 'utf8' });
+    } catch (e) {
+      failed = JSON.parse(e.stdout);
+    }
+    assert.ok(failed, 'the verifier must exit non-zero on a tampered document');
+    assert.strictEqual(failed.ok, false);
+    assert.ok(failed.checks.some((c) => c.name === 'message_digest_matches_document' && !c.ok));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the receipt marker is a pointer, not the proof', async () => {
+  const qes = qesRequire('../relay/lib/qes/index.js');
+  const field = qes.receiptField({
+    providerName: 'cleverbase-sandbox',
+    certificateFingerprint: crypto.createHash('sha256').update(qesSigner.der).digest('hex'),
+    signedAt: '2026-09-03T18:00:00.000Z',
+  });
+  // The .psign stays a ParaSign artefact: the qualified signature is validated
+  // against the PDF, never against this field.
+  assert.deepStrictEqual(Object.keys(field).sort(), ['certificate_fingerprint', 'provider', 'signed_at']);
+  assert.strictEqual(field.certificate_fingerprint.length, 64);
+});


### PR DESCRIPTION
Prototype of a QES layer for ParaSign, entirely behind `PARASIGN_QES_PROVIDER`.
Empty is the default and empty means nothing changes: `POST /v2/qes/sign` does
not exist, `/v2/auth/capabilities` reports no provider, the sign page shows no
extra option, and the `.psign` receipt comes out exactly as before.

The point is to answer one question without a contract: does a qualified
signature fit next to what ParaSign already does. It does.

## The three layers stay separate

1. The PAdES signature inside the PDF, made by a qualified trust service
   provider over a hash. There is no upload path in the Cleverbase Signing API
   and none here: the document stays put.
2. The `.psign` receipt, unchanged, with one extra top-level field pointing at
   the qualified signature.
3. The public log, untouched.

Verifiable without us holds for both halves separately: the receipt through the
existing verify page, the PAdES signature through Adobe or the EU DSS validator.

## What is new

| File | What it is |
|---|---|
| `relay/lib/qes/asn1.js` | Minimal DER encoder and decoder. No new dependency. |
| `relay/lib/qes/cms.js` | Detached CAdES-BES SignedData, the signed attributes, and the one digest that leaves. |
| `relay/lib/qes/pades.js` | PDF incremental-update writer: signature dictionary, ByteRange, signature field, cross-reference section. |
| `relay/lib/qes/tsa.js` | RFC 3161 timestamping. |
| `relay/lib/qes/cleverbase.js` | Cloud Signature Consortium API v1.0.4 client. |
| `relay/lib/qes/index.js` | The flag, and the two phases either side of the provider call. |
| `scripts/qes-verify.mjs` | Independent verification, honest about what it does not check. |
| `docs/qes-prototype.md` | What the sandbox allowed, and what production still needs. |

pdf-lib cannot write an incremental update: `save()` rewrites the whole file,
which would break any signature already present and makes "the original bytes
are untouched" impossible to assert. So pdf-lib is the object model only and
`pades.js` writes the bytes. One real bug came out of that: pdf-lib's
`largestObjectNumber` under-reports on object-stream PDFs, so naive numbering
clobbered the object stream holding the page tree. Poppler caught it, pdf-lib
did not.

## What the sandbox allowed

Checked 3 September 2026 against `https://connect.acc.cleverbase.com`.

- `POST /csc/v1/info` answers 200 without credentials: `specs 1.0.4.0`,
  `region NL`, `authType ["oauth2code"]`, methods `auth/revoke,
  credentials/info, credentials/list, info, oauth2/authorize, oauth2/revoke,
  oauth2/token, signatures/signHash`.
- Hash-only signing is confirmed by absence: there is no `signatures/signDoc`.
  That is the finding the architecture rests on and it holds.
- No `signatures/timestamp` either, so the qualified timestamp has to come from
  somewhere else.

## What it did not allow

- The credentials published on the client-registration page are for the trust
  driver stubs. Against the signing host they return `error=invalid_client`.
  There is no self-service OAuth client for the Signing API; registration is a
  manual step with an account manager.
- `authType` is `oauth2code` and nothing else. Asking for `client_credentials`
  returns `invalid_request: Invalid parameter grant_type`. Every signature needs
  a natural person authorising in the provider app after identifying there with
  an NFC chip read plus biometrics. No test can produce a signature, and that is
  what makes the signature qualified rather than a sandbox gap to route around.

So: the client speaks the protocol, request and response shapes are pinned by
unit tests against the documented payloads, the discovery call runs live when
asked, and the one call that produces a signature has never been made.

## Level

`QES_TSA_URL` defaults to a free public timestamp service, which works and gives
PAdES-B-T in shape. It is not on any member state's trusted list, so it is B-T
in shape only. Setting it empty stays honestly at B-B. Production needs a
provider with a granted TSA/QTST service.

## Tests

- `relay/test/qes-pades.test.js`, 13 checks: the original bytes survive verbatim
  on both cross-reference styles, the update points back at the previous
  section, ByteRange covers everything except the `/Contents` blob, embedding
  changes only the reserved span, a flipped byte breaks the digest, pdf-lib sees
  the signature field, and a second signature does not disturb the first.
- `relay/test/qes-cms.test.js`, 20 checks: DER encodings against known values,
  signed attributes DER-sorted, only a 32-byte digest ever leaves, the flag off
  by default and deaf to unknown values, and the outbound signHash body pinned
  field by field.
- `relay/test/qes-receipt.test.js`, 4 checks: the marker goes in before the
  notary counter-signature, and adding it after breaks verification, which is
  the trap this guards.
- `tests/qes-pdf-readable.test.mjs`, 4 checks: pdf-lib and pdf.js both still
  read the signed document, and the verifier passes a good signature and fails
  a tampered one.
- `tests/qes-cleverbase-live.test.mjs`: real calls, skipped with a reason unless
  `CLEVERBASE_SANDBOX=1`.

Green locally: relay units 376/376, root suite 226 pass with one pre-existing
failure unrelated to this branch (`heartbeat-lib` cannot resolve
`@noble/post-quantum` in this checkout), browser sign suites 33/33 and 52/52,
`static-sanity`, `env-documented`, `frontend-loading-contract`, cache-bust,
csp-inline and eslint all clean.

## Still needed for production

A contract with the provider, a qualified TSA, long term validation material
(DSS dictionary plus document timestamp) for B-LTA, the Belgian identification
gap, and a deliberate rewrite of the public wording before any of this is
offered to customers.

## Credentials

None, anywhere. `deploy/.env.example` names `CLEVERBASE_CLIENT_ID` and
`CLEVERBASE_CLIENT_SECRET` with empty values and points at the vendor's client
registration page for the pair it publishes for its stubs. `.gitleaks.toml` is
untouched by this branch.
