### PR TITLE
The band tag reads once and correctly

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -409,7 +409,7 @@ footer a{color:var(--fg)}
     <path d="M0 208h1440v22H0z" fill="#4E6E72"/>
     <path d="M0 208h1440" stroke="#EAE2CE" stroke-opacity=".35"/>
   </svg>
-  <span class="hp-band-tag">Paramant <span class="hp-band-tag">Paramant &middot; from Harderwijk</span>middot; made in the Netherlands, hosted in the EU</span>
+  <span class="hp-band-tag">Paramant &middot; made in the Netherlands, hosted in the EU</span>
 </div>
 
 <section class="home-hero">

--- a/tests/first-screen.test.mjs
+++ b/tests/first-screen.test.mjs
@@ -163,6 +163,7 @@ const PAGES = [
       // Mick, 4 September: one note is enough. The founder line left both hero
       // states; the letter signature further down the page is the one place the
       // homepage still names him, and tests/ui-truthfulness pins that block.
+      { name: 'the band tag, once, with the two frames that sell (5 September: a merge left it doubled and garbled)', css: '.hp-band-tag', text: 'Paramant · made in the Netherlands, hosted in the EU' },
       { name: 'the heading of the five facts, which now come before the gift (panel of 4 September: facts convince, the letter can wait)', css: '#check-h', text: 'Five things you can check' },
     ],
   },


### PR DESCRIPTION
A conflict resolution between #414 and #417 nested the old band tag inside the new one; the first line of the homepage was garbled above the fold. One tag again, pinned by first-screen.