### PR TITLE
Send a link: the ParaSend web app can now send to someone who is not online

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -128,6 +128,91 @@ Response:
 
 ---
 
+### The share link: `/v2/dl/<token>` end to end
+
+`POST /v2/inbound` hands back a `download_token`. That token is the whole of the
+asynchronous route: it lets somebody who was not present when you uploaded come
+and fetch the blob later, with no account, no API key and no second browser
+awake. This is what the "Send a link" stand on the ParaSend web app is built on,
+and what an integration builds on directly.
+
+**1. Upload the sealed bytes.** The file is encrypted on the sender's side. The
+relay is handed ciphertext and a SHA-256 of exactly those bytes, and it verifies
+the two match before it stores anything, so the hash written into the CT log
+leaf is a hash of bytes the relay really held.
+
+```bash
+curl -X POST https://relay.paramant.app/v2/inbound \
+  -H "X-Api-Key: pgp_your_key" \
+  -H "Content-Type: application/json" \
+  -d '{"hash":"sha256hex","payload":"base64_ciphertext","ttl_ms":3600000}'
+```
+
+**2. Take the token out of the response.**
+
+```json
+{ "ok": true, "hash": "a3f2…", "ttl_ms": 3600000, "download_token": "6b3c…" }
+```
+
+`download_token` is 24 random bytes as 48 hex characters. `ttl_ms` is the value
+the relay actually applied, which is **not** always the one you asked for: the
+upload clamps your request to the account's ParaSend tier ceiling (`view_ttl_ms`
+in `relay/lib/tiers.js`: 1 hour on Community, 24 hours on Pro, 7 days on
+Business and Enterprise, and the table under "ParaSend limits per tier" above is
+generated from the same rows). Compute the expiry the receiver is told from the
+`ttl_ms` that came back, never from the one you sent.
+
+**3. Build the link, and put the key after the `#`.** A URL fragment is never
+put on the wire by a browser, so a key that lives there is a key the relay
+cannot see even while it is holding the ciphertext. Everything before the `#`
+is fair game for the relay, a proxy, a mail server and a log; everything after
+it is not.
+
+```
+https://paramant.app/get?t=<download_token>&r=<sector>#<base64url(key||iv)>
+```
+
+| Part | What it is |
+|---|---|
+| `t` | the `download_token` from step 2 |
+| `r` | which relay sector holds the blob: `health`, `legal`, `finance` or `iot`. An account is valid on exactly one. Omitted, `/get` asks `health`. |
+| fragment | `base64url(key32 then iv12)`, unpadded: the AES-256-GCM key and nonce, 44 bytes before encoding |
+
+The plaintext `/get` expects inside the ciphertext is
+`[uint32-LE nameLen][name UTF-8][file bytes]`, so the file name travels sealed
+and the relay never learns it. The same wire is produced by the "Send a link"
+stand in the web app (`frontend/js/parashare.page.js`) and read by
+`frontend/js/get.page.js`.
+
+**4. The receiver opens it.** Three routes serve the link, and only one of them
+burns anything:
+
+| Route | What it does |
+|---|---|
+| `GET /v2/dl/:token` | An HTML confirmation page. Safe for link preloaders and mail scanners: known preload user-agents get a static placeholder, and nothing is spent. |
+| `GET /v2/dl/:token/get` | The download itself, and the only route that burns. Answers `410` to a known preload user-agent's twin, `409` while another download of the same token is in flight, and `410` once the token is spent or expired. |
+| `GET /v2/dl/:token/info` | `{ ok, enc_meta, file_size, ttl_left_s, used }` while the link is live, `404` once it is not. No credential. |
+
+**5. It works exactly once.** The blob is deleted and its buffer zeroed on the
+`finish` event of the download response, not when the response starts: a
+transfer that dies mid-flight leaves the token spendable, so a dropped
+connection is a retry and not a lost file. Once a download does finish, the
+token is marked used and the bytes are gone. The TTL is enforced separately by a
+timer, so a link nobody opens is destroyed when it expires whether or not
+anybody asks.
+
+**No delivery receipt on this route.** The relay signs a delivery receipt for
+`GET /v2/outbound/:hash`, the API's own download path, and you fetch it back
+from `GET /v2/transfers/:receipt_id/receipt`. The `/v2/dl` family signs nothing.
+If you need proof that a specific person took the file, use `/v2/outbound` and
+its receipt; `/v2/dl/:token/info` gives you a status and not a proof, and it
+cannot tell "downloaded" apart from "expired" on its own: both answer `404`.
+A caller that recorded the expiry at upload time can separate the two by its own
+clock, which is what the web app's "sent links" list does, and that inference is
+the caller's, not the relay's.
+
+---
+
 ### GET /v2/outbound/:hash — Download (burn-on-read)
 
 ```bash

--- a/frontend/docs/api.md
+++ b/frontend/docs/api.md
@@ -61,6 +61,91 @@ Response:
 
 ---
 
+### The share link: `/v2/dl/<token>` end to end
+
+`POST /v2/inbound` hands back a `download_token`. That token is the whole of the
+asynchronous route: it lets somebody who was not present when you uploaded come
+and fetch the blob later, with no account, no API key and no second browser
+awake. This is what the "Send a link" stand on the ParaSend web app is built on,
+and what an integration builds on directly.
+
+**1. Upload the sealed bytes.** The file is encrypted on the sender's side. The
+relay is handed ciphertext and a SHA-256 of exactly those bytes, and it verifies
+the two match before it stores anything, so the hash written into the CT log
+leaf is a hash of bytes the relay really held.
+
+```bash
+curl -X POST https://relay.paramant.app/v2/inbound \
+  -H "X-Api-Key: pgp_your_key" \
+  -H "Content-Type: application/json" \
+  -d '{"hash":"sha256hex","payload":"base64_ciphertext","ttl_ms":3600000}'
+```
+
+**2. Take the token out of the response.**
+
+```json
+{ "ok": true, "hash": "a3f2…", "ttl_ms": 3600000, "download_token": "6b3c…" }
+```
+
+`download_token` is 24 random bytes as 48 hex characters. `ttl_ms` is the value
+the relay actually applied, which is **not** always the one you asked for: the
+upload clamps your request to the account's ParaSend tier ceiling (`view_ttl_ms`
+in `relay/lib/tiers.js`: 1 hour on Community, 24 hours on Pro, 7 days on
+Business and Enterprise, and the table under "ParaSend limits per tier" above is
+generated from the same rows). Compute the expiry the receiver is told from the
+`ttl_ms` that came back, never from the one you sent.
+
+**3. Build the link, and put the key after the `#`.** A URL fragment is never
+put on the wire by a browser, so a key that lives there is a key the relay
+cannot see even while it is holding the ciphertext. Everything before the `#`
+is fair game for the relay, a proxy, a mail server and a log; everything after
+it is not.
+
+```
+https://paramant.app/get?t=<download_token>&r=<sector>#<base64url(key||iv)>
+```
+
+| Part | What it is |
+|---|---|
+| `t` | the `download_token` from step 2 |
+| `r` | which relay sector holds the blob: `health`, `legal`, `finance` or `iot`. An account is valid on exactly one. Omitted, `/get` asks `health`. |
+| fragment | `base64url(key32 then iv12)`, unpadded: the AES-256-GCM key and nonce, 44 bytes before encoding |
+
+The plaintext `/get` expects inside the ciphertext is
+`[uint32-LE nameLen][name UTF-8][file bytes]`, so the file name travels sealed
+and the relay never learns it. The same wire is produced by the "Send a link"
+stand in the web app (`frontend/js/parashare.page.js`) and read by
+`frontend/js/get.page.js`.
+
+**4. The receiver opens it.** Three routes serve the link, and only one of them
+burns anything:
+
+| Route | What it does |
+|---|---|
+| `GET /v2/dl/:token` | An HTML confirmation page. Safe for link preloaders and mail scanners: known preload user-agents get a static placeholder, and nothing is spent. |
+| `GET /v2/dl/:token/get` | The download itself, and the only route that burns. Answers `410` to a known preload user-agent's twin, `409` while another download of the same token is in flight, and `410` once the token is spent or expired. |
+| `GET /v2/dl/:token/info` | `{ ok, enc_meta, file_size, ttl_left_s, used }` while the link is live, `404` once it is not. No credential. |
+
+**5. It works exactly once.** The blob is deleted and its buffer zeroed on the
+`finish` event of the download response, not when the response starts: a
+transfer that dies mid-flight leaves the token spendable, so a dropped
+connection is a retry and not a lost file. Once a download does finish, the
+token is marked used and the bytes are gone. The TTL is enforced separately by a
+timer, so a link nobody opens is destroyed when it expires whether or not
+anybody asks.
+
+**No delivery receipt on this route.** The relay signs a delivery receipt for
+`GET /v2/outbound/:hash`, the API's own download path, and you fetch it back
+from `GET /v2/transfers/:receipt_id/receipt`. The `/v2/dl` family signs nothing.
+If you need proof that a specific person took the file, use `/v2/outbound` and
+its receipt; `/v2/dl/:token/info` gives you a status and not a proof, and it
+cannot tell "downloaded" apart from "expired" on its own: both answer `404`.
+A caller that recorded the expiry at upload time can separate the two by its own
+clock, which is what the web app's "sent links" list does, and that inference is
+the caller's, not the relay's.
+
+---
+
 ### GET /v2/outbound/:hash — Download (burn-on-read)
 
 ```bash

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -533,7 +533,7 @@ footer a{color:var(--fg)}
           <!-- The handshake, on the card rather than on /parashare step 1. A
                reviewer on 3 September 2026 bought ParaSign and refused ParaSend
                over exactly this, and he only found it out after the button. -->
-          <li>In the web app you and the receiver are both online and compare a short code, and the file is handed over live. Sending to someone who is not online right now needs the API or the SDK.</li>
+          <li>In the web app you and the receiver are both online and compare a short code, and the file is handed over live. Sending to someone who is not online right now needs the API, the SDK, or the Send a link mode in the web app.</li>
         </ul>
         <div class="prod-cta"><a class="hp-btn hp-btn-line" href="/parasend">What ParaSend is</a><a class="hp-btn hp-btn-fill" href="/parashare">Send a file</a></div>
       </li>

--- a/frontend/js/get.page.js
+++ b/frontend/js/get.page.js
@@ -1,6 +1,19 @@
 'use strict';
 
-const RELAY = 'https://health.paramant.app';
+// Which relay sector holds the blob. An account is valid on exactly one sector,
+// and the sender's page knows which one, so the link carries it in `&r=`. Before
+// that this file always asked health, which is right for most accounts and
+// silently wrong for the rest: a legal or finance sender's receiver got a 404
+// and the page called the file burned when it was sitting on another sector.
+// An unknown or missing `r` still falls back to health, so every link minted
+// before this change keeps working.
+const RELAY_SECTORS = {
+  health:  'https://health.paramant.app',
+  legal:   'https://legal.paramant.app',
+  finance: 'https://finance.paramant.app',
+  iot:     'https://iot.paramant.app',
+};
+const DEFAULT_RELAY = RELAY_SECTORS.health;
 
 function showStep(id) {
   document.querySelectorAll('.step').forEach(s => s.classList.remove('active'));
@@ -115,6 +128,7 @@ async function init() {
   const params = new URLSearchParams(location.search);
   const token = params.get('t');
   const fragment = location.hash.slice(1);
+  const RELAY = RELAY_SECTORS[params.get('r')] || DEFAULT_RELAY;
 
   if (!token && !fragment) {
     showStep('step-enter');

--- a/frontend/js/parashare.page.js
+++ b/frontend/js/parashare.page.js
@@ -37,6 +37,20 @@ const TOKEN_URL = '/api/user/parasend/token';
 const TOKEN_MARGIN_MS = 60000;
 let sessionToken = '', ws = null;
 let receiverPubs = null;
+// Which of the two stands the page is in. 'live' is the handshake this page was
+// built for: both online, a code compared, nothing stored. 'link' is the stand
+// added for the sender whose receiver is not at a desk right now -- the file is
+// sealed in this browser, parked on the relay under a one-time download token,
+// and the key travels in the URL fragment where no server ever sees it.
+let sendMode = 'live';
+// The per-plan link lifetimes, straight from tiers.js by way of GET
+// /v2/check-key. Never written into the page by hand: see the comment on the
+// chooser in parashare.html.
+let planTtlByPlan = null, planTtlMs = 0;
+// The links this browser session has minted, newest last. Page-local on
+// purpose: the relay keeps no list of a sender's outstanding links, and
+// pretending otherwise would be a claim this build cannot keep.
+const sentLinks = [];
 
 // ── Helpers ──
 function $(id) { return document.getElementById(id); }
@@ -58,8 +72,12 @@ function showStep(id) {
   globeOnStepChange(id);
   // The 5-stage stepper describes the sender's journey. Hide it for the
   // receiver-only download path (step-tb-download); show + advance otherwise.
+  // The stepper is the LIVE journey: share the link, compare the code, encrypt.
+  // The receiver-only download path never walks it, and neither does the
+  // Send-a-link stand, which has no share-and-compare stage to be at. Showing it
+  // there would put a sender on "3 . Compare" in a flow with nothing to compare.
   var stepper = $('ps-stepper');
-  if (stepper) stepper.style.display = (id === 'step-tb-download') ? 'none' : '';
+  if (stepper) stepper.style.display = (id === 'step-tb-download' || sendMode === 'link') ? 'none' : '';
   var stepperKey = ({
     'step-setup': 'setup',
     'step-waiting': 'share',
@@ -397,7 +415,10 @@ async function discoverRelay() {
         signal: AbortSignal.timeout(5000)
       });
       const d = await r.json();
-      return { sector, url, plan: d.plan, valid: !!d.valid };
+      return {
+        sector, url, plan: d.plan, valid: !!d.valid,
+        link_ttl_ms: d.link_ttl_ms, link_ttl_ms_by_plan: d.link_ttl_ms_by_plan,
+      };
     })
   );
   const answered = results.filter(r => r.status === 'fulfilled').map(r => r.value);
@@ -432,6 +453,7 @@ async function discoverAndReport() {
   if (d.found) {
     RELAY_API = d.found.url;
     relayReady = true;
+    applyPlanTtls(d.found);
     const sectorLabel = d.found.sector !== 'health' ? ` · ${d.found.sector}` : '';
     setStatus('key-status', `✓ Valid, plan: ${d.found.plan}${sectorLabel}`, 'ok');
   } else if (d.rejected) {
@@ -744,6 +766,324 @@ async function confirmFingerprint() {
       $('enc-status').className = 'status-line err';
     }
   }
+}
+
+// ── Send a link ──────────────────────────────────────────────────────────────
+//
+// WHAT THIS STAND IS FOR. An administratiekantoor wants to mail a payslip to
+// somebody who is not online right now. The live handshake above cannot do it
+// by design: it needs two browsers awake at the same moment. So this stand
+// seals the file here, parks it on the relay under a one-time download token,
+// and hands the sender one link.
+//
+// WHERE THE KEY GOES. Into the URL fragment, after the '#'. A fragment is never
+// put on the wire by a browser, so the relay holds ciphertext it cannot open
+// even though it is holding it. That is the same trick the mail extensions
+// already use, and the wire format below is the one /get already reads, byte
+// for byte: [u32le nameLen][name utf8][file bytes], AES-256-GCM, and the
+// fragment is base64url(key32 || iv12). Reusing it rather than inventing a
+// second one is what makes the receiving half of this feature already exist.
+//
+// WHY NOT THE LIVE STAND'S WIRE. That one is ML-KEM-768 + ECDH to the
+// RECEIVER'S public key, and in this stand there is no receiver yet to have a
+// public key. There is nothing to do a key exchange with, so the file is sealed
+// under a symmetric key that travels beside the link instead.
+
+// The ceiling POST /v2/inbound enforces: MAX_BLOB, 5 MB, on every ParaSend tier
+// today. One link is one blob, so a file bigger than that cannot be sent this
+// way and is refused here with the number, rather than at the upload with a 413.
+const LINK_MAX_BLOB = 5 * 1024 * 1024;
+// AES-GCM tag (16) + the 4-byte name-length header. The file name itself is
+// counted per file, below.
+const LINK_OVERHEAD = 20;
+
+function b64url(u8) {
+  return toB64(u8).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+function u32le(n) {
+  const b = new Uint8Array(4);
+  new DataView(b.buffer).setUint32(0, n, true);
+  return b;
+}
+
+// "1 hour", "24 hours", "7 days". Built from the millisecond number the relay
+// serves so the sentence cannot drift from tiers.js.
+function humanDuration(ms) {
+  const n = Number(ms);
+  if (!Number.isFinite(n) || n <= 0) return '';
+  const days = n / 86400000, hours = n / 3600000, mins = n / 60000;
+  // Hours win up to two days. tiers.js Pro is 86_400_000, and "1 day on Pro"
+  // next to "1 hour on Community" reads as a smaller step than it is; the
+  // pricing page has always sold that row as 24 hours, and the two have to
+  // agree word for word or a buyer thinks they are two different limits.
+  if (days >= 2 && Number.isInteger(days))   return days  + ' days';
+  if (hours >= 1 && Number.isInteger(hours)) return hours + (hours === 1 ? ' hour'   : ' hours');
+  if (mins >= 1)                             return Math.round(mins) + ' minutes';
+  return Math.round(n / 1000) + ' seconds';
+}
+
+// The chooser's second sentence, written from the served table. Called once a
+// sector has answered; until then the markup's plan-free sentence stands, which
+// is true of every plan and names no time it might get wrong.
+function applyPlanTtls(found) {
+  planTtlMs = Number(found && found.link_ttl_ms) || 0;
+  planTtlByPlan = (found && found.link_ttl_ms_by_plan) || null;
+  const el = $('ps-mode-link-ttl');
+  if (!el || !planTtlByPlan) return;
+  const c = humanDuration(planTtlByPlan.community);
+  const pr = humanDuration(planTtlByPlan.pro);
+  const b = humanDuration(planTtlByPlan.business);
+  if (!c || !pr || !b) return;
+  // "web app" is not decoration. tests/site-claims.test.mjs block 37 holds every
+  // page about a client that never sends max_views to naming that client beside
+  // a single-read claim, because "up to 10 reads on Pro" is something this page
+  // will never do: it asks the relay for no read count at all.
+  el.textContent = 'The sealed file waits on our server for up to ' + c + ' on Community, ' +
+    pr + ' on Pro and ' + b + ' on Business, and a link from this web app is wiped after the first download.';
+  // The TTL picker in step 1 offers 24 hours to an account whose plan stops at
+  // one, and POST /v2/inbound silently clamps it. Saying the ceiling here is
+  // cheaper than letting the sender pick a number the relay will not honour.
+  const note = $('ttl-status');
+  if (note && planTtlMs) {
+    note.textContent = 'When the link runs out we destroy the file, picked up or not. ' +
+      'Your plan holds a link to ' + humanDuration(planTtlMs) + ' at most; a longer choice is shortened to that.';
+  }
+}
+
+// ── The chooser ──────────────────────────────────────────────────────────────
+// Both cards stay in the DOM; only what the chosen stand does not use is
+// hidden. The stepper is the live journey (share, compare) and describes
+// nothing the link stand walks, so it goes away rather than lying about where
+// the sender is.
+function setSendMode(mode) {
+  sendMode = mode === 'link' ? 'link' : 'live';
+  const live = $('ps-mode-live'), link = $('ps-mode-link');
+  if (live) live.setAttribute('aria-checked', String(sendMode === 'live'));
+  if (link) link.setAttribute('aria-checked', String(sendMode === 'link'));
+  const stepper = $('ps-stepper');
+  if (stepper) stepper.style.display = (sendMode === 'link') ? 'none' : '';
+  // "The person you send to has to be online while you send" is the one
+  // sentence on this page that the link stand makes false.
+  const note = $('ps-live-note');
+  if (note) {
+    note.textContent = (sendMode === 'link')
+      ? 'The person you send to does not have to be online. You get a link to pass on; it works once.'
+      : 'The person you send to has to be online while you send; you confirm a short code together.';
+  }
+  const btn = $('btn-create-session');
+  if (btn) btn.textContent = (sendMode === 'link') ? 'Seal the file and make a link →' : 'Create secure session →';
+  setCreateStatus('');
+}
+function chooseModeLive() { setSendMode('live'); }
+function chooseModeLink() { setSendMode('link'); }
+
+// The one button at the bottom of step 1, dispatched on the chosen stand. The
+// two flows share step 1 entirely -- same credential, same file picker, same
+// expiry choice -- and part company only here.
+async function startSend() {
+  return (sendMode === 'link') ? createLink() : createSession();
+}
+
+// ── Seal one file and upload it ──────────────────────────────────────────────
+// Returns { name, size, token, key, expires_ms }. Throws on refusal, with the
+// relay's quota JSON attached when that is what happened, so the caller can
+// render the upgrade notice the live stand already renders.
+async function sealAndUpload(file, ttlMs) {
+  const nameBytes = new TextEncoder().encode(file.name);
+  if (file.size + nameBytes.length + LINK_OVERHEAD > LINK_MAX_BLOB) {
+    throw new Error(file.name + ' is too big for a link. One link is one 5 MB block; ' +
+      'send it with the live hand-over, which splits a file into chunks.');
+  }
+  const plain = concat(u32le(nameBytes.length), nameBytes, new Uint8Array(await file.arrayBuffer()));
+  const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt']);
+  const rawKey = new Uint8Array(await crypto.subtle.exportKey('raw', key));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plain));
+
+  const hashBuf = await crypto.subtle.digest('SHA-256', ct);
+  const hash = u8toHex(new Uint8Array(hashBuf));
+  const ur = await relayFetch(RELAY_API + '/v2/inbound', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      hash, payload: toB64(ct), ttl_ms: ttlMs,
+      // No file name and no size on the relay side: the name lives only inside
+      // the sealed bytes, which is the same rule the live stand keeps.
+      meta: { device_id: 'transfer-web-link' }
+    }),
+    signal: AbortSignal.timeout(120000)
+  });
+  const ud = await ur.json();
+  if (window.paQuotaUpgrade && window.paQuotaUpgrade.isQuota402(ur.status, ud)) {
+    const qe = new Error(ud.error); qe.quota = ud; throw qe;
+  }
+  if (!ud.ok) throw new Error(ud.error || 'Upload failed: ' + file.name);
+  return {
+    name: file.name, size: file.size, token: ud.download_token,
+    // The relay's ttl_ms, not the one that was asked for: POST /v2/inbound
+    // clamps to the tier, and the expiry the sender is shown has to be the one
+    // the relay will actually act on.
+    expires_ms: Date.now() + Number(ud.ttl_ms || ttlMs),
+    key: b64url(concat(rawKey, iv)),
+    state: 'waiting',
+  };
+}
+
+function setSealProgress(pct) {
+  const rounded = Math.max(0, Math.min(100, Math.round(Number(pct) || 0)));
+  const bar = $('seal-progress');
+  const readout = $('seal-pct');
+  const track = $('seal-progress-track');
+  if (bar) bar.style.width = rounded + '%';
+  if (readout) readout.textContent = rounded + '%';
+  if (track) track.setAttribute('aria-valuenow', String(rounded));
+}
+
+async function createLink() {
+  if (!relayReady) {
+    setCreateStatus('Looking for a relay sector...');
+    await discoverAndReport();
+    if (!relayReady) {
+      setCreateStatus(relayError || failureText('relay sector discovery', new Error('no sector answered')), 'err');
+      return;
+    }
+  }
+  setCreateStatus('');
+  const files = [...$('file-input').files];
+  if (!files.length) return;
+  const ttlMs = parseInt($('ttl-select').value);
+  const sector = Object.entries(RELAY_SECTORS).find(([, u]) => u === RELAY_API)?.[0] || 'health';
+
+  showStep('step-sealing');
+  setSealProgress(0);
+  try {
+    for (let i = 0; i < files.length; i++) {
+      $('seal-status').textContent = (files.length > 1 ? 'File ' + (i + 1) + '/' + files.length + ': ' : '') +
+        'Sealing ' + files[i].name + ' in this browser...';
+      setSealProgress(Math.round((i / files.length) * 90));
+      const row = await sealAndUpload(files[i], ttlMs);
+      // The sector rides in the link because an account lives on exactly one of
+      // them; without it /get asks health and a legal sender's receiver is told
+      // the file is burned when it is sitting on another sector.
+      row.url = location.origin + '/get?t=' + encodeURIComponent(row.token) +
+        '&r=' + encodeURIComponent(sector) + '#' + row.key;
+      sentLinks.push(row);
+    }
+    setSealProgress(100);
+    renderSentLinks();
+    showStep('step-link');
+    refreshSentLinks();
+  } catch (e) {
+    if (e && e.quota && window.paQuotaUpgrade) {
+      $('seal-status').className = 'status-line';
+      $('seal-status').innerHTML = window.paQuotaUpgrade.html(e.quota);
+    } else {
+      $('seal-status').textContent = failureText('seal and upload', e);
+      $('seal-status').className = 'status-line err';
+    }
+  }
+}
+
+// ── The sent-links list ──────────────────────────────────────────────────────
+// NOT a receipt list, and the page says so under it. The relay signs a delivery
+// receipt on the API download path (GET /v2/outbound, fetched back from
+// /v2/transfers/:id/receipt); the browser download path, GET /v2/dl/:token/get,
+// signs nothing. What is left is GET /v2/dl/:token/info, which answers 200 with
+// the time remaining while the link is live and 404 once it is "not found, used,
+// or expired" -- one status for three outcomes. This page separates the last two
+// with its own clock: a 404 before the expiry it recorded means the file was
+// taken, after it means it timed out. That is an inference, and the note under
+// the list calls it one.
+function linkStateLabel(row) {
+  if (row.state === 'delivered') return 'Downloaded, and the file is gone';
+  if (row.state === 'expired')   return 'Expired, and the file is gone';
+  return 'Waiting for the receiver';
+}
+
+function renderSentLinks() {
+  const list = $('ps-link-list');
+  if (!list) return;
+  list.innerHTML = '';
+  sentLinks.forEach((row, i) => {
+    const li = document.createElement('li');
+    li.className = 'ps-link-row';
+    li.dataset.linkIndex = String(i);
+
+    const name = document.createElement('div');
+    name.className = 'ps-link-name';
+    name.textContent = row.name;
+    li.appendChild(name);
+
+    const url = document.createElement('div');
+    url.className = 'ps-link-url';
+    url.textContent = row.url;
+    li.appendChild(url);
+
+    const meta = document.createElement('div');
+    meta.className = 'ps-link-meta';
+    const state = document.createElement('span');
+    state.className = 'ps-link-state is-' + row.state;
+    state.textContent = linkStateLabel(row);
+    meta.appendChild(state);
+    const exp = document.createElement('span');
+    // One date format for the whole site (#424): day, month in full, year, and
+    // the clock in UTC, because a one-hour link is a moment and not a day.
+    exp.textContent = 'Expires ' + (window.paramantDate
+      ? window.paramantDate.moment(row.expires_ms)
+      : new Date(row.expires_ms).toISOString());
+    meta.appendChild(exp);
+    const once = document.createElement('span');
+    once.textContent = 'Works once';
+    meta.appendChild(once);
+    li.appendChild(meta);
+
+    const copy = document.createElement('button');
+    copy.type = 'button';
+    copy.className = 'ps-copy';
+    copy.setAttribute('data-click', 'copySentLink');
+    copy.setAttribute('data-link-index', String(i));
+    copy.textContent = 'Copy link';
+    li.appendChild(copy);
+
+    list.appendChild(li);
+  });
+}
+
+async function copySentLink(el) {
+  const i = parseInt(el && el.getAttribute('data-link-index'), 10);
+  const row = sentLinks[i];
+  if (!row) return;
+  let copied = true;
+  await navigator.clipboard.writeText(row.url).catch(() => { copied = false; });
+  if (el._resetTimer) clearTimeout(el._resetTimer);
+  el.textContent = copied ? 'Copied' : 'Copy failed';
+  el.classList.toggle('is-copied', copied);
+  el._resetTimer = setTimeout(() => {
+    el.textContent = 'Copy link';
+    el.classList.remove('is-copied');
+  }, 2000);
+}
+
+// No credential on this call: /v2/dl/:token/info is the receiver's half of the
+// route family and takes none. Sending the session token here would be widening
+// a fifteen-minute credential to a route that does not want it.
+async function refreshSentLinks() {
+  const btn = $('ps-link-refresh');
+  if (btn) { btn.disabled = true; btn.textContent = 'Checking...'; }
+  for (const row of sentLinks) {
+    if (row.state !== 'waiting') continue;
+    try {
+      const r = await fetch(RELAY_API + '/v2/dl/' + encodeURIComponent(row.token) + '/info',
+        { signal: AbortSignal.timeout(8000) });
+      if (r.ok) row.state = 'waiting';
+      else if (r.status === 404) row.state = (Date.now() < row.expires_ms) ? 'delivered' : 'expired';
+    } catch (_) {
+      // A check that did not arrive says nothing about the link. Leave the row
+      // as it was rather than reporting a delivery that may not have happened.
+    }
+  }
+  renderSentLinks();
+  if (btn) { btn.disabled = false; btn.textContent = 'Check again'; }
 }
 
 function rejectFingerprint() {
@@ -1155,7 +1495,9 @@ function updateGlobeTransfer(userLat, userLng) {
 act('change','fpConfirmToggle',(el)=>{const b=document.getElementById('fp-confirm-btn');if(b)b.disabled=!el.checked;});
 act('change','onFileSelect',()=>onFileSelect());
 act('click','confirmFingerprint',()=>confirmFingerprint());act('click','copyLink',()=>copyLink());
-act('click','createSession',()=>createSession());act('click','expandApiKeyCard',()=>expandApiKeyCard());
+act('click','createSession',()=>startSend());act('click','expandApiKeyCard',()=>expandApiKeyCard());
+act('click','chooseModeLive',()=>chooseModeLive());act('click','chooseModeLink',()=>chooseModeLink());
+act('click','copySentLink',(el)=>copySentLink(el));act('click','refreshSentLinks',()=>refreshSentLinks());
 act('click','rejectFingerprint',()=>rejectFingerprint());act('input','onKeyInput',()=>onKeyInput());
 act('click','reload',()=>location.reload());
 act('click','reopenSession',()=>reopenSession());

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -220,7 +220,7 @@
          and gets on with its work, and a receiver who has to be sitting there at
          the same moment is not a route that office can use. So it is said here,
          above the button, in the words the reviewer would have wanted. -->
-    <p class="ps-live">In the web app you and the receiver are both online and compare a short code, and the file is handed over live. Sending to someone who is not online right now needs the API or the SDK.</p>
+    <p class="ps-live">In the web app you and the receiver are both online and compare a short code, and the file is handed over live. Sending to someone who is not online right now needs the API, the SDK, or the Send a link mode in the web app.</p>
     <div class="ps-actions">
       <a href="/parashare" class="btn btn-primary">Send a file &rarr;</a>
       <a href="/pricing" class="btn btn-secondary">See pricing &rarr;</a>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -40,6 +40,34 @@ h1{font-size:clamp(26px,5vw,38px);font-weight:600;letter-spacing:-.028em;line-he
 .ps-step.done:not(:last-child)::after{background:var(--sig-done)}
 @media (max-width:560px){.ps-step-label{font-size:9px;letter-spacing:.06em}.ps-stepper{gap:2px}}
 
+/* The two ways to send, offered before anything else on the page. A koper who
+   wants to mail a payslip to somebody who is not at a desk right now used to
+   read the live-handshake note, conclude the product could not do it, and
+   leave. Both stands are named in plain words, and the second one says what it
+   costs: the sealed file waits on our server. */
+.ps-mode{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:26px}
+@media (max-width:640px){.ps-mode{grid-template-columns:1fr}}
+.ps-mode-card{display:flex;flex-direction:column;gap:6px;text-align:left;padding:14px 16px;border:1px solid var(--line);border-radius:var(--r-1);background:var(--surface);color:var(--ink-2);font:inherit;cursor:pointer;transition:border-color var(--d-2) var(--e-standard),background var(--d-2) var(--e-standard)}
+.ps-mode-card:hover{border-color:var(--line-2)}
+.ps-mode-card[aria-checked="true"]{border-color:var(--accent);background:var(--surface-sunk);box-shadow:inset 2px 0 0 var(--accent)}
+.ps-mode-title{font-family:var(--mono);font-size:11px;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--ink-3)}
+.ps-mode-card[aria-checked="true"] .ps-mode-title{color:var(--ink-1)}
+.ps-mode-body{font-size:13px;line-height:1.6;color:var(--ink-2)}
+
+/* The links this browser session has minted. Not a receipt list: the relay
+   issues no signed delivery receipt on the /v2/dl path, so each row says what
+   GET /v2/dl/:token/info says plus this page's own clock, and the note under
+   the list says exactly that rather than dressing a status up as proof. */
+.ps-links{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:10px}
+.ps-link-row{border:1px solid var(--line);border-radius:var(--r-1);padding:12px 14px;background:var(--surface-sunk)}
+.ps-link-name{font-size:13.5px;font-weight:600;color:var(--ink-1);word-break:break-all}
+.ps-link-url{font-family:var(--mono);font-size:11px;color:var(--ink-2);word-break:break-all;margin-top:6px;line-height:1.55}
+.ps-link-meta{font-family:var(--mono);font-size:10.5px;letter-spacing:.04em;color:var(--ink-3);margin-top:7px;display:flex;flex-wrap:wrap;gap:10px;align-items:center}
+.ps-link-state{font-weight:600}
+.ps-link-state.is-waiting{color:var(--sig-wait)}
+.ps-link-state.is-delivered{color:var(--sig-done)}
+.ps-link-state.is-expired{color:var(--ink-3)}
+
 /* Inline along-the-way guide -- explains what is happening at each step */
 .ps-guide{font-family:var(--sans);font-size:13.5px;line-height:1.62;color:var(--ink-2);padding:13px 15px;border:1px solid var(--line);border-left:2px solid var(--mark);background:var(--surface-sunk);margin-bottom:18px;border-radius:0 var(--r-1) var(--r-1) 0}
 .ps-guide strong{color:var(--ink-1);font-weight:600}
@@ -424,6 +452,23 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 
 <main id="main-content" style="position:relative;z-index:10">
 
+<!-- Two stands, chosen before anything else. The Send-a-link sentence carries
+     no times in the markup on purpose: the hours per plan are tiers.js
+     view_ttl_ms and are written in by parashare.page.js from the plan API
+     (GET /v2/check-key), so a tier change cannot leave a stale hour on the
+     page. Until that answer arrives the sentence says only what is true of
+     every plan. -->
+<div class="ps-mode" id="ps-mode" role="radiogroup" aria-label="How do you want to send this file">
+  <button type="button" class="ps-mode-card" id="ps-mode-live" role="radio" aria-checked="true" data-click="chooseModeLive">
+    <span class="ps-mode-title">Hand over live</span>
+    <span class="ps-mode-body">Both of you are online, you compare a code, and nothing is ever stored.</span>
+  </button>
+  <button type="button" class="ps-mode-card" id="ps-mode-link" role="radio" aria-checked="false" data-click="chooseModeLink">
+    <span class="ps-mode-title">Send a link</span>
+    <span class="ps-mode-body">The receiver opens it later. <span id="ps-mode-link-ttl">The sealed file waits on our server until its link expires, and a link from this web app is wiped after the first download.</span></span>
+  </button>
+</div>
+
 <!-- Stepper -- visible above the active step, updates as you move through -->
 <ol class="ps-stepper" id="ps-stepper" aria-label="Sending progress">
   <li class="ps-step active" data-step-key="setup">
@@ -618,6 +663,54 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
   </div>
 </div>
 
+<!-- SEND A LINK: sealing and uploading. Its own step and not a shared one with
+     the live hand-over, for two reasons. The copy differs: there is no
+     receiver's public key here to wrap a session key for, so the sentence next
+     to the bar has to say what really happens. And tests/ui-truthfulness.test.mjs
+     pins that exactly one path reaches #step-encrypting, because the live
+     promise "the receiver has to be online" holds only while confirmFingerprint
+     is the single door into it. This stand walks its own door. -->
+<div class="step" id="step-sealing">
+  <h2 class="paramant-h1">Sealing &amp; uploading</h2>
+  <p class="sub">Your browser locks the file under a fresh AES-256-GCM key, then uploads the locked bytes. The key stays here and goes into the link, after the #, where no server ever sees it.</p>
+
+  <div class="card">
+    <div class="card-head"><div class="dot amber"></div><div class="card-head-title">Upload progress</div></div>
+    <div class="card-body">
+      <div class="ps-progress-head">
+        <span class="status-line" id="seal-status">Starting...</span>
+        <span class="ps-pct" id="seal-pct" aria-live="polite">0%</span>
+      </div>
+      <div class="progress-bar-wrap" role="progressbar" id="seal-progress-track" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="progress-bar" id="seal-progress"></div></div>
+    </div>
+  </div>
+</div>
+
+<!-- SEND A LINK: the link is ready. Reached only from the Send-a-link stand;
+     the live stand never shows this step. -->
+<div class="step" id="step-link">
+  <h2 class="paramant-h1">Your link is ready</h2>
+  <p class="sub">Send it any way you like. The key sits after the # in the link, which browsers never send to a server, so we cannot open the file even though we are holding it.</p>
+
+  <div class="card">
+    <div class="card-head"><div class="dot"></div><div class="card-head-title">Sent links</div></div>
+    <div class="card-body">
+      <ul class="ps-links" id="ps-link-list"></ul>
+      <p class="ps-meta" id="ps-link-note">Each link works once. The first completed download wipes the file from our relay; if nobody opens it, it is destroyed when it expires.</p>
+      <p class="ps-meta" id="ps-link-receipt-note">There is no signed delivery receipt for a link download yet: the relay signs one for the API download path, not for this one. What a row says is the link's own status plus this page's clock, and it lives only as long as this tab.</p>
+      <button type="button" class="ps-copy" id="ps-link-refresh" data-click="refreshSentLinks">Check again</button>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;display:flex;gap:4px;flex-wrap:wrap">
+    <span class="tag green">AES-256-GCM in your browser</span>
+    <span class="tag green">Key in the URL fragment</span>
+    <span class="tag green">Spent by one download</span>
+  </div>
+
+  <button class="btn btn-outline" data-click="reload" style="margin-top:16px">Send another file</button>
+</div>
+
 <div class="step" id="step-done">
   <aside class="parapear-block is-success" aria-label="Transfer complete">
     <img class="parapear-img" src="/assets/parapear/parapear-success.png" alt="" aria-hidden="true" loading="lazy" decoding="async" width="120" height="120">
@@ -709,7 +802,11 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
      two different contents under one immutable url is exactly what the ?v= is
      there to prevent, and check-cache-bust cannot see it because both sides
      agree on the number. -->
-<script src="/js/parashare.page.js?v=7" defer></script>
+<!-- One date format for the whole site (#424). The Send-a-link stand prints
+     an expiry moment, and a slashed locale date next to "24 hours on Pro"
+     is the exact ambiguity that file exists to kill. -->
+<script src="/js/format-date.js?v=1" defer></script>
+<script src="/js/parashare.page.js?v=8" defer></script>
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
 <footer>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -436,7 +436,7 @@
            is a live handshake, and until 3 September 2026 that stood only on
            /parashare, step 1, which is after the money. -->
       <p style="font-size:var(--text-sm);color:var(--ink-dim);line-height:1.7;max-width:760px;margin-top:var(--space-3)">
-        In the web app you and the receiver are both online and compare a short code, and the file is handed over live. Sending to someone who is not online right now needs the API or the SDK.
+        In the web app you and the receiver are both online and compare a short code, and the file is handed over live. Sending to someone who is not online right now needs the API, the SDK, or the Send a link mode in the web app.
       </p>
     </div>
     <div class="tier-grid">

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -4236,8 +4236,32 @@ async function handleRelayRequest(req, res) {
   if (path === '/v2/check-key') {
     if (!checkKeyRateOk(clientIp)) { res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': '60' }); return res.end(J({ error: 'Too many requests. Retry after 60 seconds.' })); }
     const kd = apiKeys.get(apiKey);
+    // How long a sealed file waits on the relay, in milliseconds, straight out
+    // of tiers.js. The "Send a link" chooser on /parashare has to name those
+    // times in its own first sentence, before a file is picked, and a sentence
+    // that carries hand-written hours is a sentence that goes stale the first
+    // time a tier changes. So the numbers are served, not written.
+    //
+    // Two fields because the page asks two different questions. `link_ttl_ms`
+    // is the ceiling THIS key is really held to, read through the ParaSend
+    // entitlement, so a ParaSend Pro buyer whose legacy `plan` still says
+    // community is told 24 hours and not 1 hour -- the same source POST
+    // /v2/inbound clamps against, so the page cannot promise what the upload
+    // will not give. `link_ttl_ms_by_plan` is the plain tiers.js table the
+    // chooser needs to say "1 hour on Community, 24 hours on Pro, 7 days on
+    // Business" to a reader who is on none of them yet.
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    return res.end(J({ valid: !!(kd?.active), plan: kd?.plan || null }));
+    return res.end(J({
+      valid: !!(kd?.active),
+      plan: kd?.plan || null,
+      link_ttl_ms: parasendLimitsOf(kd).limits.view_ttl_ms,
+      link_ttl_ms_by_plan: {
+        community:  tiers.tierLimit('community',  'view_ttl_ms'),
+        pro:        tiers.tierLimit('pro',        'view_ttl_ms'),
+        business:   tiers.tierLimit('business',   'view_ttl_ms'),
+        enterprise: tiers.tierLimit('enterprise', 'view_ttl_ms'),
+      },
+    }));
   }
 
   // ── GET /v2/lookup-signer/:pk_hash — public reverse-lookup for verifiers ──

--- a/relay/test/route-dl-share-link.test.js
+++ b/relay/test/route-dl-share-link.test.js
@@ -1,0 +1,189 @@
+'use strict';
+// route-dl-share-link.test.js: the asynchronous half of ParaSend, against a
+// real relay and a real redis.
+//
+// WHAT THIS SUITE IS FOR. /parashare grew a "Send a link" stand so an office
+// can mail a payslip to somebody who is not online. That stand rests on three
+// promises the relay has to keep, and the browser suite
+// (tests/parasend-send-a-link.test.mjs) cannot measure any of them, because
+// there the relay is a stub:
+//
+//   1. a pst_ session token, the credential the page really runs on, may upload
+//      -- POST /v2/inbound is in its allowlist, and this is the test that fails
+//      if somebody ever narrows that list without reading the page
+//   2. the link works exactly once, and the second attempt is refused with a
+//      sentence a receiver can act on rather than a stack trace
+//   3. the times the page prints per plan come off tiers.js through the plan
+//      API, so a tier change moves the copy and a stale hour cannot be shipped
+//
+// It also pins the two things a caller has to get right and would otherwise
+// find out about in production: that GET /v2/dl/:token/info needs no credential
+// at all (the receiver has none), and that the relay clamps the requested TTL
+// to the account's tier rather than honouring what was asked.
+//
+// Run: REDIS_URL=redis://127.0.0.1:6399 node --test relay/test/route-dl-share-link.test.js
+//   (docker run --rm -d -p 6399:6379 redis:7.4.8-alpine)
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const { boot, killAll } = require('./_relay-server');
+const { requireRedis, summary } = require('./_requires');
+const tiers = require('../lib/tiers');
+
+const DEFAULT_REDIS = 'redis://127.0.0.1:6399';
+const DL_INTERNAL = 'internal-token-for-the-dl-share-link-suite';
+// Fresh per run: every route suite shares one redis, and the quota counters
+// below are keyed on the account id.
+const DL_SUFFIX = crypto.randomBytes(6).toString('hex');
+const DL_OWNER = `pgp_owner_key_for_the_dl_share_link_suite_${DL_SUFFIX}`;
+const DL_ACCT = `acct_dlshare_${DL_SUFFIX}`;
+
+let dlRc = null;
+let dlSrv;
+let dlChecks = 0;
+const dlDid = () => { dlChecks++; };
+
+before(async () => {
+  dlRc = await requireRedis(DEFAULT_REDIS);
+  dlSrv = await boot({
+    tag: 'dlshare',
+    users: { api_keys: [{ key: DL_OWNER, plan: 'community', active: true, email: 'owner@example.test', account_id: DL_ACCT }] },
+    env: { INTERNAL_AUTH_TOKEN: DL_INTERNAL, REDIS_URL: process.env.REDIS_URL || DEFAULT_REDIS },
+    usersFile: true,
+  });
+});
+
+after(async () => {
+  await killAll();
+  if (dlRc) { try { await dlRc.disconnect(); } catch (_) { /* already gone */ } }
+  summary('route-dl-share-link', dlChecks);
+});
+
+async function dlMint() {
+  const r = await dlSrv.post('/v2/session-token', {
+    headers: { 'X-Internal-Auth': DL_INTERNAL, 'X-Api-Key': DL_OWNER },
+  });
+  assert.equal(r.status, 200, 'the suite cannot run without a session token');
+  return r.json.token;
+}
+
+// The sealed bytes the "Send a link" stand uploads: opaque to the relay, and
+// hashed exactly as sent, which POST /v2/inbound verifies before it stores.
+function dlSealed(label) {
+  const payload = Buffer.from(`${label}-${crypto.randomBytes(24).toString('hex')}`);
+  return { payload, hash: crypto.createHash('sha256').update(payload).digest('hex') };
+}
+
+// ── 1. The credential the web app really runs on may park a file ─────────────
+
+test('a pst_ session token can upload, and gets a download token back', async (t) => {
+  if (!dlRc) return t.skip('no redis');
+  const token = await dlMint();
+  const b = dlSealed('payslip');
+  const r = await dlSrv.post('/v2/inbound', {
+    headers: { Authorization: `Bearer ${token}` },
+    body: { hash: b.hash, payload: b.payload.toString('base64'), ttl_ms: 3_600_000 },
+  });
+  assert.equal(r.status, 200, 'POST /v2/inbound refused a pst_ token; the "Send a link" stand cannot upload at all');
+  assert.equal(r.json.ok, true);
+  assert.match(r.json.download_token, /^[a-f0-9]{48}$/,
+    'the upload no longer mints a download token, so there is no link to hand to a receiver who arrives later');
+  dlDid();
+});
+
+// ── 2. The link works once ───────────────────────────────────────────────────
+
+test('the share link serves the sealed bytes once and refuses the second time', async (t) => {
+  if (!dlRc) return t.skip('no redis');
+  const token = await dlMint();
+  const b = dlSealed('once');
+  const up = await dlSrv.post('/v2/inbound', {
+    headers: { Authorization: `Bearer ${token}` },
+    body: { hash: b.hash, payload: b.payload.toString('base64'), ttl_ms: 3_600_000 },
+  });
+  assert.equal(up.status, 200);
+  const dl = up.json.download_token;
+
+  // The receiver carries NO credential. That is the whole feature: an office
+  // mails a link to a client who has no account and never will have one.
+  const info = await dlSrv.get(`/v2/dl/${dl}/info`);
+  assert.equal(info.status, 200, 'GET /v2/dl/:token/info refused an anonymous caller; the receiver has no credential to offer');
+  assert.equal(info.json.used, false);
+  assert.ok(info.json.ttl_left_s > 0, 'the link reports no time left while it is still live');
+
+  const first = await dlSrv.get(`/v2/dl/${dl}/get`);
+  assert.equal(first.status, 200, 'the first download failed; the link a sender handed out does not work');
+  assert.equal(Buffer.compare(first.buf, b.payload), 0,
+    'the bytes came back changed; a receiver decrypting these would get a GCM failure and be told the link was tampered with');
+  assert.equal(first.headers['x-burned'], 'true');
+
+  const second = await dlSrv.get(`/v2/dl/${dl}/get`);
+  assert.equal(second.status, 410,
+    'the link served a second download; "works once" is on the page and in the docs, and this is the only thing that makes it true');
+  assert.match(second.text, /already been downloaded and burned/i,
+    'the second attempt must say what happened in a sentence a receiver can act on');
+
+  // And the status route agrees, which is what the sender-side "sent links"
+  // list reads. It cannot tell burned from expired -- both are 404 -- which is
+  // why the page separates them on its own recorded expiry and says so.
+  const after = await dlSrv.get(`/v2/dl/${dl}/info`);
+  assert.equal(after.status, 404, 'a spent link still reports itself live; the sent-links list would say "waiting" forever');
+  dlDid();
+});
+
+test('a link the sender never handed out still expires on its own', async (t) => {
+  if (!dlRc) return t.skip('no redis');
+  const token = await dlMint();
+  const b = dlSealed('ttl');
+  // 30 seconds is the shortest the page offers. Asking for it proves the relay
+  // honours a request UNDER the ceiling exactly as asked, which is the other
+  // half of the clamp measured below.
+  const up = await dlSrv.post('/v2/inbound', {
+    headers: { Authorization: `Bearer ${token}` },
+    body: { hash: b.hash, payload: b.payload.toString('base64'), ttl_ms: 30_000 },
+  });
+  assert.equal(up.status, 200);
+  assert.equal(up.json.ttl_ms, 30_000, 'a TTL under the tier ceiling must be honoured as asked, not rounded up to the ceiling');
+  const info = await dlSrv.get(`/v2/dl/${up.json.download_token}/info`);
+  assert.ok(info.json.ttl_left_s <= 30, 'the link reports more time than the upload was given');
+  dlDid();
+});
+
+// ── 3. The TTL the sender is shown is the one the relay applied ──────────────
+
+test('the relay clamps a too-long link to the tier, and says so in the response', async (t) => {
+  if (!dlRc) return t.skip('no redis');
+  const token = await dlMint();
+  const b = dlSealed('clamp');
+  // The account is community: tiers.js gives it a 1 hour link. Ask for a week.
+  const up = await dlSrv.post('/v2/inbound', {
+    headers: { Authorization: `Bearer ${token}` },
+    body: { hash: b.hash, payload: b.payload.toString('base64'), ttl_ms: 604_800_000 },
+  });
+  assert.equal(up.status, 200);
+  assert.equal(up.json.ttl_ms, tiers.tierLimit('community', 'view_ttl_ms'),
+    'the upload no longer clamps to the tier ceiling, or no longer reports the value it applied; the expiry the sender shows a receiver would then be a number the relay never agreed to');
+  dlDid();
+});
+
+// ── 4. The chooser sentence comes off tiers.js ───────────────────────────────
+
+test('the plan API serves the per-plan link lifetimes the chooser prints', async (t) => {
+  if (!dlRc) return t.skip('no redis');
+  const r = await dlSrv.get('/v2/check-key', { headers: { 'X-Api-Key': DL_OWNER } });
+  assert.equal(r.status, 200);
+  assert.equal(r.json.valid, true);
+  assert.equal(r.json.link_ttl_ms, tiers.tierLimit('community', 'view_ttl_ms'),
+    'GET /v2/check-key no longer reports the link lifetime this key is really held to');
+  for (const plan of ['community', 'pro', 'business', 'enterprise']) {
+    assert.equal(r.json.link_ttl_ms_by_plan[plan], tiers.tierLimit(plan, 'view_ttl_ms'),
+      `GET /v2/check-key reports a ${plan} link lifetime that is not the tiers.js row; the /parashare chooser prints these numbers and would print a stale one`);
+  }
+  // The three the chooser names out loud, so a tier edit that changes what the
+  // sentence should say fails here and not in front of a buyer.
+  assert.equal(r.json.link_ttl_ms_by_plan.community, 3_600_000, 'the chooser says "1 hour on Community"');
+  assert.equal(r.json.link_ttl_ms_by_plan.pro, 86_400_000, 'the chooser says "24 hours on Pro"');
+  assert.equal(r.json.link_ttl_ms_by_plan.business, 604_800_000, 'the chooser says "7 days on Business"');
+  dlDid();
+});

--- a/relay/test/route-session-token.test.js
+++ b/relay/test/route-session-token.test.js
@@ -94,6 +94,28 @@ async function mint(key = OWNER, server = srv, purpose = undefined) {
 }
 const bearer = (token) => ({ Authorization: `Bearer ${token}` });
 
+// What GET /v2/check-key answers for a community owner, in full. The two
+// assertions below compare the WHOLE object on purpose: this route is reached
+// with a fifteen-minute browser credential, and the point of pinning the shape
+// is that a future field cannot quietly become a way to read the account
+// through a token that was minted to upload a file.
+//
+// The link-lifetime fields joined it when /parashare grew the "Send a link"
+// stand, which has to say how long a sealed file waits per plan BEFORE a file
+// is picked. They are the tiers.js view_ttl_ms rows and nothing else: the same
+// numbers the pricing page prints to anyone, tied to no account and to no
+// identity. `link_ttl_ms` is the one number that IS about this key, and it is
+// the same ceiling POST /v2/inbound would clamp its upload to, so it tells a
+// holder nothing the next request would not.
+const CHECK_KEY_COMMUNITY = {
+  valid: true,
+  plan: 'community',
+  link_ttl_ms: 3_600_000,
+  link_ttl_ms_by_plan: {
+    community: 3_600_000, pro: 86_400_000, business: 604_800_000, enterprise: 604_800_000,
+  },
+};
+
 // A fresh blob every time: the store is keyed on the sha256 and rejects a
 // repeat with 409.
 function blob(label) {
@@ -168,8 +190,8 @@ test('a token authenticates as the owner on all five ParaSend routes', async (t)
   // reported valid:false and the page would have refused its own credential.
   const ck = await srv.get('/v2/check-key', { headers: h });
   assert.strictEqual(ck.status, 200);
-  assert.deepStrictEqual(ck.json, { valid: true, plan: 'community' },
-    'a token must report the owner as valid, with the owner plan');
+  assert.deepStrictEqual(ck.json, CHECK_KEY_COMMUNITY,
+    'a token must report the owner as valid, with the owner plan, and nothing about the account beyond that');
 
   const ticket = await srv.post('/v2/ws-ticket', { headers: h });
   assert.strictEqual(ticket.status, 200, ticket.text);
@@ -535,7 +557,7 @@ test('THE STORE HOLDS NO KEY: a leak of redis is a leak of hashes', async (t) =>
   // rather than merely safe: the relay looks the hash up in the api-key table
   // it already has in memory.
   const ck = await srv.get('/v2/check-key', { headers: bearer(token) });
-  assert.deepStrictEqual(ck.json, { valid: true, plan: 'community' },
+  assert.deepStrictEqual(ck.json, CHECK_KEY_COMMUNITY,
     'hashing the record must not cost the relay the ability to resolve it');
   did();
 });

--- a/tests/parasend-send-a-link.test.mjs
+++ b/tests/parasend-send-a-link.test.mjs
@@ -1,0 +1,232 @@
+// parasend-send-a-link.test.mjs: the asynchronous stand on /parashare, driven
+// in a real browser from the chooser to the receiver's saved file.
+//
+// WHY THIS SUITE EXISTS. The ParaSend web app was a live handshake and nothing
+// else: both sides online, a short code compared out loud, then the file moves.
+// An administratiekantoor that wants to mail a payslip to somebody who is not
+// at a desk right now cannot use that, and said so. The "Send a link" stand is
+// the answer, and it is a chain of five things that each have to hold or the
+// feature is a link that does not open:
+//
+//   1. the chooser really switches the page to the other stand
+//   2. the file is sealed IN THE BROWSER, so what reaches /v2/inbound is
+//      ciphertext and the key is not in the request at all
+//   3. the link carries the key after the '#', where no server sees it
+//   4. /get takes that link, with no account, and gives the file back BYTE FOR
+//      BYTE. This is the assertion that would catch a wire-format drift
+//      between the sender and the receiver, which is the failure that turns a
+//      shipped link in somebody's mailbox into a permanent error page
+//   5. opening it a second time fails, and says why
+//
+// Everything the relay would do is stubbed at the network edge, so this suite
+// is about the two browser halves agreeing with each other. That the relay
+// really burns a token on the second fetch is the other half of the pair, and
+// it is measured against a real relay in relay/test/route-dl-share-link.test.js.
+//
+// Run: node tests/parasend-send-a-link.test.mjs
+//      (PLAYWRIGHT_CHROMIUM_PATH=... to pick a browser)
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = { '.js': 'text/javascript', '.css': 'text/css', '.html': 'text/html', '.svg': 'image/svg+xml', '.png': 'image/png', '.woff2': 'font/woff2', '.wasm': 'application/wasm', '.json': 'application/json' };
+const aliases = { '/': '/index.html', '/parashare': '/parashare.html', '/get': '/get.html' };
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://localhost');
+  const rel = aliases[url.pathname] || url.pathname;
+  const file = path.join(ROOT, rel);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end('no'); }
+  fs.readFile(file, (err, buf) => {
+    if (err) { res.writeHead(404); return res.end('not found'); }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(buf);
+  });
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const ORIGIN = `http://localhost:${server.address().port}`;
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+
+const checks = [];
+function ok(name, condition, detail = '') { checks.push({ name, pass: !!condition, detail: String(detail) }); }
+
+// The file the office is sending. Deliberately not text: a payslip is a PDF,
+// and a byte-for-byte comparison of arbitrary bytes is what catches an encoding
+// bug that a string round-trip would hide.
+const PAYLOAD_BYTES = Array.from({ length: 777 }, (_, i) => (i * 37 + 11) % 256);
+const FILE_NAME = 'loonstrook-2026-09.bin';
+const TTL_MS = 3_600_000;
+const DL_TOKEN = 'a'.repeat(48);
+
+// What the stubbed relay was handed. The whole point of half the assertions
+// below is what is NOT in here.
+let uploaded = null;
+
+async function stubRelay(page) {
+  // Broad first, specific after: Playwright tries the LAST registered handler
+  // first, so registering the catch-all second would swallow the token mint and
+  // the page would sit on "Account session could not be started" forever.
+  await page.route('**/api/user/**', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }));
+  await page.route('**/api/user/parasend/token', (route) => route.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ token: 'pst_' + 'b'.repeat(64), expires_in_s: 900 }),
+  }));
+  // Only the health sector answers, which is also how the page picks a sector.
+  for (const host of ['legal', 'finance', 'iot']) {
+    await page.route(`https://${host}.paramant.app/**`, (route) => route.abort());
+  }
+  await page.route('https://health.paramant.app/v2/check-key', (route) => route.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({
+      valid: true, plan: 'pro', link_ttl_ms: 86400000,
+      link_ttl_ms_by_plan: { community: 3600000, pro: 86400000, business: 604800000, enterprise: 604800000 },
+    }),
+  }));
+  await page.route('https://health.paramant.app/v2/inbound', async (route) => {
+    uploaded = JSON.parse(route.request().postData() || '{}');
+    await route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ ok: true, hash: uploaded.hash, ttl_ms: TTL_MS, size: 0, download_token: DL_TOKEN }),
+    });
+  });
+  await page.route('https://health.paramant.app/v2/dl/**', (route) => route.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ ok: true, enc_meta: null, file_size: 0, ttl_left_s: 3600, used: false }),
+  }));
+}
+
+// ── The sender ───────────────────────────────────────────────────────────────
+const sender = await browser.newPage();
+await stubRelay(sender);
+await sender.goto(`${ORIGIN}/parashare`, { waitUntil: 'domcontentloaded' });
+
+// The chooser is on the page before anything is picked, which is the whole
+// complaint this feature answers: the buyer must not have to reach step 2 to
+// find out which stands exist.
+ok('the chooser offers both stands above step 1',
+  await sender.locator('#ps-mode-live').isVisible() && await sender.locator('#ps-mode-link').isVisible());
+ok('the live stand is the one selected on arrival',
+  await sender.locator('#ps-mode-live').getAttribute('aria-checked') === 'true');
+
+// The times in the Send-a-link sentence come from the plan API, not from the
+// markup. The stub answered with the tiers.js rows; the page must have written
+// them in. A page that still shows the plan-free fallback sentence here is a
+// page that would show a stale hour after a tier change.
+await sender.waitForFunction(() => /Community/.test(document.getElementById('ps-mode-link-ttl').textContent), null, { timeout: 15000 });
+const ttlSentence = await sender.locator('#ps-mode-link-ttl').textContent();
+ok('the chooser names the per-plan link lifetimes from the plan API',
+  /1 hour on Community/.test(ttlSentence) && /24 hours on Pro/.test(ttlSentence) && /7 days on Business/.test(ttlSentence),
+  ttlSentence);
+ok('the chooser says the file is wiped after the first download',
+  /wiped after the first download/.test(ttlSentence), ttlSentence);
+// No hour written into the markup a visitor sees. Developer comments are
+// stripped first: this checks the page, not the file, and the comment above the
+// chooser explains the rule by quoting it.
+const markup = fs.readFileSync(path.join(ROOT, 'parashare.html'), 'utf8').replace(/<!--[\s\S]*?-->/g, ' ');
+ok('no per-plan link lifetime is hardcoded in the chooser markup',
+  !/on Community/.test(markup) && !/on Pro/.test(markup) && !/on Business/.test(markup),
+  'the times must come from tiers.js through the plan API, never from the page');
+
+await sender.locator('#ps-mode-link').click();
+ok('choosing Send a link switches the stand',
+  await sender.locator('#ps-mode-link').getAttribute('aria-checked') === 'true'
+  && await sender.locator('#ps-mode-live').getAttribute('aria-checked') === 'false');
+ok('the live-handshake promise is withdrawn on the Send-a-link stand',
+  /does not have to be online/.test(await sender.locator('#ps-live-note').textContent()));
+ok('the live stepper is hidden on the Send-a-link stand',
+  !(await sender.locator('#ps-stepper').isVisible()));
+
+await sender.locator('#file-input').setInputFiles({
+  name: FILE_NAME, mimeType: 'application/octet-stream', buffer: Buffer.from(PAYLOAD_BYTES),
+});
+await sender.waitForFunction(() => !document.getElementById('btn-create-session').disabled, null, { timeout: 15000 });
+await sender.locator('#btn-create-session').click();
+await sender.waitForSelector('#step-link.active', { timeout: 30000 });
+
+// What the relay was handed. It is base64, it is not the file, and there is no
+// key anywhere in the request body.
+ok('the upload carries a payload and a hash', !!uploaded && !!uploaded.payload && /^[a-f0-9]{64}$/.test(uploaded.hash || ''));
+const sentBytes = Buffer.from(uploaded.payload, 'base64');
+ok('what reached the relay is not the file',
+  Buffer.compare(sentBytes.subarray(0, PAYLOAD_BYTES.length), Buffer.from(PAYLOAD_BYTES)) !== 0,
+  'the bytes on the wire equal the plaintext, so nothing was encrypted');
+ok('the file name never reaches the relay',
+  !JSON.stringify(uploaded).includes(FILE_NAME),
+  'the name is inside the sealed bytes and must not be in the request');
+ok('no key material is in the request body',
+  !('key' in uploaded) && !('iv' in uploaded) && !JSON.stringify(uploaded.meta || {}).includes('key'));
+
+const shownLink = (await sender.locator('#ps-link-list .ps-link-url').first().textContent()).trim();
+ok('the link points at /get with the token', shownLink.includes('/get?t=' + DL_TOKEN), shownLink);
+ok('the link names the relay sector', /[?&]r=health/.test(shownLink), shownLink);
+const fragment = shownLink.split('#')[1] || '';
+ok('the key travels in the URL fragment', fragment.length >= 58 && !shownLink.split('#')[0].includes(fragment),
+  'fragment: ' + fragment.slice(0, 12) + '...');
+ok('the fragment is unpadded base64url', /^[A-Za-z0-9_-]+$/.test(fragment), fragment.slice(0, 12));
+
+const metaText = (await sender.locator('#ps-link-list .ps-link-meta').first().textContent()).replace(/\s+/g, ' ');
+// One date format for the whole site (#424): a month written out, a year, and a
+// named zone. A slashed date here is the exact ambiguity that rule exists for.
+ok('the expiry is written in the one site date format',
+  /Expires \d{1,2} (January|February|March|April|May|June|July|August|September|October|November|December) \d{4}, \d{2}:\d{2} UTC/.test(metaText),
+  metaText);
+ok('the row warns the link works once', /Works once/.test(metaText), metaText);
+ok('the row starts out waiting for the receiver', /Waiting for the receiver/.test(metaText), metaText);
+ok('the page says there is no signed receipt for this path',
+  /no signed delivery receipt/i.test(await sender.locator('#ps-link-receipt-note').textContent()));
+ok('a copy button sits on the row', await sender.locator('#ps-link-list button[data-click="copySentLink"]').first().isVisible());
+
+// ── The receiver ─────────────────────────────────────────────────────────────
+// A different browser context: no account, no session, nothing carried over
+// from the sender but the link itself.
+const receiverCtx = await browser.newContext({ acceptDownloads: true });
+const receiver = await receiverCtx.newPage();
+let dlServed = 0;
+await receiver.route('https://health.paramant.app/v2/dl/**/get', async (route) => {
+  dlServed++;
+  if (dlServed > 1) {
+    return route.fulfill({ status: 410, contentType: 'text/html', body: '<h1>burned</h1>' });
+  }
+  await route.fulfill({ status: 200, contentType: 'application/octet-stream', body: sentBytes });
+});
+
+const receiveUrl = ORIGIN + shownLink.slice(shownLink.indexOf('/get'));
+const downloadPromise = receiver.waitForEvent('download', { timeout: 30000 });
+await receiver.goto(receiveUrl, { waitUntil: 'domcontentloaded' });
+const download = await downloadPromise;
+const saved = path.join(process.env.TMPDIR || '/tmp', 'parasend-link-' + process.pid + '.bin');
+await download.saveAs(saved);
+const back = fs.readFileSync(saved);
+fs.unlinkSync(saved);
+
+ok('the receiver needs no account: the link opens straight onto the file', dlServed === 1);
+ok('the saved file has the sender\'s name back', download.suggestedFilename() === FILE_NAME, download.suggestedFilename());
+ok('the file comes back byte for byte', Buffer.compare(back, Buffer.from(PAYLOAD_BYTES)) === 0,
+  `got ${back.length} bytes, sent ${PAYLOAD_BYTES.length}`);
+
+await receiver.waitForSelector('#step-done.active', { timeout: 15000 });
+ok('the receiver is told the relay copy is gone',
+  /permanently destroyed/i.test(await receiver.locator('#step-done .sub').textContent()));
+
+// ── The second open ──────────────────────────────────────────────────────────
+const second = await receiverCtx.newPage();
+await second.route('https://health.paramant.app/v2/dl/**/get', (route) =>
+  route.fulfill({ status: 410, contentType: 'text/html', body: '<h1>burned</h1>' }));
+await second.goto(receiveUrl, { waitUntil: 'domcontentloaded' });
+await second.waitForSelector('#step-burned.active', { timeout: 15000 });
+const burned = (await second.locator('#step-burned').textContent()).replace(/\s+/g, ' ');
+ok('a second open says the file has already been downloaded and burned',
+  /already been downloaded and burned/i.test(burned), burned.slice(0, 120));
+ok('a second open says why: the links are single-use',
+  /single-use/i.test(burned), burned.slice(0, 200));
+
+for (const check of checks) console.log(`${check.pass ? 'PASS' : 'FAIL'} ${check.name}${check.detail ? ' :: ' + check.detail : ''}`);
+await browser.close();
+server.close();
+server.closeAllConnections();
+if (checks.some((c) => !c.pass)) process.exit(1);
+console.log(`\nparasend-send-a-link: ${checks.length} checks passed`);

--- a/tests/site-claims.test.mjs
+++ b/tests/site-claims.test.mjs
@@ -2442,8 +2442,24 @@ test('the two legal facts are stated with their limits, and never as a promise',
 // Verified by sabotage: take the WebSocket out of parashare.page.js, or take
 // the download-token mint out of relay.js, and the sentence stops being true in
 // one half or the other; this block names which.
+//
+// AMENDED once the web app grew the asynchronous stand. The tail used to read
+// "needs the API or the SDK", which was true when it was written and became a
+// false discouragement the moment /parashare shipped a "Send a link" mode: the
+// office that refused ParaSend for exactly this reason would have read a page
+// telling it to go and write code for something two clicks away. The tail now
+// names the third route, and a THIRD half is pinned below, because a sentence
+// that sends a buyer to a mode in the web app is only honest while that mode
+// exists and really is asynchronous:
+//
+//   the web app can send a link  -> parashare.html offers the stand, and
+//                                   parashare.page.js seals the file, uploads it
+//                                   to /v2/inbound and puts the key in the URL
+//                                   fragment, with no peer anywhere in the flow
+//   the receiver needs no account -> /get reads that fragment and spends the
+//                                   one-time download token
 test('the pages before the button say the ParaSend web app is a live handshake, and say what is not', () => {
-  const SENTENCE = 'In the web app you and the receiver are both online and compare a short code, and the file is handed over live. Sending to someone who is not online right now needs the API or the SDK.';
+  const SENTENCE = 'In the web app you and the receiver are both online and compare a short code, and the file is handed over live. Sending to someone who is not online right now needs the API, the SDK, or the Send a link mode in the web app.';
 
   // Half one. The web app really does need the other side present, and really
   // does compare a code before anything moves.
@@ -2475,6 +2491,29 @@ test('the pages before the button say the ParaSend web app is a live handshake, 
     'the sentence sends a buyer to "the SDK"; the repository must still name one');
   assert.match(read('frontend/docs.html'), /\/v2\/inbound/,
     '/docs no longer documents the endpoint the sentence sends an asynchronous sender to');
+
+  // Half three. The web app really does have the asynchronous stand the tail now
+  // names, and it really is asynchronous: no socket, no code to compare, no
+  // second browser awake. Pinned against code rather than against the copy,
+  // because the copy is what this block exists to distrust.
+  assert.match(read('frontend/parashare.html'), /data-click="chooseModeLink"/,
+    '/parashare no longer offers the "Send a link" stand that the three pages send a buyer to');
+  assert.ok(visible(read('frontend/parashare.html')).includes('Send a link'),
+    '/parashare must name the stand in the same words the three pages use, or the buyer arrives and cannot find it');
+  assert.match(share, /function createLink\(/,
+    'the "Send a link" stand has no flow behind it; the tail of the sentence promises one');
+  assert.match(share, /\/v2\/inbound/,
+    'the "Send a link" stand no longer uploads to the relay, so there is nothing for a later receiver to fetch');
+  assert.match(share, /'\/get\?t='/,
+    'the link the stand hands out no longer points at /get; the receiving half of the sentence is unreachable');
+  assert.match(share, /'#' \+ row\.key/,
+    'the key no longer travels in the URL fragment; move it into the query and the relay would see it, and "we cannot open it" becomes false');
+  // And the page that opens that link needs no account and spends the token.
+  const getSrc = stripJsComments(read('frontend/js/get.page.js'));
+  assert.match(getSrc, /location\.hash/,
+    '/get no longer reads the key out of the fragment, so a link minted by the web app cannot be opened');
+  assert.match(getSrc, /'\/v2\/dl\/' \+ token \+ '\/get'/,
+    '/get no longer spends the one-time download token; nothing burns and "works once" has no mechanism behind it');
 
   // The three pages. Same sentence on all three: the site says this one way, as
   // it does with the read counts above.

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -1889,6 +1889,25 @@ console.log('ui-truthfulness: the appearance switch says only what theme.js and 
 
   assert.match(parashare, /The person you send to has to be online while you send; you confirm a short code together\./,
     '/parashare must say above step 1 that the receiver has to be there; a sender should not discover a live handshake on step 2');
+
+  // The sentence above became a sentence about ONE of two stands the moment
+  // /parashare grew "Send a link", so it may only be shown while that stand is
+  // chosen. Three things have to hold together or the page starts lying in one
+  // direction or the other: the chooser exists and offers both, the live
+  // sentence is the DEFAULT (the live stand is the one selected on arrival, so
+  // a sender who chooses nothing reads the promise that is true of what he is
+  // about to do), and the sentence is really swapped when the other stand is
+  // picked rather than left standing over a flow it does not describe.
+  // Sabotage: delete either mode card, flip aria-checked to the link card, or
+  // take the swap out of setSendMode, and this goes red.
+  assert.match(parashare, /id="ps-mode-live"[^>]*aria-checked="true"/,
+    'the live stand must be the one selected on arrival: it is the stand the sentence above step 1 describes');
+  assert.match(parashare, /id="ps-mode-link"[^>]*aria-checked="false"/,
+    'the "Send a link" stand must not be pre-selected while the live sentence stands above step 1');
+  assert.match(psJs, /note\.textContent = \(sendMode === 'link'\)/,
+    'setSendMode no longer swaps the live-handshake sentence; choosing "Send a link" would leave a promise on screen that that stand does not keep');
+  assert.match(psJs, /does not have to be online/,
+    'the "Send a link" stand must say the receiver does not have to be online; that is the whole reason it exists');
   // Above step 1 means above it, not somewhere on the page: the sentence has to
   // sit before the step-1 guide inside #step-setup.
   const setupAt = parashare.indexOf('id="step-setup"');


### PR DESCRIPTION
An administratiekantoor read the site, wanted to mail a payslip to a client who is not at a desk right now, and left. The ParaSend web app was a live handshake and nothing else: both sides online, a short code compared out loud, then the file moves. The three pages before the button said so honestly and then sent that buyer to the API or the SDK, which for a three-person office is the same as no.

The relay could already do it. `POST /v2/inbound` parks a sealed blob against a TTL and mints a one-time download token, `GET /v2/dl/<token>/get` serves it once and burns it, and `/get` has read a key out of the URL fragment since it was written but had nothing minting links for it. What was missing was the two clicks in between.

## What the stand does

`/parashare` now opens on a choice:

| Stand | What it says |
|---|---|
| Hand over live | Both of you are online, you compare a code, and nothing is ever stored. |
| Send a link | The receiver opens it later. The sealed file waits on our server for up to 1 hour on Community, 24 hours on Pro and 7 days on Business, and a link from this web app is wiped after the first download. |

Those hours are **not in the markup**. They are the `tiers.js` `view_ttl_ms` rows, served by `GET /v2/check-key` beside the plan it already reported, so a tier change moves the sentence and a stale hour cannot ship. The static HTML names no time at all until the plan API answers.

Picking "Send a link" seals the file in the browser under a fresh AES-256-GCM key, uploads the ciphertext to `/v2/inbound` on the `pst_` session token, and puts the key after the `#`, where no browser ever puts it on the wire. The wire is the one `/get` already reads, byte for byte, so the receiving half needed no new page: `[uint32-LE nameLen][name][file bytes]`, fragment `base64url(key32 then iv12)`. The relay never sees the key and never sees the file name.

## The token scope did not have to grow

`POST /v2/inbound` was already one of the five routes a `pst_` token opens (`relay/lib/session-token.js`), and `/v2/dl/<token>/info` takes no credential at all, so the sent-links list reads it with no `Authorization` header rather than widening a fifteen-minute credential onto a route that does not want it.

## What this does not claim

There is no signed delivery receipt on this path. The relay signs one for `GET /v2/outbound`; the `/v2/dl` family signs nothing. So the sent-links list says what `/v2/dl/<token>/info` says plus the page's own clock (a 404 before the recorded expiry is a download, after it is a timeout), the note under the list calls that an inference, and `docs/api.md` says the same to an integrator.

## Also here

- `/get` honours `&r=<sector>`. It always asked `health`, which is right for most accounts and silently wrong for the rest: a legal or finance sender's receiver got a 404 and was told the file had burned.
- The stand walks its own `#step-sealing`, so `ui-truthfulness` keeps its invariant that exactly one path reaches `#step-encrypting`, which is what makes "the receiver has to be online" true of the live stand.
- `docs/api.md` documents `/v2/dl/<token>` end to end: upload, token, link with fragment, the TTL clamp, the three routes, what burns and when, and why there is no receipt.
- The tail on `/`, `/parasend` and `/pricing` now reads "the API, the SDK, or the Send a link mode in the web app". `site-claims` block 38 follows, with a third half that pins the stand against code rather than against the copy.

## Tests

- `tests/parasend-send-a-link.test.mjs` (new, Playwright, API stubbed): 27 checks. Chooser switches the stand, the per-plan times come from the plan API and are absent from the markup, the file is sealed, the request carries no key and no file name, the link carries the token and the sector and the key in the fragment, the expiry is in the one site date format, `/get` opens it with no account and gives the file back **byte for byte**, and a second open lands on the burned page with the single-use sentence.
- `relay/test/route-dl-share-link.test.js` (new, real relay + redis): 5 checks. A `pst_` token uploads and gets a download token, the link serves once and answers 410 after, `/info` needs no credential, a TTL under the ceiling is honoured as asked and one over it is clamped and reported, and the per-plan lifetimes match `tiers.js` row for row.
- `relay/test/route-session-token.test.js`: the two `deepStrictEqual` shape pins on `/v2/check-key` now name the new fields, with a note on why they are not an account leak.

Green: site-claims (40), ui-truthfulness, navigation-shell (55), frontend-loading-contract, frontend-module-scripts, seo-contract, links, date-format-visible, static-sanity, check-cache-bust, check-csp-inline, eslint, relay units (376), relay routes (141). `tests/heartbeat-lib.test.mjs` fails on `origin/main` untouched and is unrelated.
