### PR TITLE
CT log: publish the entry index from its position, and repair the stored field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- **The public CT log listing numbers its entries by position again.** On the
+  live log at `/v2/ct/log` five entries reported the indices 4 to 8 a second
+  time while 42 to 46 were missing: they sat at positions 42 to 46 and had kept
+  the stored index field from before an April rebuild moved them. Only the
+  listing was affected. The Merkle root, the inclusion proofs and the signed
+  tree head all verify, and `/v2/ct/proof?index=42` returned the entry at
+  position 42 the whole time, because those address the log by position. The
+  listing, the `/ct/feed` tail and the relay registry rebuild now derive the
+  index from the position too, so the stored field is no longer read on any
+  path that hands an index out. On startup the relay recounts a persisted log
+  once, logs a single line naming how many entries were wrong, and writes the
+  corrected field back through a temp file and a rename. The recount touches
+  nothing but that field: line order and leaf hashes are left alone, so the
+  Merkle root is byte-identical before and after, which
+  `relay/test/route-ct-log-index.test.js` recomputes from the file to prove.
+  A second boot finds nothing to do.
 - **No redis call in the relay or the admin panel can hang any more.** node-redis
   holds commands on an offline queue while it reconnects, and it never times a
   command out, so against a store that is gone a route neither succeeded nor

--- a/docs/api.md
+++ b/docs/api.md
@@ -447,6 +447,10 @@ curl "https://relay.paramant.app/v2/ct/log?limit=20"
 # {"ok":true,"entries":[{…}],"tree_size":43,"root":"c7a9…"}
 ```
 
+`index` is the entry's position in the log, counted from the start. It is
+derived at request time, so it always matches the index `/v2/ct/proof` resolves
+and the leaf position the Merkle tree commits to.
+
 ---
 
 ### GET /v2/ct/proof — Inclusion proof for a specific index

--- a/frontend/docs/api.md
+++ b/frontend/docs/api.md
@@ -380,6 +380,10 @@ curl "https://relay.paramant.app/v2/ct/log?limit=20"
 # {"ok":true,"entries":[{…}],"tree_size":43,"root":"c7a9…"}
 ```
 
+`index` is the entry's position in the log, counted from the start. It is
+derived at request time, so it always matches the index `/v2/ct/proof` resolves
+and the leaf position the Merkle tree commits to.
+
 ---
 
 ### GET /v2/ct/proof — Inclusion proof for a specific index

--- a/frontend/js/ct-log.page.js
+++ b/frontend/js/ct-log.page.js
@@ -86,6 +86,9 @@ function render() {
 
   document.getElementById('entries').innerHTML = slice.map(function(e, i) {
     var gi  = start + i;
+    // e.index comes straight from /v2/ct/log, which derives it from the
+    // entry's position in the log, so it is the same number /v2/ct/proof takes.
+    // The fallback is for a relay too old to send the field at all.
     var idx = e.index !== undefined ? e.index : (filtered.length - 1 - gi);
     var ts  = e.ts;
     var time = ts

--- a/relay/lib/ct-window.js
+++ b/relay/lib/ct-window.js
@@ -13,6 +13,17 @@
 //   - window position : 0..windowLength-1, where the Merkle tree/proof live.
 // An entry whose logical index has aged out of the window returns null on
 // lookup (honestly "pruned") instead of a wrong or duplicate-indexed entry.
+//
+// POSITION IS THE AUTHORITY (2026-09). An entry also carries a stored .index
+// field, written once at append time and persisted with the entry. That field
+// is a cache, not a source of truth: a rebuild or migration of the persisted
+// log can leave it stale while order and leaf_hashes are perfectly fine, which
+// is exactly what happened on the public log (five entries at positions 42..46
+// carried indices 4..8, so the listing showed duplicates while /v2/ct/proof,
+// which resolves by position, kept answering correctly). Every read path that
+// hands an index out therefore derives it from the position -- page(),
+// recentPage() and logicalIndexAt() exist for that -- and reindex() /
+// reindexEntries() repair the stored field so the two can no longer diverge.
 class CtWindow {
   constructor(max) {
     this.max = max;
@@ -35,6 +46,10 @@ class CtWindow {
     const p = logicalIndex - this.base;
     return (p >= 0 && p < this.entries.length) ? p : -1;
   }
+
+  // The logical index of the entry at window position `p`. This, not the
+  // stored .index field, is what a caller must publish for an entry.
+  logicalIndexAt(position) { return this.base + position; }
 
   // Retrieve an entry by its logical index, or null if pruned/absent.
   get(logicalIndex) {
@@ -63,8 +78,29 @@ class CtWindow {
     return this.entries.slice(start, start + count);
   }
 
+  // sliceByIndex plus the logical index the first returned entry actually sits
+  // at, so a listing can number its rows `start_index + i` instead of trusting
+  // the stored .index field. `from` below base clamps to base, so start_index
+  // is what the caller got, not what it asked for.
+  page(fromLogical, count) {
+    const start = Math.max(0, fromLogical - this.base);
+    return { start_index: this.base + start, entries: this.entries.slice(start, start + count) };
+  }
+
   // The most recent `n` entries (for the /ct feed).
   recent(n) { return this.entries.slice(-n); }
+
+  // recent(n) with the logical index of its first entry, same reason as page().
+  recentPage(n) {
+    const start = Math.max(0, this.entries.length - n);
+    return { start_index: this.base + start, entries: this.entries.slice(start) };
+  }
+
+  // One-shot repair of the retained window: force every stored .index back to
+  // its position (base + p). Returns how many were wrong. Order, leaf_hash and
+  // tree_hash are never touched, so the Merkle root over the window is
+  // byte-identical before and after. Idempotent: a second call returns 0.
+  reindex() { return reindexEntries(this.entries); }
 
   // Rehydrate from a persisted list (oldest first). Each entry carries its own
   // monotonic .index; base is taken from the first retained entry. Trims to the
@@ -77,4 +113,25 @@ class CtWindow {
   }
 }
 
-module.exports = { CtWindow };
+// Recount a persisted, oldest-first entry list in place so every entry's stored
+// .index equals its position relative to the first entry's index. The first
+// entry is the anchor by definition: nothing else on disk says where a rotated
+// or trimmed file starts, so its own index is taken at face value (0 when it
+// has none). Returns the number of entries whose field was wrong. Only .index
+// is written; order and leaf_hashes are left alone, which is what keeps the
+// Merkle root identical. Idempotent.
+function reindexEntries(list) {
+  if (!Array.isArray(list) || list.length === 0) return 0;
+  const first = list[0];
+  const anchor = first && Number.isInteger(first.index) ? first.index : 0;
+  let fixed = 0;
+  for (let p = 0; p < list.length; p++) {
+    const entry = list[p];
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const want = anchor + p;
+    if (entry.index !== want) { entry.index = want; fixed++; }
+  }
+  return fixed;
+}
+
+module.exports = { CtWindow, reindexEntries };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -353,7 +353,7 @@ const CT_MAX = 10000;
 // Bounded, monotonically-indexed window (see lib/ct-window). Past CT_MAX the
 // logical index keeps advancing (no duplicates / frozen STH) and lookups for a
 // pruned index return null instead of the wrong entry.
-const { CtWindow } = require('./lib/ct-window');
+const { CtWindow, reindexEntries } = require('./lib/ct-window');
 const ctWindow = new CtWindow(CT_MAX);
 const CT_FILE     = process.env.CT_FILE     || null; // opt-in only — auto-derive disabled to preserve RAM-only default
 const CT_MAX_SIZE = parseInt(process.env.CT_MAX_SIZE || String(100 * 1024 * 1024)); // 100 MB default
@@ -424,6 +424,28 @@ if (CT_FILE) {
           loaded.push(parsed);
         }
       } catch {}
+    }
+    // One-shot, idempotent recount of the stored index field (2026-09). The
+    // public log had five entries whose persisted .index was stale after an
+    // April rebuild: positions 42..46 carried indices 4..8, so /v2/ct/log
+    // listed duplicates while /v2/ct/proof, which resolves by position, was
+    // right all along. The index of an entry IS its position, so recount from
+    // position here, before the window is built, and persist the correction so
+    // the next boot finds nothing to do. Only the index field is rewritten:
+    // the line order and every leaf_hash stay exactly as they were, which is
+    // what keeps the Merkle root byte-identical. One log line per log.
+    const ctFixed = reindexEntries(loaded);
+    if (ctFixed > 0) {
+      log('info', 'ct_log_reindexed', { fixed: ctFixed, entries: loaded.length, file: CT_FILE });
+      // Write to a sibling temp file and rename over the original, so a crash
+      // mid-write leaves the old log intact rather than a half-written one.
+      try {
+        const tmp = CT_FILE + '.reindex.tmp';
+        fs.writeFileSync(tmp, loaded.map(e => JSON.stringify(e) + '\n').join(''));
+        fs.renameSync(tmp, CT_FILE);
+      } catch (e) {
+        log('warn', 'ct_log_reindex_write_failed', { err: e.message, file: CT_FILE });
+      }
     }
     ctWindow.load(loaded);
     if (ctWindow.windowLength) log('info', 'ct_log_loaded', { entries: ctWindow.windowLength, file: CT_FILE });
@@ -531,21 +553,28 @@ const relayRegistry = new Map();
 const MAX_RELAY_REGISTRY = parseInt(process.env.MAX_RELAY_REGISTRY || '10000');
 
 function relayRegistryFromCTLog() {
-  for (const entry of ctWindow.entries) {
+  // ct_index is taken from the window position, not from the entry's stored
+  // index field: this runs over entries rehydrated from disk, and that field
+  // is the one a rebuild can leave stale. The startup recount above already
+  // repairs it, but reading position keeps this correct even when the log is
+  // fed from somewhere the recount did not touch.
+  for (let p = 0; p < ctWindow.entries.length; p++) {
+    const entry = ctWindow.entries[p];
     if (entry.type !== 'relay_reg') continue;
     const key = entry.relay_pk_hash;
     if (!key) continue;
+    const ctIndex = ctWindow.logicalIndexAt(p);
     const existing = relayRegistry.get(key);
     if (!existing) {
       relayRegistry.set(key, {
         url: entry.relay_url, sector: entry.relay_sector,
         version: entry.relay_version, edition: entry.relay_edition || 'community',
         pk_hash: key, verified_since: entry.ts, last_seen: entry.ts,
-        ct_index: entry.index, last_ct_index: entry.index
+        ct_index: ctIndex, last_ct_index: ctIndex
       });
     } else {
       existing.last_seen    = entry.ts;
-      existing.last_ct_index = entry.index;
+      existing.last_ct_index = ctIndex;
       existing.version      = entry.relay_version;
       existing.edition      = entry.relay_edition || existing.edition;
     }
@@ -588,6 +617,12 @@ function canonicalJSON(obj) {
   return '{' + Object.keys(obj).sort().map(k => JSON.stringify(k) + ':' + canonicalJSON(obj[k])).join(',') + '}';
 }
 
+// Every ctAppend* below takes its index from ctWindow.nextIndex(), which is
+// base + window length: the position the new leaf is about to occupy. The
+// value is stored on the entry as a convenience for the response it goes into,
+// and CtWindow.append() rejects an entry whose index is not nextIndex(), so a
+// freshly appended entry can never disagree with its position. Read paths that
+// serve entries back out do not rely on that field regardless; see /v2/ct/log.
 function ctAppend(deviceId, pubKeyHex, apiKey) {
   const ts = new Date().toISOString();
   const deviceIdHash = crypto.createHash('sha3-256').update(deviceId + apiKey.slice(0,8)).digest('hex');
@@ -4439,7 +4474,9 @@ async function handleRelayRequest(req, res) {
 
   // ── GET /ct/feed — public JSON feed for CT log UI (no auth, no keys) ─────────
   if (path === '/ct/feed' && req.method === 'GET') {
-    const last50 = ctWindow.recent(50);
+    // `i` comes from the window position (start_index + i), never from the
+    // entry's stored index field. See /v2/ct/log below.
+    const last50 = ctWindow.recentPage(50);
     const root   = ctWindow.last() ? ctWindow.last().tree_hash : '0'.repeat(64);
     res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' });
     return res.end(J({
@@ -4448,8 +4485,8 @@ async function handleRelayRequest(req, res) {
       version:  VERSION,
       tree_size: ctWindow.size,
       root,
-      entries: last50.map(e => ({
-        i:    e.index,
+      entries: last50.entries.map((e, i) => ({
+        i:    last50.start_index + i,
         t:    e.ts,
         h:    e.leaf_hash ? e.leaf_hash.slice(0, 16) + '...' : null,
         type: e.type || 'key_reg',
@@ -4470,7 +4507,14 @@ async function handleRelayRequest(req, res) {
     // across sector relays. The transparency guarantee does NOT depend on it:
     // tamper-evidence comes from leaf_hash + tree_hash + the Merkle proof
     // (/v2/ct/proof) + the signed tree head, none of which reveal identity.
-    const entries = ctWindow.sliceByIndex(from, limit).map(e => ({ index: e.index, type: e.type, leaf_hash: e.leaf_hash, tree_hash: e.tree_hash, ts: ctCoarseTs(e.ts) }));
+    // The published index is the entry's POSITION in the log (start_index + i),
+    // never the index field stored with the entry. Those two agreed until an
+    // April rebuild left five entries with a stale field, and the listing then
+    // reported indices 4..8 twice while the entries really sat at 42..46. The
+    // Merkle tree, /v2/ct/proof and the STH were all correct throughout,
+    // because they address the log by position; only this projection lied.
+    const pageR = ctWindow.page(from, limit);
+    const entries = pageR.entries.map((e, i) => ({ index: pageR.start_index + i, type: e.type, leaf_hash: e.leaf_hash, tree_hash: e.tree_hash, ts: ctCoarseTs(e.ts) }));
     res.writeHead(200, { 'Content-Type': 'application/json' });
     return res.end(J({ ok: true, size: ctWindow.size, root: ctWindow.last() ? ctWindow.last().tree_hash : '0'.repeat(64), entries }));
   }
@@ -4478,6 +4522,9 @@ async function handleRelayRequest(req, res) {
   const ctpq0 = (!ctpm0 && path === '/v2/ct/proof') ? query.index : null;
   if (ctpm0 || (ctpq0 !== null && ctpq0 !== undefined)) {
     const idx = parseInt(ctpm0 ? ctpm0[1] : ctpq0);
+    // Positional by construction: get() resolves idx - base into the window, so
+    // this route never consulted the stored index field and was already right
+    // while the listing was wrong. The echoed `index` is the requested one.
     const entry = ctWindow.get(idx);
     if (!entry) { res.writeHead(404); return res.end(J({ error: 'Index not found' })); }
     res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/relay/test/ct-window.test.js
+++ b/relay/test/ct-window.test.js
@@ -5,7 +5,7 @@
 // first shift. Run: node relay/test/ct-window.test.js
 const assert = require('assert');
 const crypto = require('crypto');
-const { CtWindow } = require('../lib/ct-window');
+const { CtWindow, reindexEntries } = require('../lib/ct-window');
 const { ctTreeHash, ctInclusionProof, ctNodeHash } = require('../lib/ct-hash');
 
 let passed = 0;
@@ -129,6 +129,102 @@ function fill(w, n) {
   assert.strictEqual(w.get(24).leaf_hash, last.leaf_hash);
   assert.strictEqual(w.get(10), null, 'a pruned index is gone, not misresolved');
   ok('integration: inclusion proof validates for a fresh entry past the cap');
+}
+
+// ── the stored index field is a cache, the position is the truth ────────────
+// Reproduces the public-log defect of 2026-09: five entries whose persisted
+// .index survived an April rebuild unchanged while their position had moved,
+// so the listing showed indices 4..8 twice and 42..46 not at all.
+function poisoned(n) {
+  const list = [];
+  for (let i = 0; i < n; i++) list.push({ index: i, leaf_hash: 'leaf' + i, type: 't' });
+  for (let p = 42; p <= 46; p++) list[p].index = p - 38;   // 42..46 -> 4..8
+  return list;
+}
+
+{
+  const w = new CtWindow(1000);
+  w.load(poisoned(60));
+  // page() numbers rows from the position, so the poisoned field is bypassed.
+  const pg = w.page(40, 8);
+  assert.strictEqual(pg.start_index, 40);
+  assert.deepStrictEqual(pg.entries.map((e, i) => pg.start_index + i), [40,41,42,43,44,45,46,47]);
+  assert.deepStrictEqual(pg.entries.map(e => e.leaf_hash),
+    ['leaf40','leaf41','leaf42','leaf43','leaf44','leaf45','leaf46','leaf47'],
+    'position 42 still carries the leaf that was appended 43rd');
+  // The stored field is still wrong at this point; that is the whole point.
+  assert.strictEqual(pg.entries[2].index, 4, 'stored field is stale, and unused');
+  ok('page() numbers entries from position, not from the stored index field');
+}
+
+{
+  const w = new CtWindow(1000);
+  w.load(poisoned(60));
+  const feed = w.recentPage(10);
+  assert.strictEqual(feed.start_index, 50);
+  assert.deepStrictEqual(feed.entries.map((e, i) => feed.start_index + i),
+    [50,51,52,53,54,55,56,57,58,59]);
+  assert.strictEqual(w.logicalIndexAt(42), 42);
+  ok('recentPage() and logicalIndexAt() are positional too');
+}
+
+// ── the repair: idempotent, and the Merkle root does not move ───────────────
+{
+  const w = new CtWindow(1000);
+  w.load(poisoned(60));
+  const rootBefore = ctTreeHash(w.entries);
+  const leavesBefore = w.entries.map(e => e.leaf_hash);
+  const proofBefore = ctInclusionProof(w.entries, 42);
+
+  assert.strictEqual(w.reindex(), 5, 'exactly the five poisoned entries are corrected');
+  assert.deepStrictEqual(w.entries.map(e => e.index), w.entries.map((_, p) => p),
+    'every stored index now equals its position');
+  assert.strictEqual(w.reindex(), 0, 'idempotent: a second pass finds nothing');
+
+  assert.deepStrictEqual(w.entries.map(e => e.leaf_hash), leavesBefore, 'no leaf moved');
+  assert.strictEqual(ctTreeHash(w.entries), rootBefore, 'root is byte-identical after the repair');
+  assert.deepStrictEqual(ctInclusionProof(w.entries, 42), proofBefore, 'audit path is unchanged');
+  // And lookups that were already positional keep answering the same entry.
+  assert.strictEqual(w.get(42).leaf_hash, 'leaf42');
+  ok('reindex() repairs the field, is idempotent, and leaves the root untouched');
+}
+
+// ── reindexEntries on the persisted list, including the rotated case ────────
+{
+  const list = poisoned(60);
+  const rootBefore = ctTreeHash(list);
+  assert.strictEqual(reindexEntries(list), 5);
+  assert.strictEqual(reindexEntries(list), 0);
+  assert.strictEqual(ctTreeHash(list), rootBefore, 'root unchanged over the persisted list');
+
+  // A rotated file does not start at 0. The first entry is the anchor, so the
+  // recount must continue from it rather than renumber the whole file from 0.
+  const rotated = [{ index: 900, leaf_hash: 'a' }, { index: 7, leaf_hash: 'b' }, { index: 902, leaf_hash: 'c' }];
+  assert.strictEqual(reindexEntries(rotated), 1);
+  assert.deepStrictEqual(rotated.map(e => e.index), [900, 901, 902]);
+
+  // No index field at all (a very old line) counts as wrong and gets one.
+  const legacy = [{ leaf_hash: 'a' }, { leaf_hash: 'b' }];
+  assert.strictEqual(reindexEntries(legacy), 2);
+  assert.deepStrictEqual(legacy.map(e => e.index), [0, 1]);
+
+  assert.strictEqual(reindexEntries([]), 0);
+  assert.strictEqual(reindexEntries(null), 0);
+  ok('reindexEntries anchors on the first entry, handles rotated and legacy lines');
+}
+
+// ── load() of a repaired list keeps appending monotonically ────────────────
+{
+  const list = poisoned(60);
+  reindexEntries(list);
+  const w = new CtWindow(1000);
+  w.load(list);
+  assert.strictEqual(w.base, 0);
+  assert.strictEqual(w.nextIndex(), 60);
+  const index = w.nextIndex();
+  w.append({ index, leaf_hash: 'leaf60' });
+  assert.strictEqual(w.get(60).leaf_hash, 'leaf60');
+  ok('a repaired log rehydrates and keeps appending without a gap');
 }
 
 console.log(`\n${passed} passed`);

--- a/relay/test/route-ct-log-index.test.js
+++ b/relay/test/route-ct-log-index.test.js
@@ -1,0 +1,195 @@
+'use strict';
+// The public CT log listing must number its entries by POSITION, and the relay
+// must repair a persisted log whose stored index field says otherwise.
+//
+// WHY THIS SUITE EXISTS. On 2026-09-04 the live log at /v2/ct/log served 4720
+// entries whose Merkle root, inclusion proofs and signed tree head all verified
+// against relay/lib/ct-hash.js, while the listing reported the indices 4..8
+// twice and 42..46 not at all: five entries kept an index field from before an
+// April rebuild moved them. Nothing about the tree was wrong, because the tree
+// is addressed by position. Only the projection that read the stored field was.
+// So the listing lied about where an entry sat while /v2/ct/proof?index=42
+// happily returned the entry at position 42, which is the worst possible split
+// for a transparency log: two endpoints of the same server disagreeing about
+// what "index" means.
+//
+// Two things are asserted here, on a really booted relay.js reading a really
+// poisoned CT_FILE:
+//   1. the listing and the feed number rows from the position regardless of
+//      what the stored field says;
+//   2. the startup recount rewrites that field back to the position, is a
+//      no-op on the next boot, and leaves the Merkle root byte-identical -
+//      recomputed here from the file's own leaf hashes, not taken on trust.
+// Run: node --test relay/test/route-ct-log-index.test.js
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { boot, killAll } = require('./_relay-server');
+const { ctTreeHash, ctInclusionProof, ctNodeHash } = require('../lib/ct-hash');
+
+const N = 60;              // entries in the fixture log
+const BAD_FROM = 42;       // the five poisoned positions, as seen in production
+const BAD_TO = 46;
+const BAD_SHIFT = 38;      // position 42 stored 4, 43 stored 5, and so on
+
+let dir;
+let checks = 0;
+const did = () => { checks++; };
+
+// A CT log the relay will accept on load: oldest first, one JSON object per
+// line, each with the leaf_hash and tree_hash a real append would have written.
+// The index field of positions 42..46 is then poisoned exactly the way the
+// production log was, and nothing else is touched.
+function writeFixture(file) {
+  const entries = [];
+  for (let i = 0; i < N; i++) {
+    const leaf_hash = crypto.createHash('sha3-256').update('ct-fixture-leaf-' + i).digest('hex');
+    const soFar = [...entries, { leaf_hash }];
+    entries.push({
+      index: i,
+      type: 'key_reg',
+      leaf_hash,
+      tree_hash: ctTreeHash(soFar),
+      ts: new Date(Date.UTC(2026, 3, 14, 19, 0, 0) + i * 1000).toISOString(),
+      proof: ctInclusionProof(soFar, soFar.length - 1),
+    });
+  }
+  for (let p = BAD_FROM; p <= BAD_TO; p++) entries[p].index = p - BAD_SHIFT;
+  fs.writeFileSync(file, entries.map((e) => JSON.stringify(e) + '\n').join(''));
+  return entries;
+}
+
+const readLog = (file) =>
+  fs.readFileSync(file, 'utf8').split('\n').filter((l) => l.trim()).map((l) => JSON.parse(l));
+
+const rootFromProof = (leaf, pathSteps) =>
+  (pathSteps || []).reduce(
+    (r, step) => (step.position === 'right' ? ctNodeHash(r, step.hash) : ctNodeHash(step.hash, r)),
+    leaf);
+
+before(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ctindex-')); });
+after(async () => {
+  await killAll();
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) { /* gone */ }
+  assert.ok(checks >= 4, `expected at least 4 checks, ran ${checks}`);
+});
+
+test('a poisoned CT log is served, repaired and re-served by position', async (t) => {
+  const file = path.join(dir, 'ct-log.jsonl');
+  const written = writeFixture(file);
+  const truthLeaves = written.map((e) => e.leaf_hash);
+  const truthRoot = ctTreeHash(written);
+
+  // The fixture really is broken before the relay ever sees it.
+  assert.deepStrictEqual(
+    written.slice(BAD_FROM, BAD_TO + 1).map((e) => e.index), [4, 5, 6, 7, 8],
+    'fixture reproduces the production defect');
+
+  const srv = await boot({ tag: 'ctindex', dir, env: { CT_FILE: file } });
+
+  await t.test('the listing numbers entries by position, not by the stored field', async () => {
+    const r = await srv.get('/v2/ct/log?from=0&limit=1000');
+    assert.strictEqual(r.status, 200);
+    assert.strictEqual(r.json.size, N, 'the whole fixture was loaded');
+    const idxs = r.json.entries.map((e) => e.index);
+    assert.deepStrictEqual(idxs, written.map((_, i) => i),
+      'indices 0..59 exactly once each, no duplicate 4..8, no missing 42..46');
+    assert.strictEqual(new Set(idxs).size, N, 'no duplicates at all');
+    assert.deepStrictEqual(r.json.entries.map((e) => e.leaf_hash), truthLeaves,
+      'the row labelled n still carries the leaf that was appended n-th');
+    did();
+  });
+
+  await t.test('a page not starting at zero is numbered from where it starts', async () => {
+    const r = await srv.get('/v2/ct/log?from=40&limit=8');
+    assert.strictEqual(r.status, 200);
+    assert.deepStrictEqual(r.json.entries.map((e) => e.index), [40, 41, 42, 43, 44, 45, 46, 47]);
+    assert.strictEqual(r.json.entries[2].leaf_hash, truthLeaves[42],
+      'row 42 is the entry at position 42, which is what /v2/ct/proof already returned');
+    // The feed is the same projection over the tail.
+    const feed = await srv.get('/ct/feed');
+    assert.strictEqual(feed.status, 200);
+    const feedIdx = feed.json.entries.map((e) => e.i);
+    assert.deepStrictEqual(feedIdx, feedIdx.map((_, i) => N - feedIdx.length + i),
+      'the feed numbers its tail from position too');
+    did();
+  });
+
+  await t.test('listing and proof agree, and the proof still verifies', async () => {
+    for (const i of [0, 41, 42, 44, 46, 59]) {
+      const p = await srv.get('/v2/ct/proof?index=' + i);
+      assert.strictEqual(p.status, 200, `proof for index ${i}`);
+      assert.strictEqual(p.json.index, i);
+      assert.strictEqual(p.json.leaf_hash, truthLeaves[i],
+        `proof at ${i} resolves the same entry the listing labels ${i}`);
+      assert.strictEqual(rootFromProof(p.json.leaf_hash, p.json.proof), p.json.tree_hash,
+        `audit path at ${i} recomputes its own tree root`);
+    }
+    // The indices the poisoned field claimed must NOT resolve to those entries.
+    const stale = await srv.get('/v2/ct/proof?index=4');
+    assert.strictEqual(stale.json.leaf_hash, truthLeaves[4],
+      'index 4 is the fourth entry, not the one that wrongly stored a 4');
+    did();
+  });
+
+  await t.test('the recount rewrote the stored field and left the root alone', async () => {
+    const after1 = readLog(file);
+    assert.strictEqual(after1.length, N, 'no line was added or dropped');
+    assert.deepStrictEqual(after1.map((e) => e.index), written.map((_, i) => i),
+      'the persisted index field now equals the position everywhere');
+    assert.deepStrictEqual(after1.map((e) => e.leaf_hash), truthLeaves,
+      'not one leaf hash moved or changed');
+    assert.strictEqual(ctTreeHash(after1), truthRoot,
+      'the Merkle root over the repaired log is byte-identical');
+    assert.deepStrictEqual(after1.map((e) => e.tree_hash), written.map((e) => e.tree_hash),
+      'the per-entry tree_hash column is untouched');
+    assert.deepStrictEqual(after1.map((e) => e.proof), written.map((e) => e.proof),
+      'the stored audit paths are untouched');
+    assert.match(srv.log(), /"msg":"ct_log_reindexed"[^\n]*"fixed":5/,
+      'one line per log, naming how many entries were wrong');
+    did();
+  });
+
+  await t.test('a second boot on the repaired log is a no-op', async () => {
+    const before2 = readLog(file);
+    const srv2 = await srv.restart();
+    const r = await srv2.get('/v2/ct/log?from=0&limit=1000');
+    assert.deepStrictEqual(r.json.entries.map((e) => e.index), written.map((_, i) => i));
+    assert.deepStrictEqual(readLog(file), before2, 'the file was not rewritten again');
+    assert.ok(!/"msg":"ct_log_reindexed"/.test(srv2.log()),
+      'idempotent: the second boot finds nothing to correct and says nothing');
+    assert.strictEqual(ctTreeHash(readLog(file)), truthRoot, 'root still identical');
+    await srv2.stop();
+    did();
+  });
+});
+
+test('a clean CT log boots without being rewritten', async () => {
+  const dir2 = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ctclean-'));
+  try {
+    const file = path.join(dir2, 'ct-log.jsonl');
+    const entries = [];
+    for (let i = 0; i < 12; i++) {
+      const leaf_hash = crypto.createHash('sha3-256').update('clean-' + i).digest('hex');
+      const soFar = [...entries, { leaf_hash }];
+      entries.push({ index: i, type: 'key_reg', leaf_hash, tree_hash: ctTreeHash(soFar), ts: '2026-04-14T19:00:00.000Z' });
+    }
+    fs.writeFileSync(file, entries.map((e) => JSON.stringify(e) + '\n').join(''));
+    const raw = fs.readFileSync(file, 'utf8');
+
+    const srv = await boot({ tag: 'ctclean', dir: dir2, env: { CT_FILE: file } });
+    const r = await srv.get('/v2/ct/log?from=0&limit=100');
+    assert.deepStrictEqual(r.json.entries.map((e) => e.index), entries.map((_, i) => i));
+    assert.ok(!/"msg":"ct_log_reindexed"/.test(srv.log()), 'nothing to repair, nothing logged');
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), raw, 'the file was left byte-for-byte alone');
+    assert.ok(!fs.existsSync(file + '.reindex.tmp'), 'no temp file left behind');
+    await srv.stop();
+    did();
+  } finally {
+    try { fs.rmSync(dir2, { recursive: true, force: true }); } catch (_) { /* gone */ }
+  }
+});


### PR DESCRIPTION
## What was wrong

`https://health.paramant.app/v2/ct/log` serves 4720 entries. The Merkle root and
the inclusion proofs recompute correctly against `relay/lib/ct-hash.js`, and the
signed tree head verifies with the relay key. The listing, however, reported the
indices 4 to 8 twice and 42 to 46 not at all: the five entries at positions 42
to 46 (ts 2026-04-14T19:00Z) still carried the index field they were written
with before an April rebuild or migration moved them.

Only the listing lied. `/v2/ct/proof?index=42` returned the entry at position 42
the whole time, because that route resolves `idx - base` into the window. So two
endpoints of the same transparency log disagreed about what "index" means, and
the one an auditor reads first was the wrong one.

## Where the stored field was being read

| Place | Before | Now |
| --- | --- | --- |
| `GET /v2/ct/log` (`relay.js`) | `sliceByIndex(...).map(e => ({ index: e.index }))` | `CtWindow.page()` returns `start_index`; rows are numbered `start_index + i` |
| `GET /ct/feed` (`relay.js`) | `recent(50).map(e => ({ i: e.index }))` | `CtWindow.recentPage()`, same `start_index + i` |
| `relayRegistryFromCTLog()` (`relay.js`) | `ct_index: entry.index` over entries rehydrated from disk | `ctWindow.logicalIndexAt(p)` |
| `GET /v2/ct/proof` (`relay.js`) | already positional (`ctWindow.get(idx)`), echoes the requested index | unchanged, comment added |
| `POST /v2/verify-receipt` (`relay.js`) | never reads an index: it rebinds the leaf with `blobLeafHash` and re-walks `audit_path` | unchanged |
| `ctAppend*` (`relay.js`) | `index = ctWindow.nextIndex()`, which is the position the new leaf takes, and `CtWindow.append()` throws if it is not | unchanged, contract documented |
| `.psign` notary `ct_log_index` (`relay/parasign.js`) | signed into the envelope at mint time from a fresh `ctEntry.index` | unchanged; the repair never touches envelopes |
| CT log page (`frontend/js/ct-log.page.js`) | displays and searches `e.index` from the listing | unchanged; correct once the server sends the position, comment added |
| `relay/lib/ct-hash.js` | pure hashing, no index anywhere | unchanged |

## The repair

The log is persisted as JSONL at `CT_FILE` (no redis path exists for it). On
startup, after the lines are parsed and before the window is built,
`reindexEntries()` walks the list and forces every stored `index` to
`anchor + position`, where the anchor is the first entry's own index so a
rotated file that does not start at 0 keeps its offset. If anything was wrong it
logs one line, `ct_log_reindexed` with the count, and writes the list back
through `CT_FILE.reindex.tmp` plus a rename, so a crash mid-write leaves the old
log intact.

Only the index field is written. Line order, `leaf_hash`, `tree_hash` and the
stored audit paths are untouched, which is what keeps the Merkle root
byte-identical. The test recomputes the root from the file itself before and
after rather than taking that on trust. A second boot finds nothing and rewrites
nothing.

## Tests

- `relay/test/ct-window.test.js` (13 checks): `page`, `recentPage` and
  `logicalIndexAt` ignore a poisoned field; `reindex` corrects exactly the five
  entries, is idempotent, and leaves `ctTreeHash` and `ctInclusionProof(42)`
  identical; `reindexEntries` handles the rotated and the no-index-at-all cases;
  a repaired log rehydrates and keeps appending without a gap.
- `relay/test/route-ct-log-index.test.js` (new, 7 checks): boots a real
  `relay.js` on a 60 entry log poisoned exactly the way production was. Asserts
  the listing returns 0..59 once each, that a page starting at 40 is numbered
  from 40, that the feed numbers its tail from position, that the listing and
  `/v2/ct/proof` resolve the same entry for 0, 41, 42, 44, 46 and 59 and every
  audit path recomputes its own root, that the file on disk is repaired with the
  root unchanged, and that a restart is a no-op. A second case proves a clean
  log is left byte-for-byte alone with no temp file behind.

Run locally:

- `node --test relay/test/route-*.test.js relay/test/ct-window.test.js relay/test/ct-receipt.test.js` with redis on 6399: 149 passed, 0 failed.
- `node --test` over the remaining `relay/test/*.test.js`: 392 passed, 0 failed.
- `bash tests/static-sanity.sh`: PASS.
- `npx eslint` on every changed file: clean.

## Not changed, worth knowing

- The rotated `CT_FILE.1` is not recounted. It is never served or loaded, so a
  stale field in there cannot reach a client.
- `tree_size: ctEntry.index + 1` on the transfer receipts (`relay.js` around the
  inbound handlers) assumes the window has never wrapped. It holds today
  (`CT_MAX` is 10000, the live log is at 4720) and diverges only past the cap,
  where the audit path is built over the window while `index` keeps advancing.
  Left alone here to keep the receipt payload untouched; it is a separate fix.
- The anchor problem has no on-disk answer: if the very first retained entry's
  index were itself wrong, nothing in the file says so. Documented in
  `reindexEntries`.
