### PR TITLE
A PDF ends on the same screen as everything else, and both sides read one handshake field

### DIFF
--- a/frontend/get.html
+++ b/frontend/get.html
@@ -37,11 +37,16 @@
 *{box-sizing:border-box;margin:0;padding:0}
 body{background:var(--bone);color:var(--ink);font-family:var(--sans);min-height:100vh}
 main{max-width:520px;margin:0 auto;padding:80px 24px}
-main:has(#step-preview.active){max-width:880px}
-#preview-canvas-list canvas{width:100%;height:auto;display:block;border:1px solid var(--ink-hair);margin-bottom:12px;background:var(--card)}
-.page-wrap{position:relative;margin-bottom:12px}
-.btn-row{display:flex;gap:10px;flex-wrap:wrap}
-.btn-row .btn{flex:1;margin:0}
+/* The PDF, inside the end screen's payload slot. Capped and scrollable on
+   purpose: the answer ("you have it, here it is, save it") has to stay on one
+   phone screen, and a document is as long as it is. */
+.done-preview{max-height:min(40vh,460px);overflow-y:auto;border:1px solid var(--ink-hair);border-radius:10px;padding:8px;background:var(--bone-2,var(--bone))}
+/* A page is paper. PDF.js paints its own white ground into the bitmap; this
+   puts the same ground on the element, so a canvas that is sized but not yet
+   drawn does not flash the dark app background through the document. */
+.done-preview canvas{width:100%;height:auto;display:block;border:1px solid var(--ink-hair);background:#ffffff}
+.done-preview .page-wrap{position:relative;margin-bottom:8px}
+.done-preview .page-wrap:last-child{margin-bottom:0}
 h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 .sub{font-size:13px;color:var(--ink-dim);margin-bottom:32px;line-height:1.7}
 .step{display:none;animation:fadeIn .2s ease}
@@ -59,8 +64,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 .status-line{font-family:var(--mono);font-size:11px;color:var(--ink-dim);padding:2px 0;line-height:1.7}
 .status-line.ok{color:var(--cobalt)}
 .status-line.err{color:rgba(196, 96, 79, 1)}
-.file-name{font-family:var(--mono);font-size:15px;font-weight:700;color:var(--navy);margin:8px 0 4px;word-break:break-all}
-.file-size{font-family:var(--mono);font-size:11px;color:var(--ink-dim)}
 .burned-icon{font-size:36px;margin-bottom:16px;display:block;text-align:center}
 .burned-msg{font-size:14px;color:var(--ink);text-align:center;line-height:1.7;margin-bottom:8px}
 .burned-sub{font-size:11px;color:var(--ink-dim);text-align:center;line-height:1.7}
@@ -68,8 +71,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 .btn:hover{opacity:.85}
 .btn-outline{background:transparent;color:var(--ink);border:1px solid var(--ink-hair)}
 .btn-outline:hover{color:var(--cobalt);border-color:var(--cobalt)}
-.tag{display:inline-block;font-family:var(--mono);font-size:10px;padding:3px 8px;border:1px solid var(--ink-hair);color:var(--ink-dim);margin-right:4px;margin-top:4px}
-.tag.green{border-color:var(--cobalt);color:var(--cobalt)}
 @media(max-width:640px){main{padding:48px 16px}h1{font-size:19px}}
 </style>
 <style>
@@ -217,39 +218,12 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
       <summary>What made this safe</summary>
       <div class="done-details-body">
         <p>The unlocking happened here, in your browser. The file arrived sealed and was opened with the key that sat in the link after the <code>#</code>, which is the part of a link a browser never sends to a server (<code>AES-256-GCM</code>).</p>
-        <p>A link from this web app opens once. Now that this download has finished, the copy on our side is wiped and the link will not open a second time.</p>
+        <p>A link from this web app opens once. The copy on our side was wiped as your browser took it, so the link will not open a second time.</p>
         <p>The file name travelled inside the sealed bytes rather than beside them, so it was never something we could read either.</p>
+        <p id="done-pdf-note" hidden>The pages above were drawn by this browser out of the file itself. Nothing was sent anywhere to draw them, and nothing of the document stays behind when you close this tab.</p>
       </div>
     </details>
   </div>
-</div>
-
-<!-- PDF preview (rendered in-browser, no auto-download) -->
-<div class="step" id="step-preview">
-  <h1>Document received</h1>
-  <p class="sub">Decrypted in your browser. The relay copy has been permanently destroyed.</p>
-
-  <div class="card">
-    <div class="card-head"><div class="dot"></div><div class="card-head-title">PDF preview</div></div>
-    <div class="card-body">
-      <div class="file-name" id="preview-filename"></div>
-      <div class="file-size"><span id="preview-pagecount"></span> &middot; <span id="preview-filesize"></span></div>
-    </div>
-  </div>
-
-  <div id="preview-canvas-list" style="margin:16px 0"></div>
-
-  <div style="margin-bottom:24px">
-    <span class="tag green">Decrypted locally</span>
-    <span class="tag green">Relay copy burned</span>
-    <span class="tag green">Rendered in browser</span>
-  </div>
-
-  <div class="btn-row" id="preview-actions">
-    <a class="btn" href="/sign">Sign this document</a>
-    <button class="btn btn-outline" id="preview-download" type="button">Download original PDF</button>
-  </div>
-  <a href="/dashboard" class="btn btn-outline" style="margin-top:12px">Open your dashboard</a>
 </div>
 
 <!-- Burned / already used -->
@@ -307,6 +281,6 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/done-state.js?v=1" defer></script>
-<script src="/js/get.page.js?v=3" defer></script>
+<script src="/js/get.page.js?v=4" defer></script>
 </body>
 </html>

--- a/frontend/js/get.page.js
+++ b/frontend/js/get.page.js
@@ -65,15 +65,24 @@ async function waitForPdfjs() {
   return window.ready.within('pdfjs', 10000, 'PDF.js');
 }
 
-async function renderPdfPreview(bytes, name) {
+// A PDF is the one arrival that has something worth putting on the end screen:
+// the document itself. So it goes in the payload slot of the shared done state
+// (see frontend/done-state.css) rather than on a fifth screen of its own with
+// its own headline, its own card and its own row of badges, which is what this
+// page had until 4 September 2026.
+//
+// Returns the element to hand to paramantDone.payload(), plus the page count
+// for the one sentence above it.
+async function renderPdfPreview(bytes) {
   const pdfjs = await waitForPdfjs();
   // PDF.js mutates the input buffer. Pass a copy so the original stays intact
-  // for the download-original path.
+  // for the save path.
   const copy = new Uint8Array(bytes);
   const pdf = await pdfjs.getDocument({ data: copy, disableAutoFetch: true, disableStream: true }).promise;
 
-  const container = document.getElementById('preview-canvas-list');
-  container.innerHTML = '';
+  const container = document.createElement('div');
+  container.className = 'done-preview';
+  container.id = 'preview-canvas-list';
   const MAX_PAGES = Math.min(pdf.numPages, 30);
   for (let i = 1; i <= MAX_PAGES; i++) {
     const page = await pdf.getPage(i);
@@ -84,7 +93,6 @@ async function renderPdfPreview(bytes, name) {
     const wrap = document.createElement('div');
     wrap.className = 'page-wrap';
     wrap.dataset.pageIndex = String(i - 1);
-    wrap._pdfPage = { width: baseViewport.width, height: baseViewport.height, index: i - 1 };
     const canvas = document.createElement('canvas');
     canvas.width = Math.floor(viewport.width);
     canvas.height = Math.floor(viewport.height);
@@ -93,14 +101,7 @@ async function renderPdfPreview(bytes, name) {
     await page.render({ canvasContext: canvas.getContext('2d'), viewport }).promise;
   }
 
-  document.getElementById('preview-filename').textContent = name;
-  document.getElementById('preview-pagecount').textContent =
-    pdf.numPages + ' page' + (pdf.numPages === 1 ? '' : 's') +
-    (pdf.numPages > MAX_PAGES ? ' (showing first ' + MAX_PAGES + ')' : '');
-  document.getElementById('preview-filesize').textContent = formatSize(bytes.length);
-
-  const dlBtn = document.getElementById('preview-download');
-  dlBtn.onclick = () => downloadBytes(bytes, name, 'application/pdf');
+  return { node: container, pages: pdf.numPages, shown: MAX_PAGES };
 }
 
 function downloadBytes(bytes, name, mime) {
@@ -193,15 +194,36 @@ async function init() {
                   fileData[2] === 0x44 && fileData[3] === 0x46;
 
     if (isPdf) {
-      setStatus('Rendering PDF in browser...', 90);
+      setStatus('Opening the document...', 90);
       try {
-        await renderPdfPreview(fileData, filename);
+        const preview = await renderPdfPreview(fileData);
         setStatus('Done.', 100);
-        showStep('step-preview');
+        // Same heading and same shape as every other ending. The sentence says
+        // what is true of THIS branch: nothing has been written to disk yet,
+        // and the link is already spent, so saving is the one thing left to do.
+        const pageCount = preview.pages + ' page' + (preview.pages === 1 ? '' : 's') +
+          (preview.pages > preview.shown ? ', first ' + preview.shown + ' shown' : '');
+        window.paramantDone.fill('step-done', {
+          title: 'You have the file.',
+          line: filename + ' (' + pageCount + ', ' + formatSize(fileData.length) + ') is open ' +
+                'here in this tab. Our copy has been permanently destroyed, so save it now if ' +
+                'you want to keep it.',
+        });
+        window.paramantDone.payload('step-done', preview.node);
+        const note = document.getElementById('done-pdf-note');
+        if (note) note.hidden = false;
+        // One loud button, and on this branch it is the save that has not
+        // happened yet. The bytes are deliberately NOT dropped when the tab
+        // goes to the background: the document is on the screen, and a reader
+        // who comes back to it has to still be able to save it.
+        savedFile = { name: filename, bytes: fileData, mime: 'application/pdf' };
+        const saveBtn = document.getElementById('done-save');
+        if (saveBtn) saveBtn.textContent = 'Save';
+        showStep('step-done');
         return;
       } catch (e) {
-        // Fall through to download if preview fails for any reason.
-        setStatus('Preview unavailable, downloading instead...', 95);
+        // Fall through to the plain save if the document will not open.
+        setStatus('The document would not open here, saving it instead...', 95);
       }
     }
 
@@ -253,7 +275,7 @@ function dropSavedFile() {
 }
 function saveAgain() {
   if (!savedFile) return;
-  downloadBytes(savedFile.bytes, savedFile.name, 'application/octet-stream');
+  downloadBytes(savedFile.bytes, savedFile.name, savedFile.mime || 'application/octet-stream');
 }
 
 window.addEventListener('DOMContentLoaded', init);

--- a/frontend/js/handshake-meta.js
+++ b/frontend/js/handshake-meta.js
@@ -1,0 +1,101 @@
+// handshake-meta.js - one reading of the ParaSend handshake field.
+//
+// THE BUG THIS EXISTS TO KILL
+//
+// A live ParaSend hand-over ends with the sender posting a small record to
+// /v2/pubkey under the key `<session>_ready`. The relay has exactly two free
+// text fields there, `ecdh_pub` and `kyber_pub`, so the sender borrows the
+// second one to say what is coming: the file name, how many sealed blocks it
+// was cut into, and how long our copy is held.
+//
+// The two sides had drifted apart. frontend/js/parashare.page.js wrote three
+// fields:
+//
+//     IMG_4276.jpeg|1|86400000            name | chunks | ttl in ms
+//
+// and frontend/js/ontvang.page.js read two, the format from before a name was
+// ever put in there:
+//
+//     1|86400000                          chunks | ttl in ms
+//
+// So the receiver took the file name for the block count and the block count
+// for the time to live. A single-block transfer became `ttl_ms = 1`, and
+// /ontvang printed a line saying our copy had auto-expired at a clock time
+// worked out from it. The line was removed on 4 September 2026 (#427); this
+// file removes the reason it could be written.
+//
+// THE RULE
+//
+// Neither page parses the field itself any more. Both call this, so the writing
+// and the reading can only ever change together.
+//
+// THE FORMAT, and how an old sender still gets through
+//
+//   named   name|chunks|ttl        what parashare.page.js writes today
+//           vault|count|ttl        the same shape for a multi-file vault
+//   legacy  chunks|ttl             a sender minted before the name was added
+//
+// Told apart on the number of fields, not on guesswork about the contents: a
+// third field means the first one is a name. The numbers are read from the END
+// of the string rather than the start, so a file name that itself contains a
+// "|" still comes back whole and still leaves chunks and ttl in the right
+// place. A file named exactly "vault" is the one case the shape cannot settle
+// on its own, so `kind` is a hint and the caller confirms it: /ontvang treats
+// the record as a vault only when the other field really does hold a JSON list.
+'use strict';
+
+(function () {
+  if (window.paramantHandshake && window.paramantHandshake.__paramant) return;
+
+  // What a receiver falls back to when the field says nothing usable. One hour
+  // is the shortest life any plan gives a blob, so it is the safe assumption.
+  var DEFAULT_TTL_MS = 3600000;
+  var VAULT_NAME = 'vault';
+
+  function positiveInt(value, fallback) {
+    var n = parseInt(value, 10);
+    return isFinite(n) && n > 0 ? n : fallback;
+  }
+
+  // Write the field. `kind` is 'vault' for a multi-file send and 'file' for one
+  // file; a vault carries its file count where a single send carries its block
+  // count, which is what the old code did too.
+  function encode(meta) {
+    meta = meta || {};
+    var ttlMs = positiveInt(meta.ttlMs, DEFAULT_TTL_MS);
+    var chunks = positiveInt(meta.chunks, 1);
+    var name = meta.kind === 'vault' ? VAULT_NAME : String(meta.name == null ? '' : meta.name);
+    return name + '|' + chunks + '|' + ttlMs;
+  }
+
+  // Read the field. Always answers with the same four keys, whatever came in,
+  // so no caller has to check the shape before using it.
+  function decode(value) {
+    var raw = String(value == null ? '' : value);
+    var parts = raw.split('|');
+    var out = { kind: 'file', name: '', chunks: 1, ttlMs: DEFAULT_TTL_MS, format: 'unknown' };
+    if (parts.length < 2) return out;
+    out.ttlMs = positiveInt(parts[parts.length - 1], DEFAULT_TTL_MS);
+    out.chunks = positiveInt(parts[parts.length - 2], 1);
+    if (parts.length === 2) {
+      out.format = 'legacy';
+      return out;
+    }
+    out.format = 'named';
+    var name = parts.slice(0, parts.length - 2).join('|');
+    if (name === VAULT_NAME) {
+      out.kind = 'vault';
+      return out;
+    }
+    out.name = name;
+    return out;
+  }
+
+  window.paramantHandshake = {
+    __paramant: true,
+    encode: encode,
+    decode: decode,
+    VAULT_NAME: VAULT_NAME,
+    DEFAULT_TTL_MS: DEFAULT_TTL_MS,
+  };
+})();

--- a/frontend/js/ontvang.page.js
+++ b/frontend/js/ontvang.page.js
@@ -206,16 +206,26 @@ async function init() {
             if (_transferClaimed) return;
             _transferClaimed = true;
             clearInterval(pollTransfer);
-            const parts = d.kyber_pub.split('|');
-            if (parts[0] === 'vault') {
-              // Vault mode: meerdere bestanden
-              const ttl_ms = parseInt(parts[2]) || 3600000;
-              const vaultFiles = JSON.parse(d.ecdh_pub);
-              await receiveVault(vaultFiles, ttl_ms, myPrivateKey_MLKEM, myPrivateKey_ECDH_RAW);
+            // The sender wrote this field with frontend/js/handshake-meta.js and
+            // this side reads it with the same module. Reading it here by hand
+            // is what put the block count in ttl until 4 September 2026.
+            const meta = window.paramantHandshake.decode(d.kyber_pub);
+            // 'vault' is a hint from a name field, so confirm it against the
+            // thing a vault actually carries: a JSON list of files. A single
+            // file that happens to be named "vault" then still arrives.
+            let vaultFiles = null;
+            if (meta.kind === 'vault') {
+              try { vaultFiles = JSON.parse(d.ecdh_pub); } catch (_) { vaultFiles = null; }
+              if (!Array.isArray(vaultFiles)) vaultFiles = null;
+            }
+            if (vaultFiles) {
+              await receiveVault(vaultFiles, meta.ttlMs, myPrivateKey_MLKEM, myPrivateKey_ECDH_RAW);
             } else {
-              // Enkelvoudig bestand — formaat: total_chunks|ttl_ms (bestandsnaam zit alleen in encrypted payload)
-              const ttl_ms = parseInt(parts[1]) || 3600000;
-              await receiveFile({ tokens: d.ecdh_pub, file_name: 'download', total_chunks: parseInt(parts[0]) || 1, ttl_ms }, myPrivateKey_MLKEM, myPrivateKey_ECDH_RAW);
+              // The name is a courtesy from the handshake and only used until
+              // chunk 0 arrives: the real name travels inside the sealed bytes,
+              // and receiveFile() overwrites this with it.
+              await receiveFile({ tokens: d.ecdh_pub, file_name: meta.name || 'download',
+                total_chunks: meta.chunks, ttl_ms: meta.ttlMs }, myPrivateKey_MLKEM, myPrivateKey_ECDH_RAW);
             }
           }
         }

--- a/frontend/js/parashare.page.js
+++ b/frontend/js/parashare.page.js
@@ -758,9 +758,13 @@ async function confirmFingerprint() {
       body: JSON.stringify({
         device_id: sessionToken + '_ready',
         ecdh_pub: isVault ? JSON.stringify(vaultFiles) : vaultFiles[0].tokens.join(','),
+        // One writer, one reader: frontend/js/handshake-meta.js. The receiver
+        // read this field with its own split() until 4 September 2026 and was
+        // one field out of step, which is how a block count ended up in ttl.
         kyber_pub: isVault
-          ? 'vault|' + files.length + '|' + ttlMs
-          : files[0].name + '|' + vaultFiles[0].tokens.length + '|' + ttlMs
+          ? window.paramantHandshake.encode({ kind: 'vault', chunks: files.length, ttlMs: ttlMs })
+          : window.paramantHandshake.encode({ kind: 'file', name: files[0].name,
+              chunks: vaultFiles[0].tokens.length, ttlMs: ttlMs })
       })
     });
 

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -274,7 +274,8 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 <script type="module" src="/js/ontvang.inline1.js?v=2"></script>
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/done-state.js?v=1" defer></script>
-<script src="/js/ontvang.page.js?v=3" defer></script>
+<script src="/js/handshake-meta.js?v=1" defer></script>
+<script src="/js/ontvang.page.js?v=4" defer></script>
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
 </body>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -823,7 +823,8 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
      is the exact ambiguity that file exists to kill. -->
 <script src="/js/format-date.js?v=1" defer></script>
 <script src="/js/done-state.js?v=1" defer></script>
-<script src="/js/parashare.page.js?v=9" defer></script>
+<script src="/js/handshake-meta.js?v=1" defer></script>
+<script src="/js/parashare.page.js?v=10" defer></script>
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
 <footer>

--- a/tests/end-screen-calm.test.mjs
+++ b/tests/end-screen-calm.test.mjs
@@ -131,6 +131,48 @@ async function audit(page, label, sel) {
   return text;
 }
 
+// A real one-page PDF, built here rather than fetched, so the /get PDF branch is
+// driven by bytes pdf.js will actually open. The offsets in the xref table are
+// counted off the assembled body, which is what makes this a document and not
+// just a blob that starts with %PDF.
+function minimalPdf(title) {
+  const objs = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] ' +
+      '/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  const stream = `BT /F1 24 Tf 60 760 Td (${title}) Tj ET`;
+  objs.push(`<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`);
+
+  let out = '%PDF-1.4\n';
+  const offsets = [];
+  objs.forEach((body, i) => {
+    offsets.push(out.length);
+    out += `${i + 1} 0 obj\n${body}\nendobj\n`;
+  });
+  const xref = out.length;
+  out += `xref\n0 ${objs.length + 1}\n0000000000 65535 f \n`;
+  for (const o of offsets) out += String(o).padStart(10, '0') + ' 00000 n \n';
+  out += `trailer\n<< /Size ${objs.length + 1} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`;
+  return Buffer.from(out, 'latin1');
+}
+
+// Both /get endings open the same envelope, so seal it in one place:
+// [uint32-LE nameLen][name][file], AES-256-GCM, key and iv in the fragment.
+async function sealForGet(fileName, fileBytes) {
+  const nameBytes = Buffer.from(fileName, 'utf8');
+  const head = Buffer.alloc(4); head.writeUInt32LE(nameBytes.length, 0);
+  const rawKey = wc.getRandomValues(new Uint8Array(32));
+  const iv = wc.getRandomValues(new Uint8Array(12));
+  const key = await wc.subtle.importKey('raw', rawKey, { name: 'AES-GCM' }, false, ['encrypt']);
+  const ct = Buffer.from(await wc.subtle.encrypt({ name: 'AES-GCM', iv }, key,
+    Buffer.concat([head, nameBytes, Buffer.from(fileBytes)])));
+  return { ct, frag: Buffer.concat([Buffer.from(rawKey), Buffer.from(iv)]).toString('base64url') };
+}
+
+
 // ── /parashare, both stands ─────────────────────────────────────────────────
 const MERKLE = { leaf_hash: 'b'.repeat(64), leaf_index: 41, tree_size: 42,
   audit_path: ['c'.repeat(64)], root: 'd'.repeat(64), sth: { signature: 'e'.repeat(40) },
@@ -217,14 +259,7 @@ async function stubSender(page) {
 {
   const FILE_NAME = 'loonstrook-2026-09.pdf';
   const fileBytes = Buffer.from(Array.from({ length: 1777 }, (_, i) => (i * 37 + 11) % 256));
-  const nameBytes = Buffer.from(FILE_NAME, 'utf8');
-  const head = Buffer.alloc(4); head.writeUInt32LE(nameBytes.length, 0);
-  const rawKey = wc.getRandomValues(new Uint8Array(32));
-  const iv = wc.getRandomValues(new Uint8Array(12));
-  const key = await wc.subtle.importKey('raw', rawKey, { name: 'AES-GCM' }, false, ['encrypt']);
-  const ct = Buffer.from(await wc.subtle.encrypt({ name: 'AES-GCM', iv },
-    key, Buffer.concat([head, nameBytes, fileBytes])));
-  const frag = Buffer.concat([Buffer.from(rawKey), Buffer.from(iv)]).toString('base64url');
+  const { ct, frag } = await sealForGet(FILE_NAME, fileBytes);
 
   const ctx = await browser.newContext({ viewport: PHONE, acceptDownloads: true });
   const page = await ctx.newPage();
@@ -237,6 +272,49 @@ async function stubSender(page) {
   const text = await audit(page, '/get', '#step-done');
   ok('/get: it says the file is here and that our copy is gone',
     /is saved on your device/.test(text) && /permanently destroyed/.test(text), text.slice(0, 200));
+  await ctx.close();
+}
+
+// ── /get, and the file is a PDF ─────────────────────────────────────────────
+//
+// A PDF does not save itself: the page draws it and waits, because there is
+// something worth looking at. Until 4 September 2026 that meant a fifth ending
+// with a headline of its own ("Document received"), a card headed PDF PREVIEW,
+// three badges reading Decrypted locally / Relay copy burned / Rendered in
+// browser, and two buttons of equal weight. It is the same end screen as the
+// rest now, with the document itself in the payload slot.
+{
+  const FILE_NAME = 'loonstrook-2026-09.pdf';
+  const { ct, frag } = await sealForGet(FILE_NAME, minimalPdf('Loonstrook september 2026'));
+
+  const ctx = await browser.newContext({ viewport: PHONE, acceptDownloads: true });
+  const page = await ctx.newPage();
+  await page.route('https://health.paramant.app/v2/dl/**/get', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/octet-stream', body: ct }));
+  await page.goto(`${ORIGIN}/get?t=${'a'.repeat(48)}&r=health#${frag}`, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('#step-done.active', { timeout: 40000 });
+  await page.locator('#step-done .done-payload canvas').first().waitFor({ timeout: 40000 });
+  const text = await audit(page, '/get PDF', '#step-done');
+  ok('/get PDF: the fifth end screen is gone', (await page.locator('#step-preview').count()) === 0);
+  ok('/get PDF: it uses the same heading as every other arrival',
+    /You have the file\./.test(text), text.slice(0, 220));
+  ok('/get PDF: it names the document and claims no save that has not happened',
+    text.includes(FILE_NAME) && /1 page/.test(text) && /is open here in this tab/.test(text) &&
+    !/is saved on your device/.test(text), text.slice(0, 260));
+  ok('/get PDF: it says our copy is gone', /permanently destroyed/.test(text), text.slice(0, 260));
+  ok('/get PDF: the badges are gone', (await page.locator('#step-done .tag').count()) === 0);
+  ok('/get PDF: the document itself is on the screen',
+    (await page.locator('#step-done .done-payload canvas').count()) === 1);
+  ok('/get PDF: the one loud button is the save',
+    (await page.locator('#done-save').textContent()).trim() === 'Save');
+
+  // And it does what it says: the original bytes, under the original name.
+  const [saved] = await Promise.all([
+    page.waitForEvent('download', { timeout: 20000 }),
+    page.locator('#done-save').click(),
+  ]);
+  ok('/get PDF: Save hands the document over under its own name',
+    saved.suggestedFilename() === FILE_NAME, saved.suggestedFilename());
   await ctx.close();
 }
 

--- a/tests/handshake-meta.test.mjs
+++ b/tests/handshake-meta.test.mjs
@@ -1,0 +1,231 @@
+// handshake-meta.test.mjs: the sender and the receiver read one field the same way.
+//
+// WHY THIS SUITE EXISTS
+//
+// A live ParaSend hand-over is announced by posting a record to /v2/pubkey. The
+// relay has two free text fields there, and the sender borrows `kyber_pub` to
+// say what is coming. On 4 September 2026 the two sides were one field out of
+// step: frontend/js/parashare.page.js wrote `name|chunks|ttl` and
+// frontend/js/ontvang.page.js read `chunks|ttl`, so the receiver took the file
+// name for the block count and the block count for the time to live. A
+// single-block transfer arrived with `ttl_ms = 1`, and /ontvang printed a line
+// claiming our copy had auto-expired at a clock time worked out from it.
+//
+// frontend/js/handshake-meta.js is now the only place that string is written or
+// read. This suite holds three things:
+//
+//   1. Both formats decode, and they are told apart on the number of fields:
+//      three means the first one is a name, two is a sender minted before the
+//      name was added and still has to work.
+//   2. The bug itself cannot come back: a named field decoded by the shared
+//      reader gives the ttl the sender put in, not the block count.
+//   3. The real pages agree. The sender page is driven through a hand-over in a
+//      browser, the string it actually posts is captured off the wire, and the
+//      receiver page decodes that exact string. Name, chunks and ttl have to
+//      match what the sender had in hand.
+//
+// The relay is stubbed at the network edge, the same way
+// tests/end-screen-calm.test.mjs does it. No relay, no redis, no account.
+//
+// Run: node tests/handshake-meta.test.mjs
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const FRONTEND = path.join(ROOT, 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+
+const checks = [];
+function ok(name, condition, detail = '') { checks.push({ name, pass: !!condition, detail: String(detail) }); }
+function eq(name, actual, expected) {
+  ok(name, Object.is(actual, expected), `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+// ── 1. the module on its own ────────────────────────────────────────────────
+// Loaded the way the browser loads it: a plain script that hangs one object off
+// window. No import, no shim in the file itself.
+const win = {};
+new Function('window', fs.readFileSync(path.join(FRONTEND, 'js', 'handshake-meta.js'), 'utf8'))(win);
+const H = win.paramantHandshake;
+
+ok('the module hangs paramantHandshake off window', !!(H && H.encode && H.decode));
+
+{
+  const m = H.decode('IMG_4276.jpeg|1|86400000');
+  eq('named: the name comes back whole', m.name, 'IMG_4276.jpeg');
+  eq('named: chunks is the block count', m.chunks, 1);
+  eq('named: ttl is the ttl and not the block count', m.ttlMs, 86400000);
+  eq('named: it is a single file', m.kind, 'file');
+  eq('named: the format is recognised on three fields', m.format, 'named');
+}
+
+{
+  // What a sender built before the name was added still sends.
+  const m = H.decode('3|3600000');
+  eq('legacy: chunks is the first field', m.chunks, 3);
+  eq('legacy: ttl is the second field', m.ttlMs, 3600000);
+  eq('legacy: there is no name to give', m.name, '');
+  eq('legacy: the format is recognised on two fields', m.format, 'legacy');
+}
+
+{
+  const m = H.decode('vault|4|604800000');
+  eq('vault: it is recognised as a vault', m.kind, 'vault');
+  eq('vault: chunks carries the file count', m.chunks, 4);
+  eq('vault: ttl survives', m.ttlMs, 604800000);
+}
+
+{
+  // A file name is whatever the sender's disk allowed, "|" included. The
+  // numbers are read from the end of the string, so the name still comes back
+  // in one piece and still leaves chunks and ttl where they belong.
+  const m = H.decode('holiday | budget.xlsx|2|3600000');
+  eq('a name containing a pipe survives the round trip', m.name, 'holiday | budget.xlsx');
+  eq('a name containing a pipe leaves chunks alone', m.chunks, 2);
+  eq('a name containing a pipe leaves ttl alone', m.ttlMs, 3600000);
+}
+
+{
+  eq('encode writes the three-field form', H.encode({ kind: 'file', name: 'a.pdf', chunks: 2, ttlMs: 900000 }),
+    'a.pdf|2|900000');
+  eq('encode writes a vault the same way', H.encode({ kind: 'vault', chunks: 3, ttlMs: 900000 }),
+    'vault|3|900000');
+  const round = H.decode(H.encode({ kind: 'file', name: 'loonstrook-2026-09.pdf', chunks: 7, ttlMs: 86400000 }));
+  ok('encode and decode are each other\'s inverse',
+    round.name === 'loonstrook-2026-09.pdf' && round.chunks === 7 && round.ttlMs === 86400000,
+    JSON.stringify(round));
+}
+
+{
+  // Nothing usable in, something usable out. No caller has to check the shape.
+  const m = H.decode('');
+  ok('an empty field still answers with a usable record',
+    m.kind === 'file' && m.chunks === 1 && m.ttlMs === H.DEFAULT_TTL_MS, JSON.stringify(m));
+  const n = H.decode('x.pdf|not-a-number|also-not');
+  ok('unreadable numbers fall back rather than becoming NaN',
+    n.chunks === 1 && n.ttlMs === H.DEFAULT_TTL_MS, JSON.stringify(n));
+}
+
+// The bug in one line: reading the named form with the old two-field rule.
+{
+  const field = H.encode({ kind: 'file', name: 'IMG_4276.jpeg', chunks: 1, ttlMs: 86400000 });
+  const oldReading = parseInt(field.split('|')[1], 10);
+  ok('the old two-field reading of a named field is exactly the reported bug',
+    oldReading === 1 && H.decode(field).ttlMs === 86400000,
+    `old reading gave ttl=${oldReading}, shared reader gives ttl=${H.decode(field).ttlMs}`);
+}
+
+// ── 2. the two real pages, in a browser ─────────────────────────────────────
+const MIME = { '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.html': 'text/html',
+  '.svg': 'image/svg+xml', '.png': 'image/png', '.woff2': 'font/woff2', '.wasm': 'application/wasm',
+  '.json': 'application/json', '.ico': 'image/x-icon' };
+const ALIAS = { '/': '/index.html', '/parashare': '/parashare.html', '/ontvang': '/ontvang.html' };
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://localhost');
+  const rel = ALIAS[url.pathname] || url.pathname;
+  const file = path.join(FRONTEND, rel);
+  if (!file.startsWith(FRONTEND)) { res.writeHead(403); return res.end('no'); }
+  fs.readFile(file, (err, buf) => {
+    if (err) { res.writeHead(404); return res.end('not found'); }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(buf);
+  });
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const ORIGIN = `http://localhost:${server.address().port}`;
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+
+const FILE_NAME = 'IMG_4276.jpeg';
+let posted = null;                    // the kyber_pub the sender actually put on the wire
+let senderTtlMs = null;               // the ttl the sender had in hand
+
+{
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  await page.addInitScript(() => {
+    const stub = { initCrypto: async () => {}, encryptBlob: async (p) => new Uint8Array(p.length + 32),
+      decryptBlob: async () => new Uint8Array() };
+    Object.defineProperty(window, '_cryptoBridge', { get: () => stub, set: () => {}, configurable: true });
+  });
+  await page.route('**/api/user/**', (r) => r.fulfill({ status: 200, contentType: 'application/json', body: '{}' }));
+  await page.route('**/api/user/parasend/token', (r) => r.fulfill({ status: 200, contentType: 'application/json',
+    body: JSON.stringify({ token: 'pst_' + 'b'.repeat(64), expires_in_s: 900 }) }));
+  for (const host of ['legal', 'finance', 'iot']) await page.route(`https://${host}.paramant.app/**`, (r) => r.abort());
+  await page.route('https://relay.paramant.app/**', (r) => r.abort());
+  await page.route('https://health.paramant.app/v2/check-key', (r) => r.fulfill({ status: 200, contentType: 'application/json',
+    body: JSON.stringify({ valid: true, plan: 'pro', link_ttl_ms: 86400000,
+      link_ttl_ms_by_plan: { community: 3600000, pro: 86400000, business: 604800000, enterprise: 604800000 } }) }));
+  await page.route('https://health.paramant.app/v2/inbound', (r) => r.fulfill({ status: 200, contentType: 'application/json',
+    body: JSON.stringify({ ok: true, hash: 'a'.repeat(64), ttl_ms: 86400000, size: 0,
+      download_token: 'a'.repeat(48), merkle_proof: null }) }));
+  await page.route('https://health.paramant.app/v2/dl/**', (r) => r.fulfill({ status: 200, contentType: 'application/json',
+    body: JSON.stringify({ ok: true, enc_meta: null, file_size: 0, ttl_left_s: 3600, used: false }) }));
+  let receiverThere = false;
+  await page.route('https://health.paramant.app/v2/pubkey/**', (r) => receiverThere
+    ? r.fulfill({ status: 200, contentType: 'application/json',
+        body: JSON.stringify({ kyber_pub: 'ab'.repeat(64), ecdh_pub: 'cd'.repeat(32) }) })
+    : r.fulfill({ status: 404, body: '' }));
+  // The record under test. Captured rather than asserted here: what it has to
+  // agree with is the receiver, not a string in this file.
+  await page.route('https://health.paramant.app/v2/pubkey', (r) => {
+    const body = r.request().postDataJSON();
+    if (body && typeof body.device_id === 'string' && body.device_id.endsWith('_ready')) posted = body.kyber_pub;
+    return r.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+  });
+
+  await page.goto(`${ORIGIN}/parashare`, { waitUntil: 'domcontentloaded' });
+  await page.locator('#file-input').setInputFiles({ name: FILE_NAME, mimeType: 'image/jpeg',
+    buffer: Buffer.from(Array.from({ length: 2048 }, (_, i) => (i * 13 + 7) % 256)) });
+  await page.waitForFunction(() => !document.getElementById('btn-create-session').disabled, null, { timeout: 20000 });
+  await page.locator('#btn-create-session').click();
+  await page.waitForSelector('#step-waiting.active', { timeout: 20000 });
+  receiverThere = true;
+  await page.waitForFunction(() => /^[0-9A-F]{4}(-[0-9A-F]{4}){4}$/.test((document.getElementById('fp-display')?.textContent || '').trim()),
+    null, { timeout: 20000, polling: 250 });
+  senderTtlMs = parseInt(await page.locator('#ttl-select').inputValue(), 10);
+  await page.locator('#fp-confirm-check').check();
+  await page.locator('#fp-confirm-btn').click();
+  await page.waitForSelector('#step-done.active', { timeout: 40000 });
+  await page.close();
+}
+
+ok('the sender page posts a handshake field at all', typeof posted === 'string' && posted.length > 0, String(posted));
+
+{
+  // The receiver page, reading the string the sender really sent. Loading
+  // /ontvang gives us the module exactly as that page has it, cache-buster and
+  // all, rather than a copy of the file this test picked up itself.
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  await page.route('https://health.paramant.app/**', (r) => r.abort());
+  await page.route('https://relay.paramant.app/**', (r) => r.abort());
+  await page.goto(`${ORIGIN}/ontvang`, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => !!window.paramantHandshake, null, { timeout: 20000 });
+  const read = await page.evaluate((field) => window.paramantHandshake.decode(field), posted);
+
+  eq('sender and receiver agree on the file name', read.name, FILE_NAME);
+  eq('sender and receiver agree on the block count', read.chunks, 1);
+  eq('sender and receiver agree on the ttl', read.ttlMs, senderTtlMs);
+  ok('the ttl the receiver reads is not the block count',
+    read.ttlMs !== read.chunks, `ttl=${read.ttlMs} chunks=${read.chunks}`);
+
+  // And the old sender still gets through the page that ships today.
+  const legacy = await page.evaluate(() => window.paramantHandshake.decode('2|3600000'));
+  ok('the receiver page still reads a sender that sends the old two-field form',
+    legacy.chunks === 2 && legacy.ttlMs === 3600000 && legacy.format === 'legacy', JSON.stringify(legacy));
+  await page.close();
+}
+
+await browser.close();
+server.close();
+server.closeAllConnections();
+
+let failed = 0;
+for (const c of checks) {
+  console.log(`${c.pass ? 'ok  ' : 'FAIL'}  ${c.name}${c.pass || !c.detail ? '' : '  -- ' + c.detail}`);
+  if (!c.pass) failed++;
+}
+console.log(`\n${checks.length - failed}/${checks.length} checks passed`);
+if (failed) process.exit(1);

--- a/tests/parasend-session-key.test.mjs
+++ b/tests/parasend-session-key.test.mjs
@@ -118,7 +118,11 @@ function runPage({ keyResponses, sectorOk = true, relayStatus = null }) {
       querySelectorAll: () => [],
       createElement: () => makeElement('created'),
       head: { appendChild() {} },
-      body: { appendChild() {} },
+      // A real element, not a bag with appendChild on it. showStep() marks the
+      // body .ps-ended once a stand has finished, and a body without a
+      // classList made every step change throw where a browser does nothing at
+      // all. That is the harness lagging the page, not the page misbehaving.
+      body: makeElement('body'),
       addEventListener: (type, fn) => { listeners.set(type, (listeners.get(type) || []).concat(fn)); },
     },
     // Every timer resolves on the next microtask; the delay asked for is


### PR DESCRIPTION
Two things #427 left behind.

## 1. The fifth end screen on /get

Four screens got one calm ending last week. /get had a fifth one nobody counted, because it only appears when the file that arrives is a PDF: the page does not save it, it draws it, and the result landed on a screen of its own. A headline "Document received". A card headed PDF PREVIEW carrying the name, the page count and the size in three separate rows. Three badges reading `Decrypted locally`, `Relay copy burned`, `Rendered in browser`. Two buttons of equal weight, "Sign this document" and "Download original PDF", and a third below them. All of it the things the other four endings had just stopped doing.

It is the same end screen now. A document is the one arrival with something worth putting in the payload slot, so that is where it goes, capped at `40vh` and scrollable, because the answer still has to fit a phone with the fold shut.

> **You have the file.**
> `loonstrook-2026-09.pdf` (1 page, 1.7 KB) is open here in this tab. Our copy has been permanently destroyed, so save it now if you want to keep it.
>
> *[ the document ]*
>
> `[ Save ]`
> Open your dashboard
> `+ What made this safe`

The sentence is deliberately not the one the other /get branch says. Nothing has been written to disk on this path and the link is already spent, so the screen says where the file is and what is left to do, rather than "is saved on your device" for a save that has not happened. The badges are gone. The fold gains one line: the pages were drawn by this browser out of the file itself, nothing was sent anywhere to draw them.

The old screen's "Sign this document" link goes with it. This screen gets one loud button and that button is the save.

## 2. The parse fault behind the invented expiry time

A live hand-over is announced by posting a record to `/v2/pubkey`. The relay has two free text fields there, so the sender borrows `kyber_pub` to say what is coming. The two sides had drifted one field apart:

| | field | read as |
|---|---|---|
| `parashare.page.js` wrote | `IMG_4276.jpeg｜1｜86400000` | name, chunks, ttl |
| `ontvang.page.js` read | `1｜86400000` | chunks, ttl |

So the receiver took the file name for the block count and the block count for the time to live. A single-block transfer arrived with `ttl_ms = 1`, and /ontvang printed a clock time worked out from it. #427 removed the line; this removes the reason it could be written.

`frontend/js/handshake-meta.js` is the only place that string is written or read now, and both pages call it.

- **An old sender still gets through.** Three fields mean the first one is a name; two fields are the older `chunks|ttl` form and still work. Told apart on the number of fields, not on guesswork about the contents.
- **The numbers are read from the end of the string**, not the start, so a file name containing a `|` comes back whole and still leaves chunks and ttl where they belong.
- **`vault` stays a hint rather than a verdict.** /ontvang confirms it against the JSON list a vault actually carries, so a single file named `vault` now arrives instead of being torn apart.

## Proof

`tests/handshake-meta.test.mjs`, 28 checks. Both formats, the round trip, a piped file name, unreadable numbers, and the bug itself written out as a check. Then the two real pages: the sender is driven through a hand-over in a browser, the string it actually posts is captured off the wire, and the receiver page decodes that exact string. Name, chunks and ttl have to match what the sender had in hand.

`tests/end-screen-calm.test.mjs` gains the PDF branch and holds it to the same shape as the other five, on a real one-page PDF built in the test rather than a blob that starts with `%PDF`: no algorithm name outside the fold, exactly one loud button, the whole answer inside 390x844 with the fold shut, the fold closed on arrival, and `Save` handing over the original bytes under the original name. 49 checks.

Green: `end-screen-calm`, `handshake-meta`, `parasend-send-a-link`, `receive-filename`, `vault-filename`, `frontend-loading-contract`, `frontend-module-scripts`, `ui-truthfulness`, `site-claims`, `first-screen`, `navigation-shell`, `seo-contract`, `motion-safety`, `links`, `app-contrast`, `theme-contrast`, `check-csp-inline`, `check-cache-bust`, `static-sanity`, `eslint`.

## And main was red

The first CI run on this branch failed `relay - unit suite`, and so does the run on `main` at `4e0c49f0`, on the same check: `TypeError: Cannot read properties of undefined (reading 'toggle')` out of `showStep`. #427 taught `showStep` to mark the document body `.ps-ended` once a stand has finished, which is how the chooser and the stage bar leave an end screen. The vm harness in `tests/parasend-session-key.test.mjs` builds its own small DOM, and its `body` was a bag with one `appendChild` on it and no `classList`, so every step change threw where a browser does nothing at all.

Nothing is wrong with the page, so the harness gets the same element the rest of it already uses. `parasend-session-key`: 13 of 13.

Cache-busters moved with the code: `get.page.js` to `?v=4`, `ontvang.page.js` to `?v=4`, `parashare.page.js` to `?v=10`, and the new `handshake-meta.js` at `?v=1` on both pages that load it. `design-system.css` was not touched.
