### PR TITLE
The signed-in homepage opens on the work, not on three buttons

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -97,6 +97,104 @@ html[data-session="in"] .home-hero{padding-bottom:56px}
 .hp-proof{font-size:14.5px;line-height:1.5;color:var(--fg-mid);margin:10px 0 0;max-width:40ch}
 @media (min-width:900px){.hp-proof{display:none}}
 
+/* ---------- signed in: the work, not a page of buttons ----------
+   Mick read this on his phone on 4 September and got a band, his name, one
+   paragraph and three buttons over an empty screen: "I see ONLY 3 buttons, as
+   if it were a test page." The yardstick he set is BeerWeer, which opens on the
+   one reading that matters (22 degrees), draws a small object next to it, and
+   lays the rest out in quiet cards underneath.
+
+   So this hero carries the same rhythm:
+
+     one figure, large, with a small drawn object beside it
+     a hairline strip of secondary readings under it, in mono
+     a card of the requests that are still open, one row each
+     a card of the last three documents, with a way to all of them
+     one line about the plan
+     the three buttons, UNDER the work rather than instead of it
+
+   Every card holds its height whether or not it has data, so a new account gets
+   a page that looks intended rather than a page with a hole in it. The figures
+   come from the routes /dashboard already reads; js/home-auth.js fills them and
+   hides whatever did not arrive. */
+.hw{margin-top:22px;max-width:40rem}
+.hw-card{border:1px solid var(--line);border-radius:16px;background:var(--card);padding:16px 16px 18px;margin-top:16px}
+.hw-kicker{font-family:var(--hp-mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--fg-dim);margin:0;font-weight:500;display:flex;align-items:center;gap:8px}
+.hw-kicker::before{content:"";flex:0 0 auto;width:8px;height:8px;border-radius:50%;background:var(--ochre)}
+
+/* the figure card. The number is cream and the qualifier next to it is dim,
+   the same weighting BeerWeer gives 22 and the degree sign. */
+.hw-figure{min-height:208px;display:flex;flex-direction:column}
+.hw-figure-body{display:flex;align-items:flex-start;justify-content:space-between;gap:14px;flex:1 1 auto}
+.hw-figure-words{min-width:0}
+.hw-read{display:flex;align-items:baseline;gap:10px;margin-top:10px}
+.hw-num{font-size:clamp(3.4rem,16vw,4.8rem);line-height:.9;font-weight:700;letter-spacing:-.045em;color:var(--fg)}
+.hw-of{font-family:var(--hp-mono);font-size:clamp(1rem,4.2vw,1.3rem);color:var(--fg-dim)}
+.hw-cap{font-size:16px;line-height:1.35;font-weight:600;color:var(--fg);margin:12px 0 0;max-width:20ch}
+.hw-sub{font-size:14px;line-height:1.5;color:var(--fg-mid);margin:6px 0 0;max-width:34ch}
+
+/* the small drawn object: the band's own hand, one sheet with a seal. */
+.hw-obj{flex:0 0 auto;width:88px;height:88px;display:block;margin-top:4px}
+@media (max-width:359px){.hw-obj{width:68px;height:68px}}
+
+/* the strip of secondary readings, the H / L / humidity row of this page. */
+.hw-strip{display:flex;flex-wrap:wrap;gap:6px 20px;margin-top:16px;padding-top:14px;border-top:1px solid var(--line);font-family:var(--hp-mono);font-size:12px;letter-spacing:.04em}
+.hw-strip-item{display:inline-flex;align-items:baseline;gap:7px}
+.hw-strip-lab{color:var(--fg-dim);text-transform:uppercase;letter-spacing:.12em;font-size:10.5px}
+.hw-strip-val{color:var(--fg);font-weight:600}
+
+/* the two lists. One row per document: a status dot, the name, the date in
+   mono, and the progress. Rows read; they do not pretend to be buttons. */
+.hw-list-card{min-height:150px;display:flex;flex-direction:column}
+.hw-list{list-style:none;margin:12px 0 0;padding:0;flex:1 1 auto}
+.hw-row{display:flex;align-items:flex-start;gap:11px;padding:11px 0;border-bottom:1px solid var(--line)}
+.hw-row:first-child{padding-top:2px}
+.hw-row:last-child{border-bottom:0}
+.hw-dot{flex:0 0 auto;width:9px;height:9px;border-radius:50%;background:var(--fg-dim);margin-top:6px}
+.hw-dot.wait{background:var(--ochre)}
+.hw-dot.busy{background:var(--teal)}
+.hw-dot.done{background:rgba(var(--tint),.42)}
+.hw-row-main{min-width:0;flex:1 1 auto}
+.hw-name{display:block;font-size:15px;font-weight:600;color:var(--fg);line-height:1.35;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.hw-meta{display:block;font-family:var(--hp-mono);font-size:11.5px;letter-spacing:.06em;color:var(--fg-mid);margin-top:3px}
+.hw-tail{flex:0 0 auto;font-size:12.5px;color:var(--fg-mid);text-align:right;line-height:1.35;padding-top:1px}
+.hw-more{display:inline-block;margin-top:14px;font-size:14px;font-weight:600;color:var(--fg-mid);text-decoration:underline;text-underline-offset:4px}
+.hw-more:hover,.hw-more:focus-visible{color:var(--fg)}
+
+/* a new account. The same card, the same height, its own object: nothing here
+   is allowed to read as a page that failed to load. */
+.hw-empty{min-height:196px;display:flex;flex-direction:column;justify-content:center}
+.hw-empty-body{display:flex;align-items:flex-start;justify-content:space-between;gap:14px}
+.hw-empty strong{display:block;font-size:17px;line-height:1.3;color:var(--fg);margin:10px 0 6px}
+.hw-empty p{font-size:14.5px;line-height:1.6;color:var(--fg-mid);margin:0;max-width:34ch}
+.hw-empty-actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:16px}
+
+/* the plan, one line, and a way to renew only once the term is close. */
+.hw-plan{font-size:14px;line-height:1.55;color:var(--fg-mid);margin:18px 0 0}
+.hw-plan b{color:var(--fg);font-weight:600}
+.hw-renew{color:var(--ochre);text-decoration:underline;text-underline-offset:4px;margin-left:8px;font-weight:600;white-space:nowrap}
+.hw-renew:hover,.hw-renew:focus-visible{color:var(--ochre-2)}
+
+/* a route did not answer. One calm line inside the card that would have held
+   the reading, so the shape of the page does not change under a reader. */
+.hw-quiet{font-size:15px;line-height:1.6;color:var(--fg-mid);margin:14px 0 0;max-width:34ch}
+
+html[data-session="in"] [data-home="in"] .home-actions{margin-top:22px;padding-top:20px;border-top:1px solid var(--line)}
+/* A new account already has both first steps inside its own card, so the row
+   underneath would be the same two buttons a second time. js/home-auth.js sets
+   data-hw-state="empty" and this takes the repeat away; Documents stays one tap
+   away in the nav's user menu, which every signed-in page carries. */
+.hw[data-hw-state="empty"] + .home-actions{display:none}
+
+@media (min-width:900px){
+  .hw{max-width:none}
+  .hw-figure{min-height:236px}
+  .hw-num{font-size:5.4rem}
+  .hw-obj{width:108px;height:108px}
+  .hw-cols{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:16px}
+  .hw-cols > .hw-card{margin-top:0}
+}
+
 /* the art: a document that gets signed, sealed, and then is gone. Desktop only; on a phone the band is the picture. */
 .hp-art{position:relative;z-index:1;height:150px;pointer-events:none;user-select:none}
 .hp-art-glow{position:absolute;inset:-40% -20%;background:
@@ -426,7 +524,78 @@ footer a{color:var(--fg)}
     </div>
     <div class="home-state" data-home="in" hidden>
       <h2 class="paramant-h1">Your documents<span class="home-hi-name" data-home-name></span>.</h2>
-      <p class="lede">Pick up an open request, get a new document signed with ParaSign, or send a file with the ParaSend web app, which deletes it after the first read.</p>
+
+      <!-- The workbench. Every value in here is written by js/home-auth.js from
+           /api/user/documents, /api/user/dashboard/overview and
+           /api/user/billing/status, the same routes /dashboard and /account
+           read. Nothing is filled in by the markup, and a block whose route did
+           not answer hides itself rather than showing a zero it cannot stand
+           behind. -->
+      <div class="hw" data-hw>
+
+        <div class="hw-card hw-figure">
+          <p class="hw-kicker" data-hw-kicker>Your month</p>
+          <div class="hw-figure-body">
+            <div class="hw-figure-words">
+              <div class="hw-read" data-hw-read hidden>
+                <span class="hw-num" data-hw-num></span>
+                <span class="hw-of" data-hw-of hidden></span>
+              </div>
+              <p class="hw-cap" data-hw-cap hidden></p>
+              <p class="hw-sub" data-hw-sub hidden></p>
+              <p class="hw-quiet" data-hw-quiet hidden>Your documents are not loading right now. Nothing on the account has changed. Open documents below, or try again in a minute.</p>
+            </div>
+            <svg class="hw-obj" viewBox="0 0 96 96" aria-hidden="true" focusable="false">
+              <rect x="17" y="5" width="59" height="76" rx="4" fill="var(--cream, #EAE2CE)" opacity=".93"/>
+              <g fill="var(--night, #15191C)" opacity=".5">
+                <rect x="27" y="20" width="39" height="4.5" rx="2.25"/>
+                <rect x="27" y="33" width="39" height="4.5" rx="2.25"/>
+                <rect x="27" y="46" width="24" height="4.5" rx="2.25"/>
+              </g>
+              <circle cx="69" cy="70" r="13.5" fill="var(--ochre, #D9A441)" stroke="var(--night, #15191C)" stroke-width="3.5"/>
+            </svg>
+          </div>
+          <div class="hw-strip" data-hw-strip hidden></div>
+        </div>
+
+        <div class="hw-cols">
+          <div class="hw-card hw-list-card" data-hw-waiting hidden>
+            <p class="hw-kicker">Waiting on a signature</p>
+            <ul class="hw-list" data-hw-waiting-list></ul>
+            <a class="hw-more" href="/dashboard">Open requests</a>
+          </div>
+
+          <div class="hw-card hw-list-card" data-hw-recent hidden>
+            <p class="hw-kicker">Recent</p>
+            <ul class="hw-list" data-hw-recent-list></ul>
+            <a class="hw-more" href="/dashboard">All documents</a>
+          </div>
+        </div>
+
+        <div class="hw-card hw-empty" data-hw-empty hidden>
+          <div class="hw-empty-body">
+            <div>
+              <p class="hw-kicker">Your first minute</p>
+              <strong>Nothing here yet.</strong>
+              <p>Sign your first document or send your first file; both take under a minute.</p>
+            </div>
+            <svg class="hw-obj" viewBox="0 0 96 96" aria-hidden="true" focusable="false">
+              <g transform="translate(8 21)">
+                <rect x="0" y="0" width="80" height="54" rx="3" fill="var(--cream, #EAE2CE)" opacity=".93"/>
+                <path d="M0 3l40 29 40-29" fill="none" stroke="var(--night, #15191C)" stroke-opacity=".5" stroke-width="3.5" stroke-linejoin="round"/>
+                <circle cx="40" cy="33" r="9.5" fill="var(--ochre, #D9A441)" stroke="var(--night, #15191C)" stroke-width="3"/>
+              </g>
+            </svg>
+          </div>
+          <div class="hw-empty-actions">
+            <a class="hp-btn hp-btn-fill" href="/sign">Start signing</a>
+            <a class="hp-btn hp-btn-line" href="/parashare">Send securely</a>
+          </div>
+        </div>
+
+        <p class="hw-plan" data-hw-plan hidden><span data-hw-plan-text></span><a class="hw-renew" href="/pricing" data-hw-renew hidden>Renew</a></p>
+      </div>
+
       <div class="home-actions">
         <a class="hp-btn hp-btn-fill" href="/dashboard">Open documents</a>
         <a class="hp-btn hp-btn-line" href="/sign">Start signing</a>
@@ -650,6 +819,7 @@ footer a{color:var(--fg)}
 </footer>
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
-<script src="/js/home-auth.js?v=2" defer></script>
+<script src="/js/format-date.js?v=1" defer></script>
+<script src="/js/home-auth.js?v=3" defer></script>
 </body>
 </html>

--- a/frontend/js/home-auth.js
+++ b/frontend/js/home-auth.js
@@ -1,27 +1,414 @@
-/* Homepage state swap.
+/* The signed-in homepage: the work, filled in.
+ *
+ * WHAT THIS PAGE IS
  *
  * The homepage ships the logged-out pitch by default (so it works with JS off
  * and is what link scrapers see). When a valid session is present, swap to the
- * logged-in variant: "Welcome back" + quick actions, marketing badges gone.
+ * logged-in variant and stamp data-session="in" on <html>, off which index.html
+ * hides every section under the hero in CSS: no inline script (CSP
+ * script-src 'self'), and a section added tomorrow is covered the day it lands.
  *
- * Swapping the hero was only half of it. Everything BELOW the hero is the sales
- * page -- why half of it is free, the two products, what it costs, who is
- * behind it -- and it stayed on screen for a customer who had already bought.
- * A signed-in phone got three actions and then eight screens of pitch. So this
- * also stamps data-session="in" on <html>, and index.html hides every section
- * after the hero off that one attribute. The hiding is CSS, not JS: no inline
- * script (CSP script-src 'self'), and nothing here walks the section list, so
- * a new section is covered the day it is added.
+ * WHY IT NOW FETCHES ANYTHING AT ALL
  *
- * Uses the same probe the nav uses (GET /api/user/session/verify, credentials
- * included). CSP-safe: external file, no inline script, no eval. Best-effort,
- * tolerant: any failure leaves the logged-out pitch in place.
+ * Until 4 September the signed-in hero was a heading, one paragraph and three
+ * buttons over an empty screen. Mick, reading it on his phone: "I see ONLY 3
+ * buttons, as if it were a test page. This never passed marketing." The
+ * yardstick he set is BeerWeer, which opens on the one reading that matters and
+ * lays the rest out quietly under it. A customer who is signed in has real
+ * numbers waiting for him one page away; a homepage that shows him none of them
+ * is a menu, not a workbench.
+ *
+ * So this reads three routes that /dashboard and /account already read, and
+ * writes the answers into slots the markup owns:
+ *
+ *   GET /api/user/documents            the account's own signing requests
+ *   GET /api/user/dashboard/overview   quota.signs and quota.caps.signs
+ *   GET /api/user/billing/status       the plan and the end of the term
+ *
+ * WHAT IT DOES NOT SAY, and why
+ *
+ * "2 waiting for YOUR signature" is not a sentence this page can honestly
+ * write. /api/user/documents is the SENT list: relay/envelope.js indexes an
+ * envelope under its creator (parsign:acct:<id>:envelopes, written once, in
+ * create()), and there is no reverse index from a party's email hash to the
+ * envelopes it appears in. Nothing on the relay can answer "which documents are
+ * waiting for me to sign" without a fleet-wide scan, and an invited signer
+ * reaches his document by the capability link in the mail. So the figure counts
+ * requests that are open and says exactly that: waiting ON a signature, not FOR
+ * yours. The day a party index exists this file gains a fourth fetch and a
+ * truer sentence; until then it does not borrow one.
+ *
+ * NO KEY IN THE BROWSER. All three routes ride the session cookie the same way
+ * /dashboard does. Nothing here mints or holds a credential, so #413 stands:
+ * the account's pgp_ key never reaches this page.
+ *
+ * TOLERANT BY DESIGN. Every fetch resolves to null on any failure. A block
+ * whose data did not arrive hides itself, one calm line takes the place of the
+ * figure, and the three buttons keep working. Nothing here can leave the reader
+ * on a raw error, and nothing writes a zero it cannot stand behind.
+ *
+ * Values go in with textContent and rows are built from nodes, never from a
+ * string of markup: a file name is chosen by somebody else and has no business
+ * near innerHTML.
  */
 (function () {
   'use strict';
+
   var out = document.querySelector('[data-home="out"]');
   var inn = document.querySelector('[data-home="in"]');
   if (!out || !inn) return;
+
+  function pick(name) { return inn.querySelector('[data-' + name + ']'); }
+  function show(node, on) { if (node) node.hidden = !on; }
+  function words(node, value) { if (node) node.textContent = value; }
+
+  // One notation for every date a reader sees, from /js/format-date.js:
+  // "28 August 2026", never a slashed date. Same file /dashboard and /account
+  // use, so the day this page prints and the day they print are one day.
+  function day(value) {
+    return (window.paramantDate && window.paramantDate.day(value, '')) || '';
+  }
+
+  function getJSON(url) {
+    return fetch(url, {
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+      cache: 'no-store'
+    }).then(function (r) {
+      if (!r.ok) throw new Error('http_' + r.status);
+      return r.json();
+    }).catch(function () { return null; });
+  }
+
+  // ── The state of one signing request ───────────────────────────────────────
+  // The same four states /dashboard shows, derived the same way, so a document
+  // does not read as "in progress" here and "waiting" one click later.
+  function stateOf(doc) {
+    if (doc.status === 'complete') return 'completed';
+    if (doc.status === 'void') return 'cancelled';
+    return Number(doc.signed_count || 0) > 0 ? 'in_progress' : 'waiting';
+  }
+  var STATE_WORD = {
+    waiting: 'Waiting',
+    in_progress: 'In progress',
+    completed: 'Completed',
+    cancelled: 'Cancelled'
+  };
+  var STATE_DOT = {
+    waiting: 'wait',
+    in_progress: 'busy',
+    completed: 'done',
+    cancelled: 'done'
+  };
+  function isOpen(doc) {
+    var s = stateOf(doc);
+    return s === 'waiting' || s === 'in_progress';
+  }
+
+  // Who a request is still waiting on. The list route hands back party labels
+  // and their status and nothing else: no addresses, no invite tokens. A party
+  // without a label is counted, never invented.
+  function pending(doc) {
+    var parties = Array.isArray(doc.parties) ? doc.parties : [];
+    var open = parties.filter(function (p) { return p.status !== 'signed'; });
+    var named = open.map(function (p) { return String(p.label || '').trim(); }).filter(Boolean);
+    if (!named.length) return '';
+    if (named.length === 1) return 'Waiting on ' + named[0];
+    if (named.length === 2) return 'Waiting on ' + named[0] + ' and ' + named[1];
+    return 'Waiting on ' + named[0] + ' and ' + (named.length - 1) + ' others';
+  }
+
+  function row(doc, meta, tail, dot) {
+    var li = document.createElement('li');
+    li.className = 'hw-row';
+
+    var mark = document.createElement('span');
+    mark.className = 'hw-dot ' + dot;
+    li.appendChild(mark);
+
+    var main = document.createElement('div');
+    main.className = 'hw-row-main';
+    var name = document.createElement('span');
+    name.className = 'hw-name';
+    name.textContent = doc.original_filename || 'Signing request';
+    name.title = name.textContent;
+    main.appendChild(name);
+    if (meta) {
+      var sub = document.createElement('span');
+      sub.className = 'hw-meta';
+      sub.textContent = meta;
+      main.appendChild(sub);
+    }
+    li.appendChild(main);
+
+    if (tail) {
+      var end = document.createElement('span');
+      end.className = 'hw-tail';
+      end.textContent = tail;
+      li.appendChild(end);
+    }
+    return li;
+  }
+
+  function fill(list, rows) {
+    if (!list) return;
+    list.textContent = '';
+    rows.forEach(function (node) { list.appendChild(node); });
+  }
+
+  // ── The strip of secondary readings ────────────────────────────────────────
+  // The H / L / humidity row of this page: what did not earn the big number but
+  // is still worth a glance. Built from what actually arrived.
+  function strip(host, items) {
+    if (!host) return;
+    host.textContent = '';
+    items.forEach(function (item) {
+      var wrap = document.createElement('span');
+      wrap.className = 'hw-strip-item';
+      var lab = document.createElement('span');
+      lab.className = 'hw-strip-lab';
+      lab.textContent = item[0];
+      var val = document.createElement('span');
+      val.className = 'hw-strip-val';
+      val.textContent = item[1];
+      wrap.appendChild(lab);
+      wrap.appendChild(val);
+      host.appendChild(wrap);
+    });
+    show(host, items.length > 0);
+  }
+
+  // ── The plan, in one line ──────────────────────────────────────────────────
+  // Same rule and same words as /account and /dashboard: a checkout here buys
+  // one month or one year outright, so paid_until_<product> is the day access
+  // stops and there is nothing to cancel. Two products can hold two dates; the
+  // one that matters is the nearest one still ahead, and once they have all
+  // passed it is the last one, because that is the day the account fell back.
+  var TERM_WARN_DAYS = 7;
+  var PRODUCT_NAMES = { pro: 'Pro', business: 'Business', enterprise: 'Enterprise' };
+  var PLAN_ALIASES = { free: 'community', dev: 'community', licensed: 'enterprise' };
+  var PLAN_NAMES = { community: 'Community', pro: 'Pro', business: 'Business', enterprise: 'Enterprise' };
+
+  function normalisePlan(plan) {
+    var id = String(plan == null ? '' : plan).toLowerCase();
+    if (PLAN_ALIASES[id]) return PLAN_ALIASES[id];
+    return PLAN_NAMES[id] ? id : 'community';
+  }
+
+  function termState(d, nowMs) {
+    var now = typeof nowMs === 'number' ? nowMs : Date.now();
+    var ends = [
+      ['parasign', d.paid_until_parasign, d.plan_parasign],
+      ['parasend', d.paid_until_parasend, d.plan_parasend]
+    ].map(function (r) { return { product: r[0], at: r[1] ? Date.parse(r[1]) : NaN, tier: r[2] }; })
+      .filter(function (r) { return !isNaN(r.at); });
+    if (!ends.length) return null;
+    var ahead = ends.filter(function (r) { return r.at > now; });
+    var pool = ahead.length ? ahead : ends;
+    var chosen = pool.reduce(function (best, r) {
+      if (!best) return r;
+      return (ahead.length ? r.at < best.at : r.at > best.at) ? r : best;
+    }, null);
+    var days = (chosen.at - now) / 86400000;
+    return {
+      at: chosen.at,
+      product: chosen.product,
+      tier: String(chosen.tier || '').toLowerCase(),
+      ended: chosen.at <= now,
+      warn: days > 0 && days <= TERM_WARN_DAYS
+    };
+  }
+
+  function termLabel(term) {
+    var tier = PRODUCT_NAMES[term.tier];
+    if (!tier) return '';
+    return (term.product === 'parasign' ? 'ParaSign ' : 'ParaSend ') + tier;
+  }
+
+  function planLine(d) {
+    var term = termState(d);
+    if (term) {
+      var label = termLabel(term);
+      if (term.ended) {
+        return label
+          ? { name: label, rest: ' ended on ' + day(term.at) + '. You are on Community now.', renew: true }
+          : { name: 'Community', rest: ', free for good. Your paid term ended on ' + day(term.at) + '.', renew: true };
+      }
+      if (label) return { name: label, rest: ', ends on ' + day(term.at) + ', nothing renews automatically.', renew: term.warn };
+    }
+    var id = normalisePlan(d.current_plan);
+    if (id === 'community') return { name: 'Community', rest: ', free for good.', renew: false };
+    return { name: PLAN_NAMES[id], rest: ', with no term recorded. Nothing renews automatically.', renew: false };
+  }
+
+  // ── The one big reading ────────────────────────────────────────────────────
+  // Open requests first, because a request nobody has signed is the only thing
+  // on this account that is actually waiting. Nothing open, and the reading
+  // becomes the month's signature balance, which is the number the buyer review
+  // of 5 September found nowhere on the site while the route already had it.
+  function renderFigure(docs, overview) {
+    var kicker = pick('hw-kicker');
+    var read = pick('hw-read');
+    var num = pick('hw-num');
+    var of = pick('hw-of');
+    var cap = pick('hw-cap');
+    var sub = pick('hw-sub');
+    var quiet = pick('hw-quiet');
+
+    var open = docs ? docs.filter(isOpen) : null;
+    var done = docs ? docs.filter(function (d) { return stateOf(d) === 'completed'; }) : null;
+
+    var quota = overview && overview.quota ? overview.quota : null;
+    var caps = quota && quota.caps ? quota.caps : {};
+    var used = quota ? Math.max(0, Number(quota.signs || 0)) : null;
+    var limit = (caps.signs === null || caps.signs === undefined) ? null : Number(caps.signs);
+    var capped = quota && limit !== null && isFinite(limit) && limit > 0;
+    var left = capped ? Math.max(0, limit - used) : null;
+
+    // The strip only carries readings a reader can do something with. On a
+    // brand new account "documents 0, completed 0, open 0" is three zeros in a
+    // row, which reads as a counter that failed rather than as an account that
+    // is new; the card underneath already says so in words.
+    var items = [];
+    if (docs && docs.length) {
+      items.push(['Documents', String(docs.length)]);
+      items.push(['Completed', String(done.length)]);
+    }
+
+    if (open && open.length) {
+      var oldest = open.reduce(function (best, d) {
+        var t = Date.parse(d.created_at || '');
+        if (isNaN(t)) return best;
+        return (!best || t < best.t) ? { t: t, doc: d } : best;
+      }, null);
+      show(quiet, false);
+      words(kicker, 'Still open');
+      words(num, String(open.length));
+      show(of, false);
+      words(cap, open.length === 1 ? 'request is waiting on a signature' : 'requests are waiting on a signature');
+      words(sub, oldest ? 'The oldest went out on ' + day(oldest.t) + '.' : 'Sent from this account.');
+      show(read, true); show(cap, true); show(sub, true);
+      if (capped) items.push(['Signatures left', left + ' of ' + limit]);
+      strip(pick('hw-strip'), items);
+      return;
+    }
+
+    if (quota) {
+      show(quiet, false);
+      words(kicker, 'This month');
+      if (capped) {
+        words(num, String(left));
+        words(of, 'of ' + limit);
+        show(of, true);
+        words(cap, left === 1 ? 'signature left this month' : 'signatures left this month');
+      } else {
+        words(num, String(used));
+        show(of, false);
+        words(cap, used === 1 ? 'signature this month' : 'signatures this month');
+      }
+      words(sub, 'The count resets on ' + day(resetDate()) + '.');
+      show(read, true); show(cap, true); show(sub, true);
+      if (docs && docs.length) items.push(['Open', String(open ? open.length : 0)]);
+      strip(pick('hw-strip'), items);
+      return;
+    }
+
+    // Neither route answered. One line, no number, no raw error.
+    show(read, false); show(cap, false); show(sub, false);
+    words(kicker, 'Your account');
+    show(quiet, true);
+    strip(pick('hw-strip'), items);
+  }
+
+  // The signature counters are calendar-month keys in UTC (relay/lib/quota.js
+  // writes paramant:quota:signs:<account>:<YYYY-MM>), so the day they start
+  // again is the first of the next month, and it is a fact rather than a guess.
+  function resetDate() {
+    var now = new Date();
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+  }
+
+  function renderDocuments(docs) {
+    var host = pick('hw');
+    var waiting = pick('hw-waiting');
+    var recent = pick('hw-recent');
+    var empty = pick('hw-empty');
+    if (host) host.removeAttribute('data-hw-state');
+
+    if (!docs) { show(waiting, false); show(recent, false); show(empty, false); return; }
+
+    // A new account. One card of its own, with its own object and the two
+    // first steps in it. index.html drops the action row underneath off
+    // data-hw-state, because repeating the same two buttons eight lines lower
+    // is the page-of-buttons this whole change exists to end; the nav's user
+    // menu keeps carrying Documents either way.
+    if (!docs.length) {
+      show(waiting, false);
+      show(recent, false);
+      show(empty, true);
+      if (host) host.setAttribute('data-hw-state', 'empty');
+      return;
+    }
+    show(empty, false);
+
+    var open = docs.filter(isOpen).slice(0, 3);
+    var listed = {};
+    if (open.length) {
+      fill(pick('hw-waiting-list'), open.map(function (doc) {
+        listed[doc.id] = true;
+        var total = Math.max(0, Number(doc.party_count || 0));
+        var signed = Math.max(0, Math.min(total, Number(doc.signed_count || 0)));
+        var who = pending(doc);
+        var when = day(doc.created_at);
+        var meta = who ? (when ? who + ' · sent ' + when : who) : (when ? 'Sent ' + when : '');
+        return row(doc, meta, total ? signed + ' of ' + total : '', STATE_DOT[stateOf(doc)]);
+      }));
+    }
+    show(waiting, open.length > 0);
+
+    // The last three, minus whatever the card above already shows. A document
+    // printed twice on one screen is the fault the buyer review found on
+    // /account, where the end of the term was announced three times in three
+    // tones; a homepage is not the place to reintroduce it.
+    var last = docs.filter(function (doc) { return !listed[doc.id]; }).slice(0, 3);
+    fill(pick('hw-recent-list'), last.map(function (doc) {
+      var state = stateOf(doc);
+      var when = day(state === 'completed' && doc.completed_at ? doc.completed_at : doc.created_at);
+      return row(doc, when, STATE_WORD[state], STATE_DOT[state]);
+    }));
+    show(recent, last.length > 0);
+  }
+
+  function renderPlan(billing) {
+    var host = pick('hw-plan');
+    var text = pick('hw-plan-text');
+    var renew = pick('hw-renew');
+    if (!billing) { show(host, false); return; }
+    var line = planLine(billing);
+    if (text) {
+      text.textContent = '';
+      var name = document.createElement('b');
+      name.textContent = line.name;
+      text.appendChild(name);
+      text.appendChild(document.createTextNode(line.rest));
+    }
+    show(renew, !!line.renew);
+    show(host, true);
+  }
+
+  function load() {
+    Promise.all([
+      getJSON('/api/user/documents'),
+      getJSON('/api/user/dashboard/overview'),
+      getJSON('/api/user/billing/status')
+    ]).then(function (answers) {
+      var body = answers[0];
+      var docs = body && Array.isArray(body.documents) ? body.documents : null;
+      renderFigure(docs, answers[1]);
+      renderDocuments(docs);
+      renderPlan(answers[2]);
+    });
+  }
 
   fetch('/api/user/session/verify', { credentials: 'include', cache: 'no-store' })
     .then(function (r) { return r.ok ? r.json() : null; })
@@ -29,7 +416,7 @@
       if (!data || !data.authenticated) return;
 
       // Personalise with the email local-part if we have it (textContent, so
-      // no markup injection). Falls back to a plain "Welcome back." otherwise.
+      // no markup injection). Falls back to a plain "Your documents." otherwise.
       var nameEl = inn.querySelector('[data-home-name]');
       if (nameEl && data.email) {
         var at = String(data.email).indexOf('@');
@@ -40,6 +427,7 @@
       out.hidden = true;
       inn.hidden = false;
       document.documentElement.setAttribute('data-session', 'in');
+      load();
     })
     .catch(function () { /* stay on the logged-out pitch */ });
 })();

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,6 +25,7 @@ Guards the auth + TOTP stack against the class of breakage that hit production r
 | `tests/brand-shots-optin.test.mjs` | Root integration suites, and `tests/static-sanity.sh` (pre-commit) | The reference screenshots under `docs/brand/assets/app-2026/` are opt-in. `scripts/app-shots.mjs` used to write 36 tracked PNGs on every run, so `git status` was never clean after a browser suite and the next `git commit -a` shipped them. Three layers: the resolver's own rules, a real dry run of `scripts/app-shots.mjs` that has to name a directory outside the repo and leave the references byte-identical, and a scan so no other suite hardcodes the path. See [Refreshing the app screenshots](#refreshing-the-app-screenshots) |
 | `tests/env-documented.test.mjs` | Root integration suites | Every `process.env` name the relay or admin reads must be in [deploy/.env.example](../deploy/.env.example) with a purpose, a default and the file that reads it. Nothing may be documented there that no code reads, and every `read in:` pointer must name a file that exists and mentions the variable. 40 of 57 were undocumented on 2026-09-02 |
 | `tests/end-screen-calm.test.mjs` | sign-e2e job `Browser suites` (selected by its playwright import) | The four end screens of the product (ParaSend live and Send-a-link, ParaSign after signing and after sending invitations, and both receiving pages) held to one shape at 390x844: no algorithm name on the face of the screen, exactly one button with the loud paint, the answer fitting a phone with the `<details>` shut, and that fold closed on arrival. Written after the owner read the ParaSend end screen on a phone on 4 September 2026 and found the same fact stated four times in jargon, one statement of it untrue of a live hand-over |
+| `tests/signed-in-home.test.mjs` | sign-e2e job `Browser suites` (selected by its playwright import) | The signed-in homepage at 390x844, in four states (open requests, only finished documents, a brand new account, and every route down), with the API mocked the way `navigation-shell` mocks it. Holds three things: the big figure on screen is the number in the mocked API, no state leaves the reader with three buttons over a hole (measured as the gap between the last thing drawn in `<main>` and the top of the footer, 120px), and no relay vocabulary reaches the words. Written after the owner read his own homepage on a phone on 4 September 2026 and got a heading, one paragraph, three buttons and an empty screen: "I see ONLY 3 buttons, as if it were a test page" |
 
 ## Running manually
 
@@ -94,9 +95,11 @@ move the ground under assertions taken after the shot and would make the
 reduced-motion pair in `app-shots.mjs` identical to the normal pair.
 
 The suites that write a screenshot as a byproduct call it too: `navigation-shell`,
-`cosign-document-delivery`, `user-dashboard-documents`, `sign-invite-delivery`
-and `developer-parasign-dashboard`. Those calls are gated on a
-`PARAMANT_*_SCREENSHOT_PATH` variable and never fire in CI, but a builder taking
+`cosign-document-delivery`, `user-dashboard-documents`, `sign-invite-delivery`,
+`signed-in-home` and `developer-parasign-dashboard`. Those calls are gated on a
+`PARAMANT_*_SCREENSHOT_PATH` variable (`signed-in-home` takes a directory, in
+`PARAMANT_HOME_IN_SCREENSHOT_DIR`, because it photographs four states) and never
+fire in CI, but a builder taking
 one by hand on a busy laptop hits the same wall the runner did.
 
 ### Refreshing the app screenshots

--- a/tests/signed-in-home.test.mjs
+++ b/tests/signed-in-home.test.mjs
@@ -1,0 +1,259 @@
+// The signed-in homepage has to be a workbench, not a menu.
+//
+// WHAT WENT WRONG
+//
+// Mick opened paramant.app on his iPhone on 4 September 2026, signed in, and
+// got: the band, "Your documents, mickbr.", one paragraph, three buttons, and
+// then an empty screen down to the footer. His two readings of it, in order:
+// "this is overly simple", and then "I see ONLY 3 buttons, as if it were a test
+// page. This never passed commerce or marketing."
+//
+// The yardstick he set is BeerWeer (weer.mickbeer.com): one big reading at the
+// top with a small drawn object beside it, then the rest laid out quietly in
+// cards. So this file measures the three things that turn the hero back into a
+// menu if they slip:
+//
+//   1. THE FIGURE IS REAL. The number on screen is the number in the mocked
+//      API, in all three states. A big number that is decoration rather than
+//      data is worse than no number.
+//   2. NO STATE IS THREE BUTTONS OVER A HOLE. Including the empty account and
+//      the state where every route is down. Measured as the gap between the
+//      last thing drawn in <main> and the top of the footer.
+//   3. THE WORDS ARE THE READER'S. No hashes, no envelopes, no endpoints, no
+//      plan IDs. The buyer review of 5 September scored the signing flow down
+//      for exactly this and the homepage must not import it.
+//
+// The API is mocked the way tests/navigation-shell.test.mjs mocks it: route
+// interception over a static file server, no relay, no Redis. The shapes are
+// copied from the real ones -- relay/envelope.js listAccountEnvelopes for the
+// documents, admin/server.js:2600 for the overview, admin/server.js:3167 for
+// billing -- so a change in those shapes shows up here as a red test rather
+// than as an empty card in production.
+//
+// PARAMANT_HOME_IN_SCREENSHOT_DIR=<dir> writes one screenshot per state into that
+// directory. Off by default; the assertions do not need it.
+import { chromium } from 'playwright';
+import { stableScreenshot } from '../scripts/stable-screenshot.mjs';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const SHOTS = process.env.PARAMANT_HOME_IN_SCREENSHOT_DIR || '';
+const MIME = { '.js':'text/javascript', '.css':'text/css', '.html':'text/html', '.svg':'image/svg+xml', '.png':'image/png', '.woff2':'font/woff2', '.json':'application/json', '.ico':'image/x-icon' };
+const aliases = { '/':'/index.html', '/dashboard':'/dashboard.html', '/sign':'/sign.html', '/parashare':'/parashare.html', '/pricing':'/pricing.html' };
+
+const server = http.createServer((req, res) => {
+  let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+  pathname = aliases[pathname] || pathname;
+  const file = path.join(ROOT, pathname);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+  fs.readFile(file, (error, body) => {
+    if (error) { res.writeHead(404); return res.end(); }
+    res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  });
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const ORIGIN = `http://localhost:${server.address().port}`;
+const browser = await chromium.launch({ headless:true, ...(EXE ? { executablePath:EXE } : {}) });
+
+const checks = [];
+function ok(name, condition, detail='') { checks.push({ name, pass:!!condition, detail:String(detail) }); }
+
+// The one notation the site shows a reader, rebuilt here rather than imported,
+// so a bug in js/format-date.js cannot make this test agree with it.
+const MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+const day = (v) => { const d = new Date(v); return `${d.getUTCDate()} ${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`; };
+const inDays = (n) => new Date(Date.now() + n * 86400000).toISOString();
+const agoDays = (n) => new Date(Date.now() - n * 86400000).toISOString();
+
+const OPEN_OLDEST = agoDays(9);
+const documentsOpen = { ok:true, count:3, documents:[
+  { id:'env_open_one', original_filename:'Engagement letter Bakker.pdf', status:'pending', created_at:OPEN_OLDEST, expires_at:inDays(21), party_count:2, signed_count:0,
+    parties:[{ index:0, label:'Anna Bakker', status:'pending' }, { index:1, label:'Joris de Wit', status:'pending' }] },
+  { id:'env_open_two', original_filename:'Payroll August 2026.pdf', status:'pending', created_at:agoDays(3), expires_at:inDays(27), party_count:2, signed_count:1,
+    parties:[{ index:0, label:'Anna Bakker', status:'signed' }, { index:1, label:'Joris de Wit', status:'pending' }] },
+  { id:'env_done_one', original_filename:'Annual accounts 2025.pdf', status:'complete', created_at:agoDays(20), completed_at:agoDays(19), party_count:2, signed_count:2,
+    parties:[{ index:0, label:'Anna Bakker', status:'signed' }, { index:1, label:'Joris de Wit', status:'signed' }] },
+]};
+const documentsDone = { ok:true, count:3, documents:[
+  { id:'env_done_a', original_filename:'Annual accounts 2025.pdf', status:'complete', created_at:agoDays(6), completed_at:agoDays(5), party_count:2, signed_count:2,
+    parties:[{ index:0, label:'Anna Bakker', status:'signed' }, { index:1, label:'Joris de Wit', status:'signed' }] },
+  { id:'env_done_b', original_filename:'Lease Harderwijk.pdf', status:'complete', created_at:agoDays(12), completed_at:agoDays(11), party_count:1, signed_count:1,
+    parties:[{ index:0, label:'Anna Bakker', status:'signed' }] },
+  { id:'env_void_a', original_filename:'Old quote.pdf', status:'void', created_at:agoDays(30), voided_at:agoDays(29), party_count:2, signed_count:0,
+    parties:[{ index:0, label:'Anna Bakker', status:'pending' }, { index:1, label:'Joris de Wit', status:'pending' }] },
+]};
+const documentsNone = { ok:true, count:0, documents:[] };
+
+const overviewCommunity = { plan:'community', quota:{ transfers:1, signs:0, caps:{ transfers:10, signs:2 } }, audit:[] };
+const overviewPro       = { plan:'pro', quota:{ transfers:12, signs:3, caps:{ transfers:500, signs:100 } }, audit:[] };
+
+const PRO_ENDS = inDays(29);
+const billingCommunity = { current_plan:'community', plan_parasign:'free', plan_parasend:'community', paid_until_parasign:null, paid_until_parasend:null, auto_renews:false, access_until:null };
+const billingPro       = { current_plan:'community', plan_parasign:'pro', plan_parasend:'community', paid_until_parasign:PRO_ENDS, paid_until_parasend:null, auto_renews:false, access_until:PRO_ENDS };
+
+async function openHome({ documents, overview, billing, down = false }) {
+  const page = await browser.newPage({ viewport:{ width:390, height:844 } });
+  await page.route('**/api/user/session/verify', (r) => r.fulfill({ status:200, contentType:'application/json', body:JSON.stringify({ authenticated:true, email:'mickbr@example.com' }) }));
+  const answer = (payload) => (r) => (down
+    ? r.fulfill({ status:500, contentType:'application/json', body:'{"error":"unavailable"}' })
+    : r.fulfill({ status:200, contentType:'application/json', body:JSON.stringify(payload) }));
+  await page.route('**/api/user/documents', answer(documents));
+  await page.route('**/api/user/dashboard/overview', answer(overview));
+  await page.route('**/api/user/billing/status', answer(billing));
+  await page.goto(ORIGIN + '/', { waitUntil:'domcontentloaded' });
+  await page.locator('[data-home="in"]:not([hidden])').waitFor();
+  // The workbench is filled by three fetches that resolve after the swap, so
+  // wait for the state each case is actually about rather than for a timer.
+  await page.waitForFunction(() => {
+    const fig = document.querySelector('[data-hw-read]');
+    const quiet = document.querySelector('[data-hw-quiet]');
+    return (fig && !fig.hidden) || (quiet && !quiet.hidden);
+  });
+  return page;
+}
+
+// What is drawn, where, and what the reader can read. One evaluate per state.
+async function measure(page) {
+  return page.evaluate(() => {
+    const vis = (el) => el && !el.hidden && getComputedStyle(el).display !== 'none';
+    const inn = document.querySelector('[data-home="in"]');
+    const main = document.querySelector('main');
+    const footer = document.querySelector('footer');
+    // The lowest thing main actually draws. Text nodes only: an empty wrapper
+    // that happens to stretch is exactly the hole this is looking for.
+    let lowest = main.getBoundingClientRect().top;
+    for (const node of main.querySelectorAll('*')) {
+      if (!vis(node)) continue;
+      const style = getComputedStyle(node);
+      if (style.visibility === 'hidden') continue;
+      const box = node.getBoundingClientRect();
+      if (box.width < 1 || box.height < 1) continue;
+      const paints = (node.childNodes.length && Array.from(node.childNodes).some((c) => c.nodeType === 3 && c.textContent.trim()))
+        || node.tagName === 'SVG' || node.tagName === 'svg' || node.tagName === 'IMG'
+        || style.borderBottomWidth !== '0px' || style.backgroundImage !== 'none';
+      if (paints && box.bottom > lowest) lowest = box.bottom;
+    }
+    return {
+      num: (document.querySelector('[data-hw-num]') || {}).textContent || '',
+      of: vis(document.querySelector('[data-hw-of]')) ? document.querySelector('[data-hw-of]').textContent : '',
+      cap: vis(document.querySelector('[data-hw-cap]')) ? document.querySelector('[data-hw-cap]').textContent : '',
+      sub: vis(document.querySelector('[data-hw-sub]')) ? document.querySelector('[data-hw-sub]').textContent : '',
+      quiet: vis(document.querySelector('[data-hw-quiet]')),
+      strip: vis(document.querySelector('[data-hw-strip]')) ? document.querySelector('[data-hw-strip]').innerText.replace(/\s+/g, ' ').trim() : '',
+      waiting: vis(document.querySelector('[data-hw-waiting]')),
+      waitingRows: Array.from(document.querySelectorAll('[data-hw-waiting-list] .hw-row')).map((r) => r.innerText.replace(/\s+/g, ' ').trim()),
+      recent: vis(document.querySelector('[data-hw-recent]')),
+      recentRows: Array.from(document.querySelectorAll('[data-hw-recent-list] .hw-row')).map((r) => r.innerText.replace(/\s+/g, ' ').trim()),
+      empty: vis(document.querySelector('[data-hw-empty]')),
+      plan: vis(document.querySelector('[data-hw-plan]')) ? document.querySelector('[data-hw-plan]').innerText.replace(/\s+/g, ' ').trim() : '',
+      renew: vis(document.querySelector('[data-hw-renew]')),
+      actions: Array.from(document.querySelectorAll('[data-home="in"] .home-actions a')).map((a) => a.getAttribute('href')),
+      buttons: Array.from(document.querySelectorAll('[data-home="in"] a.hp-btn')).filter((a) => a.offsetParent !== null).map((a) => a.getAttribute('href')),
+      text: inn.innerText,
+      gap: Math.round(footer.getBoundingClientRect().top - lowest),
+      cards: Array.from(document.querySelectorAll('[data-home="in"] .hw-card')).filter(vis).length,
+    };
+  });
+}
+
+// The vocabulary a bookkeeper in Apeldoorn does not have to learn to read his
+// own homepage. Every one of these is a real string from somewhere in this
+// codebase, which is why it is worth pinning that none of them arrive here.
+const JARGON = /\benvelope|env_|pgp_|pst_|sha3|ml-dsa|ml-kem|merkle|recipe_version|api key|endpoint|payload|http \d|\bjson\b|redis|quota\b|caps\b|parasign_|paid_until|current_plan/i;
+
+const states = [
+  { key:'open',   title:'open requests',        args:{ documents:documentsOpen, overview:overviewCommunity, billing:billingCommunity } },
+  { key:'recent', title:'recent documents only', args:{ documents:documentsDone, overview:overviewPro, billing:billingPro } },
+  { key:'empty',  title:'a new account',        args:{ documents:documentsNone, overview:overviewCommunity, billing:billingCommunity } },
+  { key:'down',   title:'every route down',     args:{ documents:documentsOpen, overview:overviewCommunity, billing:billingCommunity, down:true } },
+];
+
+const seen = {};
+for (const state of states) {
+  const page = await openHome(state.args);
+  const m = await measure(page);
+  seen[state.key] = m;
+  if (SHOTS) {
+    fs.mkdirSync(SHOTS, { recursive:true });
+    await stableScreenshot(page, { path:path.join(SHOTS, `home-in-${state.key}-390.png`), fullPage:true });
+  }
+  ok(`${state.title}: the reader is never left with three buttons over a hole`, m.gap <= 120, `gap ${m.gap}px, cards ${m.cards}`);
+  ok(`${state.title}: the words are the reader's, not the relay's`, !JARGON.test(m.text), (m.text.match(JARGON) || [''])[0]);
+  ok(`${state.title}: the three actions stay, and stay in order`, JSON.stringify(m.actions) === JSON.stringify(['/dashboard','/sign','/parashare']), JSON.stringify(m.actions));
+  await page.close();
+}
+
+// 1. Open requests. Two of the three mocked documents are open, so the figure
+// is 2, both of them are listed, and the oldest one is named by date.
+ok('open requests: the figure is the number of open requests in the API', seen.open.num === '2' && seen.open.of === '', `${seen.open.num} ${seen.open.of}`);
+ok('open requests: the line under the figure says what the 2 are', /requests are waiting on a signature/.test(seen.open.cap), seen.open.cap);
+ok('open requests: the oldest one is dated in the one notation', seen.open.sub === `The oldest went out on ${day(OPEN_OLDEST)}.`, seen.open.sub);
+ok('open requests: both open documents are listed with who they wait on', seen.open.waiting && seen.open.waitingRows.length === 2
+  && seen.open.waitingRows[0].includes('Engagement letter Bakker.pdf')
+  && seen.open.waitingRows[0].includes('Waiting on Anna Bakker and Joris de Wit')
+  && seen.open.waitingRows[0].includes('0 of 2')
+  && seen.open.waitingRows[1].includes('Waiting on Joris de Wit')
+  && seen.open.waitingRows[1].includes('1 of 2'), JSON.stringify(seen.open.waitingRows));
+// Recent shows what is NOT already in the card above it. Three mocked
+// documents, two of them open and listed as open, leaves exactly the finished
+// one here. A homepage that printed the same file name twice on one screen
+// would be repeating the fault the buyer review found on /account, where the
+// end of the term was announced three times in three tones.
+ok('open requests: recent lists what the waiting card does not, with a state and a date', seen.open.recent
+  && seen.open.recentRows.length === 1
+  && seen.open.recentRows[0].includes('Annual accounts 2025.pdf')
+  && seen.open.recentRows[0].includes('Completed'), JSON.stringify(seen.open.recentRows));
+ok('open requests: no document is printed twice on one screen', new Set(
+  [...seen.open.waitingRows, ...seen.open.recentRows].map((r) => r.split('\n')[0])).size
+  === seen.open.waitingRows.length + seen.open.recentRows.length, JSON.stringify([seen.open.waitingRows, seen.open.recentRows]));
+ok('open requests: the month balance is still readable, in the strip', /SIGNATURES LEFT 2 of 2/i.test(seen.open.strip), seen.open.strip);
+ok('open requests: a free account is told the plan is free and is not sold to', seen.open.plan === 'Community, free for good.' && !seen.open.renew, seen.open.plan);
+ok('open requests: nothing is empty, so no empty card', !seen.open.empty, String(seen.open.empty));
+
+// 2. Nothing open. The figure falls back to the month's signature balance,
+// which is the number the buyer review of 5 September found nowhere on the site
+// while /api/user/dashboard/overview already had it.
+ok('recent only: the figure is the signatures left this month, from the API', seen.recent.num === '97' && seen.recent.of === 'of 100', `${seen.recent.num} ${seen.recent.of}`);
+ok('recent only: the figure is named in plain words', seen.recent.cap === 'signatures left this month', seen.recent.cap);
+ok('recent only: the reader is told when the count starts again', /^The count resets on \d+ [A-Z][a-z]+ \d{4}\.$/.test(seen.recent.sub), seen.recent.sub);
+ok('recent only: nothing is open, so the waiting card is not drawn', !seen.recent.waiting && seen.recent.recent && seen.recent.recentRows.length === 3, JSON.stringify(seen.recent.recentRows));
+ok('recent only: a paid term names its end and says nothing renews', seen.recent.plan === `ParaSign Pro, ends on ${day(PRO_ENDS)}, nothing renews automatically.`, seen.recent.plan);
+ok('recent only: a term 29 days out does not shout Renew yet', !seen.recent.renew, String(seen.recent.renew));
+
+// 3. A new account. Not a hole: one card, its own object, two ways out, and the
+// month balance above it, so the first screen is full and deliberate.
+ok('a new account: the figure is the full monthly allowance', seen.empty.num === '2' && seen.empty.of === 'of 2', `${seen.empty.num} ${seen.empty.of}`);
+ok('a new account: one friendly card takes the place of the two lists', seen.empty.empty && !seen.empty.waiting && !seen.empty.recent, JSON.stringify([seen.empty.empty, seen.empty.waiting, seen.empty.recent]));
+ok('a new account: no strip of zeros where a reading would go', seen.empty.strip === '', seen.empty.strip);
+ok('a new account: the card says both first steps and how long they take', /Nothing here yet\./.test(seen.empty.text) && /both take under a minute/.test(seen.empty.text), '');
+// The card carries Start signing and Send securely. Drawing the same two again
+// eight lines lower is the page-of-buttons this change exists to end, so the
+// row underneath is taken away in this one state and Documents stays in the
+// nav's user menu.
+ok('a new account: the two first steps are offered once, not twice', seen.empty.buttons.length === 2
+  && JSON.stringify(seen.empty.buttons) === JSON.stringify(['/sign','/parashare']), JSON.stringify(seen.empty.buttons));
+ok('every other state keeps the three actions on screen', seen.open.buttons.length === 3 && seen.recent.buttons.length === 3 && seen.down.buttons.length === 3,
+  JSON.stringify([seen.open.buttons, seen.recent.buttons, seen.down.buttons]));
+
+// 4. Every route down. A calm line, no number invented, no raw error, and the
+// page keeps its shape.
+ok('every route down: no figure is invented', seen.down.quiet && seen.down.cap === '' && seen.down.of === '', JSON.stringify([seen.down.quiet, seen.down.cap]));
+ok('every route down: the reader gets a sentence, not a status code', /not loading right now/.test(seen.down.text) && !/error|failed|500/i.test(seen.down.text), '');
+ok('every route down: no half-filled cards are left behind', !seen.down.waiting && !seen.down.recent && !seen.down.empty && seen.down.plan === '', JSON.stringify([seen.down.waiting, seen.down.recent, seen.down.empty, seen.down.plan]));
+
+// And the paragraph that used to sit above the buttons is gone in every state.
+// It described the three buttons in prose, one line above the three buttons.
+ok('the hero no longer explains its own buttons in a paragraph', !/Pick up an open request/.test(seen.open.text + seen.empty.text), '');
+
+await browser.close();
+server.close();
+
+const failed = checks.filter((c) => !c.pass);
+for (const c of checks) console.log(`${c.pass ? 'ok  ' : 'FAIL'}  ${c.name}${c.detail ? `  -- ${c.detail}` : ''}`);
+console.log(`\n${checks.length - failed.length}/${checks.length} passed`);
+if (failed.length) process.exit(1);


### PR DESCRIPTION
Signed in on a phone, the homepage was a band, "Your documents, mickbr.", one paragraph, three buttons, and then an empty screen down to the footer. The owner's two readings of it: "this is overly simple", and "I see ONLY 3 buttons, as if it were a test page. This never passed commerce or marketing."

The yardstick set for it is BeerWeer: one big reading at the top with a small drawn object beside it, then the rest laid out quietly in cards.

## What the hero carries now

**One figure.** Open requests when there are any ("2 requests are waiting on a signature", with the oldest one dated). Otherwise the month's signature balance, "2 of 2 signatures left this month" on Community and "97 of 100" on Pro, with the day the count starts again. The buyer review of 5 September found no usage counter anywhere on the site while `/api/user/dashboard/overview` already carried one.

**A strip of secondary readings** under a hairline, in mono: documents, completed, and whichever of open or signatures-left the figure did not take.

**Waiting on a signature.** The open requests, one row each: the file name, who it is still waiting on, the day it went out, and how far it has got. A dot in ochre for waiting, petrol for in progress.

**Recent.** The last documents with their state and date, minus whatever the card above already shows, and a link to all of them.

**The plan, in one line.** "Community, free for good." or "ParaSign Pro, ends on 3 October 2026, nothing renews automatically.", with Renew appearing from seven days out. Same rule, same words and the same date helper as /account and /dashboard.

**The three actions stay**, under the work rather than instead of it. The paragraph that described those three buttons in prose one line above the three buttons is gone.

## The two states that used to be a hole

**A new account** gets its own card, its own drawn object and the two first steps, at the same weight as the rest: "Nothing here yet. Sign your first document or send your first file; both take under a minute." The action row underneath is dropped in that one state, because the card already carries both buttons and the nav's user menu keeps carrying Documents. Nothing else changes shape.

**Every route down** gives one calm sentence where the figure would have been. No number is invented, no status code is shown, and the buttons keep working.

## What it does not say, and why

"2 waiting for YOUR signature" is not a sentence this page can honestly write. `/api/user/documents` is the sent list: `relay/envelope.js` indexes an envelope under its creator (`parasign:acct:<id>:envelopes`, written once, in `create()`), there is no reverse index from a party's email hash to the envelopes it appears in, and an invited signer reaches his document by the capability link in the mail. So the figure counts requests that are open and says exactly that: waiting **on** a signature, not **for** yours. For the same reason the rows carry no per-row Sign button: the dashboard is deliberately never given the per-party invite token that opens a document.

An inbound worklist is buildable but is not a route, it is a data-model change: a party index written at `create()` time, a `listPartyEnvelopes` beside `listAccountEnvelopes`, a relay route, an admin proxy, a backfill, and a decision about how a recipient opens the document without the emailed token. That belongs in its own PR.

## Plumbing

Three fetches, all on the session cookie, all to routes /dashboard and /account already read: `/api/user/documents`, `/api/user/dashboard/overview`, `/api/user/billing/status`. No new route. No key in the browser, so #413 stands. Every fetch resolves to null on any failure and a block whose data did not arrive hides itself. Values go in with `textContent` and rows are built from nodes, never from a string of markup. No inline script; `js/home-auth.js?v=3` and `js/format-date.js?v=1`, so one notation for every date. `design-system.css` untouched.

## Proof

`tests/signed-in-home.test.mjs`, 37 checks over four states with the API mocked the way `navigation-shell` mocks it, and the shapes copied from the real ones so a change in `listAccountEnvelopes` or the overview shows up red here rather than as an empty card in production. It measures that the figure on screen equals the number in the mock; that no state leaves a gap over 120px between the last thing `<main>` draws and the top of the footer; that no document is printed twice on one screen; and that no relay vocabulary reaches the words. Screenshots at 390x844 in all four states, plus 1440x900, taken and read.

Green: `signed-in-home`, `navigation-shell` (55), `first-screen` (9), `ui-truthfulness`, `site-claims` (40), `theme-contrast`, `app-contrast`, `frontend-loading-contract` (7), `check-csp-inline`, `static-sanity`, `links`, `eslint`.
