### PR TITLE
The night edition reaches the parts of the page that are not text

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -26,7 +26,7 @@
   </style>
 <style>.skip-link{position:absolute;top:-200px;left:0;background:var(--bone-2);color:var(--ink);padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid var(--ochre);transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:var(--ochre)}</style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/parapear.css?v=4">
 <style>

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .about-band{padding:var(--space-8) 0;border-top:1px solid var(--ink-hair)}

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -9,7 +9,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <meta property="og:title" content="Your account · Paramant">
 <meta property="og:description" content="Your account · Paramant">

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -356,6 +356,6 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
 
 
 <script src="/js/delegate.js?v=1" defer></script>
-<script src="/js/admin.page.js?v=1" defer></script>
+<script src="/js/admin.page.js?v=2" defer></script>
 </body>
 </html>

--- a/frontend/all-systems-go.html
+++ b/frontend/all-systems-go.html
@@ -7,7 +7,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/all-systems-go">
   <link rel="stylesheet" href="/design-system.css?v=28">
-  <link rel="stylesheet" href="/nav.css?v=23">
+  <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
     .asg { max-width: 560px; margin: 64px auto; padding: 0 24px; }

--- a/frontend/apply-nav.py
+++ b/frontend/apply-nav.py
@@ -90,7 +90,7 @@ LEGAL_STRIP = '''\
 </footer>'''
 
 DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=28">'
-NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=23">'
+NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=24">'
 NAV_JS    = '<script src="/nav.js?v=15" defer></script>'
 NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=8" defer></script>'
 

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -63,11 +63,54 @@ body{font-family:Inter,system-ui,-apple-system,sans-serif}
 
 /* ── diagram box ── */
 .arch-diagram{background:var(--paper);border:1px solid var(--ink-hair);border-radius:var(--r);padding:40px;margin:32px 0;overflow-x:auto}
-/* The three diagrams below are drawn with fixed ink, the way a printed figure
-   is: their fills and strokes are SVG presentation attributes, not CSS, and
-   redrawing them for the night would be a redraw and not a recolour. So the
-   frame is the cream paper of the design system, and the figure sits on it
-   like a printed sheet on the night desk. */
+
+/* ── the ink of the drawn figures ──
+   The figures sit on the cream paper of the design system, like a printed
+   sheet on the night desk, and that part was already right. Their INK was not.
+   It was the old light theme's navy, cobalt, lime and slate, written into the
+   SVG as presentation attributes, where no token could reach it: the stage
+   frames were #e2e8f0 on cream, which measures 1.03:1, and the arrow labels
+   were #94a3b8 at 2.13:1. WCAG 2.1 SC 1.4.11 asks 3:1 of the parts of a
+   graphic that carry its meaning, and a frame that is not there carries none.
+   scripts/ui-contrast-sweep.mjs measures exactly this and could not see it
+   before, because the text gate only ever looked at text.
+
+   So the ink is CSS now, and it is the paper palette. A presentation attribute
+   loses to a rule, which is why a class is enough. Measured on #F1EAD6:
+     --paper-ink    #1B1F22   13.8:1   the figure's own words
+     --paper-ink-2  #4A4A44    7.4:1   frames, arrows, secondary labels
+     --petrol       #155E75    6.4:1   the encrypted path
+     --ochre-ink    #8A5E10    4.7:1   the key, the root
+     --brick        #C4604F    3.7:1   the erasure                            */
+.arch-diagram .d-panel{fill:none;stroke:var(--paper-ink-2);stroke-width:1.5}
+.arch-diagram .d-slot{fill:none;stroke:var(--petrol);stroke-width:1}
+.arch-diagram .d-slot-bad{fill:none;stroke:var(--brick);stroke-width:1}
+.arch-diagram .d-gone{fill:none;stroke:var(--brick);stroke-width:1.5}
+.arch-diagram .d-bar{fill:var(--paper-ink)}
+.arch-diagram .d-bar-ink{fill:var(--ochre)}
+.arch-diagram .d-root{fill:var(--ochre-ink)}
+.arch-diagram .d-root-ink{fill:var(--paper)}
+.arch-diagram .d-h{fill:var(--paper-ink)}
+.arch-diagram .d-t{fill:var(--paper-ink-2)}
+.arch-diagram .d-accent{fill:var(--petrol)}
+.arch-diagram .d-bad{fill:var(--brick)}
+.arch-diagram .d-line{stroke:var(--paper-ink-2);stroke-width:1.5}
+.arch-diagram .d-arrow{fill:var(--paper-ink-2)}
+
+/* ── the location radar ──
+   Concentric rings on the deeper slab. The rings used to be white at 6-10% and
+   the two inner ones the old lime; the ring is ochre now, so the figure is in
+   the same hand as the rest of the night. The rings themselves fade out on
+   purpose, which is what a radar does: the place is named in the two lines of
+   type above and below it, and by the centre dot, which is the ochre at full
+   strength. tests/ui-elements-contrast.test.mjs carries that reading as a
+   named exception rather than as silence. */
+.loc-ring{fill:none;stroke:rgba(var(--tint), .10);stroke-width:1}
+.loc-ring-2{fill:none;stroke:rgba(217, 164, 65, .22);stroke-width:1}
+.loc-ring-3{fill:none;stroke:rgba(217, 164, 65, .38);stroke-width:1.5}
+.loc-dot{fill:var(--ochre)}
+.loc-cross{stroke:rgba(217, 164, 65, .55);stroke-width:1}
+.loc-coord{fill:var(--ochre)}
 
 /* ── takeaway callout ── */
 .arch-takeaway{border-left:3px solid var(--ochre);padding:16px 20px;background:var(--card);margin-top:32px}
@@ -328,58 +371,58 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       <svg viewBox="0 0 860 220" xmlns="http://www.w3.org/2000/svg" style="width:100%;height:auto;min-width:480px">
         <!-- Stage boxes -->
         <!-- 1: YOUR BROWSER -->
-        <rect x="0" y="40" width="180" height="140" rx="2" fill="#F8FAFC" stroke="#e2e8f0" stroke-width="1.5"/>
-        <text x="90" y="64" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" font-weight="700" letter-spacing="0.08em" fill="#0B3A6A">YOUR BROWSER</text>
-        <rect x="20" y="76" width="140" height="28" rx="2" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-        <text x="90" y="95" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#1D4ED8">file.pdf</text>
-        <text x="90" y="118" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" fill="#475569">AES-256-GCM</text>
-        <text x="90" y="132" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" fill="#475569">encrypt in browser</text>
-        <rect x="20" y="144" width="140" height="24" rx="2" fill="#0B3A6A"/>
-        <text x="90" y="160" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#B2FF3F">🔑 key generated</text>
+        <rect x="0" y="40" width="180" height="140" rx="2" class="d-panel"/>
+        <text x="90" y="64" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" font-weight="700" letter-spacing="0.08em" class="d-h">YOUR BROWSER</text>
+        <rect x="20" y="76" width="140" height="28" rx="2" class="d-slot"/>
+        <text x="90" y="95" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" class="d-accent">file.pdf</text>
+        <text x="90" y="118" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" class="d-t">AES-256-GCM</text>
+        <text x="90" y="132" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" class="d-t">encrypt in browser</text>
+        <rect x="20" y="144" width="140" height="24" rx="2" class="d-bar"/>
+        <text x="90" y="160" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" class="d-bar-ink">&#x1F511; key generated</text>
 
         <!-- Arrow 1→2 -->
-        <line x1="183" y1="110" x2="227" y2="110" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arr)"/>
-        <text x="205" y="102" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#94a3b8">ciphertext</text>
+        <line x1="183" y1="110" x2="227" y2="110" class="d-line" marker-end="url(#arr)"/>
+        <text x="205" y="102" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" class="d-t">ciphertext</text>
 
         <!-- 2: PARAMANT RELAY -->
-        <rect x="230" y="40" width="180" height="140" rx="2" fill="#F8FAFC" stroke="#e2e8f0" stroke-width="1.5"/>
-        <text x="320" y="64" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" font-weight="700" letter-spacing="0.08em" fill="#0B3A6A">PARAMANT RELAY</text>
-        <rect x="250" y="76" width="140" height="52" rx="2" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
-        <text x="320" y="98" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#dc2626">████████████</text>
-        <text x="320" y="114" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#dc2626">opaque ciphertext</text>
-        <text x="320" y="146" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" fill="#475569">RAM only &mdash; no disk write</text>
-        <text x="320" y="160" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" fill="#475569">no key, no plaintext</text>
+        <rect x="230" y="40" width="180" height="140" rx="2" class="d-panel"/>
+        <text x="320" y="64" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" font-weight="700" letter-spacing="0.08em" class="d-h">PARAMANT RELAY</text>
+        <rect x="250" y="76" width="140" height="52" rx="2" class="d-slot-bad"/>
+        <text x="320" y="98" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" class="d-bad">████████████</text>
+        <text x="320" y="114" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" class="d-bad">opaque ciphertext</text>
+        <text x="320" y="146" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" class="d-t">RAM only &mdash; no disk write</text>
+        <text x="320" y="160" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" class="d-t">no key, no plaintext</text>
 
         <!-- Arrow 2→3 -->
-        <line x1="413" y1="110" x2="457" y2="110" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arr)"/>
-        <text x="435" y="102" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#94a3b8">ciphertext</text>
+        <line x1="413" y1="110" x2="457" y2="110" class="d-line" marker-end="url(#arr)"/>
+        <text x="435" y="102" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" class="d-t">ciphertext</text>
 
         <!-- 3: RECIPIENT BROWSER -->
-        <rect x="460" y="40" width="180" height="140" rx="2" fill="#F8FAFC" stroke="#e2e8f0" stroke-width="1.5"/>
-        <text x="550" y="64" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" font-weight="700" letter-spacing="0.08em" fill="#0B3A6A">RECIPIENT BROWSER</text>
-        <rect x="480" y="76" width="140" height="28" rx="2" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
-        <text x="550" y="95" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#166534">file.pdf ✓</text>
-        <text x="550" y="118" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" fill="#475569">key from link #fragment</text>
-        <text x="550" y="132" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" fill="#475569">decrypt locally</text>
-        <rect x="480" y="144" width="140" height="24" rx="2" fill="#0B3A6A"/>
-        <text x="550" y="160" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#B2FF3F">flagged for erasure</text>
+        <rect x="460" y="40" width="180" height="140" rx="2" class="d-panel"/>
+        <text x="550" y="64" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" font-weight="700" letter-spacing="0.08em" class="d-h">RECIPIENT BROWSER</text>
+        <rect x="480" y="76" width="140" height="28" rx="2" class="d-slot"/>
+        <text x="550" y="95" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" class="d-accent">file.pdf ✓</text>
+        <text x="550" y="118" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" class="d-t">key from link #fragment</text>
+        <text x="550" y="132" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" class="d-t">decrypt locally</text>
+        <rect x="480" y="144" width="140" height="24" rx="2" class="d-bar"/>
+        <text x="550" y="160" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" class="d-bar-ink">flagged for erasure</text>
 
         <!-- Arrow 3→4 -->
-        <line x1="643" y1="110" x2="687" y2="110" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arr)"/>
-        <text x="665" y="102" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#94a3b8">burn</text>
+        <line x1="643" y1="110" x2="687" y2="110" class="d-line" marker-end="url(#arr)"/>
+        <text x="665" y="102" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" class="d-t">burn</text>
 
         <!-- 4: GONE -->
-        <rect x="690" y="40" width="170" height="140" rx="2" fill="#fff1f2" stroke="#fecdd3" stroke-width="1.5" stroke-dasharray="4 3"/>
-        <text x="775" y="64" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" font-weight="700" letter-spacing="0.08em" fill="#dc2626">GONE</text>
-        <text x="775" y="95" text-anchor="middle" font-size="28" fill="#dc2626">⌫</text>
-        <text x="775" y="126" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" fill="#dc2626">erased from RAM</text>
-        <text x="775" y="142" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" fill="#dc2626">410 Gone</text>
-        <text x="775" y="158" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" fill="#dc2626">no recovery</text>
+        <rect x="690" y="40" width="170" height="140" rx="2" class="d-gone" stroke-dasharray="4 3"/>
+        <text x="775" y="64" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" font-weight="700" letter-spacing="0.08em" class="d-bad">GONE</text>
+        <text x="775" y="95" text-anchor="middle" font-size="28" class="d-bad">⌫</text>
+        <text x="775" y="126" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" class="d-bad">erased from RAM</text>
+        <text x="775" y="142" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" class="d-bad">410 Gone</text>
+        <text x="775" y="158" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" class="d-bad">no recovery</text>
 
         <!-- Arrowhead marker -->
         <defs>
           <marker id="arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-            <path d="M0,0 L0,6 L8,3 z" fill="#94a3b8"/>
+            <path d="M0,0 L0,6 L8,3 z" class="d-arrow"/>
           </marker>
         </defs>
       </svg>
@@ -484,8 +527,8 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
       </div>
       <div class="lifecycle-state lifecycle-state--gone">
         <svg class="lifecycle-gone-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-          <circle cx="10" cy="10" r="9" stroke="#ef4444" stroke-width="1.5"/>
-          <path d="M6.5 6.5L13.5 13.5M13.5 6.5L6.5 13.5" stroke="#ef4444" stroke-width="1.75"/>
+          <circle cx="10" cy="10" r="9" stroke="currentColor" stroke-width="1.5"/>
+          <path d="M6.5 6.5L13.5 13.5M13.5 6.5L6.5 13.5" stroke="currentColor" stroke-width="1.75"/>
         </svg>
         <div class="lifecycle-num">State 03 &mdash; gone</div>
         <div class="lifecycle-heading">Erased</div>
@@ -509,49 +552,49 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
     <div class="arch-diagram" role="img" aria-label="Merkle tree diagram showing root hash derived from four leaf events">
       <svg viewBox="0 0 680 260" xmlns="http://www.w3.org/2000/svg" style="width:100%;height:auto">
         <!-- ROOT -->
-        <rect x="265" y="10" width="150" height="44" rx="2" fill="#B2FF3F"/>
-        <text x="340" y="30" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" font-weight="700" letter-spacing="0.06em" fill="#0B3A6A">MERKLE ROOT</text>
-        <text x="340" y="46" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#0B3A6A">SHA3-256 fingerprint</text>
+        <rect x="265" y="10" width="150" height="44" rx="2" class="d-root"/>
+        <text x="340" y="30" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" font-weight="700" letter-spacing="0.06em" class="d-root-ink">MERKLE ROOT</text>
+        <text x="340" y="46" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" class="d-root-ink">SHA3-256 fingerprint</text>
 
         <!-- Mid-level lines -->
-        <line x1="290" y1="54" x2="175" y2="110" stroke="#cbd5e1" stroke-width="1.5"/>
-        <line x1="390" y1="54" x2="505" y2="110" stroke="#cbd5e1" stroke-width="1.5"/>
+        <line x1="290" y1="54" x2="175" y2="110" class="d-line"/>
+        <line x1="390" y1="54" x2="505" y2="110" class="d-line"/>
 
         <!-- Mid-level nodes -->
-        <rect x="105" y="110" width="140" height="38" rx="2" fill="#F8FAFC" stroke="#e2e8f0" stroke-width="1.5"/>
-        <text x="175" y="127" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#475569">hash(A + B)</text>
-        <text x="175" y="141" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#94a3b8">transfers 1–2</text>
+        <rect x="105" y="110" width="140" height="38" rx="2" class="d-panel"/>
+        <text x="175" y="127" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" class="d-t">hash(A + B)</text>
+        <text x="175" y="141" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" class="d-t">transfers 1–2</text>
 
-        <rect x="435" y="110" width="140" height="38" rx="2" fill="#F8FAFC" stroke="#e2e8f0" stroke-width="1.5"/>
-        <text x="505" y="127" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#475569">hash(C + D)</text>
-        <text x="505" y="141" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#94a3b8">transfers 3–4</text>
+        <rect x="435" y="110" width="140" height="38" rx="2" class="d-panel"/>
+        <text x="505" y="127" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" class="d-t">hash(C + D)</text>
+        <text x="505" y="141" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" class="d-t">transfers 3–4</text>
 
         <!-- Leaf lines -->
-        <line x1="145" y1="148" x2="75" y2="196" stroke="#cbd5e1" stroke-width="1.5"/>
-        <line x1="205" y1="148" x2="265" y2="196" stroke="#cbd5e1" stroke-width="1.5"/>
-        <line x1="475" y1="148" x2="415" y2="196" stroke="#cbd5e1" stroke-width="1.5"/>
-        <line x1="545" y1="148" x2="605" y2="196" stroke="#cbd5e1" stroke-width="1.5"/>
+        <line x1="145" y1="148" x2="75" y2="196" class="d-line"/>
+        <line x1="205" y1="148" x2="265" y2="196" class="d-line"/>
+        <line x1="475" y1="148" x2="415" y2="196" class="d-line"/>
+        <line x1="545" y1="148" x2="605" y2="196" class="d-line"/>
 
         <!-- Leaf nodes -->
-        <rect x="25" y="196" width="100" height="48" rx="2" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-        <text x="75" y="212" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" font-weight="700" fill="#1D4ED8">EVENT A</text>
-        <text x="75" y="228" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7.5" fill="#64748b">transfer 1</text>
-        <text x="75" y="240" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7" fill="#94a3b8">timestamp + hash</text>
+        <rect x="25" y="196" width="100" height="48" rx="2" class="d-slot"/>
+        <text x="75" y="212" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" font-weight="700" class="d-accent">EVENT A</text>
+        <text x="75" y="228" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7.5" class="d-t">transfer 1</text>
+        <text x="75" y="240" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7" class="d-t">timestamp + hash</text>
 
-        <rect x="215" y="196" width="100" height="48" rx="2" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-        <text x="265" y="212" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" font-weight="700" fill="#1D4ED8">EVENT B</text>
-        <text x="265" y="228" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7.5" fill="#64748b">transfer 2</text>
-        <text x="265" y="240" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7" fill="#94a3b8">timestamp + hash</text>
+        <rect x="215" y="196" width="100" height="48" rx="2" class="d-slot"/>
+        <text x="265" y="212" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" font-weight="700" class="d-accent">EVENT B</text>
+        <text x="265" y="228" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7.5" class="d-t">transfer 2</text>
+        <text x="265" y="240" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7" class="d-t">timestamp + hash</text>
 
-        <rect x="365" y="196" width="100" height="48" rx="2" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-        <text x="415" y="212" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" font-weight="700" fill="#1D4ED8">EVENT C</text>
-        <text x="415" y="228" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7.5" fill="#64748b">transfer 3</text>
-        <text x="415" y="240" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7" fill="#94a3b8">timestamp + hash</text>
+        <rect x="365" y="196" width="100" height="48" rx="2" class="d-slot"/>
+        <text x="415" y="212" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" font-weight="700" class="d-accent">EVENT C</text>
+        <text x="415" y="228" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7.5" class="d-t">transfer 3</text>
+        <text x="415" y="240" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7" class="d-t">timestamp + hash</text>
 
-        <rect x="555" y="196" width="100" height="48" rx="2" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-        <text x="605" y="212" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" font-weight="700" fill="#1D4ED8">EVENT D</text>
-        <text x="605" y="228" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7.5" fill="#64748b">transfer 4</text>
-        <text x="605" y="240" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7" fill="#94a3b8">timestamp + hash</text>
+        <rect x="555" y="196" width="100" height="48" rx="2" class="d-slot"/>
+        <text x="605" y="212" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8.5" font-weight="700" class="d-accent">EVENT D</text>
+        <text x="605" y="228" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7.5" class="d-t">transfer 4</text>
+        <text x="605" y="240" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7" class="d-t">timestamp + hash</text>
       </svg>
     </div>
 
@@ -573,20 +616,20 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 
       <svg viewBox="0 0 360 280" xmlns="http://www.w3.org/2000/svg" style="width:100%;max-width:360px;margin:0 auto;display:block" aria-label="Concentric circles showing relay location in Nuremberg, Germany">
         <!-- Concentric circles -->
-        <circle cx="180" cy="140" r="130" fill="none" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
-        <circle cx="180" cy="140" r="100" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="1"/>
-        <circle cx="180" cy="140" r="72" fill="none" stroke="rgba(255,255,255,0.10)" stroke-width="1"/>
-        <circle cx="180" cy="140" r="46" fill="none" stroke="rgba(178,255,63,0.2)" stroke-width="1"/>
-        <circle cx="180" cy="140" r="22" fill="none" stroke="rgba(178,255,63,0.35)" stroke-width="1.5"/>
+        <circle cx="180" cy="140" r="130" class="loc-ring"/>
+        <circle cx="180" cy="140" r="100" class="loc-ring"/>
+        <circle cx="180" cy="140" r="72" class="loc-ring"/>
+        <circle cx="180" cy="140" r="46" class="loc-ring-2"/>
+        <circle cx="180" cy="140" r="22" class="loc-ring-3"/>
         <!-- Center dot -->
-        <circle cx="180" cy="140" r="5" fill="#B2FF3F"/>
+        <circle cx="180" cy="140" r="5" class="loc-dot"/>
         <!-- Cross-hairs -->
-        <line x1="180" y1="110" x2="180" y2="118" stroke="rgba(178,255,63,0.5)" stroke-width="1"/>
-        <line x1="180" y1="162" x2="180" y2="170" stroke="rgba(178,255,63,0.5)" stroke-width="1"/>
-        <line x1="150" y1="140" x2="158" y2="140" stroke="rgba(178,255,63,0.5)" stroke-width="1"/>
-        <line x1="202" y1="140" x2="210" y2="140" stroke="rgba(178,255,63,0.5)" stroke-width="1"/>
+        <line x1="180" y1="110" x2="180" y2="118" class="loc-cross"/>
+        <line x1="180" y1="162" x2="180" y2="170" class="loc-cross"/>
+        <line x1="150" y1="140" x2="158" y2="140" class="loc-cross"/>
+        <line x1="202" y1="140" x2="210" y2="140" class="loc-cross"/>
         <!-- Coordinates label -->
-        <text x="196" y="128" font-family="'IBM Plex Mono',monospace" font-size="8" fill="rgba(178,255,63,0.7)">49.45°N 11.08°E</text>
+        <text x="196" y="128" font-family="'IBM Plex Mono',monospace" font-size="8" class="loc-coord">49.45°N 11.08°E</text>
       </svg>
 
       <div style="font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:11px;color:rgba(217, 164, 65, 0.8);letter-spacing:.08em;margin-top:8px">paramant-relay · 49.45N · 11.08E</div>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -20,7 +20,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <link rel="canonical" href="https://paramant.app/audit-log-export">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 a{color:var(--ink);text-decoration:none}

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -10,7 +10,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 /* Een auth-scherm is op een telefoon één taak. Kop, één zin en de knop moeten

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -22,7 +22,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 /* Compact auth layout — existing design tokens only; design-system.css untouched. */

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -10,7 +10,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 /* Same compact phone rhythm as /auth/backup: existing tokens only,

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -10,7 +10,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 /* Same compact phone rhythm as /auth/backup: existing tokens only,

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -10,7 +10,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <script src="/js/qrcode.min.js?v=1"></script>
 <style>
@@ -288,7 +288,7 @@
 
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
-<script src="/js/auth-setup.js?v=2"></script>
+<script src="/js/auth-setup.js?v=3"></script>
 <script type="module" src="/js/passkey.js?v=5"></script>
 
 <footer class="legal-strip">

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -24,7 +24,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -26,7 +26,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#15191C">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -67,8 +67,12 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 .banner.ok{border-color:var(--cobalt);color:var(--cobalt);background:rgba(var(--tint), 0.04)}
 .banner.err{border-color:rgba(196, 96, 79, 0.6);color:rgba(196, 96, 79, 1);background:rgba(196, 96, 79, 0.06)}
 .banner.warn{border-color:#d4a017;background:var(--card);color:var(--warn-ink)}
-.disclaimer{background:var(--card);border:1px solid #d4a017;padding:10px 14px;font-size:12px;color:var(--warn-ink);margin-bottom:14px;line-height:1.5}
-.disclaimer strong{display:block;font-size:11px;letter-spacing:.06em;text-transform:uppercase;margin-bottom:4px;color:#7a5300}
+/* The warning band. Its border was #d4a017 and its heading #7a5300, both from
+   the days of a bone page: on the night the heading is a dark ochre on a dark
+   card and there is nothing left to read. The band keeps its meaning and takes
+   the system's warning ink. */
+.disclaimer{background:var(--card);border:1px solid var(--ochre);padding:10px 14px;font-size:12px;color:var(--warn-ink);margin-bottom:14px;line-height:1.5}
+.disclaimer strong{display:block;font-size:11px;letter-spacing:.06em;text-transform:uppercase;margin-bottom:4px;color:var(--warn-ink)}
 .tag{display:inline-block;font-family:var(--mono);font-size:10px;padding:3px 8px;border:1px solid var(--ink-hair);color:var(--ink-dim);margin-right:4px}
 .tag.green{border-color:var(--cobalt);color:var(--cobalt)}
 .tag.red{border-color:rgba(196, 96, 79, 0.6);color:rgba(196, 96, 79, 1)}
@@ -87,6 +91,15 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 .doc-page canvas,.doc-page img{display:block;width:100%;height:auto;border:1px solid var(--ink-hair);background:#FFFFFF}
 .doc-page.appearance-page{position:relative;cursor:crosshair}
 .appearance-layer{position:absolute;inset:0;pointer-events:auto;cursor:crosshair}
+/* ── The document layer ──
+   Everything with .appearance-* on it is drawn ON the page being signed, and a
+   page is white paper in every theme. The blue is the ink that ends up in the
+   PDF, the same #1D4ED8 the seal is drawn with in frontend/js/sign-flow.js and
+   pinned in sign.html: a box the signer sees in cream on a warm dark ground
+   would be a preview of a document nobody will ever receive. So these values
+   are fixed on purpose, they are the one place on this page where a token is
+   deliberately not used, and scripts/ui-contrast-sweep.mjs has them on its
+   known list for that reason and no other. */
 .appearance-field{position:absolute;display:flex;align-items:center;overflow:hidden;border:2px solid #1D4ED8;background:rgba(255,255,255,.94);color:#0C1B2A;padding:5px 8px;font:600 10px/1.25 var(--sans);box-shadow:0 3px 12px rgba(0, 0, 0, .16);pointer-events:auto}
 .appearance-field.date{border-color:#5C6A78;font-family:var(--mono);font-weight:500}
 /* The box the SENDER asked for, before the signer has touched it. It must not

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="Algorithms you can swap without rebuilding. Identifiers travel in the header, not in the code path. NIST FIPS 203, 204, 205 and 206 loaded in production.">
 <link rel="canonical" href="https://paramant.app/crypto-agility">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 a{color:var(--ink);text-decoration:none}

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -18,7 +18,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <meta property="og:title" content="Certificate transparency log · Paramant">
 <meta property="og:description" content="Every public key registration is appended to a tamper-evident Merkle tree. Anyone can verify that a device was registered, without seeing the payload.">

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -11,7 +11,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://relay.paramant.app">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/parapear.css?v=4">
 <noscript><meta http-equiv="refresh" content="0;url=/auth/login?next=/dashboard"></noscript>
@@ -133,7 +133,10 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 .dh-document-progress { min-width: 0; }
 /* Never a bar without the number next to it. */
 .dh-document-progress span { display: block; margin-bottom: 7px; font-family: var(--mono); font-size: 11px; letter-spacing: .04em; color: var(--ink-2); }
-.dh-progress { width: 100%; height: 3px; border-radius: var(--r-0); background: var(--line-2); overflow: hidden; }
+/* The track has to be dark enough for the meter to read against it. On
+   --line-2 the ochre fill measures 2.92:1, which is the wrong side of the
+   3:1 WCAG 2.1 SC 1.4.11 asks of a control that shows a state. */
+.dh-progress { width: 100%; height: 3px; border-radius: var(--r-0); background: var(--ink-hair); overflow: hidden; }
 .dh-progress i { display: block; height: 100%; background: var(--accent); transform-origin: left center; animation: dh-meter var(--d-3) var(--e-standard) both; }
 @keyframes dh-meter { from { transform: scaleX(0); } to { transform: scaleX(1); } }
 /* The four states are the four words dashboard.js renders, and nothing else. */
@@ -274,7 +277,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 .dh-ops-row .dim { font-family: var(--mono); font-size: 11px; color: var(--ink-3); flex: 0 0 auto; }
 .dh-usage-row { margin-bottom: var(--space-3); }
 .dh-usage-lab { display: flex; justify-content: space-between; font-family: var(--mono); font-size: 12px; color: var(--ink-1); margin-bottom: 6px; }
-.dh-bar { height: 3px; border-radius: var(--r-0); background: var(--line-2); overflow: hidden; }
+.dh-bar { height: 3px; border-radius: var(--r-0); background: var(--ink-hair); overflow: hidden; }
 .dh-bar > i { display: block; height: 100%; width: 0; background: var(--accent); transition: width var(--d-3) var(--e-standard); }
 .dh-bar.warn > i { background: var(--sig-wait); }
 .dh-usage-upsell { display: inline-block; margin-top: 6px; font-family: var(--mono); font-size: 11px; color: var(--accent); text-decoration: none; }

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -10,7 +10,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#15191C">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <style>
 *{box-sizing:border-box}
 body{background:linear-gradient(180deg,#f8faff 0,var(--card) 460px)}

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/docs">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -67,7 +67,7 @@ pre{font-family:var(--mono);font-size:12px;line-height:1.7;color:var(--ink);back
 </style>
 <style>.skip-link{position:absolute;top:-200px;left:0;background:var(--bone-2);color:var(--ink);padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid var(--ochre);transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:var(--ochre)}</style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <script type="application/ld+json" data-paramant-seo="1">
 {

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="The GDPR Article 28 agreement between Paramantis Solutions B.V. as processor and your organisation as controller. Sign it electronically, EU and German law.">
 <link rel="canonical" href="https://paramant.app/dpa">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 a{color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-hair)}

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -30,7 +30,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/done-state.css?v=1">
   <style>

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -73,7 +73,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -59,7 +59,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -73,7 +73,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -75,7 +75,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -77,7 +77,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -57,7 +57,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/parapear.css?v=4">
 <style>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -72,7 +72,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -71,7 +71,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -77,7 +77,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -71,7 +71,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 }
 </style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,7 +23,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="manifest" href="/manifest.json">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <style>
 /* Homepage 2026, night edition: the same hand as BeerWeer. The night itself is
    no longer here: frontend/design-system.css carries it for the whole site, so
@@ -80,7 +80,9 @@ html[data-session="in"] .home-hero{padding-bottom:56px}
 .hp-band{position:relative;height:clamp(132px,34vw,230px);overflow:hidden;background:var(--paper-2);border-bottom:1px solid var(--line)}
 .hp-band svg{position:absolute;inset:0;width:100%;height:100%;display:block}
 .hp-band-tag{position:absolute;right:var(--pad);top:14px;font-family:var(--hp-mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:rgba(27,31,34,.82);display:flex;align-items:center;gap:8px}
-.hp-band-tag::before{content:"";width:9px;height:9px;border-radius:50%;background:var(--ochre)}
+/* The dot next to the strip line. Full ochre on the band's cream sky is
+   1.66:1; the ochre-as-ink token is the same hue at 4.7:1 on that paper. */
+.hp-band-tag::before{content:"";width:9px;height:9px;border-radius:50%;background:var(--ochre-ink)}
 @media (min-width:900px){.hp-band-tag{right:max(var(--pad), calc((100% - var(--maxw)) / 2))}}
 
 /* ---------- hero ---------- */

--- a/frontend/js/admin.page.js
+++ b/frontend/js/admin.page.js
@@ -185,7 +185,7 @@ const PURPOSE_LABELS={personal:'Personal use',organisation:'Organisation',client
 function purposeLine(u){
   if(!u.usage_purpose)return '';
   const hot=u.usage_purpose==='organisation'||u.usage_purpose==='client_management';
-  return '<div class="mono" style="font-size:11px;color:'+(hot?'#0B3A6A;font-weight:600':'#475569')+'" title="Usage purpose ('+esc(u.usage_purpose_at?u.usage_purpose_at.split('T')[0]:'')+')">use: '+esc(PURPOSE_LABELS[u.usage_purpose]||u.usage_purpose)+'</div>';
+  return '<div class="mono" style="font-size:11px;color:'+(hot?'var(--ochre);font-weight:600':'var(--ink-dim)')+'" title="Usage purpose ('+esc(u.usage_purpose_at?u.usage_purpose_at.split('T')[0]:'')+')">use: '+esc(PURPOSE_LABELS[u.usage_purpose]||u.usage_purpose)+'</div>';
 }
 function usersTable(users){
   if(!users.length)return '<div class="empty">No users match filters</div>';
@@ -286,9 +286,9 @@ function uAction(action,btn){
 }
 function showNewKeyModal(){
   const o=document.createElement('div');
-  o.style.cssText='position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(11,58,106,.4);z-index:100;display:flex;align-items:center;justify-content:center;padding:24px';
-  o.innerHTML='<div style="background:#F8FAFC;border:1.5px solid rgba(11,58,106,.12);padding:28px;max-width:480px;width:100%">'+
-    '<div style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:#475569;margin-bottom:16px">Create new API key</div>'+
+  o.style.cssText='position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(12, 15, 17, .72);z-index:100;display:flex;align-items:center;justify-content:center;padding:24px';
+  o.innerHTML='<div style="background:var(--bone-2);border:1.5px solid var(--line);padding:28px;max-width:480px;width:100%;color:var(--ink)">'+
+    '<div style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:16px">Create new API key</div>'+
     '<label class="l-lbl">Label</label><input id="nk-l" class="l-inp" placeholder="acme-corp"><br>'+
     '<label class="l-lbl">Plan</label><select id="nk-p" class="l-inp"><option value="community">community</option><option value="pro" selected>pro</option><option value="enterprise">enterprise</option><option value="trial">trial</option></select><br>'+
     '<label class="l-lbl">Email (optional)</label><input id="nk-e" class="l-inp" type="email" placeholder="client@example.com"><br>'+
@@ -310,11 +310,11 @@ async function doCreateKey(){
   const res=document.getElementById('nk-res');
   if(r.ok&&r.data?.created?.length){
     const key=r.data.created[0]?.key||'(see response)';
-    res.innerHTML='<div style="background:#fff;border:1px solid rgba(11,58,106,.12);padding:12px;word-break:break-all;color:#0B3A6A">'+esc(key)+'</div>'+
+    res.innerHTML='<div style="background:var(--card-2);border:1px solid var(--line);padding:12px;word-break:break-all;color:var(--ochre)">'+esc(key)+'</div>'+
       '<div style="color:#059669;margin-top:6px">Key created. Save it — shown once.</div>';
     LOADED.users=false;
   }else{
-    res.innerHTML='<div style="color:#dc2626">Failed: '+esc(r.data?.failed?.[0]?.error||r.data?.error||'unknown')+'</div>';
+    res.innerHTML='<div style="color:var(--brick-ink)">Failed: '+esc(r.data?.failed?.[0]?.error||r.data?.error||'unknown')+'</div>';
   }
 }
 
@@ -361,7 +361,7 @@ async function fetchAudit(){
       '<td class="mono" style="font-size:11px;white-space:nowrap">'+esc(e.ts?new Date(e.ts).toISOString().replace('T',' ').slice(0,19):'—')+'</td>'+
       '<td><span class="chip active">'+esc(e.event_type||'—')+'</span></td>'+
       '<td class="mono" style="font-size:11px;color:#475569">'+esc((e.user_id||'').slice(0,20))+'</td>'+
-      '<td><details><summary style="cursor:pointer;font-size:11px;color:#475569">show</summary><pre style="font-size:10px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;margin-top:4px;color:#0B3A6A;white-space:pre-wrap">'+esc(JSON.stringify(e.metadata||{},null,2))+'</pre></details></td>'+
+      '<td><details><summary style="cursor:pointer;font-size:11px;color:var(--ink-dim)">show</summary><pre style="font-size:10px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;margin-top:4px;color:var(--ink-2);white-space:pre-wrap">'+esc(JSON.stringify(e.metadata||{},null,2))+'</pre></details></td>'+
     '</tr>').join('')+'</tbody></table>';
 }
 
@@ -437,7 +437,7 @@ async function fetchRelay(){
   }).join('');
   const cards=document.getElementById('r-cards');
   if(cards)cards.innerHTML=Object.entries(sectors).map(([name,s])=>{
-    if(s.error)return '<div class="card"><div class="card-hdr">'+esc(name)+' <small style="color:#dc2626">offline</small></div><div class="empty">'+esc(s.error)+'</div></div>';
+    if(s.error)return '<div class="card"><div class="card-hdr">'+esc(name)+' <small style="color:var(--brick-ink)">offline</small></div><div class="empty">'+esc(s.error)+'</div></div>';
     const st=s.stats||{};
     return '<div class="card"><div class="card-hdr">'+esc(name)+' relay<small>v'+esc(s.version||'?')+'</small></div>'+
       '<table class="tbl"><tbody>'+

--- a/frontend/js/auth-setup.js
+++ b/frontend/js/auth-setup.js
@@ -28,8 +28,8 @@
         text: setupData.otpauth,
         width: 240,
         height: 240,
-        colorDark: '#0B3A6A',
-        colorLight: '#F8FAFC',
+        colorDark: '#1B1F22',
+        colorLight: '#F1EAD6',
         correctLevel: QRCode.CorrectLevel.M,
       });
 

--- a/frontend/js/parashare.page.js
+++ b/frontend/js/parashare.page.js
@@ -527,7 +527,7 @@ function onFileSelect() {
     const vl = $('vault-list');
     vl.style.display = 'block';
     vl.innerHTML = [...files].map(f =>
-      '<div style="font-size:10px;color:rgba(248,250,252,.65);padding:2px 0;font-family:var(--mono)">' + f.name + ' <span style="color:rgba(248,250,252,.5)">(' + (f.size/1024/1024).toFixed(1) + ' MB)</span></div>'
+      '<div style="font-size:10px;color:var(--ink-2);padding:2px 0;font-family:var(--mono)">' + f.name + ' <span style="color:var(--ink-dim)">(' + (f.size/1024/1024).toFixed(1) + ' MB)</span></div>'
     ).join('');
   }
   updateBtn();
@@ -1267,8 +1267,8 @@ function toggleGlobe() {
     // Fullscreen HUD mode: hide UI, show HUD panels
     overlay.classList.add('globe-fullscreen');
     if (mainEl) mainEl.style.display = 'none';
-    const _gb = document.getElementById('globe-btn'); if (_gb) _gb.style.color = '#B2FF3F';
-    if (_gb) _gb.style.boxShadow = '0 0 12px rgba(178,255,63,.3)';
+    const _gb = document.getElementById('globe-btn'); if (_gb) _gb.style.color = 'var(--ochre)';
+    if (_gb) _gb.style.boxShadow = '0 0 12px rgba(217, 164, 65, .3)';
     if (_gb) _gb.textContent = '✕ Close';
   } else {
     // Background mode: restore UI, hide HUD panels
@@ -1310,12 +1310,19 @@ async function initGlobe() {
   const wrap = document.getElementById('globe-canvas-wrap');
 
   // Globe.gl instantiëren
+  // The globe is WebGL: three.js is handed colours, not a cascade, so it cannot
+  // read a custom property and the accent has to be written out. GLOBE_ACCENT
+  // is the ochre of design-system.css (--ochre, #D9A441). It used to be the
+  // old lime #B2FF3F, which is a colour the night edition retired from the UI
+  // in PR #417 and which survived here only because no stylesheet touches it.
+  const GLOBE_ACCENT = '#D9A441';
+  const GLOBE_ACCENT_RGB = '217,164,65';
   globeInstance = Globe({ animateIn: true })
     .globeImageUrl('/images/globe/earth-night.jpg')
     .bumpImageUrl('/images/globe/earth-topology.png')
     .backgroundImageUrl('/images/globe/night-sky.png')
     .showAtmosphere(true)
-    .atmosphereColor('#B2FF3F')
+    .atmosphereColor(GLOBE_ACCENT)
     .atmosphereAltitude(0.18)
     // HTML dots — crisp DOM elements, no pixelation at any zoom
     .htmlElementsData([
@@ -1324,7 +1331,7 @@ async function initGlobe() {
     ])
     .htmlElement(d => {
       const wrap = document.createElement('div');
-      const color = d.type === 'relay' ? '#B2FF3F' : 'var(--ink-dim)';
+      const color = d.type === 'relay' ? GLOBE_ACCENT : 'var(--ink-dim)';
       wrap.innerHTML = `<div title="${d.label}" style="
         width:14px;height:14px;border-radius:50%;
         background:${color};
@@ -1344,7 +1351,7 @@ async function initGlobe() {
       {
         startLat: userLat, startLng: userLng,
         endLat: RELAY_LOC.lat, endLng: RELAY_LOC.lng,
-        color: ['rgba(178,255,63,0)', '#B2FF3F', '#B2FF3F', 'rgba(178,255,63,0)'],
+        color: [`rgba(${GLOBE_ACCENT_RGB},0)`, GLOBE_ACCENT, GLOBE_ACCENT, `rgba(${GLOBE_ACCENT_RGB},0)`],
         label: 'Ghost Pipe · Encrypted Channel',
       }
     ])
@@ -1355,11 +1362,11 @@ async function initGlobe() {
     .arcStroke(0.4)
     .arcAltitudeAutoScale(0.35)
     .arcLabel(d => `<div style="font:10px monospace;background:rgba(12,12,12,.9);
-      border:1px solid rgba(178,255,63,.25);padding:4px 8px;color:#B2FF3F">${d.label}</div>`)
+      border:1px solid rgba(217, 164, 65, .25);padding:4px 8px;color:${GLOBE_ACCENT}">${d.label}</div>`)
     // Pulserende ringen op knooppunten
     .ringsData([
-      { lat: userLat, lng: userLng, maxR: 3, propagationSpeed: 2.5, repeatPeriod: 1200, color: () => 'rgba(178,255,63,' },
-      { lat: RELAY_LOC.lat, lng: RELAY_LOC.lng, maxR: 2.5, propagationSpeed: 2, repeatPeriod: 1600, color: () => 'rgba(178,255,63,' },
+      { lat: userLat, lng: userLng, maxR: 3, propagationSpeed: 2.5, repeatPeriod: 1200, color: () => `rgba(${GLOBE_ACCENT_RGB},` },
+      { lat: RELAY_LOC.lat, lng: RELAY_LOC.lng, maxR: 2.5, propagationSpeed: 2, repeatPeriod: 1600, color: () => `rgba(${GLOBE_ACCENT_RGB},` },
     ])
     .ringColor(d => t => `${d.color()}${1 - t})`)
     .ringMaxRadius('maxR')
@@ -1454,17 +1461,17 @@ function updateSessionsPanel() {
     ? sessions.map(s => `<div class="hud-session">
         <span class="hud-dot${s.active ? '' : ' amber'}"></span>
         <span style="flex:1">${s.label}</span>
-        <span style="color:rgba(178,255,63,.5);font-size:9px">${s.status}</span>
+        <span style="color:var(--ink-dim);font-size:9px">${s.status}</span>
       </div>`).join('')
     : '<div class="hud-session"><span class="hud-dot amber"></span><span>No active session</span></div>';
 }
 
 // ── Globe state machine ───────────────────────────────────────────────────────
 const _GLOBE_STATES = {
-  idle:       { arcSpeed: 2800, arcColor: ['rgba(178,255,63,0)','#B2FF3F','#B2FF3F','rgba(178,255,63,0)'], ringSpeed: 1800, ringMax: 2.5, label: 'Ghost Pipe · Encrypted Channel' },
-  waiting:    { arcSpeed: 1800, arcColor: ['rgba(178,255,63,0)','var(--ink-dim)','var(--ink-dim)','rgba(178,255,63,0)'], ringSpeed: 1200, ringMax: 3,   label: 'Ghost Pipe · Receiver Connected' },
-  encrypting: { arcSpeed: 700,  arcColor: ['rgba(178,255,63,0)','#fff','var(--ink-dim)','rgba(178,255,63,0)'],   ringSpeed: 600,  ringMax: 4,   label: 'Ghost Pipe · Transmitting ▶' },
-  done:       { arcSpeed: 2800, arcColor: ['rgba(178,255,63,0)','#B2FF3F','#B2FF3F','rgba(178,255,63,0)'], ringSpeed: 1800, ringMax: 2.5, label: 'Ghost Pipe · Transfer Complete ✓' },
+  idle:       { arcSpeed: 2800, arcColor: ['rgba(217,164,65,0)','#D9A441','#D9A441','rgba(217,164,65,0)'], ringSpeed: 1800, ringMax: 2.5, label: 'Ghost Pipe · Encrypted Channel' },
+  waiting:    { arcSpeed: 1800, arcColor: ['rgba(217,164,65,0)','var(--ink-dim)','var(--ink-dim)','rgba(217,164,65,0)'], ringSpeed: 1200, ringMax: 3,   label: 'Ghost Pipe · Receiver Connected' },
+  encrypting: { arcSpeed: 700,  arcColor: ['rgba(217,164,65,0)','#fff','var(--ink-dim)','rgba(217,164,65,0)'],   ringSpeed: 600,  ringMax: 4,   label: 'Ghost Pipe · Transmitting ▶' },
+  done:       { arcSpeed: 2800, arcColor: ['rgba(217,164,65,0)','#D9A441','#D9A441','rgba(217,164,65,0)'], ringSpeed: 1800, ringMax: 2.5, label: 'Ghost Pipe · Transfer Complete ✓' },
 };
 
 function _globeApplyState(name) {
@@ -1482,8 +1489,8 @@ function _globeApplyState(name) {
     .arcColor(d => d.color)
     .arcDashAnimateTime(s.arcSpeed)
     .ringsData([
-      { lat: uLat, lng: uLng, maxR: s.ringMax, propagationSpeed: 2.5, repeatPeriod: s.ringSpeed, color: () => 'rgba(178,255,63,' },
-      { lat: rLat, lng: rLng, maxR: s.ringMax * 0.9, propagationSpeed: 2, repeatPeriod: s.ringSpeed * 1.15, color: () => 'rgba(178,255,63,' },
+      { lat: uLat, lng: uLng, maxR: s.ringMax, propagationSpeed: 2.5, repeatPeriod: s.ringSpeed, color: () => `rgba(${GLOBE_ACCENT_RGB},` },
+      { lat: rLat, lng: rLng, maxR: s.ringMax * 0.9, propagationSpeed: 2, repeatPeriod: s.ringSpeed * 1.15, color: () => `rgba(${GLOBE_ACCENT_RGB},` },
     ])
     .ringColor(d => t => `${d.color()}${1 - t})`)
     .ringMaxRadius('maxR')
@@ -1498,8 +1505,8 @@ function _globeBurst() {
   // Big burst rings — 3 waves from relay and user
   const burstRings = [];
   for (let i = 0; i < 3; i++) {
-    burstRings.push({ lat: rLat, lng: rLng, maxR: 8 + i * 4, propagationSpeed: 5 + i, repeatPeriod: 99999, color: () => 'rgba(178,255,63,' });
-    burstRings.push({ lat: uLat, lng: uLng, maxR: 6 + i * 3, propagationSpeed: 4 + i, repeatPeriod: 99999, color: () => 'rgba(178,255,63,' });
+    burstRings.push({ lat: rLat, lng: rLng, maxR: 8 + i * 4, propagationSpeed: 5 + i, repeatPeriod: 99999, color: () => `rgba(${GLOBE_ACCENT_RGB},` });
+    burstRings.push({ lat: uLat, lng: uLng, maxR: 6 + i * 3, propagationSpeed: 4 + i, repeatPeriod: 99999, color: () => `rgba(${GLOBE_ACCENT_RGB},` });
   }
   globeInstance
     .ringsData(burstRings)
@@ -1512,7 +1519,7 @@ function _globeBurst() {
   globeInstance.arcsData([{
     startLat: uLat, startLng: uLng,
     endLat: rLat, endLng: rLng,
-    color: ['rgba(255,255,255,0)', '#fff', 'var(--ink-dim)', 'rgba(178,255,63,0)'],
+    color: ['rgba(255,255,255,0)', '#fff', 'var(--ink-dim)', 'rgba(217,164,65,0)'],
     label: 'Ghost Pipe · Transfer Complete ✓',
   }]).arcDashAnimateTime(400);
 

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/nav.css
+++ b/frontend/nav.css
@@ -276,7 +276,12 @@ nav.nav .nav-hamburger span {
   display: block;
   width: 22px;
   height: 2px;
-  background: var(--invert);
+  /* The three bars are the whole button: it has no label. They were painted in
+     --invert, which on the bone site was the navy slab and read as ink, and
+     which the night edition turned into #0C0F11, a shade DEEPER than the bar
+     it sits on. That is 1.09:1 against the nav on a phone, on every page of
+     the site, for the one control that opens the menu. It is the ink now. */
+  background: var(--ink);
   transition: transform var(--duration-base) var(--ease-out),
               opacity var(--duration-fast) var(--ease-out);
   pointer-events: none;

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -10,7 +10,7 @@
 <title>Receive a file · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/done-state.css?v=1">
 <meta name="description" content="A secure file is waiting for you. It decrypts in your browser and burns after one download.">

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -24,7 +24,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .ps-hero{padding:var(--space-10) 0 var(--space-6)}

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -12,7 +12,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/parapear.css?v=4">
 <style>
@@ -30,7 +30,11 @@ h1{font-size:clamp(26px,5vw,38px);font-weight:600;letter-spacing:-.028em;line-he
 /* Stepper at the top of the flow -- gives the user a "you are here" sense */
 .ps-stepper{list-style:none;margin:0 0 28px;padding:0;display:flex;gap:0;position:relative}
 .ps-step{flex:1;display:flex;flex-direction:column;align-items:center;gap:8px;position:relative;min-width:0}
-.ps-step-dot{width:10px;height:10px;border-radius:50%;background:var(--surface);border:1.5px solid var(--line-2);transition:background var(--d-2) var(--e-standard),border-color var(--d-2) var(--e-standard),transform var(--d-2) var(--e-standard);position:relative;z-index:2}
+/* The ring is the state. It was a --surface disc inside a --line-2 ring,
+   which measures 1.07:1 and 1.6:1 on the night: a step indicator nobody
+   can see is not an indicator. The disc is gone and the ring carries it at
+   3.8:1, which is what WCAG 2.1 SC 1.4.11 asks of a state. */
+.ps-step-dot{width:10px;height:10px;border-radius:50%;background:transparent;border:1.5px solid rgba(var(--tint), .45);transition:background var(--d-2) var(--e-standard),border-color var(--d-2) var(--e-standard),transform var(--d-2) var(--e-standard);position:relative;z-index:2}
 .ps-step.active .ps-step-dot{background:var(--accent);border-color:var(--accent);transform:scale(1.2);box-shadow:0 0 0 4px var(--accent-soft)}
 .ps-step.done .ps-step-dot{background:var(--sig-done);border-color:var(--sig-done)}
 .ps-step-label{font-family:var(--mono);font-size:10px;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--ink-3);text-align:center;line-height:1.3;transition:color var(--d-2) var(--e-standard)}
@@ -824,7 +828,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 <script src="/js/format-date.js?v=1" defer></script>
 <script src="/js/done-state.js?v=1" defer></script>
 <script src="/js/handshake-meta.js?v=1" defer></script>
-<script src="/js/parashare.page.js?v=10" defer></script>
+<script src="/js/parashare.page.js?v=11" defer></script>
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
 <footer>

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -24,7 +24,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .ps-hero{padding:var(--space-10) 0 var(--space-6)}

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/partners">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 
 <style>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="The Community plan is free, forever. Organisations pay for higher limits: sending from 15 euro a month, signing from 49, excl. btw. From Paramantis Solutions B.V.">
 <link rel="canonical" href="https://paramant.app/pricing">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .tier-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--ink-hair)}

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -10,7 +10,7 @@
 <meta http-equiv="refresh" content="8;url=/signup">
 <link rel="canonical" href="https://paramant.app/signup">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -40,7 +40,7 @@
     footer{border-top:1px solid var(--ink-hair);padding:32px 48px}
   </style>
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <script type="application/ld+json" data-paramant-seo="1">
 {

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -7,7 +7,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/setup">
   <link rel="stylesheet" href="/design-system.css?v=28">
-  <link rel="stylesheet" href="/nav.css?v=23">
+  <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 </head>
 <body>
@@ -108,6 +108,6 @@
     </div>
   </main>
 
-  <script src="/setup.js?v=2"></script>
+  <script src="/setup.js?v=3"></script>
 </body>
 </html>

--- a/frontend/setup.js
+++ b/frontend/setup.js
@@ -160,10 +160,10 @@ function renderReview() {
   ];
   var html = '<dl class="review-list">';
   rows.forEach(function (r) {
-    html += '<div class="review-row" style="display:flex;justify-content:space-between;gap:12px;padding:6px 0;border-bottom:1px solid #eee">' +
-      '<dt style="color:#666">' + esc(r.label) + '</dt>' +
+    html += '<div class="review-row" style="display:flex;justify-content:space-between;gap:12px;padding:6px 0;border-bottom:1px solid var(--line)">' +
+      '<dt style="color:var(--ink-dim)">' + esc(r.label) + '</dt>' +
       '<dd style="margin:0;text-align:right"><span>' + esc(r.value) + '</span> ' +
-      '<button type="button" class="edit-link" data-edit="' + r.step + '" style="background:none;border:none;color:#1d4ed8;cursor:pointer;font-size:12px">Edit</button></dd>' +
+      '<button type="button" class="edit-link" data-edit="' + r.step + '" style="background:none;border:none;color:var(--ochre);cursor:pointer;font-size:12px">Edit</button></dd>' +
       '</div>';
   });
   html += '</dl>';

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -1260,6 +1260,13 @@ function onPenDown(e) {
   live.height = Math.max(1, Math.round(rect.height * density));
   const ctx = live.getContext('2d');
   ctx.setTransform(density, 0, 0, density, 0, 0);
+  // DOCUMENT INK. Every #0b3a6a in this file is the ink that ends up in the
+  // PDF: the pen stroke, the drawn annotation, the seal border and its band.
+  // A page is white paper in every theme, so this colour does NOT follow the
+  // night edition's tokens, the same way sign.html pins its document layer.
+  // Recolouring it in cream would preview a document no printer will produce.
+  // scripts/ui-contrast-sweep.mjs carries the document layer as a named
+  // exception for that reason and no other.
   ctx.strokeStyle = '#0b3a6a';
   ctx.lineWidth = PEN_STROKE_PT * (rect.width / wrap._pdfPage.width);
   ctx.lineCap = 'round';

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -24,7 +24,7 @@
 <link rel="canonical" href="https://paramant.app/sign">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/components-parasign.css?v=6">
 <style>
@@ -366,9 +366,13 @@ body[data-ds-step="step-done"] .ds-stepper{display:none}
    stamp that no printer will ever produce. So the document layer is pinned to
    fixed values here, on purpose, and it is the one place in the app where a
    token is deliberately not used, and it is why the night edition left it
-   alone: frontend/js/sign-flow.js draws the seal into the PDF with these exact
+   alone: frontend/sign-flow.js draws the seal into the PDF with these exact
    values, so a preview in cream on a warm dark ground would be a preview of a
-   document that does not exist. */
+   document that does not exist. The cobalt #1D4ED8 in particular is the seal's
+   own colour and it STAYS: it is what the customer gets in the PDF. The
+   non-text sweep, scripts/ui-contrast-sweep.mjs, measures this layer against
+   the white page it is drawn on rather than against the app around it, which
+   is the same reason. */
 .ds-page-wrap canvas,
 .ds-review-pane.has-pdf,
 .ds-signature-sheet-preview,

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -25,7 +25,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 .nav-help {

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -8,7 +8,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/signup/verified">
   <link rel="stylesheet" href="/design-system.css?v=28">
-  <link rel="stylesheet" href="/nav.css?v=23">
+  <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/sla">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/terms">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{margin:0;padding:0;box-sizing:border-box}

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -27,7 +27,7 @@
 <meta name="theme-color" content="#15191C">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -22,7 +22,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#15191C">
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/components-parasign.css?v=6">
 <script type="application/ld+json" data-paramant-seo="1">

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -21,7 +21,7 @@
 <link rel="canonical" href="https://paramant.app/vs">
 
 <link rel="stylesheet" href="/design-system.css?v=28">
-<link rel="stylesheet" href="/nav.css?v=23">
+<link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>

--- a/scripts/ui-contrast-sweep.mjs
+++ b/scripts/ui-contrast-sweep.mjs
@@ -1,0 +1,543 @@
+// The non-text sweep. What tests/theme-contrast.test.mjs cannot see.
+//
+// Why this file exists. The contrast gate we already had walks TEXT nodes: it
+// takes a text colour, flattens it onto the first opaque background above it,
+// and scores the pair. That gate is green. It was green on the day a phone
+// review found icons, rules and chips that had simply vanished, because none
+// of what vanished was text. design-system.css v5 moved the whole site onto a
+// warm dark ground; every colour that came from a token followed. Every colour
+// that was written as a hex in a page, a script or an SVG did not. A navy
+// stroke that read fine on bone is invisible on #15191C, and no test that only
+// looks at text will ever say so.
+//
+// WCAG 2.1 SC 1.4.11 Non-text Contrast asks 3:1 for the visual information
+// needed to identify user interface components and states, and for the parts
+// of a graphic that carry its meaning. That is the bar used here.
+//
+// WHAT IS MEASURED, and why each one is in the list:
+//
+//   svg      Every leaf shape (path, rect, circle, ellipse, line, polyline,
+//            polygon, use) and its fill AND its stroke, separately. An icon is
+//            a graphic whose meaning is its shape, so it is held to 3:1 in
+//            both directions of the theme.
+//   img      Raster and <img>-loaded SVG cannot be read from the cascade, so
+//            the image is drawn to a canvas and its mean colour over the
+//            non-transparent pixels is scored against the ground behind it.
+//            This is the check that catches a dark logo on a dark page, which
+//            no style rule would ever reveal.
+//   pseudo   ::before and ::after with a real content string. Checkmarks,
+//            chevrons, bullets and rule glyphs are drawn this way and they are
+//            not in the DOM's text, so the text gate steps straight over them.
+//   fill     An element with an opaque-ish background (alpha >= .5) and no
+//            text of its own: a badge, a pill, a dot, a swatch, a progress
+//            bar. A solid mark is deliberate, so it is held to 3:1.
+//   line     Borders, outlines and <hr>. These are held to 3:1 ONLY when they
+//            run against the grain of the theme, and that needs a word.
+//
+// THE GRAIN RULE, for lines and washes. A deliberate hairline on a dark ground
+// is LIGHTER than the ground; on cream paper it is DARKER. It sits on the same
+// side of its background as the page's own ink does. That is what a divider
+// is: a whisper in the direction of the writing. A line that sits on the WRONG
+// side of its background is not a whisper, it is a leftover from another
+// theme: navy on night, bone on paper. So a line under 3:1 that runs with the
+// grain is reported as decorative and not gated, and a line under 3:1 that
+// runs against it is a finding. This is the exact shape of the bug this sweep
+// was written for and it keeps the gate free of the hundreds of intentional
+// 16%-cream hairlines the design system paints on every card.
+//
+// Reused by tests/ui-elements-contrast.test.mjs, which turns the result into a
+// gate with a known-defects list. Run it by hand for the report and the
+// screenshots:
+//
+//   node scripts/ui-contrast-sweep.mjs                     report only
+//   node scripts/ui-contrast-sweep.mjs --shots /some/dir   report + screenshots
+//   node scripts/ui-contrast-sweep.mjs --json out.json     report + raw rows
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// The tree to serve. Overridable so the same sweep can be pointed at a clean
+// checkout and give a before-and-after that differs only in the code.
+export const ROOT = process.env.PARAMANT_FRONTEND
+  ? path.resolve(process.env.PARAMANT_FRONTEND)
+  : path.join(HERE, '..', 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+const MIME = {
+  '.js':'text/javascript', '.mjs':'text/javascript', '.css':'text/css', '.html':'text/html',
+  '.svg':'image/svg+xml', '.png':'image/png', '.jpg':'image/jpeg', '.jpeg':'image/jpeg',
+  '.webp':'image/webp', '.gif':'image/gif', '.woff2':'font/woff2', '.json':'application/json',
+  '.ico':'image/x-icon', '.txt':'text/plain', '.wasm':'application/wasm',
+};
+
+// The routes nginx serves. The first sixteen are the public list of
+// tests/theme-contrast.test.mjs, unchanged, so both gates walk the same site.
+// The three after it are the pages that carry the drawn work: the architecture
+// diagrams, the agility table and the co-sign explainer. They were not in the
+// text gate because they have no colour of their own to give text; they are in
+// this one because almost everything on them is a graphic.
+const ALIAS = {
+  '/':'/index.html', '/pricing':'/pricing.html', '/dashboard':'/dashboard.html',
+  '/parasign':'/parasign.html', '/parasend':'/parasend.html', '/sign':'/sign.html',
+  '/parashare':'/parashare.html', '/signup':'/signup.html', '/account':'/account.html',
+  '/security':'/security.html', '/trust':'/trust.html', '/docs':'/docs.html',
+  '/about':'/about.html', '/help':'/help/index.html', '/download':'/download.html',
+  '/login':'/auth/login.html', '/verify':'/verify.html',
+  '/architecture':'/architecture.html', '/crypto-agility':'/crypto-agility.html',
+  '/co-sign':'/co-sign.html',
+  '/developer':'/developer.html',
+  '/signup/verified':'/signup/verified.html',
+  '/auth/login':'/auth/login.html', '/auth/setup':'/auth/setup.html',
+  '/auth/backup':'/auth/backup.html', '/auth/request-reset':'/auth/request-reset.html',
+  '/auth/reset-confirm':'/auth/reset-confirm.html',
+};
+
+export const PUBLIC_PAGES = [
+  '/', '/pricing', '/parasign', '/parasend', '/sign', '/signup', '/security',
+  '/trust', '/docs', '/about', '/help', '/download', '/login', '/verify',
+  '/architecture', '/crypto-agility', '/co-sign', '/developer',
+];
+
+// The signed-in screens, with the same stubs as tests/navigation-shell.test.mjs
+// and tests/app-contrast.test.mjs so the app renders its real furniture.
+export const APP_PAGES = [
+  { slug:'/dashboard', ready:'#dh-root:not([hidden]) .dh-document' },
+  { slug:'/account',   ready:'#state-account:not(.hidden)' },
+  { slug:'/parashare', ready:'main' },
+  { slug:'/sign',      ready:'main' },
+  { slug:'/signup',    ready:'main' },
+  { slug:'/signup/verified', ready:'main', signedIn:false },
+  { slug:'/auth/login', ready:'form' },
+  { slug:'/auth/setup', ready:'main' },
+  { slug:'/auth/backup', ready:'main' },
+  { slug:'/auth/request-reset', ready:'main' },
+  { slug:'/auth/reset-confirm', ready:'main' },
+];
+
+export const SIZES = [[390, 844], [1440, 900]];
+export const THEMES = ['dark', 'light'];
+const THEME_KEY = 'paramant.theme.v1';
+
+const future = new Date(Date.now() + 30 * 86400000).toISOString();
+const ME = {
+  email:'demo@example.com', label:'Demo', plan:'community', created_at:'2026-06-01T10:00:00.000Z',
+  backup_codes_remaining:8, session_expires_at:future, usage_purpose:'organisation',
+  api_key_masked:'pgp_****', sessions:[],
+  plan_parasign:null, plan_parasend:null, paid_until_parasign:null, paid_until_parasend:null,
+};
+const DOCS = { documents:[
+  { id:'env_waiting_abcdefghijklmnop', original_filename:'Lease agreement 2026.pdf', status:'sent', created_at:'2026-08-21T10:00:00.000Z', party_count:3, signed_count:0 },
+  { id:'env_progress_abcdefghijklmnop', original_filename:'Service order.pdf', status:'sent', created_at:'2026-08-20T10:00:00.000Z', party_count:4, signed_count:2 },
+  { id:'env_complete_abcdefghijklmnop', original_filename:'Consultancy contract.pdf', status:'complete', created_at:'2026-08-19T10:00:00.000Z', party_count:2, signed_count:2 },
+  { id:'env_void_abcdefghijklmnop', original_filename:'Draft NDA.pdf', status:'void', created_at:'2026-08-18T10:00:00.000Z', party_count:1, signed_count:0 },
+] };
+
+// Playwright tries handlers newest-first, so the catch-all goes on FIRST.
+async function stubSignedIn(page, signedIn) {
+  await page.route('**/api/user/**', (r) => r.fulfill({ status:200, contentType:'application/json', body:'{}' }));
+  await page.route('**/api/user/session/verify', (r) => r.fulfill({ status:200, contentType:'application/json',
+    body: signedIn ? '{"authenticated":true,"email":"demo@example.com"}' : '{"authenticated":false}' }));
+  await page.route('**/api/user/me', (r) => r.fulfill({ status:200, contentType:'application/json', body:JSON.stringify(ME) }));
+  await page.route('**/api/user/account', (r) => r.fulfill({ status:200, contentType:'application/json', body:JSON.stringify(ME) }));
+  await page.route('**/api/user/billing/status', (r) => r.fulfill({ status:200, contentType:'application/json', body:JSON.stringify({ current_plan:'community', ...ME }) }));
+  await page.route('**/api/user/billing/history', (r) => r.fulfill({ status:200, contentType:'application/json', body:'{"history":[]}' }));
+  await page.route('**/api/user/documents**', (r) => r.fulfill({ status:200, contentType:'application/json', body:JSON.stringify(DOCS) }));
+  await page.route('**/api/user/dashboard/overview', (r) => r.fulfill({ status:500, body:'' }));
+  await page.route('**/api/user/account/**', (r) => r.fulfill({ status:200, contentType:'application/json', body:'{"keys":[{"label":"Signing key"}],"passkeys":[{"label":"Passkey"}]}' }));
+}
+
+export function serve() {
+  const server = http.createServer((req, res) => {
+    let pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+    pathname = ALIAS[pathname] || pathname;
+    const file = path.join(ROOT, pathname);
+    if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+    fs.readFile(file, (error, body) => {
+      if (error) { res.writeHead(404); return res.end(); }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      res.end(body);
+    });
+  });
+  return server;
+}
+
+// ── the probe ────────────────────────────────────────────────────────────────
+// Runs inside the page. Returns every non-text thing it can see, with the
+// colour it is painted in, the ground it sits on and the ratio between them.
+const PROBE = async () => {
+  const parse = (value) => {
+    const s = String(value || '');
+    const m = s.match(/rgba?\(([^)]+)\)/);
+    if (!m) return null;
+    const parts = m[1].split(/[,\s/]+/).filter(Boolean).map(Number);
+    if (parts.length < 3 || parts.some(Number.isNaN)) return null;
+    return { r:parts[0], g:parts[1], b:parts[2], a: parts.length > 3 ? parts[3] : 1 };
+  };
+  const over = (top, bottom) => ({
+    r: top.r * top.a + bottom.r * (1 - top.a),
+    g: top.g * top.a + bottom.g * (1 - top.a),
+    b: top.b * top.a + bottom.b * (1 - top.a),
+    a: 1,
+  });
+  const lum = (c) => {
+    const f = (v) => { const s = v / 255; return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4); };
+    return 0.2126 * f(c.r) + 0.7152 * f(c.g) + 0.0722 * f(c.b);
+  };
+  const ratio = (a, b) => { const x = lum(a), y = lum(b); return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05); };
+  const hex = (c) => '#' + [c.r, c.g, c.b].map((v) => Math.round(v).toString(16).padStart(2, '0')).join('');
+
+  // The ground under an element: every background above it composited down to
+  // the first opaque one, exactly as the browser paints it.
+  const groundOf = (node, { skipSelf = false } = {}) => {
+    const stack = [];
+    for (let el = skipSelf ? node.parentElement : node; el; el = el.parentElement) {
+      const bg = parse(getComputedStyle(el).backgroundColor);
+      if (bg && bg.a > 0) { stack.push(bg); if (bg.a >= 1) break; }
+    }
+    const html = parse(getComputedStyle(document.documentElement).backgroundColor);
+    let base = html && html.a >= 1 ? html : { r:255, g:255, b:255, a:1 };
+    for (let i = stack.length - 1; i >= 0; i--) base = over(stack[i], base);
+    return base;
+  };
+
+  const visible = (el) => {
+    if (typeof el.checkVisibility === 'function'
+        && !el.checkVisibility({ checkOpacity:true, checkVisibilityCSS:true })) return false;
+    const cs = getComputedStyle(el);
+    if (cs.visibility === 'hidden' || cs.display === 'none' || Number(cs.opacity) === 0) return false;
+    // aria-hidden is deliberately NOT a reason to skip. Nearly every icon on
+    // this site is aria-hidden, because its meaning is carried by the label
+    // next to it, and an icon nobody can see is still an icon nobody can see.
+    // The first version of this probe skipped them and found four pages'
+    // worth of nothing while the homepage skyline went unmeasured.
+    if (el.closest('[hidden], template, script, style, noscript')) return false;
+    const box = el.getBoundingClientRect();
+    return box.width >= 1 && box.height >= 1;
+  };
+
+  const where = (el) => {
+    const tag = el.tagName.toLowerCase();
+    const id = el.id ? '#' + el.id : '';
+    const cls = (typeof el.className === 'string' && el.className.trim())
+      ? '.' + el.className.trim().split(/\s+/).slice(0, 2).join('.')
+      : (el.className && el.className.baseVal ? '.' + String(el.className.baseVal).trim().split(/\s+/).slice(0, 2).join('.') : '');
+    // A bare <path> says nothing; the box it lives in says where to look.
+    const host = el.closest('svg') ? (el.closest('svg').parentElement || el) : el;
+    const hostBit = host !== el
+      ? ' in ' + host.tagName.toLowerCase() + (host.id ? '#' + host.id : '')
+        + (typeof host.className === 'string' && host.className.trim() ? '.' + host.className.trim().split(/\s+/)[0] : '')
+      : '';
+    return tag + id + cls + hostBit;
+  };
+
+  // Which way the ink leans off its ground, HERE, at this element. A hairline
+  // that leans the same way as the text beside it is the system whispering;
+  // one that leans the other way is a colour from a theme this page no longer
+  // wears. Measured locally and not once for the page, because the night has
+  // one inverted surface in it: a cream paper panel on a dark page reads its
+  // ink downwards while everything around it reads upwards, and a page-wide
+  // grain would call every correct border on that panel a defect.
+  const grainAt = (el, ground) => {
+    const ink = parse(getComputedStyle(el.closest ? (el.closest('*') || el) : el).color);
+    if (!ink) return 1;
+    return Math.sign(lum(over(ink, ground)) - lum(ground)) || 1;
+  };
+  const pageGround = groundOf(document.body);
+
+  const rows = [];
+  const add = (kind, el, colour, ground, extra = {}) => {
+    if (!colour || colour.a <= 0.02) return;
+    const flat = over(colour, ground);
+    const r = ratio(flat, ground);
+    const leans = Math.sign(lum(flat) - lum(ground)) || 0;
+    rows.push({
+      kind, sel: where(el), ratio: Math.round(r * 100) / 100,
+      colour: hex(flat), raw: `rgba(${[colour.r, colour.g, colour.b].map(Math.round).join(',')},${colour.a})`,
+      ground: hex(ground), againstGrain: leans !== 0 && leans !== grainAt(el, ground),
+      ...extra,
+    });
+  };
+
+  const SHAPES = 'path, rect, circle, ellipse, line, polyline, polygon, use, text, tspan';
+  const own = (el) => Array.from(el.childNodes).some((n) => n.nodeType === 3 && n.nodeValue.trim());
+
+  // 1. SVG shapes, fill and stroke apart.
+  for (const el of document.querySelectorAll('svg')) {
+    if (!visible(el)) continue;
+    // A drawing that declares itself decorative is exempt from 1.4.11, and it
+    // has to be: the homepage skyline is cream clouds on a cream sky, which is
+    // what a drawing looks like, not what a broken icon looks like. The claim
+    // has to be made in the markup, on the svg itself, where a reviewer can
+    // see it. An icon in an aria-hidden WRAPPER is not covered by this: its
+    // svg says nothing, so it is held to the bar like any other icon.
+    const role = (el.getAttribute('role') || '').toLowerCase();
+    const art = role === 'presentation' || role === 'none' || el.getAttribute('aria-hidden') === 'true';
+    const shapes = el.querySelectorAll(SHAPES);
+    const targets = shapes.length ? shapes : [el];
+    const svgGround = groundOf(el, { skipSelf:true });
+    // A drawing stacks. The label inside a filled box does not sit on the page,
+    // it sits on the box, and scoring it against the page is how a sweep
+    // reports a perfectly readable diagram as broken. So the shapes are walked
+    // in paint order and every opaque area fill is remembered with its
+    // rectangle; whatever is drawn inside that rectangle afterwards is scored
+    // against it. A shape that ends up holding something is a PANEL, which is
+    // a ground and not a mark, and a shape that holds nothing is a mark.
+    const painted = [];
+    const rowsFor = [];
+    const holds = (outer, inner) => inner.left >= outer.left - 1 && inner.right <= outer.right + 1
+      && inner.top >= outer.top - 1 && inner.bottom <= outer.bottom + 1;
+    for (const shape of targets) {
+      const cs = getComputedStyle(shape);
+      const box = shape.getBoundingClientRect ? shape.getBoundingClientRect() : null;
+      if (!box || (box.width < 1 && box.height < 1)) continue;
+      if (cs.display === 'none' || cs.visibility === 'hidden' || Number(cs.opacity) === 0) continue;
+      // A shape inside <defs>, <clipPath> or <mask> is never painted.
+      if (shape.closest('defs, clipPath, mask, symbol')) continue;
+      let ground = svgGround;
+      let under = null;
+      for (let i = painted.length - 1; i >= 0; i--) {
+        if (holds(painted[i].box, box)) { ground = painted[i].colour; under = painted[i]; break; }
+      }
+      if (under) under.holding = true;
+      const fillOpacity = Number(cs.fillOpacity === '' ? 1 : cs.fillOpacity);
+      const strokeOpacity = Number(cs.strokeOpacity === '' ? 1 : cs.strokeOpacity);
+      // <line> and <polyline> have no interior: a fill on them paints nothing.
+      const fillable = !['line', 'polyline'].includes(shape.tagName.toLowerCase());
+      let entry = null;
+      if (fillable && cs.fill && cs.fill !== 'none' && !cs.fill.startsWith('url')) {
+        const c = parse(cs.fill);
+        if (c && fillOpacity > 0) {
+          const colour = { ...c, a: c.a * fillOpacity };
+          entry = { box, colour: over(colour, ground), holding:false, shape, ground };
+          if (colour.a >= 0.95) painted.push(entry);
+          rowsFor.push({ entry, kind:'fill', shape, colour, ground });
+        }
+      }
+      if (cs.stroke && cs.stroke !== 'none' && !cs.stroke.startsWith('url') && parseFloat(cs.strokeWidth) > 0) {
+        const c = parse(cs.stroke);
+        if (c && strokeOpacity > 0) rowsFor.push({ entry:null, kind:'stroke', shape, colour:{ ...c, a: c.a * strokeOpacity }, ground });
+      }
+    }
+    for (const row of rowsFor) {
+      const panel = row.kind === 'fill' && row.entry && row.entry.holding;
+      const kind = (art || panel ? 'art-' : 'svg-') + row.kind;
+      add(kind, row.shape, row.colour, row.ground, panel ? { panel:true } : {});
+    }
+  }
+
+  // 2. Images. Drawn to a canvas and averaged over what is actually opaque,
+  //    because there is no other way to know whether a logo is dark.
+  for (const el of document.querySelectorAll('img')) {
+    if (!visible(el)) continue;
+    const ground = groundOf(el, { skipSelf:true });
+    let mean = null;
+    try {
+      // A lazy image inside a panel that never opens never loads, and decode()
+      // on it never settles. It also paints nothing, so it is not a defect:
+      // wait a beat, then move on. This one line is why the sweep used to hang
+      // forever on the app's /parashare.
+      if (!el.complete) {
+        await Promise.race([el.decode().catch(() => {}), new Promise((r) => setTimeout(r, 750))]);
+      }
+      if (!el.complete || !el.naturalWidth) continue;
+      const w = Math.min(64, Math.max(1, el.naturalWidth || Math.round(el.getBoundingClientRect().width)));
+      const h = Math.min(64, Math.max(1, el.naturalHeight || Math.round(el.getBoundingClientRect().height)));
+      const canvas = document.createElement('canvas');
+      canvas.width = w; canvas.height = h;
+      const ctx = canvas.getContext('2d', { willReadFrequently:true });
+      ctx.drawImage(el, 0, 0, w, h);
+      const data = ctx.getImageData(0, 0, w, h).data;
+      let r = 0, g = 0, b = 0, n = 0;
+      for (let i = 0; i < data.length; i += 4) {
+        if (data[i + 3] < 24) continue;
+        const a = data[i + 3] / 255;
+        r += data[i] * a; g += data[i + 1] * a; b += data[i + 2] * a; n += a;
+      }
+      if (n > 0) mean = { r: r / n, g: g / n, b: b / n, a: Math.min(1, n / (w * h) + 0.0) };
+    } catch { mean = null; }
+    if (!mean) { rows.push({ kind:'img-unreadable', sel: where(el), ratio: null, src: el.getAttribute('src') }); continue; }
+    add('img', el, { ...mean, a:1 }, ground, { src: el.getAttribute('src'), coverage: Math.round(mean.a * 100) / 100 });
+  }
+
+  // 3. Pseudo-elements that draw a glyph, and the ones that draw a block.
+  for (const el of document.querySelectorAll('body *')) {
+    if (!visible(el)) continue;
+    for (const pseudo of ['::before', '::after']) {
+      const cs = getComputedStyle(el, pseudo);
+      if (!cs || cs.content === 'none' || cs.content === 'normal') continue;
+      if (cs.display === 'none' || cs.visibility === 'hidden' || Number(cs.opacity) === 0) continue;
+      const ground = groundOf(el);
+      const hasGlyph = /^"/.test(cs.content) && cs.content.replace(/^"|"$/g, '').trim() !== '';
+      if (hasGlyph) add('pseudo-glyph', el, parse(cs.color), ground, { at: pseudo, content: cs.content.slice(0, 16) });
+      const bg = parse(cs.backgroundColor);
+      const w = parseFloat(cs.width), h = parseFloat(cs.height);
+      if (bg && bg.a >= 0.5 && (w > 0 || h > 0)) add('pseudo-fill', el, bg, ground, { at: pseudo });
+    }
+  }
+
+  // 4. Solid marks with no text of their own: badges, pills, dots, bars.
+  //    And 5. lines: borders, outlines, <hr>.
+  //
+  //    A mark is a shape that carries meaning on its own. A card, a nav bar, a
+  //    hero band and a form field all have a background too, and none of them
+  //    is a mark: the card is a surface its text sits on, and a form field is
+  //    identified by its border and its label, not by its filling. So the fill
+  //    rule asks for three things at once: nothing anywhere inside it reads as
+  //    text, it is not a form control, and it is small enough to be an object
+  //    rather than a ground. Without the first of those this sweep reported
+  //    every nav and every card on the site as a defect, which is how you get
+  //    a gate nobody trusts.
+  const MARK_AREA = 40000;
+  const CONTROL = new Set(['INPUT', 'SELECT', 'TEXTAREA', 'BUTTON', 'PROGRESS', 'METER']);
+  for (const el of document.querySelectorAll('body *')) {
+    if (el.closest('svg')) continue;
+    if (!visible(el)) continue;
+    const cs = getComputedStyle(el);
+    const ground = groundOf(el, { skipSelf:true });
+    const bg = parse(cs.backgroundColor);
+    const box = el.getBoundingClientRect();
+    const isMark = !el.textContent.trim() && !CONTROL.has(el.tagName) && box.width * box.height <= MARK_AREA;
+    if (bg && bg.a > 0 && !own(el)) {
+      add(isMark && bg.a >= 0.5 ? 'fill' : 'wash', el, bg, ground);
+    }
+    for (const side of ['Top', 'Right', 'Bottom', 'Left']) {
+      const width = parseFloat(cs[`border${side}Width`]);
+      const style = cs[`border${side}Style`];
+      if (!(width > 0) || style === 'none' || style === 'hidden') continue;
+      const c = parse(cs[`border${side}Color`]);
+      if (!c || c.a <= 0.02) continue;
+      // One row per distinct border colour on an element, not four.
+      add('line', el, c, bg && bg.a >= 1 ? bg : ground, { side });
+      break;
+    }
+    if (parseFloat(cs.outlineWidth) > 0 && cs.outlineStyle !== 'none') {
+      add('line', el, parse(cs.outlineColor), ground, { side:'outline' });
+    }
+  }
+
+  return { ground: hex(pageGround), rows };
+};
+
+export async function sweep({ shotDir = null, pages = PUBLIC_PAGES, appPages = APP_PAGES, themes = THEMES, sizes = SIZES, keepAll = false } = {}) {
+  const server = serve();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const origin = `http://localhost:${server.address().port}`;
+  const browser = await chromium.launch({ headless:true, ...(EXE ? { executablePath:EXE } : {}) });
+  const findings = [];
+  const decorative = [];
+  const everything = [];
+  let measured = 0;
+  if (shotDir) fs.mkdirSync(shotDir, { recursive:true });
+
+  const visit = async (name, slug, theme, width, height, opts) => {
+    const context = await browser.newContext({ viewport:{ width, height }, colorScheme: theme });
+    if (opts.app) {
+      await context.addInitScript(([key, value]) => {
+        try { window.localStorage.setItem(key, value); } catch { /* storage off */ }
+      }, [THEME_KEY, theme]);
+    }
+    const page = await context.newPage();
+    if (opts.app) await stubSignedIn(page, opts.signedIn !== false);
+    else await page.route('**/api/user/session/verify', (r) => r.fulfill({ status:401, contentType:'application/json', body:'{"authenticated":false}' }));
+    await page.goto(origin + slug, { waitUntil:'domcontentloaded' });
+    if (opts.ready) { try { await page.locator(opts.ready).first().waitFor({ timeout:6000 }); } catch { /* audit what rendered */ } }
+    // A transition still running yields a colour that was never the intent.
+    await page.addStyleTag({ content: '*,*::before,*::after{transition:none !important;animation:none !important}' });
+    // A lazy image below the fold has no pixels to average, so it has to be
+    // fetched before the probe can say anything about it. The obvious way is
+    // to scroll the page to the bottom and back, and that is what this did
+    // first: it also woke the WebGL globe on the app's /parashare, which in a
+    // headless renderer with no GPU under it never gave the main thread back
+    // and hung the whole sweep. Asking for the images directly costs nothing
+    // and wakes nothing. An image inside a closed panel is not fetched by
+    // this and does not need to be: it is not on screen either.
+    await page.evaluate(async () => {
+      for (const img of document.images) if (img.loading === 'lazy') img.loading = 'eager';
+      await Promise.all(Array.from(document.images).map((i) => (i.complete ? null
+        : Promise.race([i.decode().catch(() => {}), new Promise((r) => setTimeout(r, 750))]))));
+    });
+    await page.waitForTimeout(400);
+    const result = await page.evaluate(PROBE);
+    measured += result.rows.length;
+    if (process.env.PARAMANT_SWEEP_PROGRESS) process.stderr.write(`  ${name} ${theme} ${width}: ${result.rows.length}\n`);
+    for (const row of result.rows) {
+      const at = { page:name, theme, width, ...row };
+      if (keepAll) everything.push(at);
+      if (row.ratio === null) { findings.push({ ...at, ratio:0, why:'image could not be read' }); continue; }
+      if (row.ratio >= 3 - 0.005) continue;
+      // What is held to 3:1 and what is only written down.
+      //   gated      icons, images, CSS glyphs and solid marks, always; and a
+      //              line that runs against the grain, which is the leftover
+      //              from the light theme this sweep exists to find.
+      //   written    a wash is a ground and not a mark, so a footer cut a
+      //              shade deeper than the page is not a defect; a line with
+      //              the grain is the system's own hairline; and a shape
+      //              inside a graphic the markup calls decorative is a tone in
+      //              a drawing.
+      const GROUND = row.kind === 'wash' || row.kind.startsWith('art-');
+      const gated = GROUND ? false : (row.kind === 'line' ? row.againstGrain : true);
+      (gated ? findings : decorative).push(at);
+    }
+    if (shotDir) {
+      const file = path.join(shotDir, `${name.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '') || 'home'}--${theme}--${width}.png`);
+      try { await page.screenshot({ path:file, fullPage:true, timeout:60000, animations:'disabled' }); } catch { /* a shot is never a gate */ }
+    }
+    await context.close();
+  };
+
+  // One page must not be able to take the sweep down with it. The app's
+  // /parashare boots a WebGL globe, and a headless renderer that runs out of
+  // room under it takes the whole context with it: the run either hangs on a
+  // dead target or throws. So every visit is capped and caught, and a visit
+  // that does not come back is written down as unmeasured instead of silently
+  // becoming a clean page.
+  const unmeasured = [];
+  const guarded = async (name, ...rest) => {
+    let timer;
+    try {
+      await Promise.race([
+        visit(name, ...rest),
+        new Promise((_, reject) => { timer = setTimeout(() => reject(new Error('timed out after 90s')), 90000); }),
+      ]);
+    } catch (error) {
+      unmeasured.push(`${name} ${rest[1]} ${rest[2]}: ${String(error.message || error).split('\n')[0]}`);
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+  for (const slug of pages) {
+    for (const theme of themes) for (const [w, h] of sizes) await guarded(slug, slug, theme, w, h, { app:false });
+  }
+  for (const screen of appPages) {
+    for (const theme of themes) for (const [w, h] of sizes) {
+      await guarded('app ' + screen.slug, screen.slug, theme, w, h, { app:true, ready:screen.ready, signedIn:screen.signedIn });
+    }
+  }
+  await browser.close();
+  // A keep-alive socket the browser left behind holds the process open long
+  // after the last page is measured. Node 18 gave us the hammer for that.
+  if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
+  server.close();
+
+  // One row per place and colour pair; 390 and 1440 see the same defect twice.
+  const key = (r) => `${r.page}|${r.theme}|${r.kind}|${r.sel}|${r.colour}|${r.ground}`;
+  const uniq = (list) => [...new Map(list.map((r) => [key(r), r])).values()];
+  return { measured, unmeasured, findings: uniq(findings), decorative: uniq(decorative), all: keepAll ? everything : [] };
+}
+
+export const line = (r) => `${r.page} [${r.theme}] ${r.kind} ${r.sel}: ${r.ratio}:1 ${r.colour} on ${r.ground}${r.src ? ' <' + r.src + '>' : ''}${r.at ? ' ' + r.at : ''}`;
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+  const shotAt = process.argv.indexOf('--shots');
+  const jsonAt = process.argv.indexOf('--json');
+  const result = await sweep({ shotDir: shotAt > -1 ? process.argv[shotAt + 1] : null });
+  console.log(`measured ${result.measured} non-text paints`);
+  for (const one of result.unmeasured) console.log(`  NOT MEASURED: ${one}`);
+  console.log(`under 3:1 and gated: ${result.findings.length}`);
+  for (const r of result.findings.sort((a, b) => a.ratio - b.ratio)) console.log('  ' + line(r));
+  console.log(`under 3:1 but running with the grain (decorative): ${result.decorative.length}`);
+  for (const r of result.decorative.sort((a, b) => a.ratio - b.ratio).slice(0, 40)) console.log('  ~ ' + line(r));
+  if (jsonAt > -1) fs.writeFileSync(process.argv[jsonAt + 1], JSON.stringify(result, null, 2));
+}

--- a/tests/access-log-visitors.test.mjs
+++ b/tests/access-log-visitors.test.mjs
@@ -49,7 +49,7 @@ test('a crawler that really renders is reported apart, not as a person', () => {
   const ua = 'Mozilla/5.0 (compatible; heritrix/3.14.2-SNAPSHOT-20250101 +http://archive.org)';
   const r = analyse([
     line({ ip: '7.7.7.7', path: '/', ua }),
-    line({ ip: '7.7.7.7', path: '/nav.css?v=23', ua }),
+    line({ ip: '7.7.7.7', path: '/nav.css?v=24', ua }),
   ]);
   assert.equal(r.atMostVisitors, 0, 'a named crawler was counted as a possible visitor');
   assert.equal(r.verdicts.declared_automation, 1);

--- a/tests/ui-elements-contrast.test.mjs
+++ b/tests/ui-elements-contrast.test.mjs
@@ -1,0 +1,76 @@
+// Everything on the page that is NOT text, measured against the ground it sits
+// on. The other half of tests/theme-contrast.test.mjs.
+//
+// Why this file exists. On 2026-09-04 a phone review found parts of the site
+// that had gone missing under the night edition (design-system.css v5, PR
+// #417): the hamburger on every page, the step indicator of the app's
+// /parashare, the frames of the architecture figures, the meter on the
+// dashboard. None of it was reported by anything. tests/theme-contrast.test.mjs
+// walks TEXT nodes and it was green, on the same commit, on the same pages. It
+// could not have caught any of this: a hamburger has no text, a frame has no
+// text, and a meter has no text. Every colour that came from a token followed
+// the night; every colour written as a hex in a page, a script or an SVG did
+// not, and a navy bar that read fine on bone is invisible on #15191C.
+//
+// WCAG 2.1 SC 1.4.11 Non-text Contrast asks 3:1 for the visual information
+// needed to identify user interface components and their states, and for the
+// parts of a graphic that carry its meaning. That is the bar here.
+//
+// The measurement lives in scripts/ui-contrast-sweep.mjs, next to the comment
+// that explains what each category is and why lines are judged by the grain of
+// the theme rather than by the ratio alone. That file is also runnable by hand,
+// with --shots, when you want to look at the pages instead of the numbers:
+//
+//   node scripts/ui-contrast-sweep.mjs --shots /tmp/shots
+//
+// Run: node --test tests/ui-elements-contrast.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sweep, line, PUBLIC_PAGES, APP_PAGES } from '../scripts/ui-contrast-sweep.mjs';
+
+// What is under 3:1 on purpose. Same contract as KNOWN_LIGHT in
+// tests/theme-contrast.test.mjs: this list may get SHORTER and never longer. A
+// finding that is not on it is a regression, whether or not anyone has noticed
+// it yet. Matched on page + kind + selector, because the colour values move
+// with the brand and the place does not.
+const KNOWN = [
+  // The radar on /architecture. Concentric rings around one point, fading
+  // outwards, which is what a radar does and the whole of what it says. The
+  // location itself is carried by the two lines of type around the figure and
+  // by the centre dot, which is the ochre at full strength and well over 3:1.
+  // The outer rings are the fade, not the message.
+  { page:'/architecture', kind:'svg-stroke', sel:'circle.loc-ring in div',
+    why:'the outermost radar rings fade to nothing on purpose' },
+  { page:'/architecture', kind:'svg-stroke', sel:'circle.loc-ring-2 in div',
+    why:'the middle radar ring is part of that fade' },
+  { page:'/architecture', kind:'svg-stroke', sel:'circle.loc-ring-3 in div',
+    why:'the inner radar ring is the last step of that fade, at 2.19:1' },
+];
+
+test('every non-text element clears 3:1 in dark and light, at 390 and 1440', async (t) => {
+  const result = await sweep();
+
+  t.diagnostic(`measured ${result.measured} non-text paints over ${PUBLIC_PAGES.length} public pages`
+    + ` and ${APP_PAGES.length} app screens, at 390 and 1440, in dark and light`);
+  t.diagnostic(`${result.decorative.length} paints under 3:1 run with the grain of the theme and are the system's own hairlines`);
+
+  // A page that could not be rendered is a hole in this gate, not a pass.
+  assert.deepEqual(result.unmeasured, [], `\nThese pages were never measured:\n  ${result.unmeasured.join('\n  ')}\n`);
+
+  const unexpected = [];
+  const stillThere = new Set();
+  for (const hit of result.findings) {
+    const known = KNOWN.find((k) => k.page === hit.page && k.kind === hit.kind && k.sel === hit.sel);
+    if (known) { stillThere.add(`${line(hit)} :: ${known.why}`); continue; }
+    unexpected.push(line(hit));
+  }
+  t.diagnostic(`${stillThere.size} of the ${KNOWN.length} known exceptions are still present`);
+  for (const one of stillThere) t.diagnostic(`still on the known list: ${one}`);
+
+  assert.deepEqual(unexpected, [],
+    `\nNon-text contrast failures. Every one of these is under the 3:1 that WCAG 2.1 SC 1.4.11\n`
+    + `asks of a meaningful graphic or a UI component, and none of them is on the known list:\n  `
+    + `${unexpected.join('\n  ')}\n\n`
+    + `Fix the colour with a token from frontend/design-system.css. If it is a deliberate\n`
+    + `exception, add it to KNOWN with the reason. Do not loosen the ratio.`);
+});


### PR DESCRIPTION
## What was wrong

Since the night edition (design-system.css v5, PR #417) the site has places where an old light-theme accent is dark on dark. `tests/theme-contrast.test.mjs` is green on all of them, and always would be: it walks TEXT nodes, and none of what went missing is text.

Measured, not guessed. On the branch point, over 7642 non-text paints on 18 public pages and 11 app screens, in dark and light, at 390 and 1440:

| | dark | light | total |
|---|---|---|---|
| under 3:1, before | 47 | 35 | **82** |
| under 3:1, after | 3 | 3 | **6** |

The six that remain are the fading outer rings of the location radar on `/architecture`, on the known list with the reason.

The five worst, with the place:

1. `1.03:1` `/architecture` `svg-stroke rect in .arch-diagram` `#e2e8f0` on cream: the frames of the transfer figure, drawn for a white page.
2. `1.07:1` app `/parashare` `span.ps-step-dot`: the step indicator, a disc at 1.07:1 inside a ring at 1.6:1.
3. `1.09:1` every page `span` in `button.nav-hamburger` `#0c0f11` on `#15191c`: the three bars of the menu button, on every phone, on every page. The button has no label, so this was the whole control.
4. `1.66:1` `/` `.hp-band-tag::before`: the ochre dot on the strip's cream sky.
5. `2.92:1` app `/dashboard` `.dh-progress i`: the ochre meter on its `--line-2` track.

WCAG 2.1 SC 1.4.11 asks 3:1 of a UI component and of the parts of a graphic that carry its meaning.

## The measurement

`scripts/ui-contrast-sweep.mjs`, reusable and runnable by hand:

```
node scripts/ui-contrast-sweep.mjs --shots /tmp/shots --json /tmp/sweep.json
```

For every visible non-text thing it reads the effective colour and the ground under it, flattening the whole stack of backgrounds above the element with alpha, and scores the pair by WCAG 2.1 relative luminance. Six categories: SVG shapes (fill and stroke apart, and it tracks what is drawn ON what inside a figure, so a label inside a filled box is scored against the box and not against the page), images (drawn to a canvas and averaged over the non-transparent pixels, which is the only way to catch a dark logo in an `<img>`), CSS glyphs in `::before`/`::after`, solid marks with no text of their own, and lines.

Lines are the reason a first version of this was useless. A deliberate hairline on a dark ground is LIGHTER than the ground; on cream paper it is DARKER. It sits on the same side of its background as the ink beside it. So a line under 3:1 that runs WITH that grain is written down as decorative, and one that runs against it is a finding. That grain is measured locally, per element, because the night has one inverted surface in it and a page-wide reading would call every correct border on a cream panel a defect. Without the rule the report was 1062 intentional hairlines deep.

## The gate

`tests/ui-elements-contrast.test.mjs`, same contract as theme-contrast: a KNOWN list that may only get shorter, green in both themes, and a page that could not be rendered fails rather than passing quietly. It runs in about 60 s.

## The fixes

All of them take a token from `design-system.css`:

- **nav.css** the hamburger bars were `--invert`, which on bone was the navy slab and on the night is a shade deeper than the bar. They are `--ink`.
- **architecture.html** the two figures keep their cream paper and lose the old navy, cobalt, lime and slate. Their ink is the paper palette now, as CSS classes, so a presentation attribute can no longer put a figure beyond the reach of the system. The location radar is ochre. The erasure icon takes `currentColor`.
- **parashare.html** the step dot is a ring at 3.8:1 instead of a disc at 1.07:1.
- **dashboard.html** the meter track is `--ink-hair`, so the ochre reads at 4.6:1.
- **index.html** the strip dot is `--ochre-ink`, the same hue at 4.7:1 on that paper.
- **co-sign.html** the warning band was `#d4a017` on `#7a5300`, a dark ochre heading on a dark card.
- **js/parashare.page.js** the globe is ochre. three.js resolves no custom property, so the value is written out once, next to the reason.
- **js/admin.page.js, setup.js, js/auth-setup.js** navy text on the night, a bone modal, a cobalt link, and a QR pinned to the old bone and navy.

## What deliberately did NOT change

The document layer. The seal on `/sign`, the pen stroke and drawn annotation in `sign-flow.js`, and the field boxes on `/co-sign` stay `#1D4ED8` and `#0b3a6a`: a page is white paper in every theme and that is the ink the customer gets in the PDF. Previewing it in cream would be a preview of a document nobody will ever receive. All three files now say so at the colour.

`frontend/images/paramant-auth-flows.svg`, `paramant-system-architecture.svg` and `paramant-login-sequence.svg` still carry 67 of the old hex values between them. Nothing in the repo references any of the three, so none of them renders on the site and none is a contrast defect; recolouring a figure nobody loads is churn without a picture to check it against.

Old hex values across the frontend, counted the same way before and after: **134 to 99**. Of the 99 that remain, 67 are in those three unreferenced files and 32 are the document layer.

## Also run, all green

`ui-elements-contrast`, `theme-contrast`, `app-contrast`, `app-theme`, `navigation-shell`, `first-screen`, `motion-safety`, `site-claims`, `ui-truthfulness`, `access-log-visitors`, `frontend-loading-contract`, `apply-nav-idempotent`, `code-manifest`, `links`, `seo-contract`, `frontend-module-scripts`, `static-sanity.sh`, `check-csp-inline.sh`, `check-cache-bust.sh`. 87 tests, 0 failures.

Cache-busts bumped for every changed asset: nav.css v24, sign-flow.js v54, js/parashare.page.js v11, js/admin.page.js v2, js/auth-setup.js v3, setup.js v3, with `apply-nav.py` and the access-log fixture kept in step.
