### PR TITLE
One tier table: the dashboard reads the caps the relay enforces, per product

### DIFF
--- a/admin/lib/developer-snapshot.js
+++ b/admin/lib/developer-snapshot.js
@@ -1,34 +1,55 @@
 'use strict';
-// Builds the initial-render snapshot for the /developer operations dashboard.
-// Dependencies (redis client, getAuditEvents, resolved plan) are injected so it
-// unit-tests without booting the admin server.
+// Builds the initial-render snapshot for the /developer operations dashboard
+// and for GET /api/user/dashboard/overview.
+//
+// Dependencies (redis client, getAuditEvents, the account's entitlements) are
+// injected so it unit-tests without booting the admin server.
+//
+// There is NO tier table in this file, and there must never be one again.
+// It used to carry its own copy of relay/lib/tiers.js with three rows
+// (community/pro/enterprise) and read them off the unified `plan` field. Both
+// halves were wrong at once:
+//   * the `business` row was missing, so a Business account fell through to the
+//     community row and was shown 2 signatures a month where the relay grants
+//     1000;
+//   * the unified `plan` does not move when someone buys. The Mollie webhook
+//     path calls entitlements.applyProductTier, which writes ONLY
+//     plan_parasign / plan_parasend and by design never touches `plan`. So a
+//     self-serve ParaSign Pro customer kept plan "community" and was told
+//     "2 signatures left" on /dashboard while the relay was letting him sign
+//     100. A number in the face of a paying customer that his own supplier
+//     knows to be false.
+// The relay owns the numbers (relay/lib/tiers.js -> relay/lib/entitlements.js)
+// and enforces them. The admin only shows them, and it asks the relay for them
+// per account: GET /v2/admin/entitlements/:account_id. Nothing here decides.
 
 const { DEVELOPER_TOOLS, toolsStatusFromAudit } = require('./developer-tools');
 
-// Per-account monthly caps. Mirrors relay/lib/tiers.js — duplicated honestly
-// here because the admin Docker image does not ship the relay package.
-const TIER_CAPS = {
-  community:  { transfers: 10,  signs: 2 },
-  pro:        { transfers: 500, signs: 100 },
-  enterprise: { transfers: Infinity, signs: Infinity },
-};
-function normalisePlan(p) {
-  p = String(p || '').toLowerCase();
-  if (p === 'free' || p === 'dev') return 'community';
-  if (p === 'licensed') return 'enterprise';
-  return (p === 'pro' || p === 'enterprise') ? p : 'community';
-}
 function ymKey(d) { return d.toISOString().slice(0, 7); }            // YYYY-MM
 function maskKey(k) { k = String(k || ''); return k.length <= 12 ? k : k.slice(0, 8) + '…' + k.slice(-4); }
-const capOut = (n) => (n === Infinity ? null : n);                   // null = unlimited (JSON-safe)
 
-// deps: { redis: () => client, getAuditEvents, plan, now? }
+// A cap as the API reports it. The relay's entitlement layer holds every
+// metered monthly quota to a finite ceiling (ENTERPRISE_MONTHLY_CEILING), so a
+// number is what normally arrives. Anything that is not a real number is
+// reported as null ("not known"), never as a made-up figure.
+function capOut(n) {
+  return (typeof n === 'number' && Number.isFinite(n)) ? n : null;
+}
+
+// deps: { redis: () => client, getAuditEvents, entitlements, now? }
+// `entitlements` is the relay's answer for THIS account:
+//   { parasend: { tier, quotas: { transfers_month }, ... },
+//     parasign: { tier, quotas: { signs_month }, ... } }
+// It is required. Without it the caps are unknown, and a dashboard that guesses
+// a cap is the bug this file exists to prevent, so we refuse instead.
 async function buildSnapshot(deps, userSession) {
+  const ent = deps.entitlements;
+  if (!ent || !ent.parasend || !ent.parasign) {
+    throw new Error('entitlements_required');
+  }
   const uid = userSession.user_id;        // == pgp_ key == account_id (1:1 today)
   const email = userSession.email;
   const r = deps.redis();
-  const np = normalisePlan(deps.plan);
-  const caps = TIER_CAPS[np];
 
   const ym = ymKey(deps.now || new Date());
   const num = async (k) => { try { return parseInt((await r.get(k)) || '0', 10) || 0; } catch { return 0; } };
@@ -40,15 +61,24 @@ async function buildSnapshot(deps, userSession) {
 
   return {
     email,
-    plan: np,
+    // Per product, because the two are bought and billed apart. There is no
+    // single "plan" to print: an account can be ParaSign Pro and ParaSend
+    // Community on the same day, and one word cannot say that.
+    tiers: { parasend: ent.parasend.tier, parasign: ent.parasign.tier },
     key_masked: maskKey(uid),
     quota: {
       transfers, signs,
-      caps: { transfers: capOut(caps.transfers), signs: capOut(caps.signs) },
+      caps: {
+        // Transfers are a ParaSend capacity, signatures a ParaSign one. Each
+        // reads its own product's quota, so neither can be decided by the other
+        // product's tier or by the unified plan.
+        transfers: capOut(ent.parasend.quotas.transfers_month),
+        signs: capOut(ent.parasign.quotas.signs_month),
+      },
     },
     audit,
     tools_status: toolsStatusFromAudit(DEVELOPER_TOOLS, audit),
   };
 }
 
-module.exports = { buildSnapshot, TIER_CAPS, normalisePlan, maskKey, ymKey };
+module.exports = { buildSnapshot, maskKey, ymKey };

--- a/admin/server.js
+++ b/admin/server.js
@@ -545,6 +545,35 @@ async function callRelay(endpoint, body, method = "POST", sector = "health") {
   return res;
 }
 
+// The effective entitlements of ONE account, straight from the relay.
+//
+// This is the only place a limit shown to a customer may come from. The relay
+// owns the tier table (relay/lib/tiers.js) and the product split
+// (relay/lib/entitlements.js), and it is the thing that actually says no at the
+// quota gate, so it is also the thing that gets to say what the ceiling is. The
+// admin image does not ship the relay package and must not carry a copy of the
+// numbers: a second table is a table that drifts, and it drifted. It had no
+// `business` row and it was keyed on the unified `plan`, which a purchase never
+// moves (entitlements.applyProductTier writes plan_parasign / plan_parasend and
+// nothing else), so a paying ParaSign Pro account was shown the community cap.
+//
+// Returns the { parasend, parasign } entitlement object, or null when the relay
+// could not answer. Callers must read null as "unknown" and refuse to render a
+// cap at all, never as a reason to fall back to a guess.
+async function readAccountEntitlements(accountId) {
+  if (!accountId) return null;
+  try {
+    const r = await callRelay(`/v2/admin/entitlements/${encodeURIComponent(accountId)}`, null, "GET");
+    if (!r.ok) return null;
+    const body = await r.json().catch(() => null);
+    if (!body || body.ok !== true || !body.entitlements) return null;
+    return body.entitlements;
+  } catch (err) {
+    console.error("[entitlements read]", err.message);
+    return null;
+  }
+}
+
 // Find API key entry by email (queries health relay).
 // reveal=1: the returned entry's full .key becomes the session user_id (Redis
 // id + relay operation token), so this server-to-server lookup needs the raw
@@ -2410,10 +2439,12 @@ api.get("/user/developer/snapshot", authUser, developerGate, async (req, res) =>
   const uid = req.userSession.user_id;
   const hit = _snapCache.get(uid);
   if (hit && Date.now() - hit.at < 3000) return res.json(hit.data);
-  let plan = "community";
-  try { const u = await findUserByEmail(req.userSession.email); if (u && u.plan) plan = u.plan; } catch {}
+  // The caps come from the relay, per account and per product. No local table,
+  // and no unified `plan` anywhere near a limit.
+  const ents = await readAccountEntitlements(uid);
+  if (!ents) return res.status(503).json({ error: "entitlements_unavailable" });
   try {
-    const data = await buildSnapshot({ redis, getAuditEvents, plan }, req.userSession);
+    const data = await buildSnapshot({ redis, getAuditEvents, entitlements: ents }, req.userSession);
     _snapCache.set(uid, { at: Date.now(), data });
     if (_snapCache.size > 500) _snapCache.clear();
     res.json(data);
@@ -2602,15 +2633,19 @@ api.get("/user/dashboard/overview", authUser, async (req, res) => {
   const uid = req.userSession.user_id;
   const hit = _ovCache.get(uid);
   if (hit && Date.now() - hit.at < 3000) return res.json(hit.data);
-  let plan = "community";
-  try { const u = await findUserByEmail(req.userSession.email); if (u && u.plan) plan = u.plan; } catch {}
+  // Same one source as the developer snapshot. When the relay cannot answer we
+  // say so with a 503 and the page keeps whatever it last drew; it does NOT
+  // fall back to a community cap, which is how a Pro customer came to read
+  // "2 signatures left" on a page his own supplier served him.
+  const ents = await readAccountEntitlements(uid);
+  if (!ents) return res.status(503).json({ error: "entitlements_unavailable" });
   try {
-    const snap = await buildSnapshot({ redis, getAuditEvents, plan }, req.userSession);
+    const snap = await buildSnapshot({ redis, getAuditEvents, entitlements: ents }, req.userSession);
     // key_masked is deliberately NOT passed on. /dashboard no longer prints a
     // key in any form, and a payload that still carries one is a payload that
     // will be printed again by the next person who reads it and assumes it is
     // there to be used. The account key lives on /account, behind its fold.
-    const data = { plan: snap.plan, quota: snap.quota, audit: snap.audit };
+    const data = { tiers: snap.tiers, quota: snap.quota, audit: snap.audit };
     _ovCache.set(uid, { at: Date.now(), data });
     if (_ovCache.size > 500) _ovCache.clear();
     res.json(data);

--- a/admin/test/developer-snapshot.test.js
+++ b/admin/test/developer-snapshot.test.js
@@ -1,10 +1,31 @@
 'use strict';
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { buildSnapshot, normalisePlan, maskKey, ymKey, TIER_CAPS } = require('../lib/developer-snapshot');
+const fs = require('node:fs');
+const path = require('node:path');
+const { buildSnapshot, maskKey, ymKey } = require('../lib/developer-snapshot');
 const { DEVELOPER_TOOLS, toolsStatusFromAudit, isToolEvent } = require('../lib/developer-tools');
 
+// The relay's entitlement layer, the one source for every tier number. The
+// admin image does not ship it (its Dockerfile copies server.js, lib/ and
+// public/ and nothing else), which is precisely why the caps are FETCHED from
+// the relay at runtime instead of copied into admin/lib. The test can require
+// it because the test runs in the repo, and that is the point: the numbers this
+// suite asserts are the relay's own, not a second set written down here.
+const relayEntitlements = require('../../relay/lib/entitlements');
+
 function fakeRedis(map) { return () => ({ get: async (k) => (k in map ? String(map[k]) : null) }); }
+
+// Build the deps a route hands to buildSnapshot for an account with these
+// stored per-product plans, exactly as GET /v2/admin/entitlements/:id answers.
+function depsFor(account, extra) {
+  return Object.assign({
+    redis: fakeRedis({}),
+    getAuditEvents: async () => [],
+    entitlements: relayEntitlements.getEntitlements(account),
+    now: new Date('2026-05-31T12:00:00Z'),
+  }, extra || {});
+}
 
 test('catalogue: 10 tools, each with category/install/usage/source', () => {
   assert.equal(DEVELOPER_TOOLS.length, 10);
@@ -16,13 +37,9 @@ test('catalogue: 10 tools, each with category/install/usage/source', () => {
   }
 });
 
-test('maskKey / normalisePlan / ymKey', () => {
+test('maskKey / ymKey', () => {
   assert.equal(maskKey('pgp_' + 'a'.repeat(40)), 'pgp_aaaa…aaaa');
   assert.equal(maskKey('short'), 'short');
-  assert.equal(normalisePlan('free'), 'community');
-  assert.equal(normalisePlan('licensed'), 'enterprise');
-  assert.equal(normalisePlan('PRO'), 'pro');
-  assert.equal(normalisePlan('whatever'), 'community');
   assert.equal(ymKey(new Date('2026-05-31T12:00:00Z')), '2026-05');
 });
 
@@ -58,10 +75,12 @@ test('buildSnapshot: full shape, caps, masked key, no key leak', async () => {
     [`paramant:quota:signs:${uid}:2026-05`]: '1',
   });
   const getAuditEvents = async () => [{ event_type: 'webauthn_login', ts: Date.parse('2026-05-31T10:00:00Z'), metadata: {} }];
-  const snap = await buildSnapshot({ redis, getAuditEvents, plan: 'community', now: new Date('2026-05-31T12:00:00Z') }, { user_id: uid, email: 'dev@x.io' });
+  const snap = await buildSnapshot(
+    depsFor({ plan: 'community', plan_parasend: 'community', plan_parasign: 'free' }, { redis, getAuditEvents }),
+    { user_id: uid, email: 'dev@x.io' });
 
   assert.equal(snap.email, 'dev@x.io');
-  assert.equal(snap.plan, 'community');
+  assert.deepEqual(snap.tiers, { parasend: 'community', parasign: 'free' });
   assert.equal(snap.key_masked, 'pgp_bbbb…bbbb');
   assert.ok(!snap.key_masked.includes(uid), 'full key never returned');
   assert.equal(snap.quota.transfers, 7);
@@ -72,9 +91,93 @@ test('buildSnapshot: full shape, caps, masked key, no key leak', async () => {
   assert.equal(Object.keys(snap.tools_status).length, 10);
 });
 
-test('buildSnapshot: enterprise caps = unlimited (null), missing counters = 0', async () => {
-  const snap = await buildSnapshot({ redis: fakeRedis({}), getAuditEvents: async () => [], plan: 'enterprise', now: new Date('2026-05-31T00:00:00Z') }, { user_id: 'pgp_x', email: 'e@x.io' });
+// ── The bug this file was rewritten for ─────────────────────────────────────
+//
+// A self-serve ParaSign Pro customer keeps the unified `plan` he signed up
+// with, because entitlements.applyProductTier writes plan_parasign alone. The
+// admin's own tier table read that unified field, and had no `business` row at
+// all, so /dashboard and the signed-in homepage told a paying customer he had
+// 2 signatures a month while the relay was granting him 100, and told a
+// Business customer the same where the relay grants 1000.
+//
+// Every number below comes out of relay/lib/entitlements.js. Reinstating any
+// local table in admin/lib/developer-snapshot.js fails these cases, because a
+// table keyed on `plan` answers community for the first account.
+test('ParaSign Pro on a community ParaSend account: 100 signs, 10 transfers', async () => {
+  const snap = await buildSnapshot(
+    depsFor({ plan: 'community', plan_parasign: 'pro', plan_parasend: 'community' }),
+    { user_id: 'pgp_pro', email: 'pro@x.io' });
+  assert.deepEqual(snap.tiers, { parasend: 'community', parasign: 'pro' });
+  assert.equal(snap.quota.caps.signs, 100, 'the relay grants ParaSign Pro 100 signatures a month');
+  assert.equal(snap.quota.caps.transfers, 10, 'buying ParaSign does not move the ParaSend tier');
+});
+
+test('ParaSign Business: 1000 signs, and the row exists at all', async () => {
+  const snap = await buildSnapshot(
+    depsFor({ plan: 'community', plan_parasign: 'business', plan_parasend: 'community' }),
+    { user_id: 'pgp_biz', email: 'biz@x.io' });
+  assert.equal(snap.tiers.parasign, 'business');
+  assert.equal(snap.quota.caps.signs, 1000, 'business is a tier the pricing page sells, not a fall-through to community');
+  assert.equal(snap.quota.caps.transfers, 10);
+});
+
+test('community on both products: 2 signs, 10 transfers, counters default to 0', async () => {
+  const snap = await buildSnapshot(
+    depsFor({ plan: 'community', plan_parasign: 'free', plan_parasend: 'community' }),
+    { user_id: 'pgp_free', email: 'free@x.io' });
+  assert.equal(snap.quota.caps.signs, 2);
+  assert.equal(snap.quota.caps.transfers, 10);
   assert.equal(snap.quota.transfers, 0);
-  assert.equal(snap.quota.caps.transfers, null);
-  assert.equal(snap.quota.caps.signs, null);
+  assert.equal(snap.quota.signs, 0);
+});
+
+test('ParaSend Pro on a free ParaSign account: 500 transfers, still 2 signs', async () => {
+  // The mirror image of the Pro case above, so neither product can be shown to
+  // decide the other one's ceiling.
+  const snap = await buildSnapshot(
+    depsFor({ plan: 'community', plan_parasign: 'free', plan_parasend: 'pro' }),
+    { user_id: 'pgp_send', email: 'send@x.io' });
+  assert.equal(snap.quota.caps.transfers, 500);
+  assert.equal(snap.quota.caps.signs, 2);
+});
+
+test('every metered cap is a finite number, enterprise included', async () => {
+  // relay/lib/entitlements.js holds even enterprise to a real monthly ceiling,
+  // so the dashboard may never print an infinity sign. null here would mean
+  // "not read", and that must not happen for an account the relay answered for.
+  const snap = await buildSnapshot(
+    depsFor({ plan: 'enterprise', plan_parasign: 'enterprise', plan_parasend: 'enterprise' }),
+    { user_id: 'pgp_ent', email: 'e@x.io' });
+  for (const dim of ['transfers', 'signs']) {
+    assert.equal(typeof snap.quota.caps[dim], 'number', `${dim} cap must be a number`);
+    assert.ok(Number.isFinite(snap.quota.caps[dim]), `${dim} cap must be finite`);
+  }
+});
+
+test('no entitlements means no snapshot, never a guessed cap', async () => {
+  // The relay being unreachable is not a licence to invent a ceiling. The route
+  // turns this into a 503 and the page keeps what it last drew.
+  await assert.rejects(
+    () => buildSnapshot({ redis: fakeRedis({}), getAuditEvents: async () => [] }, { user_id: 'pgp_x', email: 'x@x.io' }),
+    /entitlements_required/);
+  await assert.rejects(
+    () => buildSnapshot({ redis: fakeRedis({}), getAuditEvents: async () => [], entitlements: { parasend: {} } }, { user_id: 'pgp_x', email: 'x@x.io' }),
+    /entitlements_required/);
+});
+
+// ── Sabotage guard ──────────────────────────────────────────────────────────
+//
+// The behavioural cases above already fail if a copied table comes back and is
+// used. This one fails if a copied table comes back at all, used or not, and it
+// names the reason: a second table is a table that drifts, and the last one
+// drifted into telling a paying customer a false number about his own account.
+test('admin/lib/developer-snapshot.js carries no tier table of its own', () => {
+  const SRC = fs.readFileSync(path.join(__dirname, '..', 'lib', 'developer-snapshot.js'), 'utf8');
+  const code = SRC.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/^[ \t]*\/\/.*$/gm, ' ');
+  assert.doesNotMatch(code, /\b(community|pro|business|enterprise|free|licensed|dev)\s*:/,
+    'no tier row may be written in this file; the relay owns the numbers');
+  assert.doesNotMatch(code, /\b(transfers|signs|transfers_month|signs_month)\s*:\s*\d/,
+    'no cap may be hard-coded in this file');
+  assert.equal(require('../lib/developer-snapshot').TIER_CAPS, undefined,
+    'developer-snapshot must not export a tier table');
 });

--- a/admin/test/user-plan-fields.test.js
+++ b/admin/test/user-plan-fields.test.js
@@ -85,3 +85,45 @@ test('the helper is defined before every use', () => {
   assert.ok(/^function productPlanFields/m.test(SERVER),
     'productPlanFields must stay a top-level function declaration');
 });
+
+// ── The two usage endpoints ask the relay for the ceilings ──────────────────
+//
+// Same rule as above, one layer down: the unified `plan` may not decide a
+// number a customer reads. /api/user/dashboard/overview and
+// /api/user/developer/snapshot used to look the account up by email, take its
+// `plan`, and run it through a tier table copied into admin/lib. That table had
+// no `business` row and the field it was keyed on never moves on a purchase, so
+// a ParaSign Pro customer was shown "2 signatures" where the relay grants 100.
+//
+// The relay owns the tiers and enforces them, so the relay is asked. This is a
+// source-text test because reaching these handlers needs Redis, a session
+// cookie and a live relay; what can go wrong is the lookup quietly reverting to
+// the plan field, and that is what source inspection catches.
+// admin/test/developer-snapshot.test.js pins the resulting numbers.
+test('the usage endpoints read caps from the relay, not from a plan field', () => {
+  for (const route of ['"/user/dashboard/overview"', '"/user/developer/snapshot"']) {
+    const start = SERVER.indexOf(`api.get(${route}`);
+    assert.notEqual(start, -1, `admin/server.js must serve GET ${route}`);
+    const body = SERVER.slice(start, start + 1600);
+    const handler = body.slice(0, body.indexOf('\n});') + 1);
+
+    assert.match(handler, /readAccountEntitlements\(/,
+      `GET ${route} must ask the relay for this account's entitlements`);
+    assert.match(handler, /entitlements:\s*ents\b/,
+      `GET ${route} must hand those entitlements to buildSnapshot`);
+    assert.doesNotMatch(handler, /\bplan\s*[=:]/,
+      `GET ${route} must not resolve a plan of its own; the caps come per product from the relay`);
+    assert.match(handler, /entitlements_unavailable/,
+      `GET ${route} must refuse rather than render a guessed cap when the relay cannot answer`);
+  }
+});
+
+test('readAccountEntitlements reads the relay endpoint and returns null on failure', () => {
+  const start = SERVER.indexOf('async function readAccountEntitlements(');
+  assert.notEqual(start, -1, 'admin/server.js must define readAccountEntitlements()');
+  const fn = SERVER.slice(start, start + 1200);
+  assert.match(fn, /\/v2\/admin\/entitlements\//,
+    'it must read GET /v2/admin/entitlements/:account_id, the relay\'s own entitlement answer');
+  assert.match(fn, /return null/,
+    'an unreachable or unhappy relay must yield null, so the caller can refuse instead of guess');
+});

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -709,6 +709,6 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
-<script src="/js/dashboard.js?v=13" defer></script>
+<script src="/js/dashboard.js?v=14" defer></script>
 </body>
 </html>

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -157,6 +157,6 @@ curl -X POST https://paramant.app/v1/envelopes \
 
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
-<script src="/js/developer.js?v=7" defer></script>
+<script src="/js/developer.js?v=8" defer></script>
 </body>
 </html>

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -746,10 +746,14 @@
     var day = d.getDate() + ' ' + mon + (d.getFullYear() !== now.getFullYear() ? ' ' + d.getFullYear() : '');
     return day + ' ' + hm;
   }
+  // The caps arrive per product from the relay's own entitlement layer, which
+  // is the thing that enforces them. A missing cap therefore means "not read",
+  // never "no ceiling": no tier is unbounded. So an absent number draws as --
+  // with an empty bar rather than as an infinity sign nobody is entitled to.
   function opsBar(used, cap) {
-    var unlimited = (cap == null);
-    var pct = unlimited ? 4 : Math.min(100, Math.round(((used || 0) / Math.max(1, cap)) * 100));
-    return { pct: pct, warn: !unlimited && pct >= 80, capTxt: unlimited ? '&#8734;' : String(cap) };
+    var known = (typeof cap === 'number');
+    var pct = known ? Math.min(100, Math.round(((used || 0) / Math.max(1, cap)) * 100)) : 0;
+    return { pct: pct, warn: known && pct >= 80, capTxt: known ? String(cap) : '--' };
   }
   function renderOpsTimeline() {
     var el = document.getElementById('dh-ops-timeline');

--- a/frontend/js/developer.js
+++ b/frontend/js/developer.js
@@ -42,17 +42,28 @@
     var email = document.querySelector('[data-dv="email"]');
     var plan = document.querySelector('[data-dv="plan"]');
     if (email) email.textContent = data.email || '--';
-    if (plan) plan.textContent = String(data.plan || '--').toUpperCase();
+    // This is the ParaSign developer page, so the tier it names is the ParaSign
+    // tier. It used to print the unified `plan`, which a purchase never moves,
+    // so a ParaSign Pro buyer read COMMUNITY next to his own email. The snapshot
+    // now carries a tier per product because an account can hold two different
+    // ones at once.
+    var tiers = data.tiers || {};
+    if (plan) plan.textContent = String(tiers.parasign || '--').toUpperCase();
     byId('api-status-dot').className = 'status-dot ok';
 
     var quota = data.quota || {};
     var used = Number(quota.signs || 0);
     var cap = quota.caps && quota.caps.signs;
     byId('sign-used').textContent = String(used);
-    byId('sign-cap').textContent = cap == null ? 'no fixed limit' : 'of ' + cap;
-    var percent = cap == null ? (used ? 8 : 0) : Math.min(100, Math.round((used / Math.max(1, cap)) * 100));
+    // A missing cap means the relay could not be asked, not that there is no
+    // ceiling: every tier has a finite monthly one (relay/lib/entitlements.js
+    // holds even enterprise to a real number). So the honest reading of an
+    // absent cap is "we do not know right now", and the page says that instead
+    // of promising a limit nobody grants.
+    byId('sign-cap').textContent = cap == null ? 'of --' : 'of ' + cap;
+    var percent = cap == null ? 0 : Math.min(100, Math.round((used / Math.max(1, cap)) * 100));
     var bar = byId('sign-bar'); bar.style.width = percent + '%'; bar.className = percent >= 80 ? 'warn' : '';
-    byId('usage-note').textContent = cap == null ? 'Your current plan has no fixed monthly signing cap.' : Math.max(0, cap - used) + ' signatures remain in the current month.';
+    byId('usage-note').textContent = cap == null ? 'Your monthly signing allowance could not be read just now.' : Math.max(0, cap - used) + ' signatures remain in the current month.';
     renderActivity((data.audit || []).filter(isSignEvent));
   }
 
@@ -106,7 +117,11 @@
     button.disabled = true; button.textContent = 'Creating'; error.hidden = true;
     json(API, { method:'POST', headers:{ 'Content-Type':'application/json', Accept:'application/json' }, body:JSON.stringify({ label:label }) }).then(function (data) {
       byId('psk-secret').textContent = data.key || '';
-      byId('psk-meta').textContent = 'Key ' + (data.kid || '--') + ' · ' + (data.mode || 'live') + ' · plan ' + (data.plan || snapshot && snapshot.plan || '--');
+      // The key's own plan when the relay named one, otherwise the account's
+      // ParaSign tier from the snapshot. Not the unified plan: this is a
+      // ParaSign key, so the tier beside it is the ParaSign one.
+      var snapTier = snapshot && snapshot.tiers && snapshot.tiers.parasign;
+      byId('psk-meta').textContent = 'Key ' + (data.kid || '--') + ' · ' + (data.mode || 'live') + ' · plan ' + (data.plan || snapTier || '--');
       showView('secret'); loadKeys();
     }).catch(function (failure) {
       error.textContent = failure.status === 403 ? 'Your account does not have ParaSign API access. Check the plan or ask an administrator to enable it.' : 'The key could not be created. ' + failure.message;

--- a/tests/app-pages-no-api-key.test.mjs
+++ b/tests/app-pages-no-api-key.test.mjs
@@ -73,7 +73,9 @@ const BODIES = {
   [KEY_URL]: { api_key: FAKE_KEY, revealable: true },
   '/api/user/me': { email: 'demo@example.com', plan: 'pro', usage_purpose: 'organisation' },
   '/api/user/documents': { documents: [] },
-  '/api/user/dashboard/overview': { plan: 'pro', quota: { transfers: 1, signs: 1, caps: {} }, audit: [] },
+  // Per product: the overview carries no unified plan any more, because one
+  // word cannot say ParaSign Pro and ParaSend Community at once.
+  '/api/user/dashboard/overview': { tiers: { parasend: 'pro', parasign: 'pro' }, quota: { transfers: 1, signs: 1, caps: { transfers: 500, signs: 100 } }, audit: [] },
   '/api/user/app/token': { token: 'pst_' + 'ab12cd34'.repeat(8), expires_in_s: 900 },
 };
 

--- a/tests/developer-parasign-dashboard.test.mjs
+++ b/tests/developer-parasign-dashboard.test.mjs
@@ -31,7 +31,7 @@ let createBody = null;
 let revokeBody = null;
 let toolsRequests = 0;
 await page.route('**/api/user/developer/snapshot', (route) => route.fulfill({ status:200, contentType:'application/json', body:JSON.stringify({
-  email:'developer@example.com', plan:'pro', quota:{ signs:18, transfers:400, caps:{ signs:100, transfers:500 } },
+  email:'developer@example.com', tiers:{ parasend:'pro', parasign:'pro' }, quota:{ signs:18, transfers:400, caps:{ signs:100, transfers:500 } },
   audit:[{ event_type:'envelope_created', ts:Date.now() }, { event_type:'transfer_sent', ts:Date.now() - 1000 }],
 }) }));
 await page.route('**/api/user/developer/tools', (route) => { toolsRequests++; return route.fulfill({ status:500, body:'' }); });

--- a/tests/signed-in-home.test.mjs
+++ b/tests/signed-in-home.test.mjs
@@ -101,8 +101,12 @@ const inboxWaiting = { ok:true, count:2, documents:[
 ]};
 const inboxNone = { ok:true, count:0, documents:[] };
 
-const overviewCommunity = { plan:'community', quota:{ transfers:1, signs:0, caps:{ transfers:10, signs:2 } }, audit:[] };
-const overviewPro       = { plan:'pro', quota:{ transfers:12, signs:3, caps:{ transfers:500, signs:100 } }, audit:[] };
+// The overview names a tier per product, not one plan word: the caps come from
+// the relay's entitlement layer, where ParaSign Pro and ParaSend Community can
+// sit on the same account. That is why overviewPro pairs 100 signatures with
+// the community transfer ceiling the ParaSign grant leaves alone.
+const overviewCommunity = { tiers:{ parasend:'community', parasign:'free' }, quota:{ transfers:1, signs:0, caps:{ transfers:10, signs:2 } }, audit:[] };
+const overviewPro       = { tiers:{ parasend:'community', parasign:'pro' }, quota:{ transfers:12, signs:3, caps:{ transfers:10, signs:100 } }, audit:[] };
 
 const PRO_ENDS = inDays(29);
 const billingCommunity = { current_plan:'community', plan_parasign:'free', plan_parasend:'community', paid_until_parasign:null, paid_until_parasend:null, auto_renews:false, access_until:null };


### PR DESCRIPTION
`admin/lib/developer-snapshot.js` carried its own copy of `relay/lib/tiers.js`: three rows, no `business` row, keyed on the unified `plan` field. Both halves were wrong at once. A purchase never moves `plan`, because `entitlements.applyProductTier` writes `plan_parasign` or `plan_parasend` and by design touches nothing else. So a self-serve ParaSign Pro customer read "2 signatures left" on /dashboard, on the signed-in homepage and on the ParaSign developer page while the relay was granting him 100, and a Business account got the same 2 where the relay grants 1000. A number in the face of a paying customer that his own supplier knows to be false.

## Where the limits come from now

The relay owns the numbers and is the thing that says no at the quota gate, so it is the thing that says what the ceiling is. `admin/server.js` asks it per account through the endpoint that already existed, `GET /v2/admin/entitlements/:account_id`, and hands the answer to `buildSnapshot`:

- transfers from `parasend.quotas.transfers_month`
- signatures from `parasign.quotas.signs_month`

Neither product decides the other's ceiling and the unified `plan` decides nothing. There is no tier table left in `admin/lib`, and a test fails if one comes back.

When the relay cannot answer, the two endpoints return 503 rather than a fallback cap, and the pages read an absent cap as unknown (`--`, empty bar) instead of as no ceiling, which no tier has: `entitlements.js` holds even enterprise to a finite monthly number.

The overview and snapshot payloads now carry `tiers.parasend` and `tiers.parasign` in place of one `plan` word, because an account can hold two different ones at once. The developer page prints its own product's tier.

Side effect worth naming: that relay call replaces a full `/v2/admin/keys?reveal=1` read of every account on every 5 second dashboard poll.

## Test

`admin/test/developer-snapshot.test.js` drives the numbers through `relay/lib/entitlements.js` itself, so the suite asserts the relay's figures rather than a second set written down beside them:

| stored plans | signs | transfers |
| --- | --- | --- |
| `plan_parasign=pro`, `plan_parasend=community` | 100 | 10 |
| `plan_parasign=business` | 1000 | 10 |
| both floor tiers | 2 | 10 |
| `plan_parasend=pro`, `plan_parasign=free` | 2 | 500 |

Plus: every metered cap is a finite number, and no entitlements means no snapshot rather than a guessed cap.

Sabotage check, run on the branch: restoring the old table fails 6 of the 13 cases, one of them on the table existing at all.

Green here: admin suite 102/102 (`ADMIN_TEST_SKIP=relay`, no `@paramant/core` built locally), relay units 376/376, relay routes plus `parasign-signs-quota` 148/148, `tests/signed-in-home.test.mjs` 37/37, `tests/user-dashboard-documents.test.mjs` 28/28, `tests/developer-parasign-dashboard.test.mjs` 10/10, `tests/app-pages-no-api-key.test.mjs` 16/16, `tests/plan-term-visible.test.mjs` 18/18, `tests/app-contrast.test.mjs`, `ui-truthfulness`, `static-sanity` PASS, eslint clean.

`tests/signed-in-home.test.mjs` now reads "97 of 100" for the Pro case where its mock used to be told 2 by a payload the server could not have produced.