### PR TITLE
The globe accent is in reach of the state machine again

### DIFF
--- a/frontend/js/parashare.page.js
+++ b/frontend/js/parashare.page.js
@@ -1290,6 +1290,13 @@ function loadScript(src) {
   });
 }
 
+// Module scope on purpose: initGlobe() and the state machine below both read
+// these, and a const inside initGlobe was out of reach for setGlobeState,
+// which threw GLOBE_ACCENT_RGB is not defined on every ring tick (main at
+// 23bf6006, caught by the heartbeat).
+const GLOBE_ACCENT = '#D9A441';
+const GLOBE_ACCENT_RGB = '217,164,65';
+
 async function initGlobe() {
   if (globeInstance) { startGlobePoll(); return; }
 
@@ -1315,8 +1322,6 @@ async function initGlobe() {
   // is the ochre of design-system.css (--ochre, #D9A441). It used to be the
   // old lime #B2FF3F, which is a colour the night edition retired from the UI
   // in PR #417 and which survived here only because no stylesheet touches it.
-  const GLOBE_ACCENT = '#D9A441';
-  const GLOBE_ACCENT_RGB = '217,164,65';
   globeInstance = Globe({ animateIn: true })
     .globeImageUrl('/images/globe/earth-night.jpg')
     .bumpImageUrl('/images/globe/earth-topology.png')

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -828,7 +828,7 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 <script src="/js/format-date.js?v=1" defer></script>
 <script src="/js/done-state.js?v=1" defer></script>
 <script src="/js/handshake-meta.js?v=1" defer></script>
-<script src="/js/parashare.page.js?v=11" defer></script>
+<script src="/js/parashare.page.js?v=12" defer></script>
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=8" defer></script>
 <footer>


### PR DESCRIPTION
#431 declared GLOBE_ACCENT and GLOBE_ACCENT_RGB inside initGlobe(); setGlobeState() reads them on every ring tick and threw. Live since deploy 25; the product heartbeat caught it on main. Both constants at module scope now, parashare.page.js v12.