### PR TITLE
The no-browser CI job asks the import graph, and the sweep closes its server

### DIFF
--- a/.github/workflows/sign-e2e.yml
+++ b/.github/workflows/sign-e2e.yml
@@ -46,5 +46,13 @@ jobs:
       # exception. The rule: tests/ is for files that assert something, and a
       # file that only produces artefacts goes in scripts/, browser or not.
       # Same move as the heartbeat canaries in test.yml. See tests/README.md.
+      #
+      # Selected by scripts/browser-suites.mjs, which walks the imports instead
+      # of grepping the first lines of the test file. A suite that reaches
+      # playwright through a helper is a browser suite too, and until 2026-09-04
+      # it was in neither half: tests/ui-elements-contrast.test.mjs got its
+      # browser from scripts/ui-contrast-sweep.mjs, so the grep left it out of
+      # this step and handed it to the job that installs no Chromium, where it
+      # hung the run rather than failing it.
       - name: Browser suites
-        run: node --test $(grep -l "from 'playwright'" tests/*.mjs | grep -vE 'sign-full|product-heartbeat')
+        run: node --test $(node scripts/browser-suites.mjs --browser | grep -vE 'sign-full|product-heartbeat')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -393,7 +393,18 @@ jobs:
         # running in no workflow, which is what let a skipping canary report
         # green for as long as it did. What guards scripts/heartbeat/ itself is
         # tests/heartbeat-lib.test.mjs, picked up by the same glob.
-        run: node --test $(grep -L "from 'playwright'" tests/*.mjs)
+        #
+        # The half is chosen by scripts/browser-suites.mjs, not by a grep for
+        # "from 'playwright'" in the test file. That grep read one file deep and
+        # on 2026-09-04 it put tests/ui-elements-contrast.test.mjs in this job:
+        # the suite imports scripts/ui-contrast-sweep.mjs and the sweep is what
+        # imports playwright. This job installs no Chromium, the launch failed,
+        # the sweep's http server stayed up, and this step never returned. Three
+        # runs on main and a pull request hung on it. The selector now follows
+        # the imports as deep as they go; the sweep closes its server whatever
+        # happens (scripts/ui-contrast-sweep.mjs), so a job without a browser
+        # goes red in seconds instead of silent for hours.
+        run: node --test $(node scripts/browser-suites.mjs --no-browser)
 
   admin-unit-tests:
     name: admin - unit suite

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -196,7 +196,7 @@ verifications. Every request past the failure threshold also has to carry a real
 **Root integration suites** (node builtins plus the root deps, no browser):
 
 ```bash
-node --test $(grep -L "from 'playwright'" tests/*.mjs)
+node --test $(node scripts/browser-suites.mjs --no-browser)
 #   # tests 190   # pass 188   # skipped 2   # fail 0    ~1.2s
 ```
 
@@ -259,7 +259,7 @@ npx playwright install chromium
 node tests/sign-full.test.mjs
 #   33/33 passed                          ~4s
 
-node --test $(grep -l "from 'playwright'" tests/*.mjs | grep -vE 'sign-full|product-heartbeat')
+node --test $(node scripts/browser-suites.mjs --browser | grep -vE 'sign-full|product-heartbeat')
 #   # tests 12   # pass 12   # fail 0     ~7s
 ```
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -102,7 +102,7 @@ cd ..
 # root integration suites, no browser. CI installs the root deps first, and so
 # must you: tests/heartbeat-lib.test.mjs imports @noble/post-quantum.
 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
-node --test $(grep -L "from 'playwright'" tests/*.mjs)
+node --test $(node scripts/browser-suites.mjs --no-browser)
 
 # the static gates
 tests/static-sanity.sh

--- a/scripts/browser-suites.mjs
+++ b/scripts/browser-suites.mjs
@@ -1,0 +1,93 @@
+// Which root suites drive a browser, answered by the import graph instead of
+// by the first line of the file.
+//
+// Two workflows split tests/*.mjs in half: test.yml runs the half that needs
+// no browser (it installs no Chromium), sign-e2e.yml runs the half that does.
+// Both asked the question with `grep -l "from 'playwright'" tests/*.mjs`, which
+// reads one file and stops there.
+//
+// On 2026-09-04 that cost the repo three hours of CI. tests/ui-elements-contrast
+// .test.mjs (PR #431) imports scripts/ui-contrast-sweep.mjs, and the sweep is
+// what imports playwright. The grep saw no playwright in the test file, so the
+// no-browser job took the suite, PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD meant there
+// was no Chromium to launch, and the step never came back. The same blind spot
+// kept the suite out of sign-e2e, so the only new gate of that pull request ran
+// nowhere while it was hanging everywhere.
+//
+// So the question is asked of everything the suite pulls in: this walks the
+// relative imports from each test file, as deep as they go, and reports a suite
+// as a browser suite as soon as anything it reaches imports playwright. A
+// helper that grows a browser dependency moves its suites with it, on the run
+// after the commit, with no list to keep.
+//
+//   node scripts/browser-suites.mjs --browser      needs a browser
+//   node scripts/browser-suites.mjs --no-browser   the rest
+//
+// Paths are printed one per line, sorted, relative to the repo root, so the
+// output drops straight into `node --test $(...)`.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BROWSER_PACKAGES = new Set(['playwright', 'playwright-core', '@playwright/test']);
+
+// `from '...'`, `import '...'` and `import('...')`, which is every shape an
+// import specifier takes in this repo. A specifier inside a string or a comment
+// would be a false positive; erring towards "needs a browser" is the safe side,
+// since that half of the split installs one.
+const SPECIFIERS = /(?:\bfrom\s*|\bimport\s*\(?\s*|\brequire\s*\(\s*)['"]([^'"\n]+)['"]/g;
+
+function specifiers(file) {
+  let source;
+  try { source = fs.readFileSync(file, 'utf8'); } catch { return []; }
+  return [...source.matchAll(SPECIFIERS)].map((m) => m[1]);
+}
+
+// Bare specifier: is it the browser, or is it anything else. Relative: keep
+// walking. A directory or an extensionless path is resolved the way node does,
+// enough of it for the files that live here.
+function resolveLocal(from, spec) {
+  const base = path.resolve(path.dirname(from), spec);
+  const tries = [base, base + '.mjs', base + '.js', path.join(base, 'index.mjs'), path.join(base, 'index.js')];
+  for (const one of tries) {
+    try { if (fs.statSync(one).isFile()) return one; } catch { /* next */ }
+  }
+  return null;
+}
+
+export function needsBrowser(entry) {
+  const seen = new Set();
+  const queue = [path.resolve(entry)];
+  while (queue.length) {
+    const file = queue.pop();
+    if (seen.has(file)) continue;
+    seen.add(file);
+    for (const spec of specifiers(file)) {
+      if (BROWSER_PACKAGES.has(spec) || [...BROWSER_PACKAGES].some((p) => spec.startsWith(p + '/'))) return true;
+      if (spec.startsWith('.')) {
+        const local = resolveLocal(file, spec);
+        if (local) queue.push(local);
+      }
+    }
+  }
+  return false;
+}
+
+const suites = fs.readdirSync(path.join(ROOT, 'tests'))
+  .filter((name) => name.endsWith('.test.mjs'))
+  .map((name) => path.join('tests', name))
+  .sort();
+
+const wanted = process.argv.includes('--browser') ? true
+  : process.argv.includes('--no-browser') ? false
+  : null;
+
+if (wanted === null) {
+  process.stderr.write('usage: node scripts/browser-suites.mjs --browser | --no-browser\n');
+  process.exit(2);
+}
+
+for (const suite of suites) {
+  if (needsBrowser(path.join(ROOT, suite)) === wanted) console.log(suite);
+}

--- a/scripts/ui-contrast-sweep.mjs
+++ b/scripts/ui-contrast-sweep.mjs
@@ -420,11 +420,41 @@ const PROBE = async () => {
   return { ground: hex(pageGround), rows };
 };
 
-export async function sweep({ shotDir = null, pages = PUBLIC_PAGES, appPages = APP_PAGES, themes = THEMES, sizes = SIZES, keepAll = false } = {}) {
+// The static server and the browser are opened here and closed in the finally,
+// and that is the whole point of splitting this from measure() below.
+//
+// It used to open both at the top of one long function and close them at the
+// bottom, on the happy path only. On 2026-09-04 that took the "Root integration
+// suites (no browser)" job on main from a 20-minute run to a job that never
+// ended: tests/ui-elements-contrast.test.mjs had landed in that job (see
+// scripts/browser-suites.mjs for why), the job installs no Chromium, so
+// chromium.launch() rejected. The rejection is the correct outcome and would
+// have been a red test in seconds, except the listening http server was already
+// up and nothing closed it. `node --test` waits for the event loop to drain, an
+// open listener never drains, and the child process sat there with the failure
+// it had already decided on. Three runs on main and one pull request hung on
+// exactly that.
+//
+// So: anything that opens a handle in here is closed on the way out, whichever
+// way out it is.
+export async function sweep(options = {}) {
   const server = serve();
   await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  let browser = null;
+  try {
+    browser = await chromium.launch({ headless:true, ...(EXE ? { executablePath:EXE } : {}) });
+    return await measure(server, browser, options);
+  } finally {
+    if (browser) await browser.close().catch(() => { /* closing over a crash */ });
+    // A keep-alive socket the browser left behind holds the process open long
+    // after the last page is measured. Node 18 gave us the hammer for that.
+    if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
+    server.close();
+  }
+}
+
+async function measure(server, browser, { shotDir = null, pages = PUBLIC_PAGES, appPages = APP_PAGES, themes = THEMES, sizes = SIZES, keepAll = false } = {}) {
   const origin = `http://localhost:${server.address().port}`;
-  const browser = await chromium.launch({ headless:true, ...(EXE ? { executablePath:EXE } : {}) });
   const findings = [];
   const decorative = [];
   const everything = [];
@@ -515,12 +545,6 @@ export async function sweep({ shotDir = null, pages = PUBLIC_PAGES, appPages = A
       await guarded('app ' + screen.slug, screen.slug, theme, w, h, { app:true, ready:screen.ready, signedIn:screen.signedIn });
     }
   }
-  await browser.close();
-  // A keep-alive socket the browser left behind holds the process open long
-  // after the last page is measured. Node 18 gave us the hammer for that.
-  if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
-  server.close();
-
   // One row per place and colour pair; 390 and 1440 see the same defect twice.
   const key = (r) => `${r.page}|${r.theme}|${r.kind}|${r.sel}|${r.colour}|${r.ground}`;
   const uniq = (list) => [...new Map(list.map((r) => [key(r), r])).values()];

--- a/tests/README.md
+++ b/tests/README.md
@@ -67,9 +67,26 @@ Moving the file changes nothing about the workflow's selection line. The real
 browser suites it selects are the same sixteen minus this one:
 
 ```bash
-# What the sign-e2e Browser suites step runs, before and after:
-grep -l "from 'playwright'" tests/*.mjs | grep -vE 'sign-full|product-heartbeat'
+# What the sign-e2e Browser suites step runs:
+node scripts/browser-suites.mjs --browser | grep -vE 'sign-full|product-heartbeat'
 ```
+
+### Which half a suite belongs to is decided by the import graph
+
+That selection line used to be `grep -l "from 'playwright'" tests/*.mjs`, which
+reads the test file and nothing it imports. `tests/ui-elements-contrast.test.mjs`
+imports `scripts/ui-contrast-sweep.mjs`, and the sweep is what imports
+playwright, so the grep called it a no-browser suite. On 2026-09-04 that sent it
+to the `Root integration suites (no browser)` job in test.yml, which installs no
+Chromium on purpose. `chromium.launch()` rejected, the sweep's static server was
+already listening and nothing closed it, and `node --test` waited for an event
+loop that would never drain: three runs on main and a pull request hung in that
+step for hours instead of failing in seconds. The suite also ran in no browser
+job at all, so the only new gate of that pull request was measuring nothing.
+
+`scripts/browser-suites.mjs` answers the same question by walking the relative
+imports from each suite as deep as they go. A helper that grows a browser
+dependency takes its suites with it on the next run, with no list to keep.
 
 The rule this leaves behind: a file under `tests/` is a gate and asserts
 something. A file that only produces artefacts belongs in `scripts/`, whether or


### PR DESCRIPTION
## What was broken

Since 12:41 on 4 September the step **Root integration suites (no browser)** in `test.yml` never finished. Three runs on main (33864441591, 33866967216, 33868376537) and PR #432 sat in it for hours with no output. The last green run before it was #430.

Two faults, one behind the other.

**1. The half was chosen one file deep.** The step picked its suites with `grep -L "from 'playwright'" tests/*.mjs`, which reads the test file and nothing it imports. `tests/ui-elements-contrast.test.mjs` (new in #431) imports `scripts/ui-contrast-sweep.mjs`, and the sweep is what imports playwright. So the grep called it a no-browser suite and handed it to the job that installs no Chromium on purpose. `sign-e2e` selected with the mirror image of the same grep, so the suite ran in no browser job either: the only new gate of that pull request was measuring nothing while it was hanging everything.

**2. A failure left a listener behind.** In that job `chromium.launch()` rejects, which is correct and should be a red test in half a second. It was not: `sweep()` opened its static server at the top of one long function and closed it at the bottom, on the happy path only. `node --test` waits for the event loop to drain, a listening server never drains, and the child process sat there on a failure it had already decided. A job that hangs reports nothing and blocks every pull request behind it, which is worse than the red it was hiding.

## The fix

- `scripts/ui-contrast-sweep.mjs`: the server and the browser are opened in `sweep()` and closed in its `finally`; the measuring moved to `measure()`. Whichever way the function is left, no handle stays open. No timeout was added to the workflow: a global timeout would have turned a three-hour hang into a shorter hang, not into an answer.
- `scripts/browser-suites.mjs` (new): walks the relative imports from each suite as deep as they go and prints `--browser` or `--no-browser`. A helper that grows a browser dependency takes its suites with it on the next run, with no list to keep.
- `test.yml`, `sign-e2e.yml`, `docs/ONBOARDING.md`, `docs/RELEASE.md` and `tests/README.md` ask that script instead of the grep. `ui-elements-contrast` moves to the `Browser suites` step, where it has a Chromium.

## Proof

- The no-browser selection runs to the end three times in a row: 238 checks, exit 0, about 2 seconds each.
- `tests/ui-elements-contrast.test.mjs` against a real Chromium: 1 check, pass, 61 s, the three known radar rings still on the list.
- With the browsers hidden (`PLAYWRIGHT_BROWSERS_PATH` pointing nowhere) that suite now fails in 0.4 s. Before this change the same command hung until it was killed.
- Relay unit suite 376/376, `tests/static-sanity.sh` PASS (twelve checks), `scripts/check-test-declarations.sh` OK over 174 suites, `eslint` clean.