### PR TITLE
Gift codes on the admin screen that is actually served, and a billing banner that is true

### DIFF
--- a/admin/public/app.js
+++ b/admin/public/app.js
@@ -433,7 +433,17 @@ async function loadBilling(){
   const dist=d.plan_distribution||{};
   const total=Object.values(dist).reduce((a,b)=>a+b,0)||1;
   el.innerHTML=
-    '<div class="banner stub" role="status"><strong>Beta billing</strong> &mdash; Payment processing (Mollie) is in integration. Customers are manually invoiced. Data shown is stub only.'+'</div>'+
+    /* This line used to announce a billing beta: Mollie not yet connected,
+       customers invoiced by hand, figures made up. Every clause of that was
+       false by September 2026. relay.js POST
+       /v2/billing/checkout calls mollie.createPayment against api.mollie.com
+       unconditionally, and the webhook issues a numbered invoice (lib/invoice.js,
+       series PS-YYYY-NNNN) or a credit note (lib/credit-note.js, CN-YYYY-NNNN)
+       on its own. BILLING_MODE is empty in production, which turns the recurring
+       layer off and nothing else: payments are real, they are one-off per term.
+       What IS worth saying is the limit of this tab, because the card below it
+       counts admin plan_changed audit events and never a self-serve payment. */
+    '<div class="banner info" role="status"><strong>Billing</strong> Mollie payments are live: one payment per term, no subscription and no direct debit. A numbered invoice or credit note is issued automatically from the payment webhook. This tab shows plan distribution and admin plan changes, not payments or revenue.</div>'+
       '<div class="card"><div class="card-hdr">Recent plan changes <small>'+( d.recent_checkouts?.length||0)+' events</small></div>'+
         (d.recent_checkouts&&d.recent_checkouts.length?
           '<table class="tbl"><thead><tr><th>Time</th><th>User</th><th>Event</th></tr></thead><tbody>'+
@@ -444,7 +454,134 @@ async function loadBilling(){
           '</tr>').join('')+'</tbody></table>':
           '<div class="empty">No plan changes recorded yet</div>')+
       '</div>'+
+      renderCouponsShell()+
     '</div>';
+  fetchCoupons();
+}
+
+/* ── Gift codes ────────────────────────────────────────
+   A code gives somebody a term, and no money moves: relay/lib/coupon.js holds
+   the rules, /admin/coupons in admin/server.js is the hop that carries this
+   panel's X-Session to the relay, and this is the window on both. Two things
+   belong on the screen and nothing else does: how to make a code, and how many
+   seats of each one are gone.
+
+   There is deliberately no edit. Raising the cap on a code people are already
+   redeeming against, or changing what it grants under them, is how two
+   customers get different answers for the same code. Withdraw it and make
+   another; the terms already granted are never taken back. */
+
+// The relay answers in machine words. Nobody minting a code should have to
+// know what bad_valid_until means, so every one of them is said in a sentence
+// that names the field and what to do about it.
+const COUPON_ERRORS={
+  code_exists:'That code already exists. Withdraw the old one, or pick another name.',
+  bad_code:'A code is 3 to 32 characters long: letters, digits and dashes only.',
+  bad_valid_until:'That end date is not a date. Pick one from the calendar, or leave it empty for no end date.',
+  bad_max_redemptions:'Maximum redemptions must be a whole number between 1 and 100000.',
+  bad_days:'Days must be a whole number between 1 and 3650.',
+  unknown_code:'That code no longer exists.',
+  coupons_unavailable:'The coupon store is not reachable, so nothing was changed. Try again in a moment.',
+  no_redis:'The coupon store is not reachable, so nothing was changed. Try again in a moment.',
+  rate_limited:'Too many coupon changes in a row. Wait a minute and try again.',
+};
+function couponError(r){
+  const err=(r&&r.data&&r.data.error)||'';
+  if(COUPON_ERRORS[err])return COUPON_ERRORS[err];
+  if(!r||r.status===0)return 'The relay could not be reached, so nothing was changed.';
+  if(r.status===502||r.status===503||r.status===504)return 'The relay could not be reached, so nothing was changed.';
+  if(r.status===401||r.status===403)return 'Your admin session has expired. Sign in again.';
+  return err?('Failed: '+err):'Something went wrong, and nothing was changed.';
+}
+
+// api() lets a network failure throw. Everywhere else on this screen that ends
+// in an unhandled rejection and a tab that just stops; here it has to become
+// the sentence above, so the throw is caught and given a status of its own.
+async function couponApi(path,opts){
+  try{return await api(path,opts||{});}catch{return{ok:false,status:0,data:null};}
+}
+
+function couponMsg(text,ok){
+  const msg=document.getElementById('c-msg');
+  if(!msg)return;
+  msg.style.color=ok?'#059669':'#dc2626';
+  msg.textContent=text;
+}
+
+function renderCouponsShell(){
+  return '<div class="card"><div class="card-hdr">Gift codes <small>a term given, no payment, no invoice</small></div>'+
+    '<div class="fb">'+
+      '<input id="c-code" placeholder="CODE" style="width:160px;text-transform:uppercase" aria-label="Code">'+
+      '<input id="c-max" type="number" min="1" value="100" style="width:110px" title="Maximum redemptions" aria-label="Maximum redemptions">'+
+      '<input id="c-days" type="number" min="1" value="90" style="width:90px" title="Days granted" aria-label="Days granted">'+
+      '<input id="c-until" type="date" style="width:160px" title="Valid until" aria-label="Valid until">'+
+      '<div class="sp"></div>'+
+      '<button class="btn" data-click="doCreateCoupon">Create code</button>'+
+      '<button class="btn out" data-click="fetchCoupons">Refresh</button>'+
+    '</div>'+
+    '<div id="c-msg" role="status" style="font-size:12px;margin-bottom:8px"></div>'+
+    '<div id="c-results"><div class="empty"><span class="sp-icon"></span>Loading…</div></div>'+
+  '</div>';
+}
+
+async function fetchCoupons(){
+  const el=document.getElementById('c-results');
+  if(!el)return;
+  const r=await couponApi('/admin/coupons');
+  if(!r.ok){el.innerHTML='<div class="empty">'+esc(couponError(r))+'</div>';return}
+  const list=(r.data&&r.data.coupons)||[];
+  if(!list.length){el.innerHTML='<div class="empty">No gift codes yet</div>';return}
+  el.innerHTML='<div class="tbl-wrap"><table class="tbl"><thead><tr><th>Code</th><th>Gives</th><th>Used</th><th>Valid until</th><th>Status</th><th></th></tr></thead><tbody>'+
+    list.map(c=>'<tr>'+
+      '<td class="mono">'+esc(c.code)+'</td>'+
+      '<td style="font-size:12px">'+esc(c.describes||'')+'</td>'+
+      '<td class="mono">'+esc(c.used+' of '+c.max_redemptions)+'</td>'+
+      '<td style="font-size:12px">'+esc(c.valid_until?c.valid_until.slice(0,10):'no end date')+'</td>'+
+      '<td>'+(c.revoked_at?'<span class="chip revoked">withdrawn</span>':(c.remaining>0?'<span class="chip active">open</span>':'<span class="chip none">used up</span>'))+'</td>'+
+      '<td>'+(c.revoked_at?'':'<button class="btn out" data-click="doRevokeCoupon" data-code="'+esc(c.code)+'">Withdraw</button>')+'</td>'+
+    '</tr>').join('')+'</tbody></table></div>';
+}
+
+async function doCreateCoupon(){
+  const code=(document.getElementById('c-code')?.value||'').trim().toUpperCase();
+  const max=parseInt(document.getElementById('c-max')?.value||'0',10);
+  const days=parseInt(document.getElementById('c-days')?.value||'0',10);
+  const until=(document.getElementById('c-until')?.value||'').trim();
+  if(!code){couponMsg('Enter a code first.',false);return}
+  if(!/^[A-Z0-9-]{3,32}$/.test(code)){couponMsg(COUPON_ERRORS.bad_code,false);return}
+  if(!(max>=1)){couponMsg(COUPON_ERRORS.bad_max_redemptions,false);return}
+  if(!(days>=1)){couponMsg(COUPON_ERRORS.bad_days,false);return}
+  // An empty date means no end date. A date that is not a date is refused here
+  // rather than read as one, the same rule coupon.js validateValidUntil follows.
+  if(until&&Number.isNaN(Date.parse(until+'T23:59:59Z'))){couponMsg(COUPON_ERRORS.bad_valid_until,false);return}
+  /* Both products on Pro is the campaign this shipped for. The relay validates
+     every field again; nothing sent from here is trusted. */
+  const body={code:code,max_redemptions:max,grants:[
+    {product:'parasign',tier:'pro',days:days},
+    {product:'parasend',tier:'pro',days:days},
+  ]};
+  if(until)body.valid_until=until+'T23:59:59Z';
+  couponMsg('Creating…',true);
+  const r=await couponApi('/admin/coupons',{method:'POST',body:JSON.stringify(body)});
+  if(r.ok){
+    couponMsg('Created '+code+': '+((r.data&&r.data.coupon&&r.data.coupon.describes)||'')+', '+max+' redemptions.',true);
+    const inp=document.getElementById('c-code');if(inp)inp.value='';
+    fetchCoupons();
+  }else{
+    couponMsg(couponError(r),false);
+  }
+}
+
+async function doRevokeCoupon(el){
+  const code=el&&el.dataset?el.dataset.code:'';
+  if(!code)return;
+  const r=await couponApi('/admin/coupons/'+encodeURIComponent(code),{method:'DELETE'});
+  if(r.ok){
+    couponMsg(code+' withdrawn. Terms already redeemed keep running.',true);
+    fetchCoupons();
+  }else{
+    couponMsg(couponError(r),false);
+  }
 }
 
 /* ── Relay ───────────────────────────────────────────────────────────────── */
@@ -744,6 +881,9 @@ act('click', 'doCreateKey', () => doCreateKey());
 act('click', 'showNewKeyModal', () => showNewKeyModal());
 act('click', 'exportAuditCSV', () => exportAuditCSV());
 act('click', 'fetchAudit', () => fetchAudit());
+act('click', 'doCreateCoupon', () => doCreateCoupon());
+act('click', 'doRevokeCoupon', (el) => doRevokeCoupon(el));
+act('click', 'fetchCoupons', () => fetchCoupons());
 act('click', 'fetchRelay', () => fetchRelay());
 act('click', 'uAction', (el) => uAction(el.dataset.uact, el));
 act('click', 'toggleMenu', (el, ev) => toggleMenu(ev, el.dataset.menu));

--- a/admin/test/admin-ui-coupons.test.js
+++ b/admin/test/admin-ui-coupons.test.js
@@ -1,0 +1,283 @@
+'use strict';
+// The gift-code block, in the admin screen that is actually served.
+//
+// WHY THIS FILE EXISTS. The coupon UI was built once already, in
+// frontend/js/admin.page.js, and it was invisible. Nginx sends /admin/ to the
+// admin container and never to the docroot (deploy/nginx-paramant-public.conf
+// to 127.0.0.1:4200, deploy/nginx-paramant-live.conf:313 to 127.0.0.1:3002),
+// and that container serves admin/public/index.html plus admin/public/app.js.
+// The file the block was written in is on no route an admin uses. Everything
+// passed anyway: the relay routes had
+// tests, the panel's three proxy hops had tests (coupons.test.js), and the
+// screen an admin opens had no Gift codes card on it at all.
+//
+// So this suite asserts the one thing none of those did: that the block is in
+// the SERVED file, that it is rendered by the Billing tab, and that the button
+// on it reaches the panel's own /admin/coupons route with the session header
+// the rest of that screen uses. A test that read admin.page.js would have gone
+// green through the whole outage, which is exactly the failure being closed.
+//
+// HOW. app.js is a plain browser script with no module system and no framework,
+// so it is run in a vm on a hand-built document: getElementById hands back
+// stub nodes, fetch records what it was called with, and the real functions do
+// the rest. Nothing about the coupon path is reimplemented here; if
+// doCreateCoupon stops sending X-Session, or starts calling the relay directly,
+// this fails.
+//
+// Run: node --test admin/test/admin-ui-coupons.test.js
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const PUBLIC = path.join(__dirname, '..', 'public');
+const APP_JS = fs.readFileSync(path.join(PUBLIC, 'app.js'), 'utf8');
+const INDEX_HTML = fs.readFileSync(path.join(PUBLIC, 'index.html'), 'utf8');
+
+// ── A document just large enough for app.js to load and for the Billing tab
+// to render into. Anything the script asks for exists; nothing pretends to lay
+// out or to bubble an event.
+function makeNode(id) {
+  return {
+    id,
+    value: '',
+    innerHTML: '',
+    textContent: '',
+    disabled: false,
+    style: {},
+    dataset: {},
+    classList: { add() {}, remove() {}, contains() { return false; } },
+    addEventListener() {},
+    removeEventListener() {},
+    setAttribute() {},
+    getAttribute() { return null; },
+    focus() {},
+    closest() { return null; },
+    querySelectorAll() { return []; },
+    appendChild() {},
+    remove() {},
+  };
+}
+
+function boot({ session = '', fetchImpl } = {}) {
+  const nodes = new Map();
+  const calls = [];
+  const document = {
+    getElementById(id) {
+      if (!nodes.has(id)) nodes.set(id, makeNode(id));
+      return nodes.get(id);
+    },
+    createElement: (tag) => makeNode(tag),
+    querySelectorAll: () => [],
+    addEventListener() {},
+    body: makeNode('body'),
+  };
+  const sandbox = {
+    document,
+    sessionStorage: { getItem: () => session, setItem() {}, removeItem() {} },
+    location: { hash: '', href: '' },
+    console,
+    setTimeout,
+    clearTimeout,
+    setInterval: () => 0,
+    clearInterval: () => {},
+    requestAnimationFrame: (fn) => fn(),
+    Date,
+    JSON,
+    URLSearchParams,
+    Number,
+    Math,
+    String,
+    Array,
+    Object,
+    parseInt,
+    parseFloat,
+    isNaN,
+    encodeURIComponent,
+    decodeURIComponent,
+    fetch: async (url, opts) => {
+      calls.push({ url, opts: opts || {} });
+      return fetchImpl ? fetchImpl(url, opts || {}, calls.length) : jsonResponse(200, {});
+    },
+  };
+  sandbox.window = sandbox;
+  sandbox.globalThis = sandbox;
+  const context = vm.createContext(sandbox);
+  vm.runInContext(APP_JS, context, { filename: 'app.js' });
+  return { context, nodes, calls, run: (src) => vm.runInContext(src, context) };
+}
+
+function jsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => 'application/json' },
+    json: async () => body,
+  };
+}
+
+const COUPON = {
+  code: 'COFFEE',
+  grants: [{ product: 'parasign', tier: 'pro', days: 90 }],
+  max_redemptions: 100,
+  used: 0,
+  remaining: 100,
+  valid_until: null,
+  revoked_at: null,
+  describes: '3 months of ParaSign Pro and ParaSend Pro',
+};
+
+// ── 1. The block is in the served file and on the Billing tab ────────────────
+
+test('the served screen is admin/public, and admin/public/app.js holds the coupon block', () => {
+  // The pair that is actually served together. A block in frontend/ is not on
+  // this screen, whatever it looks like in a diff.
+  assert.match(INDEX_HTML, /<script src="app\.js"/, 'index.html must load app.js');
+  assert.ok(APP_JS.includes('renderCouponsShell'),
+    'admin/public/app.js has no coupon block; the one in frontend/js/admin.page.js is served by nothing');
+  for (const fn of ['fetchCoupons', 'doCreateCoupon', 'doRevokeCoupon']) {
+    assert.ok(APP_JS.includes('function ' + fn), `${fn} is missing from the served app.js`);
+  }
+});
+
+test('the three coupon actions are registered on the delegated click registry', () => {
+  // index.html carries no inline handlers (CSP drops unsafe-inline), so a
+  // button that is not in the registry is a button that does nothing.
+  const { context } = boot();
+  const clicks = vm.runInContext('Object.keys(ACTIONS.click)', context);
+  for (const name of ['doCreateCoupon', 'doRevokeCoupon', 'fetchCoupons']) {
+    assert.ok(clicks.includes(name), `data-click="${name}" has no registered action`);
+  }
+});
+
+test('opening the Billing tab renders the gift-code card with its four fields', async () => {
+  const { context, nodes, run } = boot({
+    fetchImpl: (url) => (String(url).includes('/admin/coupons')
+      ? jsonResponse(200, { ok: true, coupons: [COUPON] })
+      : jsonResponse(200, { plan_distribution: { pro: 2 }, recent_checkouts: [] })),
+  });
+  await run('loadBilling()');
+  const html = nodes.get('tab-billing').innerHTML;
+  assert.match(html, /Gift codes/, 'the Billing tab renders no gift-code card');
+  assert.match(html, /id="c-code"/, 'no code field');
+  assert.match(html, /id="c-max"[^>]*value="100"/, 'no maximum redemptions field defaulting to 100');
+  assert.match(html, /id="c-days"[^>]*value="90"/, 'no days field defaulting to 90');
+  assert.match(html, /id="c-until"[^>]*type="date"/, 'no valid-until date field');
+  assert.match(html, /data-click="doCreateCoupon"/, 'no create button');
+  // And the table under it, filled from the list route.
+  await new Promise((r) => setTimeout(r, 0));
+  const rows = nodes.get('c-results').innerHTML;
+  assert.match(rows, /COFFEE/);
+  assert.match(rows, /0 of 100/, 'the table must show used of maximum');
+  assert.match(rows, /no end date/);
+  assert.match(rows, /data-click="doRevokeCoupon"/, 'an open code needs a withdraw button');
+  assert.ok(vm.runInContext('true', context));
+});
+
+// ── 2. The button reaches the panel's own route, with the session ────────────
+
+test('Create code posts to the panel route /admin/api/admin/coupons with X-Session', async () => {
+  const { nodes, calls, run } = boot({
+    session: 'sess-abc',
+    fetchImpl: (url, opts) => (opts.method === 'POST'
+      ? jsonResponse(201, { ok: true, coupon: COUPON })
+      : jsonResponse(200, { ok: true, coupons: [COUPON] })),
+  });
+  nodes.set('c-code', Object.assign(makeNode('c-code'), { value: 'coffee' }));
+  nodes.set('c-max', Object.assign(makeNode('c-max'), { value: '50' }));
+  nodes.set('c-days', Object.assign(makeNode('c-days'), { value: '30' }));
+  nodes.set('c-until', Object.assign(makeNode('c-until'), { value: '2026-12-31' }));
+  await run('doCreateCoupon()');
+
+  const post = calls.find((c) => c.opts.method === 'POST');
+  assert.ok(post, 'the create button sent no request');
+  assert.strictEqual(post.url, '/admin/api/admin/coupons',
+    'the create button must go through the admin panel, which swaps the session for ADMIN_TOKEN; the browser never holds that token and cannot call the relay directly');
+  assert.strictEqual(post.opts.headers['X-Session'], 'sess-abc',
+    'the create request carries no admin session');
+  const body = JSON.parse(post.opts.body);
+  assert.strictEqual(body.code, 'COFFEE', 'the code must be normalised to upper case, as coupon.js does');
+  assert.strictEqual(body.max_redemptions, 50);
+  assert.deepStrictEqual(body.grants.map((g) => g.days), [30, 30], 'every grant on one code runs the same number of days');
+  assert.strictEqual(body.valid_until, '2026-12-31T23:59:59Z', 'a date field means the end of that day');
+  assert.match(nodes.get('c-msg').textContent, /Created COFFEE/);
+});
+
+test('Withdraw sends a DELETE with the code in the path and no body', async () => {
+  const { nodes, calls, run } = boot({
+    session: 'sess-abc',
+    fetchImpl: () => jsonResponse(200, { ok: true, coupon: { ...COUPON, revoked_at: '2026-09-04T10:00:00Z' } }),
+  });
+  // The registry hands doRevokeCoupon the button itself, so the code travels in
+  // its dataset and never in a body.
+  await run('doRevokeCoupon({dataset:{code:"COFFEE"}})');
+  const del = calls.find((c) => c.opts.method === 'DELETE');
+  assert.ok(del, 'the withdraw button sent no request');
+  assert.strictEqual(del.url, '/admin/api/admin/coupons/COFFEE',
+    'the code belongs in the path, on the panel route, not in a body and not on the relay');
+  assert.strictEqual(del.opts.headers['X-Session'], 'sess-abc');
+  assert.strictEqual(del.opts.body, undefined,
+    'the withdraw must send no body; a DELETE body the relay refuses before reading desynchronises a kept-alive connection');
+  assert.match(nodes.get('c-msg').textContent, /withdrawn/);
+});
+
+// ── 3. The failures say what happened, in words ──────────────────────────────
+
+test('a rejected code is explained in a sentence, not in a relay error word', async () => {
+  const cases = [
+    [409, { error: 'code_exists' }, /already exists/i],
+    [400, { error: 'bad_valid_until' }, /not a date/i],
+    [503, { error: 'coupons_unavailable' }, /not reachable/i],
+  ];
+  for (const [status, body, expect] of cases) {
+    const { nodes, run } = boot({ fetchImpl: () => jsonResponse(status, body) });
+    nodes.set('c-code', Object.assign(makeNode('c-code'), { value: 'COFFEE' }));
+    nodes.set('c-max', Object.assign(makeNode('c-max'), { value: '100' }));
+    nodes.set('c-days', Object.assign(makeNode('c-days'), { value: '90' }));
+    await run('doCreateCoupon()');
+    const msg = nodes.get('c-msg').textContent;
+    assert.match(msg, expect, `${body.error} was shown as: ${msg}`);
+    assert.doesNotMatch(msg, new RegExp(body.error), `${body.error} was shown raw to the admin`);
+  }
+});
+
+test('an unreachable relay is said out loud instead of dying in an unhandled rejection', async () => {
+  const { nodes, run } = boot({ fetchImpl: () => { throw new TypeError('fetch failed'); } });
+  nodes.set('c-code', Object.assign(makeNode('c-code'), { value: 'COFFEE' }));
+  nodes.set('c-max', Object.assign(makeNode('c-max'), { value: '100' }));
+  nodes.set('c-days', Object.assign(makeNode('c-days'), { value: '90' }));
+  await run('doCreateCoupon()');
+  assert.match(nodes.get('c-msg').textContent, /could not be reached/i);
+});
+
+test('a code that cannot be a code never leaves the browser', async () => {
+  const { nodes, calls, run } = boot();
+  nodes.set('c-code', Object.assign(makeNode('c-code'), { value: 'A B' }));
+  nodes.set('c-max', Object.assign(makeNode('c-max'), { value: '100' }));
+  nodes.set('c-days', Object.assign(makeNode('c-days'), { value: '90' }));
+  await run('doCreateCoupon()');
+  assert.strictEqual(calls.length, 0, 'a malformed code was sent to the relay anyway');
+  assert.match(nodes.get('c-msg').textContent, /letters, digits and dashes/i);
+});
+
+// ── 4. The banner over it is no longer a lie ─────────────────────────────────
+
+test('the Billing tab no longer calls itself a beta stub', async () => {
+  const { nodes, run } = boot({
+    fetchImpl: (url) => (String(url).includes('/admin/coupons')
+      ? jsonResponse(200, { ok: true, coupons: [] })
+      : jsonResponse(200, { plan_distribution: {}, recent_checkouts: [] })),
+  });
+  await run('loadBilling()');
+  const html = nodes.get('tab-billing').innerHTML;
+  assert.doesNotMatch(html, /Beta billing/,
+    'payments run through Mollie today: relay.js POST /v2/billing/checkout calls mollie.createPayment unconditionally');
+  assert.doesNotMatch(html, /stub only|manually invoiced|in integration/i,
+    'invoices and credit notes are drawn automatically from the payment webhook (relay/lib/invoice.js, relay/lib/credit-note.js)');
+  assert.match(html, /Mollie payments are live/,
+    'the tab should say what is true rather than nothing');
+  assert.match(html, /no subscription and no direct debit/i,
+    'BILLING_MODE is empty in production, which leaves the recurring layer off (relay/lib/mollie.js billingStance)');
+});


### PR DESCRIPTION
## What was wrong

PR #439 built the coupon admin UI in `frontend/js/admin.page.js`. That is not the admin screen anyone opens. Nginx sends `/admin/` to the admin container (`deploy/nginx-paramant-public.conf` to `127.0.0.1:4200`, `deploy/nginx-paramant-live.conf:313` to `127.0.0.1:3002`), and the container serves `admin/public/index.html` plus `admin/public/app.js`. That file contained zero lines of coupon code, so the Billing tab showed no Gift codes card at all, while the relay routes and the panel's three proxy hops were live and tested the whole time.

## What this does

**1. The gift-code block moves to the served file** (`admin/public/app.js`), under the Billing tab, in that file's own vanilla style and on its CSP-safe `data-click` registry.

- Fields: code, maximum redemptions (default 100), days (default 90), valid until (date).
- The table under it: code, what it gives, used of maximum, valid until, status, and a Withdraw button on the codes still open.
- Create and withdraw go through the file's own `api()` helper, so they carry `X-Session` to `/admin/api/admin/coupons` and `/admin/api/admin/coupons/:code`. The browser never holds `ADMIN_TOKEN` and never talks to the relay directly.
- The withdraw sends the code in the path and no body, which is what the relay's admin gate requires.

**Failures are said in words.** `code_exists`, `bad_valid_until`, `coupons_unavailable` and the rest are mapped to sentences that name the field and what to do about it. A malformed code or an impossible date never leaves the browser. A `fetch` that throws is caught and becomes "the relay could not be reached, so nothing was changed" rather than an unhandled rejection and a tab that stops.

**2. The beta banner over that tab is gone**, because every clause of it was false:

> Beta billing. Payment processing (Mollie) is in integration. Customers are manually invoiced. Data shown is stub only.

`relay.js` `POST /v2/billing/checkout` calls `mollie.createPayment` against `api.mollie.com` unconditionally. The webhook draws a numbered invoice (`relay/lib/invoice.js`, series `PS-YYYY-NNNN`) or a credit note (`relay/lib/credit-note.js`, `CN-YYYY-NNNN`) on its own. `BILLING_MODE` is empty in production, which turns the recurring layer off (`relay/lib/mollie.js` `billingStance`) and nothing else. It now reads:

> **Billing** Mollie payments are live: one payment per term, no subscription and no direct debit. A numbered invoice or credit note is issued automatically from the payment webhook. This tab shows plan distribution and admin plan changes, not payments or revenue.

The last sentence is there on purpose: the card below counts `plan_changed` admin audit events and never a self-serve Mollie payment.

**3. A test that would have caught the original miss.** `admin/test/admin-ui-coupons.test.js` runs `app.js` in a `vm` on a hand-built document, with `fetch` recording what it was called with. It asserts the block is in the served file, that `loadBilling()` renders it with its four fields, that Create posts to `/admin/api/admin/coupons` with `X-Session` and an upper-cased code, that Withdraw sends a body-less DELETE with the code in the path, that each relay error word is shown as a sentence, and that the banner no longer claims a beta stub. Verified by mutation: dropping the card off the Billing tab turns it red.

## frontend/admin.html and frontend/js/admin.page.js

Left in place, untouched, for Mick to decide on. Findings:

- Nothing routes `/admin/` to them. Their only nginx mention, `nginx-paramant-live.conf:29`, is a dead alias shadowed one hop earlier by the public block.
- They are still rsynced into the docroot (`deploy/server-fix.sh:22`, `deploy/deploy-3.1.sh:1271-1281`) and are therefore reachable as `https://paramant.app/admin.html` through the generic `try_files` fallback, unauthenticated. `/developer.html` has an explicit `return 404` guard; `/admin.html` has none. Worth a separate decision.
- `tests/ui-truthfulness.test.mjs:9-10` reads both by name with an unguarded `readFileSync`, so deleting them fails that suite until it is edited too.

## Tests

- `admin/test/admin-ui-coupons.test.js`: 9 pass, and 1 fails under mutation.
- Full admin suite: 121 of 122 pass. The one failure is `login-timing.test.js` needing `@paramant/core` built, which this machine does not have and which CI runs in the crypto job.
- Relay unit suite: 388 pass.
- `tests/static-sanity.sh`: PASS. `tests/ui-truthfulness.test.mjs`: pass.
- `npx eslint@9 .`: clean. `scripts/check-csp-inline.sh`: clean. `scripts/check-cache-bust.sh`: clean (no frontend file changed, so no `?v` bump was needed).
