### PR TITLE
The plan-change mail stops promising invoicing that already happens, and the second admin screen stops answering 200

### DIFF
--- a/admin/lib/email-templates.js
+++ b/admin/lib/email-templates.js
@@ -274,7 +274,23 @@ https://paramant.app`;
 }
 
 // ── 4. BILLING CONFIRMATION ───────────────────────────────────────────────────
-function billingConfirmationEmail({ planName, period, amountStr, stub = true }) {
+// Sent by the admin panel when a plan is set on an account from the inside.
+// Every caller of this template is that path, and the note it carries used to
+// say the opposite of the truth: that payments were in beta, that the customer
+// would be invoiced by hand, that real invoicing was still waiting on Mollie.
+// All three were false by September 2026. relay.js POST /v2/billing/checkout
+// calls mollie.createPayment against api.mollie.com unconditionally, the
+// webhook only grants on a re-fetched status paid (lib/billing.js), and it
+// issues a numbered document per payment on its own: lib/invoice.js, series
+// PS-YYYY-NNNN, an invoice when a seller VAT number is configured and a payment
+// receipt when it is not, plus lib/credit-note.js (CN-YYYY-NNNN) when money
+// goes back.
+//
+// What IS true of THIS mail is the other half: an admin-set plan is not a
+// purchase. No payment was taken, so no document is issued for it, and the
+// customer should not go looking for one. noPayment says exactly that and
+// nothing more.
+function billingConfirmationEmail({ planName, period, amountStr, noPayment = true }) {
   const preheader = `Your Paramant plan is now ${planName}.`;
   const periodLabel = period === 'yearly' ? 'Yearly' : period === 'monthly' ? 'Monthly' : 'Admin-provisioned';
 
@@ -285,7 +301,7 @@ Your Paramant plan has been upgraded.
 Plan:    ${planName}
 Billing: ${periodLabel}
 Amount:  ${amountStr || 'N/A'}
-${stub ? '\nNote: payment processing is in beta. This confirmation reflects the\nplan change on your account. Formal invoicing follows when Mollie\nintegration goes live.\n' : ''}
+${noPayment ? '\nNote: Paramant set this plan on your account. Nothing was charged for\nit, so this change has no invoice. A plan bought on paramant.app is paid\nthrough Mollie, and every payment gets a numbered invoice or payment\nreceipt that stays on your account page.\n' : ''}
 Questions about billing? Reply to this email.
 
 Paramant
@@ -299,7 +315,7 @@ https://paramant.app`;
       <tr><td style="padding:10px 0;border-bottom:1px solid rgba(11,58,106,0.06);color:#64748b;font-size:14px;">Billing</td><td style="padding:10px 0;border-bottom:1px solid rgba(11,58,106,0.06);font-weight:600;text-align:right;">${periodLabel}</td></tr>
       <tr><td style="padding:10px 0;color:#64748b;font-size:14px;">Amount</td><td style="padding:10px 0;font-weight:700;color:#1D4ED8;text-align:right;">${amountStr || 'N/A'}</td></tr>
     </table>
-    ${stub ? '<div style="background:#FEF3C7;border-left:3px solid #D97706;padding:12px 16px;margin:24px 0;"><p style="margin:0;line-height:1.5;color:#92400E;font-size:13px;"><strong>Beta note:</strong> payment processing is not yet live. This confirmation reflects the plan change on your account. Formal invoicing follows when Mollie integration goes live.</p></div>' : ''}
+    ${noPayment ? '<div style="background:rgba(11,58,106,0.04);border-left:3px solid #1D4ED8;padding:12px 16px;margin:24px 0;"><p style="margin:0;line-height:1.5;color:#475569;font-size:13px;"><strong>No payment for this change:</strong> Paramant set this plan on your account, so nothing was charged and this change has no invoice. A plan bought on paramant.app is paid through Mollie, and every payment gets a numbered invoice or payment receipt that stays on your account page.</p></div>' : ''}
     <p style="margin:16px 0 0 0;line-height:1.6;color:#475569;font-size:14px;">Questions about billing? Reply to this email.</p>
   `);
 
@@ -312,9 +328,10 @@ https://paramant.app`;
 // ── 4b. PER-PRODUCT PLAN CHANGE ───────────────────────────────────────────────
 // Sent when an admin sets a SINGLE product's tier (ParaSign or ParaSend) without
 // touching the other product or the unified plan. Deliberately carries NO
-// "beta / no charge / stub" language: this is a scoped entitlement change, not a
-// billing-stub confirmation. productName is a display name ("ParaSign"),
-// tierName the tier ("Pro"); both are constants from the caller.
+// billing note of any kind: this is a scoped entitlement change, and the mail
+// above is the one that answers for a plan and its money. productName is a
+// display name ("ParaSign"), tierName the tier ("Pro"); both are constants
+// from the caller.
 function productPlanChangeEmail({ productName, tierName }) {
   const safeProduct = escHtml(productName || 'your product');
   const safeTier = escHtml(tierName || '');

--- a/admin/server.js
+++ b/admin/server.js
@@ -3233,12 +3233,17 @@ const PLANS = [
   },
 ];
 
+// No caller since the stub checkout was hard-disabled below; the plan-change
+// route mails its own copy. Left in place, and the note is derived rather than
+// forced on: a plan the admin set was not paid for and says so, a plan that
+// arrived through a payment is already answered by the relay, which mails the
+// numbered invoice or receipt with the PDF attached (relay/lib/invoice.js).
 async function sendBillingConfirmation(email, plan, amount, period) {
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) { console.warn('[billing] RESEND_API_KEY not set'); return; }
   const planName = PLANS.find(p => p.id === plan)?.name || plan;
   const amountStr = amount === 0 ? 'Free' : `€${amount}/${period === 'yearly' ? 'yr' : 'mo'}`;
-  const msg = emailTemplates.billingConfirmationEmail({ planName, period, amountStr, stub: true });
+  const msg = emailTemplates.billingConfirmationEmail({ planName, period, amountStr, noPayment: period === 'admin' });
   const res = await fetch('https://api.resend.com/emails', {
     method: 'POST',
     headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
@@ -3601,10 +3606,14 @@ api.get("/admin/billing", authMiddleware, async (req, res) => {
       telemetry.getPlanDistribution(relayFetch, ADMIN_TOKEN),
       telemetry.getRecentAuditEvents(200),
     ]);
+    // stub_mode, mrr_eur and churn_this_month are gone. The first said billing
+    // was a stub, which stopped being true when Mollie went live; the other two
+    // were hardcoded zeros, a revenue and a churn figure this route never
+    // counted. Nothing read any of the three: the served admin screen
+    // (admin/public/app.js) renders plan_distribution and recent_checkouts and
+    // says in the tab itself that it shows neither payments nor revenue.
     res.json({
-      stub_mode: true, mrr_eur: 0,
       total_customers: Object.values(planDist).reduce((a, b) => a + b, 0),
-      churn_this_month: 0,
       plan_distribution: planDist,
       recent_checkouts: recentAudit.filter(e => e.event_type === "plan_changed").slice(0, 20),
     });
@@ -3863,7 +3872,7 @@ api.post('/admin/change-plan', authMiddleware, async (req, res) => {
     const allOk = mutation.failed.length === 0 && readBack.failed.length === 0 && mismatched.length === 0;
     if (allOk && notify && meta.email) {
       const planName = new_plan.charAt(0).toUpperCase() + new_plan.slice(1);
-      emailTemplates.sendEmail(meta.email, emailTemplates.billingConfirmationEmail({ planName, period: 'admin', amountStr: 'admin-provisioned', stub: true })).catch(e => console.error('[admin/change-plan] email:', e.message));
+      emailTemplates.sendEmail(meta.email, emailTemplates.billingConfirmationEmail({ planName, period: 'admin', amountStr: 'admin-provisioned', noPayment: true })).catch(e => console.error('[admin/change-plan] email:', e.message));
     }
     try { await logAuditEvent(key, 'admin_plan_changed', { from: meta.plan, to: new_plan, admin_ip: req.headers['x-real-ip'] || 'unknown' }); } catch {}
     res.status(allOk ? 200 : 207).json({ ok: allOk, partial_failure: !allOk, error: allOk ? null : 'fleet_not_consistent', from: meta.plan, to: new_plan, failed_sectors: mutation.failed, read_back_failed: readBack.failed, verification_failed: mismatched, retried_sectors: mutation.retried, entitlements_by_sector: readBack.results, sector_count: Object.keys(SECTORS).length, email_sent: !!(allOk && notify && meta.email) });
@@ -3877,7 +3886,7 @@ api.post('/admin/change-plan', authMiddleware, async (req, res) => {
 // path as change-plan via callRelay), then reloads users fleet-wide so the
 // entitlement is observable at once. An unknown product or a tier not on that
 // product's ladder is rejected 400. Optional notify uses the per-product mail
-// (productPlanChangeEmail) - NO billing-stub / no-charge language.
+// (productPlanChangeEmail), which carries no billing note at all.
 api.post('/admin/set-product-plan', authMiddleware, async (req, res) => {
   const { key, product, tier, notify = false } = req.body || {};
   const LADDERS = { parasign: ['free', 'pro', 'business', 'enterprise'], parasend: ['community', 'pro', 'enterprise'] };
@@ -4051,7 +4060,11 @@ api.get('/admin/user-details/:key', authMiddleware, async (req, res) => {
       created: meta.created_at || k.created || null,
       totp_status,
       active_sessions: sessionCount,
-      billing: billing || { plan: k.plan || 'community', stub: true },
+      // No billing record in redis means this account never went through a
+      // payment, so the fallback says the plan and nothing else. The old
+      // `stub: true` on that fallback claimed the billing system was a stub,
+      // which it has not been since Mollie went live, and nothing read it.
+      billing: billing || { plan: k.plan || 'community' },
       audit_events: auditEvents,
     });
   } catch (err) { console.error('[admin/user-details]', err.message); res.status(500).json({ error: 'internal' }); }
@@ -4073,7 +4086,10 @@ api.post('/admin/preview-email', authMiddleware, async (req, res) => {
     if (type === 'welcome') tpl = emailTemplates.welcomeEmail({ apiKey: key || 'pgp_preview00000000', plan: meta.plan, label: meta.label, sectors: meta.sectors });
     else if (type === 'setup') tpl = emailTemplates.setupEmail({ token: fakeToken, requestedAt: Date.now(), requestIP: '0.0.0.0', isReset: options.isReset || false });
     else if (type === 'reset-confirm') tpl = emailTemplates.resetConfirmationEmail({ confirmToken: fakeToken, requestedAt: Date.now(), requestIP: '0.0.0.0' });
-    else if (type === 'billing') { const planName = (options.plan || meta.plan || 'pro'); tpl = emailTemplates.billingConfirmationEmail({ planName: planName.charAt(0).toUpperCase()+planName.slice(1), period: 'monthly', amountStr: '€9/mo', stub: true }); }
+    // Previewed as the admin-set plan, because that is the only shape this mail
+    // is ever sent in: /admin/change-plan is its one live caller. A preview
+    // showing "Monthly, EUR 9/mo" showed a mail nobody receives.
+    else if (type === 'billing') { const planName = (options.plan || meta.plan || 'pro'); tpl = emailTemplates.billingConfirmationEmail({ planName: planName.charAt(0).toUpperCase()+planName.slice(1), period: 'admin', amountStr: 'admin-provisioned', noPayment: true }); }
     else if (type === 'cancellation') { const planName = meta.plan || 'pro'; tpl = emailTemplates.billingCancellationEmail({ planName: planName.charAt(0).toUpperCase()+planName.slice(1), cancelDate: new Date(Date.now()+30*86_400_000).toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'}) }); }
     else if (type === 'deletion') tpl = emailTemplates.accountDeletionEmail({ email, deletedAt: Date.now(), reason: options.reason || 'preview' });
     res.json({ ...tpl, recipient: email });

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -1384,7 +1384,7 @@ EOF
     fi
   fi
 
-  step "5c. the six nginx changes, by hand, keeping the ParaID deny"
+  step "5c. the seven nginx changes, by hand, keeping the ParaID deny"
   remote_nginx "nginx edits" "$TS" "$NGINX_SITES" "$NGINX_BACKUP_DIR" "$NGINX_CONF_SLOTS" <<'EOF'
 set -euo pipefail
 TS="$1"; SITES="$2"; NGBK="$3"; SLOTS="$4"
@@ -1445,6 +1445,7 @@ SIGN_LOC_RE='location = /sign[[:space:]]*\{'
 DICOM404_RE='location = /dicom[[:space:]]*\{[[:space:]]*return 404'
 PARAID_RE='paraid/issue'
 RULES_RE='location = /pararules'
+ADMIN_RE='location = /admin\.html|location = /js/admin\.page\.js'
 OUT_RE='^[[:space:]]*location[[:space:]]*~[[:space:]]*\^/v2/outbound[[:space:]]*\{'
 BUF_RE='proxy_buffer_size 32k'
 
@@ -1487,6 +1488,58 @@ RULES_COUNT_AWK='
 END { for (i in deny) { t++; if (has[i]) w++ } printf "%d %d\n", t+0, w+0 }'
 
 count_rules() { awk "$RULES_COUNT_AWK" $TARGETS | awk '{t+=$1; w+=$2} END{printf "%d %d\n", t, w}'; }
+
+# /admin.html and /js/admin.page.js answer 404.
+#
+# There are two admin screens in this repository. The one that is served is
+# admin/public/index.html, behind the admin container on :4200, which asks for
+# a session. The other, frontend/admin.html, is routed from nowhere, and phase
+# 5a rsyncs the whole of frontend/ into the docroot, so it lands on disk anyway
+# and the generic `try_files $uri $uri.html` picks it up: /admin.html answered
+# 200 with the full admin markup to anyone who typed the name. Its loader,
+# /js/admin.page.js, was served by the versioned-asset regex location for the
+# same reason and has no other consumer.
+#
+# The files are not pruned. tests/ui-truthfulness.test.mjs reads both admin
+# screens by name, and 5b prunes only what git says was deleted. This is the
+# treatment /developer.html already has in the repo conf: the markup stays, the
+# URL stops existing.
+#
+# The anchor is the ParaID deny, for the same reason as the /pararules edit:
+# paramant-live.conf carries no server_name, so the deny is the only line that
+# marks a block as one that answers for this site in both confs. Two passes,
+# and each of the two lines is judged on its own, so a conf that already
+# carries one of them gets only the other.
+ADMIN_AWK='
+FNR==NR {
+  if ($0 ~ /^server[[:space:]]*\{/) b++
+  if ($0 ~ /location = \/admin\.html/) hashtml[b]=1
+  if ($0 ~ /location = \/js\/admin\.page\.js/) hasjs[b]=1
+  if ($0 ~ /paraid\/issue/) deny[b]=1
+  next
+}
+{
+  print
+  if ($0 ~ /^server[[:space:]]*\{/) j++
+  if ($0 ~ /paraid\/issue/ && deny[j] && !ins[j]) {
+    if (!hashtml[j]) print "    location = /admin.html { return 404; }"
+    if (!hasjs[j])   print "    location = /js/admin.page.js { return 404; }"
+    ins[j]=1
+  }
+}'
+
+# Count the server blocks that answer for the site and how many of those carry
+# BOTH 404s. Half of the pair is not done: admin.html without its loader still
+# leaves the script on the open web, and the loader without the page leaves the
+# page on it.
+ADMIN_COUNT_AWK='
+/^server[[:space:]]*\{/ { b++ }
+/paraid\/issue/ { deny[b]=1 }
+/location = \/admin\.html/ { hashtml[b]=1 }
+/location = \/js\/admin\.page\.js/ { hasjs[b]=1 }
+END { for (i in deny) { t++; if (hashtml[i] && hasjs[i]) w++ } printf "%d %d\n", t+0, w+0 }'
+
+count_admin() { awk "$ADMIN_COUNT_AWK" $TARGETS | awk '{t+=$1; w+=$2} END{printf "%d %d\n", t, w}'; }
 
 # access_log off in the server block that backs /dicom/, the one on
 # listen 127.0.0.1:8090. It was the only block in paramant-live.conf still
@@ -1630,6 +1683,10 @@ read -r _abt _abw _abf <<< "$(count_alog)"
 echo "before 8090 blocks = $_abt"
 echo "before 8090 blocks with access_log off = $_abw"
 echo "before 8090 blocks logging to a file = $_abf"
+read -r _dbt _dbw <<< "$(count_admin)"
+echo "before admin guard blocks = $_dbt"
+echo "before admin guard blocks with 404 = $_dbw"
+echo "before admin guard lines = $(count "$ADMIN_RE")"
 
 # Each edit is in one of three states, and only one of them is a stop:
 #
@@ -1683,11 +1740,13 @@ for st in "$SIGN_STATE" "$COMP_STATE" "$DICOM_STATE"; do
   [ "$st" = todo ] && pending=$((pending + 1))
 done
 # A /v2/outbound block without the buffer is a fourth thing still to do, a
-# site block without the /pararules redirect a fifth, and a :8090 block that
-# still writes an access log a sixth.
+# site block without the /pararules redirect a fifth, a :8090 block that
+# still writes an access log a sixth, and a site block that still serves the
+# second admin screen a seventh.
 pending=$((pending + _obt - _obw))
 pending=$((pending + _rbt - _rbw))
 pending=$((pending + _abt - _abw))
+pending=$((pending + _dbt - _dbw))
 echo "before edits pending = $pending"
 if [ "$pending" -eq 0 ]; then
   echo "before everything already applied = yes"
@@ -1742,6 +1801,11 @@ for f in $TARGETS; do
   awk "$ALOG_AWK" "$f" "$f" > "/tmp/nginx-alog.$$"
   cat "/tmp/nginx-alog.$$" > "$f"
   rm -f "/tmp/nginx-alog.$$"
+  # 7. the second admin screen answers 404: /admin.html and its only loader
+  #    /js/admin.page.js, one pair per site block.
+  awk "$ADMIN_AWK" "$f" "$f" > "/tmp/nginx-admin.$$"
+  cat "/tmp/nginx-admin.$$" > "$f"
+  rm -f "/tmp/nginx-admin.$$"
   if ! cmp -s "$f" "/tmp/nginx-pre-3.1-$(basename "$f").$TS"; then
     echo "edited $(basename "$f")"
     edited=$((edited + 1))
@@ -1767,6 +1831,10 @@ read -r _aat _aaw _aaf <<< "$(count_alog)"
 echo "after 8090 blocks = $_aat"
 echo "after 8090 blocks with access_log off = $_aaw"
 echo "after 8090 blocks logging to a file = $_aaf"
+read -r _dat _daw <<< "$(count_admin)"
+echo "after admin guard blocks = $_dat"
+echo "after admin guard blocks with 404 = $_daw"
+echo "after admin guard lines = $(count "$ADMIN_RE")"
 
 # Restore exactly the confs this phase edited, not whatever the backup dir
 # happens to hold for this TS. The precondition above proved every one of them
@@ -1797,6 +1865,18 @@ if [ "$_saw" -gt 0 ]; then
   exit 1
 fi
 
+# The second admin screen is the one edit whose failure is silent: nothing
+# breaks, the deploy goes green, and https://paramant.app/admin.html keeps
+# answering 200 with admin markup to anyone who asks. Assert the end state
+# rather than trust the insert.
+if [ "$_daw" -ne "$_dat" ]; then
+  echo "FATAL $((_dat - _daw)) of $_dat site block(s) still serve the second admin screen after the edit:"
+  echo "FATAL /admin.html or /js/admin.page.js has no 'return 404' there, so the unrouted admin"
+  echo "FATAL markup stays on the open web. Restoring the backed up confs."
+  restore
+  exit 1
+fi
+
 rc=0
 nginx -t > /tmp/paramant-nginxt.$$ 2>&1 || rc=$?
 sed 's/^/  nginxt /' /tmp/paramant-nginxt.$$
@@ -1820,8 +1900,9 @@ EOF
   # holds is the END state, and that is asserted hard just below: no
   # auth_request on /sign, no /compliance locations, /dicom answering 404, a
   # buffer inside every /v2/outbound block, the /pararules 301 inside every
-  # block that answers for the site, and access_log off inside every :8090
-  # block. Those six are the deploy.
+  # block that answers for the site, access_log off inside every :8090 block,
+  # and a 404 on /admin.html and /js/admin.page.js in every block that answers
+  # for the site. Those seven are the deploy.
   if [ "$DRY_RUN" -eq 1 ]; then
     printf '  SKIP  assert (dry-run): both named confs were rewritten, unless every edit was already applied\n'
   else
@@ -1831,7 +1912,7 @@ EOF
     [ -n "$pend" ] && [ -n "$edited" ] \
       || die "could not read the nginx edit state from the server"
     if [ "$pend" = yes ]; then
-      ok "nginx: already applied. All three edits, the outbound buffers, the /pararules 301 and access_log off on :8090 were in place before this run, so nothing was rewritten (edited files = $edited)"
+      ok "nginx: already applied. All three edits, the outbound buffers, the /pararules 301, access_log off on :8090 and the 404 on the second admin screen were in place before this run, so nothing was rewritten (edited files = $edited)"
     else
       [ "$edited" -ge 1 ] \
         || die "$(remote_field 'before edits pending') nginx edit(s) were still pending but no conf was rewritten"
@@ -1844,6 +1925,8 @@ EOF
   expect_min "after dicom 404" 1 "/dicom now returns 404"
   expect_min "before outbound locations" 1 "the /v2/outbound location the buffers go on exists"
   expect_min "after pararules redirect lines" 1 "/pararules answers a 301 to /rules"
+  expect_min "after admin guard lines" 1 \
+    "/admin.html and /js/admin.page.js answer 404, so the unrouted second admin screen is off the open web"
   expect 'reloaded nginx' "nginx reloaded"
   if [ "$DRY_RUN" -eq 0 ]; then
     local ol bf

--- a/deploy/nginx-paramant-live.conf
+++ b/deploy/nginx-paramant-live.conf
@@ -33,6 +33,25 @@ server {
     location = /r34ct0r { return 301 https://$host/admin/; }
     location = /r34ct0r.html { return 301 https://$host/admin/; }
 
+    # ── The second admin screen: force-404'd, same as /developer.html ────────
+    # /admin/ on the apex is answered by the admin container
+    # (paramant-public.conf proxies it to 127.0.0.1:4200), which asks for a
+    # session before it renders anything. frontend/admin.html is the OTHER
+    # admin screen, the one nothing routes to. The deploy rsyncs the whole of
+    # frontend/ into the docroot, so the file is on disk, and the generic
+    # `try_files $uri $uri.html` at the bottom of this block handed it to
+    # anyone who typed the name: https://paramant.app/admin.html answered 200
+    # with the full admin markup and no session asked for.
+    # The file is NOT deleted. tests/ui-truthfulness.test.mjs reads both admin
+    # screens by name, and a deleted file would make that test unrunnable
+    # instead of true. It is 404'd here, exactly the treatment /developer.html
+    # gets below: the markup stays in the repo, the URL stops existing.
+    # /js/admin.page.js is admin.html's only loader and has no other consumer,
+    # so it goes the same way. The exact-match beats the versioned-asset regex
+    # location further down, which would otherwise serve it.
+    location = /admin.html { return 404; }
+    location = /js/admin.page.js { return 404; }
+
     location = /outlook/taskpane {
         alias /home/paramant/app/outlook/taskpane.html;
         default_type text/html;

--- a/deploy/nginx-paramant-public.conf
+++ b/deploy/nginx-paramant-public.conf
@@ -25,6 +25,17 @@ server {
         proxy_pass http://127.0.0.1:8080/r34ct0r.html;
         proxy_set_header Host $host;
     }
+    # The admin screen that is actually served: the container on :4200, which
+    # asks for a session. frontend/admin.html is the second, unrouted one; it
+    # sits in the docroot because the deploy rsyncs all of frontend/, and
+    # without the two exact matches below the request falls through to
+    # `location /` -> :8080 -> try_files, which answered 200 with the whole
+    # admin markup to anyone who typed the name. Both are 404'd in
+    # nginx-paramant-live.conf as well; this is the same wall one hop earlier,
+    # so the apex never forwards the request at all. The files stay on disk:
+    # tests/ui-truthfulness.test.mjs reads them by name.
+    location = /admin.html { return 404; }
+    location = /js/admin.page.js { return 404; }
     location /admin/ {
         proxy_pass http://127.0.0.1:4200/admin/;
         proxy_http_version 1.1;

--- a/docs/api.md
+++ b/docs/api.md
@@ -1040,19 +1040,18 @@ Revokes all sessions except the current one.
 
 Generates a new set of backup codes and invalidates all previous ones.
 
-### POST /api/user/billing/checkout
+### POST /api/user/billing/checkout (410 Gone)
 
-Creates a pending plan-change order and returns an internal confirmation URL. This flow does not charge a payment method (see the `stub_notice` field on billing status); paid ParaSend and ParaSign upgrades are billed through the Mollie checkout on the relay, see [Billing (Mollie)](#billing-mollie) below.
+Removed on 20 July 2026 and kept as a 410 so a stale client gets a clean answer: it granted a plan without a payment. `GET /api/user/billing/checkout/:token` and `POST /api/user/billing/checkout/:token/confirm` answer the same.
 
 ```bash
 curl -X POST https://paramant.app/api/user/billing/checkout \
-  -H "Cookie: paramant_user_session=<token>" \
-  -H "Content-Type: application/json" \
-  -d '{"plan_id":"pro","period":"monthly"}'
-# {"checkout_url":"/billing/checkout/<token>","expires_at":"2026-…"}
+  -H "Cookie: paramant_user_session=<token>"
+# 410
+# {"error":"billing_stub_removed","message":"Checkout moved to Mollie; this endpoint no longer grants plans."}
 ```
 
-The order expires after one hour. `GET /api/user/billing/checkout/:token` returns the pending order (`plan_id`, `plan_name`, `period`, `amount_eur`, `email`, `status`). `POST /api/user/billing/checkout/:token/confirm` applies the plan change and returns `{"success":true,"new_plan":"pro","effective_from":"…"}`.
+The one path to a paid plan is the Mollie checkout on the relay, `POST /v2/billing/checkout`, see [Billing (Mollie)](#billing-mollie) below. The tier is granted by `/v2/billing/webhook` only after Mollie confirms the payment as paid for the amount the catalog names, and that same webhook issues the invoice or payment receipt. The `stub_notice` field this section used to point at is gone from `GET /api/user/billing/status` too.
 
 ### POST /api/user/billing/cancel
 

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -158,12 +158,23 @@ footer{border-top:1px solid rgba(var(--tint), .1);padding:40px 48px;display:flex
       <h2>Unreleased</h2>
     </div>
     <p class="release-summary">Features in active development.</p>
+    <h3>Added</h3>
+    <ul>
+      <!-- Billing left the Planned list below, where it stood as "Mollie
+           integration for billing (currently stub mode)". That has not been
+           true since payments went live: relay.js POST /v2/billing/checkout
+           calls Mollie unconditionally and the webhook issues the document by
+           itself. Same facts as CHANGELOG.md under Unreleased. -->
+      <li>Payments through Mollie: one payment per term, no subscription and no direct debit</li>
+      <li>A numbered document per payment, issued automatically: an invoice, or a payment receipt while our VAT number is pending</li>
+      <li>A numbered credit note when money goes back, on a chargeback or a refund</li>
+      <li>Both appear on your account page and arrive by email as a PDF</li>
+    </ul>
     <h3>Planned</h3>
     <ul>
       <li>Prometheus + Grafana monitoring via Tailscale-only access</li>
       <li>Outlook add-in (<code>addin.paramant.app</code>): source scaffold done</li>
       <li>Chrome Web Store public listing</li>
-      <li>Mollie integration for billing (currently stub mode)</li>
       <li>Team accounts + SSO</li>
       <li>WebAuthn / Passkey second-factor option</li>
       <li>Admin email preview modal with per-user send actions</li>

--- a/frontend/js/admin.page.js
+++ b/frontend/js/admin.page.js
@@ -389,7 +389,17 @@ async function loadBilling(){
   const dist=d.plan_distribution||{};
   const total=Object.values(dist).reduce((a,b)=>a+b,0)||1;
   el.innerHTML=
-    '<div class="banner stub" role="status"><strong>Beta billing</strong> &mdash; Payment processing (Mollie) is in integration. Customers are manually invoiced. Data shown is stub only.'+'</div>'+
+    /* The same line, and the same correction, as admin/public/app.js. Every
+       clause of what stood here was false by September 2026: relay.js POST
+       /v2/billing/checkout calls mollie.createPayment against api.mollie.com
+       unconditionally, and the webhook issues a numbered invoice
+       (lib/invoice.js, PS-YYYY-NNNN) or a credit note (lib/credit-note.js,
+       CN-YYYY-NNNN) on its own. Nobody is invoiced by hand and the tab is not
+       a fixture. This screen is served by nothing (nginx sends /admin/ to the
+       admin container), and it is corrected rather than deleted because
+       tests/ui-truthfulness.test.mjs reads it by name, and because a wrong
+       copy left lying next to a right one is how the wrong one comes back. */
+    '<div class="banner info" role="status"><strong>Billing</strong> Mollie payments are live: one payment per term, no subscription and no direct debit. A numbered invoice or credit note is issued automatically from the payment webhook. This tab shows plan distribution and admin plan changes, not payments or revenue.</div>'+
       '<div class="card"><div class="card-hdr">Recent plan changes <small>'+( d.recent_checkouts?.length||0)+' events</small></div>'+
         (d.recent_checkouts&&d.recent_checkouts.length?
           '<table class="tbl"><thead><tr><th>Time</th><th>User</th><th>Event</th></tr></thead><tbody>'+

--- a/tests/deploy-3.1-dryrun.test.sh
+++ b/tests/deploy-3.1-dryrun.test.sh
@@ -511,6 +511,35 @@ if [ "$(field_5c "$OUT1" 'after pararules redirect lines')" = "2" ]; then
 else
   fail "5c wrote $(field_5c "$OUT1" 'after pararules redirect lines') redirect line(s), expected 2"
 fi
+# The second admin screen. frontend/admin.html is routed from nowhere, but 5a
+# rsyncs all of frontend/ into the docroot and the generic try_files served it:
+# /admin.html answered 200 with the full admin markup and no session asked for.
+# The 404 has to travel with a deploy, or the next one puts the page back on the
+# open web. Same block anchor as the /pararules 301, so it is read the same way:
+# every site block, both lines, once each.
+if [ "$(field_5c "$OUT1" 'before admin guard blocks with 404')" = "0" ]; then
+  pass "the fixture starts serving the second admin screen, so the edit has work to do"
+else
+  fail "the fixture already carries the admin 404s; this run would prove nothing"
+fi
+if [ "$(field_5c "$OUT1" 'after admin guard blocks with 404')" \
+   = "$(field_5c "$OUT1" 'after admin guard blocks')" ] \
+   && [ "$(field_5c "$OUT1" 'after admin guard blocks')" = "2" ]; then
+  pass "every site block came out with /admin.html and /js/admin.page.js on 404"
+else
+  fail "the admin 404s landed in $(field_5c "$OUT1" 'after admin guard blocks with 404') of $(field_5c "$OUT1" 'after admin guard blocks') site blocks"
+fi
+if [ "$(field_5c "$OUT1" 'after admin guard lines')" = "4" ]; then
+  pass "both 404 lines were written once per conf, not twice"
+else
+  fail "5c wrote $(field_5c "$OUT1" 'after admin guard lines') admin 404 line(s), expected 4"
+fi
+if grep -q 'location = /admin\.html { return 404; }' "$NG/available/paramant-live.conf" \
+   && grep -q 'location = /js/admin\.page\.js { return 404; }' "$NG/available/paramant-live.conf"; then
+  pass "the guard is in the conf on disk, not only in the counters"
+else
+  fail "neither 404 reached paramant-live.conf on disk"
+fi
 
 echo ""
 echo "6g-2. Second run on the same confs: already applied, not FATAL"
@@ -531,6 +560,8 @@ for want in "before sign state:done" "before compliance state:done" "before dico
             "before edits pending:0" "before everything already applied:yes" \
             "before pararules blocks with redirect:2" \
             "after pararules redirect lines:2" \
+            "before admin guard blocks with 404:2" \
+            "after admin guard lines:4" \
             "after edited files:0"; do
   f="${want%%:*}"; v="${want##*:}"
   if [ "$(field_5c "$OUT2" "$f")" = "$v" ]; then pass "second run reports $f = $v"; else
@@ -572,8 +603,21 @@ check_has "$FULL"   'before edits pending'  "the dry run shows the pending-edit 
 check_has "$FULL"   'before sign state'     "the dry run shows the per-edit state read"
 check_has "$SCRIPT" 'location = /pararules { return 301 https://\$host/rules; }' \
   "phase 5c writes the permanent 301 from /pararules to /rules"
-check_has "$SCRIPT" 'the six nginx changes' \
-  "the 5c step name counts the /pararules redirect and the :8090 access_log as edits"
+check_has "$SCRIPT" 'the seven nginx changes' \
+  "the 5c step name counts the /pararules redirect, the :8090 access_log and the admin 404 as edits"
+check_has "$SCRIPT" 'location = /admin\.html \{ return 404; \}' \
+  "phase 5c writes the 404 on the second admin screen"
+check_has "$SCRIPT" 'location = /js/admin\.page\.js \{ return 404; \}' \
+  "phase 5c writes the 404 on the loader that screen is the only consumer of"
+# The repo confs and the phase have to agree. 5c edits the live confs by anchor
+# and never copies a repo file over them, so a guard that lives in only one of
+# the two is a guard that a rebuilt server, or a hand-applied 5c, would miss.
+for conf in nginx-paramant-live.conf nginx-paramant-public.conf; do
+  check_has "$ROOT/deploy/$conf" 'location = /admin\.html \{ return 404; \}' \
+    "$conf 404s /admin.html, so the repo conf says what the phase does"
+  check_has "$ROOT/deploy/$conf" 'location = /js/admin\.page\.js \{ return 404; \}' \
+    "$conf 404s /js/admin.page.js"
+done
 
 echo ""
 echo "6g-4. A multi-line auth_request on /sign is todo, never already applied"
@@ -654,6 +698,8 @@ make_dicom_conf() {   # file, alog(missing|present|none)
     echo '    location = /dicom { return 404; }'
     echo '    location = /v1/paraid/issue-document { deny all; }'
     echo '    location = /pararules { return 301 https://$host/rules; }'
+    echo '    location = /admin.html { return 404; }'
+    echo '    location = /js/admin.page.js { return 404; }'
     echo '    location /dicom/ { proxy_pass http://127.0.0.1:8090; }'
     echo '    location ~ ^/v2/outbound {'
     echo '        proxy_buffer_size 32k;'

--- a/tests/ui-truthfulness.test.mjs
+++ b/tests/ui-truthfulness.test.mjs
@@ -33,7 +33,39 @@ assert.doesNotMatch(email, /sign up again|Files already relayed are not affected
 // same thing: the check digits add up and nothing about the document itself
 // was verified. Matched on the claim, not on one exact sentence.
 
-console.log('ui-truthfulness: deactivation and MRZ scope are stated honestly');
+// ── Billing stopped being a stub, so the copy has to stop saying it is ───────
+// Payments run through Mollie for real (relay/lib/mollie.js, called
+// unconditionally by POST /v2/billing/checkout), the webhook grants only on a
+// re-fetched paid status (relay/lib/billing.js), and it issues a numbered
+// document by itself: relay/lib/invoice.js (PS-YYYY-NNNN) or
+// relay/lib/credit-note.js (CN-YYYY-NNNN) when money goes back. Nobody is
+// invoiced by hand, nothing waits on an integration, and no figure on the
+// billing tab is a fixture.
+//
+// admin/test/admin-ui-coupons.test.js guards admin/public/app.js, the screen
+// that is served. This guards the two copies that test does not read: the
+// unrouted second admin screen, which carried the same banner and is exactly
+// how a corrected line gets copied back in, and the customer email, where the
+// claim actually reached a customer.
+// Both admin screens carry a block comment explaining which sentence used to
+// stand there and why it was false, so they quote the very wording this check
+// forbids. Same problem, same answer as signVisible below: read what a person
+// sees, not what the file says about itself.
+const adminJsVisible = adminJs.replace(/\/\*[\s\S]*?\*\//g, '');
+const emailVisible = email.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+const billingLies = /Beta billing|beta note|payment processing is (in beta|not yet live)|manually invoiced|invoiced by hand|stub only|Mollie[^.]{0,40}(is in integration|goes live)|Formal invoicing follows/i;
+assert.doesNotMatch(adminJsVisible, billingLies,
+  'no admin screen may call billing a beta or a stub: Mollie payments are live');
+assert.doesNotMatch(emailVisible, billingLies,
+  'no customer email may promise invoicing that already happens');
+// And the mail has to say what IS true of an admin-set plan: it was not paid
+// for, so it has no document, while a plan that IS paid for gets one.
+assert.match(email, /Nothing was charged for[\s\S]{0,4}it, so this change has no invoice/,
+  'the plan-change mail must say an admin-set plan was not charged for');
+assert.match(email, /numbered invoice or payment receipt/,
+  'the plan-change mail must say what a real payment does get');
+
+console.log('ui-truthfulness: deactivation, MRZ scope and billing are stated honestly');
 
 
 // ── The signing page now that /sign is served to everyone ────────────────────


### PR DESCRIPTION
Two remnants of the billing stub, found while restoring the admin screen in #441.

## 1. The mail told the customer the opposite of what the code does

`admin/lib/email-templates.js`, `billingConfirmationEmail`. Old text part:

> Note: payment processing is in beta. This confirmation reflects the plan change on your account. Formal invoicing follows when Mollie integration goes live.

Old HTML part:

> **Beta note:** payment processing is not yet live. This confirmation reflects the plan change on your account. Formal invoicing follows when Mollie integration goes live.

Every clause is false. `relay.js` POST `/v2/billing/checkout` calls `mollie.createPayment` against api.mollie.com unconditionally, `lib/billing.js` grants only on a re-fetched `paid` status with a catalog-matching amount, and `relay.js` `_issueInvoiceForPayment` issues a numbered document per payment on its own: `lib/invoice.js`, series `PS-YYYY-NNNN`, an invoice when a seller VAT number is configured and a payment receipt when it is not, plus `lib/credit-note.js` (`CN-YYYY-NNNN`) when money goes back. `_mailInvoice` mails it with the PDF attached.

What is true of *this* mail is the other half, and that is what it says now. Text part:

> Note: Paramant set this plan on your account. Nothing was charged for it, so this change has no invoice. A plan bought on paramant.app is paid through Mollie, and every payment gets a numbered invoice or payment receipt that stays on your account page.

HTML part, in a neutral box instead of the amber beta one:

> **No payment for this change:** Paramant set this plan on your account, so nothing was charged and this change has no invoice. A plan bought on paramant.app is paid through Mollie, and every payment gets a numbered invoice or payment receipt that stays on your account page.

The parameter that switched it was called `stub`; it is `noPayment` now, because that is what it means. All three call sites pass it. `/admin/preview-email` previewed the mail as "Monthly, EUR 9/mo", a shape nobody ever receives; it previews the admin-set plan the one live caller sends.

Three more untrue billing texts in the same sweep:

- `frontend/js/admin.page.js`: the unrouted second admin screen carried the banner #441 corrected on the served one ("Beta billing, Payment processing (Mollie) is in integration. Customers are manually invoiced. Data shown is stub only."). It now carries the corrected line word for word. It is not deleted: `tests/ui-truthfulness.test.mjs` reads it by name, and a wrong copy lying next to a right one is how the wrong one comes back.
- `admin/server.js` `/admin/billing` returned `stub_mode: true`, `mrr_eur: 0` and `churn_this_month: 0`. The first stopped being true when Mollie went live, the other two were hardcoded figures this route never counted. Nothing read any of the three. Same for `stub: true` on the `/admin/user-details` billing fallback.
- `docs/api.md` documented `POST /api/user/billing/checkout` as a working flow and pointed at a `stub_notice` field. Those three endpoints have answered **410 Gone** since 20 July 2026 (`admin/lib/billing-stub.js`) and `stub_notice` was removed from billing status. The section says so now and points at the Mollie route.
- `frontend/changelog.html` listed "Mollie integration for billing (currently stub mode)" under **Planned**. It moves to an **Added** block under Unreleased, with the same facts `CHANGELOG.md` already carries.

## 2. /admin.html was public, HTTP 200, no session asked for

`/admin/` on the apex is the admin container on `:4200` (`deploy/nginx-paramant-public.conf`), which asks for a session. `frontend/admin.html` is the *other* admin screen, routed from nowhere, but deploy phase 5a rsyncs the whole of `frontend/` into the docroot and the generic `try_files $uri $uri.html` in the `:8080` block served it to anyone who typed the name. Its loader `/js/admin.page.js` was served by the versioned-asset regex location for the same reason.

`/developer.html` already had this exact guard: gated route serves the file, the file's own URL is force-404'd. The same treatment now, in three places so it cannot drift apart:

- `deploy/nginx-paramant-live.conf` and `deploy/nginx-paramant-public.conf`: `location = /admin.html { return 404; }` and `location = /js/admin.page.js { return 404; }`. Exact matches, which beat the versioned-asset regex location. The `location = /admin/` alias in the live conf is untouched and still works, because `alias` reads the file and does not re-enter location matching.
- `deploy/deploy-3.1.sh`, phase 5c: a seventh anchor edit. Two passes over each conf, anchored on the ParaID deny like the `/pararules` 301 (paramant-live.conf carries no `server_name`, so the deny is the only line that marks a site block in both confs), each of the two lines judged on its own, idempotent. The phase counts site blocks and site blocks carrying both 404s, adds the difference to its pending count, and after the edit restores the backed-up confs if any block came out without both. This is the one edit whose failure is silent: nothing breaks, the deploy goes green, and the page stays on the open web.

The files are not removed, deliberately. `tests/ui-truthfulness.test.mjs` reads both admin screens by name, and 5b prunes only what git says was deleted.

## Tests

- `tests/deploy-3.1-dryrun.test.sh`: **461 passed, 0 failed** (was 455). New checks prove the fixture starts serving the screen, that both 404s land in every site block, that they are written once per conf and not twice, that they reach the conf on disk, that a second run is a no-op, and that both repo confs carry the same lines the phase writes.
- `tests/ui-truthfulness.test.mjs`: a `billingLies` regex over both admin screens' JS and the whole email module, plus two positive assertions on what the mail must say. Comments are stripped first, because both screens explain the sentence they replaced and would fail on their own explanation.
- Admin suite: 122/122 with `ADMIN_TEST_SKIP=relay` (the one skip is the `@paramant/core` binding, not built here, unrelated to this change).
- site-claims 43/43, seo-contract 14/14, links, static-sanity PASS, eslint clean, relay entitlements/tiers/quota 30/30.
