### PR TITLE
Een waarborg die stopt met werken meldt zichzelf

### DIFF
--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -1,0 +1,153 @@
+name: guards
+
+# Do the guards still bark?
+#
+# Every other workflow here watches the product. This one watches the watchers,
+# because in one night three separate safeguards turned out to be decoration and
+# all three looked, in the code, exactly like a working check.
+#
+# The one it exists for: heartbeat.yml raises its alarm from a step INSIDE the
+# job that a repository variable switches off. With HEARTBEAT_ENABLED unset the
+# job is skipped, `if: failure()` never fires, and the only thing that could
+# report the silence is silenced by the same switch. Nineteen scheduled runs in
+# a row came back "skipped" between 2 and 5 September; GitHub renders a skipped
+# run grey and notifies nobody, so nothing went red and nobody knew.
+#
+# An alarm cannot cover its own absence. Something outside it has to, and that
+# is the whole job of this file.
+#
+# THIS WORKFLOW HAS NO OFF SWITCH, and that is enforced, not just intended:
+# scripts/check-guards.mjs fails the build if any job here gains an `if:` that
+# reads a variable or a secret, or if the schedule or the pull_request trigger
+# goes away. A gate on the watchdog is the exact bug it was built to catch.
+on:
+  schedule:
+    # 07:11, once a day. Deliberately not hourly. The repository already learned
+    # that lesson the other way round: an alarm that fires every hour for a known
+    # reason is one people train themselves to ignore, and that is how the last
+    # monitor died. Once a day, into a single issue that stays open and counts
+    # the days, is a signal that survives being ignored for a week.
+    - cron: '11 7 * * *'
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Read the run history of the workflows being watched, and file the one issue.
+  actions: read
+  issues: write
+
+concurrency:
+  group: guards-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guards:
+    name: guards - can every check still fire
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      # The static half: every way a guard could be silenced is declared, and
+      # every declared silencer is still there. No network, so this half is a
+      # hard gate on every pull request. tests/guards-can-fire.test.mjs runs the
+      # same code in the test job; it is repeated here so that this workflow
+      # fails for its own reasons rather than only reporting on others.
+      - name: Every silencer is declared and watched
+        run: node scripts/check-guards.mjs
+
+      # The live half: is the switch on, and has the job behind it actually
+      # produced a passing run inside its window. Asked of the JOB, not the run:
+      # security-posture.yml reports "success" for a run whose production job was
+      # skipped and whose self-test job passed.
+      - name: Is every watched guard actually running
+        id: live
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # The switch values, read here because a workflow cannot list its own
+          # repository variables by name from inside a script. Unset renders as
+          # the empty string, which is what "off" looks like.
+          SWITCH_HEARTBEAT_ENABLED: ${{ vars.HEARTBEAT_ENABLED }}
+          SWITCH_SECURITY_POSTURE_ENABLED: ${{ vars.SECURITY_POSTURE_ENABLED }}
+          # Red on the daily run, reported on a pull request. While the switch is
+          # off, and only the holder of the canary secrets can turn it on, a hard
+          # failure on every pull request would block work that cannot fix it,
+          # and a check that is always red gets routed around. The daily run
+          # costs a red run and an open issue instead.
+          GUARDS_ENFORCE: ${{ github.event_name == 'schedule' && '1' || '0' }}
+        # set -o pipefail is load-bearing, not decoration. GitHub runs a `run:`
+        # block as `bash -e`, which does NOT set pipefail, so the exit code of
+        # `node ... | tee` is tee's, and tee always succeeds. Without this line
+        # the enforcing run could never go red: the watchdog would report a
+        # silent guard and then exit 0, which is the failure it exists to catch,
+        # inside the thing built to catch it. scripts/check-guards.mjs now fails
+        # the build on any piped run block that does not set it.
+        run: |
+          set -o pipefail
+          node scripts/guards-live.mjs | tee "$GITHUB_STEP_SUMMARY"
+
+      # One issue, reopened and commented rather than duplicated, closed again
+      # when every guard is running. Same shape as the heartbeat's own alarm,
+      # for the same reason: an issue list that tracks reality instead of
+      # collecting noise. The difference is that this one cannot be switched off.
+      - name: Open or update the issue while a guard is silent
+        if: always() && steps.live.outputs.silent != '0' && github.event_name == 'schedule'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const title = 'Een waakhond blaft niet';
+            const body = [
+              `**${process.env.SUMMARY.split('\n')[0]}**`,
+              '',
+              process.env.SUMMARY.split('\n').slice(1).join('\n'),
+              '',
+              'A guard that cannot fire is worse than no guard, because it produces calm.',
+              'This issue stays open, and is updated once a day, until every guard above is running.',
+              '',
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              `_${new Date().toISOString()}_`,
+            ].join('\n');
+            // state:all, newest first: the previous episode's issue was closed by
+            // the run that ended it, so looking only at open issues would file a
+            // fresh one every episode, which is the noise this prevents.
+            const all = await github.rest.issues.listForRepo({
+              ...context.repo, state: 'all', labels: 'guards',
+              sort: 'created', direction: 'desc', per_page: 100,
+            });
+            const mine = all.data.filter(i => !i.pull_request && i.title === title);
+            if (!mine.length) {
+              await github.rest.issues.create({ ...context.repo, title, body, labels: ['guards'] });
+            } else {
+              const issue = mine.find(i => i.state === 'open') || mine[0];
+              if (issue.state !== 'open') {
+                await github.rest.issues.update({ ...context.repo, issue_number: issue.number, state: 'open' });
+              }
+              await github.rest.issues.createComment({ ...context.repo, issue_number: issue.number, body });
+            }
+        env:
+          SUMMARY: ${{ steps.live.outputs.body }}
+
+      - name: Close the issue when every guard is running again
+        if: steps.live.outputs.silent == '0' && github.event_name == 'schedule'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const open = await github.rest.issues.listForRepo({
+              ...context.repo, state: 'open', labels: 'guards',
+            });
+            for (const issue of open.data) {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number,
+                body: `Every watched guard has run and passed within its window, as of run ${context.runId}. Closing.`,
+              });
+              await github.rest.issues.update({ ...context.repo, issue_number: issue.number, state: 'closed' });
+            }

--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -41,8 +41,14 @@ permissions:
   issues: write
 
 concurrency:
-  group: guards-${{ github.ref }}
-  cancel-in-progress: true
+  # The event is part of the group on purpose. With only the ref in it, a push to
+  # main shares a group with the daily scheduled run on the same ref, and
+  # cancel-in-progress would let a push silently cancel the one run that opens
+  # the issue. A cancelled run reports neither red nor green, which is the same
+  # invisible non-result this workflow exists to make impossible. Pull request
+  # runs still supersede each other, which is all that was wanted from it.
+  group: guards-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   guards:

--- a/deploy/deploy-3.1.sh
+++ b/deploy/deploy-3.1.sh
@@ -161,7 +161,15 @@ HOSTS="paramant.app health.paramant.app legal.paramant.app finance.paramant.app 
 #                       those is a statement about the DNS zone or the server,
 #                       not about whether main deploys. Same reasoning as
 #                       heartbeat.yml, one row up.
-REQUIRED_WORKFLOWS="${PARAMANT_REQUIRED_WORKFLOWS:-test.yml csp-inline-check.yml sign-e2e.yml product-heartbeat.yml}"
+#
+# guards.yml IS in the list, unlike the two above, and the difference is worth
+# stating. On a push to main it runs only its static half: every way a gate could
+# be silenced is declared, and every declaration still real. That is a statement
+# about this repository, and it is answerable from the checkout alone. Its live
+# half, which reads whether the switched-off guards have actually run, is set to
+# report rather than fail on anything but the daily schedule, so a deploy is
+# never blocked by a switch that only Mick can turn on.
+REQUIRED_WORKFLOWS="${PARAMANT_REQUIRED_WORKFLOWS:-test.yml csp-inline-check.yml sign-e2e.yml product-heartbeat.yml guards.yml}"
 
 # A required workflow still in_progress or queued on the sha we would deploy is
 # neither a pass nor a failure: it is an answer that has not arrived. The old

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,16 @@ services:
       SECTOR: "health"
       RELAY_SELF_URL: "https://health.paramant.app"
       RELAY_PRIMARY_URL: "http://localhost:3000"
-      RAM_LIMIT_MB: "8192"
+      # Below the 8g cap above, and it has to be. relay.js:1356 refuses an
+      # upload when rss + 5*(inFlight+1) > RAM_LIMIT_MB + RAM_RESERVE_MB, and
+      # RAM_RESERVE_MB is ADDED there, so the guard trips at the sum of the two.
+      # This was 8192 + 512 = 8704 inside a container capped at 8192, so the
+      # kernel always reached its own limit first: the relay never answered "at
+      # capacity", it vanished mid-upload instead. 6656 + 512 = 7168 leaves a
+      # gigabyte between the guard and the OOM killer, which is the whole point
+      # of having a guard. scripts/check-guards.mjs fails the build if the sum
+      # ever climbs back up to the cap.
+      RAM_LIMIT_MB: "6656"
       RAM_RESERVE_MB: "512"
     ports:
       - "127.0.0.1:3001:3000"

--- a/docs/guards.md
+++ b/docs/guards.md
@@ -1,0 +1,123 @@
+# De waakhonden
+
+Elke poort in deze repo, en per stuk het enige antwoord dat telt: **kan hij
+vandaag afgaan?**
+
+Een controle die per ongeluk niets meer toetst is erger dan geen controle, want
+hij geeft rust. In de nacht van 2 op 3 september bleken er drie tegelijk zo te
+staan, en alle drie zagen er in de code uit alsof ze werkten.
+
+## Het patroon, vier keer
+
+| | wat er stond | waarom hij niets deed |
+| --- | --- | --- |
+| 1 | de uurlijkse zelftest die bewijst dat het product werkt | uit achter een repository-variabele, en het alarm dat dat moest melden was een stap *in* de job die de variabele uitzet |
+| 2 | de geheimencontrole in de bouwstraat | zeven weken rood om twee gemaskeerde voorbeeldsleutels, dus geen enkele wijziging kon er groen op worden |
+| 3 | de geheugenbewaking van relay-health | drempel 8704 MB in een container van 8192 MB, dus de kernel greep altijd eerder in |
+| 4 | een uitzonderingsregel in de geheimenscanner | `condition = "AND"` wordt geaccepteerd en genegeerd, dus `paths` naast `regexes` stelde het hele bestand vrij |
+
+Eén vorm, vier keer: **een controle die niet kan afgaan**. Punt 1 bleef drie
+dagen onopgemerkt omdat een overgeslagen run bij GitHub grijs is, niet rood, en
+niemand een melding geeft. Negentien geplande runs op rij.
+
+## Wat dit nu tegenhoudt
+
+### `scripts/check-guards.mjs`, de poort op de poorten
+
+Leest alle workflows en zoekt naar alles wat een poort stil kan zetten. De regel
+is overgenomen van `relay/test/_requires.js`, één niveau hoger: **wat een poort
+kan uitschakelen is een harde fout, tenzij het bij naam gedeclareerd staat**, met
+de reden én met datgene wat het meldt zolang het uit staat. Andersom net zo: een
+declaratie die niet meer voorkomt is ook rood, zodat de lijst niet volloopt met
+geruststellingen over dingen die er niet meer zijn.
+
+Wat hij herkent:
+
+| regel | wat hij vangt |
+| --- | --- |
+| `switch` | een job achter `vars.X` of `secrets.X`: niet gezet betekent overgeslagen, en overgeslagen is grijs |
+| `circular-alarm` | het alarm staat *in* de job die de schakelaar uitzet, dus het kan zijn eigen stilte niet melden |
+| `unsettled-soft-failure` | een `continue-on-error`-stap waarvan niets de uitkomst leest of een oordeel herafleidt |
+| `evidence-optional` | bewijs uploaden met `if-no-files-found: warn`: een run die niets vastlegde slaagt alsnog |
+| `optional-tool` | een gereedschap dat de runner mag missen, met een waarschuwing in plaats van rood |
+| `no-change-trigger` | een workflow die op geen enkele wijziging draait |
+| `pipe-without-pipefail` | `a \| tee b` onder `bash -e` geeft de exitcode van `tee`, en `tee` slaagt altijd |
+
+Plus drie invarianten waar geen uitzondering op bestaat, en die dus geen
+declaratie kennen:
+
+- `.gitleaks.toml` bevat geen `paths` en geen enkelvoudige `[allowlist]`
+- voor elke relay geldt `RAM_LIMIT_MB + RAM_RESERVE_MB` < de containerlimiet
+- `guards.yml` bestaat, heeft geen schakelaar, en draait op schedule én pull request
+
+### `.github/workflows/guards.yml`, de waakhond die van buiten kijkt
+
+Dagelijks om 07:11, en op elke push en pull request. **Zonder eigen
+uitschakelaar**, en dat wordt afgedwongen: `check-guards.mjs` maakt de bouw rood
+zodra een job hier een `if:` op een variabele of secret krijgt, of de schedule of
+de pull request-trigger verdwijnt.
+
+Hij stelt de vraag over de **job**, niet over de run. `security-posture.yml`
+meldt namelijk "success" voor een run waarin de productiescan werd overgeslagen
+en alleen de zelftest liep.
+
+Staat er een waakhond stil, dan gaat de dagelijkse run rood en komt er één issue
+open dat wordt bijgewerkt tot het opgelost is. Bewust dagelijks en niet uurlijks:
+deze repo heeft die les al andersom geleerd, een alarm dat elk uur om een bekende
+reden afgaat leert men negeren, en zo stierf de vorige bewaking.
+
+Op een pull request meldt hij wel en faalt hij niet. Zolang de schakelaar uit
+staat en alleen Mick hem aan kan zetten, zou een harde fout elke pull request
+blokkeren op iets dat geen pull request kan repareren.
+
+## De stand vandaag
+
+| waakhond | kan hij vandaag afgaan? |
+| --- | --- |
+| `test.yml`, 9 jobs (static-sanity, shell-syntax, undefined-names, deploy-dryrun, cache-bust, relay-crypto, relay-unit, admin-unit, gitleaks) | ja, kaal, geen `if:` en geen `continue-on-error` |
+| `csp-inline-check.yml` | ja |
+| `product-heartbeat.yml` | ja, op elke push en PR |
+| `sign-e2e.yml` | ja |
+| `build-image.yml` | ja, als `relay/**` wijzigt |
+| `docker-publish.yml` | ja, na merge naar main |
+| `security-posture.yml` zelftest | ja, op elke PR |
+| **`heartbeat.yml` productie** | **nee.** `HEARTBEAT_ENABLED` bestaat niet, `PARAMANT_CANARY_KEY` en `PARASIGN_CANARY_KEY` bestaan niet |
+| **`security-posture.yml` productie** | **nee.** `SECURITY_POSTURE_ENABLED` bestaat niet |
+| `guards.yml` | ja, en hij meldt de twee hierboven |
+
+De twee die niet kunnen afgaan zijn nu niet meer stil: ze kosten vanaf nu een rode
+dagelijkse run en een open issue.
+
+## Aanzetten
+
+De sleutels kan alleen Mick zetten.
+
+```bash
+gh secret set PARAMANT_CANARY_KEY
+gh secret set PARASIGN_CANARY_KEY
+gh variable set HEARTBEAT_ENABLED --body true
+gh variable set SECURITY_POSTURE_ENABLED --body true
+gh label create guards --description "een waakhond blaft niet" --color B60205
+```
+
+Zet de variabele alleen aan als de secrets er zijn. Zet je alleen de variabele,
+dan blijft `guards.yml` terecht rood: hij eist een geslaagde run van de job zelf,
+niet een aangezette schakelaar. Dat is met opzet, want anders is de waakhond af
+te kopen met een vinkje.
+
+## Zelf draaien
+
+```bash
+node scripts/check-guards.mjs          # de statische helft, rood op een vondst
+node scripts/check-guards.mjs --list   # alles wat hij vond, gedeclareerd of niet
+node --test tests/guards-can-fire.test.mjs
+
+GH_TOKEN=$(gh auth token) GITHUB_REPOSITORY=Apolloccrypt/paramant-relay \
+  node scripts/guards-live.mjs         # de live helft
+```
+
+## Verwant
+
+- [heartbeat.md](heartbeat.md): wat de uurlijkse zelftest bewijst en waarom hij herbouwd is
+- [`relay/test/_requires.js`](../relay/test/_requires.js): dezelfde regel, een niveau lager. Een testsuite die zijn voorwaarde niet haalt faalt, tenzij de runner hem bij naam vrijgeeft
+- `.github/workflows/test.yml`: de "asserted nothing in this job"-poorten waar dit op voortbouwt

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -272,6 +272,18 @@ HEARTBEAT_DRY_RUN=1 node scripts/heartbeat/run.mjs parasend
 Or from the Actions tab: **heartbeat** has `workflow_dispatch`, which ignores the
 `HEARTBEAT_ENABLED` gate, so a run can always be started by hand.
 
+## Wie merkt het als deze zelftest zelf stilvalt
+
+Deze workflow niet. Het alarm hierboven is een stap *in* de job die
+`HEARTBEAT_ENABLED` uitzet, dus zolang die schakelaar uit staat wordt de job
+overgeslagen, vuurt `if: failure()` nooit, en meldt niets dat er niets gemeten
+wordt. Zo bleef het van 2 tot 5 september stil: negentien geplande runs op rij
+overgeslagen, en een overgeslagen run is bij GitHub grijs, niet rood.
+
+Dat is nu van buiten belegd bij [`guards.yml`](../.github/workflows/guards.yml),
+die dagelijks kijkt of deze job werkelijk een geslaagde run heeft opgeleverd en
+er anders één issue voor open zet. Zie [guards.md](guards.md).
+
 Environment: `PARAMANT_RELAY_URL` (default `https://relay.paramant.app`),
 `PARAMANT_BASE_URL` (default `https://paramant.app`), `HEARTBEAT_EVIDENCE_DIR`
 (default `heartbeat-evidence`).

--- a/scripts/check-guards.mjs
+++ b/scripts/check-guards.mjs
@@ -1,0 +1,627 @@
+// Do the guards still bark?
+//
+// WHY THIS FILE EXISTS. In one night three separate safeguards turned out to be
+// decoration. Each of them read, in the code, like a working check:
+//
+//   * the hourly self-test that proves the products work was switched off behind
+//     a repository variable, and the alarm that should have reported that was a
+//     step INSIDE the job the variable switches off. Nineteen scheduled runs in
+//     a row reported "skipped", which GitHub does not colour red and does not
+//     notify anyone about. Nobody noticed for three days.
+//   * the secret scan sat red for seven weeks over two masked example keys, so
+//     no change could go green on it and the signal meant nothing.
+//   * the memory guard was set above the container's own limit, so the kernel
+//     always acted first and the guard could never refuse anything.
+//
+// A fourth had the same shape: a gitleaks allowlist accepted `condition = "AND"`
+// and then ignored it, which turned a narrowing rule into a whole-file pass.
+//
+// One pattern, four times: A CHECK THAT CANNOT FIRE. That is worse than no check
+// at all, because it produces calm. This file is the check on the checks.
+//
+// THE RULE, taken from relay/test/_requires.js and applied one level up. There,
+// a test that cannot meet its precondition fails unless the runner names it as
+// deliberately absent (RELAY_TEST_SKIP), which moves the decision out of the
+// test and into a file a reviewer reads. Here, anything that can stop a workflow
+// gate from firing is a hard failure unless it is named in DECLARED below, with
+// the reason and with the thing that keeps it visible while it is off.
+//
+// It also works the other way: an entry in DECLARED that is no longer found is a
+// failure too. A silencer that gets removed must be removed from the list, so
+// the list cannot fill up with reassuring entries about things that are gone.
+//
+//   node scripts/check-guards.mjs          report and exit non-zero on a finding
+//   node scripts/check-guards.mjs --list   print what was found, exit 0
+//
+// tests/guards-can-fire.test.mjs runs this, and the "guards" workflow reports
+// the half that only live state can answer: whether the switches are actually on.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW_DIR = path.join(ROOT, '.github', 'workflows');
+
+// ---------------------------------------------------------------------------
+// A workflow file, read structurally.
+//
+// Deliberately not a YAML library. The repo has no yaml dependency and the root
+// job installs only what tests/heartbeat-lib.test.mjs needs; adding a parser to
+// production dependencies to read CI config is the wrong trade. What is needed
+// here is small and indentation-driven: which jobs exist, the `if:` on each, and
+// the steps with their keys. Anything this parser cannot read, it reports rather
+// than skips (see UNREADABLE), because a guard file that silently parses to zero
+// jobs would be the very failure this file exists to catch.
+// ---------------------------------------------------------------------------
+
+const indentOf = (line) => line.length - line.trimStart().length;
+const isBlank = (line) => line.trim() === '' || line.trim().startsWith('#');
+
+// A `key:` whose value runs on over following, more-indented lines (`|`, `>-`).
+// Returns the whole value as one flat string so a regex can be asked about it.
+function blockValue(lines, i, keyIndent) {
+  const first = lines[i].slice(lines[i].indexOf(':') + 1).trim();
+  if (!/^[|>][-+]?$/.test(first)) return { value: first, next: i + 1 };
+  const parts = [];
+  let j = i + 1;
+  for (; j < lines.length; j++) {
+    if (isBlank(lines[j])) { parts.push(''); continue; }
+    if (indentOf(lines[j]) <= keyIndent) break;
+    parts.push(lines[j].trim());
+  }
+  return { value: parts.join(' ').trim(), next: j };
+}
+
+export function parseWorkflow(file) {
+  const text = fs.readFileSync(file, 'utf8');
+  const lines = text.split('\n');
+  const wf = {
+    file,
+    name: path.basename(file),
+    triggers: new Set(),
+    jobs: [],
+    text,
+    unreadable: [],
+  };
+
+  // The `on:` block. Both `on:` and the quoted `"on":` spelling, and both the
+  // list form (`on: [push]`) and the mapping form.
+  let i = 0;
+  for (; i < lines.length; i++) {
+    const m = /^(?:on|"on"|'on'):(.*)$/.exec(lines[i]);
+    if (!m) continue;
+    const inline = m[1].trim();
+    if (inline) {
+      for (const t of inline.replace(/[[\]]/g, '').split(',')) {
+        if (t.trim()) wf.triggers.add(t.trim());
+      }
+      break;
+    }
+    for (let j = i + 1; j < lines.length; j++) {
+      if (isBlank(lines[j])) continue;
+      if (indentOf(lines[j]) === 0) break;
+      const e = /^\s{2}([a-z_]+):/.exec(lines[j]);
+      if (e && indentOf(lines[j]) === 2) wf.triggers.add(e[1]);
+    }
+    break;
+  }
+
+  // The `jobs:` block: job ids at indent 2, their keys at indent 4, steps as
+  // list items at indent 6 with their keys at indent 8.
+  const jobsAt = lines.findIndex((l) => /^jobs:\s*$/.test(l));
+  if (jobsAt === -1) {
+    wf.unreadable.push('no `jobs:` block found');
+    return wf;
+  }
+
+  let job = null;
+  let step = null;
+  for (let k = jobsAt + 1; k < lines.length; k++) {
+    const line = lines[k];
+    if (isBlank(line)) continue;
+    const ind = indentOf(line);
+    if (ind === 0) break;
+
+    const jobHead = ind === 2 && /^\s{2}([A-Za-z_][\w-]*):\s*$/.exec(line);
+    if (jobHead) {
+      job = { id: jobHead[1], line: k + 1, ifExpr: '', steps: [], keys: {} };
+      wf.jobs.push(job);
+      step = null;
+      continue;
+    }
+    if (!job) continue;
+
+    // Job-level keys.
+    if (ind === 4 && /^\s{4}[A-Za-z_][\w-]*:/.test(line)) {
+      const key = line.trim().split(':')[0];
+      if (key === 'if') {
+        const { value } = blockValue(lines, k, 4);
+        job.ifExpr = value;
+      } else {
+        job.keys[key] = line.slice(line.indexOf(':') + 1).trim();
+      }
+      if (key !== 'steps') step = null;
+      continue;
+    }
+
+    // A step: `      - key: value`, or `      - uses: ...`.
+    const stepHead = ind === 6 && /^\s{6}-\s+(\S)/.test(line);
+    if (stepHead) {
+      step = { id: '', name: '', uses: '', run: '', keys: {}, line: k + 1 };
+      job.steps.push(step);
+      const inner = line.replace(/^\s{6}-\s+/, '');
+      const km = /^([A-Za-z_][\w-]*):(.*)$/.exec(inner);
+      if (km) {
+        const key = km[1];
+        const val = km[2].trim();
+        if (key === 'run' && /^[|>][-+]?$/.test(val)) {
+          const { value } = blockValue(lines, k, 6);
+          step.run = value;
+        } else if (key in step) {
+          step[key] = val;
+        } else {
+          step.keys[key] = val;
+        }
+      }
+      continue;
+    }
+
+    // A step's own keys, at indent 8.
+    if (step && ind === 8 && /^\s{8}[A-Za-z_][\w-]*:/.test(line)) {
+      const key = line.trim().split(':')[0];
+      const { value } = blockValue(lines, k, 8);
+      if (key === 'run' || key === 'id' || key === 'name' || key === 'uses') {
+        step[key] = value;
+      } else {
+        step.keys[key] = value;
+      }
+      continue;
+    }
+
+    // `with:` and `env:` bodies sit deeper than a step key. Their contents are
+    // flattened onto the step so `if-no-files-found` and the like are visible
+    // without modelling the whole tree.
+    if (step && ind >= 10) {
+      const km = /^\s*([A-Za-z_][\w-]*):(.*)$/.exec(line);
+      if (km) step.keys[km[1]] = km[2].trim();
+    }
+  }
+
+  if (!wf.jobs.length) wf.unreadable.push('`jobs:` block parsed to zero jobs');
+  return wf;
+}
+
+// ---------------------------------------------------------------------------
+// What counts as a silencer: something that can stop a gate from firing without
+// anything turning red.
+// ---------------------------------------------------------------------------
+
+// An expression that can switch a whole job off from outside the repository's
+// code: a repository variable or a secret read in a job-level `if:`.
+const SWITCH_RE = /\b(vars|secrets)\.([A-Z][A-Z0-9_]*)/g;
+
+// A step that opens or comments on an issue. This is what "the alarm" looks like
+// in this repo (heartbeat.yml and security-posture.yml both do it this way).
+const ALARMS = /issues\.create|issues\.createComment|actions\/github-script/;
+
+export function findSilencers(workflows) {
+  const found = [];
+  const add = (id, kind, where, detail) => found.push({ id, kind, where, detail });
+
+  for (const wf of workflows) {
+    for (const u of wf.unreadable) {
+      add(`${wf.name}#unreadable`, 'unreadable', `${wf.name}`, u);
+    }
+
+    // R4. A workflow that no change ever runs cannot gate a change. It may still
+    // be a fine alarm, but then something else has to notice when it stops.
+    if (!wf.triggers.has('push') && !wf.triggers.has('pull_request')) {
+      add(`${wf.name}#no-change-trigger`, 'no-change-trigger', wf.name,
+        `triggers are ${[...wf.triggers].join(', ') || 'none'}: no push or pull_request`);
+    }
+
+    for (const job of wf.jobs) {
+      const where = `${wf.name}:${job.line} job "${job.id}"`;
+
+      // R1. A switch on the job. This is how the heartbeat went quiet.
+      const switches = [...job.ifExpr.matchAll(SWITCH_RE)].map((m) => `${m[1]}.${m[2]}`);
+      for (const sw of new Set(switches)) {
+        add(`${wf.name}/${job.id}#switch:${sw}`, 'switch', where,
+          `job-level if reads ${sw}: unset means this job does not run, and a job that does not run is "skipped", not red`);
+      }
+
+      // R6. The circular alarm, which is the shape of the original bug: the step
+      // that raises the alarm lives inside the job the switch turns off, so the
+      // one thing that could report the silence is silenced by the same switch.
+      if (switches.length) {
+        const alarm = job.steps.find(
+          (s) => (s.keys.if || '').includes('failure()') && ALARMS.test(`${s.uses} ${s.run}`),
+        );
+        if (alarm) {
+          add(`${wf.name}/${job.id}#circular-alarm`, 'circular-alarm', where,
+            `the alarm at line ${alarm.line} runs on failure() inside a job gated by ${[...new Set(switches)].join(', ')}. While the switch is off the job is skipped, failure() never fires, and the alarm cannot report its own silence. Something OUTSIDE this job has to.`);
+        }
+      }
+
+      for (const step of job.steps) {
+        const label = step.id || step.name || step.uses || `line ${step.line}`;
+
+        // R2. continue-on-error is not itself a bypass: both workflows that use
+        // it settle the outcome in a later step. But it IS a bypass the moment
+        // that later step goes away, so the settling step has to be found, by
+        // name, and a step without an id can never be settled at all.
+        if ((step.keys['continue-on-error'] || '') === 'true') {
+          const later = job.steps.slice(job.steps.indexOf(step) + 1);
+          // Two shapes count as settling it, and both are in use here.
+          //   a. a later step reads steps.<id>.outcome and exits on it
+          //      (heartbeat.yml, "Say in one line what failed")
+          //   b. a later `if: always()` step re-derives the verdict from the
+          //      evidence and exits 1 on it (security-posture.yml, "A run
+          //      without a report is a failed run"). This is the stronger of
+          //      the two: it asserts what was produced, not what was returned.
+          const readsOutcome = step.id && later.some(
+            (s) => new RegExp(`steps\\.${step.id}\\.(outcome|conclusion)`).test(`${s.run} ${s.keys.if || ''}`),
+          );
+          const alwaysVerdict = later.some(
+            (s) => /always\(\)/.test(s.keys.if || '') && /\bexit 1\b|process\.exit\(1\)/.test(s.run),
+          );
+          if (!readsOutcome && !alwaysVerdict) {
+            add(`${wf.name}/${job.id}#soft:${label}`, 'unsettled-soft-failure', where,
+              step.id
+                ? `step "${label}" (line ${step.line}) is continue-on-error, and no later step reads steps.${step.id}.outcome or re-derives a verdict under if: always(). Its failure ends the job green.`
+                : `step "${label}" (line ${step.line}) is continue-on-error and has no id, so no later step can read its outcome`);
+          }
+        }
+
+        // R3. Evidence that is allowed to be absent. A run that records nothing
+        // and says so with a warning is a run that proves nothing.
+        if ((step.keys['if-no-files-found'] || '') === 'warn') {
+          add(`${wf.name}/${job.id}#warn-artifact:${label}`, 'evidence-optional', where,
+            `step "${label}" (line ${step.line}) uploads evidence with if-no-files-found: warn, so a run that produced no evidence still passes this step`);
+        }
+
+        // R7. A pipe without pipefail. GitHub runs a `run:` block as `bash -e`,
+        // which does NOT set pipefail, so `a | tee b` reports tee's exit code
+        // and tee practically always succeeds. Every gate in this repo that
+        // pipes a test runner into tee and then greps the log depends on this,
+        // and the repo already writes `set -o pipefail` in all four of them by
+        // hand. A hand-kept habit is not a guard, so it is checked: a piped
+        // command whose failure is swallowed is a check that cannot fire.
+        // A pipe inside `$( ... )` does not decide the step's exit code (the
+        // command around it does), so those are removed before asking.
+        const topLevel = step.run.replace(/\$\([^)]*\)/g, '');
+        if (/\|\s*(tee|grep|head|tail)\b/.test(topLevel) && !/set -[a-z]*o[a-z]* pipefail|set -o pipefail/.test(step.run)) {
+          add(`${wf.name}/${job.id}#unpiped:${label}`, 'pipe-without-pipefail', where,
+            `step "${label}" (line ${step.line}) pipes a command and does not set pipefail, so the step reports the exit code of the LAST command in the pipe and a failure on the left of the pipe passes silently`);
+        }
+
+        // R5. A tool the runner may or may not have, with a warning instead of a
+        // failure when it does not. The check quietly shrinks to whatever is
+        // installed, and the log line that says so is not red.
+        if (/::warning[ :]/.test(step.run) && /command -v\s+(\S+)/.test(step.run)) {
+          const tool = /command -v\s+(\S+)/.exec(step.run)[1];
+          add(`${wf.name}/${job.id}#optional-tool:${tool}`, 'optional-tool', where,
+            `step "${label}" (line ${step.line}) degrades to a ::warning:: when ${tool} is missing, so the check shrinks without going red`);
+        }
+      }
+    }
+  }
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// DECLARED. Every silencer that is allowed to exist, by id, with the reason and
+// with the thing that keeps it visible. Anything not named here fails the gate;
+// anything named here that is no longer found fails it too.
+//
+// "visible" is the load-bearing column. A silencer is acceptable only when
+// something OUTSIDE it reports that it is silent. For the two switches that is
+// .github/workflows/guards.yml, which has no switch of its own (guarded by
+// NO_SWITCH_WORKFLOWS below) and opens one issue while a guard is off.
+// ---------------------------------------------------------------------------
+
+export const DECLARED = {
+  'heartbeat.yml#no-change-trigger': {
+    why: 'the hourly proof runs against production, so a pull request must not fire it. It is a schedule, not a gate.',
+    visible: 'guards.yml checks that a successful heartbeat run exists within HEARTBEAT_MAX_AGE_HOURS and opens an issue when it does not',
+  },
+  'heartbeat.yml/proof#switch:vars.HEARTBEAT_ENABLED': {
+    why: 'the two canary secrets do not exist yet and only Mick can create them. Ungated, the job would go red at :17 every hour for a known reason, and an alarm that cries hourly is one people learn to ignore.',
+    visible: 'guards.yml reports the switch itself as red-in-an-issue while it is off, so "off" costs an open issue instead of nothing',
+  },
+  'heartbeat.yml/proof#circular-alarm': {
+    why: 'the issue-opening step is correctly placed for a run that HAPPENS; it cannot also cover a run that is skipped.',
+    visible: 'guards.yml is that outside observer. It runs on a schedule of its own and cannot be switched off.',
+  },
+  'heartbeat.yml/proof#warn-artifact:Keep the evidence': {
+    why: 'a run that fails before it writes anything must still reach the step that turns the failure red; if-no-files-found: error here would fail the upload first and hide the cause.',
+    visible: 'the "Say in one line what failed" step settles the job regardless, and scripts/heartbeat/run.mjs fails any step that records no proof',
+  },
+  'security-posture.yml/posture#switch:vars.SECURITY_POSTURE_ENABLED': {
+    why: 'same order-of-operations reason as the heartbeat: the nightly scan is known-red until the deploy decisions are carried out.',
+    visible: 'guards.yml reports the switch as red-in-an-issue while it is off',
+  },
+  'security-posture.yml/posture#circular-alarm': {
+    why: 'as heartbeat: the alarm covers a run that happens, not a run that is skipped.',
+    visible: 'guards.yml, from outside',
+  },
+  'security-posture.yml/selftest#optional-tool:shellcheck': {
+    why: 'shellcheck is a lint on top of `bash -n`, which always runs and is the actual gate.',
+    visible: 'the ::warning:: is emitted on the run page, and bash -n failing is still a hard red',
+  },
+};
+
+// The guards that .github/workflows/guards.yml watches from outside, and what
+// "running" means for each. Every DECLARED switch must appear here: a silencer
+// is only acceptable while something reports it, and this list is that
+// something. tests/guards-can-fire.test.mjs holds the two lists against each
+// other, so a switch cannot be declared as watched without actually being
+// watched.
+//
+// `job` is the DISPLAY name of the job, because the job is what has to be asked
+// about. security-posture.yml reports the whole run as "success" when its
+// production job was skipped and only the self-test ran, so a run-level check
+// there would confirm a guard that measured nothing.
+export const WATCHED = [
+  {
+    workflow: 'heartbeat.yml',
+    job: 'heartbeat - production',
+    switchVar: 'HEARTBEAT_ENABLED',
+    // It runs at :17 every hour. Three hours allows for a queue, a re-run and
+    // an hour of GitHub being slow before it counts as absent.
+    maxAgeHours: 3,
+    what: 'the hourly proof that a file still transfers and a document still signs',
+    turnOn: 'gh secret set PARAMANT_CANARY_KEY && gh secret set PARASIGN_CANARY_KEY && gh variable set HEARTBEAT_ENABLED --body true',
+  },
+  {
+    workflow: 'security-posture.yml',
+    job: 'security posture, production',
+    switchVar: 'SECURITY_POSTURE_ENABLED',
+    // Daily at 04:43. Two days allows one missed night without crying.
+    maxAgeHours: 48,
+    what: 'the nightly scan of the public surface: DNS, TLS, headers and the closed ParaID route',
+    turnOn: 'gh variable set SECURITY_POSTURE_ENABLED --body true',
+  },
+];
+
+// Workflows that may never carry a switch, because they are what watches the
+// switched things. A gate on the watchdog is the bug this whole file is about.
+export const NO_SWITCH_WORKFLOWS = ['guards.yml'];
+
+// ---------------------------------------------------------------------------
+// Invariants that are not exception-able: rules with no legitimate exception, so
+// they carry no DECLARED entry to add.
+// ---------------------------------------------------------------------------
+
+// "8g" / "1500m" / "512" as a number of MB.
+function toMB(raw) {
+  const m = /^(\d+(?:\.\d+)?)\s*([gGmMkK]?)b?$/.exec(String(raw).trim().replace(/["']/g, ''));
+  if (!m) return null;
+  const n = parseFloat(m[1]);
+  const unit = m[2].toLowerCase();
+  if (unit === 'g') return Math.round(n * 1024);
+  if (unit === 'k') return Math.round(n / 1024);
+  return Math.round(n); // docker-compose treats a bare number as bytes, but this
+  // file always writes a unit; a bare number here is a mistake worth reporting
+  // rather than silently reading as 8192 bytes.
+}
+
+export function checkRamGuards(file = path.join(ROOT, 'docker-compose.yml')) {
+  const problems = [];
+  if (!fs.existsSync(file)) return [`${path.basename(file)} is missing; the RAM guard's ceiling cannot be checked.`];
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+
+  // Defaults from the shared anchors: `RAM_LIMIT_MB: "${RAM_LIMIT_MB:-1024}"`
+  // and the `memory:` under the shared resources anchor.
+  const defaultOf = (name) => {
+    const re = new RegExp(`${name}:\\s*"?\\$\\{${name}:-(\\d+)\\}`);
+    for (const l of lines) { const m = re.exec(l); if (m) return parseInt(m[1], 10); }
+    return null;
+  };
+  const defaults = { limit: defaultOf('RAM_LIMIT_MB'), reserve: defaultOf('RAM_RESERVE_MB') };
+
+  // The `memory:` directly under a `limits:` key, anywhere in the file, indexed
+  // by the service block it sits in. `reservations:` also carries a `memory:`
+  // and must not be mistaken for the ceiling.
+  const servicesAt = lines.findIndex((l) => /^services:\s*$/.test(l));
+  if (servicesAt === -1) return ['docker-compose.yml has no `services:` block.'];
+
+  let anchorLimit = null;
+  for (let i = 0; i < servicesAt; i++) {
+    if (/^\s*limits:\s*$/.test(lines[i])) {
+      for (let j = i + 1; j < Math.min(i + 4, servicesAt); j++) {
+        const m = /^\s*memory:\s*(\S+)/.exec(lines[j]);
+        if (m) { anchorLimit = toMB(m[1]); break; }
+      }
+    }
+  }
+
+  const services = [];
+  let cur = null;
+  let inLimits = false;
+  for (let i = servicesAt + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (isBlank(line)) continue;
+    const ind = indentOf(line);
+    if (ind === 0) break;
+    const head = ind === 2 && /^\s{2}([A-Za-z_][\w-]*):\s*$/.exec(line);
+    if (head) {
+      cur = { name: head[1], line: i + 1, limitMB: null, ramLimit: null, ramReserve: null };
+      services.push(cur);
+      inLimits = false;
+      continue;
+    }
+    if (!cur) continue;
+    if (/^\s*limits:\s*$/.test(line)) { inLimits = true; continue; }
+    if (/^\s*(reservations|environment|volumes|ports|networks):\s*$/.test(line)) { inLimits = false; continue; }
+    const mem = /^\s*memory:\s*(\S+)/.exec(line);
+    if (mem && inLimits) cur.limitMB = toMB(mem[1]);
+    const rl = /^\s*RAM_LIMIT_MB:\s*"?(\d+)"?\s*$/.exec(line);
+    if (rl) cur.ramLimit = parseInt(rl[1], 10);
+    const rr = /^\s*RAM_RESERVE_MB:\s*"?(\d+)"?\s*$/.exec(line);
+    if (rr) cur.ramReserve = parseInt(rr[1], 10);
+  }
+
+  let checked = 0;
+  for (const s of services) {
+    const limit = s.limitMB ?? anchorLimit;
+    const ramLimit = s.ramLimit ?? defaults.limit;
+    const reserve = s.ramReserve ?? defaults.reserve;
+    // Services that run no relay (redis, the admin panel) set no RAM_LIMIT_MB
+    // and inherit no relay env; nothing to compare.
+    if (limit == null || ramLimit == null || reserve == null) continue;
+    if (!/relay/.test(s.name)) continue;
+    checked++;
+    const trips = ramLimit + reserve;
+    if (trips >= limit) {
+      problems.push(
+        `docker-compose.yml service "${s.name}" (line ${s.line}): the RAM guard refuses at ` +
+        `RAM_LIMIT_MB + RAM_RESERVE_MB = ${ramLimit} + ${reserve} = ${trips} MB, but the container is ` +
+        `capped at ${limit} MB. The kernel kills it first, so the guard can never refuse an upload: ` +
+        `relay.js:1356 is unreachable on this service. Set the sum below ${limit}.`,
+      );
+    }
+  }
+  // A parser that quietly matched nothing would report a clean bill of health
+  // over an unread file, which is the shape of bug this whole script is about.
+  if (!checked) {
+    problems.push('docker-compose.yml: no relay service could be read for its RAM guard. The check matched nothing and would have passed over anything.');
+  }
+  return problems;
+}
+
+export function checkInvariants() {
+  const problems = [];
+
+  // I1. gitleaks: no `paths` key, and no singular [allowlist] table.
+  //
+  // Neither the pinned 8.28.0 nor any earlier version enforces
+  // `condition = "AND"`: it is accepted and then ignored. So in an allowlist
+  // block that also has `regexes`, a `paths` entry does not narrow the rule, it
+  // replaces it, and the whole file is allowlisted. Measured on this repo: with
+  // paths set, an injected stripe-access-token in frontend/js/relay-trust-
+  // anchors.js was not reported; without it, it was. The rule was written down
+  // in a comment in .gitleaks.toml, and a comment is not a gate.
+  const gitleaksFile = path.join(ROOT, '.gitleaks.toml');
+  if (!fs.existsSync(gitleaksFile)) {
+    problems.push('.gitleaks.toml is gone. The secret scan falls back to the default config and the documented placeholders go red again.');
+  } else {
+    const toml = fs.readFileSync(gitleaksFile, 'utf8');
+    const code = toml.split('\n').filter((l) => !l.trim().startsWith('#')).join('\n');
+    if (/^\s*paths\s*=/m.test(code)) {
+      problems.push('.gitleaks.toml has a `paths` entry. gitleaks accepts `condition = "AND"` and ignores it, so paths beside regexes allowlists the WHOLE file, not the matching line. A real key in that file would go unreported. Narrow with regexes only.');
+    }
+    if (/^\s*\[allowlist\]\s*$/m.test(code)) {
+      problems.push('.gitleaks.toml has a singular [allowlist] table. Use [[allowlists]]: the singular form is the one older gitleaks silently ignores.');
+    }
+  }
+
+  // I2. A guard whose threshold sits above the ceiling that kills the process
+  // first can never refuse anything.
+  //
+  // relay.js:1356 refuses an upload when
+  //   rss + BLOB_SIZE_MB * (inFlight + 1) > RAM_LIMIT_MB + RAM_RESERVE_MB
+  // and the container is killed by the kernel at its cgroup limit. If the sum on
+  // the right is at or above that limit, the kernel always acts first and the
+  // branch is dead code: the relay never answers "at capacity", it just
+  // disappears mid-upload. That is what relay-health has been doing, with the
+  // guard set to 8192+512 inside a container capped at 8192.
+  //
+  // Note that RAM_RESERVE_MB is added, not subtracted, so it is headroom ABOVE
+  // the limit rather than a reserve held back below it. That is why the sum is
+  // what has to be compared, not RAM_LIMIT_MB on its own.
+  problems.push(...checkRamGuards());
+
+  // I3. The watchdog may not be switchable, and must run both on a schedule and
+  // on a change, so it cannot rot unnoticed between deploys.
+  for (const name of NO_SWITCH_WORKFLOWS) {
+    const file = path.join(WORKFLOW_DIR, name);
+    if (!fs.existsSync(file)) {
+      problems.push(`${name} is missing. It is what reports that a switched-off guard is off; without it that silence costs nothing again.`);
+      continue;
+    }
+    const wf = parseWorkflow(file);
+    for (const job of wf.jobs) {
+      if (SWITCH_RE.test(job.ifExpr)) {
+        SWITCH_RE.lastIndex = 0;
+        problems.push(`${name} job "${job.id}" is gated on a variable or secret. The watchdog may not have an off switch.`);
+      }
+      SWITCH_RE.lastIndex = 0;
+    }
+    for (const need of ['schedule', 'pull_request']) {
+      if (!wf.triggers.has(need)) {
+        problems.push(`${name} has no ${need} trigger. It needs the schedule to notice a guard going quiet and the pull request to notice itself being broken.`);
+      }
+    }
+  }
+
+  return problems;
+}
+
+// ---------------------------------------------------------------------------
+
+export function readWorkflows() {
+  return fs.readdirSync(WORKFLOW_DIR)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .sort()
+    .map((f) => parseWorkflow(path.join(WORKFLOW_DIR, f)));
+}
+
+export function run() {
+  const workflows = readWorkflows();
+  const found = findSilencers(workflows);
+  const foundIds = new Set(found.map((f) => f.id));
+
+  const undeclared = found.filter((f) => !(f.id in DECLARED));
+  const stale = Object.keys(DECLARED).filter((id) => !foundIds.has(id));
+  const invariants = checkInvariants();
+
+  return { workflows, found, undeclared, stale, invariants };
+}
+
+function main() {
+  const list = process.argv.includes('--list');
+  const { workflows, found, undeclared, stale, invariants } = run();
+
+  console.log(`guards: read ${workflows.length} workflows, ${workflows.reduce((n, w) => n + w.jobs.length, 0)} jobs`);
+  if (list) {
+    for (const f of found) {
+      const state = f.id in DECLARED ? 'declared' : 'UNDECLARED';
+      console.log(`  [${state}] ${f.id}\n      ${f.detail}`);
+    }
+    return;
+  }
+
+  let bad = false;
+  if (undeclared.length) {
+    bad = true;
+    console.log('\nSomething can stop a guard from firing, and it is not declared:');
+    for (const f of undeclared) {
+      console.log(`  ${f.id}\n      at ${f.where}\n      ${f.detail}`);
+    }
+    console.log('\n  Either remove it, or add it to DECLARED in scripts/check-guards.mjs with');
+    console.log('  the reason AND the thing that reports it while it is silent. A silencer');
+    console.log('  nothing watches is the bug this gate exists to catch.');
+  }
+  if (stale.length) {
+    bad = true;
+    console.log('\nDeclared, but no longer there:');
+    for (const id of stale) console.log(`  ${id}`);
+    console.log('\n  Remove these from DECLARED. A list that keeps entries for things that are');
+    console.log('  gone stops describing the repository and starts reassuring about it.');
+  }
+  if (invariants.length) {
+    bad = true;
+    console.log('\nInvariant broken:');
+    for (const p of invariants) console.log(`  ${p}`);
+  }
+
+  if (bad) {
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`guards: ${found.length} silencers, all ${Object.keys(DECLARED).length} declared and each one watched from outside; ${'invariants hold'}`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/guards-live.mjs
+++ b/scripts/guards-live.mjs
@@ -1,0 +1,167 @@
+// Are the guards actually running? The half of the question only live state can
+// answer.
+//
+// scripts/check-guards.mjs reads the workflow files and proves that every way a
+// guard could be silenced is declared and watched. It cannot tell whether the
+// switch is on today, or whether the job behind it has actually produced a run.
+// That is what this does, from OUTSIDE the jobs it watches, which is the part
+// that was missing:
+//
+//   heartbeat.yml has an alarm, and the alarm is a step inside the job that a
+//   repository variable switches off. With the variable unset the job is
+//   skipped, `if: failure()` never fires, and the one thing that could report
+//   the silence is silenced by the same switch. Nineteen scheduled runs in a
+//   row came back "skipped", which GitHub renders grey and notifies nobody
+//   about, and nothing anywhere went red for three days.
+//
+// security-posture.yml is the same shape with a worse disguise: only its
+// production job is switched off, so the run as a whole still reports "success"
+// off the back of the self-test job that always passes.
+//
+// So this asks about the JOB, not the run. A workflow that is green because the
+// only job that did anything was the one testing itself is not a guard.
+//
+//   node scripts/guards-live.mjs              report, exit 0
+//   GUARDS_ENFORCE=1 node scripts/guards-live.mjs   exit 1 on a silent guard
+//
+// Enforcing is on for the scheduled run and off for a pull request. Not to be
+// lenient: while HEARTBEAT_ENABLED is off, and only Mick can turn it on, a
+// hard failure on every pull request would block work on a thing no pull
+// request can fix, and a check that is always red is one people route around.
+// The scheduled run costs an open issue and a red run once a day instead, which
+// is a signal that survives being ignored for a week.
+
+import { WATCHED } from './check-guards.mjs';
+
+const REPO = process.env.GITHUB_REPOSITORY || 'Apolloccrypt/paramant-relay';
+const TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
+
+async function api(pathname) {
+  const res = await fetch(`https://api.github.com${pathname}`, {
+    headers: {
+      accept: 'application/vnd.github+json',
+      'x-github-api-version': '2022-11-28',
+      ...(TOKEN ? { authorization: `Bearer ${TOKEN}` } : {}),
+    },
+  });
+  if (!res.ok) throw new Error(`GET ${pathname} -> ${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+const hoursSince = (iso) => (Date.now() - Date.parse(iso)) / 3600000;
+const plural = (n, one, many) => `${n} ${n === 1 ? one : many}`;
+
+// The state of one watched guard, read from the runs API.
+async function inspect(guard) {
+  const state = {
+    ...guard,
+    switchOn: (process.env[`SWITCH_${guard.switchVar}`] || '').trim() === 'true',
+    lastGoodRun: null,
+    lastGoodAgeH: null,
+    skippedStreak: 0,
+    jobConclusion: null,
+    problems: [],
+  };
+
+  const { workflow_runs: runs = [] } = await api(
+    `/repos/${REPO}/actions/workflows/${guard.workflow}/runs?event=schedule&per_page=30`,
+  );
+
+  // The newest scheduled run whose WATCHED JOB actually reached a conclusion.
+  // Deliberately not the run's own conclusion: security-posture.yml reports
+  // "success" for a run in which the production job was skipped and only the
+  // self-test ran.
+  for (const run of runs) {
+    if (run.conclusion === 'skipped') { state.skippedStreak++; continue; }
+    break;
+  }
+
+  for (const run of runs.slice(0, 8)) {
+    let jobs;
+    try { ({ jobs } = await api(`/repos/${REPO}/actions/runs/${run.id}/jobs?per_page=30`)); }
+    catch { continue; }
+    const job = jobs.find((j) => j.name === guard.job);
+    if (!job) continue;
+    if (state.jobConclusion === null) state.jobConclusion = job.conclusion;
+    if (job.conclusion === 'success') {
+      state.lastGoodRun = run;
+      state.lastGoodAgeH = hoursSince(run.created_at);
+      break;
+    }
+  }
+
+  if (!state.switchOn) {
+    state.problems.push(
+      `the switch is off: repository variable ${guard.switchVar} is not "true", so every scheduled run of ${guard.workflow} skips the job "${guard.job}". A skipped job is grey, not red, and notifies nobody.`
+      + (state.skippedStreak ? ` The last ${plural(state.skippedStreak, 'scheduled run has', 'scheduled runs have')} been skipped.` : ''),
+    );
+  }
+  if (state.lastGoodRun === null) {
+    state.problems.push(
+      `no scheduled run of "${guard.job}" has succeeded in the last ${runs.length} scheduled runs`
+      + (state.jobConclusion ? ` (most recent conclusion: ${state.jobConclusion})` : ' (the job did not run at all)')
+      + `. ${guard.what} is not being proved by anything.`,
+    );
+  } else if (state.lastGoodAgeH > guard.maxAgeHours) {
+    state.problems.push(
+      `the last successful "${guard.job}" was ${Math.round(state.lastGoodAgeH)} hours ago, and it is expected at least every ${guard.maxAgeHours}. ${guard.what} has been unproved since then.`,
+    );
+  }
+  return state;
+}
+
+function render(states) {
+  const lines = [];
+  const bad = states.filter((s) => s.problems.length);
+  lines.push(bad.length
+    ? `${plural(bad.length, 'guard is', 'guards are')} not running.`
+    : 'Every watched guard has run and passed within its window.');
+  lines.push('');
+  for (const s of states) {
+    lines.push(`### ${s.workflow} - ${s.what}`);
+    if (!s.problems.length) {
+      lines.push(`- green: last successful "${s.job}" ${Math.round(s.lastGoodAgeH)}h ago, within the ${s.maxAgeHours}h window.`);
+    } else {
+      for (const p of s.problems) lines.push(`- RED: ${p}`);
+      lines.push(`- to turn it on: \`${s.turnOn}\``);
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+// The two outputs the workflow reads. Written on every path, including the
+// failure path: a step that goes red without setting `silent` would leave the
+// issue step with an empty body, which is a report that says nothing.
+async function emit(silent, body) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  const { appendFileSync } = await import('node:fs');
+  appendFileSync(process.env.GITHUB_OUTPUT, `silent=${silent}\n`);
+  appendFileSync(process.env.GITHUB_OUTPUT, `body<<GUARDS_EOF\n${body}\nGUARDS_EOF\n`);
+}
+
+async function main() {
+  const states = [];
+  for (const guard of WATCHED) states.push(await inspect(guard));
+  const body = render(states);
+  console.log(body);
+
+  const bad = states.filter((s) => s.problems.length);
+  await emit(bad.length, body);
+  if (bad.length) {
+    console.log(`::error title=A guard is not running::${bad.map((s) => s.workflow).join(', ')}: see the summary above.`);
+    if (process.env.GUARDS_ENFORCE === '1') process.exitCode = 1;
+  }
+}
+
+main().catch(async (e) => {
+  // A watchdog that cannot reach the API must say so and go red. Answering
+  // "nothing to report" because the lookup failed is the failure mode this
+  // whole file exists to prevent. It counts as one silent guard so the issue is
+  // opened with a body that says what actually happened.
+  const body = `The guard watcher could not read the run history, so it does not know whether any guard is running.\n\n- RED: ${e.message}`;
+  console.log(body);
+  console.log(`::error title=The guard watcher could not run::${e.message}`);
+  await emit(1, body);
+  process.exitCode = 1;
+});

--- a/tests/auth-smoke.sh
+++ b/tests/auth-smoke.sh
@@ -27,11 +27,22 @@ check() {
   fi
 }
 
+# "not this status code" needs one more case than it looks like. curl writes
+# %{http_code} as 000 when it never got a response at all: DNS failure, refused
+# connection, or the --max-time 8 running out. Compared against '500' that is
+# "not 500", so every one of the ten checks below reported PASS for an endpoint
+# that answered nothing, which is a worse outcome than the 500 they exist to
+# catch. This script is a post-deploy and post-rollback gate, and a hung route
+# next to a healthy homepage is exactly the partial outage it should catch.
 check_not() {
   local name="$1"
   local actual="$2"
   local bad="$3"
-  if [ "$actual" != "$bad" ]; then
+  if [ -z "$actual" ] || [ "$actual" = "000" ]; then
+    printf "  FAIL  %s  (no response at all: curl returned '%s')\n" "$name" "$actual"
+    FAIL=$((FAIL + 1))
+    FAILURES="$FAILURES\n  - $name (no response)"
+  elif [ "$actual" != "$bad" ]; then
     printf "  PASS  %s\n" "$name"
     PASS=$((PASS + 1))
   else

--- a/tests/guards-can-fire.test.mjs
+++ b/tests/guards-can-fire.test.mjs
@@ -1,0 +1,222 @@
+// Can every guard in this repository still fire?
+//
+// The gate on scripts/check-guards.mjs, and the place where its two registers
+// are held against each other. Picked up automatically by
+// scripts/browser-suites.mjs --no-browser, so it runs in test.yml on every push
+// and every pull request with no list to keep.
+//
+// The failure this defends against, in one sentence: a check that cannot fire
+// reports green, and green is what people act on. Three of those turned up in
+// one night, and the reason none of them was noticed is that every one of them
+// looked correct in the code.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+import {
+  ROOT, DECLARED, WATCHED, NO_SWITCH_WORKFLOWS,
+  parseWorkflow, findSilencers, readWorkflows, checkInvariants, checkRamGuards, run,
+} from '../scripts/check-guards.mjs';
+
+const wfPath = (n) => path.join(ROOT, '.github', 'workflows', n);
+
+test('the workflow reader actually reads: jobs, triggers and steps', () => {
+  // The reader is hand-rolled, so it gets asserted before anything is concluded
+  // from it. A parser that quietly returns nothing would make every check below
+  // pass over an unread file, which is the exact shape of the bug being fixed.
+  const workflows = readWorkflows();
+  assert.ok(workflows.length >= 8, `expected at least 8 workflows, read ${workflows.length}`);
+  for (const wf of workflows) {
+    assert.equal(wf.unreadable.length, 0, `${wf.name}: ${wf.unreadable.join('; ')}`);
+    assert.ok(wf.jobs.length > 0, `${wf.name} parsed to zero jobs`);
+    assert.ok(wf.triggers.size > 0, `${wf.name} parsed to zero triggers`);
+  }
+
+  const heartbeat = parseWorkflow(wfPath('heartbeat.yml'));
+  assert.deepEqual([...heartbeat.triggers].sort(), ['schedule', 'workflow_dispatch']);
+  assert.equal(heartbeat.jobs.length, 1);
+  assert.match(heartbeat.jobs[0].ifExpr, /vars\.HEARTBEAT_ENABLED/,
+    'the reader must see the job-level if, which is where the switch lives');
+  assert.ok(heartbeat.jobs[0].steps.length >= 8,
+    `heartbeat proof job parsed to ${heartbeat.jobs[0].steps.length} steps`);
+});
+
+test('every way a guard can be silenced is declared, and every declaration is still real', () => {
+  const { undeclared, stale } = run();
+  assert.deepEqual(undeclared.map((u) => u.id), [],
+    'undeclared silencer: something can stop a guard firing and nothing says so. '
+    + 'Add it to DECLARED in scripts/check-guards.mjs with the reason and with what reports it while it is silent.');
+  assert.deepEqual(stale, [],
+    'DECLARED names a silencer that no longer exists. Remove it: a list that keeps '
+    + 'entries for things that are gone stops describing the repository and starts reassuring about it.');
+});
+
+test('a declared switch is watched from outside, by name', () => {
+  // The load-bearing link. A switch may be declared only because something
+  // outside the switched job reports it, and this is where "outside" is checked
+  // rather than asserted in a comment.
+  const declaredSwitches = Object.keys(DECLARED)
+    .filter((id) => id.includes('#switch:'))
+    .map((id) => id.split('#switch:')[1].replace(/^vars\./, ''));
+  assert.ok(declaredSwitches.length > 0, 'no declared switches found; the parser or the ids changed shape');
+
+  const watchedVars = WATCHED.map((w) => w.switchVar);
+  for (const sw of declaredSwitches) {
+    assert.ok(watchedVars.includes(sw),
+      `${sw} is declared as an acceptable switch but WATCHED does not list it, so nothing reports it while it is off. `
+      + 'That is exactly how the heartbeat went quiet for three days.');
+  }
+});
+
+test('every watched guard names a job that exists in the workflow it names', () => {
+  // A watcher that looks for a job name nobody uses any more finds nothing and
+  // reports nothing, which reads identically to "all is well".
+  for (const w of WATCHED) {
+    const file = wfPath(w.workflow);
+    assert.ok(fs.existsSync(file), `WATCHED names ${w.workflow}, which does not exist`);
+    const wf = parseWorkflow(file);
+    const names = wf.jobs.map((j) => j.keys.name && j.keys.name.replace(/^['"]|['"]$/g, ''));
+    assert.ok(names.includes(w.job),
+      `WATCHED expects a job called "${w.job}" in ${w.workflow}, which has ${JSON.stringify(names)}. `
+      + 'The watcher would look for a job that is not there and find nothing to complain about.');
+    assert.match(wf.jobs.map((j) => j.ifExpr).join(' '), new RegExp(`vars\\.${w.switchVar}`),
+      `${w.workflow} no longer reads vars.${w.switchVar}; the watcher is watching a switch that is gone`);
+  }
+});
+
+test('the watchdog has no off switch of its own', () => {
+  for (const name of NO_SWITCH_WORKFLOWS) {
+    const wf = parseWorkflow(wfPath(name));
+    for (const job of wf.jobs) {
+      assert.doesNotMatch(job.ifExpr, /\b(vars|secrets)\./,
+        `${name} job "${job.id}" is gated on a variable or a secret. The thing that reports a switched-off guard may not itself be switchable.`);
+    }
+    for (const need of ['schedule', 'pull_request']) {
+      assert.ok(wf.triggers.has(need), `${name} lost its ${need} trigger`);
+    }
+  }
+});
+
+test('a piped gate sets pipefail, so a failure on the left of the pipe is not swallowed', () => {
+  // Four gates in test.yml pipe a test runner into tee and then grep the log.
+  // Under `bash -e`, which is what GitHub runs, the exit code of a pipeline is
+  // the LAST command's, and tee always succeeds. Every one of them writes
+  // `set -o pipefail` by hand today; this is what keeps it that way.
+  const found = findSilencers(readWorkflows()).filter((f) => f.kind === 'pipe-without-pipefail');
+  assert.deepEqual(found.map((f) => f.id), [], found.map((f) => f.detail).join('\n'));
+});
+
+test('the RAM guard trips before the kernel does', () => {
+  // relay.js:1356 refuses an upload above RAM_LIMIT_MB + RAM_RESERVE_MB, and the
+  // container is killed at its cgroup limit. Set the sum at or above that limit
+  // and the branch is dead code: the relay never says "at capacity", it vanishes
+  // mid-upload. relay-health shipped that way, 8192 + 512 inside a cap of 8192.
+  assert.deepEqual(checkRamGuards(), []);
+});
+
+test('the gitleaks allowlist narrows a rule instead of switching off a file', () => {
+  // gitleaks accepts `condition = "AND"` and then ignores it, in every version
+  // this repo has run including the pinned 8.28.0. So `paths` beside `regexes`
+  // does not narrow the allowlist, it widens it to the whole file, and a real
+  // key dropped into that file goes unreported. The rule was written down as a
+  // comment in .gitleaks.toml; this is the same rule as something that fails.
+  const toml = fs.readFileSync(path.join(ROOT, '.gitleaks.toml'), 'utf8');
+  const code = toml.split('\n').filter((l) => !l.trim().startsWith('#')).join('\n');
+  assert.doesNotMatch(code, /^\s*paths\s*=/m,
+    'a `paths` entry in .gitleaks.toml allowlists the whole file rather than narrowing the rule');
+  assert.doesNotMatch(code, /^\s*\[allowlist\]\s*$/m,
+    'the singular [allowlist] table is the one older gitleaks silently ignores; use [[allowlists]]');
+  assert.match(code, /\[\[allowlists\]\]/, 'the allowlists are gone entirely, which is a different bug');
+});
+
+test('every invariant holds on the repository as it stands', () => {
+  assert.deepEqual(checkInvariants(), []);
+});
+
+// The sabotage cases. Each one switches off the thing a check guards and proves
+// the check goes red, because a check that has never been seen to fail is a
+// check nobody has tested.
+test('sabotage: an undeclared switch on a job is caught', () => {
+  const wf = parseWorkflow(wfPath('csp-inline-check.yml'));
+  // csp-inline-check has no switch today. Give it one, in memory.
+  wf.jobs[0].ifExpr = "vars.CSP_CHECK_ENABLED == 'true'";
+  const found = findSilencers([wf]);
+  const hit = found.find((f) => f.kind === 'switch');
+  assert.ok(hit, 'a job gated on a repository variable must be reported');
+  assert.ok(!(hit.id in DECLARED), 'and it must not already be declared');
+});
+
+test('sabotage: an unsettled continue-on-error is caught', () => {
+  const wf = parseWorkflow(wfPath('sign-e2e.yml'));
+  const job = wf.jobs[0];
+  job.steps[job.steps.length - 1].keys['continue-on-error'] = 'true';
+  const found = findSilencers([wf]).filter((f) => f.kind === 'unsettled-soft-failure');
+  assert.equal(found.length, 1,
+    'a continue-on-error step whose outcome nothing reads must be reported: its failure ends the job green');
+});
+
+test('sabotage: a settled continue-on-error is not reported', () => {
+  // The other direction. heartbeat.yml uses continue-on-error three times and
+  // settles all three; security-posture.yml settles its one by re-deriving the
+  // verdict from the evidence under `if: always()`. A gate that cannot tell
+  // those apart would be turned off within a week.
+  const found = findSilencers([parseWorkflow(wfPath('security-posture.yml'))]);
+  assert.deepEqual(found.filter((f) => f.kind === 'unsettled-soft-failure'), []);
+});
+
+test('sabotage: the RAM guard check goes red when the threshold passes the cap', () => {
+  const original = fs.readFileSync(path.join(ROOT, 'docker-compose.yml'), 'utf8');
+  const broken = original.replace(/RAM_LIMIT_MB: "6656"/, 'RAM_LIMIT_MB: "8192"');
+  assert.notEqual(broken, original, 'the sabotage did not apply; the value moved');
+  const tmp = path.join(ROOT, 'docker-compose.sabotage.tmp.yml');
+  try {
+    fs.writeFileSync(tmp, broken);
+    const problems = checkRamGuards(tmp);
+    assert.equal(problems.length, 1, 'the unreachable RAM guard must be reported');
+    assert.match(problems[0], /relay-health/);
+    assert.match(problems[0], /8704 MB, but the container is capped at 8192 MB/);
+  } finally {
+    fs.rmSync(tmp, { force: true });
+  }
+});
+
+test('sabotage: a pipe that loses its pipefail is caught', () => {
+  const wf = parseWorkflow(wfPath('test.yml'));
+  const job = wf.jobs.find((j) => j.id === 'admin-unit-tests');
+  const step = job.steps.find((s) => /pipefail/.test(s.run));
+  assert.ok(step, 'expected a piped gate with pipefail in admin-unit-tests');
+  step.run = step.run.replace(/set -o pipefail/, '');
+  const found = findSilencers([wf]).filter((f) => f.kind === 'pipe-without-pipefail');
+  assert.equal(found.length, 1, 'a piped gate without pipefail reports the exit code of tee, which always succeeds');
+});
+
+test('a "not 500" check fails when there was no response at all', () => {
+  // curl writes %{http_code} as 000 when nothing answered, and "000" is not
+  // "500", so the ten check_not assertions in tests/auth-smoke.sh reported PASS
+  // for a route that never replied. That script is the post-deploy and
+  // post-rollback gate, so the check that should catch a broken route was
+  // green precisely when the route was at its most broken.
+  //
+  // The real function is extracted from the file rather than restated here: a
+  // copy of the logic would keep passing after the original was changed back.
+  const src = fs.readFileSync(path.join(ROOT, 'tests', 'auth-smoke.sh'), 'utf8');
+  const fn = /^check_not\(\) \{$[\s\S]*?^\}$/m.exec(src);
+  assert.ok(fn, 'check_not() could not be found in tests/auth-smoke.sh');
+
+  const drive = (code) => {
+    return execFileSync('bash', ['-c', `PASS=0; FAIL=0; FAILURES=""
+${fn[0]}
+check_not 'x not 500' '${code}' '500'
+echo "FAIL=$FAIL"`], { encoding: 'utf8' });
+  };
+
+  assert.match(drive('000'), /FAIL=1/, 'no response at all must fail, not pass for not being a 500');
+  assert.match(drive(''), /FAIL=1/, 'an empty status must fail too');
+  assert.match(drive('500'), /FAIL=1/, 'the case it was written for must still fail');
+  assert.match(drive('401'), /FAIL=0/, 'a real answer that is not the bad one must still pass');
+});
+
+console.log('\nguards-can-fire: every silencer declared, every declared switch watched from outside, and each check seen to go red');


### PR DESCRIPTION
Poort 5 uit `Plan/Paramant - wanneer is het verkoopbaar`: een breuk moet Mick bereiken, niet zijn klant.

## De aanleiding

Vier waarborgen met dezelfde vorm. Elk zag er in de code uit alsof hij werkte, en geen van vieren kon afgaan.

| | wat er stond | waarom hij niets deed |
| --- | --- | --- |
| 1 | de uurlijkse zelftest | uit achter een repositoryvariabele, en het alarm dat dat moest melden was een stap in de job die diezelfde variabele uitzet |
| 2 | de geheimencontrole | zeven weken rood om twee gemaskeerde voorbeeldsleutels |
| 3 | de geheugenbewaking van relay-health | drempel 8704 MB in een container van 8192 MB |
| 4 | een uitzondering in de geheimenscanner | `condition = "AND"` wordt geaccepteerd en genegeerd |

Gemeten, niet aangenomen: de geplande zelftest is **negentien keer op rij overgeslagen** sinds 2 september 18:45. De drie handmatige pogingen daarvoor faalden alle drie. Een overgeslagen run is bij GitHub grijs, niet rood, en meldt niemand iets.

## Twee waarborgen die nu niets deden, gerepareerd

**De geheugenbewaking was niet gerepareerd.** `relay-health` draait met `RAM_LIMIT_MB` 8192 plus `RAM_RESERVE_MB` 512 in een container die op 8192 MB wordt afgekapt. `RAM_RESERVE_MB` wordt in `relay.js:1356` opgeteld, niet afgetrokken, dus de bewaking greep in op 8704 en de kernel was altijd eerder. De relay weigerde nooit capaciteit, hij verdween midden in een upload. Nu 6656 plus 512, met een gigabyte tussen de bewaking en de OOM-killer.

**`check_not` in de auth-smoke slaagde bij geen antwoord.** `curl` schrijft `000` als er niets antwoordde, en `"000" != "500"` is PASS. Tien controles die een crash moesten vangen slaagden dus juist wanneer een route helemaal niet reageerde. Dit script is de poort na elke deploy en elke rollback.

**Nog een stille uitschakeling gevonden:** `security-posture.yml` heeft dezelfde constructie als de zelftest. De dagelijkse productiescan hangt aan `SECURITY_POSTURE_ENABLED`, die niet bestaat. Erger vermomd: de run meldt "success" omdat de zelftest-job wel groen wordt, terwijl de scan-job `skipped` is. In de laatste 100 runs staan 98 pull requests en 2 schedules, en de productiejob is in geen enkele gedraaid.

## Wat er gebouwd is

**`scripts/check-guards.mjs`** past de regel van `relay/test/_requires.js` een niveau hoger toe. Daar faalt een testsuite die zijn voorwaarde niet haalt, tenzij de runner hem bij naam vrijgeeft. Hier is alles wat een poort stil kan zetten een harde fout, tenzij het bij naam gedeclareerd staat, met de reden en met datgene wat het meldt zolang het uit staat. Een declaratie die niet meer voorkomt is ook rood.

Zeven vormen: de schakelaar op een job, het alarm binnen de uitgezette job, een niet-afgevangen `continue-on-error`, optioneel bewijs, een optioneel gereedschap, een workflow die op geen wijziging draait, en een pijp zonder `pipefail`. Plus drie invarianten zonder uitzondering: geen `paths` in `.gitleaks.toml`, elke relay-drempel onder zijn containerlimiet, en de waakhond zonder eigen schakelaar.

**`.github/workflows/guards.yml`** kijkt van buiten. Hij vraagt naar de **job**, niet naar de run, precies omdat een run groen kan zijn terwijl het enige dat draaide de zelftest van de scanner was. Hij heeft geen eigen uitschakelaar en dat wordt afgedwongen. Dagelijks, niet uurlijks: deze repo weet al dat een alarm dat elk uur om een bekende reden afgaat wordt genegeerd, en zo stierf de vorige bewaking. Op een pull request meldt hij en faalt hij niet, want de schakelaar is niet vanuit een pull request te zetten.

De sleutels van de zelftest staan hier niet in. Het feit dat hij uit staat kost vanaf nu een rode dagelijkse run en een open issue.

## Sabotagetoetsen

Elke nieuwe controle is rood gezien met de waarborg eronder uitgezet. Vijftien gevallen in `tests/guards-can-fire.test.mjs`, waarvan zes sabotage.

| sabotage | uitkomst |
| --- | --- |
| schakelaar op een job zonder declaratie | rood, gemeld als `switch` |
| `continue-on-error` waarvan niets de uitkomst leest | rood |
| `continue-on-error` die wel wordt afgevangen | groen, geen vals alarm |
| geheugendrempel terug op 8192 | rood, met de exacte 8704 tegen 8192 |
| `set -o pipefail` uit een poort halen | rood |
| `check_not` met `000`, leeg, `500` en `401` | rood, rood, rood, groen |
| schakelaar aanzetten zonder geslaagde run | blijft rood, dus niet af te kopen met een vinkje |
| GitHub-API onbereikbaar | rood, niet stil groen |

De waakhond had zelf de bug die hij moet vangen: `node ... | tee` zonder `pipefail` geeft de exitcode van `tee`, dus de handhaving zou nooit hebben gevuurd. Dat is de reden dat `pipe-without-pipefail` nu een regel is, en die regel vond meteen een tweede geval.

## Nog te doen, alleen door Mick

```bash
gh secret set PARAMANT_CANARY_KEY
gh secret set PARASIGN_CANARY_KEY
gh variable set HEARTBEAT_ENABLED --body true
gh variable set SECURITY_POSTURE_ENABLED --body true
gh label create guards --description "een waakhond blaft niet" --color B60205
```
