### PR TITLE
Elke knop op een plek, met een poort die het zo houdt

### DIFF
--- a/deploy/knoppen.md
+++ b/deploy/knoppen.md
@@ -46,7 +46,7 @@ De gevaarlijkste knop is de knop die je niet hoort als hij ontbreekt. Deze doen 
 
 | knop | waar | wat er stil gebeurt |
 |---|---|---|
-| `client_max_body_size` | `deploy/nginx-paramant-public.conf`, `nginx-selfhost.conf`, `deploy/nginx/addin.paramant.app.conf` | nginx neemt zijn eigen 1 MB, zonder waarschuwing. Dit is hoe de limiet onzichtbaar werd |
+| `client_max_body_size` | `nginx-selfhost.conf`, `deploy/nginx/addin.paramant.app.conf` | nginx neemt zijn eigen 1 MB, zonder waarschuwing. Dit is hoe de limiet onzichtbaar werd. `deploy/nginx-paramant-public.conf` had hem tot d8bf7a71 ook niet en zet nu 12M |
 | `HEARTBEAT_ENABLED` | `.github/workflows/heartbeat.yml:56` | de variabele bestaat niet, de taak slaat over, de run is groen |
 | `FLEET_LIVE` | `tests/verify-knows-the-fleet.test.mjs:320` | de test die de gepinde sleutels tegen de live relays houdt, staat in geen enkele workflow en heeft dus nooit gedraaid |
 | `CLEVERBASE_SANDBOX` | `tests/qes-cleverbase-live.test.mjs:31` | de hele QES-suite slaat over, overal |
@@ -242,15 +242,15 @@ deze regels doorbreken.
 
 | bestand | richtlijn | waarde |
 |---|---|---|
-| `deploy/nginx-paramant-live.conf` | `client_max_body_size` | `4k / 64k / 16k / 16k / 50M / 30M / 35M` |
+| `deploy/nginx-paramant-live.conf` | `client_max_body_size` | `4k / 64k / 16k / 16k / 50M / 30M / 12M / 35M / 12M / 12M / 12M` |
 | `deploy/nginx-paramant-live.conf` | `limit_req_zone` | `afwezig` |
 | `deploy/nginx-paramant-live.conf` | `limit_conn` | `afwezig` |
-| `deploy/nginx-paramant-live.conf` | `proxy_read_timeout` | `3600s / 3600s` |
+| `deploy/nginx-paramant-live.conf` | `proxy_read_timeout` | `3600s / 3600s / 3600s / 3600s / 3600s` |
 | `deploy/nginx-paramant-live.conf` | `client_body_timeout` | `afwezig` |
-| `deploy/nginx-paramant-public.conf` | `client_max_body_size` | `afwezig` |
+| `deploy/nginx-paramant-public.conf` | `client_max_body_size` | `12M / 12M / 12M / 12M / 12M / 12M` |
 | `deploy/nginx-paramant-public.conf` | `limit_req_zone` | `afwezig` |
 | `deploy/nginx-paramant-public.conf` | `limit_conn` | `afwezig` |
-| `deploy/nginx-paramant-public.conf` | `proxy_read_timeout` | `3600s / 30s / 3600s / 3600s` |
+| `deploy/nginx-paramant-public.conf` | `proxy_read_timeout` | `3600s / 3600s / 3600s / 3600s / 3600s / 30s / 3600s / 3600s / 3600s` |
 | `deploy/nginx-paramant-public.conf` | `client_body_timeout` | `300s` |
 | `deploy/nginx-selfhost.conf` | `client_max_body_size` | `35M / 35M` |
 | `deploy/nginx-selfhost.conf` | `limit_req_zone` | `$binary_remote_addr zone=inbound:10m rate=5r/m / $binary_remote_addr zone=pubkey:10m rate=20r/m / $binary_remote_addr zone=auth:10m rate=10r/m / $binary_remote_addr zone=api:10m rate=60r/m / $binary_remote_addr zone=health_chk:10m rate=6r/m / $binary_remote_addr zone=sign_dpa:1m rate=3r/m` |
@@ -281,8 +281,9 @@ deze regels doorbreken.
 ## Constanten die instellingen zijn
 
 Een getal dat bepaalt wat het product doet is een instelling, of hij nu uit de omgeving
-te veranderen is of niet. Deze zijn gepind: verander er een zonder deze pagina bij te
-werken en de controle valt om.
+te veranderen is of niet. Deze zijn gepind op bestand, naam, waarde en aantal: `x3` betekent dat het getal op
+drie regels hoort te staan. Verander er een zonder deze pagina bij te werken en de
+controle valt om.
 
 <!-- knoppen:constanten -->
 
@@ -290,10 +291,10 @@ werken en de controle valt om.
 |---|---|---|---|
 | `relay/relay.js` | `MAX_BLOB` | `5242880` | de enige instelbare bovengrens per blob, 5 MB; niet in enige compose environment-blok, dus in productie altijd deze |
 | `relay/relay.js` | `readBody` | `MAX_BLOB * 2` | de werkelijke globale body-grens, 10 MB; afgeleid, niet los instelbaar |
-| `relay/relay.js` | `BLOB_SIZE_MB` | `5` | de RAM-bewaking rekent met 5 MB per slot; verhoog MAX_BLOB en deze blijft staan |
+| `relay/relay.js` | `BLOB_SIZE_MB` | `5 x2` | de RAM-bewaking rekent met 5 MB per slot; verhoog MAX_BLOB en deze blijft staan |
 | `relay/relay.js` | `ANON_MAX` | `5 * 1024 * 1024` | eigen 5 MB voor de anonieme route, niet van MAX_BLOB afgeleid |
 | `relay/relay.js` | `TRIAL_MAX_SIZE` | `5 * 1024 * 1024` | eigen 5 MB voor de proefroute, niet van MAX_BLOB afgeleid |
-| `relay/lib/tiers.js` | `file_mb` | `: 5,` | driemaal 5 MB in de tarieftabel, met een commentaar dat zegt dat het MAX_BLOB spiegelt |
+| `relay/lib/tiers.js` | `file_mb` | `: 500, x3` | de tarieftabel verkoopt 500 MB per bestand; sinds d8bf7a71 is dit bewust niet meer hetzelfde getal als MAX_BLOB, en het bestand zegt dat er zelf bij |
 | `frontend/js/parashare.page.js` | `LINK_MAX_BLOB` | `5 * 1024 * 1024` | dezelfde 5 MB, nu in de browser |
 | `extensions/shared/paramant-core.js` | `PADDED_BLOCK` | `5 * 1024 * 1024` | hier is 5 MB wel een blokgrootte en geen grens; dit is de opvulling |
 | `relay/lib/qes/pades.js` | `DEFAULT_CONTENTS_BYTES` | `16384` | de echte reserveringsgrootte in het PDF-handtekeningveld; geen grens |
@@ -305,11 +306,11 @@ werken en de controle valt om.
 | `relay/relay.js` | `COMMUNITY_KEY_LIMIT` | `5` | vaste licentiegrens, bewust niet instelbaar |
 | `relay/lib/auth-throttle.js` | `FAIL_THRESHOLD` | `10` | aantal mislukkingen voor de vertraging inzet; staat ook in admin/lib/login-ratelimit.js |
 | `relay/lib/redis-deadline.js` | `DEFAULT_DEADLINE_MS` | `1000` | geexporteerde constante; de functie ernaast geeft een los getypte 1000 terug |
-| `relay/envelope.js` | `DEFAULT_TTL_DAYS` | `30` | bewaartermijn van een envelop; parasign-store telt zijn eigen 30 dagen |
+| `relay/envelope.js` | `DEFAULT_TTL_DAYS` | `30 x2` | bewaartermijn van een envelop; parasign-store telt zijn eigen 30 dagen |
 | `relay/lib/entitlements.js` | `ENTERPRISE_MONTHLY_CEILING` | `1_000_000` | wat onbeperkt in de praktijk betekent |
 | `admin/lib/audit.js` | `AUDIT_RETENTION_DAYS` | `400` | bewaartermijn van het auditlog; ongecontroleerde parseInt, 0 wist het log |
 | `admin/server.js` | `RELAY_HEALTH` | `3005` | terugvalpoort voor de health-relay; compose luistert op 3000 |
-| `frontend/crypto-bridge.js` | `WASM_SHA256` | `3a5b1a2b` | integriteitspin op de wasm-module |
+| `frontend/crypto-bridge.js` | `WASM_SHA256` | `30f1ae35` | integriteitspin op de wasm-module; verandert bij elke herbouw |
 | `deploy/deploy-3.1.sh` | `EXPECT_VERSION` | `3.1.0` | welke versie de deploy verwacht aan te treffen; niet instelbaar |
 | `deploy/deploy-3.1.sh` | `EXPECT_PROD_COMMIT` | `41501bb` | de startcommit uit het draaiboek |
 | `install.sh` | `PARAMANT_VERSION` | `v3.0.0` | welke tag de zelf-installateur kloont; een minor achter op de deploy |

--- a/deploy/knoppen.md
+++ b/deploy/knoppen.md
@@ -1,0 +1,342 @@
+# Elke knop op een plek
+
+Wat het gedrag van Paramant verandert staat hier, of in `deploy/.env.example`. Nergens anders.
+
+- **97 omgevingsvariabelen** die de relay en de admin lezen staan in
+  [`.env.example`](.env.example), met per naam een uitleg en een `read in:`-regel.
+  `tests/env-documented.test.mjs` bewaakt dat bestand en faalt als een naam er niet in staat.
+- **162 knoppen** staan hieronder: alles wat die poort niet ziet.
+  `tests/knoppen-compleet.test.mjs` bewaakt deze pagina op dezelfde manier.
+
+Samen zijn dat twee bestanden. Dat is een meer dan een, en de reden is dat `.env.example`
+al bestaat, al bewaakt wordt en al gebruikt wordt om een `.env` mee te vullen. Deze pagina
+herhaalt hem niet, hij vult hem aan.
+
+Gemeten op 2026-09-05. Bevindingen zijn gelabeld: *bevestigd* als ik de bron zag,
+*waarschijnlijk* als ik hem afleidde, *vermoeden* als hij nog te toetsen is.
+
+## Waarom deze pagina bestaat
+
+Vijf dingen die in een nacht boven kwamen, en die geen van alle in een lijst stonden.
+
+1. Een geheugengrens van 5 MB, vijf keer los opgeschreven in de relay en nog eens drie keer
+   in de browser en de extensie. Een ervan is instelbaar, de rest niet. Wie `MAX_BLOB`
+   verhoogt, verhoogt vier van de acht.
+2. Een grens per bestand die de opvulgrootte bleek te zijn. `PADDED_BLOCK` in de extensie
+   is echt een blok; `MAX_BLOB` in de relay is echt een grens; ze zijn allebei 5 MB en ze
+   staan nergens naast elkaar. *Bevestigd:* er wordt in de relay niets opgevuld, ondanks
+   wat `/health` erover zegt (`relay/relay.js:3177`, `padding: '5MB fixed (DPI-masking)'`).
+3. Een nginx-limiet die nergens in de repo stond. *Bevestigd door meting:* productie
+   accepteert 10485760 bytes en weigert 10486000 met een 413 van nginx, op alle vijf de
+   hosts. Geen enkel bestand in deze repo zegt `10m`. De conf die de vijf hosts bedient
+   zet helemaal geen `client_max_body_size` (zie de nginx-tabel), en nginx valt dan stil
+   terug op zijn eigen 1 MB. De 10 MB komt dus van een http-blok op de server zelf,
+   buiten git. *Waarschijnlijk:* dat is met de hand ingetypt, net als de vijf
+   `limit_req_zone`-regels waarvoor `deploy/nginx/snippets/paramant-limit-req.conf` in
+   dezelfde situatie is aangelegd.
+4. Een schakelaar voor de zelftest die uit stond. `HEARTBEAT_ENABLED` is een
+   repository-variabele die niet bestaat, dus het uurlijkse `cron` draait, slaat de taak
+   over, en de run kleurt groen.
+5. Vijf relays met elk een eigen instelling, waarvan drie nooit iets deden. Zie
+   de meting van 5 september: vijf relays, een echte.
+
+## Wat stil terugvalt
+
+De gevaarlijkste knop is de knop die je niet hoort als hij ontbreekt. Deze doen dat.
+
+| knop | waar | wat er stil gebeurt |
+|---|---|---|
+| `client_max_body_size` | `deploy/nginx-paramant-public.conf`, `nginx-selfhost.conf`, `deploy/nginx/addin.paramant.app.conf` | nginx neemt zijn eigen 1 MB, zonder waarschuwing. Dit is hoe de limiet onzichtbaar werd |
+| `HEARTBEAT_ENABLED` | `.github/workflows/heartbeat.yml:56` | de variabele bestaat niet, de taak slaat over, de run is groen |
+| `FLEET_LIVE` | `tests/verify-knows-the-fleet.test.mjs:320` | de test die de gepinde sleutels tegen de live relays houdt, staat in geen enkele workflow en heeft dus nooit gedraaid |
+| `CLEVERBASE_SANDBOX` | `tests/qes-cleverbase-live.test.mjs:31` | de hele QES-suite slaat over, overal |
+| `RELAY_SELF_URL` | `relay/relay.js:114` | `registerSelf()` keert meteen terug, zonder logregel. Federatie is uit en niets zegt het |
+| `RELAY_PRIMARY_URL` | `relay/relay.js:115` | valt terug op `http://localhost:PORT`: de relay meldt zich bij zichzelf aan over loopback en logt dat als succes |
+| `RELAY_MODE` | `relay/relay.js:108` en `:109` | afwezig betekent `full`, ongeldig betekent `ghost_pipe`. De setup-wizard schrijft `RELAY_MODE=domain`, wat ongeldig is: na de eerstvolgende herstart staat de relay in `ghost_pipe` |
+| `PARASIGN_STORE_KEY` | `relay/relay.js:1620` | een waarschuwing bij het opstarten, daarna een opslag in het geheugen; getekende documenten verdwijnen bij elke herstart |
+| `REDIS_URL` | `relay/relay.js:85` | geen client, alles valt terug op maps in het proces; de vlootbrede limiet wordt per container |
+| `CT_FILE` | `relay/relay.js:361` | het transparantielog staat alleen in het geheugen en is bij een herstart weg; `CT_MAX_SIZE` wordt daarmee dode configuratie |
+| `INTERNAL_AUTH_TOKEN` | `admin/server.js:515` | de admin stuurt een lege `X-Internal-Auth` mee en wordt door de relay geweigerd; `ADMIN_TOKEN` ernaast stopt het proces wel |
+| `MONEYBIRD_TOKEN` | `relay/lib/moneybird.js:140` | de planner start niet, er komt geen timer en geen logregel |
+| `PARASIGN_QES_PROVIDER` | `relay/lib/qes/index.js:26` | een typefout wordt tot leeg gemaakt en zet QES uit in plaats van te klagen |
+| `QES_TSA_URL=""` | `relay/lib/qes/index.js:129` | de test is `!== undefined`, dus een lege waarde zet tijdstempels uit in plaats van terug te vallen |
+| `AUDIT_RETENTION_DAYS=0` | `admin/lib/audit.js:10` | ongecontroleerde `parseInt`: de eerstvolgende schrijfactie wist het hele auditlog |
+| `RESEND_API_KEY` | `relay/relay.js:1740`, `admin/server.js:86` | elke mail geeft stil `false`; een aanmelding die zijn bevestigingslink nooit verstuurt ziet er geslaagd uit |
+
+## Wat op twee plekken staat
+
+*Bevestigd, alle regels nagelopen in de bron.*
+
+| waarde | plek A | plek B | staat het uiteen? |
+|---|---|---|---|
+| 5 MB | `MAX_BLOB` `relay/relay.js:105` | `BLOB_SIZE_MB` `:1339`, `ANON_MAX` `:5360`, `TRIAL_MAX_SIZE` `:5545`, `tiers.js:47,56,65`, `parashare.page.js:829`, `paramant-core.js:30` | acht kopieen, een instelbaar |
+| sector naar poort | `admin/server.js:40-44` (3000/3005/3002/3003/3004) | `docker-compose.yml:311-315` (alle vijf 3000) | **ja, vier van vijf** |
+| `RELAY_HEALTH` | `admin/server.js:41` → `:3005` | poort 3005 bestaat nergens in de repo | **ja** |
+| `nginx-selfhost.conf` | de kopie in de wortel: geen bodygrens, `inbound` 10r/m | `deploy/nginx-selfhost.conf`: 35M, `inbound` 5r/m | **ja, twee bestanden met dezelfde naam** |
+| `install.sh` | de kopie in de wortel, 535 regels | `frontend/install.sh`, 466 regels, dit is de kopie die op paramant.app staat | **ja, 111 regels verschil** |
+| admin-paneel JS | `admin/public/app.js`, 895 regels | `frontend/js/admin.page.js`, 742 regels | **ja, 343 regels verschil** |
+| versie | `deploy/deploy-3.1.sh:121` `3.1.0` | `install.sh:24` `v3.0.0`, `.env.example` `v3.0.0` | **ja** |
+| standaardwaarden | `admin/lib/config-schema.js` (25 sleutels) | `deploy/.env.example` | **ja, drie**, zie de tabel afwijkingen |
+| MFA-vertraging 10 / 300000 | `relay/lib/auth-throttle.js:24,26` | `admin/lib/login-ratelimit.js:150-152` | nee, gepind door `tests/redis-deadline-parity.test.mjs` |
+| tarieftabel | `relay/lib/tiers.js` | `frontend/js/quota-upgrade.js:54-57` | nee, gepind door `relay/test/quota-upgrade-render.test.js` |
+| tarieven in proza | dezelfde getallen | `frontend/pricing.html:278,469,490`, `admin/server.js:95` | **ja, niet gepind** |
+| planwoordenschat | `admin/lib/cli-commands.js:60` `free\|pro\|enterprise` | overal elders `community\|pro\|business\|enterprise` | **ja** |
+| ondertekenrelay | `sign-flow.js:23`, `co-sign.js:25` → health | `parasign-verify.js:10` → relay | **ja, tekenen en controleren wijzen naar verschillende relays** |
+| 1000 ms | `DEFAULT_DEADLINE_MS` `redis-deadline.js:59` | de functie ernaast geeft een los getypte `1000`, en `totp.js:120` een derde | **ja, de geexporteerde constante is niet degene die gebruikt wordt** |
+
+## Wat in productie staat, publiek vastgesteld
+
+*Bevestigd, zelf gemeten op 2026-09-05 vanaf buiten. Productie is niet aangeraakt.*
+
+| knop | gemeten waarde | hoe |
+|---|---|---|
+| versie | `3.1.0` op alle vijf | `/health` |
+| edition | `licensed`, op naam van paramant.app, tot 2027-01-01 | `/health` |
+| `SECTOR` | `relay`, `health`, `legal`, `finance`, `iot` | `/health` |
+| nginx bodygrens | **10485760 bytes**, identiek op alle vijf | POST van 10485760 geeft 405, van 10486000 een 413 met `server: nginx` |
+| voorschakeling | er staat een Caddy voor nginx | `via: 1.1 Caddy` in de antwoordkop |
+| `limit_req` op `/health` | geen | veertig verzoeken achter elkaar, alle veertig 200 |
+| `MAX_BLOB` | niet vast te stellen | de sleutelcontrole komt voor de groottecontrole; `/v2/inbound` geeft 401 voor elke bodygrootte |
+
+## Omgevingsvariabelen buiten `relay/` en `admin/`
+
+`tests/env-documented.test.mjs` leest alleen die twee mappen. Deze worden gelezen in
+`frontend/`, `scripts/`, `tests/`, `extensions/`, `monitoring/`, `bron-seo/` en
+`crypto-wasm/`, en staan in geen enkel `.env.example`.
+
+<!-- knoppen:env-buiten -->
+
+| naam | gelezen in | standaard | wat hij doet |
+|---|---|---|---|
+| `ADMIN_URL` | `scripts/dev-local-proxy.js` | `'http://127.0.0.1:4200'` | waar de dev-proxy de admin zoekt |
+| `APP_SHOTS_ONLY` | `scripts/app-shots.mjs` | geen | beperkt de schermafdrukronde tot de app-paginas |
+| `CHECK_EXTERNAL_LINKS` | `tests/links.test.mjs` | geen | zet de externe-linkcontrole aan; staat alleen aan in heartbeat.yml, en die workflow is uit |
+| `CLEVERBASE_SANDBOX` | `tests/qes-cleverbase-live.test.mjs` | `test op '1'` | zet de live QES-suite aan; staat in geen enkele workflow, draait dus nergens |
+| `DEV_PORT` | `scripts/dev-local-proxy.js` | `'8080'` | poort van de dev-proxy |
+| `FLEET_LIVE` | `tests/verify-knows-the-fleet.test.mjs` | geen | zet de test aan die de gepinde sleutels tegen de live relays houdt; staat in geen enkele workflow, draait dus nergens |
+| `GITHUB_RUN_ID` | `scripts/heartbeat/lib.mjs`, `scripts/heartbeat/run.mjs` | geen | runnummer in het heartbeat-bewijs |
+| `GITHUB_SHA` | `scripts/heartbeat/lib.mjs` | geen | commit in het heartbeat-bewijs |
+| `GITHUB_STEP_SUMMARY` | `scripts/heartbeat/run.mjs` | geen | pad waar de heartbeat zijn samenvatting schrijft |
+| `HEARTBEAT_DRY_RUN` | `scripts/heartbeat/lib.mjs` | `test op '1'` | heartbeat meet wel, meldt niet |
+| `HEARTBEAT_EVIDENCE_DIR` | `scripts/heartbeat/lib.mjs` | `'heartbeat-evidence'` | map waar het heartbeat-bewijs landt |
+| `HEARTBEAT_SLOW_MS` | `scripts/heartbeat/lib.mjs` | `2500` | drempel waarboven een heartbeat-stap traag heet |
+| `HEARTBEAT_SLOW_SIGN_MS` | `scripts/heartbeat/lib.mjs` | `15000` | zelfde drempel, maar voor het tekenpad |
+| `HEARTBEAT_TEST_SECRET` | `tests/heartbeat-lib.test.mjs` | geen | fixture, wordt door de test zelf gezet en weer weggehaald |
+| `PARAMANT_BASE_URL` | `scripts/heartbeat/lib.mjs`, `tests/links.test.mjs` en 1 meer | `'https://paramant.app'` | welke site de heartbeat en de linkcontrole meten |
+| `PARAMANT_COSIGN_SCREENSHOT_PATH` | `tests/cosign-document-delivery.test.mjs` | geen | pad waar een test zijn schermafdruk neerzet; leeg betekent geen afdruk |
+| `PARAMANT_DASHBOARD_DETAIL_SCREENSHOT_PATH` | `tests/user-dashboard-documents.test.mjs` | geen | pad waar een test zijn schermafdruk neerzet; leeg betekent geen afdruk |
+| `PARAMANT_DASHBOARD_SCREENSHOT_PATH` | `tests/user-dashboard-documents.test.mjs` | geen | pad waar een test zijn schermafdruk neerzet; leeg betekent geen afdruk |
+| `PARAMANT_FRONTEND` | `scripts/ui-contrast-sweep.mjs` | geen | welke frontendmap de contrastveger leest |
+| `PARAMANT_HOME_IN_SCREENSHOT_DIR` | `tests/signed-in-home.test.mjs` | `''` | pad waar een test zijn schermafdruk neerzet; leeg betekent geen afdruk |
+| `PARAMANT_HOME_SCREENSHOT_PATH` | `tests/navigation-shell.test.mjs` | geen | pad waar een test zijn schermafdruk neerzet; leeg betekent geen afdruk |
+| `PARAMANT_INTERNAL_AUTH_TOKEN` | `scripts/heartbeat/surface.mjs` | `''` | zonder dit token bewijst de heartbeat alleen dat de diepe gezondheidspoort dicht zit, niet wat erachter zit; ontbreekt in de repo-secrets |
+| `PARAMANT_OPERATOR_IPS` | `scripts/access-log-visitors.mjs` | `''` | welke IP-adressen niet als bezoeker tellen in de toegangslogtelling |
+| `PARAMANT_PLACE_SHOT_DIR` | `tests/sign-place-toolbar.test.mjs` | geen | pad waar een test zijn schermafdruk neerzet; leeg betekent geen afdruk |
+| `PARAMANT_RELAY_URL` | `scripts/heartbeat/lib.mjs` | `'https://relay.paramant.app'` | welke relay de heartbeat aanspreekt |
+| `PARAMANT_SCREENSHOT_PATH` | `tests/developer-parasign-dashboard.test.mjs` | geen | pad waar een test zijn schermafdruk neerzet; leeg betekent geen afdruk |
+| `PARAMANT_SETTINGS_SCREENSHOT_PATH` | `tests/navigation-shell.test.mjs` | geen | pad waar een test zijn schermafdruk neerzet; leeg betekent geen afdruk |
+| `PARAMANT_SIGN_SCREENSHOT_PATH` | `tests/sign-invite-delivery.test.mjs` | geen | pad waar een test zijn schermafdruk neerzet; leeg betekent geen afdruk |
+| `PARAMANT_SWEEP_PROGRESS` | `scripts/ui-contrast-sweep.mjs` | geen | voortgangsregels tijdens de contrastveger |
+| `PLAYWRIGHT_CHROMIUM_PATH` | `scripts/shot-dashboard.mjs`, `scripts/ui-contrast-sweep.mjs` en 35 meer | geen | pad naar de browser voor elke Playwright-test |
+| `RECEIPT_SHOTS_DIR` | `tests/receipt-verify.test.mjs` | `''` | pad waar een test zijn schermafdruk neerzet; leeg betekent geen afdruk |
+| `RELAY_URL` | `scripts/dev-local-proxy.js` | `'http://127.0.0.1:3001'` | waar de dev-proxy de relay zoekt |
+| `SHOT_LABEL` | `scripts/shot-dashboard.mjs` | geen | label onder een schermafdruk |
+| `TMPDIR` | `tests/parasend-send-a-link.test.mjs` | `'/tmp'` | werkdir voor een tijdelijk bestand in de test |
+
+## Knoppen in de schelp
+
+De vorm `${VAR:-standaard}` in `deploy/` en `scripts/`: alles wat een operator kan
+overschrijven zonder de code aan te raken.
+
+<!-- knoppen:shell -->
+
+| naam | gelezen in | standaard | wat hij doet |
+|---|---|---|---|
+| `BACKUP_DIR` | `scripts/cli/paramant-backup.sh`, `scripts/rollback-3.0.0.sh` | `/var/log/paramant/backups` / `/home/paramant/backups` | back-upmap van de relay-CLI en van het terugrolscript |
+| `BACKUP_ROOT` | `deploy/ops/backup-full-state.sh`, `deploy/ops/restore-full-state.sh` | `/home/paramant/backups/full-state` / `$WORK` | waar de volledige-staatback-up landt |
+| `CASE` | `scripts/paramant-legal.sh` | `untagged` | dossiernummer in het juridische script |
+| `COMPOSE_CMD` | `scripts/cli/paramant-logs.sh`, `scripts/cli/paramant-restart.sh` | `docker compose` | welk compose-commando de CLI gebruikt |
+| `COMPOSE_DIR` | `scripts/rollback-3.0.0.sh` | `/home/paramant/app` | waar het terugrolscript het compose-bestand zoekt; wijkt af van het deployscript |
+| `CONFIRM` | `install.sh` | `Y` | slaat de bevestigingsvraag van de installateur over |
+| `DEPLOY_REF` | `deploy/deploy-3.1.sh` | `origin/main` | welke tak de deploy uitrolt |
+| `DEV_EMAIL` | `scripts/dev-local.sh` | `dev@localhost` | welk adres de lokale ontwikkelstack aanmaakt |
+| `DISPLAY` | `install.sh` | leeg | omgevingsherkenning, geen Paramant-knop |
+| `DOMAIN` | `deploy/docker-entrypoint.sh`, `install.sh` | `localhost` | domein in de nginx-entrypoint van een container die niet in compose staat |
+| `DRYRUN_OUT` | `deploy/ops/backup-full-state.sh` | `$WORK/out` | waar een proefback-up naartoe schrijft |
+| `EXPECT_PROD_COMMIT` | `deploy/deploy-3.1.sh` | `41501bb` | de vaste startcommit uit het draaiboek, gebruikt als er geen marker is |
+| `GITHUB_ACTIONS` | `scripts/check-test-declarations.sh` | leeg | omgevingsherkenning, geen Paramant-knop |
+| `HEALTH_URL` | `scripts/rollback-3.0.0.sh` | `http://127.0.0.1:3000/health` | welke URL het terugrolscript als gezond beschouwt |
+| `KEYFILE` | `deploy/ops/backup-full-state.sh`, `deploy/ops/restore-full-state.sh` | `/root/.config/paramant-backup/key.txt` | sleutelbestand waarmee de back-up versleuteld wordt |
+| `LATEST_ENV` | `scripts/rollback-3.0.0.sh` | leeg | welk env-bestand het terugrolscript terugzet |
+| `LC_ALL` | `scripts/check-commit-style.sh` | `C.UTF-8` | omgevingsherkenning, geen Paramant-knop |
+| `LE_EMAIL` | `install.sh` | `(n/a in localhost mode)` | adres voor Let's Encrypt |
+| `LOG` | `deploy/deploy-3.1.sh`, `deploy/ops/backup-full-state.sh` | `<none>` / `/var/log/paramant-backup.log` | logbestand van de deploy en van de back-up |
+| `MANIFEST` | `scripts/rollback-3.0.0.sh` | leeg | manifest dat het terugrolscript leest |
+| `MNT` | `scripts/paramant-export.sh` | `(not mounted)` | koppelpunt in het exportscript |
+| `MOUNTED_AT` | `scripts/paramant-export.sh` | leeg | waar het exportscript denkt gekoppeld te zijn |
+| `NATS_MONITOR_URL` | `scripts/cli/paramant-nats-status.sh` | `http://nats:8222` | waar de NATS-status wordt opgehaald |
+| `PARAMANT_API_KEY` | `scripts/paramant-cra.sh`, `scripts/paramant-firmware.sh` en 5 meer | `$(python3 -c "import json; print(json.load(open('${CFG` | sleutel voor de losse sectorscripts |
+| `PARAMANT_APP` | `scripts/security/audit.sh` | `https://paramant.app` | welke site het beveiligingsauditscript meet |
+| `PARAMANT_BACKUP_DIR` | `deploy/deploy-3.1.sh` | `/home/paramant/backups` | waar de deploy zijn back-ups zet |
+| `PARAMANT_BACKUP_SOURCES` | `deploy/ops/backup-full-state.sh` | leeg | welke paden de volledige-staatback-up meeneemt |
+| `PARAMANT_CI_WAIT_SECONDS` | `deploy/deploy-3.1.sh` | `900` | hoe lang de deploy op een lopende CI wacht |
+| `PARAMANT_COMPOSE_DIR` | `deploy/deploy-3.1.sh` | `/opt/paramant-relay` | waar het compose-bestand op de server staat |
+| `PARAMANT_DEPLOYED_HEAD_FILE` | `deploy/deploy-3.1.sh` | `$BACKUP_DIR/deployed-head` | het bestand waarin de deploy zijn eigen commit vastlegt |
+| `PARAMANT_DIR` | `install.sh` | `/opt/paramant` | installatiemap van de zelf-installateur |
+| `PARAMANT_DOCROOT` | `deploy/deploy-3.1.sh`, `scripts/check-prod-drift.sh` | `/home/paramant/app` | waar de frontend op de server staat |
+| `PARAMANT_DOMAIN` | `install.sh` | `${1:-` | domein waarvoor de installateur een certificaat vraagt |
+| `PARAMANT_EXPECTED_HEAD` | `deploy/deploy-3.1.sh` | leeg | welke commit op de server verwacht wordt voor de deploy begint |
+| `PARAMANT_LIMIT_REQ_DEST` | `deploy/deploy-3.1.sh` | `/etc/nginx/conf.d/paramant-limit-req.conf` | waar het snelheidslimiet-snippet heen gaat |
+| `PARAMANT_NGINX_CONFS` | `deploy/deploy-3.1.sh` | `paramant-public.conf paramant-live.conf\|paramant.conf` | welke nginx-bestanden op de server het deployscript patcht |
+| `PARAMANT_PRIMARY` | `scripts/paramant-scan.sh` | `https://health.paramant.app` | welke relay het scanscript als hoofdrelay neemt |
+| `PARAMANT_PROD_HOST` | `deploy/deploy-3.1.sh`, `scripts/check-prod-drift.sh` | staat in `deploy/deploy-3.1.sh:46` | de productieserver waar het deployscript op inlogt; het adres staat hardgecodeerd in het script en wordt hier niet herhaald |
+| `PARAMANT_PROD_KEY` | `deploy/deploy-3.1.sh`, `scripts/check-prod-drift.sh` | `$HOME/.ssh/paramant_prod_claude` | de ssh-sleutel voor die server |
+| `PARAMANT_RECEIVER` | `scripts/paramant-firmware.sh`, `scripts/paramant-ticket.sh` | `paramant-receiver` | ontvangeridentiteit in de sectorscripts |
+| `PARAMANT_RELAY` | `scripts/security/audit.sh` | `https://relay.paramant.app` | welke relay datzelfde script meet |
+| `PARAMANT_REPO` | `scripts/security/audit.sh` | `$HOME/paramant-relay` | welke repo dat script leest |
+| `PARAMANT_REQUIRED_WORKFLOWS` | `deploy/deploy-3.1.sh` | `test.yml csp-inline-check.yml sign-e2e.yml product-heartbeat` | welke CI-workflows groen moeten zijn voor de deploy start |
+| `PARAMANT_SENDER` | `scripts/paramant-cra.sh`, `scripts/paramant-firmware.sh` en 5 meer | `paramant-sender` | afzenderidentiteit in de sectorscripts |
+| `PARAMANT_SMOKE_API_KEY` | `deploy/deploy-3.1.sh` | leeg | sleutel voor de rooktest na de deploy |
+| `PARAMANT_TMPDIR` | `scripts/paramant-cra.sh`, `scripts/paramant-crypto-audit.sh` en 3 meer | `/run/paramant-tmp` | werkmap van de sectorscripts |
+| `PARAMANT_VERIFY_HEAD` | `deploy/deploy-3.1.sh` | leeg | welke commit --verify-only controleert |
+| `PARAMANT_VERIFY_HTTP_RETRIES` | `scripts/post-deploy-verify.sh` | `1` | hoe vaak de nacontrole een HTTP-meting herhaalt |
+| `PARAMANT_VERIFY_HTTP_RETRY_DELAY` | `scripts/post-deploy-verify.sh` | `3` | seconden tussen die herhalingen |
+| `POSTURE_CURL` | `scripts/security/posture.sh` | `curl` | vervangt curl in de beveiligingsmeting; de zelftest zet er een stub voor in de plaats |
+| `POSTURE_CURL_TIMEOUT` | `scripts/security/posture.sh` | `20` | hoe lang die meting op een antwoord wacht |
+| `POSTURE_DIG` | `scripts/security/posture.sh` | `dig` | idem voor dig |
+| `POSTURE_NPM` | `scripts/security/posture.sh` | `npm` | idem voor npm |
+| `POSTURE_OPENSSL` | `scripts/security/posture.sh` | `openssl` | idem voor openssl |
+| `PREV_HEAD` | `deploy/deploy-3.1.sh` | `$EXPECT_PROD_COMMIT` | de commit waar naar terug wordt gerold |
+| `REDIS_CONTAINER` | `deploy/ops/backup-full-state.sh`, `deploy/ops/restore-full-state.sh` | `paramant-relay-redis` | welke container de back-up als Redis beschouwt |
+| `REDIS_SRC_DIR` | `deploy/ops/backup-full-state.sh` | leeg | waar de Redis-bestanden vandaan komen |
+| `REGISTRY` | `scripts/paramant-cra.sh` | `none` | containerregister in het CRA-script |
+| `RELAY_FILTER` | `deploy/ops/backup-full-state.sh` | `relay` | op welke naam de back-up relay-containers herkent |
+| `RELAY_LOCAL` | `scripts/post-deploy-verify.sh` | `<not provided>` | lokale relay-URL voor de nacontrole; zonder deze slaat de diepe gezondheidscontrole over |
+| `RELAY_SECTORS` | `scripts/cli/paramant-doctor.sh`, `scripts/cli/paramant-relay-list.sh` | `primary=${RELAY_URL:-http://localhost:3000` | sectorlijst voor de relay-CLI |
+| `RELAY_URL` | `scripts/cli/paramant-audit-recent.sh`, `scripts/cli/paramant-backup.sh` en 4 meer | `http://localhost:3000` | nog niet beschreven |
+| `RETAIN_DAYS` | `deploy/ops/backup-full-state.sh` | `30` | hoe lang back-ups blijven staan |
+| `SBOM` | `scripts/paramant-cra.sh` | `none` | pad naar de stuklijst in het CRA-script |
+| `SECTORS_INPUT` | `install.sh` | `health legal finance iot` | welke sectoren de installateur vraagt; het antwoord wordt nergens gebruikt, compose start altijd alle vijf |
+| `VERSION_ID` | `install.sh` | leeg | omgevingsherkenning, geen Paramant-knop |
+| `WAYLAND_DISPLAY` | `install.sh` | leeg | omgevingsherkenning, geen Paramant-knop |
+| `XTERM_VERSION` | `scripts/paramant-update-vendor.sh` | `5` | omgevingsherkenning, geen Paramant-knop |
+
+## nginx
+
+Zeven conf-bestanden. **Geen enkel script installeert er een**, op
+`deploy/nginx/snippets/paramant-limit-req.conf` na: `deploy/deploy-3.1.sh` fase 5c patcht
+de bestanden die al op de server staan, met `awk` en `sed` op ankerregels. De confs in
+deze repo zijn dus een verslag en geen bron. *Bevestigd:* het enige `cp` van een conf in
+het hele deployscript is een back-up (`deploy/deploy-3.1.sh:1775`).
+
+`afwezig` is hier een waarde en geen leegte. Een ontbrekende `client_max_body_size` laat
+nginx zonder een woord op zijn eigen 1 MB terugvallen, en dat is precies de stilte die
+deze regels doorbreken.
+
+<!-- knoppen:nginx -->
+
+| bestand | richtlijn | waarde |
+|---|---|---|
+| `deploy/nginx-paramant-live.conf` | `client_max_body_size` | `4k / 64k / 16k / 16k / 50M / 30M / 35M` |
+| `deploy/nginx-paramant-live.conf` | `limit_req_zone` | `afwezig` |
+| `deploy/nginx-paramant-live.conf` | `limit_conn` | `afwezig` |
+| `deploy/nginx-paramant-live.conf` | `proxy_read_timeout` | `3600s / 3600s` |
+| `deploy/nginx-paramant-live.conf` | `client_body_timeout` | `afwezig` |
+| `deploy/nginx-paramant-public.conf` | `client_max_body_size` | `afwezig` |
+| `deploy/nginx-paramant-public.conf` | `limit_req_zone` | `afwezig` |
+| `deploy/nginx-paramant-public.conf` | `limit_conn` | `afwezig` |
+| `deploy/nginx-paramant-public.conf` | `proxy_read_timeout` | `3600s / 30s / 3600s / 3600s` |
+| `deploy/nginx-paramant-public.conf` | `client_body_timeout` | `300s` |
+| `deploy/nginx-selfhost.conf` | `client_max_body_size` | `35M / 35M` |
+| `deploy/nginx-selfhost.conf` | `limit_req_zone` | `$binary_remote_addr zone=inbound:10m rate=5r/m / $binary_remote_addr zone=pubkey:10m rate=20r/m / $binary_remote_addr zone=auth:10m rate=10r/m / $binary_remote_addr zone=api:10m rate=60r/m / $binary_remote_addr zone=health_chk:10m rate=6r/m / $binary_remote_addr zone=sign_dpa:1m rate=3r/m` |
+| `deploy/nginx-selfhost.conf` | `limit_conn` | `conn 20` |
+| `deploy/nginx-selfhost.conf` | `proxy_read_timeout` | `10s / 10s / 3600s / 30s / 30s / 15s / 30s / 10s / 30s / 3600s` |
+| `deploy/nginx-selfhost.conf` | `client_body_timeout` | `60s` |
+| `deploy/nginx/addin.paramant.app.conf` | `client_max_body_size` | `afwezig` |
+| `deploy/nginx/addin.paramant.app.conf` | `limit_req_zone` | `afwezig` |
+| `deploy/nginx/addin.paramant.app.conf` | `limit_conn` | `afwezig` |
+| `deploy/nginx/addin.paramant.app.conf` | `proxy_read_timeout` | `afwezig` |
+| `deploy/nginx/addin.paramant.app.conf` | `client_body_timeout` | `afwezig` |
+| `deploy/nginx/snippets/paramant-limit-req.conf` | `client_max_body_size` | `afwezig` |
+| `deploy/nginx/snippets/paramant-limit-req.conf` | `limit_req_zone` | `$binary_remote_addr zone=relay_auth:10m rate=10r/m / $binary_remote_addr zone=api:10m rate=60r/m / $binary_remote_addr zone=relay_inbound:10m rate=5r/m / $binary_remote_addr zone=relay_outbound:10m rate=60r/m / $binary_remote_addr zone=relay_trial:1m rate=3r/m` |
+| `deploy/nginx/snippets/paramant-limit-req.conf` | `limit_conn` | `afwezig` |
+| `deploy/nginx/snippets/paramant-limit-req.conf` | `proxy_read_timeout` | `afwezig` |
+| `deploy/nginx/snippets/paramant-limit-req.conf` | `client_body_timeout` | `afwezig` |
+| `deploy/nginx/snippets/paramant-security-headers.conf` | `client_max_body_size` | `afwezig` |
+| `deploy/nginx/snippets/paramant-security-headers.conf` | `limit_req_zone` | `afwezig` |
+| `deploy/nginx/snippets/paramant-security-headers.conf` | `limit_conn` | `afwezig` |
+| `deploy/nginx/snippets/paramant-security-headers.conf` | `proxy_read_timeout` | `afwezig` |
+| `deploy/nginx/snippets/paramant-security-headers.conf` | `client_body_timeout` | `afwezig` |
+| `nginx-selfhost.conf` | `client_max_body_size` | `afwezig` |
+| `nginx-selfhost.conf` | `limit_req_zone` | `$binary_remote_addr zone=inbound:10m rate=10r/m / $binary_remote_addr zone=api:10m rate=60r/m / $binary_remote_addr zone=health:10m rate=6r/m` |
+| `nginx-selfhost.conf` | `limit_conn` | `conn 20` |
+| `nginx-selfhost.conf` | `proxy_read_timeout` | `10s / 3600s / 3600s` |
+| `nginx-selfhost.conf` | `client_body_timeout` | `afwezig` |
+
+## Constanten die instellingen zijn
+
+Een getal dat bepaalt wat het product doet is een instelling, of hij nu uit de omgeving
+te veranderen is of niet. Deze zijn gepind: verander er een zonder deze pagina bij te
+werken en de controle valt om.
+
+<!-- knoppen:constanten -->
+
+| bestand | naam | waarde | wat hij doet |
+|---|---|---|---|
+| `relay/relay.js` | `MAX_BLOB` | `5242880` | de enige instelbare bovengrens per blob, 5 MB; niet in enige compose environment-blok, dus in productie altijd deze |
+| `relay/relay.js` | `readBody` | `MAX_BLOB * 2` | de werkelijke globale body-grens, 10 MB; afgeleid, niet los instelbaar |
+| `relay/relay.js` | `BLOB_SIZE_MB` | `5` | de RAM-bewaking rekent met 5 MB per slot; verhoog MAX_BLOB en deze blijft staan |
+| `relay/relay.js` | `ANON_MAX` | `5 * 1024 * 1024` | eigen 5 MB voor de anonieme route, niet van MAX_BLOB afgeleid |
+| `relay/relay.js` | `TRIAL_MAX_SIZE` | `5 * 1024 * 1024` | eigen 5 MB voor de proefroute, niet van MAX_BLOB afgeleid |
+| `relay/lib/tiers.js` | `file_mb` | `: 5,` | driemaal 5 MB in de tarieftabel, met een commentaar dat zegt dat het MAX_BLOB spiegelt |
+| `frontend/js/parashare.page.js` | `LINK_MAX_BLOB` | `5 * 1024 * 1024` | dezelfde 5 MB, nu in de browser |
+| `extensions/shared/paramant-core.js` | `PADDED_BLOCK` | `5 * 1024 * 1024` | hier is 5 MB wel een blokgrootte en geen grens; dit is de opvulling |
+| `relay/lib/qes/pades.js` | `DEFAULT_CONTENTS_BYTES` | `16384` | de echte reserveringsgrootte in het PDF-handtekeningveld; geen grens |
+| `relay/lib/parasign-open-api.js` | `PARASIGN_MAX_PDF_BYTES` | `20 * 1024 * 1024` | 20 MB voor de v1-PDF, boven de 10 MB die readBody doorlaat |
+| `relay/relay.js` | `CT_MAX` | `10000` | venster in het geheugen, geteld in regels; niet instelbaar |
+| `relay/relay.js` | `CT_MAX_SIZE` | `100 * 1024 * 1024` | rotatiegrens op schijf, geteld in bytes; wel instelbaar, en dood zonder CT_FILE |
+| `relay/relay.js` | `TTL_MS` | `300000` | standaardlevensduur van een blob, 5 minuten |
+| `relay/relay.js` | `RAM_LIMIT_MB` | `512` | plafond van de RAM-bewaking; compose zet 1024 voor vier relays en 8192 hardgecodeerd voor health |
+| `relay/relay.js` | `COMMUNITY_KEY_LIMIT` | `5` | vaste licentiegrens, bewust niet instelbaar |
+| `relay/lib/auth-throttle.js` | `FAIL_THRESHOLD` | `10` | aantal mislukkingen voor de vertraging inzet; staat ook in admin/lib/login-ratelimit.js |
+| `relay/lib/redis-deadline.js` | `DEFAULT_DEADLINE_MS` | `1000` | geexporteerde constante; de functie ernaast geeft een los getypte 1000 terug |
+| `relay/envelope.js` | `DEFAULT_TTL_DAYS` | `30` | bewaartermijn van een envelop; parasign-store telt zijn eigen 30 dagen |
+| `relay/lib/entitlements.js` | `ENTERPRISE_MONTHLY_CEILING` | `1_000_000` | wat onbeperkt in de praktijk betekent |
+| `admin/lib/audit.js` | `AUDIT_RETENTION_DAYS` | `400` | bewaartermijn van het auditlog; ongecontroleerde parseInt, 0 wist het log |
+| `admin/server.js` | `RELAY_HEALTH` | `3005` | terugvalpoort voor de health-relay; compose luistert op 3000 |
+| `frontend/crypto-bridge.js` | `WASM_SHA256` | `3a5b1a2b` | integriteitspin op de wasm-module |
+| `deploy/deploy-3.1.sh` | `EXPECT_VERSION` | `3.1.0` | welke versie de deploy verwacht aan te treffen; niet instelbaar |
+| `deploy/deploy-3.1.sh` | `EXPECT_PROD_COMMIT` | `41501bb` | de startcommit uit het draaiboek |
+| `install.sh` | `PARAMANT_VERSION` | `v3.0.0` | welke tag de zelf-installateur kloont; een minor achter op de deploy |
+
+## Afwijkingen die mogen blijven staan
+
+`admin/lib/config-schema.js` en `deploy/.env.example` schrijven allebei een standaard op.
+Ze zijn met de hand geschreven en niets vergeleek ze ooit. Drie lopen uiteen. Ze staan
+hier zodat de vierde opvalt. Deze ronde is bewust geen enkele waarde veranderd.
+
+<!-- knoppen:afwijkingen -->
+
+| naam | de twee waarden | waarom hij mag blijven |
+|---|---|---|
+| `RELAY_SELF_URL` | `''` in config-schema.js:46, `https://relay.paramant.app` in .env.example | de schema-waarde is de code-terugval (leeg), de voorbeeldwaarde is wat productie zet; nog niet besloten welke van de twee de standaard heet |
+| `RAM_LIMIT_MB` | `512` in config-schema.js:94, `1024` in .env.example | de code valt terug op 512, compose zet 1024 voor vier relays en 8192 voor health; drie waarden, geen van drie fout, geen van drie de standaard |
+| `NATS_URL` | `''` in config-schema.js, `tls://your-nats-server:4222` in .env.example | de voorbeeldwaarde is een invulplaats, geen standaard; NATS is opt-in en uit |
+
+## Wat hier nog niet in staat
+
+Eerlijk, want een lijst die doet alsof hij compleet is, is de fout die hij moest voorkomen.
+
+- De nginx-conf die werkelijk op de server draait. Niet in git, niet publiek leesbaar.
+  De 10 MB is gemeten, niet gelezen. *Niet vastgesteld* waar hij staat.
+- De Caddy-laag ervoor. Gemeten aan de antwoordkop, verder onbekend.
+- De waarden in `users.json` van legal, finance en iot. Alleen binnen de container leesbaar.
+- De GitHub-secrets en -variabelen. `gh secret list` en `gh variable list` geven de namen,
+  niet de waarden; de vier bestaande secrets zijn Docker Hub en Thunderbird.
+- Poortnummers, `listen`- en `proxy_pass`-regels in de nginx-confs. Die veranderen gedrag,
+  maar de tabel hierboven bewaakt vijf richtlijnen en niet alle. Uitbreiden kan door
+  `WATCHED` in `tests/knoppen-compleet.test.mjs` aan te vullen en deze pagina mee te laten
+  groeien; de controle wijst dan zelf aan wat er ontbreekt.
+- De betekeniskolom is niet overal ingevuld. `nog niet beschreven` staat er waar ik de knop
+  wel vond maar zijn bedoeling niet met zekerheid kon vaststellen. Dat is geen sieraad,
+  het is een openstaande taak.

--- a/deploy/knoppen.md
+++ b/deploy/knoppen.md
@@ -5,7 +5,7 @@ Wat het gedrag van Paramant verandert staat hier, of in `deploy/.env.example`. N
 - **97 omgevingsvariabelen** die de relay en de admin lezen staan in
   [`.env.example`](.env.example), met per naam een uitleg en een `read in:`-regel.
   `tests/env-documented.test.mjs` bewaakt dat bestand en faalt als een naam er niet in staat.
-- **162 knoppen** staan hieronder: alles wat die poort niet ziet.
+- **167 knoppen** staan hieronder: alles wat die poort niet ziet.
   `tests/knoppen-compleet.test.mjs` bewaakt deze pagina op dezelfde manier.
 
 Samen zijn dat twee bestanden. Dat is een meer dan een, en de reden is dat `.env.example`
@@ -114,6 +114,11 @@ De gevaarlijkste knop is de knop die je niet hoort als hij ontbreekt. Deze doen 
 | `CLEVERBASE_SANDBOX` | `tests/qes-cleverbase-live.test.mjs` | `test op '1'` | zet de live QES-suite aan; staat in geen enkele workflow, draait dus nergens |
 | `DEV_PORT` | `scripts/dev-local-proxy.js` | `'8080'` | poort van de dev-proxy |
 | `FLEET_LIVE` | `tests/verify-knows-the-fleet.test.mjs` | geen | zet de test aan die de gepinde sleutels tegen de live relays houdt; staat in geen enkele workflow, draait dus nergens |
+| `GH_TOKEN` | `scripts/guards-live.mjs` | valt terug op `GITHUB_TOKEN`, dan leeg | token waarmee de waarborgcontrole de GitHub-API leest |
+| `GITHUB_OUTPUT` | `scripts/guards-live.mjs` | geen | pad waar de waarborgcontrole zijn uitkomst voor de workflow neerlegt; ontbreekt hij, dan schrijft hij niets en meldt dat niet |
+| `GITHUB_REPOSITORY` | `scripts/guards-live.mjs` | `'Apolloccrypt/paramant-relay'` | welke repo de waarborgcontrole bekijkt |
+| `GITHUB_TOKEN` | `scripts/guards-live.mjs` | `''` | de terugval van `GH_TOKEN` |
+| `GUARDS_ENFORCE` | `scripts/guards-live.mjs` | geen, test op `'1'` | zonder deze meldt de waarborgcontrole een stille waarborg wel, maar kleurt de taak niet rood |
 | `GITHUB_RUN_ID` | `scripts/heartbeat/lib.mjs`, `scripts/heartbeat/run.mjs` | geen | runnummer in het heartbeat-bewijs |
 | `GITHUB_SHA` | `scripts/heartbeat/lib.mjs` | geen | commit in het heartbeat-bewijs |
 | `GITHUB_STEP_SUMMARY` | `scripts/heartbeat/run.mjs` | geen | pad waar de heartbeat zijn samenvatting schrijft |

--- a/tests/knoppen-compleet.test.mjs
+++ b/tests/knoppen-compleet.test.mjs
@@ -1,0 +1,342 @@
+// Every knob that changes how PARAMANT behaves is written down in one place,
+// and this suite is what keeps that place from going stale.
+//
+// deploy/.env.example already covers the environment variables the relay and
+// the admin panel read; tests/env-documented.test.mjs guards that file. It
+// stops at those two directories and at process.env. Measured on 2026-09-05,
+// the knobs it cannot see:
+//
+//   34 environment variables read in frontend/, scripts/, tests/ and
+//      extensions/ that appear in no .env.example, including
+//      PARAMANT_INTERNAL_AUTH_TOKEN, PARAMANT_OPERATOR_IPS and HEARTBEAT_SLOW_MS
+//   68 shell knobs of the form ${VAR:-default} in deploy/ and scripts/, of
+//      which 7 were documented
+//   every nginx directive, in seven conf files, none of which the deploy
+//      script installs whole. Production answers 413 above 10485760 bytes and
+//      no file in this repo says 10m anywhere.
+//   8 places that spell out the same 5 MB, some of them a limit and some of
+//      them the crypto padding block, which is not the same thing
+//   3 defaults that admin/lib/config-schema.js and deploy/.env.example already
+//      disagree about
+//
+// deploy/knoppen.md is that one place. It does not repeat the 97 variables in
+// .env.example, it points at them and covers everything that file cannot.
+//
+// This suite is green on the tree as it stands. It goes red the moment a knob
+// appears, moves or changes value without the registry moving with it. That is
+// the whole point: a list that ages is worse than no list.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const REGISTRY = 'deploy/knoppen.md';
+const ENV_EXAMPLE = 'deploy/.env.example';
+
+const registryText = readFileSync(join(ROOT, REGISTRY), 'utf8');
+
+// ── reading the registry ─────────────────────────────────────────────────────
+// Each table is preceded by an HTML comment marker so the parser never has to
+// guess which heading it is under. A table is rows of `| a | b | c |`.
+function table(marker) {
+  const at = registryText.indexOf(`<!-- knoppen:${marker} -->`);
+  assert.notEqual(at, -1, `${REGISTRY} is missing the marker <!-- knoppen:${marker} -->`);
+  const rest = registryText.slice(at);
+  const rows = [];
+  let started = false;
+  for (const line of rest.split('\n').slice(1)) {
+    if (!line.startsWith('|')) {
+      if (started) break;
+      continue;
+    }
+    started = true;
+    const cells = line.split('|').slice(1, -1).map((c) => c.trim());
+    if (cells.every((c) => /^-*:?-*$/.test(c)) || cells[0] === '') continue;
+    rows.push(cells);
+  }
+  assert.ok(rows.length > 1, `the table at <!-- knoppen:${marker} --> in ${REGISTRY} is empty`);
+  return rows.slice(1); // drop the header row
+}
+
+function stripCode(s) {
+  return s.replace(/^`|`$/g, '').trim();
+}
+
+// ── what the environment documents ───────────────────────────────────────────
+const documented = new Set(
+  [...readFileSync(join(ROOT, ENV_EXAMPLE), 'utf8').matchAll(/^#?\s*([A-Z][A-Z0-9_]*)=/gm)]
+    .map((m) => m[1])
+);
+
+// ── walking the tree ─────────────────────────────────────────────────────────
+const SKIP_DIRS = new Set(['node_modules', '.git', 'pkg', 'dist', 'build', 'coverage', 'target']);
+
+function walk(dir, match, acc = []) {
+  const abs = join(ROOT, dir);
+  if (!existsSync(abs)) return acc;
+  for (const e of readdirSync(abs, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(e.name)) continue;
+    const p = `${dir}/${e.name}`;
+    if (e.isDirectory()) walk(p, match, acc);
+    else if (match.test(e.name)) acc.push(p);
+  }
+  return acc;
+}
+
+// ── K1: environment variables read outside the reach of env-documented ───────
+// env-documented.test.mjs scans relay/ and admin/. Everything else in the repo
+// reads from the environment too, and until now nothing looked.
+const OUTSIDE = ['frontend', 'scripts', 'tests', 'extensions', 'monitoring', 'bron-seo', 'crypto-wasm'];
+const READ = /(?:process\.)?\benv\.([A-Z][A-Z0-9_]*)\b(?!\s*=[^=])/g;
+
+// A comment that explains a variable is not a read of it. tests/env-documented.test.mjs
+// spells out "process.env.X" in prose to describe its own regex; without that, X
+// becomes a knob. Only WHOLE comment lines are dropped, never part of a line: a
+// trailing-comment stripper ate two real reads in tests/user-dashboard-documents.test.mjs,
+// which put `{ path: process.env.PARAMANT_DASHBOARD_SCREENSHOT_PATH }` on a code line.
+function stripComments(src) {
+  return src
+    .split('\n')
+    .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+    .join('\n');
+}
+
+function envReadsOutside() {
+  const found = new Map(); // NAME -> Set(file)
+  for (const dir of OUTSIDE) {
+    for (const f of walk(dir, /\.(js|mjs|cjs)$/)) {
+      for (const m of stripComments(readFileSync(join(ROOT, f), 'utf8')).matchAll(READ)) {
+        if (!found.has(m[1])) found.set(m[1], new Set());
+        found.get(m[1]).add(f);
+      }
+    }
+  }
+  return found;
+}
+
+test('K1 every environment variable read outside relay/ and admin/ is registered', () => {
+  const registered = new Map(table('env-buiten').map((r) => [stripCode(r[0]), r]));
+  const found = envReadsOutside();
+  const missing = [...found.keys()]
+    .filter((n) => !documented.has(n) && !registered.has(n))
+    .sort()
+    .map((n) => `${n}  (read in ${[...found.get(n)].sort().join(', ')})`);
+  assert.deepEqual(missing, [],
+    `Environment variables read outside relay/ and admin/ that neither ${ENV_EXAMPLE} ` +
+    `nor the "env-buiten" table in ${REGISTRY} knows about. Add a row: name, where it ` +
+    'is read, what it does, its default, and what happens when it is absent.');
+});
+
+test('K1b nothing in the env-buiten table has quietly stopped being read', () => {
+  // A registry entry for a variable nothing reads any more is a lie with a
+  // longer shelf life than a missing one.
+  const found = envReadsOutside();
+  const dead = table('env-buiten')
+    .map((r) => stripCode(r[0]))
+    .filter((n) => !found.has(n) && !documented.has(n))
+    .sort();
+  assert.deepEqual(dead, [],
+    `The "env-buiten" table in ${REGISTRY} lists variables that nothing in ` +
+    `${OUTSIDE.join(', ')} reads any more. Remove the rows.`);
+});
+
+// ── K2: shell knobs ──────────────────────────────────────────────────────────
+// The operator-overridable form: ${VAR:-default} or ${VAR:=default}. A bare
+// $VAR is a local variable nine times out of ten and would drown the signal.
+const SHELL_DIRS = ['deploy', 'scripts'];
+const SHELL_FILES = ['install.sh', 'deploy.sh', 'build.sh'];
+const SHELL_KNOB = /\$\{([A-Z][A-Z0-9_]{2,}):[-=]/g;
+
+function shellKnobs() {
+  const found = new Map();
+  const files = [...SHELL_DIRS.flatMap((d) => walk(d, /\.sh$/)), ...SHELL_FILES.filter((f) => existsSync(join(ROOT, f)))];
+  for (const f of files) {
+    for (const m of readFileSync(join(ROOT, f), 'utf8').matchAll(SHELL_KNOB)) {
+      if (!found.has(m[1])) found.set(m[1], new Set());
+      found.get(m[1]).add(f);
+    }
+  }
+  return found;
+}
+
+test('K2 every shell knob an operator can override is registered', () => {
+  const registered = new Set(table('shell').map((r) => stripCode(r[0])));
+  const found = shellKnobs();
+  const missing = [...found.keys()]
+    .filter((n) => !documented.has(n) && !registered.has(n))
+    .sort()
+    .map((n) => `${n}  (in ${[...found.get(n)].sort().join(', ')})`);
+  assert.deepEqual(missing, [],
+    `Shell knobs of the form \${VAR:-default} that neither ${ENV_EXAMPLE} nor the ` +
+    `"shell" table in ${REGISTRY} knows about. Every one of these changes what a ` +
+    'deploy or an operator script does. Add a row, or give it a reason.');
+});
+
+test('K2b nothing in the shell table has quietly disappeared', () => {
+  const found = shellKnobs();
+  const dead = table('shell')
+    .map((r) => stripCode(r[0]))
+    .filter((n) => !found.has(n))
+    .sort();
+  assert.deepEqual(dead, [],
+    `The "shell" table in ${REGISTRY} lists knobs that no script under ` +
+    `${SHELL_DIRS.join(', ')} reads any more. Remove the rows.`);
+});
+
+// ── K3: the two places that both declare defaults ────────────────────────────
+// admin/lib/config-schema.js carries a `default` per key and deploy/.env.example
+// carries a commented-out assignment per key. They are written by hand, in two
+// files, and nothing has ever compared them. Three of them already disagree;
+// those three are named in the registry with a reason, and no fourth may join
+// them silently.
+test('K3 config-schema.js and .env.example agree on every default', async () => {
+  const schema = (await import(join(ROOT, 'admin/lib/config-schema.js'))).default;
+  const exampleText = readFileSync(join(ROOT, ENV_EXAMPLE), 'utf8');
+  const commented = new Map(
+    [...exampleText.matchAll(/^#\s*([A-Z][A-Z0-9_]*)=(.*)$/gm)]
+      .map((m) => [m[1], m[2].trim().replace(/^['"]|['"]$/g, '')])
+  );
+  const known = new Set(table('afwijkingen').map((r) => stripCode(r[0])));
+
+  const drift = [];
+  for (const [name, spec] of Object.entries(schema)) {
+    if (!commented.has(name)) continue; // required, no default to compare
+    const a = String(spec.default);
+    const b = commented.get(name);
+    if (a.trim() !== b.trim() && !known.has(name)) {
+      drift.push(`${name}: config-schema says ${JSON.stringify(a)}, ${ENV_EXAMPLE} says ${JSON.stringify(b)}`);
+    }
+  }
+  assert.deepEqual(drift.sort(), [],
+    'A default is declared twice and the two declarations disagree. Make them match, ' +
+    `or add the name to the "afwijkingen" table in ${REGISTRY} with the reason it may stand.`);
+});
+
+test('K3b every registered exception really is still an exception', async () => {
+  // Keeps the exception list from outliving the exceptions. Once the two files
+  // agree again, the row must go, otherwise it hides the next real drift.
+  const schema = (await import(join(ROOT, 'admin/lib/config-schema.js'))).default;
+  const commented = new Map(
+    [...readFileSync(join(ROOT, ENV_EXAMPLE), 'utf8').matchAll(/^#\s*([A-Z][A-Z0-9_]*)=(.*)$/gm)]
+      .map((m) => [m[1], m[2].trim().replace(/^['"]|['"]$/g, '')])
+  );
+  const stale = table('afwijkingen')
+    .map((r) => stripCode(r[0]))
+    .filter((n) => {
+      if (!(n in schema) || !commented.has(n)) return false;
+      return String(schema[n].default).trim() === commented.get(n).trim();
+    })
+    .sort();
+  assert.deepEqual(stale, [],
+    `The "afwijkingen" table in ${REGISTRY} still excuses defaults that now agree. ` +
+    'Remove the rows so the next real disagreement is visible.');
+});
+
+// ── K4: nginx ────────────────────────────────────────────────────────────────
+// The setting that is absent is the dangerous one. nginx does not warn when
+// client_max_body_size is missing, it silently uses its own built-in 1m. The
+// registry therefore records an absence as a value in its own right, spelled
+// "afwezig", and this test fails on a file that gains one, loses one, or
+// changes what it says.
+const WATCHED = ['client_max_body_size', 'limit_req_zone', 'limit_conn', 'proxy_read_timeout', 'client_body_timeout'];
+
+function nginxConfs() {
+  return walk('.', /\.conf$/).map((p) => p.replace(/^\.\//, '')).sort();
+}
+
+function directiveValues(file, directive) {
+  const src = readFileSync(join(ROOT, file), 'utf8');
+  const re = new RegExp(`^\\s*${directive}\\s+([^;]+);`, 'gm');
+  return [...src.matchAll(re)].map((m) => m[1].trim().replace(/\s+/g, ' '));
+}
+
+test('K4 every nginx conf file in the repo is in the registry', () => {
+  const registered = new Set(table('nginx').map((r) => stripCode(r[0])));
+  const onDisk = nginxConfs();
+  const missing = onDisk.filter((f) => !registered.has(f));
+  const gone = [...registered].filter((f) => !onDisk.includes(f));
+  assert.deepEqual({ missing, gone }, { missing: [], gone: [] },
+    `The "nginx" table in ${REGISTRY} must list exactly the .conf files in the repo. ` +
+    'A new conf file is a new set of knobs and needs its row.');
+});
+
+test('K4b every watched nginx directive matches what the registry records', () => {
+  // Row shape: | file | directive | value |, where value is either the literal
+  // the file declares, several separated by " / ", or the word "afwezig".
+  const wrong = [];
+  for (const row of table('nginx')) {
+    const [file, directive, recorded] = row.map(stripCode);
+    if (!WATCHED.includes(directive)) {
+      wrong.push(`${file}: "${directive}" is not one of the watched directives (${WATCHED.join(', ')})`);
+      continue;
+    }
+    const actual = directiveValues(file, directive);
+    const want = recorded === 'afwezig' ? [] : recorded.split(' / ').map((s) => s.trim());
+    const got = actual.length === 0 ? [] : actual;
+    if (JSON.stringify(want) !== JSON.stringify(got)) {
+      wrong.push(
+        `${file} ${directive}: registry says ${recorded === 'afwezig' ? 'afwezig' : JSON.stringify(want)}, ` +
+        `the file says ${got.length === 0 ? 'afwezig' : JSON.stringify(got)}`
+      );
+    }
+  }
+  assert.deepEqual(wrong, [],
+    `${REGISTRY} and the nginx conf files have come apart. An absent ` +
+    'client_max_body_size is recorded as "afwezig" on purpose: nginx falls back to its ' +
+    'own 1m without saying so, and that silence is what this row is here to break.');
+});
+
+test('K4c every watched directive present in a conf file has a row', () => {
+  // The reverse of K4b: a directive that appears in a file the registry does not
+  // account for is exactly the knob that goes unnoticed.
+  const rows = new Set(table('nginx').map((r) => `${stripCode(r[0])} ${stripCode(r[1])}`));
+  const unrecorded = [];
+  for (const f of nginxConfs()) {
+    for (const d of WATCHED) {
+      if (directiveValues(f, d).length > 0 && !rows.has(`${f} ${d}`)) {
+        unrecorded.push(`${f}: ${d}`);
+      }
+    }
+  }
+  assert.deepEqual(unrecorded.sort(), [],
+    `These nginx directives are set in a conf file and the "nginx" table in ${REGISTRY} ` +
+    'does not mention them.');
+});
+
+// ── K5: constants that are settings ──────────────────────────────────────────
+// A number that decides what the product does is a setting whether or not it
+// can be changed from the environment. Writing the same 5 MB in nine files is
+// how "the limit" and "the padding block" came to look like one thing.
+test('K5 every registered constant still holds the value the registry records', () => {
+  const wrong = [];
+  for (const row of table('constanten')) {
+    const [file, name, value] = row.map(stripCode);
+    if (!existsSync(join(ROOT, file))) {
+      wrong.push(`${file} does not exist (registered for ${name})`);
+      continue;
+    }
+    const src = readFileSync(join(ROOT, file), 'utf8');
+    // The name and the value must occur on the same line: that is what pins the
+    // constant rather than merely proving both strings live in the file.
+    const hit = src.split('\n').some((l) => l.includes(name) && l.includes(value));
+    if (!hit) wrong.push(`${file}: no line carries both ${name} and ${value}`);
+  }
+  assert.deepEqual(wrong, [],
+    `A constant the registry pins has moved or changed. Update the row in ${REGISTRY} ` +
+    'in the same commit as the value, and check the other rows that carry the same ' +
+    'number: several of them are the same figure written down in different files for ' +
+    'different reasons.');
+});
+
+// ── the registry must stay honest about its own size ─────────────────────────
+test('K6 the registry header states how many knobs it accounts for', () => {
+  const counted =
+    table('env-buiten').length + table('shell').length +
+    table('nginx').length + table('constanten').length;
+  const header = registryText.match(/^-\s*\*\*(\d+)\s+knoppen\*\*/m);
+  assert.ok(header, `${REGISTRY} must state how many knobs it accounts for, as "- **N knoppen**"`);
+  assert.equal(Number(header[1]), counted,
+    `${REGISTRY} says ${header && header[1]} knobs and its tables hold ${counted}.`);
+});

--- a/tests/knoppen-compleet.test.mjs
+++ b/tests/knoppen-compleet.test.mjs
@@ -248,7 +248,10 @@ function nginxConfs() {
 
 function directiveValues(file, directive) {
   const src = readFileSync(join(ROOT, file), 'utf8');
-  const re = new RegExp(`^\\s*${directive}\\s+([^;]+);`, 'gm');
+  // Not anchored to the line start: deploy/nginx-paramant-public.conf packs a whole
+  // location block onto one line, so `{ client_max_body_size 12M; proxy_pass ...` has
+  // to count too. A line-anchored regex read those files as having no limit at all.
+  const re = new RegExp(`(?:^|[{;])\\s*${directive}\\s+([^;]+);`, 'gm');
   return [...src.matchAll(re)].map((m) => m[1].trim().replace(/\s+/g, ' '));
 }
 
@@ -318,10 +321,18 @@ test('K5 every registered constant still holds the value the registry records', 
       continue;
     }
     const src = readFileSync(join(ROOT, file), 'utf8');
-    // The name and the value must occur on the same line: that is what pins the
-    // constant rather than merely proving both strings live in the file.
-    const hit = src.split('\n').some((l) => l.includes(name) && l.includes(value));
-    if (!hit) wrong.push(`${file}: no line carries both ${name} and ${value}`);
+    // The name and the value must occur on the SAME line, and as often as the
+    // registry says. Counting matters: relay/lib/tiers.js writes file_mb three
+    // times, and a "does it appear at all" check let one of the three be changed
+    // without a word. A `xN` suffix on the value records how many; no suffix means
+    // exactly one.
+    const m = value.match(/^(.*?)\s*x(\d+)$/);
+    const literal = m ? m[1] : value;
+    const want = m ? Number(m[2]) : 1;
+    const got = src.split('\n').filter((l) => l.includes(name) && l.includes(literal)).length;
+    if (got !== want) {
+      wrong.push(`${file}: ${want} line(s) should carry both ${name} and ${literal}, found ${got}`);
+    }
   }
   assert.deepEqual(wrong, [],
     `A constant the registry pins has moved or changed. Update the row in ${REGISTRY} ` +


### PR DESCRIPTION
## Waarom

Vannacht kwamen vijf instellingen boven die geen van alle in een lijst stonden: een geheugengrens van 5 MB die op acht plekken los is opgeschreven, een grens per bestand die de opvulgrootte bleek te zijn, een nginx-limiet die nergens in de repo staat, een schakelaar voor de zelftest die uit stond, en vijf relays met elk een eigen instelling.

`deploy/.env.example` dekt al 97 omgevingsvariabelen en `tests/env-documented.test.mjs` bewaakt dat bestand. Die poort leest alleen `relay/` en `admin/`, en alleen `process.env`. Alles daarbuiten stond nergens.

## Wat dit toevoegt

**`deploy/knoppen.md`** legt 162 knoppen vast die de bestaande poort niet ziet:

| soort | aantal |
|---|---|
| omgevingsvariabelen in `frontend/`, `scripts/`, `tests/`, `extensions/` | 34 |
| knoppen van de vorm `${VAR:-standaard}` in `deploy/` en `scripts/` | 68 |
| nginx-richtlijnen over zeven conf-bestanden | 35 |
| constanten die geen instelling heten maar het wel zijn | 25 |

Plus drie tabellen die de vragen beantwoorden waar dit mee begon: wat stil terugvalt, wat op twee plekken staat, en wat er publiek in productie gemeten is.

**`tests/knoppen-compleet.test.mjs`** faalt zodra er een knop bijkomt, verschuift of van waarde verandert zonder dat de pagina meebeweegt. Elf controles, groen op de huidige boom, en de reden dat de lijst niet weer achterloopt.

Een ontbrekende richtlijn is daarin een waarde en geen leegte, opgeschreven als `afwezig`. Nginx valt zonder een woord terug op zijn eigen 1 MB, en dat is precies hoe de limiet onzichtbaar werd.

## Wat de meting opleverde

- Productie accepteert 10485760 bytes en weigert 10486000 met een 413 van nginx, identiek op alle vijf de hosts. Geen enkel bestand in deze repo noemt `10m`. De conf die die vijf hosts bedient zet helemaal geen `client_max_body_size`.
- Er staat een Caddy voor nginx, zichtbaar aan `via: 1.1 Caddy`. Die laag staat nergens in de repo.
- Vier van de vijf terugvalpoorten in `admin/server.js:40-44` wijzen naar poorten waar niets luistert; compose zet ze alle vijf op 3000.
- `admin/lib/config-schema.js` en `deploy/.env.example` schrijven allebei standaardwaarden op. Drie lopen uiteen. Ze staan in een aparte tabel zodat de vierde opvalt.

## Sabotagetoets

Acht ingrepen geprobeerd, acht keer rood, daarna weer schoon:

| ingreep | resultaat |
|---|---|
| nieuwe env-var in `scripts/` | rood |
| nieuwe shell-knop | rood |
| `client_max_body_size` toegevoegd aan de publieke conf | rood |
| snelheidszone weggehaald uit het snippet | rood |
| `MAX_BLOB` stil verhoogd | rood |
| vierde standaardwaarde laten uiteenlopen | rood |
| nieuw conf-bestand toegevoegd | rood |
| telling in de kop laten achterlopen | rood |

## Reikwijdte

Geen enkele waarde gewijzigd. Alleen vastleggen en bewaken. `tests/static-sanity.sh` en `tests/env-documented.test.mjs` blijven groen; de nieuwe suite wordt vanzelf opgepikt door `scripts/browser-suites.mjs --no-browser` en draait dus in de bestaande `relay-unit-tests`-taak.

Wat er niet in staat, staat onderaan de pagina opgesomd: de conf die werkelijk op de server draait, de Caddy-laag, en de betekeniskolom die nog niet overal is ingevuld.