### PR TITLE
de drie die bleven liggen: scope afgedwongen, de sleutelloze route in kaart, de dode poorten weg

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -36,12 +36,21 @@ const BASE_PATH   = (process.env.BASE_PATH || '').replace(/\/$/, '');
 // every Object.keys(SECTORS) iteration in this file; add a sector here and
 // the rest follows. findUserByEmail() stays health-only on purpose: health
 // is the canonical admin-UI source and the lookup is hot-path.
+// The fallback is the CONTAINER-INTERNAL listener, and that is :3000 for every
+// sector (docker-compose.yml sets PORT: "3000" once, for all five). The numbers
+// 3001-3005 are host-side published ports; on the compose network nothing
+// listens there. health/legal/finance/iot carried those host numbers as their
+// fallback, so a missing or misspelt RELAY_* env pointed the admin at a dead
+// port and every fan-out for that sector failed with ECONNREFUSED instead of
+// falling back. Only main was right. Kept in sync by
+// tests/sector-fallback-ports.test.mjs, which reads the port out of
+// docker-compose.yml rather than trusting a number typed here.
 const SECTORS = {
   main:    process.env.RELAY_MAIN    || 'http://relay-main:3000',
-  health:  process.env.RELAY_HEALTH  || 'http://relay-health:3005',
-  legal:   process.env.RELAY_LEGAL   || 'http://relay-legal:3002',
-  finance: process.env.RELAY_FINANCE || 'http://relay-finance:3003',
-  iot:     process.env.RELAY_IOT     || 'http://relay-iot:3004',
+  health:  process.env.RELAY_HEALTH  || 'http://relay-health:3000',
+  legal:   process.env.RELAY_LEGAL   || 'http://relay-legal:3000',
+  finance: process.env.RELAY_FINANCE || 'http://relay-finance:3000',
+  iot:     process.env.RELAY_IOT     || 'http://relay-iot:3000',
 };
 
 if (!ADMIN_TOKEN) { console.error('[PARAMANT-ADMIN] ADMIN_TOKEN is not set — refusing to start'); process.exit(1); }

--- a/deploy/knoppen.md
+++ b/deploy/knoppen.md
@@ -70,8 +70,8 @@ De gevaarlijkste knop is de knop die je niet hoort als hij ontbreekt. Deze doen 
 | waarde | plek A | plek B | staat het uiteen? |
 |---|---|---|---|
 | 5 MB | `MAX_BLOB` `relay/relay.js:105` | `BLOB_SIZE_MB` `:1339`, `ANON_MAX` `:5360`, `TRIAL_MAX_SIZE` `:5545`, `tiers.js:47,56,65`, `parashare.page.js:829`, `paramant-core.js:30` | acht kopieen, een instelbaar |
-| sector naar poort | `admin/server.js:40-44` (3000/3005/3002/3003/3004) | `docker-compose.yml:311-315` (alle vijf 3000) | **ja, vier van vijf** |
-| `RELAY_HEALTH` | `admin/server.js:41` → `:3005` | poort 3005 bestaat nergens in de repo | **ja** |
+| sector naar poort | `admin/server.js:39-45` (alle vijf 3000) | `docker-compose.yml:311-315` (alle vijf 3000) | nee, gepind door `tests/sector-fallback-ports.test.mjs` |
+| `RELAY_HEALTH` | `admin/server.js:41` → `:3000` | de compose-listener staat op 3000 | nee, rechtgezet; stond op `:3005`, een poort die nergens in de repo bestaat |
 | `nginx-selfhost.conf` | de kopie in de wortel: geen bodygrens, `inbound` 10r/m | `deploy/nginx-selfhost.conf`: 35M, `inbound` 5r/m | **ja, twee bestanden met dezelfde naam** |
 | `install.sh` | de kopie in de wortel, 535 regels | `frontend/install.sh`, 466 regels, dit is de kopie die op paramant.app staat | **ja, 111 regels verschil** |
 | admin-paneel JS | `admin/public/app.js`, 895 regels | `frontend/js/admin.page.js`, 742 regels | **ja, 343 regels verschil** |
@@ -312,7 +312,7 @@ controle valt om.
 | `relay/envelope.js` | `DEFAULT_TTL_DAYS` | `30 x2` | bewaartermijn van een envelop; parasign-store telt zijn eigen 30 dagen |
 | `relay/lib/entitlements.js` | `ENTERPRISE_MONTHLY_CEILING` | `1_000_000` | wat onbeperkt in de praktijk betekent |
 | `admin/lib/audit.js` | `AUDIT_RETENTION_DAYS` | `400` | bewaartermijn van het auditlog; ongecontroleerde parseInt, 0 wist het log |
-| `admin/server.js` | `RELAY_HEALTH` | `3005` | terugvalpoort voor de health-relay; compose luistert op 3000 |
+| `admin/server.js` | `RELAY_HEALTH` | `3000` | terugvalpoort voor de health-relay; de container-interne listener, gepind aan docker-compose.yml |
 | `frontend/crypto-bridge.js` | `WASM_SHA256` | `30f1ae35` | integriteitspin op de wasm-module; verandert bij elke herbouw |
 | `deploy/deploy-3.1.sh` | `EXPECT_VERSION` | `3.1.0` | welke versie de deploy verwacht aan te treffen; niet instelbaar |
 | `deploy/deploy-3.1.sh` | `EXPECT_PROD_COMMIT` | `41501bb` | de startcommit uit het draaiboek |

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -468,7 +468,7 @@ hash_, receipt = gp.send(open("pacs008.xml","rb").read())
       <tr><th>Method</th><th>Endpoint</th><th>Description</th><th>Auth</th></tr>
       <tr><td><span class="method get">GET</span></td><td>/health</td><td>Node status, version, uptime, edition</td><td>n/a</td></tr>
       <tr><td><span class="method post">POST</span></td><td>/v2/inbound</td><td>Upload encrypted blob from an authenticated client (RAM-only)</td><td>Key</td></tr>
-      <tr><td><span class="method post">POST</span></td><td>/v2/anon-inbound</td><td>Deprecated. Anonymous upload retained for sdk-js 3.x backward compatibility; removed in a future major release. New integrations must use <code>/v2/inbound</code>.</td><td>n/a</td></tr>
+      <tr><td><span class="method post">POST</span></td><td>/v2/anon-inbound</td><td>Deprecated, sunset 31 December 2026 (the date the relay sends in the <code>Sunset</code> response header). Anonymous upload retained for sdk-js 3.x backward compatibility. New integrations must use <code>/v2/inbound</code>.</td><td>n/a</td></tr>
       <tr><td><span class="method get">GET</span></td><td>/v2/outbound/:hash</td><td>Download + burn: spends one read of the link</td><td>Key</td></tr>
       <tr><td><span class="method get">GET</span></td><td>/v2/status/:hash</td><td>Check blob availability without consuming</td><td>Key</td></tr>
       <tr><td><span class="method post">POST</span></td><td>/v2/ack</td><td>Confirm delivery, log latency to CT</td><td>Key</td></tr>

--- a/relay/lib/keys-table.js
+++ b/relay/lib/keys-table.js
@@ -11,10 +11,138 @@
 const crypto = require('crypto');
 const entitlements = require('./entitlements'); // per-product plan derivation
 
-// Scopes are reserved now (every key is "full"); the relay does not yet gate on
-// them. Kept as an allow-list so the enum stays stable for a non-breaking
-// future migration to composite grants.
+// The scopes a v2 API key can carry. ENFORCED, by requireScope() and
+// scopeActionFor() below, which relay.js calls once per request. Kept as an
+// allow-list so the enum stays stable for a non-breaking future migration to
+// composite grants.
 const VALID_SCOPES = new Set(['full', 'send-only', 'sign-only', 'read-only', 'parasign']);
+
+// -- Scope enforcement (single source of truth) -------------------------------
+// A v2 key is minted with a scope (relay.js POST /v2/admin/keys), the scope is
+// stored on the record, and it is shown back in every key listing and in the
+// dashboard. Until now it did nothing: `requireScope` did not exist and no
+// route consulted rec.scope, so a key handed out as read-only had full write
+// authority over the whole v2 plane, /v2/admin/* included. That is privilege
+// escalation dressed up as a security feature. sec/relay-scope-enforcement
+// found it on 16 July 2026; it stayed unlanded for 51 days.
+//
+// The design is a per-request choke point, not a per-route check, for the same
+// reason session-token.js gives: a gate each route has to remember to call is a
+// gate the next route forgets.
+//
+//   action  full  send-only  sign-only  read-only  parasign
+//   read     y       y          y          y          y     safe methods, verify, lookup
+//   common   y       y          y          .          y     shared infra writes both flows need
+//   send     y       y          .          .          .     ParaSend upload / transfer session
+//   sign     y       .          y          .          y     ParaSign envelope / signing key
+//   admin    y       .          .          .          .     account, key, credential, billing
+//   write    y       .          .          .          .     any v2 write not classified below
+//
+// Two properties this table is held to by test/keys-table-scope.test.js:
+//
+//   1. `full` is denied nothing. Every key in production today is full (or is a
+//      legacy key with no scope, normalised to full at load), so enforcement
+//      turns on without changing a single existing flow.
+//   2. Every other scope is denied something. A scope that restricts nothing is
+//      the bug this whole change exists to fix, and the test fails the moment a
+//      new name is added to VALID_SCOPES without a row here.
+//
+// `write` is the fallback, and it is full-only ON PURPOSE. An unclassified
+// mutating v2 route fails closed for narrow keys rather than being waved
+// through as a read, so a route added next year cannot silently reopen the
+// hole. The cost is bounded by property 1: it can never break a full key.
+const SCOPE_ACTIONS = {
+  read:   new Set(['full', 'send-only', 'sign-only', 'read-only', 'parasign']),
+  common: new Set(['full', 'send-only', 'sign-only', 'parasign']),
+  send:   new Set(['full', 'send-only']),
+  sign:   new Set(['full', 'sign-only', 'parasign']),
+  admin:  new Set(['full']),
+  write:  new Set(['full']),
+};
+
+// Safe methods never mutate, so they are always 'read'. Asking the method first
+// is deliberate: the 2026-07 branch classified by path first, which made
+// GET /v2/user/envelopes an 'admin' action and would have locked a read-only
+// key out of its own document list.
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+// Account, key, credential and billing management. Full keys only.
+const ADMIN_WRITE_PREFIXES = [
+  '/v2/admin/',
+  '/v2/user/webauthn/',
+  '/v2/billing/',
+];
+const ADMIN_WRITE_PATHS = new Set([
+  '/v2/admin',
+  '/v2/user/parasign-keys',      // mints and revokes API keys
+  '/v2/user/setup-totp', '/v2/user/verify-totp', '/v2/user/activate-totp',
+  '/v2/user/delete-totp', '/v2/user/get-totp-provisional',
+  '/v2/user/consume-backup', '/v2/user/regenerate-backup',
+  '/v2/claim/reveal',            // hands back a key
+  '/v2/reload-users', '/v2/setup/apply',
+  '/v2/relays/register', '/v2/team/add-device',
+]);
+
+// ParaSend data plane.
+const SEND_PATHS = new Set(['/v2/inbound', '/v2/anon-inbound', '/v2/session/create']);
+
+// ParaSign data plane.
+const SIGN_PREFIXES = ['/v2/parasign/', '/v2/user/signing-key'];
+const SIGN_PATHS = new Set([
+  '/v2/envelopes', '/v2/sign', '/v2/sign-dpa', '/v2/qes/sign', '/v2/user/envelopes',
+]);
+
+// Writes both flows need, and which are not by themselves send or sign.
+const COMMON_PATHS = new Set([
+  '/v2/pubkey', '/v2/did/register', '/v2/attest', '/v2/ack', '/v2/webhook',
+  '/v2/ws-ticket', '/v2/session/join', '/v2/session-token', '/v2/sth/ingest',
+  '/v2/user/usage-purpose', '/v2/billing/webhook',
+]);
+
+// POST routes that only read: verification and diagnostics. A read-only key
+// must be able to reach these, or "read-only" does not describe the product.
+const READ_POSTS = new Set([
+  '/v2/verify', '/v2/verify-receipt', '/v2/pubkey/verify',
+  '/v2/setup/check', '/v2/setup/dns-check',
+]);
+
+const INBOUND_ABORT_RE = /^\/v2\/inbound\/[a-f0-9]{64}$/;
+
+// Map an HTTP (method, path) onto the scope action it needs. Pure; the whole
+// route table lives here so relay.js carries no policy of its own.
+function scopeActionFor(method, path) {
+  const m = String(method || '').toUpperCase();
+  const p = String(path || '');
+  // /v1 has its own psk_ Bearer gate (lib/parasign-open-api.js) and returns
+  // before this one, and /health, /metrics and the static frontend are not the
+  // v2 data plane. Nothing outside /v2 is classified here.
+  if (!p.startsWith('/v2')) return 'read';
+  if (SAFE_METHODS.has(m)) return 'read';
+  if (READ_POSTS.has(p)) return 'read';
+
+  // The Stripe webhook lives under /v2/billing/ but carries no key at all.
+  if (p !== '/v2/billing/webhook'
+      && (ADMIN_WRITE_PATHS.has(p) || ADMIN_WRITE_PREFIXES.some((x) => p.startsWith(x)))) {
+    return 'admin';
+  }
+  if (SEND_PATHS.has(p) || INBOUND_ABORT_RE.test(p)) return 'send';
+  if (SIGN_PATHS.has(p) || SIGN_PREFIXES.some((x) => p.startsWith(x))) return 'sign';
+  if (p.startsWith('/v2/envelopes/')) return 'sign';   // party view / sign / resend
+  if (COMMON_PATHS.has(p)) return 'common';
+  return 'write';                                      // unclassified: full only
+}
+
+// May a key with this record's scope perform `action`? Default-deny on an
+// unknown action. A missing scope, or a scope string no longer in the enum, is
+// normalised to 'full', which is exactly what parseAccountFields does at load,
+// so legacy records behave identically before and after this gate exists.
+function requireScope(keyData, action) {
+  const allowed = SCOPE_ACTIONS[action];
+  if (!allowed) return false;
+  let scope = (keyData && keyData.scope) || 'full';
+  if (!VALID_SCOPES.has(scope)) scope = 'full';
+  return allowed.has(scope);
+}
 
 // ParaSign Open-API (/v1) entitlement check. A key grants the parasign scope
 // when its record says so in any of three accepted shapes, so this survives the
@@ -367,4 +495,4 @@ function erasePersonalData(data, accountOrKey) {
 
 module.exports = {
   PERSONAL_DATA_FIELDS,
-  erasePersonalData, VALID_SCOPES, hasParaSignScope, computeKid, maskApiKey, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2, computeOverLimit, designatePrimary, buildParasignKeyRecord, accountHasParasignEntitlement, PARASIGN_ENTITLED_PLANS };
+  erasePersonalData, VALID_SCOPES, SCOPE_ACTIONS, requireScope, scopeActionFor, hasParaSignScope, computeKid, maskApiKey, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2, computeOverLimit, designatePrimary, buildParasignKeyRecord, accountHasParasignEntitlement, PARASIGN_ENTITLED_PLANS };

--- a/relay/lib/public-routes.js
+++ b/relay/lib/public-routes.js
@@ -1,0 +1,73 @@
+'use strict';
+// Which relay routes are reachable without a credential, and why.
+//
+// WHY THIS FILE EXISTS. POST /v2/anon-inbound takes an upload with no API key,
+// outside getEntitlements and outside the transfer quota, and frontend/docs.html
+// advertises it with Auth "n/a". feat/close-anon-inbound (20 July 2026) proposed
+// closing it and sat unlanded for 47 days. It is deliberately NOT closed here:
+// the route carries first-party traffic today. scripts/heartbeat/parasend.mjs
+// proves the anonymous transfer path on every run (upload, fetch, byte compare,
+// burn) and admin/server.js POST /api/drop/upload proxies to it behind its own
+// per-email and per-IP daily caps. Closing it silently would take out the
+// product heartbeat and the drop flow in the same commit. The route keeps its
+// Deprecation and Sunset headers (31 December 2026) and retires on announcement,
+// not by surprise.
+//
+// What is closed instead is the drift. The keyless surface was knowable only by
+// reading 9000 lines of relay.js and hoping; docs.html said "n/a" in a table
+// nothing checked. This module is the declaration, and
+// tests/public-route-surface.test.mjs holds three things to it: the docs match
+// it, it matches relay.js, and no new keyless route joins it unannounced.
+//
+// A route belongs here ONLY if it is meant to answer a caller carrying no
+// credential at all. A route that authenticates by some other means (an invite
+// token, a signed webhook, X-Admin-Token) is not public and does not belong.
+
+// Routes the API documentation may mark Auth "n/a", each with the reason it is
+// safe to answer an anonymous caller. `docs` is the exact path string used in
+// the frontend/docs.html route table; `src` is the comparison in relay.js that
+// dispatches it, which the suite uses to prove the handler really does sit
+// above the API-key gate and not below it.
+const PUBLIC_ROUTES = [
+  { method: 'GET',  docs: '/health',
+    src: "path === '/health'",
+    why: 'liveness and version. Deliberately unauthenticated so a monitor can reach it.' },
+  { method: 'POST', docs: '/v2/anon-inbound',
+    why: 'the deprecated anonymous upload. Rate limited per IP (ANON_RATE_PER_HOUR), '
+       + 'capped at 5 MB, one read, 24h TTL. Sunset 2026-12-31. Live traffic: the '
+       + 'product heartbeat and the admin drop flow.',
+    src: "path === '/v2/anon-inbound'",
+    deprecated: true },
+  { method: 'GET',  docs: '/v2/check-key',
+    src: "path === '/v2/check-key'",
+    why: 'a client must be able to discover which relay accepts its key before it has one.' },
+  { method: 'GET',  docs: '/v2/did/:did',
+    src: 'path.match(/^\\/v2\\/did\\/([^/]+)$/)',
+    why: 'DID documents are public by definition (W3C DID resolution).' },
+  { method: 'GET',  docs: '/v2/ct/log',
+    src: "path === '/v2/ct/log'",
+    why: 'the transparency log is worthless if only the operator can read it.' },
+  { method: 'GET',  docs: '/v2/relays',
+    src: "path === '/v2/relays'",
+    why: 'relay discovery. A client picks a relay before it authenticates to one.' },
+];
+
+// The identifiers in the API-key gate in relay.js that let a request past it.
+// Each one is a hole in the gate by design; the point of pinning them is that a
+// SEVENTH cannot appear without this list, and this comment, being updated.
+//
+//   isAdminPath            /v2/admin/*, which requires X-Admin-Token instead
+//   isEnvelopePublic       an external signing party reaching their own envelope
+//   isBillingWebhook       the payment provider, verified by signature in-route
+//   isInternalBillingCancel the admin plane, verified by X-Internal-Auth
+//
+// None of these are anonymous: each authenticates by something other than an
+// API key. That is why they are listed apart from PUBLIC_ROUTES.
+const KEY_GATE_EXEMPTIONS = [
+  'isAdminPath',
+  'isEnvelopePublic',
+  'isBillingWebhook',
+  'isInternalBillingCancel',
+];
+
+module.exports = { PUBLIC_ROUTES, KEY_GATE_EXEMPTIONS };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -3476,6 +3476,38 @@ async function handleRelayRequest(req, res) {
     }));
   }
 
+  // -- The scope of a v2 API key ----------------------------------------------
+  // Beside the session-token allowlist above, and for the same reason: one
+  // choke point above every route comparison, so no route has to remember it.
+  //
+  // A key is minted read-only / send-only / sign-only, the relay stores that
+  // scope and shows it back in the key list and on the dashboard, and until now
+  // it enforced none of it. Every key, whatever its label said, could write
+  // anywhere on the v2 plane. The route table and the scope matrix both live in
+  // lib/keys-table.js (pure, unit-tested); relay.js only asks the question.
+  //
+  // Only runs when a real key resolved. Keyless and public routes keep keyData
+  // null and are untouched, as does the inv_ receiver-session bypass. A legacy
+  // key without a scope, and any key minted 'full', is allowed every action by
+  // construction, so nothing that works today stops working.
+  //
+  // 403, not 401: the key is real and active, it just does not carry authority
+  // for this route, and a 401 would send the caller off to re-authenticate with
+  // the same key and be refused again.
+  if (keyData) {
+    const _scopeAction = keysTable.scopeActionFor(req.method, path);
+    if (!keysTable.requireScope(keyData, _scopeAction)) {
+      log('warn', 'insufficient_scope', { method: req.method, path, scope: keyData.scope || 'full', required: _scopeAction });
+      res.writeHead(403, { 'Content-Type': 'application/json' });
+      return res.end(J({
+        error: 'insufficient_scope',
+        required_action: _scopeAction,
+        scope: keyData.scope || 'full',
+        hint: 'this API key was issued with a narrower scope than this route needs',
+      }));
+    }
+  }
+
   // ── Code-transparency manifest: publiek leesbaar, vóór de /v1-Bearer-gate ───
   // The SHA3-256 inventory of the deployed frontend, CT-anchored on publish.
   // Independent monitors fetch this and compare it against the live assets.

--- a/relay/test/keys-table-scope.test.js
+++ b/relay/test/keys-table-scope.test.js
@@ -1,0 +1,161 @@
+'use strict';
+// The scope of a v2 API key, and the gate that keeps it honest.
+//
+// THE CLASS, NOT THE CASE. A field the relay stores and shows back to the user
+// is a promise. `scope` was stored on every key record, echoed in every key
+// listing and rendered on the dashboard, and enforced by nothing: a key issued
+// read-only could write anywhere on the v2 plane, /v2/admin/* included. The
+// first test below fails on that shape rather than on that instance, so a
+// seventh scope added to VALID_SCOPES without a row in SCOPE_ACTIONS is red
+// before anybody ships it.
+//
+// Found on sec/relay-scope-enforcement (16 July 2026), unlanded for 51 days.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const kt = require('../lib/keys-table');
+
+const key = (scope) => (scope === undefined ? { active: true } : { active: true, scope });
+
+// Enough of the v2 surface to prove a scope bites, one per action.
+const PROBES = [
+  ['read',   'GET',    '/v2/user/envelopes'],
+  ['common', 'POST',   '/v2/pubkey'],
+  ['send',   'POST',   '/v2/inbound'],
+  ['sign',   'POST',   '/v2/envelopes'],
+  ['admin',  'POST',   '/v2/admin/keys'],
+  ['write',  'POST',   '/v2/a-route-that-does-not-exist-yet'],
+];
+
+test('every action a probe claims is the action the classifier returns', () => {
+  for (const [action, method, path] of PROBES) {
+    assert.equal(kt.scopeActionFor(method, path), action, `${method} ${path}`);
+  }
+});
+
+test('a scope that is stored and shown must deny something', () => {
+  // The bug in one assertion. Any scope other than 'full' has to be refused at
+  // least one route that 'full' is allowed; otherwise the relay is selling a
+  // restriction it does not apply.
+  const toothless = [];
+  for (const scope of kt.VALID_SCOPES) {
+    if (scope === 'full') continue;
+    const denied = PROBES.filter(([action]) => !kt.requireScope(key(scope), action));
+    if (denied.length === 0) toothless.push(scope);
+  }
+  assert.deepEqual(toothless, [],
+    'these scopes are accepted, stored and displayed but restrict nothing:\n  ' +
+    toothless.join(', ') + '\n' +
+    'Either give the scope a row in SCOPE_ACTIONS that denies something, or\n' +
+    'take it out of VALID_SCOPES so no key can be minted with it.');
+});
+
+test('every scope in the enum is known to the matrix', () => {
+  const unknown = [...kt.VALID_SCOPES].filter(
+    (s) => !Object.values(kt.SCOPE_ACTIONS).some((set) => set.has(s)));
+  assert.deepEqual(unknown, [],
+    'a scope no action grants is denied everything, including reads: ' + unknown.join(', '));
+});
+
+test('a full key is denied nothing, so enforcement changes no existing flow', () => {
+  for (const action of Object.keys(kt.SCOPE_ACTIONS)) {
+    assert.equal(kt.requireScope(key('full'), action), true, `full denied ${action}`);
+  }
+  // Legacy records carry no scope field at all, and an unrecognised string can
+  // only come from a hand-edited users.json. Both normalise to full, matching
+  // what parseAccountFields does at load.
+  for (const legacy of [key(undefined), key(''), key('what-is-this')]) {
+    for (const action of Object.keys(kt.SCOPE_ACTIONS)) {
+      assert.equal(kt.requireScope(legacy, action), true,
+        `a legacy key was denied ${action}; enforcement must be invisible to it`);
+    }
+  }
+});
+
+test('read-only cannot write, and that is the escalation that was open', () => {
+  const ro = key('read-only');
+  assert.equal(kt.requireScope(ro, 'read'), true);
+  for (const action of ['common', 'send', 'sign', 'admin', 'write']) {
+    assert.equal(kt.requireScope(ro, action), false, `read-only still allowed ${action}`);
+  }
+  // The concrete escalation: a read-only key minting another key.
+  assert.equal(kt.requireScope(ro, kt.scopeActionFor('POST', '/v2/admin/keys')), false);
+  assert.equal(kt.requireScope(ro, kt.scopeActionFor('POST', '/v2/user/parasign-keys')), false);
+  assert.equal(kt.requireScope(ro, kt.scopeActionFor('POST', '/v2/inbound')), false);
+});
+
+test('send-only and sign-only keep their own lane and stay out of the other', () => {
+  const send = key('send-only');
+  const sign = key('sign-only');
+  assert.equal(kt.requireScope(send, kt.scopeActionFor('POST', '/v2/inbound')), true);
+  assert.equal(kt.requireScope(send, kt.scopeActionFor('POST', '/v2/envelopes')), false);
+  assert.equal(kt.requireScope(sign, kt.scopeActionFor('POST', '/v2/envelopes')), true);
+  assert.equal(kt.requireScope(sign, kt.scopeActionFor('POST', '/v2/inbound')), false);
+  // Neither may touch account or key management.
+  for (const k of [send, sign]) {
+    assert.equal(kt.requireScope(k, kt.scopeActionFor('POST', '/v2/admin/keys/revoke')), false);
+    assert.equal(kt.requireScope(k, kt.scopeActionFor('POST', '/v2/billing/checkout')), false);
+  }
+  // Both may still register a public key and acknowledge a delivery.
+  for (const k of [send, sign]) {
+    assert.equal(kt.requireScope(k, kt.scopeActionFor('POST', '/v2/pubkey')), true);
+    assert.equal(kt.requireScope(k, kt.scopeActionFor('POST', '/v2/ack')), true);
+  }
+});
+
+test('an unclassified v2 write fails closed rather than passing as a read', () => {
+  // The 2026-07 branch returned 'read' for anything it did not list, so a route
+  // added later silently reopened the hole for every narrow key. The fallback
+  // is full-only instead, which cannot break a full key (see the test above).
+  assert.equal(kt.scopeActionFor('POST', '/v2/something-new'), 'write');
+  assert.equal(kt.scopeActionFor('PATCH', '/v2/something-new'), 'write');
+  assert.equal(kt.scopeActionFor('DELETE', '/v2/something-new'), 'write');
+  for (const scope of ['read-only', 'send-only', 'sign-only', 'parasign']) {
+    assert.equal(kt.requireScope(key(scope), 'write'), false, `${scope} waved through a new write route`);
+  }
+});
+
+test('safe methods are reads on every path, including the admin plane', () => {
+  for (const p of ['/v2/admin/keys', '/v2/user/webauthn/credentials', '/v2/billing/invoices']) {
+    for (const m of ['GET', 'HEAD', 'OPTIONS']) {
+      assert.equal(kt.scopeActionFor(m, p), 'read', `${m} ${p}`);
+    }
+  }
+});
+
+test('nothing outside /v2 is classified here', () => {
+  // /v1 carries its own psk_ Bearer + parasign gate and returns before this one;
+  // /health and /metrics are not the data plane. Classifying them would be a
+  // second, competing policy.
+  for (const p of ['/v1/envelopes', '/health', '/metrics', '/']) {
+    assert.equal(kt.scopeActionFor('POST', p), 'read', p);
+  }
+});
+
+test('an unknown action is denied, including to a full key', () => {
+  assert.equal(kt.requireScope(key('full'), 'teleport'), false);
+  assert.equal(kt.requireScope(key('full'), undefined), false);
+});
+
+test('relay.js actually calls the gate, above the routes it protects', () => {
+  // A pure matrix that nothing consults is the same bug in a new place, so the
+  // suite checks the wiring too, not just the policy. Source text rather than a
+  // boot: relay.js needs @paramant/core and redis at load, and this job has
+  // neither on purpose.
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const src = fs.readFileSync(path.join(__dirname, '..', 'relay.js'), 'utf8');
+
+  const call = src.indexOf('keysTable.requireScope(');
+  assert.notEqual(call, -1,
+    'relay.js no longer calls requireScope, so every key is full again regardless of its scope');
+  assert.ok(src.includes('keysTable.scopeActionFor('), 'relay.js no longer classifies the route');
+  assert.ok(src.includes("error: 'insufficient_scope'"), 'the refusal no longer names itself');
+
+  // Above the data plane. If the gate ever drifts below a route handler, that
+  // route answers before it is ever asked about scope.
+  for (const route of ["path === '/v2/inbound'", "path === '/v2/envelopes'", "path === '/v2/admin/keys'"]) {
+    const at = src.indexOf(route);
+    assert.notEqual(at, -1, `route disappeared: ${route}`);
+    assert.ok(call < at, `the scope gate sits BELOW ${route} and cannot protect it`);
+  }
+});

--- a/tests/public-route-surface.test.mjs
+++ b/tests/public-route-surface.test.mjs
@@ -1,0 +1,130 @@
+// The keyless surface, checked in both directions.
+//
+// frontend/docs.html publishes an API table with an Auth column, and a row that
+// says "n/a" is a public invitation: it tells the world this route answers
+// without a key. Nothing checked that column against the relay, in either
+// direction. A route documented as public but actually gated is a support
+// ticket; a route that is public but not documented as such is the thing you
+// only find out about from someone else.
+//
+// POST /v2/anon-inbound is the case that started this: keyless, outside the
+// entitlement and quota gates, advertised with Auth "n/a", and open since 20
+// July 2026 when feat/close-anon-inbound proposed closing it. It stays open on
+// purpose, and relay/lib/public-routes.js records why. What this suite closes is
+// the drift around it.
+//
+// Three checks:
+//   1. every docs row marked "n/a" is a declared public route
+//   2. every declared public route is in the docs, marked "n/a"
+//   3. every declared route dispatches ABOVE the API-key gate in relay.js, and
+//      the set of exemptions inside that gate is the declared set
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require_ = createRequire(import.meta.url);
+const { PUBLIC_ROUTES, KEY_GATE_EXEMPTIONS } = require_(path.join(ROOT, 'relay/lib/public-routes.js'));
+
+const docsHtml = fs.readFileSync(path.join(ROOT, 'frontend/docs.html'), 'utf8');
+const relaySrc = fs.readFileSync(path.join(ROOT, 'relay/relay.js'), 'utf8');
+
+// The API route table in docs.html: rows that open with a method pill. Four
+// cells, of which the first is the method, the second the path and the last the
+// Auth column; the description in between may carry its own markup.
+function docRows() {
+  const rows = [];
+  for (const m of docsHtml.matchAll(/<tr><td><span class="method [^"]*">([A-Z]+)<\/span><\/td>([\s\S]*?)<\/tr>/g)) {
+    const cells = [...m[2].matchAll(/<td>([\s\S]*?)<\/td>/g)]
+      .map((c) => c[1].replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim());
+    if (cells.length < 3) continue;
+    rows.push({ method: m[1], path: cells[0], auth: cells[cells.length - 1] });
+  }
+  return rows;
+}
+
+const rows = docRows();
+const declared = new Map(PUBLIC_ROUTES.map((r) => [`${r.method} ${r.docs}`, r]));
+
+test('the docs route table parses at all', () => {
+  assert.ok(rows.length >= 15, `parsed ${rows.length} rows out of docs.html; the table shape changed`);
+  assert.ok(rows.some((r) => r.path === '/health'), 'no /health row, so the parse is picking up the wrong table');
+});
+
+test('every route the docs advertise as keyless is a declared public route', () => {
+  const undeclared = rows
+    .filter((r) => /^n\/a$/i.test(r.auth))
+    .filter((r) => !declared.has(`${r.method} ${r.path}`))
+    .map((r) => `${r.method} ${r.path}`);
+  assert.deepEqual(undeclared, [],
+    'docs.html tells the world these need no key, and nothing in the relay says\n' +
+    'they are meant to be public:\n  ' + undeclared.join('\n  ') + '\n' +
+    'Either give it an entry in relay/lib/public-routes.js with the reason it is\n' +
+    'safe, or correct the Auth column.');
+});
+
+test('every declared public route is documented, and documented as keyless', () => {
+  const missing = [];
+  const mislabelled = [];
+  for (const [id, r] of declared) {
+    const row = rows.find((x) => x.method === r.method && x.path === r.docs);
+    if (!row) missing.push(id);
+    else if (!/^n\/a$/i.test(row.auth)) mislabelled.push(`${id} is documented as Auth "${row.auth}"`);
+  }
+  assert.deepEqual(missing, [],
+    'these answer an anonymous caller and the API docs do not list them:\n  ' + missing.join('\n  '));
+  assert.deepEqual(mislabelled, [],
+    'the docs claim a credential is needed where none is:\n  ' + mislabelled.join('\n  '));
+});
+
+// The line in relay.js that turns "no valid key" into 401. Everything dispatched
+// before it answers without ever being asked for one.
+function keyGateAt() {
+  // The one and only gate, not the per-route re-checks: it is the branch that
+  // pairs the key test with the exemptions.
+  const at = relaySrc.indexOf('} else if (!keyData?.active');
+  assert.notEqual(at, -1,
+    'the API-key gate in relay.js is no longer the `} else if (!keyData?.active ...` branch');
+  return at;
+}
+
+test('every declared public route dispatches above the API-key gate', () => {
+  const gate = keyGateAt();
+  const wrong = [];
+  for (const r of PUBLIC_ROUTES) {
+    const at = relaySrc.indexOf(r.src);
+    if (at === -1) wrong.push(`${r.method} ${r.docs}: no handler matching ${r.src}`);
+    else if (at > gate) wrong.push(`${r.method} ${r.docs}: handler sits BELOW the key gate, so it is not public`);
+  }
+  assert.deepEqual(wrong, [], wrong.join('\n  '));
+});
+
+test('the API-key gate has exactly the exemptions that are declared', () => {
+  // The gate reads `if (isAdminPath) {...} else if (!keyData?.active && !isX && !isY)`.
+  // Anything named there is a way past the key check. Pinning the set is what
+  // makes a new one a decision somebody has to write down.
+  const gate = keyGateAt();
+  const stmt = relaySrc.slice(relaySrc.lastIndexOf('if (isAdminPath)', gate), relaySrc.indexOf('{', gate));
+  const found = [...new Set([...stmt.matchAll(/\bis[A-Z]\w*/g)].map((m) => m[0]))].sort();
+  assert.deepEqual(found, [...KEY_GATE_EXEMPTIONS].sort(),
+    'the ways past the API-key gate have changed.\n' +
+    `  in relay.js:  ${found.join(', ')}\n` +
+    `  declared:     ${[...KEY_GATE_EXEMPTIONS].sort().join(', ')}\n` +
+    'A new exemption is a new hole in the gate. Add it to KEY_GATE_EXEMPTIONS in\n' +
+    'relay/lib/public-routes.js with the reason, or take it out of relay.js.');
+});
+
+test('the deprecated anonymous upload still carries its Sunset headers', () => {
+  // It is not closed, so the retirement signal is the only honest thing a caller
+  // has to go on. Losing it would turn a deprecation into a surprise.
+  const anon = relaySrc.indexOf("path === '/v2/anon-inbound'");
+  assert.notEqual(anon, -1, 'the anonymous upload route is gone; update public-routes.js');
+  const handler = relaySrc.slice(anon, anon + 4000);
+  assert.match(handler, /res\.setHeader\('Deprecation', 'true'\)/, 'the Deprecation header is gone');
+  assert.match(handler, /res\.setHeader\('Sunset',/, 'the Sunset header is gone');
+  assert.ok(declared.get('POST /v2/anon-inbound')?.deprecated,
+    'the declaration no longer marks the anonymous upload deprecated');
+});

--- a/tests/sector-fallback-ports.test.mjs
+++ b/tests/sector-fallback-ports.test.mjs
@@ -1,0 +1,85 @@
+// The admin fans every sector call out over SECTORS in admin/server.js. Each
+// entry is `process.env.RELAY_X || '<fallback>'`, and the fallback is what runs
+// whenever the env is missing, misspelt or empty. It must therefore name the
+// port the relay container actually listens on INSIDE the compose network.
+//
+// It did not. Between 2026-06 and today, health/legal/finance/iot carried
+// 3005/3002/3003/3004: the HOST-side published ports out of the comment block
+// at the top of docker-compose.yml. On the compose network nothing listens
+// there, so four of the five fallbacks were dead and only `main` was right.
+// fix/sector-port-drift found this on 10 June 2026 and sat unlanded for 87
+// days; the drift survived because production always sets the envs, so the
+// fallback is a path nobody walks until the day something goes wrong.
+//
+// This suite does not hardcode 3000. It reads the port out of docker-compose.yml
+// (the x-relay-env anchor every relay service merges) and holds admin/server.js
+// to it, so moving the listener moves the expectation with it and a fallback
+// left behind goes red.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const compose = fs.readFileSync(path.join(ROOT, 'docker-compose.yml'), 'utf8');
+const adminSrc = fs.readFileSync(path.join(ROOT, 'admin', 'server.js'), 'utf8');
+
+// The shared relay environment, i.e. everything under `x-relay-env: &relay-env`
+// up to the next top-level key. Scoped so the admin service's own PORT: "4200"
+// further down cannot be mistaken for the relay listener.
+function relayEnvBlock() {
+  const start = compose.indexOf('x-relay-env: &relay-env');
+  assert.notEqual(start, -1, 'docker-compose.yml no longer defines the x-relay-env anchor');
+  const rest = compose.slice(start);
+  const end = rest.slice(1).search(/\n[^\s#]/);
+  return end === -1 ? rest : rest.slice(0, end + 1);
+}
+
+function internalRelayPort() {
+  const m = relayEnvBlock().match(/^\s+PORT:\s*"?(\d+)"?\s*$/m);
+  assert.ok(m, 'x-relay-env no longer sets PORT, so there is nothing to hold the fallbacks to');
+  return m[1];
+}
+
+// The SECTORS literal in admin/server.js, as {sector: fallbackUrl}.
+function sectorFallbacks() {
+  const start = adminSrc.indexOf('const SECTORS = {');
+  assert.notEqual(start, -1, 'admin/server.js no longer declares a SECTORS map');
+  const block = adminSrc.slice(start, adminSrc.indexOf('};', start));
+  const out = {};
+  for (const m of block.matchAll(/(\w+):\s*process\.env\.(\w+)\s*\|\|\s*'([^']+)'/g)) {
+    out[m[1]] = { env: m[2], fallback: m[3] };
+  }
+  return out;
+}
+
+test('every sector fallback points at the container-internal relay port', () => {
+  const port = internalRelayPort();
+  const sectors = sectorFallbacks();
+  assert.ok(Object.keys(sectors).length >= 5,
+    `expected all five sectors in SECTORS, parsed ${Object.keys(sectors).length}`);
+
+  const wrong = [];
+  for (const [name, { env, fallback }] of Object.entries(sectors)) {
+    const u = new URL(fallback);
+    if (u.port !== port) wrong.push(`${name} (${env}) falls back to :${u.port}, relay listens on :${port}`);
+  }
+  assert.deepEqual(wrong, [],
+    'A fallback on a port nothing listens on is worse than no fallback: the admin\n' +
+    'gets ECONNREFUSED for that sector instead of a working default.\n  ' + wrong.join('\n  '));
+});
+
+test('the fallback host is the compose service name, not a host-side address', () => {
+  // 127.0.0.1:3001-3004 is the right model for the self-hosted nginx in front
+  // of published ports. It is the wrong model here: the admin container reaches
+  // its relays by service name over the compose network. Mixing the two is how
+  // the port numbers drifted in the first place.
+  const bad = [];
+  for (const [name, { fallback }] of Object.entries(sectorFallbacks())) {
+    const host = new URL(fallback).hostname;
+    if (/^(127\.|localhost$|0\.0\.0\.0$|::1$)/.test(host)) bad.push(`${name} -> ${host}`);
+    else if (!compose.includes(`  ${host}:`)) bad.push(`${name} -> ${host} is not a service in docker-compose.yml`);
+  }
+  assert.deepEqual(bad, [], bad.join('\n  '));
+});


### PR DESCRIPTION
Three security branches from the landing backlog (`deploy/landen-inhaalslag.md`, entries 1, 2 and 3). All three gaps were re-verified against main before any code was written; none of them had been closed along another route. Two are repaired here, one is deliberately not, and that is the finding.

## 1. A scope that was stored, shown, and enforced by nothing

`sec/relay-scope-enforcement`, 16 July 2026, unlanded for 51 days.

**Still open.** A v2 key can be minted `read-only`, `send-only` or `sign-only`. The relay accepts the scope, writes it onto the record, and echoes it back in every key listing and on the dashboard. `requireScope`, `scopeActionFor` and `insufficient_scope` appear zero times in 9080 lines of `relay.js`, and `relay/lib/keys-table.js` said so itself: "the relay does not yet gate on them". A read-only key therefore had full write authority over the whole v2 plane, `/v2/admin/*` included.

`scopeAllows` in `lib/session-token.js` is a different mechanism entirely: an allowlist for short-lived `pst_` session tokens. It never reads `rec.scope`.

**Rewritten, not merged.** The diagnosis held; the route table did not. `relay.js` went from 7000 to 9080 lines, `keys-table.js` from 180 to 370, and the `parasign` scope did not exist when the branch was written. Under that branch's matrix a parasign key would have been denied every action including reads. Two further changes:

- It classified by path before method, which made `GET /v2/user/envelopes` an admin action and would have locked a read-only key out of its own document list. Method comes first now.
- It defaulted an unlisted route to `read`, so any write route added afterwards silently reopened the hole. The fallback is `write`, which is full-only.

**The property that makes this safe to land:** a `full` key is denied nothing, and a record with no scope normalises to `full`. Every key in production is one or the other, so enforcement turns on without changing a single existing flow. That is asserted, not assumed.

## 2. The keyless upload: not closed, and here is why

`feat/close-anon-inbound`, 20 July 2026, unlanded for 47 days.

**Still open.** `POST /v2/anon-inbound` takes an upload with no key, outside `getEntitlements` and outside the transfer quota. `frontend/docs.html` advertises it with Auth `n/a`.

**It carries live first-party traffic.** Two callers in this repo:

- `scripts/heartbeat/parasend.mjs` exercises the anonymous path on every run: upload, fetch, byte-for-byte compare, and burn-on-read. That is the product heartbeat.
- `admin/server.js` `POST /api/drop/upload` proxies to it, behind its own per-email (3/day) and per-IP (20/day) caps.

Closing the route silently would have taken out the heartbeat and the drop flow in the same commit. So it stays open, with its `Deprecation` and `Sunset` headers intact.

**How to announce it, when you want to.** The route already sends `Sunset: Wed, 31 Dec 2026`. Four steps, in order: move the heartbeat's anonymous leg onto `/v2/inbound` with the canary key it already holds, so the monitor stops depending on the route it is meant to outlive; decide whether `/api/drop/upload` is a product you keep (if so it needs its own key, if not it goes with the route); publish the date in the changelog and on the docs page rather than only in a response header; then close it after the date with a `410` that names the successor. Nothing in this PR blocks any of that.

**What is repaired instead is the drift.** The keyless surface was knowable only by reading 9000 lines of `relay.js`, and the Auth column in the docs was checked by nothing in either direction. `relay/lib/public-routes.js` declares the six routes meant to answer a caller with no credential, each with its reason, and pins the four exemptions inside the API-key gate. The docs row now names the sunset date the relay already sends.

## 3. Four sector fallbacks pointing at dead ports

`fix/sector-port-drift`, 10 June 2026, unlanded for 87 days.

**Still open, literally unchanged.** `admin/server.js` fell back to `relay-health:3005`, `relay-legal:3002`, `relay-finance:3003`, `relay-iot:3004`. Those are host-side published ports; on the compose network every relay listens on `:3000` (`x-relay-env` sets `PORT` once, for all five). Four of the five fallbacks were dead and only `main` was right. Production always sets `RELAY_*`, which is why this never bit and could stand three months.

**Old branch used for the admin half only.** Its nginx half is dropped: main moved to `127.0.0.1:3001-3004` for the self-hosted proxy, which is the correct host-port model there.

`deploy/knoppen.md` pinned `RELAY_HEALTH = 3005` in two places and is updated in the same commit, as `tests/knoppen-compleet.test.mjs` requires.

## The gates, and what breaks them

Each repair ships a check that fails on the class rather than on the case. Every one was sabotaged and confirmed red.

| gate | sabotage | result |
|---|---|---|
| `relay/test/keys-table-scope.test.js` | add `audit-only` to `VALID_SCOPES`, wire it nowhere | red: "every scope in the enum is known to the matrix" |
| | give `read-only` every action, so the scope restricts nothing | red: "a scope that is stored and shown must deny something" |
| | make an unclassified write fall back to `read` (the old branch's behaviour) | red: "an unclassified v2 write fails closed" |
| | replace the gate call in `relay.js` with `if (false)` | red: "relay.js actually calls the gate, above the routes it protects" |
| `tests/public-route-surface.test.mjs` | mark `POST /v2/inbound` as Auth `n/a` in the docs | red, names the route |
| | quietly relabel `GET /v2/check-key` as needing a key | red, names the mislabel |
| | add a fifth exemption to the API-key gate | red, names the identifier |
| | drop the `Sunset` header from the anonymous route | red |
| `tests/sector-fallback-ports.test.mjs` | put `:3005` back on health | red, reads the expected port out of `docker-compose.yml` |
| | point a fallback at `127.0.0.1` | red, that is the host model, not the compose model |

## Existing gates

- `bash tests/static-sanity.sh`: PASS, all hard checks clear.
- `relay/test` unit suite (the CI glob, `RELAY_TEST_SKIP=redis,engine`): 412 pass, 0 fail. Was 401 before.
- Root no-browser suites: 271 pass, 3 fail. The same 3 fail on unmodified `origin/main` in this environment (`brand-shots-optin` x2 and `heartbeat-lib`, both needing something the checkout does not have). Baseline was 263 pass, 3 fail.
- `admin/test`: 37 failures on the branch and 37 on unmodified `origin/main`, unchanged.
