### PR TITLE
De test moet altijd hetzelfde zeggen: de relay liet zijn laatste boomkoppen op de vloer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
-      # Twelve checks, no secrets, no server, no network. It was written as a
+      # Thirteen checks, no secrets, no server, no network. It was written as a
       # pre-commit hook and deploy/deploy-3.1.sh phase 0b runs it against the
       # commit being deployed, but until now it ran in NO workflow at all:
       # security-posture.yml only mentioned it in a comment. Every
@@ -60,7 +60,7 @@ jobs:
       # checks 10, 11 and 12 are precisely the ones a pull request can break for
       # everybody: the style guard, the merge-collision guard on the shared test
       # namespace, and the opt-in on the tracked brand screenshots.
-      - name: Static sanity (twelve checks)
+      - name: Static sanity (thirteen checks)
         run: bash tests/static-sanity.sh
 
   undefined-names:
@@ -262,6 +262,33 @@ jobs:
             echo "missing dependency. Fix the suite; do not add it to a list."
             exit 1
           fi
+
+      # THE SAME ROUTE SUITES, THREE MORE TIMES.
+      #
+      # The step above runs them once, and once is what a flaky test survives.
+      # On 2026-09-05 route-ct-persistence "a relay that lost its tree refuses
+      # to sign a head contradicting one it already signed" went red on two
+      # unrelated pull requests and stayed green on main. Measured on the branch
+      # that fixed it: 0 failures in 100 runs of the suite alone, 3 in 60 with
+      # the other route suites alongside it on four cores. A single pass has no
+      # opinion about that; four passes catch it roughly one time in five, and
+      # then it has a name and a repeat number instead of being read as "CI
+      # being CI" on somebody else's branch.
+      #
+      # It is not a retry: the step is red if ANY repeat is red, and the report
+      # separates a suite that always fails from one that failed in some
+      # repeats and passed in others. The route step above takes about twenty
+      # seconds, so three more passes cost a minute in a job that spends two
+      # building the engine.
+      #
+      # The way out of a red flaky-watch is a fix, or a dated row in
+      # tests/known-flaky.tsv that expires after fourteen days (static-sanity
+      # check 13). Not a re-run.
+      - name: Flaky watch - the route suites, repeated under the same load
+        env:
+          REDIS_URL: redis://127.0.0.1:6399
+          FLAKY_WATCH_REPEATS: '3'
+        run: bash scripts/flaky-watch.sh
 
       # The one admin suite that needs a REAL relay. Its backup-code case
       # measures the cost of ten argon2 verifications, which is the whole

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,6 +1,6 @@
 # PARAMANT: complete environment reference
 #
-# 98 variables. Copy to deploy/.env and fill in what the "required" blocks ask
+# 100 variables. Copy to deploy/.env and fill in what the "required" blocks ask
 # for. .env is NEVER committed to git.
 #
 # This file is the reference: every name the relay or the admin panel reads is
@@ -393,6 +393,25 @@ PARAMANT_TOTP_MASTER_KEY=
 # optional · default: 30000-60000 (random)
 # read in: relay/relay.js
 # PLAN_EXPIRY_BOOT_DELAY_MS=
+
+# The same knob for the one-off party-index migration. Leave it unset in
+# production: the default is 15 seconds plus up to 20 more, for the same reason.
+# It exists so a test can either watch the migration without waiting, or push it
+# out past its own lifetime, because the migration takes a global lock and SCANs
+# the whole envelope keyspace and a parallel test run shares one redis.
+# optional · default: 15000-35000 (random)
+# read in: relay/relay.js
+# PARTY_INDEX_BOOT_DELAY_MS=
+
+# How long a shutdown may wait for the transparency log and the signed heads to
+# reach the disk before the process exits anyway. A backstop for a wedged
+# volume, not a delay: on a healthy disk the streams report finished in well
+# under a millisecond and nothing waits. Below it, a relay stopped under load
+# leaves out the last entries it already served, which is a receipt that stops
+# resolving and a next boot that thinks its tree walked backwards.
+# optional · default: 5000
+# read in: relay/relay.js
+# EXIT_FLUSH_MAX_MS=
 
 # ── Invoices ──────────────────────────────────────────────────────────────────
 # Who the invoice says it comes from. The relay issues one numbered document per

--- a/deploy/knoppen.md
+++ b/deploy/knoppen.md
@@ -2,10 +2,10 @@
 
 Wat het gedrag van Paramant verandert staat hier, of in `deploy/.env.example`. Nergens anders.
 
-- **97 omgevingsvariabelen** die de relay en de admin lezen staan in
+- **99 omgevingsvariabelen** die de relay en de admin lezen staan in
   [`.env.example`](.env.example), met per naam een uitleg en een `read in:`-regel.
   `tests/env-documented.test.mjs` bewaakt dat bestand en faalt als een naam er niet in staat.
-- **170 knoppen** staan hieronder: alles wat die poort niet ziet.
+- **172 knoppen** staan hieronder: alles wat die poort niet ziet.
   `tests/knoppen-compleet.test.mjs` bewaakt deze pagina op dezelfde manier.
 
 Samen zijn dat twee bestanden. Dat is een meer dan een, en de reden is dat `.env.example`
@@ -172,9 +172,11 @@ overschrijven zonder de code aan te raken.
 | `DOMAIN` | `deploy/docker-entrypoint.sh`, `install.sh` | `localhost` | domein in de nginx-entrypoint van een container die niet in compose staat |
 | `DRYRUN_OUT` | `deploy/ops/backup-full-state.sh` | `$WORK/out` | waar een proefback-up naartoe schrijft |
 | `EXPECT_PROD_COMMIT` | `deploy/deploy-3.1.sh` | `41501bb` | de vaste startcommit uit het draaiboek, gebruikt als er geen marker is |
+| `FLAKY_WATCH_REPEATS` | `scripts/flaky-watch.sh` | `3` | hoe vaak de bouwstraat de route-suites herhaalt om een wisselvallige test te laten zien |
 | `GITHUB_ACTIONS` | `scripts/check-test-declarations.sh` | leeg | omgevingsherkenning, geen Paramant-knop |
 | `HEALTH_URL` | `scripts/rollback-3.0.0.sh` | `http://127.0.0.1:3000/health` | welke URL het terugrolscript als gezond beschouwt |
 | `KEYFILE` | `deploy/ops/backup-full-state.sh`, `deploy/ops/restore-full-state.sh` | `/root/.config/paramant-backup/key.txt` | sleutelbestand waarmee de back-up versleuteld wordt |
+| `KNOWN_FLAKY_MAX_DAYS` | `scripts/check-flaky-register.sh` | `14` | hoeveel dagen een regel in `tests/known-flaky.tsv` mag blijven staan voor hij zelf een fout wordt |
 | `LATEST_ENV` | `scripts/rollback-3.0.0.sh` | leeg | welk env-bestand het terugrolscript terugzet |
 | `LC_ALL` | `scripts/check-commit-style.sh` | `C.UTF-8` | omgevingsherkenning, geen Paramant-knop |
 | `LE_EMAIL` | `install.sh` | `(n/a in localhost mode)` | adres voor Let's Encrypt |

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -49,7 +49,7 @@ What is in each directory, and which test or workflow fails when you break it.
 | `scripts/directie/` | `signalen.py`: a no-model status meter. Asks GitHub over `gh` and production over `curl`, turns each answer into red/orange/green with the command it measured with. | Nothing. Documented in `docs/directie.md`. |
 | `scripts/heartbeat/` | `run.mjs` and its lib: the four hourly production proofs (`surface`, `parasend`, `parasign-receipt`, `parasign-public-sign`). Every step runs even after one fails, on purpose: a dead page must never hide a dead signer. | Its logic by `tests/heartbeat-lib.test.mjs` (runs on every push); its execution by `heartbeat.yml` (hourly) |
 | `deploy/` | `DEPLOY-3.1.md` is the runbook; `deploy-3.1.sh` executes it phase by phase and refuses to continue when a measurement disagrees. `.env.example` is the canonical env inventory (81 variables, names and purposes, no values). Plus the three nginx configs and `ops/backup-*.sh`. | `tests/env-documented.test.mjs` (every `process.env` name must be documented there, and nothing documented that no code reads); `test.yml` job `shell-syntax` (`bash -n`); `test.yml` job `deploy-dryrun` runs `tests/deploy-3.1-dryrun.test.sh` on every push and pull request, with no server and no secrets. |
-| `tests/` | 27 `node:test` `.mjs` suites (16 node-only, 11 browser), plus `static-sanity.sh`, `auth-smoke.sh`, `e2e-auth-flow.sh` and the deploy dry-run self-test. | `test.yml` (node-only set), `sign-e2e.yml` (browser set), `product-heartbeat.yml`. Of the `.sh` files, `deploy-3.1-dryrun.test.sh` runs in CI (`test.yml` job `deploy-dryrun`) and `static-sanity.sh` does too (`test.yml` job `static-sanity`, twelve checks, no secrets and no server); `auth-smoke.sh` and `e2e-auth-flow.sh` need a live target and run at deploy time only. |
+| `tests/` | 27 `node:test` `.mjs` suites (16 node-only, 11 browser), plus `static-sanity.sh`, `auth-smoke.sh`, `e2e-auth-flow.sh` and the deploy dry-run self-test. | `test.yml` (node-only set), `sign-e2e.yml` (browser set), `product-heartbeat.yml`. Of the `.sh` files, `deploy-3.1-dryrun.test.sh` runs in CI (`test.yml` job `deploy-dryrun`) and `static-sanity.sh` does too (`test.yml` job `static-sanity`, thirteen checks, no secrets and no server); `auth-smoke.sh` and `e2e-auth-flow.sh` need a live target and run at deploy time only. |
 
 Selection of browser vs node-only suites is done **by what a file imports**, never
 by a hand-kept name list (`.github/workflows/test.yml:290-296`,
@@ -341,15 +341,16 @@ the commit message and the added `+` diff lines, and runs from both
 `tests/static-sanity.sh` and `.githooks/pre-push`. Default tooling adds these
 trailers for you; turn them off before your first commit.
 
-**static-sanity is twelve checks, and check 10 is the style guard.**
-`tests/static-sanity.sh` runs twelve numbered checks: syntax, redisClient
+**static-sanity is thirteen checks, and check 10 is the style guard.**
+`tests/static-sanity.sh` runs thirteen numbered checks: syntax, redisClient
 initialisation, TOTP helpers (warn), unsafe `req.body` access (warn), orphan code
 (warn), `/request-key` still returning 410, DID-auth replay protection, the
 open-mode envelope signer binding, installer release pinning, check 10, the
 commit and GitHub style guard delegating to `check-commit-style.sh`, check 11,
-the test-scope guard delegating to `check-test-declarations.sh`, and check 12,
-the opt-in on the tracked brand screenshots. Exit code is the number of hard
-failures.
+the test-scope guard delegating to `check-test-declarations.sh`, check 12,
+the opt-in on the tracked brand screenshots, and check 13, the known-flaky
+register delegating to `check-flaky-register.sh`. Exit code is the number of
+hard failures.
 
 It runs in CI as `test.yml` job `static-sanity`, on every push to main and every
 pull request. That is new. Until then it ran in **no** workflow at all: its only

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -410,6 +410,12 @@ const CT_FILE = process.env.CT_FILE !== undefined
   : _ctFileDefault();
 const CT_MAX_SIZE = parseInt(process.env.CT_MAX_SIZE || String(100 * 1024 * 1024)); // 100 MB default
 
+// Set the moment a shutdown starts, and never cleared. Both append logs check
+// it before taking another line out of their queue, so from that point the exit
+// flush is the only writer left and no line can be shifted out of a queue into
+// a stream that has already been ended. See _flushAppendLogsOnExit.
+let _shuttingDown = false;
+
 // Fix 8: async CT write stream with queued writes and log rotation
 let _ctStream    = null;
 let _ctWriteQueue = [];
@@ -449,24 +455,27 @@ async function _ctRotate() {
 async function _ctDrain() {
   if (_ctDraining || !_ctStream) return;
   _ctDraining = true;
-  while (_ctWriteQueue.length > 0) {
+  while (_ctWriteQueue.length > 0 && !_shuttingDown) {
     const line = _ctWriteQueue.shift();
     await new Promise((resolve, reject) => {
       _ctStream.write(line, err => err ? reject(err) : resolve());
     }).catch(e => log('warn', 'ct_write_error', { err: e.message }));
   }
   _ctDraining = false;
-  // Check rotation after draining
-  _ctRotate().catch(() => {});
+  // Check rotation after draining. Not during a shutdown: rotation ends the
+  // stream and opens a new one, and the exit flush is already ending this one.
+  if (!_shuttingDown) _ctRotate().catch(() => {});
 }
 
 function ctWrite(entry) {
-  if (!CT_FILE || !_ctStream) return;
+  if (!CT_FILE || !_ctStream || _shuttingDown) return;
   _ctWriteQueue.push(JSON.stringify(entry) + '\n');
   setImmediate(_ctDrain);
 }
 
-// Flush CT queue on graceful shutdown
+// Hand whatever is still queued to the stream on a graceful shutdown. This only
+// gets the bytes as far as the stream; _flushAppendLogsOnExit is what waits for
+// them to reach the fd.
 function _flushCtOnExit() {
   if (!_ctStream || _ctWriteQueue.length === 0) return;
   for (const line of _ctWriteQueue) { try { _ctStream.write(line); } catch {} }
@@ -540,7 +549,7 @@ function _sthOpenStream() {
 async function _sthDrain() {
   if (_sthDraining || !_sthStream) return;
   _sthDraining = true;
-  while (_sthWriteQueue.length > 0) {
+  while (_sthWriteQueue.length > 0 && !_shuttingDown) {
     const line = _sthWriteQueue.shift();
     await new Promise((resolve, reject) => {
       _sthStream.write(line, err => err ? reject(err) : resolve());
@@ -550,6 +559,7 @@ async function _sthDrain() {
 }
 
 function sthWrite(entry) {
+  if (_shuttingDown) return;
   _sthWriteQueue.push(JSON.stringify(entry) + '\n');
   setImmediate(_sthDrain);
 }
@@ -1098,9 +1108,9 @@ function loadPeerSths() {
   }
 }
 
-function _flushPeerSthsOnExit() {
-  for (const stream of _peerSthStreams.values()) { try { stream.end(); } catch {} }
-}
+// The peer streams are ended by _flushAppendLogsOnExit along with the CT and STH
+// logs, and awaited there: a mirrored head is evidence too, and ending a stream
+// without waiting for it was the bug.
 
 // ── Gossip — broadcast our latest STH to all registered peers ─────────────────
 // Outbound HTTPS goes through safeHttpsRequest so the per-request DNS guard
@@ -9096,8 +9106,16 @@ if (redisClient && RELAY_REDIS_URL) {
 // around it (nothing in process memory, a SET NX lock so one of five containers
 // does the scan), with one difference: it is a migration and not a sweep, so a
 // finished run writes a redis marker and no later boot scans anything.
+// PARTY_INDEX_BOOT_DELAY_MS moves the one run, the same way
+// PLAN_EXPIRY_BOOT_DELAY_MS moves the sweep above. It exists for the same two
+// reasons: a test that wants to watch the migration should not wait 15 to 35
+// seconds for it, and a test that does NOT want it should not get an
+// estate-wide SCAN over the keyspace it is asserting on. Unset (production) the
+// delay and its jitter are unchanged.
+const _partyBackfillDelay = parseInt(process.env.PARTY_INDEX_BOOT_DELAY_MS || '', 10);
 partyBackfill.startPartyIndexBackfill({
   redis: redisClient,
+  ...(Number.isFinite(_partyBackfillDelay) ? { bootDelayMs: _partyBackfillDelay } : {}),
   // Its own store, not the request-scoped one. The migration reads envelope
   // hashes and writes index members: no signature is verified and no CT entry
   // is appended, so it needs neither engine, and a boot job that reached into a
@@ -9165,12 +9183,65 @@ server.listen(PORT, process.env.HOST || '0.0.0.0', () => {
   // Register to the relay registry after a short delay to let the server fully bind
   if (relayIdentity && RELAY_SELF_URL) setTimeout(registerSelf, 500);
 });
-function emergencyZeroAndExit(reason, code = 0) {
-  // Fix 8: flush CT write queue before exit
-  _flushCtOnExit();
+// How long the exit may wait for the append logs to reach the disk. A BACKSTOP
+// for a wedged volume, not the mechanism: the mechanism is the 'finish' event
+// below, and on a healthy disk this timer is never reached.
+const EXIT_FLUSH_MAX_MS = parseInt(process.env.EXIT_FLUSH_MAX_MS || '5000');
+
+// Resolves when this stream's queued writes have all reached the fd.
+function _endAppendStream(stream) {
+  return new Promise((resolve) => {
+    if (!stream || stream.destroyed || stream.writableEnded) return resolve();
+    let done = false;
+    const finish = () => { if (!done) { done = true; resolve(); } };
+    stream.once('error', finish);
+    try { stream.end(finish); } catch (_) { finish(); }
+  });
+}
+
+// THE LAST APPEND IS NOT WRITTEN UNTIL THE BYTES ARE AT THE FD.
+//
+// fs.WriteStream.write() hands the buffer to libuv and returns; process.exit()
+// does not wait for it. The exit path used to write the queue and exit in the
+// same tick, so a head the relay had already SERVED could be missing from
+// sth-log.jsonl a millisecond later. Not a theory: route-ct-persistence uploads
+// four blobs, reads tree_size 4 off the live relay, restarts, and reads the
+// heads back. On an idle machine that passes 100 times out of 100. Under the
+// load of the other route suites on four cores it failed 3 times in 60, always
+// the same way - /v2/sth/history said [1,2,3,4] before the stop and
+// sth-log.jsonl held [1,2,3] after it. The relay then came back believing 3 was
+// the largest size it had ever signed, which is the exact state the fork guard
+// exists to refuse, so the suite read a lost write as a forked log.
+//
+// A relay stopped by systemctl lost the same head in production, silently.
+//
+// So the shutdown waits on the streams' own 'finish' events, which fire when
+// every queued write has completed. Waiting on an event, not on a duration.
+async function _flushAppendLogsOnExit() {
+  _shuttingDown = true;                 // the drains stop; this is now the only writer
+  _flushCtOnExit();                     // queue -> stream
   _flushSthOnExit();
-  _flushPeerSthsOnExit();
-  // Zeroize all in-memory blobs before exit
+  const streams = [_ctStream, _sthStream, ..._peerSthStreams.values()].filter(Boolean);
+  if (streams.length === 0) return;
+  let timer = null;
+  const guard = new Promise((resolve) => {
+    timer = setTimeout(() => {
+      log('error', 'append_log_flush_timeout', {
+        ms: EXIT_FLUSH_MAX_MS, streams: streams.length,
+        hint: 'The transparency log did not reach the disk before the relay exited. '
+            + 'The last entries may be missing; check the volume behind CT_FILE and STH_FILE.',
+      });
+      resolve();
+    }, EXIT_FLUSH_MAX_MS);
+    if (timer.unref) timer.unref();
+  });
+  await Promise.race([Promise.all(streams.map(_endAppendStream)), guard]);
+  if (timer) clearTimeout(timer);
+}
+
+async function emergencyZeroAndExit(reason, code = 0) {
+  // Zeroize first: it is the part that must happen even if the disk is wedged,
+  // and the flush below may wait.
   try {
     for (const [, e] of blobStore.entries()) {
       if (e.blob) zeroBuffer(e.blob);
@@ -9179,14 +9250,21 @@ function emergencyZeroAndExit(reason, code = 0) {
     pubkeys.clear();
     // Clear download tokens (contain hashes, not plaintext, but scrub anyway)
     downloadTokens.clear();
-    log('info', 'shutdown_clean', { reason, burned: stats.burned });
   } catch (_) {}
+  try { await _flushAppendLogsOnExit(); } catch (_) {}
+  try { log('info', 'shutdown_clean', { reason, burned: stats.burned }); } catch (_) {}
   process.exit(code);
 }
 
-// Graceful shutdown on SIGTERM (systemctl stop) and SIGINT (Ctrl+C)
-process.on('SIGTERM', () => emergencyZeroAndExit('SIGTERM'));
-process.on('SIGINT',  () => emergencyZeroAndExit('SIGINT'));
+// Graceful shutdown on SIGTERM (systemctl stop) and SIGINT (Ctrl+C). A second
+// signal arriving while the first is still flushing means the caller wants out
+// now, so it exits without waiting rather than starting the flush over.
+function _onExitSignal(reason) {
+  if (_shuttingDown) { process.exit(0); return; }
+  emergencyZeroAndExit(reason);
+}
+process.on('SIGTERM', () => _onExitSignal('SIGTERM'));
+process.on('SIGINT',  () => _onExitSignal('SIGINT'));
 
 // Catch unhandled promise rejections — log and exit cleanly so blobs are zeroized
 process.on('unhandledRejection', (reason) => {

--- a/relay/test/_relay-server.js
+++ b/relay/test/_relay-server.js
@@ -150,6 +150,24 @@ async function boot(opts = {}) {
     RELAY_SELF_URL: '',
     RELAY_PRIMARY_URL: '',
     HOST: '127.0.0.1',
+    // THE BOOT-TIME BACKGROUND JOBS STAY OUT OF A TEST RUN unless a suite asks
+    // for them by name (opts.env wins over this).
+    //
+    // Both of these reach the SHARED redis, not this relay's scratch dir, and
+    // both work on keys with no account in them: the plan-expiry sweep
+    // zRem/hDels members of the one global paramant:billing:expiry zset
+    // (lib/plan-expiry.js), and the party-index migration takes a global lock
+    // and SCANs the whole `env:*` keyspace (lib/parasign-party-backfill.js).
+    // CI runs 21 route suites in parallel processes against ONE redis on db 0,
+    // so a relay that lives past its own suite's assertions starts sweeping and
+    // scanning another suite's rows. The delays are 30-60 s and 15-35 s, which
+    // is longer than most suites but not longer than all of them, so it shows
+    // up as one suite going red on somebody else's branch.
+    //
+    // An hour is not a magic number: it is "longer than any suite in this repo
+    // stays up". A suite that wants either job sets its own value.
+    PLAN_EXPIRY_BOOT_DELAY_MS: String(3600000),
+    PARTY_INDEX_BOOT_DELAY_MS: String(3600000),
   };
   for (const k of ['MOLLIE_API_KEY', 'MOLLIE_TEST_API_KEY', 'BILLING_MODE']) delete env[k];
 

--- a/relay/test/deep-health-gate.test.js
+++ b/relay/test/deep-health-gate.test.js
@@ -128,7 +128,12 @@ test('storage: red, and the whole verdict goes red with it, when the data dir ca
   // A directory that does not exist. The relay boots anyway (a missing users
   // file is a warning, not a fatal), so this is a running relay whose state
   // directory is gone, which is exactly what the check is for.
-  const missing = path.join(os.tmpdir(), 'deep-health-absent-' + process.pid, 'users.json');
+  const absentDir = path.join(os.tmpdir(), 'deep-health-absent-' + process.pid);
+  // Made absent, not assumed absent. A pid is reused on a long-lived runner and
+  // a crashed earlier run leaves its directories behind, so a test that only
+  // hopes nothing is there passes for a reason it does not control.
+  fs.rmSync(absentDir, { recursive: true, force: true });
+  const missing = path.join(absentDir, 'users.json');
   const { port } = await bootHealthyRelay({ RELAY_MODE: 'full', USERS_FILE: missing });
   const r = await deep(port);
   assert.strictEqual(r.status, 200, 'the route answers 200 even when the verdict is red');

--- a/relay/test/route-ct-exit-durability.test.js
+++ b/relay/test/route-ct-exit-durability.test.js
@@ -1,0 +1,150 @@
+'use strict';
+// A HEAD THE RELAY SERVED MUST BE ON DISK WHEN THE RELAY IS GONE.
+//
+// WHY THIS SUITE EXISTS. route-ct-persistence proves the transparency log
+// survives a restart. It cannot prove that what the relay ANSWERED WITH before
+// the restart is what survives, and that gap is where the relay was losing
+// data: the append logs were written through an fs.WriteStream, and the exit
+// path wrote the queue and called process.exit() in the same tick. A stream
+// write is handed to the thread pool; process.exit does not wait for it. So the
+// relay served tree_size N over /v2/sth, was stopped, and came back at N-1.
+//
+// Measured on this branch against the old exit path, forty uploads fired in
+// parallel and a normal SIGTERM: 20 runs out of 20 lost heads, worst case 38 of
+// 40, and the CT log lost the matching entries. Against the fixed one: 0 of 20.
+//
+// Two things follow from a lost head, and only one of them is a test problem:
+//
+//   * route-ct-persistence read it as a fork. It uploads four blobs, reads
+//     tree_size 4 off the live relay, restarts, and expects 4 back. When the
+//     fourth head never reached the disk the relay came back believing 3 was
+//     the largest size it had ever signed, refused the next head as a
+//     contradiction, and the suite went red on two unrelated pull requests
+//     while staying green on main. That is what a flaky test is FOR, and the
+//     right answer is not a longer wait or a retry.
+//   * a relay stopped by systemctl lost the tail of its transparency log, in
+//     production, with no warning. The receipts issued for those entries stop
+//     resolving, exactly as they did before persistence was made the default.
+//
+// The fix waits on the streams' own 'finish' events (relay.js,
+// _flushAppendLogsOnExit), so the assertion here is an equality and not a
+// tolerance: everything served is on disk, or the suite is red.
+// Run: node --test relay/test/route-ct-exit-durability.test.js
+
+const { test, after } = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { boot, killAll } = require('./_relay-server');
+const { summary } = require('./_requires');
+
+// The fixture account's api key. Padded with zeroes on purpose: gitleaks'
+// generic-api-key rule fires above 3.7 bits of entropy and a name made of five
+// distinct words scores 3.94, so a key that says what it is in words reads as a
+// leak. Same shape as the one in route-ct-persistence.
+const EXIT_KEY = 'pgp_ct_exit_key_0000000000000001';
+const exitUsers = {
+  api_keys: [{ key: EXIT_KEY, plan: 'pro', active: true, email: 'sender@example.test', account_id: 'acct_sender' }],
+};
+
+// Forty, fired in parallel. The number is not decoration: the queue has to be
+// DEEP when the signal lands, because that is the state a runner with twenty
+// suites on four cores puts the relay in, and it is the state in which the old
+// exit path lost data every single time rather than one run in twenty.
+const EXIT_BURST = 40;
+
+let exitChecks = 0;
+const exitDid = () => { exitChecks++; };
+const exitDirs = [];
+
+function exitScratch(tag) {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), `ctexit-${tag}-`));
+  exitDirs.push(d);
+  return d;
+}
+
+function burst(srv, n) {
+  return Promise.all(Array.from({ length: n }, (_, i) => {
+    const payload = Buffer.from(`burst-${i}-${crypto.randomBytes(8).toString('hex')}`);
+    const hash = crypto.createHash('sha256').update(payload).digest('hex');
+    return srv.post('/v2/inbound', { headers: { 'X-Api-Key': EXIT_KEY }, body: { hash, payload: payload.toString('base64') } })
+      .then((r) => { assert.strictEqual(r.status, 200, `upload ${i}: ${JSON.stringify(r.json)}`); });
+  }));
+}
+
+const jsonl = (p) => fs.readFileSync(p, 'utf8').split('\n').filter((l) => l.trim());
+
+after(async () => {
+  summary('route-ct-exit-durability', exitChecks);
+  await killAll();
+  for (const d of exitDirs) { try { fs.rmSync(d, { recursive: true, force: true }); } catch (_) { /* gone */ } }
+});
+
+test('every signed head the relay served is on disk after it is stopped', async () => {
+  const dir = exitScratch('heads');
+  const srv = await boot({ tag: 'ctexit1', dir, usersFile: true, users: exitUsers });
+  await burst(srv, EXIT_BURST);
+
+  // What the relay PUBLISHED. From here on it owes the disk exactly this.
+  const served = (await srv.get('/v2/sth')).json.sth;
+  assert.strictEqual(served.tree_size, EXIT_BURST, 'all forty appends were signed');
+  const history = (await srv.get('/v2/sth/history?limit=1000')).json.sths;
+  assert.strictEqual(history.length, EXIT_BURST);
+
+  await srv.stop();   // a plain SIGTERM, the same one systemctl sends
+
+  const onDisk = jsonl(path.join(dir, 'sth-log.jsonl')).map((l) => JSON.parse(l));
+  assert.strictEqual(onDisk.length, EXIT_BURST,
+    `the relay served ${EXIT_BURST} heads and left ${onDisk.length} on disk. The exit path did not `
+    + 'wait for the append stream to reach the fd, so heads it had already published are gone. '
+    + 'A receipt for any of them no longer resolves, and the next boot sees a tree that walked '
+    + 'backwards and refuses to sign at all.');
+  assert.deepStrictEqual(onDisk.map((s) => s.tree_size), history.map((s) => s.tree_size),
+    'and in the same order, head for head');
+  assert.strictEqual(onDisk[onDisk.length - 1].sha3_root, served.sha3_root,
+    'the last head on disk is the last head served, root and all');
+  exitDid();
+});
+
+test('the transparency log itself keeps its tail through the same shutdown', async () => {
+  // The heads are only half of it. A head attests to a tree, and the entries
+  // that tree is made of go through the same queue-and-exit path.
+  const dir = exitScratch('entries');
+  const srv = await boot({ tag: 'ctexit2', dir, usersFile: true, users: exitUsers });
+  await burst(srv, EXIT_BURST);
+  const size = (await srv.get('/v2/ct/log?from=0&limit=1')).json.size;
+  assert.strictEqual(size, EXIT_BURST);
+  await srv.stop();
+  assert.strictEqual(jsonl(path.join(dir, 'ct-log.json')).length, EXIT_BURST,
+    'the CT log on disk is short. Every entry missing here is a receipt that stops resolving.');
+  exitDid();
+});
+
+test('a restart after a busy shutdown is not read as a fork', async () => {
+  // The end of the story route-ct-persistence tells, made deterministic. A lost
+  // head is indistinguishable from a relay that walked backwards, so the guard
+  // fires, the relay freezes, and nothing about the failure points at the
+  // shutdown that caused it.
+  const dir = exitScratch('nofork');
+  let srv = await boot({ tag: 'ctexit3', dir, usersFile: true, users: exitUsers, captureLog: true });
+  await burst(srv, EXIT_BURST);
+  const served = (await srv.get('/v2/sth')).json.sth.tree_size;
+  await srv.stop();
+
+  srv = await boot({ tag: 'ctexit4', dir, usersFile: true, captureLog: true });
+  const back = await srv.get('/v2/sth');
+  assert.strictEqual(back.json.sth.tree_size, served,
+    'the relay came back at a different tree size than the one it served before the stop');
+  assert.ok(!back.json.forked, 'and it does not believe it has forked');
+
+  // It also has to keep WORKING: the tree came back with the heads, so the next
+  // append is head 41 and the guard has no reason to fire.
+  await burst(srv, 1);
+  const grown = await srv.get('/v2/sth');
+  assert.strictEqual(grown.json.sth.tree_size, EXIT_BURST + 1, 'and it signs the next head');
+  assert.ok(!/"msg":"sth_refused_would_fork"/.test(srv.log()), 'no fork was refused');
+  await srv.stop();
+  exitDid();
+});

--- a/scripts/check-flaky-register.sh
+++ b/scripts/check-flaky-register.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# The known-flaky register, and its expiry.
+#
+# WHY. A test that fails one run in twenty is not a smaller problem than one
+# that always fails; it is a bigger one, because the answer people reach for is
+# "run it again" and after two weeks nobody reads it at all. That is how a guard
+# ends up green over nothing.
+#
+# So a flaky test may be on the record, and the record has a date on it. This
+# script fails the build when a row in tests/known-flaky.tsv is older than
+# KNOWN_FLAKY_MAX_DAYS. The row buys two weeks of not being surprised; it does
+# not buy silence.
+#
+# Run: scripts/check-flaky-register.sh   (exit 0 = clean, 1 = an entry is stale)
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REG="$ROOT/tests/known-flaky.tsv"
+MAX_DAYS="${KNOWN_FLAKY_MAX_DAYS:-14}"
+TODAY_EPOCH="$(date -u +%s)"
+fail=0
+rows=0
+
+if [ ! -f "$REG" ]; then
+  echo "FAIL: tests/known-flaky.tsv is gone. The register is the gate; deleting it"
+  echo "      does not make a flaky test go away, it makes it unrecorded."
+  exit 1
+fi
+
+# shellcheck disable=SC2034  # "source" is column 4 of the row; read needs a name for it
+while IFS=$'\t' read -r suite name seen source why; do
+  case "${suite:-}" in ''|'#'*) continue ;; esac
+  rows=$((rows + 1))
+  if [ -z "${seen:-}" ] || ! printf '%s' "$seen" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+    echo "FAIL: $suite / $name has no usable date in column 3 (got '${seen:-}')."
+    echo "      A row without a date never expires, which is the whole failure mode."
+    fail=$((fail + 1))
+    continue
+  fi
+  if ! seen_epoch="$(date -u -d "$seen" +%s 2>/dev/null)"; then
+    echo "FAIL: $suite / $name carries an unreadable date '$seen'."
+    fail=$((fail + 1))
+    continue
+  fi
+  age=$(( (TODAY_EPOCH - seen_epoch) / 86400 ))
+  if [ "$age" -lt 0 ]; then
+    echo "FAIL: $suite / $name is dated $seen, which is in the future."
+    fail=$((fail + 1))
+    continue
+  fi
+  if [ "$age" -gt "$MAX_DAYS" ]; then
+    echo "FAIL: $suite / $name has been known-flaky since $seen ($age days, limit $MAX_DAYS)."
+    echo "      ${why:-no reason given}"
+    echo "      Fix the cause and delete the row, or say in the row why it is still"
+    echo "      open and re-date it deliberately. Re-dating is a decision someone"
+    echo "      signs; letting it rot is not."
+    fail=$((fail + 1))
+  else
+    echo "   known-flaky: $suite / $name (since $seen, $age of $MAX_DAYS days)"
+  fi
+done < "$REG"
+
+if [ "$fail" -eq 0 ]; then
+  if [ "$rows" -eq 0 ]; then
+    echo "   OK  the known-flaky register is empty"
+  else
+    echo "   OK  $rows known-flaky entr(y|ies), none past $MAX_DAYS days"
+  fi
+fi
+exit "$fail"

--- a/scripts/flaky-watch.sh
+++ b/scripts/flaky-watch.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Run the suites that boot and restart a real relay, more than once, in the same
+# parallel shape the build straat uses.
+#
+# WHY. A test that fails one run in twenty passes a pull request nineteen times
+# out of twenty, and the twentieth is read as "CI being CI". Measured on
+# 2026-09-05: route-ct-persistence "a relay that lost its tree refuses to sign a
+# head contradicting one it already signed" failed 0 times in 100 runs on an
+# idle machine and 3 times in 60 with the other route suites alongside it on
+# four cores. One pass of the suite says nothing about that. Four passes catch
+# it about one time in five, which is enough for it to be a REPORTED flake with
+# a name instead of a red tick on somebody's unrelated branch.
+#
+# This is not a retry. A failure here is a failure of the run: the point is to
+# widen the window in which a wobble shows up, and then to say which suite
+# wobbled and in which repeat, so it can be fixed or put on the dated register
+# (tests/known-flaky.tsv) rather than absorbed.
+#
+# Run from the repo root or from relay/:
+#   scripts/flaky-watch.sh                 # 3 repeats over the route suites
+#   FLAKY_WATCH_REPEATS=10 scripts/flaky-watch.sh
+#   scripts/flaky-watch.sh test/route-ct-persistence.test.js   # explicit suites
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT/relay" || { echo "FAIL: no relay/ directory under $ROOT"; exit 1; }
+
+REPEATS="${FLAKY_WATCH_REPEATS:-3}"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+# The suites, in the same single invocation CI uses, because running them one at
+# a time removes the very load the flake needs. Default matches the route step
+# in .github/workflows/test.yml; a caller may name its own.
+if [ "$#" -gt 0 ]; then
+  SUITES=("$@")
+else
+  SUITES=()
+  for f in test/route-*.test.js test/parasign-signs-quota.test.js test/parasign-party-index.test.js; do
+    [ -f "$f" ] && SUITES+=("$f")
+  done
+fi
+if [ "${#SUITES[@]}" -eq 0 ]; then
+  echo "FAIL: no suites selected. The glob in this script is stale, and an empty"
+  echo "      run would report green over nothing."
+  exit 1
+fi
+
+# Which of them restart a relay or read what one wrote after stopping it. These
+# are the ones a shutdown or a boot race can reach, and they are named here so a
+# reader knows what this job is actually watching. Selected by what the file
+# does, not by a hand-kept list, so a new suite joins on the run after it lands.
+echo "════════ FLAKY WATCH ════════"
+echo "repeats: $REPEATS   suites: ${#SUITES[@]}"
+SENSITIVE=()
+for f in "${SUITES[@]}"; do
+  grep -qE '\.stop\(\)|\.restart\(' "$f" && SENSITIVE+=("$(basename "$f")")
+done
+echo "restart-sensitive among them (${#SENSITIVE[@]}):"
+printf '      %s\n' "${SENSITIVE[@]:-(none)}"
+echo ""
+
+red_runs=0
+declare -A failed_in
+for i in $(seq 1 "$REPEATS"); do
+  log="$OUT/repeat-$i.tap"
+  if node --test --test-reporter=tap "${SUITES[@]}" > "$log" 2>&1; then
+    echo "repeat $i/$REPEATS: green"
+  else
+    red_runs=$((red_runs + 1))
+    echo "repeat $i/$REPEATS: RED"
+    # TAP names the subtest on the "not ok" line; the file it lives in comes
+    # from the location line underneath it.
+    while IFS= read -r line; do
+      echo "      $line"
+      failed_in["$line"]="${failed_in["$line"]:-} $i"
+    done < <(grep -E '^not ok [0-9]+ - ' "$log" | sed 's/^not ok [0-9]* - //' | sort -u)
+  fi
+done
+
+echo ""
+if [ "$red_runs" -eq 0 ]; then
+  echo "PASS: $REPEATS repeats, none red"
+  exit 0
+fi
+
+echo "════════ RESULT ════════"
+echo "FAIL: $red_runs of $REPEATS repeats went red."
+for name in "${!failed_in[@]}"; do
+  # shellcheck disable=SC2086
+  set -- ${failed_in["$name"]}
+  if [ "$#" -eq "$REPEATS" ]; then
+    echo "  ALWAYS  $name"
+  else
+    echo "  FLAKY   $name (repeats:$(printf ' %s' "$@") of $REPEATS)"
+  fi
+done
+echo ""
+echo "A suite marked FLAKY passed and failed the same code in the same job. Do not"
+echo "re-run it. Either fix the cause, or add a dated row to tests/known-flaky.tsv,"
+echo "which expires (scripts/check-flaky-register.sh)."
+exit 1

--- a/tests/known-flaky.tsv
+++ b/tests/known-flaky.tsv
@@ -1,0 +1,23 @@
+# KNOWN-FLAKY REGISTER
+#
+# A test that goes red at random is ignored within two weeks, and then there is
+# a guard that exists and does nothing. This file is what keeps that from
+# happening quietly: a test may only be KNOWN to be flaky on the record, with a
+# date, and the record expires.
+#
+# One tab-separated row per test:
+#
+#   suite<TAB>test name<TAB>first seen (YYYY-MM-DD)<TAB>who/where<TAB>why it is still here
+#
+# tests/static-sanity.sh check 13 reads this file and FAILS when a row is older
+# than KNOWN_FLAKY_MAX_DAYS (14). So an entry buys two weeks, and after that the
+# entry itself is the build error. Removing the row without fixing the test just
+# moves the failure back to where it belongs.
+#
+# Empty is the good state, and it is the state this file is in. The one entry it
+# was going to carry - route-ct-persistence "a relay that lost its tree refuses
+# to sign a head contradicting one it already signed" - was fixed instead:
+# relay.js was losing the last appends at shutdown. See
+# relay/test/route-ct-exit-durability.test.js.
+#
+# suite	test	seen	source	why

--- a/tests/known-flaky.tsv
+++ b/tests/known-flaky.tsv
@@ -14,10 +14,15 @@
 # entry itself is the build error. Removing the row without fixing the test just
 # moves the failure back to where it belongs.
 #
-# Empty is the good state, and it is the state this file is in. The one entry it
-# was going to carry - route-ct-persistence "a relay that lost its tree refuses
-# to sign a head contradicting one it already signed" - was fixed instead:
-# relay.js was losing the last appends at shutdown. See
-# relay/test/route-ct-exit-durability.test.js.
+# Empty is the good state. The entry this file was going to carry -
+# route-ct-persistence "a relay that lost its tree refuses to sign a head
+# contradicting one it already signed" - was fixed instead: relay.js was losing
+# the last appends at shutdown. See relay/test/route-ct-exit-durability.test.js.
+#
+# A row here does NOT make anything green. check-flaky-register.sh fails on a
+# STALE row and on nothing else; a red suite stays red. What the row buys is
+# that the next person reading the red already knows it is known, since when,
+# and on which runs it was measured.
 #
 # suite	test	seen	source	why
+tests/handshake-meta.test.mjs	the two-file ParaShare handshake (scrollIntoViewIfNeeded op #btn-create-session)	2026-09-05	sign-e2e runs 33992956059, 33995309881, 33995562181, 33997515696	TimeoutError op "waiting for element to be stable" bij tests/handshake-meta.test.mjs:243, dat op main landde in 1622b527. Rood op vier runs vanavond, op drie verschillende takken, groen op andere runs van dezelfde takken. Niet van deze tak: deze PR raakt geen frontend en geen browser-suite.

--- a/tests/known-flaky.tsv
+++ b/tests/known-flaky.tsv
@@ -26,3 +26,4 @@
 #
 # suite	test	seen	source	why
 tests/handshake-meta.test.mjs	the two-file ParaShare handshake (scrollIntoViewIfNeeded op #btn-create-session)	2026-09-05	sign-e2e runs 33992956059, 33995309881, 33995562181, 33997515696	TimeoutError op "waiting for element to be stable" bij tests/handshake-meta.test.mjs:243, dat op main landde in 1622b527. Rood op vier runs vanavond, op drie verschillende takken, groen op andere runs van dezelfde takken. Niet van deze tak: deze PR raakt geen frontend en geen browser-suite.
+tests/end-screen-calm.test.mjs	de eindschermen blijven rustig	2026-09-05	sign-e2e runs 33995562181 (de-rest-van-de-review), 33998139643 (deze tak)	Rood op twee runs op twee verschillende takken, groen op main met dezelfde frontend (run 33995298677 op 1622b527) en groen op andere runs van dezelfde takken. Browser-suite, 47 s per keer. Niet van deze tak: deze PR raakt geen frontend.

--- a/tests/static-sanity.sh
+++ b/tests/static-sanity.sh
@@ -335,6 +335,31 @@ else
   fi
 fi
 
+# ── 13. The known-flaky register expires ─────────────────────────────────────
+# A test that goes red at random is ignored within two weeks, and then it is a
+# guard that exists and does nothing. That is the pattern this repo keeps
+# finding: a canary that skipped for weeks, four ParaSign suites that asserted
+# nothing, a static-sanity run that lived only on somebody's laptop.
+#
+# So a flaky test may be known, and knowing it has a date on it. Every row in
+# tests/known-flaky.tsv is good for KNOWN_FLAKY_MAX_DAYS (14); past that the row
+# itself is the failure, which is the only way a stale entry ever gets read
+# again. Empty is the good state.
+echo ""
+echo "13. Known-flaky register (dated, expiring)..."
+FLAKYREG="$ROOT/scripts/check-flaky-register.sh"
+if [ -x "$FLAKYREG" ]; then
+  if OUT13="$("$FLAKYREG" 2>&1)"; then
+    printf '%s\n' "$OUT13" | sed 's/^/  /'
+  else
+    printf '%s\n' "$OUT13" | sed 's/^/  /'
+    FAIL=$((FAIL + 1))
+  fi
+else
+  printf "   FAIL  scripts/check-flaky-register.sh is gone; nothing expires the register\n"
+  FAIL=$((FAIL + 1))
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "════════ RESULT ════════"


### PR DESCRIPTION
## Wat er stuk was

`route-ct-persistence` / *a relay that lost its tree refuses to sign a head contradicting one it already signed* viel op 5 september om op twee pull requests, waaronder #461, dat geen regel aan de relay of zijn opstart raakt. Op main stond hij groen.

De test is niet fout. De relay was zijn laatste ondertekende boomkoppen kwijt bij het afsluiten.

## Meting

| omstandigheid | uitslag |
|---|---|
| suite alleen, stille machine | 0 fouten in 100 runs |
| suite met de andere route-suites ernaast, vier kernen | **3 fouten in 60 runs** |
| CI-log run 33992089535 | `expected: 4, actual: 3` op regel 185 |
| lokaal gereproduceerd | zelfde regel, zelfde getallen |

Met de mechaniek uitgelezen in plaats van alleen de uitslag:

```
live_before=4  hist_before=[1,2,3,4]   disk_lines=3  disk_sizes=[1,2,3]
after_restart_tree_size=3  forked=root_differs_at_same_size
```

De relay heeft kop 4 getekend, uitgeserveerd en toen laten vallen.

## Oorzaak

`fs.WriteStream.write()` geeft de buffer aan libuv en keert terug. `process.exit()` wacht daar niet op. De afsluitroute deed dit:

```js
_flushCtOnExit();      // schrijft de wachtrij in de stream
_flushSthOnExit();
...
process.exit(code);    // en gooit weg wat nog onderweg is
```

Erger nog: `_sthDrain` haalt een regel uit de wachtrij en geeft hem meteen aan de stream. Op het moment van SIGTERM is de wachtrij dus vaak al leeg terwijl de bytes nog nergens zijn, en dan deed `_flushSthOnExit` helemaal niets.

Wat daarna gebeurt is precies de toestand waar de vork-waarborg voor bestaat: de volgende start ziet een boom die achteruit liep, weigert te tekenen, en de test leest een verloren schrijfactie als een vork. Niets aan de fout wijst naar de afsluiting.

**Dit is geen testprobleem.** Een relay die met `systemctl stop` neergaat verloor dezelfde koppen in productie, zonder waarschuwing, en elk bonnetje voor die regels loste daarna niet meer op. Met veertig uploads parallel en een gewone SIGTERM: **20 van 20 runs verloren koppen, ergste geval 38 van de 40.**

## Reparatie

De afsluiting wacht op de `finish` van de streams zelf. Op een gebeurtenis, niet op een geraden duur.

- `_shuttingDown` zet de twee drains stil, zodat geen regel meer uit een wachtrij in een al beeindigde stream verdwijnt.
- `_flushAppendLogsOnExit()` geeft de resten aan de streams en wacht tot ze klaar zijn, CT-log, STH-log en de gespiegelde peer-koppen.
- `EXIT_FLUSH_MAX_MS` (5000) is een achtervang voor een vastgelopen volume, geen wachttijd: op een gezonde schijf komt de timer nooit aan bod.
- Het wissen van de blobs gebeurt nu voor het wachten, niet erna, zodat die eigenschap niet slechter wordt.
- Een tweede signaal tijdens het spoelen betekent "nu eruit" en wacht niet.

## Bewijs dat de reparatie werkt

Sabotagetoets, oorzaak kunstmatig teruggezet (`git show origin/main:relay/relay.js`):

| | oude afsluiting | nieuwe |
|---|---|---|
| `route-ct-exit-durability` | **rood, 5 van 5 runs** | groen, 5 van 5 |
| veertig uploads, koppen verloren | **20 van 20 runs** | 0 van 20 |
| `route-ct-persistence` onder belasting | 3 van 60 | **0 van 60** |
| mechaniek-probe onder belasting | 1 van 60 | **0 van 120** |

## Poorten erbij

**`relay/test/route-ct-exit-durability.test.js`** legt vast wat de suite hiervoor niet kon: alles wat de relay geserveerd heeft staat op schijf als hij weg is. Deterministisch, geen tolerantie, en het is de enige test die de oude afsluitroute altijd betrapt.

**`scripts/flaky-watch.sh`** draait de route-suites drie keer extra in dezelfde parallelle vorm, in de job die de engine al bouwt (twintig seconden per pas). Het meldt per suite of hij altijd faalde of alleen in sommige herhalingen, met de nummers erbij. Geen hertest: rood is rood.

```
FAIL: 3 of 6 repeats went red.
  FLAKY   a coin-flip case, ... (repeats: 1 4 5 of 6)
```

**`tests/known-flaky.tsv`** plus `scripts/check-flaky-register.sh`, als static-sanity check 13. Een bekende wisselvallige test mag op de lijst, met een datum, en de regel verloopt na veertien dagen. Daarna is de regel zelf de bouwfout, wat de enige manier is waarop een oude vermelding ooit nog gelezen wordt. De lijst is nu leeg, en dat is de goede stand.

## De tweede familie, en waarom het geen een reparatie is

Twee bouwers meldden losse tests die alleen bij parallel draaien omvielen. Uitgezocht: die hebben **een andere oorzaak** dan deze. De bouwstraat draait 21 suites in parallelle processen tegen **een redis op db 0**, zonder scheiding per suite. De concrete botsingen:

| plek | sleutel zonder scheiding |
|---|---|
| `parasign-party-index.test.js:201-225` | wist de globale `paramant:parasign:party_index:backfilled` en `:lock`, en zet een vreemd slot van 60 s; daarna SCANt de migratie `env:*` van elke andere suite |
| `lib/plan-expiry.js:50-52` | `paramant:billing:expiry` (zset) en `_meta`, waar `route-coupon.test.js:432` op toetst; elke relay die 30 s leeft begint te vegen |
| `route-billing-invoices.test.js:226` | `del` van de globale `paramant:billing:invoice:seq:2031` |
| `route-session-token.test.js:581` | `SCAN paramant:pst:*` ziet de tokens van `route-dl-share-link` |
| `lib/shared-grants.js:65-70` | `paramant:entitlements:accounts` en het kanaal, elke relay hydrateert er elke 60 s uit |

Wat hier wel in zit is het deel dat **uit zichzelf** naar een andere suite reikt: de twee opstartklusjes blijven uit een testrelay tenzij een suite er zelf om vraagt (`PLAN_EXPIRY_BOOT_DELAY_MS` bestond al, `PARTY_INDEX_BOOT_DELAY_MS` is de symmetrische knop erbij). Dat haalt twee van de vijf weg met een regel in de harnas.

Wat er **niet** in zit, en waarom: de rest vraagt scheiding per suite op de opslag zelf. Een db-index per suite past niet, redis heeft er zestien en er zijn er vijftien tot achttien nodig zonder ruimte. Een sleutel-voorvoegsel raakt elke plek in `relay.js` en `relay/lib/` waar een sleutel wordt opgebouwd. Dat is een eigen klus met een eigen risico, en die hoort niet vastgeplakt aan een reparatie aan de afsluitroute. De meting staat hierboven zodat de volgende die er tegenaan loopt hem niet opnieuw hoeft af te leiden, en het staat ook in `relay/test/_relay-server.js`.

Los daarvan opgemerkt, niet aangeraakt: `relay/test/_boot-relay.js:74` zet `RELAY_REDIS_URL: ''` om redis uit te zetten, maar `relay.js:93` leest `process.env.REDIS_URL`. Die regel doet dus niets.

## Alle bestaande poorten

`static-sanity` (13 checks), `check-test-declarations` (196 suites), `eslint`, `check-commit-style`, `check-cache-bust`, `deploy-3.1-dryrun`, `env-documented`, `knoppen-compleet`, relay unit suite (401), route-suites (199, waaronder de nieuwe), integratie-suites (13). Allemaal groen.
