### PR TITLE
de handshaketest was niet wisselvallig, /parashare bouwde een globe

### DIFF
--- a/frontend/js/parashare.page.js
+++ b/frontend/js/parashare.page.js
@@ -1328,13 +1328,10 @@ document.addEventListener('DOMContentLoaded', () => {
         $('tb-dl-status').textContent = failureText('download', e);
         $('tb-dl-dot').className = 'dot red';
       });
-    setTimeout(() => initGlobe(), 400);
     return;
   }
 
   loadSessionCredential();
-  // Small delay so DOM is fully painted before Globe.gl reads dimensions
-  setTimeout(() => initGlobe(), 400);
 });
 
 // The session is the only source of the credential, and the credential is no
@@ -1368,6 +1365,25 @@ async function loadSessionCredential() {
   }
 }
 
+// Ctrl+G, and nothing else, opens this. Until 6 September 2026 the page booted
+// the globe 400 ms after every load anyway: 1.0 MB of globe.gl plus 1.9 MB of
+// textures, a WebGL context and a three.js render loop that autorotates for as
+// long as the tab is open, all of it behind an overlay on display:none that a
+// visitor reaches only by knowing the shortcut. On a phone that is the battery
+// and the data of a 3D scene nobody is looking at, and in a headless renderer
+// with no GPU it is a main thread that does not come back: the sweep in
+// scripts/ui-contrast-sweep.mjs had to stop scrolling because of it, the
+// comparison in tests/motion-safety.test.mjs had to be restructured around it,
+// and on 5 September it timed out tests/handshake-meta.test.mjs and
+// tests/end-screen-calm.test.mjs onto tests/known-flaky.tsv. Measured on one
+// core: one task of 26.3 s with no animation frame in it, against a Playwright
+// actionability budget of 30 s. Three workarounds and a flaky register, for a
+// decoration on a shortcut.
+//
+// So it boots on the first open, which is what the comment inside initGlobe()
+// has claimed all along. Opening it is also the moment the wrap finally has a
+// size to hand three.js, instead of the window fallback a display:none parent
+// forced. tests/parashare-boots-quiet.test.mjs is the gate.
 function toggleGlobe() {
   const overlay = document.getElementById('globe-overlay');
   const mainEl  = document.querySelector('main');
@@ -1376,6 +1392,11 @@ function toggleGlobe() {
   if (globeOpen) {
     // Fullscreen HUD mode: hide UI, show HUD panels
     overlay.classList.add('globe-fullscreen');
+    // First open builds it; every one after that only restarts the stats poll.
+    initGlobe().catch((e) => {
+      const loading = document.getElementById('globe-loading');
+      if (loading) loading.textContent = failureText('globe', e);
+    });
     if (mainEl) mainEl.style.display = 'none';
     const _gb = document.getElementById('globe-btn'); if (_gb) _gb.style.color = 'var(--ochre)';
     if (_gb) _gb.style.boxShadow = '0 0 12px rgba(217, 164, 65, .3)';
@@ -1520,8 +1541,9 @@ async function initGlobe() {
   wrap.addEventListener('mousedown', () => { globeInstance.controls().autoRotate = false; });
   wrap.addEventListener('touchstart', () => { globeInstance.controls().autoRotate = false; });
 
-  // Verberg loading
-  document.getElementById('globe-loading').style.display = 'none';
+  // Verberg loading. A class, not an inline style: the rule that shows the ring
+  // in fullscreen is !important and would win over the inline one.
+  document.getElementById('globe-overlay').classList.add('globe-ready');
 
   // Poll relay stats
   startGlobePoll();

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -226,6 +226,11 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 
 /* === Globe HUD (hidden by default; Ctrl+G to open) === */
 #globe-overlay{position:fixed;inset:0;z-index:0;background:#060c10;display:none}
+/* Ctrl+G hid main and showed nothing: toggleGlobe() adds .globe-fullscreen, and
+   until 6 September 2026 no rule turned the overlay itself back on, so the
+   shortcut left a blank page over a canvas of zero by zero. The scene was
+   built on every load and could not be reached from any of them. */
+#globe-overlay.globe-fullscreen{display:block;z-index:9000}
 #globe-overlay .hud-top,
 #globe-overlay .hud-bot,
 #globe-overlay .hc,
@@ -238,6 +243,13 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 #globe-overlay.globe-fullscreen #globe-loading{display:flex!important}
 #globe-overlay.globe-fullscreen .hud-panel{display:block!important}
 #globe-overlay.globe-fullscreen #globe-loading{display:flex!important}
+/* The ring is what you look at while the globe builds, so it has to be able to
+   leave. It could not: initGlobe() hid it with an inline display:none, and the
+   rule above is !important, which beats an inline declaration that is not. It
+   never showed because the globe was already built before anyone opened the
+   overlay. Now that it builds on the first open, the ring is on screen for
+   real, and this is how it goes away. */
+#globe-overlay.globe-fullscreen.globe-ready #globe-loading{display:none!important}
 
 #globe-overlay::before{content:'';position:absolute;inset:0;pointer-events:none;z-index:20;
   background:repeating-linear-gradient(0deg,transparent,transparent 3px,

--- a/tests/known-flaky.tsv
+++ b/tests/known-flaky.tsv
@@ -19,11 +19,26 @@
 # contradicting one it already signed" - was fixed instead: relay.js was losing
 # the last appends at shutdown. See relay/test/route-ct-exit-durability.test.js.
 #
+# The two rows this file carried from 5 to 6 September 2026 -
+# tests/handshake-meta.test.mjs and tests/end-screen-calm.test.mjs, both timing
+# out inside a /parashare hand-over - were the same defect and it was in the
+# product, not in the tests. /parashare built a WebGL globe 400 ms after every
+# load, behind an overlay on display:none that no visitor could open at all
+# (Ctrl+G hid the page and showed nothing). On a runner with no GPU that is one
+# task of 26 seconds with no animation frame in it, against Playwright's 30. The
+# globe now builds on the first Ctrl+G, the shortcut works, and
+# tests/parashare-boots-quiet.test.mjs holds it there.
+#
+# The register also got the reading wrong, and that is worth writing down. Both
+# rows said "green on main". Main was not green: it went red with the same
+# stack at 2026-09-06T01:02Z, run 34002770950, an hour after the rows were
+# written. Over the same window branches failed 9 of 48 sign-e2e runs and main 1
+# of 12, which is one rate and not two. Branches get four times the runs, so
+# they show the failure four times as often. "Not on main" was sample size.
+#
 # A row here does NOT make anything green. check-flaky-register.sh fails on a
 # STALE row and on nothing else; a red suite stays red. What the row buys is
 # that the next person reading the red already knows it is known, since when,
 # and on which runs it was measured.
 #
 # suite	test	seen	source	why
-tests/handshake-meta.test.mjs	the two-file ParaShare handshake (scrollIntoViewIfNeeded op #btn-create-session)	2026-09-05	sign-e2e runs 33992956059, 33995309881, 33995562181, 33997515696	TimeoutError op "waiting for element to be stable" bij tests/handshake-meta.test.mjs:243, dat op main landde in 1622b527. Rood op vier runs vanavond, op drie verschillende takken, groen op andere runs van dezelfde takken. Niet van deze tak: deze PR raakt geen frontend en geen browser-suite.
-tests/end-screen-calm.test.mjs	de eindschermen blijven rustig	2026-09-05	sign-e2e runs 33995562181 (de-rest-van-de-review), 33998139643 (deze tak)	Rood op twee runs op twee verschillende takken, groen op main met dezelfde frontend (run 33995298677 op 1622b527) en groen op andere runs van dezelfde takken. Browser-suite, 47 s per keer. Niet van deze tak: deze PR raakt geen frontend.

--- a/tests/parashare-boots-quiet.test.mjs
+++ b/tests/parashare-boots-quiet.test.mjs
@@ -1,0 +1,213 @@
+// The send page boots quiet: no 3D globe until somebody asks for one.
+//
+// WHAT WENT WRONG
+//
+// /parashare has a globe. It is a WebGL scene built by globe.gl on top of
+// three.js, it autorotates, it draws pulsing rings, and it lives in
+// #globe-overlay, which is display:none. There is no button for it. The only
+// way in is Ctrl+G, and the CSS comment above the overlay says so.
+//
+// Until 6 September 2026 the page built it 400 ms after every load anyway,
+// from a DOMContentLoaded handler. Every visit to the send page fetched
+// globe.gl.min.js (992 KB) plus earth-night.jpg, earth-topology.png and
+// night-sky.png (1.9 MB together), created a WebGL context and started a
+// render loop that ran for as long as the tab was open, for a scene nobody
+// had opened and almost nobody knew was there. On a phone that is battery and
+// data spent on a decoration behind an invisible overlay.
+//
+// In CI it is worse, because a headless runner has no GPU and Chromium falls
+// back to software rendering. Measured on this repo, pinned to one core:
+// building the globe is ONE task of 26.3 seconds in which the renderer runs no
+// animation frame at all. Playwright's actionability budget is 30 seconds and
+// every one of its waits polls on an animation frame, so the whole margin was
+// 3.7 seconds of whatever else the runner happened to be doing.
+//
+// It had already been paid for three times before anyone looked at the cause:
+//
+//   - scripts/ui-contrast-sweep.mjs stopped scrolling pages to the bottom,
+//     because scrolling woke the globe and "never gave the main thread back";
+//   - tests/motion-safety.test.mjs was restructured to load each page once
+//     instead of twice, because the globe's node count "never came to rest
+//     within twenty seconds" on the runner;
+//   - tests/handshake-meta.test.mjs and tests/end-screen-calm.test.mjs were
+//     entered in tests/known-flaky.tsv on 5 September, both of them timing out
+//     inside a /parashare hand-over, handshake-meta with the tell in the log:
+//     "waiting for element to be stable".
+//
+// Three workarounds and a flaky register, for something a visitor never sees.
+// The globe now builds on the first Ctrl+G, which is what the comment inside
+// initGlobe() ("alleen als globe geopend wordt") had claimed all along.
+//
+// WHAT THIS FILE HOLDS
+//
+//   1. A plain load of /parashare asks for none of the globe's 2.9 MB and
+//      builds no canvas. Measured off the wire, so it does not depend on how
+//      fast the machine is: no request, no bytes, no context.
+//   2. Ctrl+G still gives you the globe: the canvas arrives, the loading ring
+//      leaves, and while the scene ticks the page throws nothing. That last
+//      part is the guard PR #431 needed and did not have: moving
+//      GLOBE_ACCENT_RGB inside initGlobe() made every ring tick throw
+//      "GLOBE_ACCENT_RGB is not defined" on live deploy 25. It used to be
+//      caught by accident, because every page load ran the scene. Now that
+//      only an opened globe runs it, the check is made here on purpose.
+//   3. Sabotage: put the load-time boot back and check 1 goes red.
+//
+// Run: node tests/parashare-boots-quiet.test.mjs
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const FRONTEND = path.join(ROOT, 'frontend');
+const EXE = process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined;
+
+const checks = [];
+function ok(name, condition, detail = '') { checks.push({ name, pass: !!condition, detail: String(detail) }); }
+
+// Everything the globe needs and nothing else. Named here rather than matched
+// on a pattern, so a fourth texture added to initGlobe() has to be added here
+// too instead of quietly slipping past.
+const GLOBE_ASSETS = [
+  '/globe.gl.min.js',
+  '/images/globe/earth-night.jpg',
+  '/images/globe/earth-topology.png',
+  '/images/globe/night-sky.png',
+];
+const GLOBE_BYTES = GLOBE_ASSETS.reduce((n, rel) => n + fs.statSync(path.join(FRONTEND, rel)).size, 0);
+
+const MIME = { '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.html': 'text/html',
+  '.svg': 'image/svg+xml', '.png': 'image/png', '.jpg': 'image/jpeg', '.woff2': 'font/woff2',
+  '.wasm': 'application/wasm', '.json': 'application/json', '.ico': 'image/x-icon' };
+const ALIAS = { '/': '/index.html', '/parashare': '/parashare.html' };
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://localhost');
+  const rel = ALIAS[url.pathname] || url.pathname;
+  const file = path.join(FRONTEND, rel);
+  if (!file.startsWith(FRONTEND)) { res.writeHead(403); return res.end('no'); }
+  fs.readFile(file, (err, buf) => {
+    if (err) { res.writeHead(404); return res.end('not found'); }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(buf);
+  });
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const ORIGIN = `http://localhost:${server.address().port}`;
+const browser = await chromium.launch({ headless: true, ...(EXE ? { executablePath: EXE } : {}) });
+
+// A page on the send screen, with the relay stubbed at the network edge the
+// same way tests/handshake-meta.test.mjs does it. `sabotage` puts the boot that
+// was removed back, from outside the page, so check 1 can be shown to fire.
+async function sendPage({ sabotage = false } = {}) {
+  const ctx = await browser.newContext({ viewport: { width: 390, height: 844 } });
+  await ctx.addInitScript(() => {
+    const stub = { initCrypto: async () => {}, encryptBlob: async (p) => new Uint8Array(p.length + 32),
+      decryptBlob: async () => new Uint8Array() };
+    Object.defineProperty(window, '_cryptoBridge', { get: () => stub, set: () => {}, configurable: true });
+  });
+  if (sabotage) {
+    await ctx.addInitScript(() => {
+      document.addEventListener('DOMContentLoaded', () => setTimeout(() => window.initGlobe && window.initGlobe(), 400));
+    });
+  }
+  await ctx.route('**/api/user/**', (r) => r.fulfill({ status: 200, contentType: 'application/json', body: '{}' }));
+  for (const host of ['legal', 'finance', 'iot', 'relay']) await ctx.route(`https://${host}.paramant.app/**`, (r) => r.abort());
+  await ctx.route('https://health.paramant.app/**', (r) => r.fulfill({ status: 200, contentType: 'application/json',
+    body: JSON.stringify({ valid: true, plan: 'pro', link_ttl_ms: 86400000 }) }));
+
+  const asked = [];
+  const page = await ctx.newPage();
+  page.on('request', (r) => {
+    const p = new URL(r.url(), ORIGIN).pathname;
+    if (GLOBE_ASSETS.includes(p)) asked.push(p);
+  });
+  const thrown = [];
+  page.on('pageerror', (e) => thrown.push('uncaught: ' + e.message));
+  page.on('console', (m) => { if (m.type() === 'error') thrown.push('console.error: ' + m.text()); });
+  return { ctx, page, asked, thrown };
+}
+
+// The page's own handler waits 400 ms and then loads a megabyte. Two seconds is
+// five times that wait plus the fetches, on a static server on loopback. It is
+// a window in which the boot WOULD show, not a deadline anything has to beat:
+// the sabotage below is what proves the window is wide enough to see it.
+const SETTLE_MS = 2000;
+
+// ── 1. a plain load asks for none of it ─────────────────────────────────────
+{
+  const { ctx, page, asked, thrown } = await sendPage();
+  await page.goto(`${ORIGIN}/parashare`, { waitUntil: 'load' });
+  await page.waitForTimeout(SETTLE_MS);
+
+  ok(`loading /parashare asks for none of the globe's ${(GLOBE_BYTES / 1024 / 1024).toFixed(1)} MB`,
+    asked.length === 0, asked.join(', '));
+  ok('and builds no WebGL canvas for a scene nobody opened',
+    (await page.locator('#globe-canvas-wrap canvas').count()) === 0);
+  ok('the overlay it would have gone in is still shut',
+    !(await page.locator('#globe-overlay').isVisible()));
+  ok('the send button is there and reachable, which is the point of all this',
+    (await page.locator('#btn-create-session').count()) === 1);
+  ok('and the page throws nothing on the way', thrown.length === 0, thrown.join(' | '));
+  await ctx.close();
+}
+
+// ── 2. Ctrl+G still gives you the globe ─────────────────────────────────────
+{
+  const { ctx, page, asked, thrown } = await sendPage();
+  await page.goto(`${ORIGIN}/parashare`, { waitUntil: 'load' });
+  await page.waitForTimeout(SETTLE_MS);
+  ok('before the shortcut: nothing fetched', asked.length === 0, asked.join(', '));
+
+  await page.keyboard.press('Control+g');
+  await page.locator('#globe-canvas-wrap canvas').waitFor({ state: 'attached', timeout: 60000 });
+
+  ok('Ctrl+G opens the overlay', await page.locator('#globe-overlay').isVisible());
+  ok('Ctrl+G is what fetches the globe, all of it',
+    GLOBE_ASSETS.every((a) => asked.includes(a)), asked.join(', '));
+  ok('the canvas is really there', (await page.locator('#globe-canvas-wrap canvas').count()) === 1);
+  // The ring used to be unable to leave: initGlobe() hid it with an inline
+  // display:none against a rule marked !important. It never showed, because the
+  // globe was always built before the overlay was ever opened.
+  await page.waitForFunction(() => document.getElementById('globe-overlay').classList.contains('globe-ready'), null, { timeout: 60000 });
+  ok('and the loading ring gets out of the way once it is built',
+    !(await page.locator('#globe-loading').isVisible()));
+
+  // Let the scene tick. This is the #431 check: the ring animation reads
+  // GLOBE_ACCENT_RGB from module scope on every tick, and a refactor that puts
+  // it out of reach throws here and nowhere else.
+  await page.waitForTimeout(2500);
+  ok('a running globe throws nothing on its animation ticks', thrown.length === 0, thrown.join(' | '));
+
+  // Escape closes it, and closing stops the stats poll rather than leaving a
+  // timer behind on a page the sender is still using.
+  await page.keyboard.press('Escape');
+  ok('Escape shuts it again', !(await page.locator('#globe-overlay.globe-fullscreen').count()));
+  await ctx.close();
+}
+
+// ── 3. the sabotage ─────────────────────────────────────────────────────────
+// Boot the globe from a load handler again, from outside the page, and check 1
+// has to see it. Without this the first block passes just as well on a page
+// that has no globe at all, which is not what is being claimed.
+{
+  const { ctx, page, asked } = await sendPage({ sabotage: true });
+  await page.goto(`${ORIGIN}/parashare`, { waitUntil: 'load' });
+  await page.waitForTimeout(SETTLE_MS);
+  ok('sabotage: a globe booted from load is caught by the check above',
+    asked.length > 0 && asked.includes('/globe.gl.min.js'), asked.join(', '));
+  await ctx.close();
+}
+
+await browser.close();
+server.close();
+server.closeAllConnections();
+
+let failed = 0;
+for (const c of checks) {
+  console.log(`${c.pass ? 'ok  ' : 'FAIL'}  ${c.name}${c.pass || !c.detail ? '' : '  -- ' + c.detail}`);
+  if (!c.pass) failed++;
+}
+console.log(`\n${checks.length - failed}/${checks.length} checks passed`);
+if (failed) process.exit(1);


### PR DESCRIPTION
## Wat er misging

`tests/handshake-meta.test.mjs` liep vast op `scrollIntoViewIfNeeded` met `waiting for element to be stable`. Het knopje bestond en was zichtbaar. Wat ontbrak was een animatieframe: Playwright wacht op twee frames op rij met dezelfde box, en de renderer gaf er geen.

`/parashare` bouwde 400 ms na elke lading een WebGL-globe: `globe.gl.min.js` (992 KB) plus drie texturen (1,9 MB samen), een WebGL-context en een three.js-renderlus die autoroteert zolang de tab open staat. Alles achter `#globe-overlay`, dat op `display:none` staat. Er is geen knop. Ctrl+G is de enige ingang, en die was ook stuk: `toggleGlobe()` zette `main` op `display:none` en geen enkele regel zette de overlay zelf aan, dus de sneltoets leverde een leeg scherm boven een canvas van nul bij nul. **De scene werd op elke lading gebouwd en was vanaf geen enkele te bereiken.**

Op een runner zonder GPU valt Chromium terug op software rendering. Gemeten in deze repo, vastgezet op een kern:

| | lange taak bij het bouwen | eerste stabiele frame | frames in 30 s |
|---|---|---|---|
| voor | 26.292 ms | 26.650 ms | 189 |
| na | geen | 144 ms | 1801 |

Playwright heeft 30.000 ms. De hele marge was 3,4 seconden van wat de runner verder toevallig deed.

## Waarom wel op takken en niet op main

Dat klopte niet. Beide registerregels zeiden "groen op main", en main ging rood met dezelfde stack op 2026-09-06T01:02Z, run [34002770950](https://github.com/Apolloccrypt/paramant-relay/actions/runs/34002770950), een uur nadat de regels geschreven waren.

Over hetzelfde venster: takken 9 rood van 48 sign-e2e-runs, main 1 van 12. Een percentage, geen twee. Takken draaien vier keer zo vaak en laten het dus vier keer zo vaak zien. "Niet op main" was steekproefgrootte, geen mechanisme.

## Drie keer eerder betaald

De globe had al twee omwegen afgedwongen en toen een register:

- `scripts/ui-contrast-sweep.mjs` stopte met pagina's naar beneden scrollen, want scrollen wekte de globe en die "gaf de main thread nooit terug";
- `tests/motion-safety.test.mjs` werd herbouwd naar een lading in plaats van twee, want het knooppuntaantal "kwam op de CI-runner binnen twintig seconden nooit tot stilstand";
- `tests/handshake-meta.test.mjs` en `tests/end-screen-calm.test.mjs` gingen op 5 september in `tests/known-flaky.tsv`, allebei vastgelopen in een `/parashare`-overdracht.

## Wat er gerepareerd is

De globe bouwt bij de eerste Ctrl+G, wat de opmerking in `initGlobe()` al die tijd beweerde. En de sneltoets laat nu zien wat hij bouwt: één CSS-regel zet de overlay aan.

Twee dingen kwamen pas boven toen het bouwen naar het openen verhuisde en horen erbij:

- de laadring kon niet weg. `initGlobe()` verstopte hem met een inline `display:none` tegen een regel met `!important`. Dat viel nooit op omdat de globe altijd al klaar was voordat iemand de overlay opende. Nu een klasse.
- de wrap heeft bij openen eindelijk een echte maat om aan three.js te geven, in plaats van de `window`-terugval die een `display:none`-ouder afdwong.

Beide registerregels zijn weg. `check-flaky-register.sh`: leeg.

## De poort

`tests/parashare-boots-quiet.test.mjs`, 13 checks:

1. een gewone lading vraagt geen byte van de 2,9 MB en bouwt geen canvas. Gemeten van de lijn, dus niet afhankelijk van hoe snel de machine is.
2. Ctrl+G levert wel een globe: canvas komt, laadring gaat weg, en terwijl de scene tikt gooit de pagina niets. Dat laatste is de bewaking die #431 nodig had: `GLOBE_ACCENT_RGB` naar binnen verplaatsen gooide op elke ringtik en stond live in deploy 25. Die werd eerst per ongeluk gevangen doordat elke lading de scene draaide. Nu met opzet.
3. sabotage: zet het bouwen bij het laden terug en check 1 gaat rood.

## Poorten

- `bash tests/static-sanity.sh` PASS, register leeg
- browsersuites (`--browser-no-stack`, zoals sign-e2e ze selecteert): 84 pass, 0 fail
- niet-browsersuites: 286 pass, 0 fail
- `tests/product-heartbeat.test.mjs` + `tests/sign-full.test.mjs`: 10 pass, 0 fail
