### PR TITLE
de tweede ronde van de review

### DIFF
--- a/admin/lib/email-templates.js
+++ b/admin/lib/email-templates.js
@@ -81,7 +81,12 @@ function btn(url, label) {
 }
 
 // ── 1. SETUP EMAIL ────────────────────────────────────────────────────────────
-function setupEmail({ token, requestedAt, requestIP, isReset = false }) {
+// `validFor` is the human phrase for the link's lifetime. It is a parameter and
+// not a constant, because the number lives in admin/server.js
+// (SETUP_TOKEN_TTL_S) and a second copy here is how the mail came to promise
+// fourteen days after the link was shortened. setup-link-gate.test.js holds the
+// two together.
+function setupEmail({ token, requestedAt, requestIP, isReset = false, validFor = '2 days' }) {
   const url = `${BASE_URL}/auth/setup/${token}`;
   const preheader = isReset
     ? 'Your TOTP authenticator has been cleared. Scan the QR code to re-enroll.'
@@ -103,7 +108,7 @@ The link opens a page with a QR code. Scan it with your authenticator app
 (Google Authenticator, Authy, 1Password, or any TOTP app). You can also
 enter the secret manually if scanning does not work.
 
-This link is valid for 14 days.
+This link is valid for ${validFor}.
 
 Why an authenticator?
 
@@ -135,7 +140,7 @@ https://paramant.app`;
     <p style="margin:0 0 16px 0;line-height:1.6;">${isReset ? 'Your TOTP authenticator has been reset.' : 'Welcome to Paramant.'} To ${isReset ? 'reset your' : 'finish setting up your'} account, connect an authenticator app &mdash; this is what Paramant uses instead of a password.</p>
     ${btn(url, isReset ? 'Set up new authenticator' : 'Complete setup')}
     <p style="margin:0 0 16px 0;line-height:1.6;color:#475569;font-size:14px;">The link opens a page with a QR code. Scan it with your authenticator app (Google Authenticator, Authy, 1Password, or any TOTP app). You can also enter the secret manually.</p>
-    <p style="margin:0 0 24px 0;line-height:1.6;color:#475569;font-size:14px;">This link is valid for <strong>14 days</strong>.</p>
+    <p style="margin:0 0 24px 0;line-height:1.6;color:#475569;font-size:14px;">This link is valid for <strong>${escHtml(validFor)}</strong>.</p>
     <hr style="border:none;border-top:1px solid rgba(11,58,106,0.08);margin:24px 0;">
     <h2 style="margin:0 0 12px 0;font-size:14px;font-weight:600;color:#0B3A6A;">Why an authenticator?</h2>
     <p style="margin:0 0 12px 0;line-height:1.6;color:#475569;font-size:13px;">Passwords get reused, stolen, or phished. A TOTP code from your phone cannot be typed into a fake site or intercepted in a credential dump. It is the same mechanism your bank uses.</p>

--- a/admin/lib/same-origin.js
+++ b/admin/lib/same-origin.js
@@ -61,11 +61,32 @@ const EXTENSION_SCHEME = /^(chrome-extension|moz-extension|safari-web-extension)
 
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
+// Writes that are exempt, and there is exactly one.
+//
+// The Outlook task pane is served from https://addin.paramant.app
+// (deploy/nginx/addin.paramant.app.conf) and calls
+// POST https://paramant.app/api/user/logout with credentials: 'include' and no
+// body and no Content-Type. That is a SIMPLE request: no preflight, so the
+// browser sends it and the cookie rides along, and only the RESPONSE is hidden
+// from the caller by CORS. The add-in already ignores the answer. In other
+// words this call works today and an origin check would silently stop it
+// revoking the session, while `extensions/outlook-addin` keeps reporting
+// success. Its /login call is preflighted and already fails, so nothing else
+// there is at stake.
+//
+// Exempting a forced logout costs nothing an attacker wants. The worst a
+// cross-site page achieves is signing somebody out: no state is read, no state
+// is escalated, and the session it destroys is the victim's own. That is the
+// one place where breaking a shipped first-party client is the worse trade.
+// Widening this set to anything that GRANTS is not the same decision.
+const EXEMPT_PATHS = new Set(['/user/logout']);
+
 // Pure, so the whole decision table is testable without a server.
 // Returns { ok: true } or { ok: false, reason }.
-function verdict({ method, hasCookie, origin, secFetchSite, allow, allowLocalhost = false }) {
+function verdict({ method, path, hasCookie, origin, secFetchSite, allow, allowLocalhost = false }) {
   if (SAFE_METHODS.has(String(method || '').toUpperCase())) return { ok: true, reason: 'safe_method' };
   if (!hasCookie) return { ok: true, reason: 'no_session_cookie' };
+  if (EXEMPT_PATHS.has(String(path || ''))) return { ok: true, reason: 'exempt_path' };
 
   const o = String(origin || '').trim();
   if (o) {
@@ -84,4 +105,4 @@ function verdict({ method, hasCookie, origin, secFetchSite, allow, allowLocalhos
   return { ok: true, reason: 'no_browser_headers' };
 }
 
-module.exports = { buildAllowList, verdict, EXTENSION_SCHEME, SAFE_METHODS };
+module.exports = { buildAllowList, verdict, EXTENSION_SCHEME, SAFE_METHODS, EXEMPT_PATHS };

--- a/admin/lib/same-origin.js
+++ b/admin/lib/same-origin.js
@@ -1,0 +1,87 @@
+'use strict';
+// Is this state-changing request coming from our own page, or from somebody
+// else's?
+//
+// WHY THIS FILE EXISTS. Finding 19 of the 2026-09-05 hostile review: the user
+// side of the admin server has no CSRF defence at all beyond the cookie's own
+// SameSite=Lax. No token, no Origin check, no Referer check, no Sec-Fetch-Site.
+//
+// Lax was a deliberate choice (ADR R018): the co-sign flow lands a recipient
+// through a top-level navigation from an emailed link, and Strict would bounce
+// an already-logged-in signer to re-authenticate on exactly the flow the product
+// is built for. That choice is not what is being revisited. What is being closed
+// is the gap the choice does not cover: SameSite works on the REGISTRABLE
+// DOMAIN, and health.paramant.app, legal.paramant.app, finance.paramant.app,
+// iot.paramant.app and relay.paramant.app are all same-site with paramant.app.
+// One HTML injection on one sector host yields a page whose POSTs carry the
+// user's session cookie, and twelve state-changing routes need no request body
+// at all -- resetting TOTP, destroying backup codes, revoking sessions,
+// cancelling the subscription, minting a live ParaSign API key.
+//
+// THE RULE, and the order matters:
+//   1. A safe method (GET/HEAD/OPTIONS) is never checked.
+//   2. A request with no session cookie is never checked: it is authenticating
+//      by something the attacker's page cannot borrow.
+//   3. An allow-listed Origin passes. This comes FIRST, because the browser
+//      extensions are legitimate callers whose Sec-Fetch-Site is cross-site by
+//      construction.
+//   4. Sec-Fetch-Site decides when the browser sent it: same-origin, or none
+//      (typed in the address bar), and nothing else.
+//   5. An Origin that is present and not allow-listed is refused.
+//   6. Neither header: allowed. Every browser sends Origin on a POST, so this
+//      case is a non-browser client, and a non-browser client is not doing CSRF
+//      -- it either holds the cookie already or gains nothing by omitting a
+//      header. Refusing here would only break the repo's own node http tests
+//      and every curl a support engineer runs, without closing anything.
+//
+// Deliberately NOT same-site: a sector subdomain is exactly the origin this
+// exists to refuse, so the allow list names the site itself and nothing under it.
+// relay/relay.js isAllowedOrigin does accept `.paramant.app`, and that is
+// correct there (CORS for the API) and wrong here.
+
+// Origins allowed to drive a cookie-authenticated write.
+//   siteUrl:   the product's own origin, from SITE_URL.
+//   extra:     comma-separated extras from env, for a taskpane host.
+// Browser extensions are matched by scheme: their id changes per install and per
+// browser, and an unpacked build has a different one again, so an id list would
+// be a list that is always slightly wrong. The scheme is the meaningful part:
+// only code the user installed can hold such an origin.
+function buildAllowList(siteUrl, extra) {
+  const out = new Set();
+  try { out.add(new URL(siteUrl).origin); } catch (_) { /* no usable SITE_URL */ }
+  for (const raw of String(extra || '').split(',')) {
+    const o = raw.trim();
+    if (!o) continue;
+    try { out.add(new URL(o).origin); } catch (_) { /* ignore an unparseable entry */ }
+  }
+  return out;
+}
+
+const EXTENSION_SCHEME = /^(chrome-extension|moz-extension|safari-web-extension):\/\//;
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+// Pure, so the whole decision table is testable without a server.
+// Returns { ok: true } or { ok: false, reason }.
+function verdict({ method, hasCookie, origin, secFetchSite, allow, allowLocalhost = false }) {
+  if (SAFE_METHODS.has(String(method || '').toUpperCase())) return { ok: true, reason: 'safe_method' };
+  if (!hasCookie) return { ok: true, reason: 'no_session_cookie' };
+
+  const o = String(origin || '').trim();
+  if (o) {
+    if (allow.has(o)) return { ok: true, reason: 'allowed_origin' };
+    if (EXTENSION_SCHEME.test(o)) return { ok: true, reason: 'extension_origin' };
+    if (allowLocalhost && /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(o)) return { ok: true, reason: 'dev_origin' };
+    return { ok: false, reason: `cross_origin:${o}` };
+  }
+
+  const sfs = String(secFetchSite || '').trim().toLowerCase();
+  if (sfs) {
+    if (sfs === 'same-origin' || sfs === 'none') return { ok: true, reason: `sec_fetch_site:${sfs}` };
+    return { ok: false, reason: `sec_fetch_site:${sfs}` };
+  }
+
+  return { ok: true, reason: 'no_browser_headers' };
+}
+
+module.exports = { buildAllowList, verdict, EXTENSION_SCHEME, SAFE_METHODS };

--- a/admin/lib/user-sessions.js
+++ b/admin/lib/user-sessions.js
@@ -1,0 +1,139 @@
+'use strict';
+// The sessions of ONE user, addressable without reading everybody else's.
+//
+// WHY THIS FILE EXISTS. Finding 14 of the 2026-09-05 hostile review. Eight
+// places in admin/server.js answered the question "which sessions belong to
+// this user?" the same way: SCAN the whole Redis keyspace for
+// paramant:user:session:*, GET every key that comes back, parse it, and throw
+// away the ones belonging to somebody else. GET /api/user/account did it on
+// every page load of the account screen, with no rate limit and no cache, and
+// the Redis behind it is shared by all five relay sectors and the admin plane.
+// One free account plus a loop is a fleet-wide load generator.
+//
+// The cost is not only the scan. It is a serial GET per key, so the work grows
+// with the number of sessions in the entire product, and the user-agent column
+// of one person's account page is paid for by everybody's Redis.
+//
+// It is also a privacy shape nobody chose: to show you your own sessions, the
+// process reads every other customer's session blob, complete with their IP and
+// their user agent, and filters afterwards.
+//
+// So each session is written into a per-user SET as well, and the eight readers
+// ask that set. A session is two keys now, and the invariant is that the SET may
+// hold a token whose blob is already gone (an expired session, a crash between
+// the two writes) but never the other way round: the blob is written first and
+// removed last. Every reader prunes what it finds dead, so the set converges
+// without a sweeper.
+//
+// TTL. The set outlives the longest session it can hold, and every write pushes
+// it out again. A user who never comes back loses the set by expiry, which is
+// correct: there is nothing left to index.
+//
+// The fallback is deliberate. `list` and `revokeAll` take a `scan` function and
+// use it ONLY when the index is missing for a user who demonstrably has
+// sessions -- the deploy window, where sessions minted by the old code carry no
+// index entry. It is not a permanent second path: `indexed` in the result says
+// which way the answer came, so a caller (and a test) can see the difference.
+
+const SESSION_PREFIX = 'paramant:user:session:';
+const INDEX_PREFIX = 'paramant:user:sessions:';
+
+// Comfortably past the sliding one-hour session TTL and the absolute cap, so a
+// live session is never orphaned by its own index expiring first.
+const INDEX_TTL_S = 8 * 24 * 3600;
+
+const sessionKey = (token) => `${SESSION_PREFIX}${token}`;
+const indexKey = (userId) => `${INDEX_PREFIX}${userId}`;
+const tokenOf = (key) => String(key).slice(SESSION_PREFIX.length);
+
+// Write the session and index it. The blob first: a token in the set with no
+// blob is a harmless miss that the next read prunes, while a blob with no index
+// entry is a session its owner cannot see or revoke.
+async function remember(redis, userId, token, record, ttlS) {
+  await redis.set(sessionKey(token), JSON.stringify(record), { EX: ttlS });
+  if (!userId) return;
+  try {
+    await redis.sAdd(indexKey(userId), token);
+    await redis.expire(indexKey(userId), INDEX_TTL_S);
+  } catch (_) { /* the session still works; the next read falls back to a scan */ }
+}
+
+// Drop one session. Blob last, for the same reason.
+async function forget(redis, userId, token) {
+  if (userId) { try { await redis.sRem(indexKey(userId), token); } catch (_) { /* pruned on the next read */ } }
+  await redis.del(sessionKey(token));
+}
+
+async function readIndexed(redis, userId) {
+  let tokens = [];
+  try { tokens = await redis.sMembers(indexKey(userId)); } catch (_) { return null; }
+  if (!tokens || !tokens.length) return null;
+  const out = [];
+  const dead = [];
+  // One round trip for the blobs instead of one per token. mGet on an empty
+  // list is not universally safe across clients, hence the guard above.
+  let raws;
+  try { raws = await redis.mGet(tokens.map(sessionKey)); }
+  catch (_) { raws = []; for (const t of tokens) raws.push(await redis.get(sessionKey(t)).catch(() => null)); }
+  tokens.forEach((t, i) => {
+    const raw = raws[i];
+    if (!raw) { dead.push(t); return; }
+    let s;
+    // One corrupt blob must not take out the whole answer. It can only be this
+    // user's now, which is itself part of the repair.
+    try { s = JSON.parse(raw); } catch { dead.push(t); return; }
+    if (!s || s.user_id !== userId) { dead.push(t); return; }
+    out.push({ token: t, session: s });
+  });
+  if (dead.length) { try { await redis.sRem(indexKey(userId), dead); } catch (_) { /* next read */ } }
+  return out;
+}
+
+// Every live session of one user, as { token, session }.
+//   scan: optional `(redis, match) => AsyncIterable<string>` used only when the
+//         user has no index yet. Pass it during the deploy window; leave it out
+//         and a missing index simply means no sessions.
+async function list(redis, userId, scan) {
+  if (!userId) return { sessions: [], indexed: true };
+  const indexed = await readIndexed(redis, userId);
+  if (indexed) return { sessions: indexed, indexed: true };
+  if (typeof scan !== 'function') return { sessions: [], indexed: true };
+  const out = [];
+  for await (const key of scan(redis, `${SESSION_PREFIX}*`)) {
+    const raw = await redis.get(key).catch(() => null);
+    if (!raw) continue;
+    let s;
+    try { s = JSON.parse(raw); } catch { continue; }
+    if (!s || s.user_id !== userId) continue;
+    out.push({ token: tokenOf(key), session: s });
+  }
+  // Adopt what the scan found, so the fallback is paid for once per user and
+  // not once per request.
+  if (out.length) {
+    try {
+      await redis.sAdd(indexKey(userId), out.map((e) => e.token));
+      await redis.expire(indexKey(userId), INDEX_TTL_S);
+    } catch (_) { /* the answer is already correct; indexing is the optimisation */ }
+  }
+  return { sessions: out, indexed: false };
+}
+
+// Revoke every session of a user, optionally keeping the one making the request.
+// Returns how many were removed.
+async function revokeAll(redis, userId, opts = {}) {
+  const { except = null, scan = null } = opts;
+  const { sessions } = await list(redis, userId, scan);
+  let revoked = 0;
+  for (const { token } of sessions) {
+    if (except && token === except) continue;
+    await redis.del(sessionKey(token)).catch(() => {});
+    revoked++;
+  }
+  try {
+    if (except) { const keep = sessions.some((e) => e.token === except); await redis.del(indexKey(userId)); if (keep) { await redis.sAdd(indexKey(userId), except); await redis.expire(indexKey(userId), INDEX_TTL_S); } }
+    else await redis.del(indexKey(userId));
+  } catch (_) { /* the blobs are gone, which is what revocation means */ }
+  return revoked;
+}
+
+module.exports = { SESSION_PREFIX, INDEX_PREFIX, INDEX_TTL_S, sessionKey, indexKey, remember, forget, list, revokeAll };

--- a/admin/server.js
+++ b/admin/server.js
@@ -207,7 +207,12 @@ async function authMiddleware(req, res, next) {
   }
 }
 
-function relayFetch(sector, relPath, method, body, rawResponse, tokenOverride) {
+// `withInternal` adds X-Internal-Auth, the SECOND relay gate. It is opt-in per
+// call rather than always on, because relayFetch also carries calls that must
+// stay first-gate only: the anonymous inbound proxy sends an empty token, and a
+// header the caller did not earn should not ride along behind it. Routes that
+// mutate an entitlement pass it; callRelay always sends it.
+function relayFetch(sector, relPath, method, body, rawResponse, tokenOverride, withInternal) {
   return new Promise((resolve, reject) => {
     const base = SECTORS[sector];
     if (!base) return reject(new Error(`Unknown sector: ${sector}`));
@@ -219,6 +224,7 @@ function relayFetch(sector, relPath, method, body, rawResponse, tokenOverride) {
       path: url.pathname + (url.search || ''), method: method || 'GET',
       headers: { 'Content-Type': 'application/json', 'X-Admin-Token': tok, 'Authorization': `Bearer ${tok}` },
     };
+    if (withInternal) opts.headers['X-Internal-Auth'] = INTERNAL_TOKEN;
     if (payload) opts.headers['Content-Length'] = Buffer.byteLength(payload);
     const req = http.request(opts, r => {
       const chunks = [];
@@ -3314,7 +3320,7 @@ api.delete("/user/account", authUser, async (req, res) => {
   // asking to be gone, and until now their email address stayed in users.json on
   // every sector. Article 17 GDPR, and audit finding 5 of 2026-07-21.
   await eachSector(Object.keys(SECTORS), async s => {
-    await relayFetch(s, "/v2/admin/keys/erase", "POST", { key: user_id }, false, ADMIN_TOKEN);
+    await relayFetch(s, "/v2/admin/keys/erase", "POST", { key: user_id }, false, ADMIN_TOKEN, true);
   });
 
   await callRelay("/v2/user/delete-totp", { user_id });
@@ -4215,7 +4221,7 @@ api.post('/admin/set-parasign', authMiddleware, async (req, res) => {/*MARK:para
   if (!await checkAdminRl('set_parasign', 'admin', 30)) return res.status(429).json({ error: 'rate_limited' });
   try {
     const results = await eachSector(Object.keys(SECTORS), async s =>
-      relayFetch(s, '/v2/admin/keys/set-parasign', 'POST', { key, enabled }, false, ADMIN_TOKEN));
+      relayFetch(s, '/v2/admin/keys/set-parasign', 'POST', { key, enabled }, false, ADMIN_TOKEN, true));
     const anyOk = Object.values(results).some(r => r && r.status === 200);
     if (!anyOk) return res.status(502).json({ error: 'relay_error', results });
     await Promise.allSettled(Object.keys(SECTORS).map(s => relayFetch(s, '/v2/reload-users', 'POST', {}, false, ADMIN_TOKEN)));
@@ -4289,7 +4295,7 @@ api.post('/admin/delete-account', authMiddleware, async (req, res) => {
     // 2026-07-21. Errors are swallowed like the revoke above: a sector that is
     // briefly unreachable must not leave the deletion half done and unretryable,
     // and the call is idempotent so a retry is free.
-    await eachSector(Object.keys(SECTORS), async s => relayFetch(s, '/v2/admin/keys/erase', 'POST', { key }, false, ADMIN_TOKEN).catch(() => {}));
+    await eachSector(Object.keys(SECTORS), async s => relayFetch(s, '/v2/admin/keys/erase', 'POST', { key }, false, ADMIN_TOKEN, true).catch(() => {}));
     await callRelay('/v2/user/delete-totp', { user_id: key }).catch(() => {});
     for await (const rkey of scanKeys(redis(), { MATCH: `paramant:user:session:*`, COUNT: 100 })) {
       const raw = await redis().get(rkey).catch(() => null);

--- a/admin/server.js
+++ b/admin/server.js
@@ -4612,6 +4612,9 @@ const CSRF_ALLOW_LOCALHOST = process.env.NODE_ENV !== 'production';
 function requireSameOrigin(req, res, next) {
   const v = sameOrigin.verdict({
     method: req.method,
+    // req.path inside a mounted router is the path BELOW the mount, so this is
+    // '/user/logout' and not '/api/user/logout'. EXEMPT_PATHS is written that way.
+    path: req.path,
     hasCookie: !!parseCookies(req).paramant_user_session,
     origin: req.headers.origin,
     secFetchSite: req.headers['sec-fetch-site'],

--- a/admin/server.js
+++ b/admin/server.js
@@ -16,6 +16,34 @@ const cliRate = require('./lib/cli-ratelimit');
 const configStore = require('./lib/config-store');
 const webauthn = require('./lib/webauthn');
 const { sessionKeyFields, proxyApiKey, revealKey } = require('./lib/account-keys');
+// One user's sessions, without reading everybody else's. See admin/lib/user-sessions.js.
+const userSessions = require('./lib/user-sessions');
+// The scan is now a FALLBACK, handed to user-sessions only for a user who has no
+// index yet: every session minted before this deploy. Nothing calls it per
+// request any more.
+const scanSessions = (r, match) => scanKeys(r, { MATCH: match, COUNT: 100 });
+
+// How long a setup link lives. It was fourteen days, hand-typed as `14 * 86400`
+// at seven separate sites, and finding 15 of the 2026-09-05 review is what that
+// buys: for an account whose TOTP is not yet active, the link is the account.
+// Whoever can read the mailbox at any point in those two weeks turns it into a
+// secret, a code and a session in two unauthenticated requests, and an
+// unauthenticated login attempt against such an account MINTS A FRESH ONE and
+// mails it, every time, without cleaning up the last.
+//
+// Two days is long enough for a link that arrives by mail to survive a weekend,
+// and /admin/resend-setup already exists as the operator's answer to an expired
+// one. It is one constant now, so the next copy-paste cannot pick a different
+// number, and setup-link-gate.test.js refuses a literal next to a setup token.
+const SETUP_TOKEN_TTL_S = Math.max(3600, parseInt(process.env.SETUP_TOKEN_TTL_S || '', 10) || 2 * 86400);
+// The same number in words, for the mail that carries the link. One source, so
+// the mail cannot promise a fortnight for a link that lasts two days.
+function setupTokenValidFor() {
+  const h = Math.round(SETUP_TOKEN_TTL_S / 3600);
+  if (h < 48) return h === 1 ? '1 hour' : `${h} hours`;
+  const d = Math.round(h / 24);
+  return d === 1 ? '1 day' : `${d} days`;
+}
 const { buildRecipientParties, RECIPIENT_EMAIL_RE } = require('./lib/recipient-binding');
 const { acquireSignupLock } = require('./lib/signup-lock');
 const loginRate = require('./lib/login-ratelimit');
@@ -464,18 +492,12 @@ api.post('/admin/resend-setup', async (req, res) => {
       redis().del(`paramant:user:backup_codes:${user_id}`),
       redis().del(`paramant:user:backup_codes_plaintext:${user_id}`),
     ]);
-    for await (const k of scanKeys(redis(), { MATCH: 'paramant:user:setup_token:*', COUNT: 100 })) {
-      const raw = await redis().get(k);
-      if (raw) { try { const d = JSON.parse(raw); if (d.user_id === user_id) await redis().del(k); } catch {} }
-    }
-    const setupToken = crypto.randomBytes(32).toString('hex');
-    await redis().set(
-      `paramant:user:setup_token:${setupToken}`,
-      JSON.stringify({ user_id, email }),
-      { EX: 14 * 86400 }
-    );
+    // issueSetupToken also revokes this account's sessions. This route deletes
+    // the TOTP state and the backup codes and used to leave every live session
+    // standing, which is the wrong way round.
+    const setupToken = await issueSetupToken(user_id, email);
     await sendSetupEmail(email, setupToken);
-    const expiresAt = Date.now() + 14 * 86400 * 1000;
+    const expiresAt = Date.now() + SETUP_TOKEN_TTL_S * 1000;
     const setupUrl = `${SITE_URL}/auth/setup/${setupToken}`;
     try { await logAuditEvent(user_id, 'admin_setup_resent', { email, admin_ip: req.headers['x-real-ip'] || 'unknown' }); } catch {}
     console.log(`[admin/resend-setup] sent to ${maskEmail(email)}`);
@@ -689,9 +711,42 @@ async function findUserById(userId) {
   return keys.find(k => k.key === userId && k.active !== false) || null;
 }
 
+// Mint the one outstanding setup link for an account, and clear what it replaces.
+//
+// Finding 15 of the 2026-09-05 review, in one place. Three things had to be true
+// and were not:
+//   - at most ONE link is live at a time. The login path minted a fresh one on
+//     every unauthenticated attempt against a not-yet-activated account and
+//     mailed it, leaving the previous ones alive for their full term. Two weeks
+//     of attempts, two weeks of working links in one mailbox.
+//   - the link is short-lived (SETUP_TOKEN_TTL_S).
+//   - the sessions it can replace do not outlive it. This function hands out the
+//     means to take the account over; a session that predates it has no claim.
+// One outstanding token per account is an invariant, so the account only needs a
+// POINTER to it, not a scan of every token in the product to find its own. The
+// pointer may go stale (the token was consumed, or expired); a stale one costs a
+// DEL of a key that is already gone.
+const setupTokenPointer = (userId) => `paramant:user:setup_token_for:${userId}`;
+
+async function dropSetupTokenFor(userId) {
+  if (!userId) return;
+  const prev = await redis().get(setupTokenPointer(userId)).catch(() => null);
+  if (prev) await redis().del(`paramant:user:setup_token:${prev}`).catch(() => {});
+  await redis().del(setupTokenPointer(userId)).catch(() => {});
+}
+
+async function issueSetupToken(userId, email, extra = {}) {
+  await dropSetupTokenFor(userId);
+  await userSessions.revokeAll(redis(), userId, { scan: scanSessions });
+  const token = crypto.randomBytes(32).toString('hex');
+  await redis().set(`paramant:user:setup_token:${token}`, JSON.stringify({ user_id: userId, email, ...extra }), { EX: SETUP_TOKEN_TTL_S });
+  await redis().set(setupTokenPointer(userId), token, { EX: SETUP_TOKEN_TTL_S }).catch(() => {});
+  return token;
+}
+
 // Send setup email via Resend
 async function sendSetupEmail(email, setupToken, isReset = false) {
-  const msg = emailTemplates.setupEmail({ token: setupToken, requestedAt: Date.now(), requestIP: '', isReset: !!isReset });
+  const msg = emailTemplates.setupEmail({ token: setupToken, requestedAt: Date.now(), requestIP: '', isReset: !!isReset, validFor: setupTokenValidFor() });
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) throw new Error('RESEND_API_KEY not set');
   const res = await fetch('https://api.resend.com/emails', {
@@ -1044,12 +1099,7 @@ api.get("/user/signup/verify/:token", async (req, res) => {
       })
     ));
 
-    const setupToken = crypto.randomBytes(32).toString("hex");
-    await redis().set(
-      `paramant:user:setup_token:${setupToken}`,
-      JSON.stringify({ user_id: keyVal, email, label: label || null }),
-      { EX: 14 * 86400 }
-    );
+    const setupToken = await issueSetupToken(keyVal, email, { label: label || null });
     await redis().set(
       `paramant:user:meta:${keyVal}`,
       JSON.stringify({ email, created_at: createdAt })
@@ -1123,13 +1173,11 @@ api.post("/user/setup/:token/confirm", async (req, res) => {
   const activateRes = await callRelay("/v2/user/activate-totp", { user_id });
   const { backup_codes } = activateRes.ok ? await activateRes.json() : { backup_codes: [] };
   await redis().del(`paramant:user:setup_token:${token}`);
+  await redis().del(setupTokenPointer(user_id)).catch(() => {});
 
   const sessionToken = crypto.randomBytes(32).toString("hex");
-  await redis().set(
-    `paramant:user:session:${sessionToken}`,
-    JSON.stringify({ user_id, email, created_at: Date.now(), ip: req.headers["x-real-ip"] || "unknown", ua: req.get("user-agent") || "", ...sessionKeyFields(user_id) }),
-    { EX: 3600 }
-  );
+  await userSessions.remember(redis(), user_id, sessionToken,
+    { user_id, email, created_at: Date.now(), ip: req.headers["x-real-ip"] || "unknown", ua: req.get("user-agent") || "", ...sessionKeyFields(user_id) }, 3600);
 
   setUserCookie(res, sessionToken);
 
@@ -1281,11 +1329,8 @@ api.post("/user/login", async (req, res) => {
     let um = {}; try { if (metaRaw) um = JSON.parse(metaRaw); } catch {}
     if (um.totp_required) {
       if (um.email || user.email) {
-        const setupToken = (await import('crypto')).randomBytes ? require('crypto').randomBytes(32).toString('hex') : '';
-        if (setupToken) {
-          await redis().set(`paramant:user:setup_token:${setupToken}`, JSON.stringify({ user_id: user.key, email: um.email || user.email }), { EX: 14 * 86400 });
-          sendSetupEmail(um.email || user.email, setupToken).catch(e => console.error('[login/totp_required] email:', e.message));
-        }
+        const setupToken = await issueSetupToken(user.key, um.email || user.email);
+        if (setupToken) sendSetupEmail(um.email || user.email, setupToken).catch(e => console.error('[login/totp_required] email:', e.message));
       }
       // Setup mail is dispatched fire-and-forget above. Respond identically
       // to "no such account" so the status code cannot be used as an
@@ -1330,11 +1375,8 @@ api.post("/user/login", async (req, res) => {
   await loginRate.clearEmailFailures(redis(), email);
 
   const sessionToken = crypto.randomBytes(32).toString("hex");
-  await redis().set(
-    `paramant:user:session:${sessionToken}`,
-    JSON.stringify({ user_id: user.key, email: user.email, created_at: Date.now(), ip, ua: req.get("user-agent") || "", ...sessionKeyFields(user.key) }),
-    { EX: 3600 }
-  );
+  await userSessions.remember(redis(), user.key, sessionToken,
+    { user_id: user.key, email: user.email, created_at: Date.now(), ip, ua: req.get("user-agent") || "", ...sessionKeyFields(user.key) }, 3600);
 
   setUserCookie(res, sessionToken);
 
@@ -1411,11 +1453,8 @@ api.post("/user/login-with-backup", async (req, res) => {
   if (!result || !result.valid) return backupAnswer(401, { error: "invalid_credentials" });
 
   const sessionToken = crypto.randomBytes(32).toString("hex");
-  await redis().set(
-    `paramant:user:session:${sessionToken}`,
-    JSON.stringify({ user_id: user.key, email: user.email, created_at: Date.now(), ip: req.headers["x-real-ip"] || "unknown", ua: req.get("user-agent") || "", via: "backup_code", ...sessionKeyFields(user.key) }),
-    { EX: 3600 }
-  );
+  await userSessions.remember(redis(), user.key, sessionToken,
+    { user_id: user.key, email: user.email, created_at: Date.now(), ip: req.headers["x-real-ip"] || "unknown", ua: req.get("user-agent") || "", via: "backup_code", ...sessionKeyFields(user.key) }, 3600);
 
   setUserCookie(res, sessionToken);
   return backupAnswer(200, { success: true, email: user.email });
@@ -1648,11 +1687,8 @@ api.post("/user/auth/webauthn/login/verify", async (req, res) => {
   // passkey was presented: 'webauthn' (email-first) or 'webauthn_xdev'
   // (usernameless / cross-device).
   const sessionToken = crypto.randomBytes(32).toString("hex");
-  await redis().set(
-    `paramant:user:session:${sessionToken}`,
-    JSON.stringify({ user_id: authedUserId, email: authedEmail, created_at: Date.now(), ip, ua: req.get("user-agent") || "", via: flow.discoverable ? "webauthn_xdev" : "webauthn", ...sessionKeyFields(authedUserId) }),
-    { EX: 3600 }
-  );
+  await userSessions.remember(redis(), authedUserId, sessionToken,
+    { user_id: authedUserId, email: authedEmail, created_at: Date.now(), ip, ua: req.get("user-agent") || "", via: flow.discoverable ? "webauthn_xdev" : "webauthn", ...sessionKeyFields(authedUserId) }, 3600);
   setUserCookie(res, sessionToken);
   try { await logAuditEvent(authedUserId, "webauthn_login", { via: flow.discoverable ? "webauthn_xdev" : "webauthn" }); } catch {}
   res.json({ success: true, email: authedEmail });
@@ -1808,6 +1844,7 @@ api.post("/user/auth/webauthn/register/verify", async (req, res) => {
   // One-shot: consume the setup_token so it cannot be reused for another
   // registration or for TOTP setup.
   await redis().del(`paramant:user:setup_token:${flow.setup_token}`).catch(() => {});
+  await redis().del(setupTokenPointer(flow.user_id)).catch(() => {});
 
   // Issue the session — TOFU onboarding. Passkey is now this account's factor
   // (R018); NO TOTP step. Lax cookie. via:'webauthn-register'.
@@ -1815,11 +1852,8 @@ api.post("/user/auth/webauthn/register/verify", async (req, res) => {
   // stays TOTP-gated until the passkey step-up (R018) is built, so signing is
   // blocked (not bypassed) for a passkey-only account.
   const sessionToken = crypto.randomBytes(32).toString("hex");
-  await redis().set(
-    `paramant:user:session:${sessionToken}`,
-    JSON.stringify({ user_id: flow.user_id, email: flow.email, created_at: Date.now(), ip, ua: req.get("user-agent") || "", via: "webauthn-register", ...sessionKeyFields(flow.user_id) }),
-    { EX: 3600 }
-  );
+  await userSessions.remember(redis(), flow.user_id, sessionToken,
+    { user_id: flow.user_id, email: flow.email, created_at: Date.now(), ip, ua: req.get("user-agent") || "", via: "webauthn-register", ...sessionKeyFields(flow.user_id) }, 3600);
   setUserCookie(res, sessionToken);
   try { await logAuditEvent(flow.user_id, "webauthn_register", {}); } catch {}
   res.json({ success: true, email: flow.email, recovery_codes: recoveryCodes });
@@ -2357,17 +2391,10 @@ api.post("/user/auth/reset-confirm", async (req, res) => {
     redis().del(`paramant:user:backup_codes:${user_id}`),
     redis().del(`paramant:user:backup_codes_plaintext:${user_id}`),
   ]);
-  for await (const k of scanKeys(redis(), { MATCH: "paramant:user:setup_token:*", COUNT: 100 })) {
-    const r = await redis().get(k);
-    if (r) { try { const d = JSON.parse(r); if (d.user_id === user_id) await redis().del(k); } catch {} }
-  }
-
-  const setupToken = crypto.randomBytes(32).toString("hex");
-  await redis().set(
-    `paramant:user:setup_token:${setupToken}`,
-    JSON.stringify({ user_id, email }),
-    { EX: 14 * 86400 }
-  );
+  // The public variant of the reset revoked nothing at all until 2026-09-06,
+  // while the logged-in one did. That inconsistency ran in the attacker's
+  // favour: the reset he drives is precisely the one without a session.
+  const setupToken = await issueSetupToken(user_id, email);
 
   try { await logAuditEvent(user_id, "totp_reset_confirmed", { age_sec: Math.floor((Date.now() - requested_at) / 1000), ip: req.headers["x-real-ip"] || "unknown" }); } catch {}
 
@@ -2385,7 +2412,14 @@ api.post("/user/auth/reset-confirm", async (req, res) => {
 // POST /api/user/logout
 api.post("/user/logout", async (req, res) => {
   const token = parseCookies(req).paramant_user_session;
-  if (token) await redis().del(`paramant:user:session:${token}`);
+  if (token) {
+    // Read the record first, so the index entry goes with the blob. Logging out
+    // used to delete only the blob, which left a dead token in nobody's way but
+    // also in the set for a week.
+    let uid = null;
+    try { uid = JSON.parse(await redis().get(`paramant:user:session:${token}`) || 'null')?.user_id || null; } catch { /* blob already gone */ }
+    await userSessions.forget(redis(), uid, token);
+  }
   clearUserCookie(res);
   res.json({ success: true });
 });
@@ -2735,17 +2769,14 @@ api.get("/user/account", authUser, async (req, res) => {
     const user = await findUserByEmail(email);
     const backupCount = await redis().sCard(`paramant:user:backup_codes:${user_id}`).catch(() => 0);
 
+    // The account screen's session list. It used to SCAN the whole keyspace and
+    // GET every session in the product to find this user's two, on every load,
+    // with no limiter. That was finding 14, and it was also a privacy shape
+    // nobody chose: to show you your own sessions the process read everybody
+    // else's IP and user agent and filtered afterwards. The index answers in one
+    // SMEMBERS plus one MGET, and it can only return this user's records.
     const sessions = [];
-    for await (const key of scanKeys(redis(), { MATCH: "paramant:user:session:*", COUNT: 100 })) {
-      const raw = await redis().get(key);
-      if (!raw) continue;
-      // One corrupt session blob (this user's OR any other user's, since the
-      // SCAN crosses the whole keyspace before the user_id filter below) must
-      // not 500 the whole account view: skip unparseable entries.
-      let s;
-      try { s = JSON.parse(raw); } catch { continue; }
-      if (!s || s.user_id !== user_id) continue;
-      const token = key.replace("paramant:user:session:", "");
+    for (const { token, session: s } of (await userSessions.list(redis(), user_id, scanSessions)).sessions) {
       sessions.push({
         ip_masked: maskIp(s.ip || ""),
         user_agent_short: (s.ua || "").split(" ")[0].slice(0, 40) || "—",
@@ -3265,12 +3296,7 @@ api.post("/user/account/totp/reset", authUser, async (req, res) => {
 
   await callRelay("/v2/user/delete-totp", { user_id });
 
-  const setupToken = crypto.randomBytes(32).toString("hex");
-  await redis().set(
-    `paramant:user:setup_token:${setupToken}`,
-    JSON.stringify({ user_id, email }),
-    { EX: 14 * 86400 }
-  );
+  const setupToken = await issueSetupToken(user_id, email);
 
   try {
     await sendSetupEmail(email, setupToken);
@@ -3280,10 +3306,7 @@ api.post("/user/account/totp/reset", authUser, async (req, res) => {
   }
 
   // Invalidate all sessions for this user
-  for await (const key of scanKeys(redis(), { MATCH: "paramant:user:session:*", COUNT: 100 })) {
-    const raw = await redis().get(key);
-    if (raw) { const s = JSON.parse(raw); if (s.user_id === user_id) await redis().del(key); }
-  }
+  await userSessions.revokeAll(redis(), user_id, { scan: scanSessions });
 
   clearUserCookie(res);
   res.json({ success: true });
@@ -3292,17 +3315,7 @@ api.post("/user/account/totp/reset", authUser, async (req, res) => {
 // POST /api/user/account/sessions/revoke-others
 api.post("/user/account/sessions/revoke-others", authUser, async (req, res) => {
   const { user_id } = req.userSession;
-  let revoked = 0;
-  for await (const key of scanKeys(redis(), { MATCH: "paramant:user:session:*", COUNT: 100 })) {
-    const raw = await redis().get(key);
-    if (!raw) continue;
-    const s = JSON.parse(raw);
-    const token = key.replace("paramant:user:session:", "");
-    if (s.user_id === user_id && token !== req.userSessionToken) {
-      await redis().del(key);
-      revoked++;
-    }
-  }
+  const revoked = await userSessions.revokeAll(redis(), user_id, { except: req.userSessionToken, scan: scanSessions });
   res.json({ success: true, revoked });
 });
 
@@ -3325,10 +3338,7 @@ api.delete("/user/account", authUser, async (req, res) => {
 
   await callRelay("/v2/user/delete-totp", { user_id });
 
-  for await (const key of scanKeys(redis(), { MATCH: "paramant:user:session:*", COUNT: 100 })) {
-    const raw = await redis().get(key);
-    if (raw) { const s = JSON.parse(raw); if (s.user_id === user_id) await redis().del(key); }
-  }
+  await userSessions.revokeAll(redis(), user_id, { scan: scanSessions });
 
   clearUserCookie(res);
   res.json({ success: true });
@@ -4024,14 +4034,12 @@ api.post('/admin/force-totp', authMiddleware, async (req, res) => {
     if (required) {
       const totpActive = await redis().get(`paramant:user:totp_active:${key}`).catch(() => null);
       if (totpActive !== 'true') {
-        for await (const rkey of scanKeys(redis(), { MATCH: `paramant:user:session:*`, COUNT: 100 })) {
-          const raw = await redis().get(rkey).catch(() => null);
-          if (raw) { try { const ss = JSON.parse(raw); if (ss.user_id === key) { await redis().del(rkey); sessions_revoked++; } } catch {} }
-        }
+        // Counted before issueSetupToken revokes them, so the number reported
+        // back is the number that were actually cut.
+        sessions_revoked += (await userSessions.list(redis(), key, scanSessions)).sessions.length;
         if (userMeta.email) {
           try {
-            const setupToken = require('crypto').randomBytes(32).toString('hex');
-            await redis().set(`paramant:user:setup_token:${setupToken}`, JSON.stringify({ user_id: key, email: userMeta.email }), { EX: 14 * 86400 });
+            const setupToken = await issueSetupToken(key, userMeta.email);
             await sendSetupEmail(userMeta.email, setupToken);
             setup_email_sent = true;
           } catch (e) { console.error('[admin/force-totp] setup email:', e.message); }
@@ -4139,9 +4147,9 @@ api.post('/admin/reset-totp', authMiddleware, async (req, res) => {
     if (!await checkAdminRl('reset_totp', key, 5)) return res.status(429).json({ error: 'rate_limited' });
     if (mode === 'direct') {
       await callRelay('/v2/user/delete-totp', { user_id: key }).catch(() => {});
-      const setupToken = crypto.randomBytes(32).toString('hex');
-      await redis().set(`paramant:user:setup_token:${setupToken}`, JSON.stringify({ user_id: key, email: meta.email }), { EX: 14 * 86_400 });
-      await emailTemplates.sendEmail(meta.email, emailTemplates.setupEmail({ token: setupToken, requestedAt: Date.now(), requestIP: req.headers['x-real-ip'], isReset: true }));
+      // issueSetupToken revokes the sessions the old factor let through.
+      const setupToken = await issueSetupToken(key, meta.email);
+      await emailTemplates.sendEmail(meta.email, emailTemplates.setupEmail({ token: setupToken, requestedAt: Date.now(), requestIP: req.headers['x-real-ip'], isReset: true, validFor: setupTokenValidFor() }));
       try { await logAuditEvent(key, 'admin_totp_reset_initiated', { mode: 'direct', email: meta.email, admin_ip: req.headers['x-real-ip'] || 'unknown' }); } catch {}
       res.json({ ok: true, mode: 'direct', email: meta.email });
     } else {
@@ -4254,11 +4262,7 @@ api.post('/admin/revoke-sessions', authMiddleware, async (req, res) => {
   const { key } = req.body || {};
   if (!key?.startsWith('pgp_')) return res.status(400).json({ error: 'invalid_key' });
   try {
-    let count = 0;
-    for await (const rkey of scanKeys(redis(), { MATCH: 'paramant:user:session:*', COUNT: 100 })) {
-      const raw = await redis().get(rkey).catch(() => null);
-      if (raw) { try { const s = JSON.parse(raw); if (s.user_id === key) { await redis().del(rkey); count++; } } catch {} }
-    }
+    const count = await userSessions.revokeAll(redis(), key, { scan: scanSessions });
     try { await logAuditEvent(key, 'admin_sessions_revoked', { count, admin_ip: req.headers['x-real-ip'] || 'unknown' }); } catch {}
     res.json({ ok: true, revoked: count });
   } catch (err) { console.error('[admin/revoke-sessions]', err.message); res.status(500).json({ error: 'internal' }); }
@@ -4297,10 +4301,7 @@ api.post('/admin/delete-account', authMiddleware, async (req, res) => {
     // and the call is idempotent so a retry is free.
     await eachSector(Object.keys(SECTORS), async s => relayFetch(s, '/v2/admin/keys/erase', 'POST', { key }, false, ADMIN_TOKEN, true).catch(() => {}));
     await callRelay('/v2/user/delete-totp', { user_id: key }).catch(() => {});
-    for await (const rkey of scanKeys(redis(), { MATCH: `paramant:user:session:*`, COUNT: 100 })) {
-      const raw = await redis().get(rkey).catch(() => null);
-      if (raw) { try { const s = JSON.parse(raw); if (s.user_id === key) await redis().del(rkey); } catch {} }
-    }
+    await userSessions.revokeAll(redis(), key, { scan: scanSessions });
     for (const pattern of [`paramant:user:meta:${key}`, `paramant:user:totp:${key}`, `paramant:user:totp_active:${key}`, `paramant:user:billing:${key}`]) {
       await redis().del(pattern).catch(() => {});
     }
@@ -4329,11 +4330,7 @@ api.get('/admin/user-details/:key', authMiddleware, async (req, res) => {
     if (!k) return res.status(404).json({ error: 'not_found' });
     let meta = {}; try { if (metaRaw) meta = JSON.parse(metaRaw); } catch {}
     let billing = null; try { if (billingRaw) billing = JSON.parse(billingRaw); } catch {}
-    let sessionCount = 0;
-    for await (const rkey of scanKeys(redis(), { MATCH: 'paramant:user:session:*', COUNT: 100 })) {
-      const raw = await redis().get(rkey).catch(() => null);
-      if (raw) { try { const s = JSON.parse(raw); if (s.user_id === key) sessionCount++; } catch {} }
-    }
+    const sessionCount = (await userSessions.list(redis(), key, scanSessions)).sessions.length;
     const [totpActive, totpSecret] = await Promise.all([
       redis().get(`paramant:user:totp_active:${key}`).catch(() => null),
       redis().get(`paramant:user:totp:${key}`).catch(() => null),
@@ -4383,7 +4380,7 @@ api.post('/admin/preview-email', authMiddleware, async (req, res) => {
     let tpl;
     const fakeToken = 'preview' + crypto.randomBytes(8).toString('hex');
     if (type === 'welcome') tpl = emailTemplates.welcomeEmail({ apiKey: key || 'pgp_preview00000000', plan: meta.plan, label: meta.label, sectors: meta.sectors });
-    else if (type === 'setup') tpl = emailTemplates.setupEmail({ token: fakeToken, requestedAt: Date.now(), requestIP: '0.0.0.0', isReset: options.isReset || false });
+    else if (type === 'setup') tpl = emailTemplates.setupEmail({ token: fakeToken, requestedAt: Date.now(), requestIP: '0.0.0.0', isReset: options.isReset || false, validFor: setupTokenValidFor() });
     else if (type === 'reset-confirm') tpl = emailTemplates.resetConfirmationEmail({ confirmToken: fakeToken, requestedAt: Date.now(), requestIP: '0.0.0.0' });
     // Previewed as the admin-set plan, because that is the only shape this mail
     // is ever sent in: /admin/change-plan is its one live caller. A preview

--- a/admin/server.js
+++ b/admin/server.js
@@ -833,6 +833,30 @@ async function authUser(req, res, next) {
     // showed the login time. Written at most once a minute (see
     // LAST_SEEN_REFRESH_MS) so an open dashboard does not add a write per poll.
     if (!(now - Number(sess.last_seen) < LAST_SEEN_REFRESH_MS)) { sess.last_seen = now; rewrite = true; }
+    // BOUND TO THE CLIENT THAT LOGGED IN. Finding 22i: the session record holds
+    // the account's raw pgp_ API key -- twice, since user_id IS that key -- and
+    // `ip` and `ua` were stored at login and then read only to be PRINTED on the
+    // account screen. Nothing compared them. A cookie lifted off one machine
+    // therefore worked from any other, and one hour of it bought a credential
+    // with no expiry at all.
+    //
+    // The user agent and not the IP. A phone moving from wifi to mobile data
+    // changes its IP mid-session and changes its user agent never; binding to
+    // the address would log people out for walking out of the door, and an
+    // attacker on the same NAT would pass it anyway. A UA change on a live
+    // session token is close to always theft, and in the rare honest case (a
+    // browser that updated itself between two requests) the cost is one login.
+    //
+    // A record from before this field was written has no `ua` to compare: it is
+    // stamped rather than refused, so a deploy does not log everybody out.
+    const ua = req.get('user-agent') || '';
+    if (typeof sess.ua !== 'string') { sess.ua = ua; rewrite = true; }
+    else if (sess.ua !== ua) {
+      await redis().del(key).catch(() => {});
+      try { await logAuditEvent(sess.user_id, 'session_client_changed', { via: sess.via || 'totp' }); } catch (_) { /* audit is best effort */ }
+      return res.status(401).json({ error: "session_expired" });
+    }
+
     // One command either way: SET with EX both stores and slides the window.
     if (rewrite) await redis().set(key, JSON.stringify(sess), { EX: 3600 });
     else await redis().expire(key, 3600);
@@ -2908,6 +2932,13 @@ api.get("/user/account/key", authUser, async (req, res) => {
   // stap 3: reveal the account's PRIMARY api-key (== user_id today), and only
   // when the account is legacy_revealable. The `revealable` field is additive;
   // existing callers read `.api_key`, unchanged while every account is 1:1.
+  //
+  // The one route that turns a session cookie into a credential with no expiry,
+  // so it leaves a mark. It used to leave none at all: an attacker who lifted a
+  // cookie, read the key here and never came back was invisible in the audit
+  // trail, and the key he walked off with outlives every session.
+  // session-credential-gate.test.js holds this to being the only such route.
+  try { await logAuditEvent(req.userSession.user_id, 'account_key_revealed', { via: req.userSession.via || 'totp' }); } catch (_) { /* audit is best effort */ }
   res.json(revealKey(req.userSession));
 });
 
@@ -4564,6 +4595,34 @@ api.post('/admin/cli/exec', authMiddleware, async (req, res) => {
     res.end();
   });
 });
+
+// ── CSRF: a cookie-authenticated write must come from our own page ──────────
+// Finding 19. SameSite=Lax is the whole defence today and it works on the
+// registrable domain, so every sector subdomain is same-site with paramant.app:
+// one HTML injection on one of them yields a page that may POST with the user's
+// session cookie, and twelve state-changing routes need no request body at all.
+// The decision table and the reasoning live in admin/lib/same-origin.js.
+//
+// Mounted here, in front of the whole /api router, so it cannot be forgotten on
+// the next route. Refusals are logged with the origin, because the first thing
+// anybody will ask when a client breaks is which origin it sent.
+const sameOrigin = require('./lib/same-origin');
+const CSRF_ALLOWED_ORIGINS = sameOrigin.buildAllowList(SITE_URL, process.env.CSRF_EXTRA_ORIGINS);
+const CSRF_ALLOW_LOCALHOST = process.env.NODE_ENV !== 'production';
+function requireSameOrigin(req, res, next) {
+  const v = sameOrigin.verdict({
+    method: req.method,
+    hasCookie: !!parseCookies(req).paramant_user_session,
+    origin: req.headers.origin,
+    secFetchSite: req.headers['sec-fetch-site'],
+    allow: CSRF_ALLOWED_ORIGINS,
+    allowLocalhost: CSRF_ALLOW_LOCALHOST,
+  });
+  if (v.ok) return next();
+  console.warn('[csrf] refused', req.method, req.originalUrl, v.reason);
+  return res.status(403).json({ error: 'csrf_origin', message: 'This request did not come from paramant.app.' });
+}
+app.use(`${BASE_PATH}/api`, requireSameOrigin);
 
 app.use(`${BASE_PATH}/api`, api);
 // /cli -- web debug terminal page (served before the SPA wildcard fallback).

--- a/admin/test/credential-reset-gate.test.js
+++ b/admin/test/credential-reset-gate.test.js
@@ -1,0 +1,143 @@
+'use strict';
+// THE CREDENTIAL RESET GATE. A path that resets or replaces a login factor must
+// invalidate the sessions that factor authorised, and the link it mails out must
+// have one lifetime, written down once.
+//
+// WHY THIS EXISTS. Finding 15 of the 2026-09-05 hostile review, and it is two
+// faults wearing one name.
+//
+//   THE LIFETIME. `14 * 86400` was hand-typed at seven separate sites. For an
+//   account whose TOTP is not yet active, the setup link IS the account: it
+//   hands over the TOTP secret and, one code later, a session, with no other
+//   proof. Two weeks of mailbox access is two weeks of account takeover, and an
+//   unauthenticated login attempt against such an account minted a FRESH link
+//   and mailed it on every try, never clearing the last. Seven copies of a
+//   number is also how the mail came to promise a fortnight.
+//
+//   THE REVOCATION. Four of the seven paths revoked nothing. The sharpest was
+//   /admin/resend-setup, which deletes the account's TOTP state and its backup
+//   codes -- tearing down the second factor -- and left every live session
+//   standing. The logged-in reset DID revoke, the public one did not, and the
+//   reset an attacker drives is precisely the one without a session.
+//
+// The class is: a credential reset that leaves the credential's sessions alive.
+// Asserting it about four named routes catches the case; the fifth route is
+// written by copying one of the four. So this scans for the shape.
+//
+// WHAT IT REQUIRES
+//   C1  no literal TTL beside a setup-token write. One constant.
+//   C2  every setup token is minted through issueSetupToken, which clears the
+//       previous one and revokes the account's sessions.
+//   C3  a handler that tears down a factor (deletes totp / totp_active /
+//       backup_codes) also revokes, directly or through issueSetupToken.
+//   C4  the mail's promise comes from the same constant as the TTL.
+//
+// Runs anywhere: no redis, plain fs.
+
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+const TEMPLATES = fs.readFileSync(path.join(__dirname, '..', 'lib', 'email-templates.js'), 'utf8');
+const LINES = SRC.split('\n');
+
+// Deleting one of these is tearing a login factor down.
+const TEARDOWN = /del\(`paramant:user:(totp|totp_active|backup_codes|backup_codes_plaintext):/;
+// What counts as revoking. Either directly, or through the minting helper,
+// which does it on the caller's behalf.
+const REVOKES = /userSessions\.revokeAll\(|issueSetupToken\(/;
+
+function handlers() {
+  const out = [];
+  const open = /^\s*api\.(get|post|put|patch|delete)\(\s*["'`]([^"'`]+)["'`]/;
+  LINES.forEach((l, i) => {
+    const m = open.exec(l);
+    if (!m) return;
+    let d = 0; let end = LINES.length - 1;
+    for (let j = i; j < LINES.length; j++) {
+      d += (LINES[j].match(/\(/g) || []).length - (LINES[j].match(/\)/g) || []).length;
+      if (j > i && d <= 0) { end = j; break; }
+    }
+    out.push({ name: `${m[1].toUpperCase()} ${m[2]}`, line: i + 1, body: LINES.slice(i, end + 1).join('\n') });
+  });
+  return out;
+}
+
+test('the setup-token lifetime is one constant, never a literal', () => {
+  const offenders = [];
+  LINES.forEach((l, i) => {
+    if (!/setup_token/.test(l)) return;
+    if (/EX:\s*\d/.test(l) || /\d+\s*\*\s*86_?400/.test(l)) offenders.push(`admin/server.js:${i + 1} ${l.trim().slice(0, 110)}`);
+  });
+  assert.deepStrictEqual(offenders, [], `a hand-typed lifetime next to a setup token:\n  ${offenders.join('\n  ')}`);
+  assert.match(SRC, /const SETUP_TOKEN_TTL_S = /, 'the shared constant is gone');
+  // And it is short. Fourteen days was the finding; anything past a week is the
+  // finding again under a different number.
+  const decl = /const SETUP_TOKEN_TTL_S = ([^;]+);/.exec(SRC);
+  assert.ok(decl, 'SETUP_TOKEN_TTL_S is no longer a simple declaration');
+  // eslint-disable-next-line no-new-func
+  const value = Function(`"use strict"; const process = { env: {} }; return (${decl[1]});`)();
+  assert.ok(value <= 7 * 86400, `the default setup-link lifetime is ${Math.round(value / 86400)} days`);
+});
+
+test('every setup token is minted through the one helper', () => {
+  // A token written by hand skips both halves: the previous one is not cleared,
+  // and the account's sessions survive a factor reset.
+  const bare = [];
+  LINES.forEach((l, i) => {
+    if (!/redis\(\)\.set\(`paramant:user:setup_token:/.test(l)) return;
+    bare.push(`admin/server.js:${i + 1} ${l.trim().slice(0, 110)}`);
+  });
+  // The helper's own write is the exception, and it is identified by being
+  // inside issueSetupToken rather than by its line number.
+  const helper = SRC.slice(SRC.indexOf('async function issueSetupToken('), SRC.indexOf('\n}', SRC.indexOf('async function issueSetupToken(')));
+  const inHelper = bare.filter((b) => helper.includes(b.split(' ').slice(1).join(' ')));
+  assert.strictEqual(inHelper.length, 1, 'issueSetupToken no longer writes the token itself');
+  assert.deepStrictEqual(bare.filter((b) => !inHelper.includes(b)), [],
+    `a setup token minted outside issueSetupToken:\n  ${bare.join('\n  ')}`);
+});
+
+test('the minting helper clears the previous link and revokes the sessions', () => {
+  const at = SRC.indexOf('async function issueSetupToken(');
+  assert.ok(at > 0, 'issueSetupToken is gone');
+  const helper = SRC.slice(at, SRC.indexOf('\n}', at));
+  assert.match(helper, /dropSetupTokenFor\(/, 'the previous link is no longer cleared');
+  assert.match(helper, /userSessions\.revokeAll\(/, 'the sessions are no longer revoked');
+  assert.match(helper, /SETUP_TOKEN_TTL_S/, 'the helper no longer uses the shared lifetime');
+});
+
+test('a handler that tears a factor down also revokes the sessions it let through', () => {
+  const offenders = [];
+  for (const h of handlers()) {
+    if (!TEARDOWN.test(h.body)) continue;
+    if (REVOKES.test(h.body)) continue;
+    offenders.push(`admin/server.js:${h.line} ${h.name}`);
+  }
+  assert.deepStrictEqual(offenders, [], `a factor is torn down and its sessions live on:\n  ${offenders.join('\n  ')}`);
+});
+
+test('the mail does not promise a lifetime of its own', () => {
+  assert.doesNotMatch(TEMPLATES, /valid for 14 days/, 'the setup mail still promises fourteen days');
+  assert.match(TEMPLATES, /validFor/, 'the setup mail no longer takes the lifetime as a parameter');
+  assert.match(SRC, /function setupTokenValidFor\(/, 'nothing turns the constant into the phrase the mail prints');
+  assert.match(SRC, /validFor: setupTokenValidFor\(\)/, 'a caller of setupEmail does not pass the lifetime');
+  // Every caller, not just one.
+  const calls = SRC.match(/emailTemplates\.setupEmail\(\{/g) || [];
+  const withValid = SRC.match(/emailTemplates\.setupEmail\(\{[^}]*validFor:/g) || [];
+  assert.strictEqual(withValid.length, calls.length, `${calls.length - withValid.length} setupEmail call(s) print the template default instead of the real lifetime`);
+});
+
+test('self-test: the teardown and revoke patterns actually separate', () => {
+  const torn = handlers().filter((h) => TEARDOWN.test(h.body));
+  assert.ok(torn.length >= 2, `only ${torn.length} handlers tear a factor down; the pattern has drifted`);
+  const broken = [
+    'api.post("/x", async (req, res) => {',
+    '  await redis().del(`paramant:user:totp_active:${user_id}`);',
+    '  res.json({ ok: true });',
+    '});',
+  ].join('\n');
+  assert.strictEqual(TEARDOWN.test(broken), true, 'the teardown pattern misses a plain delete');
+  assert.strictEqual(REVOKES.test(broken), false, 'the revoke pattern matches a handler that revokes nothing');
+});

--- a/admin/test/credential-reset-gate.test.js
+++ b/admin/test/credential-reset-gate.test.js
@@ -77,7 +77,6 @@ test('the setup-token lifetime is one constant, never a literal', () => {
   // finding again under a different number.
   const decl = /const SETUP_TOKEN_TTL_S = ([^;]+);/.exec(SRC);
   assert.ok(decl, 'SETUP_TOKEN_TTL_S is no longer a simple declaration');
-  // eslint-disable-next-line no-new-func
   const value = Function(`"use strict"; const process = { env: {} }; return (${decl[1]});`)();
   assert.ok(value <= 7 * 86400, `the default setup-link lifetime is ${Math.round(value / 86400)} days`);
 });

--- a/admin/test/csrf-origin-gate.test.js
+++ b/admin/test/csrf-origin-gate.test.js
@@ -48,7 +48,7 @@ const SITE = 'https://paramant.app';
 const allow = sameOrigin.buildAllowList(SITE, '');
 
 const ask = (over = {}) => sameOrigin.verdict({
-  method: 'POST', hasCookie: true, origin: '', secFetchSite: '', allow, ...over,
+  method: 'POST', path: '/user/account/totp/reset', hasCookie: true, origin: '', secFetchSite: '', allow, ...over,
 });
 
 test('the check is mounted in front of the whole router, before the routes', () => {
@@ -131,6 +131,21 @@ test('the allow list is built from SITE_URL, not from a hardcoded host', () => {
   assert.match(SRC, /CSRF_EXTRA_ORIGINS/, 'there is no way to add an origin without editing code');
 });
 
+test('exactly one write is exempt, and it is the one that only destroys the caller own session', () => {
+  // The Outlook task pane runs on addin.paramant.app and its logout is a simple
+  // cross-origin POST: no preflight, cookie attached, response hidden by CORS.
+  // It works today, the add-in ignores the answer, and an origin check would
+  // silently stop it revoking anything. Signing somebody out is the one write
+  // where refusing costs a shipped client more than it buys.
+  assert.deepStrictEqual([...sameOrigin.EXEMPT_PATHS], ['/user/logout'],
+    'the exempt set has changed. A write that GRANTS anything does not belong in it.');
+  assert.strictEqual(ask({ path: '/user/logout', origin: 'https://addin.paramant.app' }).ok, true);
+  assert.strictEqual(ask({ path: '/user/logout', origin: 'https://evil.example.test' }).reason, 'exempt_path');
+  // And the exemption is a PATH, not a prefix: nothing else under it rides along.
+  assert.strictEqual(ask({ path: '/user/logout/all', origin: 'https://legal.paramant.app' }).ok, false);
+  assert.strictEqual(ask({ path: '/user/account/key', origin: 'https://addin.paramant.app' }).ok, false);
+});
+
 test('self-test: the refusal reason names the origin, so a broken client is diagnosable', () => {
   const v = ask({ origin: 'https://legal.paramant.app' });
   assert.strictEqual(v.ok, false);
@@ -186,6 +201,17 @@ async function cookie() {
   }), { EX: 3600 });
   return `paramant_user_session=${token}`;
 }
+
+test('over HTTP: the add-in can still sign a user out from its own host', async () => {
+  if (!srv) return;
+  const Cookie = await cookie();
+  const r = await fetch(`${srv.base}/api/user/logout`, {
+    method: 'POST', headers: { Cookie, Origin: 'https://addin.paramant.app' },
+  });
+  assert.notStrictEqual(r.status, 403, 'the Outlook task pane can no longer log anybody out');
+  assert.strictEqual(await rc.get(`paramant:user:session:${Cookie.split('=')[1]}`), null,
+    'the logout was allowed through but revoked nothing');
+});
 
 test('over HTTP: a same-site sector origin cannot drive a cookie write', async () => {
   if (!srv) return;

--- a/admin/test/csrf-origin-gate.test.js
+++ b/admin/test/csrf-origin-gate.test.js
@@ -1,0 +1,236 @@
+'use strict';
+// THE CSRF ORIGIN GATE. A write that authenticates with the session cookie must
+// come from our own page.
+//
+// WHY THIS EXISTS. Finding 19 of the 2026-09-05 hostile review. The user side of
+// the admin server had no CSRF defence beyond the cookie's own SameSite=Lax: no
+// token, no Origin check, no Referer check, no Sec-Fetch-Site. Grepped on
+// 2026-09-06, the word "Origin" appeared in that file only inside WebAuthn
+// configuration and inside the comment explaining SameSite.
+//
+// Lax is not the bug and is not being revisited: it is a written-down trade-off
+// for the co-sign flow, which lands a recipient through a top-level navigation
+// from an emailed link. The bug is that Lax is scoped to the REGISTRABLE DOMAIN.
+// health / legal / finance / iot / relay .paramant.app are all same-site with
+// paramant.app, so a single HTML injection on any one of them produces a page
+// whose POSTs carry the session cookie. Twelve state-changing routes need no
+// request body at all, which means a plain form submit reaches them without ever
+// being preflighted: reset the TOTP, destroy the backup codes, revoke the
+// sessions, cancel the subscription, mint a live ParaSign API key.
+//
+// The review marked the exploitation route "probable" rather than confirmed, and
+// that was right: no live injection point was found. What is confirmed is that
+// there is no second layer if one appears.
+//
+// WHAT IT REQUIRES
+//   O1  the check is mounted in FRONT of the whole /api router, not per route.
+//       A per-route list is a list that the next route is not on.
+//   O2  the allow list does not accept a sector subdomain. That origin is the
+//       one this exists to refuse, and relay.js isAllowedOrigin does accept it
+//       (correctly, for CORS on the API, and wrongly for this).
+//   O3  the decision table behaves, case by case.
+//
+// The static half runs anywhere (pure functions plus fs). The behavioural half
+// at the bottom boots a real admin against redis and is skipped by name through
+// ADMIN_TEST_SKIP, like every other suite here that needs one.
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const sameOrigin = require('../lib/same-origin');
+const { boot, killAll, stubRelay, defaultRelayState } = require('./_admin-server');
+const SRC = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+
+const SITE = 'https://paramant.app';
+const allow = sameOrigin.buildAllowList(SITE, '');
+
+const ask = (over = {}) => sameOrigin.verdict({
+  method: 'POST', hasCookie: true, origin: '', secFetchSite: '', allow, ...over,
+});
+
+test('the check is mounted in front of the whole router, before the routes', () => {
+  const mount = SRC.indexOf('app.use(`${BASE_PATH}/api`, requireSameOrigin);');
+  const router = SRC.indexOf('app.use(`${BASE_PATH}/api`, api);');
+  assert.ok(mount > 0, 'the same-origin check is not mounted');
+  assert.ok(router > 0, 'the api router mount moved');
+  assert.ok(mount < router, 'the check is mounted after the router, so it never runs first');
+  // And it is not a per-route decoration, which is the shape that goes stale.
+  const perRoute = (SRC.match(/requireSameOrigin\s*,/g) || []).length;
+  assert.strictEqual(perRoute, 0, 'the check is being applied route by route as well; one mount is the point');
+});
+
+test('a sector subdomain is refused, which is the whole finding', () => {
+  for (const host of ['health', 'legal', 'finance', 'iot', 'relay']) {
+    const o = `https://${host}.paramant.app`;
+    const v = ask({ origin: o });
+    assert.strictEqual(v.ok, false, `${o} was accepted; it is same-site, which is exactly the attack`);
+    assert.match(v.reason, /^cross_origin:/);
+  }
+  // A lookalike that merely ends in the same string, too.
+  assert.strictEqual(ask({ origin: 'https://paramant.app.example.test' }).ok, false);
+  assert.strictEqual(ask({ origin: 'https://notparamant.app' }).ok, false);
+});
+
+test('our own page passes, by Origin and by Sec-Fetch-Site', () => {
+  assert.strictEqual(ask({ origin: SITE }).ok, true);
+  assert.strictEqual(ask({ secFetchSite: 'same-origin' }).ok, true);
+  // Typed in the address bar, or a bookmark: the browser says none.
+  assert.strictEqual(ask({ secFetchSite: 'none' }).ok, true);
+  assert.strictEqual(ask({ secFetchSite: 'same-site' }).ok, false, 'same-site is the sector subdomain again');
+  assert.strictEqual(ask({ secFetchSite: 'cross-site' }).ok, false);
+});
+
+test('Origin decides before Sec-Fetch-Site, because the extensions are cross-site by construction', () => {
+  // The browser extension and the Outlook taskpane are real callers that hold a
+  // cookie and always look cross-site. If Sec-Fetch-Site were consulted first
+  // they would be refused, and the fix for that would be to weaken the rule for
+  // everyone.
+  const ext = 'chrome-extension://abcdefghijklmnopabcdefghijklmnop';
+  assert.strictEqual(ask({ origin: ext, secFetchSite: 'cross-site' }).ok, true);
+  assert.strictEqual(ask({ origin: 'moz-extension://11111111-2222-3333-4444-555555555555', secFetchSite: 'cross-site' }).ok, true);
+  // And a page merely CLAIMING to be an extension over https is not one.
+  assert.strictEqual(ask({ origin: 'https://chrome-extension.example.test' }).ok, false);
+});
+
+test('what is never checked, is never checked for a reason', () => {
+  // A read cannot change anything, and a request with no session cookie is
+  // authenticating by something an attacker's page cannot borrow.
+  for (const method of ['GET', 'HEAD', 'OPTIONS']) {
+    assert.strictEqual(ask({ method, origin: 'https://evil.example.test' }).ok, true, `${method} was refused`);
+  }
+  assert.strictEqual(ask({ hasCookie: false, origin: 'https://evil.example.test' }).ok, true, 'a keyed caller was refused');
+  // Neither header at all: a non-browser client. Every browser sends Origin on
+  // a POST, so refusing here would close nothing and break every curl and every
+  // node http test in this repo.
+  const bare = ask({});
+  assert.strictEqual(bare.ok, true);
+  assert.strictEqual(bare.reason, 'no_browser_headers');
+});
+
+test('localhost passes in development and not in production', () => {
+  const dev = sameOrigin.verdict({ method: 'POST', hasCookie: true, origin: 'http://localhost:8080', secFetchSite: '', allow, allowLocalhost: true });
+  const prod = sameOrigin.verdict({ method: 'POST', hasCookie: true, origin: 'http://localhost:8080', secFetchSite: '', allow, allowLocalhost: false });
+  assert.strictEqual(dev.ok, true);
+  assert.strictEqual(prod.ok, false, 'a production deploy accepts http://localhost as an origin');
+  assert.match(SRC, /CSRF_ALLOW_LOCALHOST = process\.env\.NODE_ENV !== 'production'/, 'the dev exception is not tied to NODE_ENV');
+});
+
+test('the allow list is built from SITE_URL, not from a hardcoded host', () => {
+  const other = sameOrigin.buildAllowList('https://staging.example.test', '');
+  assert.ok(other.has('https://staging.example.test'));
+  assert.ok(!other.has(SITE), 'the production origin is baked in regardless of SITE_URL');
+  // Extras, for a taskpane host that is not ours.
+  const withExtra = sameOrigin.buildAllowList(SITE, 'https://outlook.office.com, https://outlook.office365.com');
+  assert.ok(withExtra.has('https://outlook.office.com'));
+  assert.ok(withExtra.has('https://outlook.office365.com'));
+  // Junk in the env does not become an allowed origin.
+  assert.ok(!sameOrigin.buildAllowList(SITE, 'not a url, , ///').has('not a url'));
+  assert.match(SRC, /CSRF_EXTRA_ORIGINS/, 'there is no way to add an origin without editing code');
+});
+
+test('self-test: the refusal reason names the origin, so a broken client is diagnosable', () => {
+  const v = ask({ origin: 'https://legal.paramant.app' });
+  assert.strictEqual(v.ok, false);
+  assert.strictEqual(v.reason, 'cross_origin:https://legal.paramant.app');
+  assert.match(SRC, /console\.warn\('\[csrf\] refused'/, 'a refusal is not logged, so nobody can tell why a client broke');
+  assert.match(SRC, /error: 'csrf_origin'/, 'the refusal has no stable error code for a client to read');
+});
+
+// ── the behavioural half, on a really booted admin ───────────────────────────
+// The static half above drives the decision table. This one proves the table is
+// actually consulted, by a process, in front of the routes -- which is the half
+// that a refactor breaks silently.
+
+const DEFAULT_REDIS = 'redis://127.0.0.1:6399';
+const SUFFIX = crypto.randomBytes(4).toString('hex');
+const ACCOUNT_KEY = `pgp_csrf_${SUFFIX}`;
+const SITE_ORIGIN = 'https://paramant.app';
+let rc = null;
+let srv = null;
+let relay = null;
+
+before(async () => {
+  const url = process.env.REDIS_URL || DEFAULT_REDIS;
+  let createClient;
+  try { ({ createClient } = require('redis')); }
+  catch (e) {
+    if (String(process.env.ADMIN_TEST_SKIP || '').split(',').includes('redis')) return;
+    throw new Error('unmet precondition "redis": the redis module is not installed. Run npm ci in admin/, or declare it: ADMIN_TEST_SKIP=redis');
+  }
+  const c = createClient({ url, socket: { connectTimeout: 800, reconnectStrategy: false } });
+  c.on('error', () => {});
+  try { await c.connect(); await c.ping(); }
+  catch (e) {
+    try { await c.disconnect(); } catch (_) { /* never connected */ }
+    if (String(process.env.ADMIN_TEST_SKIP || '').split(',').includes('redis')) return;
+    throw new Error(`unmet precondition "redis": no reachable redis at ${url}: ${e.message}`);
+  }
+  rc = c;
+  relay = await stubRelay(defaultRelayState([]));
+  srv = await boot({ redisUrl: url, relay, env: { SITE_URL: SITE_ORIGIN, NODE_ENV: 'production' } });
+});
+
+after(async () => {
+  await killAll();
+  if (rc) { try { await rc.disconnect(); } catch (_) { /* already gone */ } }
+});
+
+async function cookie() {
+  const token = crypto.randomBytes(24).toString('hex');
+  await rc.set(`paramant:user:session:${token}`, JSON.stringify({
+    user_id: ACCOUNT_KEY, email: `owner-${SUFFIX}@example.test`,
+    created_at: Date.now(), primary_api_key: ACCOUNT_KEY, legacy_revealable: true,
+  }), { EX: 3600 });
+  return `paramant_user_session=${token}`;
+}
+
+test('over HTTP: a same-site sector origin cannot drive a cookie write', async () => {
+  if (!srv) return;
+  const Cookie = await cookie();
+  // The sharpest of the twelve bodyless writes: it tears down the second factor.
+  const path_ = '/api/user/account/totp/reset';
+
+  const evil = await fetch(`${srv.base}${path_}`, {
+    method: 'POST', headers: { Cookie, Origin: 'https://legal.paramant.app' },
+  });
+  assert.strictEqual(evil.status, 403, `a sector subdomain drove the reset: ${evil.status}`);
+  assert.strictEqual((await evil.json()).error, 'csrf_origin');
+
+  // And the account is untouched: the refusal happened before the handler.
+  assert.ok(await rc.get(`paramant:user:session:${Cookie.split('=')[1]}`), 'the session was revoked by a refused request');
+});
+
+test('over HTTP: our own page is not refused, and neither is a header-less client', async () => {
+  if (!srv) return;
+  const ours = await fetch(`${srv.base}/api/user/account/totp/reset`, {
+    method: 'POST', headers: { Cookie: await cookie(), Origin: SITE_ORIGIN },
+  });
+  assert.notStrictEqual(ours.status, 403, 'our own origin was refused');
+
+  const bare = await fetch(`${srv.base}/api/user/account/totp/reset`, {
+    method: 'POST', headers: { Cookie: await cookie() },
+  });
+  assert.notStrictEqual(bare.status, 403, 'a client sending no browser headers was refused');
+});
+
+test('over HTTP: a read is never refused, whatever origin it claims', async () => {
+  if (!srv) return;
+  const r = await fetch(`${srv.base}/api/user/account`, {
+    method: 'GET', headers: { Cookie: await cookie(), Origin: 'https://evil.example.test' },
+  });
+  assert.notStrictEqual(r.status, 403, 'a GET was refused on its origin');
+});
+
+test('over HTTP: the check covers every route, including one added after it', async () => {
+  if (!srv) return;
+  // Mounted in front of the router, so it applies to paths that do not exist
+  // either. That is the property: a new route is covered on the day it is
+  // written, without anybody remembering to decorate it.
+  const r = await fetch(`${srv.base}/api/user/some-route-added-next-month`, {
+    method: 'POST', headers: { Cookie: await cookie(), Origin: 'https://iot.paramant.app' },
+  });
+  assert.strictEqual(r.status, 403, 'the check is per route after all');
+});

--- a/admin/test/keyspace-scan-gate.test.js
+++ b/admin/test/keyspace-scan-gate.test.js
@@ -1,0 +1,179 @@
+'use strict';
+// THE KEYSPACE SCAN GATE. A route a customer can call must not make the shared
+// Redis walk its whole keyspace.
+//
+// WHY THIS EXISTS. Finding 14 of the 2026-09-05 hostile review. Eight places in
+// admin/server.js answered "which sessions belong to this user?" by scanning
+// paramant:user:session:* across the entire keyspace and GETting every key that
+// came back, filtering on user_id afterwards. One of them was
+// GET /api/user/account, which the account screen calls on every load, behind no
+// rate limit and no cache, against the Redis that all five relay sectors and the
+// admin plane share. One free account plus a loop is a fleet-wide load
+// generator, and the cost grows with the customer base rather than with the
+// caller.
+//
+// It is also a privacy shape nobody chose. To show you your own two sessions,
+// the process read every other customer's session blob -- their IP, their user
+// agent -- and discarded them after the comparison.
+//
+// The repair is a per-user index (admin/lib/user-sessions.js). The gate is not
+// "the session scan is gone": that catches the case, and the same shape is one
+// commit away for audit events, for setup tokens, for whatever is indexed next.
+//
+// WHAT IT REQUIRES
+//   S1  no wildcard SCAN sits in a handler reachable with a user session
+//       (authUser) or with no authentication at all, unless it is named in
+//       ALLOW with a reason and an exact count.
+//   S2  GET /api/user/account in particular contains no wildcard MATCH. It is
+//       the one a customer can call in a loop from a browser.
+//
+// An admin route (authMiddleware, ADMIN_TOKEN) may scan: the operator is not a
+// threat model here and the routes are hand-driven, not polled.
+//
+// Runs anywhere: no redis, plain fs.
+
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+const LINES = SRC.split('\n');
+
+// A scan over a pattern rather than over a known key.
+// `[\s\S]{0,160}?` and not `[^)]*`: the first argument is usually `redis()`, so
+// a pattern that cannot cross a closing paren never reaches the MATCH string and
+// matches nothing at all -- which reads as a clean scan.
+const WILDCARD = /(scanKeys|scanIterator|\.keys)\s*\([\s\S]{0,160}?['"`][^'"`]*\*/;
+
+// Routes whose middleware chain is the operator's. Everything else in this file
+// is either a customer route or an unauthenticated one.
+const ADMIN_GUARD = /authMiddleware/;
+
+// Module-level helpers that scan. A route that calls one of these is scanning
+// too, and moving the loop out of the handler is exactly how a repair passes a
+// naive gate: the setup-token scan of finding 15 ended up in issueSetupToken
+// before this rule existed. One level of call graph, which is what these
+// helpers are.
+function scanningHelpers(lines = LINES) {
+  const out = [];
+  const decl = /^\s*(?:async\s+)?function\s+(\w+)\s*\(/;
+  lines.forEach((l, i) => {
+    const m = decl.exec(l);
+    if (!m) return;
+    let d = 0; let end = lines.length - 1;
+    for (let j = i; j < lines.length; j++) {
+      d += (lines[j].match(/\{/g) || []).length - (lines[j].match(/\}/g) || []).length;
+      if (j > i && d <= 0) { end = j; break; }
+    }
+    if (WILDCARD.test(lines.slice(i, end + 1).join('\n'))) out.push(m[1]);
+  });
+  return out;
+}
+
+// Reachable by a customer or by nobody, and still scanning. Exact count.
+const ALLOW = [];
+
+function routes() {
+  const out = [];
+  const open = /^\s*api\.(get|post|put|patch|delete)\(\s*["'`]([^"'`]+)["'`]\s*,?\s*(.*)$/;
+  LINES.forEach((l, i) => {
+    const m = open.exec(l);
+    if (!m) return;
+    // The handler runs to the line that closes it at the same indentation.
+    let d = 0; let end = LINES.length - 1;
+    for (let j = i; j < LINES.length; j++) {
+      d += (LINES[j].match(/\(/g) || []).length - (LINES[j].match(/\)/g) || []).length;
+      if (j > i && d <= 0) { end = j; break; }
+    }
+    const head = LINES.slice(i, Math.min(i + 3, LINES.length)).join(' ');
+    out.push({
+      name: `${m[1].toUpperCase()} ${m[2]}`,
+      admin: ADMIN_GUARD.test(head),
+      body: LINES.slice(i, end + 1).join('\n'),
+      line: i + 1,
+    });
+  });
+  return out;
+}
+
+test('the route scanner finds the routes at all', () => {
+  const r = routes();
+  assert.ok(r.length > 60, `only ${r.length} routes found; the scanner has drifted`);
+  assert.ok(r.some((x) => x.name === 'GET /user/account'), 'the account route was not found');
+  assert.ok(r.some((x) => x.admin), 'no admin-guarded route was recognised');
+  assert.ok(r.some((x) => !x.admin), 'every route was classified as admin');
+});
+
+test('no customer-reachable route walks the whole keyspace', () => {
+  const allowed = new Set(ALLOW.map((a) => a.route));
+  const helpers = scanningHelpers();
+  const offenders = [];
+  for (const r of routes()) {
+    if (r.admin) continue;
+    const direct = WILDCARD.test(r.body);
+    const viaHelper = helpers.find((h) => new RegExp(`\\b${h}\\s*\\(`).test(r.body));
+    if (!direct && !viaHelper) continue;
+    if (allowed.has(r.name)) continue;
+    offenders.push(`admin/server.js:${r.line} ${r.name}${viaHelper ? ` (through ${viaHelper}())` : ''}`);
+  }
+  assert.deepStrictEqual(offenders, [], `a customer can make the shared redis walk its keyspace:\n  ${offenders.join('\n  ')}`);
+});
+
+test('the ALLOW list is exact and reasoned', () => {
+  const helpers = scanningHelpers();
+  const scanning = routes()
+    .filter((r) => !r.admin && (WILDCARD.test(r.body) || helpers.some((h) => new RegExp(`\\b${h}\\s*\\(`).test(r.body))))
+    .map((r) => r.name);
+  assert.deepStrictEqual([...new Set(scanning)].sort(), ALLOW.map((a) => a.route).sort(),
+    'the set of customer-reachable scanning routes has changed. Index it, or add it\n'
+    + 'here with a reason; remove an entry that has been closed.');
+  for (const a of ALLOW) assert.ok(a.reason && a.reason.length > 80, `${a.route} has no usable reason`);
+});
+
+test('the account screen holds no wildcard at all', () => {
+  // The one a browser polls. Pinned separately from the class rule so moving it
+  // between middleware chains cannot make it pass.
+  const r = routes().find((x) => x.name === 'GET /user/account');
+  assert.ok(r, 'GET /user/account is gone');
+  assert.doesNotMatch(r.body, WILDCARD, 'the account screen scans the keyspace again');
+  assert.match(r.body, /userSessions\.list\(/, 'the account screen no longer reads its sessions from the index');
+});
+
+test('every session write and delete goes through the index', () => {
+  // A session written with a bare redis().set is invisible to its owner and
+  // survives every revocation, which is worse than the scan it replaced.
+  const bare = [];
+  LINES.forEach((l, i) => {
+    if (/paramant:user:session:/.test(l) && /redis\(\)\.(set|del)\(/.test(l)) {
+      bare.push(`admin/server.js:${i + 1} ${l.trim().slice(0, 100)}`);
+    }
+  });
+  assert.deepStrictEqual(bare, [], `a session written or deleted outside the index:\n  ${bare.join('\n  ')}`);
+  assert.match(SRC, /userSessions\.remember\(/, 'nothing writes a session through the index');
+  assert.match(SRC, /userSessions\.revokeAll\(/, 'nothing revokes through the index');
+});
+
+test('self-test: a scan hidden in a helper is still a scan', () => {
+  // The rule that has to survive the next repair. Moving the loop out of the
+  // handler and into a function is what happened to the setup-token scan while
+  // finding 15 was being fixed, and a gate that only reads handler bodies would
+  // have gone green on it.
+  const synthetic = [
+    'async function purgeTokens(userId) {',
+    "  for await (const k of scanKeys(redis(), { MATCH: 'paramant:user:setup_token:*', COUNT: 100 })) {",
+    '    await redis().del(k);',
+    '  }',
+    '}',
+  ];
+  assert.deepStrictEqual(scanningHelpers(synthetic), ['purgeTokens'], 'the helper detector missed a scanning helper');
+  const clean = ['async function readOne(t) {', '  return redis().get(`paramant:user:setup_token:${t}`);', '}'];
+  assert.deepStrictEqual(scanningHelpers(clean), [], 'the helper detector flags a plain get');
+});
+
+test('self-test: the wildcard pattern separates a scan from a plain get', () => {
+  assert.strictEqual(WILDCARD.test("scanKeys(redis(), { MATCH: 'paramant:user:session:*', COUNT: 100 })"), true);
+  assert.strictEqual(WILDCARD.test('scanKeys(r, { MATCH: match, COUNT: 100 })'), false, 'a variable pattern is not evidence either way');
+  assert.strictEqual(WILDCARD.test('redis().get(`paramant:user:session:${token}`)'), false);
+  assert.strictEqual(WILDCARD.test("redis().sMembers('paramant:user:sessions:acct')"), false);
+});

--- a/admin/test/login-http.test.js
+++ b/admin/test/login-http.test.js
@@ -453,8 +453,13 @@ test('a session record written before created_at existed is capped, not exempted
   await httpRedis.set(key, JSON.stringify(
     { user_id: HTTP_OWNER_KEY, email: HTTP_OWNER_EMAIL, ip: '203.0.113.9', ua: 'probe', via: 'totp' },
   ), { EX: 3600 });
+  // The User-Agent is sent to match the one on the fixture. Since 2026-09-06
+  // authUser binds a session to the client that opened it (finding 22i), so a
+  // request from a different agent is theft and gets a 401. That is a separate
+  // property, asserted in session-credential-gate.test.js; here it would just
+  // be noise standing between this test and the thing it measures.
   const r = await httpSrv.get('/api/user/account', {
-    headers: { Cookie: `paramant_user_session=${token}` },
+    headers: { Cookie: `paramant_user_session=${token}`, 'User-Agent': 'probe' },
   });
   assert.equal(r.status, 200, `a record without created_at must keep working: ${r.status} ${r.text}`);
   const stored = JSON.parse(await httpRedis.get(key));

--- a/admin/test/session-credential-gate.test.js
+++ b/admin/test/session-credential-gate.test.js
@@ -1,0 +1,170 @@
+'use strict';
+// THE SESSION CREDENTIAL GATE. A session cookie is a one-hour capability. What
+// it can be exchanged for must not be a credential that never expires, and it
+// must not work from a machine that never logged in.
+//
+// WHY THIS EXISTS. Finding 22i of the 2026-09-05 hostile review, and it is
+// sharper than the review wrote it. The session record does not merely CARRY the
+// account's raw pgp_ API key: the key IS the identity. Every mint site writes
+//
+//     { user_id: user.key, ..., primary_api_key: user.key }
+//
+// so `session.user_id === session.primary_api_key === the credential`. Removing
+// the field would change nothing, because proxyApiKey falls back to user_id
+// (admin/lib/account-keys.js). And `ip` and `ua` were written at login and then
+// read only to be printed on the account screen; nothing compared them, so a
+// lifted cookie worked from anywhere.
+//
+// WHAT IS REPAIRED HERE, AND WHAT IS NOT. The binding is: a session is refused
+// from a client that is not the one that opened it, and the single route that
+// turns a cookie into the raw key leaves an audit entry. What is NOT repaired is
+// the identity itself. Minting sessions on an `acct_` id and resolving the key
+// from the account record is a schema change across five mint sites, the
+// account-keys module, the parasend token mint and every fixture in this
+// directory. It is a change of its own and does not belong as a rider on a
+// review round. This gate holds the surface flat in the meantime: exactly one
+// route may hand the key out, and it is the one that has always done so.
+//
+// WHAT IT REQUIRES
+//   K1  authUser compares the stored client against the request's, and refuses.
+//   K2  exactly one route in the whole file returns revealKey(). A second one is
+//       a second place a stolen cookie becomes a permanent credential.
+//   K3  that route records the reveal.
+//   K4  the binding is stamped, not enforced, on a record that predates it, so a
+//       deploy does not log everybody out.
+//
+// Runs anywhere for the source rules; the behavioural half needs a redis and is
+// declared through ADMIN_TEST_SKIP like the rest of this directory.
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const { boot, killAll, stubRelay, defaultRelayState } = require('./_admin-server');
+const SRC = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+
+function authUserBody() {
+  const at = SRC.indexOf('async function authUser(');
+  assert.ok(at > 0, 'authUser is gone');
+  return SRC.slice(at, SRC.indexOf('\n}\n', at));
+}
+
+test('authUser binds the session to the client that opened it', () => {
+  const body = authUserBody();
+  assert.match(body, /req\.get\('user-agent'\)/, 'authUser does not read the request user agent');
+  assert.match(body, /sess\.ua !== ua/, 'authUser reads the stored client and never compares it');
+  assert.match(body, /session_expired/, 'a mismatch does not end the session');
+  // Stamped, not refused, when the record predates the field.
+  assert.match(body, /typeof sess\.ua !== 'string'/, 'a record without a stored client is refused rather than stamped');
+});
+
+test('exactly one route hands the raw key to the browser', () => {
+  const reveals = [];
+  SRC.split('\n').forEach((l, i) => {
+    if (/revealKey\s*\(/.test(l) && !/require\(|function revealKey/.test(l)) reveals.push(`admin/server.js:${i + 1} ${l.trim().slice(0, 90)}`);
+  });
+  assert.strictEqual(reveals.length, 1, `expected exactly one reveal, found ${reveals.length}:\n  ${reveals.join('\n  ')}`);
+  assert.match(reveals[0], /res\.json\(revealKey\(req\.userSession\)\)/);
+});
+
+test('the reveal is recorded', () => {
+  const at = SRC.indexOf('api.get("/user/account/key"');
+  assert.ok(at > 0, 'the reveal route is gone');
+  const route = SRC.slice(at, SRC.indexOf('\n});', at));
+  assert.match(route, /logAuditEvent\([^)]*'account_key_revealed'/, 'the reveal leaves no mark');
+  assert.match(route, /authUser/, 'the reveal route lost its authentication');
+});
+
+test('the proxy hands the key to a relay, never to a response body', () => {
+  // proxyApiKey resolves the key for a server-to-server call. It must never end
+  // up in something the browser reads, which is the shape that would quietly
+  // add a second reveal route.
+  const offenders = [];
+  SRC.split('\n').forEach((l, i) => {
+    if (!/proxyApiKey\s*\(/.test(l)) return;
+    if (/res\.json\(|res\.send\(|return\s+\{/.test(l)) offenders.push(`admin/server.js:${i + 1} ${l.trim().slice(0, 90)}`);
+  });
+  assert.deepStrictEqual(offenders, [], `the account key is being written into a response:\n  ${offenders.join('\n  ')}`);
+});
+
+// ── behaviour, on a booted admin ─────────────────────────────────────────────
+
+const DEFAULT_REDIS = 'redis://127.0.0.1:6399';
+const SUFFIX = crypto.randomBytes(4).toString('hex');
+const ACCOUNT_KEY = `pgp_bind_${SUFFIX}`;
+let rc = null;
+let srv = null;
+let relay = null;
+
+before(async () => {
+  const url = process.env.REDIS_URL || DEFAULT_REDIS;
+  let createClient;
+  try { ({ createClient } = require('redis')); }
+  catch (e) {
+    if (String(process.env.ADMIN_TEST_SKIP || '').split(',').includes('redis')) return;
+    throw new Error('unmet precondition "redis": the redis module is not installed. Run npm ci in admin/, or declare it: ADMIN_TEST_SKIP=redis');
+  }
+  const c = createClient({ url, socket: { connectTimeout: 800, reconnectStrategy: false } });
+  c.on('error', () => {});
+  try { await c.connect(); await c.ping(); }
+  catch (e) {
+    try { await c.disconnect(); } catch (_) { /* never connected */ }
+    if (String(process.env.ADMIN_TEST_SKIP || '').split(',').includes('redis')) return;
+    throw new Error(`unmet precondition "redis": no reachable redis at ${url}: ${e.message}`);
+  }
+  rc = c;
+  relay = await stubRelay(defaultRelayState([]));
+  srv = await boot({ redisUrl: url, relay });
+});
+
+after(async () => {
+  await killAll();
+  if (rc) { try { await rc.disconnect(); } catch (_) { /* already gone */ } }
+});
+
+async function plant(fields = {}) {
+  const token = crypto.randomBytes(24).toString('hex');
+  await rc.set(`paramant:user:session:${token}`, JSON.stringify({
+    user_id: ACCOUNT_KEY, email: `bind-${SUFFIX}@example.test`,
+    created_at: Date.now(), last_seen: Date.now(), ip: '203.0.113.9',
+    primary_api_key: ACCOUNT_KEY, legacy_revealable: true, ...fields,
+  }), { EX: 3600 });
+  return token;
+}
+
+const ask = (token, ua) => fetch(`${srv.base}/api/user/account/key`, {
+  headers: { Cookie: `paramant_user_session=${token}`, ...(ua ? { 'User-Agent': ua } : {}) },
+});
+
+test('over HTTP: the cookie works from the client that opened it', async () => {
+  if (!srv) return;
+  const token = await plant({ ua: 'Mozilla/5.0 (honest)' });
+  const r = await ask(token, 'Mozilla/5.0 (honest)');
+  assert.strictEqual(r.status, 200, `the owner was refused: ${r.status}`);
+  assert.strictEqual((await r.json()).api_key, ACCOUNT_KEY);
+});
+
+test('over HTTP: the same cookie replayed from another client gets nothing', async () => {
+  if (!srv) return;
+  const token = await plant({ ua: 'Mozilla/5.0 (honest)' });
+  const r = await ask(token, 'Mozilla/5.0 (thief)');
+  assert.strictEqual(r.status, 401, `a lifted cookie still yields the key: ${r.status}`);
+  const body = await r.text();
+  assert.ok(!body.includes(ACCOUNT_KEY), 'the refusal leaked the key anyway');
+  // And the session is gone, so the thief cannot retry with the right agent
+  // once he notices.
+  assert.strictEqual(await rc.get(`paramant:user:session:${token}`), null, 'a session used from a second client survived');
+});
+
+test('over HTTP: a record with no stored client is stamped and keeps working', async () => {
+  if (!srv) return;
+  const token = await plant();          // no `ua` at all, as an older record has
+  const r = await ask(token, 'Mozilla/5.0 (deploy)');
+  assert.strictEqual(r.status, 200, `a pre-existing session was logged out: ${r.status}`);
+  const stored = JSON.parse(await rc.get(`paramant:user:session:${token}`));
+  assert.strictEqual(stored.ua, 'Mozilla/5.0 (deploy)', 'the client was not stamped on the way through');
+  // Stamped means bound from now on.
+  assert.strictEqual((await ask(token, 'Mozilla/5.0 (thief)')).status, 401, 'the stamp did not start binding the session');
+});

--- a/admin/test/user-sessions.test.js
+++ b/admin/test/user-sessions.test.js
@@ -1,0 +1,186 @@
+'use strict';
+// The per-user session index, against a real Redis.
+//
+// The behavioural half of finding 14. keyspace-scan-gate.test.js proves nothing
+// scans the keyspace any more; this proves the thing that replaced it actually
+// answers the same questions, including the two that a naive index gets wrong:
+//
+//   - a session whose blob expired must not keep appearing in its owner's list
+//     (the set outlives the blob by design, so every read prunes);
+//   - a user minted BEFORE this deploy has no index at all, and must still be
+//     able to see and revoke his sessions. That is the `scan` fallback, and it
+//     adopts what it finds so it is paid once per user rather than per request.
+//
+// Run: REDIS_URL=redis://127.0.0.1:6399 node --test admin/test/user-sessions.test.js
+
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+
+const userSessions = require('../lib/user-sessions');
+
+const DEFAULT_REDIS = 'redis://127.0.0.1:6399';
+let rc = null;
+let checks = 0;
+const did = () => { checks++; };
+const RUN = Math.random().toString(36).slice(2, 8);
+const USER = `pgp_us_${RUN}`;
+const OTHER = `pgp_other_${RUN}`;
+
+// The scan the admin server hands in for a user with no index yet.
+const scan = async function* (client, match) {
+  for await (const k of client.scanIterator({ MATCH: match, COUNT: 100 })) {
+    if (Array.isArray(k)) { for (const one of k) yield one; } else yield k;
+  }
+};
+
+before(async () => {
+  const url = process.env.REDIS_URL || DEFAULT_REDIS;
+  let createClient;
+  try { ({ createClient } = require('redis')); }
+  catch (e) {
+    if (String(process.env.ADMIN_TEST_SKIP || '').split(',').includes('redis')) {
+      console.log('  SKIP [redis] - the "redis" module is not installed (declared via ADMIN_TEST_SKIP)');
+      return;
+    }
+    throw new Error('unmet precondition "redis": the redis module is not installed. Run npm ci in admin/, or declare it: ADMIN_TEST_SKIP=redis');
+  }
+  const c = createClient({ url, socket: { connectTimeout: 800, reconnectStrategy: false } });
+  c.on('error', () => {});
+  try { await c.connect(); await c.ping(); }
+  catch (e) {
+    try { await c.disconnect(); } catch (_) { /* never connected */ }
+    if (String(process.env.ADMIN_TEST_SKIP || '').split(',').includes('redis')) {
+      console.log(`  SKIP [redis] - no reachable redis at ${url} (declared via ADMIN_TEST_SKIP)`);
+      return;
+    }
+    throw new Error(`unmet precondition "redis": no reachable redis at ${url}: ${e.message}`);
+  }
+  rc = c;
+});
+
+after(async () => {
+  if (rc) {
+    const keys = [];
+    for await (const k of scan(rc, `paramant:user:session*${''}`)) keys.push(k);
+    for (const k of keys) { if (k.includes(RUN)) await rc.del(k).catch(() => {}); }
+    await rc.del(userSessions.indexKey(USER)).catch(() => {});
+    await rc.del(userSessions.indexKey(OTHER)).catch(() => {});
+    try { await rc.disconnect(); } catch (_) { /* already gone */ }
+  }
+  console.log(`# user-sessions: ${checks} checks ${checks ? 'passed' : 'ran'}`);
+});
+
+const rec = (user) => ({ user_id: user, email: `${user}@example.test`, created_at: Date.now(), ip: '10.0.0.1', ua: 'probe' });
+
+test('a remembered session is listed for its owner and for nobody else', async () => {
+  if (!rc) return;
+  const a = `tok_a_${RUN}`;
+  const b = `tok_b_${RUN}`;
+  const foreign = `tok_f_${RUN}`;
+  await userSessions.remember(rc, USER, a, rec(USER), 60);
+  await userSessions.remember(rc, USER, b, rec(USER), 60);
+  await userSessions.remember(rc, OTHER, foreign, rec(OTHER), 60);
+
+  const mine = await userSessions.list(rc, USER);
+  assert.strictEqual(mine.indexed, true, 'the index was not used');
+  assert.deepStrictEqual(mine.sessions.map((s) => s.token).sort(), [a, b].sort());
+
+  const theirs = await userSessions.list(rc, OTHER);
+  assert.deepStrictEqual(theirs.sessions.map((s) => s.token), [foreign]);
+  did();
+});
+
+test('an expired blob does not linger in the list, and is pruned from the set', async () => {
+  if (!rc) return;
+  const gone = `tok_gone_${RUN}`;
+  await userSessions.remember(rc, USER, gone, rec(USER), 60);
+  // What an expiry looks like: the blob goes, the set entry stays behind.
+  await rc.del(userSessions.sessionKey(gone));
+
+  const { sessions } = await userSessions.list(rc, USER);
+  assert.ok(!sessions.some((s) => s.token === gone), 'a dead session is still listed');
+  const members = await rc.sMembers(userSessions.indexKey(USER));
+  assert.ok(!members.includes(gone), 'the dead token was not pruned from the index');
+  did();
+});
+
+test('a session record belonging to somebody else is never returned, even from the set', async () => {
+  if (!rc) return;
+  // Defence in depth: if a token ever lands in the wrong set, the record itself
+  // still decides. This is the property the old scan got right by accident and
+  // an index could lose.
+  const wrong = `tok_wrong_${RUN}`;
+  await rc.set(userSessions.sessionKey(wrong), JSON.stringify(rec(OTHER)), { EX: 60 });
+  await rc.sAdd(userSessions.indexKey(USER), wrong);
+
+  const { sessions } = await userSessions.list(rc, USER);
+  assert.ok(!sessions.some((s) => s.token === wrong), 'an index entry overrode the record');
+  await rc.del(userSessions.sessionKey(wrong));
+  did();
+});
+
+test('forget removes the blob and the index entry together', async () => {
+  if (!rc) return;
+  const t = `tok_out_${RUN}`;
+  await userSessions.remember(rc, USER, t, rec(USER), 60);
+  await userSessions.forget(rc, USER, t);
+  assert.strictEqual(await rc.get(userSessions.sessionKey(t)), null);
+  assert.ok(!(await rc.sMembers(userSessions.indexKey(USER))).includes(t), 'logout left a token in the index');
+  did();
+});
+
+test('revokeAll clears every session, and can keep the one asking', async () => {
+  if (!rc) return;
+  await rc.del(userSessions.indexKey(USER));
+  const keep = `tok_keep_${RUN}`;
+  const drop1 = `tok_d1_${RUN}`;
+  const drop2 = `tok_d2_${RUN}`;
+  for (const t of [keep, drop1, drop2]) await userSessions.remember(rc, USER, t, rec(USER), 60);
+
+  const revoked = await userSessions.revokeAll(rc, USER, { except: keep });
+  assert.strictEqual(revoked, 2);
+  assert.ok(await rc.get(userSessions.sessionKey(keep)), 'the current session was revoked too');
+  assert.strictEqual(await rc.get(userSessions.sessionKey(drop1)), null);
+  assert.deepStrictEqual(await rc.sMembers(userSessions.indexKey(USER)), [keep]);
+
+  const all = await userSessions.revokeAll(rc, USER);
+  assert.strictEqual(all, 1);
+  assert.strictEqual(await rc.get(userSessions.sessionKey(keep)), null);
+  assert.deepStrictEqual(await rc.sMembers(userSessions.indexKey(USER)), []);
+  did();
+});
+
+test('a session from before the index still shows up, and is adopted once', async () => {
+  if (!rc) return;
+  // Its own user, because the fallback SCANS: any session another test in this
+  // file left behind for USER would be found too and the count would drift.
+  const LEGACY_USER = `pgp_legacy_${RUN}`;
+  const legacy = `tok_legacy_${RUN}`;
+  // Exactly what the old code wrote: a blob, and no index entry.
+  await rc.set(userSessions.sessionKey(legacy), JSON.stringify(rec(LEGACY_USER)), { EX: 60 });
+
+  const first = await userSessions.list(rc, LEGACY_USER, scan);
+  assert.strictEqual(first.indexed, false, 'the fallback did not report itself as a fallback');
+  assert.deepStrictEqual(first.sessions.map((s) => s.token), [legacy]);
+
+  // Adopted, so the scan is paid once and not per request.
+  const second = await userSessions.list(rc, LEGACY_USER, scan);
+  assert.strictEqual(second.indexed, true, 'the fallback answer was not adopted into the index');
+  assert.deepStrictEqual(second.sessions.map((s) => s.token), [legacy]);
+
+  // And revocation reaches it either way.
+  assert.strictEqual(await userSessions.revokeAll(rc, LEGACY_USER, { scan }), 1);
+  assert.strictEqual(await rc.get(userSessions.sessionKey(legacy)), null);
+  await rc.del(userSessions.indexKey(LEGACY_USER)).catch(() => {});
+  did();
+});
+
+test('a user with nothing gets an empty answer, not a scan', async () => {
+  if (!rc) return;
+  const nobody = `pgp_nobody_${RUN}`;
+  const { sessions, indexed } = await userSessions.list(rc, nobody);
+  assert.deepStrictEqual(sessions, []);
+  assert.strictEqual(indexed, true);
+  assert.strictEqual(await userSessions.revokeAll(rc, nobody), 0);
+  did();
+});

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,6 +1,6 @@
 # PARAMANT: complete environment reference
 #
-# 102 variables. Copy to deploy/.env and fill in what the "required" blocks ask
+# 106 variables. Copy to deploy/.env and fill in what the "required" blocks ask
 # for. .env is NEVER committed to git.
 #
 # This file is the reference: every name the relay or the admin panel reads is
@@ -131,6 +131,21 @@ PARAMANT_TOTP_MASTER_KEY=
 # optional · default: 5
 # read in: relay/relay.js
 # ACCOUNT_KEY_LIMIT_COMMUNITY=5
+
+# Active API keys allowed per account on the paid plans. NOT a product limit,
+# and no page sells them: these were Infinity, which with a self-serve mint
+# route meant users.json grew by one entry per HTTP request. An abuse ceiling,
+# set far above what any real account holds. Being over it only flags a key
+# (over_limit), it never deactivates one, so a ceiling set too low is a log line
+# and not an outage. Floored at 10.
+# optional · default: 100
+# read in: relay/relay.js
+# ACCOUNT_KEY_LIMIT_PRO=100
+
+# The same ceiling for Enterprise accounts.
+# optional · default: 1000
+# read in: relay/relay.js
+# ACCOUNT_KEY_LIMIT_ENTERPRISE=1000
 
 # Licensed Edition key (plk_...), which lifts the Community key cap. An invalid
 # or expired key falls back to Community Edition rather than failing to boot.
@@ -521,6 +536,28 @@ PARAMANT_TOTP_MASTER_KEY=
 # optional · default: none (mail is skipped)
 # read in: relay/relay.js, admin/server.js, admin/lib/email-templates.js
 # RESEND_API_KEY=
+
+# How long a setup link lives, in seconds. The link hands over the TOTP secret
+# and, one code later, a session, so for an account whose second factor is not
+# yet active it IS the account: whoever reaches the mailbox inside this window
+# takes it over. It was fourteen days, hand-typed at seven sites. Floored at one
+# hour. The setup mail prints this same number in words, so lengthening it here
+# does not make the mail lie. /admin/resend-setup is the answer to an expired
+# link, so short is cheap.
+# optional · default: 172800 (2 days)
+# read in: admin/server.js
+# SETUP_TOKEN_TTL_S=172800
+
+# Extra origins allowed to drive a cookie-authenticated write on the admin API,
+# comma-separated, on top of SITE_URL. For a hosted taskpane, which is a real
+# caller on somebody else's domain. Browser extensions do NOT need an entry:
+# they are matched by scheme (chrome-extension://, moz-extension://), because
+# an extension id differs per install and an id list would always be slightly
+# wrong. A sector subdomain must never be put here; refusing exactly that origin
+# is what the check exists for (admin/lib/same-origin.js).
+# optional · default: none
+# read in: admin/server.js
+# CSRF_EXTRA_ORIGINS=
 
 # Base32 TOTP secret for the operator's own admin MFA.
 # Generate: python3 -c "import secrets,base64; print(base64.b32encode(secrets.token_bytes(20)).decode())"

--- a/deploy/DEPLOY-3.1.md
+++ b/deploy/DEPLOY-3.1.md
@@ -948,12 +948,15 @@ passing on an empty search.
    relay, from the server, with the admin token:
    ```bash
    A=$(grep '^ADMIN_TOKEN=' /opt/paramant-relay/.env | cut -d= -f2-)
+   I=$(grep '^INTERNAL_AUTH_TOKEN=' /opt/paramant-relay/.env | cut -d= -f2-)
    curl -s -X POST http://127.0.0.1:3000/v2/admin/keys/mint-parasign \
-     -H "X-Admin-Token: $A" -H 'Content-Type: application/json' \
+     -H "X-Admin-Token: $A" -H "X-Internal-Auth: $I" -H 'Content-Type: application/json' \
      -d '{"account_id":"<the canary account>","test":true,"label":"parasign-canary"}'
-   unset A
+   unset A I
    ```
-   The key is shown once (`relay.js`, `/v2/admin/keys/mint-parasign`). Then
+   Both headers, since 2026-09-06: minting a key is a two-gate route, like
+   `set-product-plan`. Without `X-Internal-Auth` the answer is a 403, not a key.
+   The key itself is shown once (`relay.js`, `/v2/admin/keys/mint-parasign`). Then
    `gh secret set PARASIGN_CANARY_KEY` and trigger `product-heartbeat.yml` once
    with `workflow_dispatch`: expected 3 pass, 0 skip on the ParaSign canary.
    Every `/v2/admin` path is behind `X-Admin-Token` (`relay.js`, `isAdminPath`),

--- a/docs/api.md
+++ b/docs/api.md
@@ -1147,8 +1147,11 @@ A refund or a chargeback arrives on the same `tr_` id as the payment. A
 returns **both** products to their floor, ParaSign to `free` and ParaSend to
 `community`, because the one payment is what held both up, and it clears the
 paid period with them. A charged-back single-product payment returns only that
-product. A **refund** moves no entitlement; the credit note is the record. The
-relay issues a **credit note** for either: its own sequential number in its own series
+product. A **full refund** does exactly the same, and it counts as full whether
+Mollie reports it as the status `refunded` or as an `amountRefunded` equal to the
+amount on a payment that is still `paid`. A **partial refund** moves no
+entitlement, and it does not renew one either. The relay issues a **credit note**
+for either: its own sequential number in its own series
 (`CN-2026-0001`, per calendar year), referring to the invoice it credits by
 number and date, with negative net, VAT and total. One per reversal, idempotent
 against a Mollie retry. A partial refund is credited for the amount that went

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -3040,12 +3040,24 @@ async function addQualifiedSignature(pdfBytes) {
 
   let bin = '';
   for (let i = 0; i < pdfBytes.length; i++) bin += String.fromCharCode(pdfBytes[i]);
+  // The envelope and the party invite token go with the request. The relay used
+  // to take this document from anybody at all; since 2026-09-06 it wants to know
+  // which signing party is asking, and this page is that party. Same capability
+  // the signature submit already uses, so nothing new is handed to the browser.
+  const qesEnv = state.envelope || {};
+  const qesLink = (qesEnv.party_links || []).find((p) => p.party_index === 0) || {};
   let res;
   try {
     res = await fetch('/v2/qes/sign', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ document: btoa(bin), signer_name: state.signer.name || null }),
+      body: JSON.stringify({
+        document: btoa(bin),
+        signer_name: state.signer.name || null,
+        envelope_id: qesEnv.id || null,
+        party_index: 0,
+        invite_token: qesLink.invite_token || null,
+      }),
     });
   } catch {
     line.textContent = 'The qualified signature could not be requested. Your ParaSign signature is unaffected.';

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -284,7 +284,7 @@ main#main-content .btn { width: 100%; justify-content: center; }
     <button type="button" id="resend-btn" class="su-linkbtn">resend the link</button>.
   </p>
   <p class="small mt-2" id="resend-status" aria-live="polite"></p>
-  <p class="small mt-3 su-dim">The link works for 14 days.</p>
+  <p class="small mt-3 su-dim">The link works for 2 days.</p>
 </section>
 
 </main>

--- a/relay/lib/billing.js
+++ b/relay/lib/billing.js
@@ -10,10 +10,43 @@
 //   3) Idempotent. A payment id that was already handled changes nothing
 //      (deps.isProcessed / deps.markProcessed), and setProductPlan is itself
 //      idempotent, so a double webhook is safe even without the marker.
-//   4) Only status 'paid' grants. failed/expired/canceled do nothing; chargeback
-//      revokes to the product floor.
+//   4) Only status 'paid' grants, and only when nothing has gone back.
+//      failed/expired/canceled do nothing; money returned in full, by chargeback
+//      OR by refund, revokes to the product floor.
 
 const catalog = require('./billing-catalog');
+const creditNote = require('./credit-note');
+const invoice = require('./invoice');
+
+// ── has any money gone back, and was it all of it ────────────────────────────
+// The document layer (credit-note.js) and this layer must agree about what
+// counts as money returned, or the customer gets a credit note for a plan he
+// keeps. Before 2026-09-06 they did not: credit-note.isReversal already read
+// both cumulative counters, while this file matched on the STATUS STRING alone
+// and only for 'chargeback'. Mollie reports a refund on the very same tr_ id
+// with the status still 'paid' and amountRefunded set, so a refund did not even
+// reach the fall-through the review pointed at -- it went down the PAID branch,
+// and only the idempotency marker stood between a refunded payment and a fresh
+// month granted on it.
+//
+// So the predicate is imported rather than restated. `full` decides revoke
+// versus leave-alone, and it is deliberately conservative in the one direction
+// that matters: a 'chargeback' status is whole no matter what the counters say,
+// which is exactly what this file did before. What is new is that a 'refunded'
+// status, and a still-'paid' payment whose counters reach the invoiced amount,
+// are whole too. A part-refund revokes nothing and grants nothing.
+function reversalOf(payment) {
+  const p = payment || {};
+  if (!creditNote.isReversal(p)) return null;
+  const cents = (v) => { const c = invoice.centsOf(v); return Number.isFinite(c) ? c : 0; };
+  const gross = cents(p.amount && p.amount.value);
+  const back = cents(p.amountRefunded && p.amountRefunded.value)
+             + cents(p.amountChargedBack && p.amountChargedBack.value);
+  const status = String(p.status || '');
+  const wholeByStatus = status === 'chargeback' || status === 'charged_back' || status === 'refunded';
+  const full = wholeByStatus || (back > 0 && gross > 0 && back >= gross);
+  return { full, kind: creditNote.reasonOf(p), back, gross };
+}
 
 // How far a paid interval carries the entitlement. Calendar months and years,
 // not 30 or 365 days: a customer who pays on the 31st should renew on a date
@@ -101,7 +134,8 @@ async function processPayment(payment, deps) {
   // payment it reverses, so a flat id check swallowed the revoke and left an
   // account that had taken its money back sitting on the paid tier. What the
   // marker records is the outcome, and only a repeat of that outcome is a no-op.
-  const revoking = status === 'chargeback' || status === 'charged_back';
+  const reversal = reversalOf(payment);
+  const revoking = !!(reversal && reversal.full);
   const wanted = revoking ? 'revoked' : 'granted';
   if (typeof d.isProcessed === 'function') {
     let done = false;
@@ -110,6 +144,39 @@ async function processPayment(payment, deps) {
     // 'granted', which is what every marker written before this meant.
     const seen = typeof done === 'string' ? done : (done ? 'granted' : null);
     if (seen === wanted) return { result: 'ignored', level: 'info', account: accountId, product, reason: 'already_processed' };
+  }
+
+  if (revoking) {
+    // Money reclaimed, in full, by chargeback or by refund. Revoke: drop this
+    // product to its floor tier.
+    // EVERY product the order bought goes back to its floor. A bundle that
+    // granted two entitlements and revoked one would leave the customer holding
+    // half a plan he has taken the money back for.
+    const revoked = [];
+    for (const g of order.grants) {
+      const floor = catalog.floorTier(g.product);
+      // null clears the period along with the tier: money reclaimed leaves no
+      // paid time on record.
+      try { await d.setProductPlan(accountId, g.product, floor, null, null); } catch { /* logged by caller via reason */ }
+      revoked.push({ product: g.product, tier: floor });
+    }
+    if (typeof d.markProcessed === 'function') { try { await d.markProcessed(payment.id, 'revoked'); } catch { /* best effort */ } }
+    return {
+      result: 'revoked', level: 'warn', account: accountId, product,
+      bundle: order.bundle || null, tier: revoked[0].tier, grants: revoked, reason: reversal.kind,
+    };
+  }
+
+  // Money went back, but not all of it. A part-refund is not a cancelled sale,
+  // so the entitlement stands -- but it must not be read as a fresh purchase
+  // either, which is what happened while a refund arrived as a still-'paid'
+  // payment and fell into the grant branch above. The credit note is issued by
+  // the webhook regardless (it is not gated on this outcome).
+  if (reversal) {
+    return {
+      result: 'ignored', level: 'info', account: accountId, product,
+      reason: `partial_${reversal.kind}:${reversal.back}_of_${reversal.gross}`,
+    };
   }
 
   if (status === 'paid') {
@@ -169,27 +236,10 @@ async function processPayment(payment, deps) {
     };
   }
 
-  if (status === 'chargeback' || status === 'charged_back') {
-    // Money reclaimed. Revoke: drop this product to its floor tier.
-    // EVERY product the order bought goes back to its floor. A bundle that
-    // granted two entitlements and revoked one would leave the customer holding
-    // half a plan he has taken the money back for.
-    const revoked = [];
-    for (const g of order.grants) {
-      const floor = catalog.floorTier(g.product);
-      // null clears the period along with the tier: money reclaimed leaves no
-      // paid time on record.
-      try { await d.setProductPlan(accountId, g.product, floor, null, null); } catch { /* logged by caller via reason */ }
-      revoked.push({ product: g.product, tier: floor });
-    }
-    if (typeof d.markProcessed === 'function') { try { await d.markProcessed(payment.id, 'revoked'); } catch { /* best effort */ } }
-    return {
-      result: 'revoked', level: 'warn', account: accountId, product,
-      bundle: order.bundle || null, tier: revoked[0].tier, grants: revoked, reason: 'chargeback',
-    };
-  }
 
-  // failed | expired | canceled | open | pending -> no entitlement change.
+  // authorized | failed | expired | canceled | open | pending -> no entitlement
+  // change. Money that went back no longer lands here: it is answered above,
+  // whatever status string it arrived under.
   return { result: 'ignored', level: 'info', account: accountId, product, reason: `status_${status}` };
 }
 
@@ -219,4 +269,4 @@ function classifyFetchError(err) {
   return { retry: true, level: 'warn', reason: status ? `mollie_${status}` : (msg || 'fetch_error') };
 }
 
-module.exports = { processPayment, classifyFetchError, periodEnd, extendFrom, bundleExtendFrom, keepLonger };
+module.exports = { processPayment, classifyFetchError, reversalOf, periodEnd, extendFrom, bundleExtendFrom, keepLonger };

--- a/relay/lib/keys-table.js
+++ b/relay/lib/keys-table.js
@@ -168,6 +168,23 @@ function parasignGrantLive(rec, now) {
   return !entitlements.effectiveProductTier(rec, 'parasign', now).expired;
 }
 
+// The ACCOUNT-level grant, which is narrower than the key-level one above and
+// has to stay narrower. A psk_ key carries scope 'parasign' for its whole life:
+// that is what the key IS, and it is a perfectly good reason to let the key
+// through the /v1 door at whatever tier it holds. It is not a reason to let the
+// ACCOUNT mint another one.
+//
+// Measured on 2026-09-06 by tests/koper-hele-weg.test.mjs, which is the only
+// test in the repo that walks the whole purchase and then charges it back: with
+// the scope shape included here, an account that had taken its money back could
+// still mint, because revoking clears the `parasign` flag on every member key
+// and cannot clear what a psk_ key is. The flag is the grant; the scope is a
+// capability the grant already handed out.
+function parasignAccountGrantLive(rec, now) {
+  if (!rec || rec.parasign !== true) return false;
+  return !entitlements.effectiveProductTier(rec, 'parasign', now).expired;
+}
+
 function hasParaSignScope(rec, now) {
   return parasignGrantLive(rec, now);
 }
@@ -456,7 +473,7 @@ const PARASIGN_ENTITLED_PLANS = new Set(['pro', 'business', 'enterprise', 'licen
 // makes it worth a gate rather than a shrug: a minted key carries parasign:true
 // itself, so it re-satisfies this very check for its own account.
 function accountHasParasignEntitlement(memberRecords, plan, now) {
-  for (const r of (memberRecords || [])) { if (parasignGrantLive(r, now)) return true; }
+  for (const r of (memberRecords || [])) { if (parasignAccountGrantLive(r, now)) return true; }
   return PARASIGN_ENTITLED_PLANS.has(plan);
 }
 
@@ -517,4 +534,4 @@ function erasePersonalData(data, accountOrKey) {
 
 module.exports = {
   PERSONAL_DATA_FIELDS,
-  erasePersonalData, VALID_SCOPES, SCOPE_ACTIONS, requireScope, scopeActionFor, hasParaSignScope, parasignGrantLive, computeKid, maskApiKey, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2, computeOverLimit, designatePrimary, buildParasignKeyRecord, accountHasParasignEntitlement, PARASIGN_ENTITLED_PLANS };
+  erasePersonalData, VALID_SCOPES, SCOPE_ACTIONS, requireScope, scopeActionFor, hasParaSignScope, parasignGrantLive, parasignAccountGrantLive, computeKid, maskApiKey, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2, computeOverLimit, designatePrimary, buildParasignKeyRecord, accountHasParasignEntitlement, PARASIGN_ENTITLED_PLANS };

--- a/relay/lib/keys-table.js
+++ b/relay/lib/keys-table.js
@@ -148,12 +148,28 @@ function requireScope(keyData, action) {
 // when its record says so in any of three accepted shapes, so this survives the
 // single-string scope enum above without a schema migration:
 //   rec.scope === 'parasign'  |  rec.parasign === true  |  rec.scopes[] has it.
-function hasParaSignScope(rec) {
+//
+// AND the grant must still be running. The flag is written by
+// entitlements.applyProductTier on a purchase and cleared only by an explicit
+// write down to the floor tier; expiry is enforced on READ and never writes
+// back. So until 2026-09-06 the three shapes above were read raw, and one month
+// of ParaSign Pro bought the /v1 API forever: the term lapsed,
+// effectiveProductTier reported `free` to everyone who asked it, and this
+// function -- the actual gate -- never asked. A grant with no recorded period
+// (an admin set-parasign, and every account from before billing existed) has no
+// term to run out and stays true, which is exactly what effectiveProductTier
+// already means by expired:false.
+function parasignGrantLive(rec, now) {
   if (!rec) return false;
-  if (rec.scope === 'parasign') return true;
-  if (rec.parasign === true) return true;
-  if (Array.isArray(rec.scopes) && rec.scopes.includes('parasign')) return true;
-  return false;
+  const flagged = rec.scope === 'parasign'
+    || rec.parasign === true
+    || (Array.isArray(rec.scopes) && rec.scopes.includes('parasign'));
+  if (!flagged) return false;
+  return !entitlements.effectiveProductTier(rec, 'parasign', now).expired;
+}
+
+function hasParaSignScope(rec, now) {
+  return parasignGrantLive(rec, now);
 }
 
 // Non-secret, stable key identifier for URLs/listings (never the raw pgp_ key).
@@ -433,8 +449,14 @@ const PARASIGN_ENTITLED_PLANS = new Set(['pro', 'business', 'enterprise', 'licen
 // key already carries the parasign grant (admin set-parasign / billing auto-grant),
 // OR the account plan itself includes ParaSign (paid). Pure: takes the account's
 // member key-records and its plan; no I/O, no globals.
-function accountHasParasignEntitlement(memberRecords, plan) {
-  for (const r of (memberRecords || [])) { if (r && r.parasign === true) return true; }
+// The period is read here too, and for the sharper reason: this is the gate on
+// MINTING. A lapsed account that can still mint gets a fresh key on every call,
+// each one floored to `free` by mintParasignKey but each one a working /v1
+// credential and a new line in users.json. The self-perpetuating part is what
+// makes it worth a gate rather than a shrug: a minted key carries parasign:true
+// itself, so it re-satisfies this very check for its own account.
+function accountHasParasignEntitlement(memberRecords, plan, now) {
+  for (const r of (memberRecords || [])) { if (parasignGrantLive(r, now)) return true; }
   return PARASIGN_ENTITLED_PLANS.has(plan);
 }
 
@@ -495,4 +517,4 @@ function erasePersonalData(data, accountOrKey) {
 
 module.exports = {
   PERSONAL_DATA_FIELDS,
-  erasePersonalData, VALID_SCOPES, SCOPE_ACTIONS, requireScope, scopeActionFor, hasParaSignScope, computeKid, maskApiKey, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2, computeOverLimit, designatePrimary, buildParasignKeyRecord, accountHasParasignEntitlement, PARASIGN_ENTITLED_PLANS };
+  erasePersonalData, VALID_SCOPES, SCOPE_ACTIONS, requireScope, scopeActionFor, hasParaSignScope, parasignGrantLive, computeKid, maskApiKey, parseAccountFields, assignKid, rebuildKeyIndexes, migrateUsersV2, computeOverLimit, designatePrimary, buildParasignKeyRecord, accountHasParasignEntitlement, PARASIGN_ENTITLED_PLANS };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -3706,10 +3706,44 @@ async function handleRelayRequest(req, res) {
   // shortcut we chose: the Cleverbase Signing API only offers authType
   // "oauth2code", so a natural person has to authorise in the Cleverbase app
   // for every batch of signatures. There is no machine-to-machine route.
+  //
+  // WHO MAY CALL IT. Finding 22c of the 2026-09-05 review: nothing but the flag
+  // check. The route sits above the API-key gate, read a 32 MB body from anyone,
+  // and two of the relay's own policy files already said otherwise --
+  // keys-table.js lists /v2/qes/sign in SIGN_PATHS, the scope class that needs a
+  // sign-capable key, and public-routes.js does NOT declare it, while promising
+  // that no keyless route joins the surface unannounced. The scope check is
+  // wrapped in `if (keyData)` and keyData is always null here, so the
+  // classification was dead policy.
+  //
+  // It is not moved below the gate, because the caller this route exists for is
+  // an external signing party who has no API key: the same person POST /sign
+  // serves. So it takes the same capability that route takes, the per-party
+  // invite token, checked against the store. A key-holding caller passes on the
+  // key instead. Either way there is now a named account or a named party behind
+  // every request, and 12 MB rather than 32.
+  //
+  // Not separately metered, and that is a decision rather than an omission: the
+  // qualified signature is a second signature over a document whose ParaSign
+  // signature the sign route already counted, and the QTSP call itself cannot be
+  // made without the signer's own service token and SAD.
   if (path === '/v2/qes/sign' && req.method === 'POST') {
     if (!qes.enabled()) { res.writeHead(404, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'not_found' })); }
+    if (!envSignRateOk(clientIp)) { res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': '60' }); return res.end(J({ error: 'Too many requests' })); }
     try {
-      const d = JSON.parse((await readBody(req, 32 * 1024 * 1024)).toString());
+      const d = JSON.parse((await readBody(req, 12 * 1024 * 1024)).toString());
+      if (!keyData?.active) {
+        const _qStore = _envStore();
+        if (!_qStore) { res.writeHead(503, { 'Content-Type': 'application/json' }); return res.end(J({ error: 'Envelope store unavailable' })); }
+        const _qEnv = String(d.envelope_id || '');
+        const _qPi = parseInt(d.party_index, 10);
+        const _qTok = String(d.invite_token || d.token || '');
+        const _qBad = () => { res.writeHead(403, { 'Content-Type': 'application/json' }); res.end(J({ error: 'qes_capability_required', message: 'A qualified signature needs the envelope and the party invite token it belongs to.' })); };
+        if (!/^[A-Za-z0-9_-]{20,64}$/.test(_qEnv) || !Number.isInteger(_qPi) || _qPi < 0 || !_qTok) return _qBad();
+        let _qParty = null;
+        try { _qParty = await _qStore.getForParty(_qEnv, _qPi, _qTok); } catch (qe) { if (redisOutage503(qe, res)) return; }
+        if (!_qParty) return _qBad();
+      }
       const pdf = Buffer.from(String(d.document || ''), 'base64');
       if (pdf.subarray(0, 5).toString('latin1') !== '%PDF-') {
         res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -6904,8 +6938,32 @@ async function handleRelayRequest(req, res) {
       }
       const did = generateDid(d.device_id, d.ecdh_pub);
       const doc = createDidDocument(did, d.device_id, d.ecdh_pub, d.dsa_pub || '');
-      const _didIsNew = !didRegistry.has(did); // overwrite of same did must not double-count
-      didRegistry.set(did, { device_id: d.device_id, key: ownerKey, doc, ts: new Date().toISOString() });
+      // FIRST REGISTRATION WINS, the same rule POST /v2/pubkey has had on its
+      // slot. Finding 22b of the 2026-09-05 review: the set was unconditional
+      // and a DID is sha3-256(device_id + ecdh_pub), both of which GET
+      // /v2/did/:did hands out to anyone who asks -- a DID is a public
+      // identifier by design, so the holder's own counterparties know both
+      // halves of its preimage.
+      //
+      // What the rebind actually did is sharper than "the device moves". The
+      // signing material cannot be swapped (the ecdh key is inside the hash, so
+      // a different key is a different DID), but authByDid resolves the
+      // principal through didRegistry.key. Rebinding pointed the VICTIM'S OWN
+      // DID-authenticated traffic at the attacker's account: his plan, his
+      // account_id, his quota buckets, his device queues.
+      //
+      // A same-owner re-register stays 200 and keeps the stored document rather
+      // than rebuilding it, so `created` does not move under a verifier that
+      // pinned it. The counter is only touched for a genuinely new DID, and a
+      // rebind can no longer leave the previous owner's slot spent forever
+      // while the attacker's count never rises.
+      const held = didRegistry.get(did);
+      if (held && held.key !== ownerKey) {
+        res.writeHead(409, { 'Content-Type': 'application/json' });
+        return res.end(J({ error: 'DID already registered: first registration wins' }));
+      }
+      const _didIsNew = !held;
+      didRegistry.set(did, { device_id: d.device_id, key: ownerKey, doc: held ? held.doc : doc, ts: new Date().toISOString() });
       if (_didIsNew && ownerKey) didKeyCounts.set(ownerKey, (didKeyCounts.get(ownerKey) || 0) + 1);
       // Pubkey TTL follows the authenticated ParaSend tier; an ANONYMOUS
       // (keyless inv_) registration gets the free-tier TTL, never the pro
@@ -6913,7 +6971,21 @@ async function handleRelayRequest(req, res) {
       // axis, and a key with no plan on file lands on community (7 days) rather
       // than being handed the pro 30 by the `|| 'pro'` default.
       const _didPlan = keyData ? parasendLimitsOf(keyData).tier : 'free';
-      pubkeys.set(`${d.device_id}:${acctOf(apiKey)}`, { ecdh_pub: d.ecdh_pub, kyber_pub: d.kyber_pub || '', dsa_pub: d.dsa_pub || '', ts: new Date().toISOString(), expires: Date.now() + (_pubkeyTtl[_didPlan] ?? _pubkeyTtl.free) });
+      // The SAME slot POST /v2/pubkey guards with its 409, written here without
+      // one. Two things came with that. Under DID-auth apiKey is '' and acctOf('')
+      // returns '', so the slot collapses to `${device_id}:` -- one namespace
+      // shared by every DID-authenticated caller, readable through
+      // GET /v2/pubkey/:device. And a live slot could be overwritten from this
+      // route even though the front door refuses. Anonymous inv_ registrations
+      // keep their own slot as before; what is refused is writing over a slot
+      // that is still alive and does not belong to this account.
+      const _didSlot = `${d.device_id}:${acctOf(apiKey)}`;
+      const _heldPk = pubkeys.get(_didSlot);
+      if (_heldPk && (!_heldPk.expires || Date.now() < _heldPk.expires) && _heldPk.ecdh_pub !== d.ecdh_pub) {
+        res.writeHead(409, { 'Content-Type': 'application/json' });
+        return res.end(J({ error: 'Pubkey already registered for this device: first registration wins' }));
+      }
+      pubkeys.set(_didSlot, { ecdh_pub: d.ecdh_pub, kyber_pub: d.kyber_pub || '', dsa_pub: d.dsa_pub || '', ts: new Date().toISOString(), expires: Date.now() + (_pubkeyTtl[_didPlan] ?? _pubkeyTtl.free) });
       const ctEntry = ctAppend(d.device_id, d.ecdh_pub, apiKey);
       incMetric('did_registrations');
       auditAppend(apiKey, 'did_registered', { did, device: d.device_id });

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -2951,6 +2951,33 @@ function mintParasignKey(accountId, opts = {}) {
   const anchorRec = apiKeys.get(accountId);
   const plan = opts.plan || (acct && acct.plan) || (anchorRec && anchorRec.plan) || 'community';
   const email = (acct && acct.email) || (anchorRec && anchorRec.email) || '';
+  // THE CAP, and it lives HERE rather than at the two routes on purpose. The
+  // 2026-09-05 review found the self-serve route minting without one: fourteen
+  // keys in a row on a Pro account, nine on a community account whose cap is
+  // five, and users.json growing by one entry per HTTP request. The admin route
+  // twenty lines away did it correctly, which is the whole story of how this
+  // happens. One generator, one cap, and a third mint route cannot drift.
+  //
+  // Checked with the insert below and nothing awaited in between, so it is
+  // atomic in the event loop, the same property the /v2/admin/keys mint relies
+  // on. Throws rather than answering, because the two callers own their own
+  // response shape; both map `code` to a 402.
+  const _capPlan = tiers.normalisePlan((acct && acct.plan) || plan);
+  const _cap = ACCOUNT_KEY_LIMIT[_capPlan] ?? ACCOUNT_KEY_LIMIT.community;
+  const _active = [...(accountKeys.get(accountId) || [])].filter((k) => apiKeys.get(k) && apiKeys.get(k).active !== false).length;
+  if (_active >= _cap) {
+    const e = new Error(`Account key limit reached (${_cap} keys on the ${_capPlan} plan).`);
+    e.code = 'account_key_limit'; e.cap = _cap; e.current = _active; e.plan = _capPlan;
+    throw e;
+  }
+  if (EDITION !== 'licensed' && LICENSE_MAX_KEYS !== Infinity) {
+    const relayActive = [...apiKeys.values()].filter((v) => v.active !== false).length;
+    if (relayActive >= LICENSE_MAX_KEYS) {
+      const e = new Error(`License limit reached (${LICENSE_MAX_KEYS} keys).`);
+      e.code = 'relay_key_limit'; e.cap = LICENSE_MAX_KEYS; e.current = relayActive; e.plan = _capPlan;
+      throw e;
+    }
+  }
   // The new key inherits the account's EFFECTIVE per-product tiers, resolved
   // over every key the account holds. Minting used to pass the legacy `plan`
   // only, which silently issued a free-tier ParaSign key to a paying account.
@@ -2991,7 +3018,19 @@ function mintParasignKey(accountId, opts = {}) {
     ud.updated = new Date().toISOString();
   }).then(() => log('info', 'parasign_key_minted', { account: String(accountId).slice(0, 12), kid, mode: opts.test ? 'test' : 'live', plan: record.plan, persisted: true }))
     .catch(we => log('warn', 'parasign_key_persist_failed', { err: we.message }));
+  // The same pass the pgp_ mint runs. Without it a psk_ key was invisible to
+  // over_limit until the next reload-users, which is only ever manual.
+  applyKeyLimitEnforcement();
   return { key, kid, account_id: accountId, plan: record.plan, mode: opts.test ? 'test' : 'live', masked: maskKey(key), scope: 'parasign', created: record.created };
+}
+
+// A mint refused by a cap is a 402 with the numbers, not a 400 or a 500. Shared
+// by both mint routes so the answer cannot differ per door.
+function keyCapReject(err, res) {
+  if (!err || (err.code !== 'account_key_limit' && err.code !== 'relay_key_limit')) return false;
+  res.writeHead(402, { 'Content-Type': 'application/json' });
+  res.end(J({ error: err.message, current_keys: err.current, max_keys: err.cap === Infinity ? null : err.cap, upgrade_url: 'https://paramant.app/pricing' }));
+  return true;
 }
 
 function loadUsers() {
@@ -4866,6 +4905,7 @@ async function handleRelayRequest(req, res) {
         note: "Store this key now -- it is shown once and cannot be retrieved in full again." }));
     } catch (err) {
       if (redisOutage503(err, res)) return;
+      if (keyCapReject(err, res)) return;
       console.error("[user/parasign-keys POST]", err.message);
       res.writeHead(500); return res.end(J({ error: "internal" }));
     }
@@ -8086,7 +8126,7 @@ async function handleRelayRequest(req, res) {
       res.writeHead(201, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
       return res.end(J({ ok: true, key: out.key, kid: out.kid, account_id: out.account_id, plan: out.plan, mode: out.mode, scope: out.scope, key_masked: out.masked,
         note: 'Store this key now - it is shown once and cannot be retrieved in full again.' }));
-    } catch(e) { res.writeHead(400); return res.end(J({ error: e.message })); }
+    } catch(e) { if (keyCapReject(e, res)) return; res.writeHead(400); return res.end(J({ error: e.message })); }
   }
 
   // ── GET /v2/admin/keys/primary/:account_id — read an account's primary + members ──
@@ -8194,6 +8234,28 @@ async function handleRelayRequest(req, res) {
   }
 
   // ── POST /v2/team/add-device ──────────────────────────────────────────────
+  // Finding 9 of the 2026-09-05 review lived here, and both the mechanism it
+  // named and the reach it assumed turned out to be wrong. Written down because
+  // the code reads as a working feature and is not one.
+  //
+  // What the review said: the minted key gets no account_id, so all three quota
+  // gates skip it. False. A backfill above all routing sets
+  // keyData.account_id = apiKey for any record that lacks one, so the gates
+  // never skip. The damage was real and different: the device became its OWN
+  // account, with its own fresh monthly bucket, uncorrelated with the seat that
+  // was paid for. Buy one Pro seat, mint devices, each one gets the whole plan.
+  //
+  // What the review did not check: `team_id` never reaches a runtime record.
+  // keysTable.parseAccountFields returns a fixed field set and drops it, and no
+  // other apiKeys.set site writes it. You need a record with team_id to mint one
+  // with team_id, so this route answers 403 to everyone and always has.
+  // deploy/paramant-admin.py team-create writes it to users.json, where it is
+  // dropped on load. The feature does not work end to end.
+  //
+  // So it is left unreachable, and the mint is fixed anyway: the day somebody
+  // teaches the loader about team_id, this must not be the shape that lands.
+  // Bound to the PARENT account, scope inherited, capped, persisted, and 32
+  // bytes like every other key in the file. key-mint-gate.test.js holds it here.
   if (path === '/v2/team/add-device' && req.method === 'POST') {
     const kd = apiKeys.get(apiKey);
     if (!kd?.active) { res.writeHead(401); return res.end(J({ error: 'unauthorized' })); }
@@ -8202,10 +8264,33 @@ async function handleRelayRequest(req, res) {
     try {
       const d = JSON.parse((await readBody(req, 4096)).toString());
       if (!d.label) { res.writeHead(400); return res.end(J({ error: 'label verplicht' })); }
-      const newKey = 'pgp_' + require('crypto').randomBytes(16).toString('hex');
-      apiKeys.set(newKey, { label: d.label, plan: kd.plan, team_id: kd.team_id, active: true, created: new Date().toISOString() });
-      log('info', 'team_device_added', { label: d.label, team: kd.team_id });
-      res.writeHead(201); return res.end(J({ ok: true, key: newKey, label: d.label, team_id: kd.team_id }));
+      const label = String(d.label).slice(0, 128);
+      const account_id = kd.account_id || apiKey;
+      const scope = keysTable.VALID_SCOPES.has(kd.scope) ? kd.scope : 'full';
+      const email = kd.email || '';
+      const capPlan = tiers.normalisePlan(kd.plan);
+      const cap = ACCOUNT_KEY_LIMIT[capPlan] ?? ACCOUNT_KEY_LIMIT.community;
+      const active = [...(accountKeys.get(account_id) || [])].filter((k) => apiKeys.get(k) && apiKeys.get(k).active !== false).length;
+      if (active >= cap) {
+        res.writeHead(402, { 'Content-Type': 'application/json' });
+        return res.end(J({ error: `Account key limit reached (${cap} keys on the ${capPlan} plan).`, current_keys: active, max_keys: cap === Infinity ? null : cap, upgrade_url: 'https://paramant.app/pricing' }));
+      }
+      const created = new Date().toISOString();
+      const newKey = 'pgp_' + crypto.randomBytes(32).toString('hex');
+      apiKeys.set(newKey, { plan: kd.plan, label, email, active: true, account_id, is_primary: false, scope, team_id: kd.team_id, created });
+      if (!accounts.has(account_id)) accounts.set(account_id, { account_id, plan: kd.plan, email, primary_api_key: null, label });
+      if (!accountKeys.has(account_id)) accountKeys.set(account_id, new Set());
+      accountKeys.get(account_id).add(newKey);
+      const kid = keysTable.assignKid(kidIndex, newKey, log);
+      apiKeys.get(newKey).kid = kid;
+      kidIndex.set(kid, newKey);
+      _mutateUsersJson(ud => {
+        ud.api_keys.push({ key: newKey, plan: kd.plan, label, email, active: true, created, account_id, is_primary: false, scope, team_id: kd.team_id });
+        ud.updated = new Date().toISOString();
+      }).then(() => log('info', 'team_device_added', { label, team: kd.team_id, account: String(account_id).slice(0, 12), persisted: true }))
+        .catch(we => log('warn', 'key_persist_failed', { err: we.message, label }));
+      applyKeyLimitEnforcement();
+      res.writeHead(201); return res.end(J({ ok: true, key: newKey, kid, account_id, label, team_id: kd.team_id }));
     } catch(e) { res.writeHead(400); return res.end(J({ error: e.message })); }
   }
 
@@ -9058,11 +9143,21 @@ let EDITION          = 'community';
 let LICENSE_MAX_KEYS = COMMUNITY_KEY_LIMIT; // effective limit — updated by checkLicense()
 // Per-account key cap (SaaS product dimension). Orthogonal to the BUSL-fixed
 // per-relay COMMUNITY_KEY_LIMIT: a key is over_limit if it busts EITHER (F).
-// Community is env-tunable within 3..5; pro/enterprise are uncapped.
+// Community is env-tunable within 3..5.
+//
+// pro and enterprise were Infinity until 2026-09-06, which read as "no product
+// limit" and worked out as "no limit at all": with a self-serve mint route and
+// no cap, a Pro account grew users.json by one entry per HTTP request, and on a
+// licensed relay the relay-total dimension is skipped so nothing ever noticed.
+// These two numbers are NOT a product limit and no page sells them. They are an
+// abuse ceiling, set far above what any real account holds, and env-tunable for
+// the one customer who ever argues with them. over_limit only flags, it never
+// deactivates, so a ceiling that turns out too low is a log line and not an
+// outage.
 const ACCOUNT_KEY_LIMIT = Object.freeze({
   community: Math.min(5, Math.max(3, parseInt(process.env.ACCOUNT_KEY_LIMIT_COMMUNITY || '5', 10) || 5)),
-  pro: Infinity,
-  enterprise: Infinity,
+  pro: Math.max(10, parseInt(process.env.ACCOUNT_KEY_LIMIT_PRO || '100', 10) || 100),
+  enterprise: Math.max(10, parseInt(process.env.ACCOUNT_KEY_LIMIT_ENTERPRISE || '1000', 10) || 1000),
 });
 let LICENSE_PAYLOAD  = null;                // { max_keys, expires_at, issued_to, issued_at }
 

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -7246,7 +7246,13 @@ async function handleRelayRequest(req, res) {
   // places the account lives, keeping what a payment must stay traceable by.
   // Idempotent: a retry after a sector was briefly unreachable finds nothing left
   // and reports zero, which is a success and not an error.
+  //
+  // Two gates since 2026-09-06: ADMIN_TOKEN by the admin-path fence, plus
+  // X-Internal-Auth here. Erasure is irreversible by design, so it belongs on
+  // the same footing as the routes that move an entitlement. Both admin call
+  // sites pass the header (admin/server.js, relayFetch withInternal).
   if (path === '/v2/admin/keys/erase' && req.method === 'POST') {
+    if (!_internalOk()) return _internalReject();
     try {
       const d = JSON.parse((await readBody(req, 1024)).toString());
       const target = d.account_id || d.key;
@@ -8016,10 +8022,17 @@ async function handleRelayRequest(req, res) {
   // ── POST /v2/admin/keys/set-parasign - grant/revoke the ParaSign /v1 API ────
   // Admin override for the `parasign` entitlement, alongside the automatic grant
   // on payment. Sets the flag on the target key AND every sibling key of its
-  // account (account-level grant), then persists to users.json. ADMIN_TOKEN-gated
-  // by the admin-path guard above; the admin server fans this out to every sector
-  // so the grant is fleet-consistent. Additive: no current relay path gates on it.
+  // account (account-level grant), then persists to users.json. The admin server
+  // fans this out to every sector so the grant is fleet-consistent.
+  //
+  // TWO gates, not one. ADMIN_TOKEN by the admin-path guard above, and
+  // X-Internal-Auth here, the same pair update-plan and set-product-plan carry.
+  // Until 2026-09-06 this route had only the first, which made one leaked secret
+  // enough to hand out the /v1 API to any account. The neighbouring routes that
+  // move the same entitlement had two, and that asymmetry is what the 2026-09-05
+  // review found. admin/server.js sends the second header on this call.
   if (path === '/v2/admin/keys/set-parasign' && req.method === 'POST') {/*MARK:parasign_endpoint*/
+    if (!_internalOk()) return _internalReject();
     try {
       const d = JSON.parse((await readBody(req, 1024)).toString());
       const key = (d.key || '').toString();
@@ -8043,17 +8056,33 @@ async function handleRelayRequest(req, res) {
   }
 
   // ── POST /v2/admin/keys/mint-parasign - mint a psk_ ParaSign /v1 key ─────────
-  // Manual admin-setup path. ADMIN_TOKEN-gated (admin-path guard above). Runs the
-  // SAME mintParasignKey generator as the self-serve route, so both paths share
-  // one key format + one storage shape. Binds the key to {account_id} (or the
-  // account of {key}); returns the FULL key ONCE (never re-retrievable in full).
+  // Manual admin-setup path. Runs the SAME mintParasignKey generator as the
+  // self-serve route, so both paths share one key format + one storage shape.
+  // Binds the key to {account_id} (or the account of {key}); returns the FULL key
+  // ONCE (never re-retrievable in full).
+  //
+  // TWO gates: ADMIN_TOKEN by the admin-path guard above, plus X-Internal-Auth,
+  // matching the self-serve route at /v2/user/parasign-keys, which has required
+  // the internal header since it was written. A route that MINTS a credential
+  // standing behind fewer gates than the route that merely moves a tier was the
+  // asymmetry in the 2026-09-05 review.
+  //
+  // `plan` is NOT read from the body any more. It reached buildParasignKeyRecord
+  // as a bare string, and on an account with no per-product plan on record
+  // {"plan":"enterprise"} minted an enterprise key with no paid_until, which
+  // entitlements reads as never expiring. The account's own plan is already the
+  // fallback inside mintParasignKey, and there is no legitimate reason to mint a
+  // key at a tier the account does not hold. set-product-plan is the route for
+  // changing what an account holds, and it validates against the ladder.
   if (path === '/v2/admin/keys/mint-parasign' && req.method === 'POST') {
+    if (!_internalOk()) return _internalReject();
     try {
       const d = JSON.parse((await readBody(req, 1024)).toString());
       let accountId = (d.account_id && String(d.account_id)) || '';
       if (!accountId && d.key) accountId = acctOf(String(d.key));
       if (!accountId) { res.writeHead(400); return res.end(J({ error: 'account_id or key required' })); }
-      const out = mintParasignKey(accountId, { test: d.test === true, label: d.label, plan: d.plan });
+      const out = mintParasignKey(accountId, { test: d.test === true, label: d.label });
+      try { auditAppend(out.key, 'admin_parasign_key_minted', { account: String(accountId).slice(0, 12), kid: out.kid, mode: out.mode, plan: out.plan }); } catch {}
       res.writeHead(201, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
       return res.end(J({ ok: true, key: out.key, kid: out.kid, account_id: out.account_id, plan: out.plan, mode: out.mode, scope: out.scope, key_masked: out.masked,
         note: 'Store this key now - it is shown once and cannot be retrieved in full again.' }));
@@ -8080,7 +8109,11 @@ async function handleRelayRequest(req, res) {
   // Promotes the chosen key, demotes the previous primary within the account
   // (keysTable.designatePrimary), then persists. Mismatched account_id => 400, so
   // a key can never be moved into an account it does not belong to.
+  // Two gates since 2026-09-06: it rewrites which key an account is billed and
+  // metered through, which is the same class of change as set-product-plan. No
+  // caller in the admin panel reaches it, so nothing had to move with it.
   if (path === '/v2/admin/keys/primary' && req.method === 'POST') {
+    if (!_internalOk()) return _internalReject();
     try {
       const d = JSON.parse((await readBody(req, 1024)).toString());
       const accountId = (d.account_id || '').toString();

--- a/relay/test/admin-gate-parity.test.js
+++ b/relay/test/admin-gate-parity.test.js
@@ -1,0 +1,152 @@
+'use strict';
+// THE ADMIN GATE PARITY GATE. A /v2/admin route that MOVES an entitlement, or
+// MINTS a credential, may not stand behind fewer gates than its neighbour.
+//
+// WHY THIS EXISTS. The 2026-09-05 hostile review filed it as an asymmetry with
+// "no escalation": set-product-plan carried both ADMIN_TOKEN and X-Internal-Auth,
+// mint-parasign carried only the first. Looked at again on 2026-09-06 the
+// asymmetry was wider than filed (set-parasign was single-gated too) and the
+// "no escalation" was too generous: mint-parasign passed `plan` from the body
+// straight through, and on an account with no per-product plan on record
+// {"plan":"enterprise"} minted an enterprise key with no paid_until, which the
+// entitlement layer reads as never expiring.
+//
+// Neither half is interesting as a pair of individual bugs. What is interesting
+// is that four routes doing the same kind of thing drifted into two different
+// gate shapes over months, and nothing said so. Asserting "mint-parasign has
+// _internalOk" catches the case. This catches the class:
+//
+//   ENUMERATE every POST handler under /v2/admin in relay.js.
+//   CLASSIFY it as mutating if its body writes an entitlement or mints a key.
+//   REQUIRE  every mutating one to carry _internalOk() and to leave an audit
+//            trail, or to be named in ALLOW with a reason and an exact count.
+//
+// The exact count is the load-bearing part, as in authz-omission-gate.test.js:
+// a fifth single-gated mutating admin route is then red on arrival rather than
+// joining an established pattern.
+//
+// HOW TO ANSWER A RED
+//   Add `if (!_internalOk()) return _internalReject();` as the first line of the
+//   handler, and an auditAppend for what it changed. If the admin panel calls
+//   the route, the caller must send the header too: callRelay in
+//   admin/server.js always does, relayFetch only with its `withInternal` flag.
+//   Adding a line to ALLOW is the last resort, and it needs a reason a reader
+//   can check.
+//
+// Runs anywhere: no redis, no engine, plain fs.
+
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(path.join(__dirname, '..', 'relay.js'), 'utf8');
+
+// A handler opens with the dispatch line and runs to the matching brace. The
+// dispatch shape in relay.js is one long if-chain of exactly this form, so a
+// regex finds the openings and a brace walk finds the ends.
+const OPEN = /if \(path === '(\/v2\/admin\/[^']+)' && req\.method === '(POST|PUT|PATCH|DELETE)'\) \{/g;
+
+function blockAfter(src, openBraceIdx) {
+  let depth = 0;
+  for (let i = openBraceIdx; i < src.length; i++) {
+    const c = src[i];
+    if (c === '{') depth++;
+    else if (c === '}') { depth--; if (depth === 0) return src.slice(openBraceIdx, i + 1); }
+  }
+  return src.slice(openBraceIdx);
+}
+
+function handlers() {
+  const out = [];
+  OPEN.lastIndex = 0;
+  let m;
+  while ((m = OPEN.exec(SRC)) !== null) {
+    const brace = SRC.indexOf('{', m.index + m[0].length - 1);
+    out.push({ route: `${m[2]} ${m[1]}`, body: blockAfter(SRC, brace) });
+  }
+  return out;
+}
+
+// What makes a handler MUTATING. Every name here writes an entitlement, a plan,
+// an access flag, or mints a credential. A read-only admin route is not this
+// class and is not flagged.
+const MUTATES = /setProductPlan\(|mintParasignKey\(|_mutateUsersJson\(|\.parasign\s*=|applyProductTier\(|apiKeys\.set\(/;
+
+// Routes allowed to be mutating with only the admin-path fence. Each needs a
+// reason a reader can check, and `count` is exact: a route joining or leaving
+// this list turns the gate red rather than passing quietly.
+const ALLOW = [
+  {
+    route: 'POST /v2/admin/keys',
+    reason: 'The key-issuance route. It predates the internal gate and the admin '
+          + 'panel reaches it through relayFetch with the operator session token, '
+          + 'not through callRelay. Giving it the second gate means moving four '
+          + 'call sites in admin/server.js at once (lines around 322, 338), which '
+          + 'is a change of its own and not a rider on a review round.',
+  },
+  {
+    route: 'POST /v2/admin/keys/revoke',
+    reason: 'Same caller and same reason as /v2/admin/keys. Revoking is the safe '
+          + 'direction: worst case a leaked ADMIN_TOKEN turns a key off.',
+  },
+];
+
+test('every mutating /v2/admin POST carries the second gate, or is named with a reason', () => {
+  const found = handlers().filter((h) => MUTATES.test(h.body));
+  assert.ok(found.length >= 4, `only ${found.length} mutating admin handlers found; the scanner is broken`);
+
+  const allowed = new Set(ALLOW.map((a) => a.route));
+  const offenders = [];
+  for (const h of found) {
+    if (/_internalOk\(\)/.test(h.body)) continue;
+    if (allowed.has(h.route)) continue;
+    offenders.push(h.route);
+  }
+  assert.deepStrictEqual(offenders, [], `mutating admin route(s) behind one gate only:\n  ${offenders.join('\n  ')}`);
+});
+
+test('the ALLOW list is exact: every entry still names a real single-gated route', () => {
+  const found = handlers().filter((h) => MUTATES.test(h.body) && !/_internalOk\(\)/.test(h.body));
+  const names = new Set(found.map((h) => h.route));
+  const stale = ALLOW.filter((a) => !names.has(a.route)).map((a) => a.route);
+  assert.deepStrictEqual(stale, [], `ALLOW names route(s) that are no longer single-gated; remove them:\n  ${stale.join('\n  ')}`);
+  assert.strictEqual(found.length, ALLOW.length, `expected exactly ${ALLOW.length} single-gated mutating admin routes, found ${found.length}: ${[...names].join(', ')}`);
+  for (const a of ALLOW) assert.ok(a.reason && a.reason.length > 40, `${a.route} has no usable reason`);
+});
+
+test('a route that mints a credential leaves an audit trail', () => {
+  const minting = handlers().filter((h) => /mintParasignKey\(|apiKeys\.set\(/.test(h.body));
+  assert.ok(minting.length >= 2, `only ${minting.length} minting admin handlers found`);
+  const silent = minting.filter((h) => !/auditAppend\(|log\('info'/.test(h.body)).map((h) => h.route);
+  assert.deepStrictEqual(silent, [], `admin route(s) mint a credential and record nothing:\n  ${silent.join('\n  ')}`);
+});
+
+test('mint-parasign does not take a tier from the request body', () => {
+  // The specific shape behind the "no escalation" that was not quite true. A
+  // mint route must derive the tier from what the account holds, never from
+  // what the caller typed: there is no legitimate reason to mint a key above
+  // the account, and set-product-plan (which validates against the ladder) is
+  // the route for changing what the account holds.
+  const h = handlers().find((x) => x.route === 'POST /v2/admin/keys/mint-parasign');
+  assert.ok(h, 'mint-parasign handler not found');
+  assert.doesNotMatch(h.body, /plan:\s*d\.plan/, 'mint-parasign passes a caller-supplied plan into the mint');
+  assert.match(h.body, /_internalOk\(\)/);
+});
+
+test('self-test: the scanner really reads handler bodies, and can go red', () => {
+  const all = handlers();
+  assert.ok(all.length >= 10, `only ${all.length} admin write handlers found; the OPEN regex has drifted`);
+  // Bodies must be balanced and non-trivial, otherwise MUTATES would match
+  // nothing and every assertion above would pass over an empty set.
+  for (const h of all) {
+    assert.ok(h.body.length > 40, `${h.route} sliced to ${h.body.length} chars`);
+    const opens = (h.body.match(/\{/g) || []).length;
+    const closes = (h.body.match(/\}/g) || []).length;
+    assert.strictEqual(opens, closes, `${h.route} brace walk unbalanced`);
+  }
+  // And the classifier separates: not everything is mutating, or the gate would
+  // be asserting something about the whole file rather than about a class.
+  const mutating = all.filter((h) => MUTATES.test(h.body)).length;
+  assert.ok(mutating > 0 && mutating < all.length, `classifier picked ${mutating} of ${all.length}`);
+});

--- a/relay/test/billing-firm.test.js
+++ b/relay/test/billing-firm.test.js
@@ -194,13 +194,44 @@ async function main() {
     ok("Mollie's other spelling, charged_back, revokes both as well");
   }
 
-  // ── a refund is money back, not an entitlement change ──────────────────────
+  // ── a refund is money back, and money back takes the bundle back ───────────
+  // Until 2026-09-06 this asserted the opposite: 'ignored', nothing moved. That
+  // was the policy the 2026-09-05 review filed as a revenue leak, and it did not
+  // survive being looked at. A refund reaches the webhook on the same tr_ id as
+  // the payment; whether it arrives as the status string or as a counter on a
+  // still-'paid' payment is a Mollie detail, not a decision about who keeps a
+  // plan. Both spellings are asserted, because the counter shape is the one the
+  // repo's own fake Mollie produces and it used to fall into the GRANT branch.
   {
     const set = spySetter();
     const r = await billing.processPayment(firmPayment({ status: 'refunded' }), { setProductPlan: set });
+    assert.strictEqual(r.result, 'revoked');
+    assert.strictEqual(r.reason, 'refund');
+    assert.strictEqual(set.calls.length, 2);
+    ok('a refunded Firm payment takes BOTH halves of the bundle back to their floor');
+  }
+  {
+    const set = spySetter();
+    const paid = firmPayment({ status: 'paid' });
+    const r = await billing.processPayment(
+      firmPayment({ status: 'paid', amountRefunded: { currency: 'EUR', value: paid.amount.value } }),
+      { setProductPlan: set },
+    );
+    assert.strictEqual(r.result, 'revoked');
+    assert.strictEqual(set.calls.length, 2);
+    ok('a full refund reported as a counter on a still-paid payment revokes just the same');
+  }
+  {
+    // The other side of the same rule: a part-refund is not a cancelled sale.
+    const set = spySetter();
+    const r = await billing.processPayment(
+      firmPayment({ status: 'paid', amountRefunded: { currency: 'EUR', value: '1.00' } }),
+      { setProductPlan: set },
+    );
     assert.strictEqual(r.result, 'ignored');
+    assert.match(r.reason, /^partial_refund:100_of_/);
     assert.strictEqual(set.calls.length, 0);
-    ok('a refunded Firm payment changes no entitlement (the credit note is the record)');
+    ok('a part-refund on a Firm bundle grants nothing and revokes nothing');
   }
 
   // ── 4. nobody who already pays loses anything ──────────────────────────────

--- a/relay/test/first-wins-gate.test.js
+++ b/relay/test/first-wins-gate.test.js
@@ -1,0 +1,149 @@
+'use strict';
+// THE FIRST-WINS GATE. A slot addressed by a value the requester can compute
+// from public information may not be refilled by somebody else.
+//
+// WHY THIS EXISTS. Two of the 2026-09-05 findings are the same sentence written
+// about two registries:
+//
+//   3    POST /v2/pubkey, the invite branch: `pubkeys.set(device_id, ...)`
+//        unconditional, so whoever saw the ?s= token in a share link could
+//        overwrite both key slots of a ParaShare session and read along. Fixed
+//        the same evening with a 409.
+//   22b  POST /v2/did/register: `didRegistry.set(did, ...)` unconditional, and
+//        a DID is sha3-256(device_id + ecdh_pub), both of which GET /v2/did/:did
+//        hands back to anyone. The existence test that was there,
+//        `const _didIsNew = !didRegistry.has(did)`, fed a COUNTER and not a
+//        refusal, which is what made it read as careful code.
+//
+// That last shape is the tell, and it is why this gate scans rather than naming
+// two routes: an existence check whose answer decides how much to increment is
+// indistinguishable, at a glance, from one that decides whether to say no.
+//
+// WHAT IT REQUIRES
+//   F1  every write to an identity registry (didRegistry, pubkeys) sits in a
+//       block that can answer 409. Not "checks existence" -- refuses.
+//   F2  the refusal compares the OWNER, not merely the presence of an entry. A
+//       slot that refuses its own owner cannot be refreshed, and a device that
+//       cannot refresh loses itself when its key expires.
+//   F3  a counter fed by an existence test is never the only use of that test.
+//
+// The behavioural halves live in route-omission-gate.test.js, DOOR 3 (pubkeys)
+// and DOOR 4 (didRegistry), on a really booted relay.
+//
+// Runs anywhere: no redis, no engine, plain fs.
+
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(path.join(__dirname, '..', 'relay.js'), 'utf8');
+const LINES = SRC.split('\n');
+
+// The registries whose key is a slot identity rather than an internal handle.
+const REGISTRIES = /^\s*(didRegistry|pubkeys)\.set\(/;
+
+// Starts one line ABOVE the write. A multi-line `pubkeys.set(slot, {` opens a
+// brace on its own line, so walking back from the write itself finds that brace
+// and returns the object literal as the "block". The gate then reported the
+// route as unguarded while the 409 sat four lines above it.
+function blockAround(idx) {
+  let depth = 0; let start = Math.max(0, idx - 1);
+  for (let i = idx - 1; i >= 0; i--) {
+    const l = LINES[i];
+    depth += (l.match(/\}/g) || []).length - (l.match(/\{/g) || []).length;
+    if (depth < 0) { start = i; break; }
+  }
+  let d = 0; let end = LINES.length - 1;
+  for (let i = start; i < LINES.length; i++) {
+    const l = LINES[i];
+    d += (l.match(/\{/g) || []).length - (l.match(/\}/g) || []).length;
+    if (i > start && d <= 0) { end = i; break; }
+  }
+  return { text: LINES.slice(start, end + 1).join('\n'), from: start + 1, to: end + 1 };
+}
+
+function writes() {
+  const out = [];
+  LINES.forEach((l, i) => { if (REGISTRIES.test(l)) out.push({ n: i + 1, text: l.trim(), block: blockAround(i) }); });
+  return out;
+}
+
+test('every identity-slot write sits behind a refusal, not just an existence test', () => {
+  const found = writes();
+  assert.ok(found.length >= 4, `only ${found.length} identity-registry writes found; the scanner has drifted`);
+  const offenders = [];
+  for (const w of found) {
+    if (!/writeHead\(409/.test(w.block.text)) offenders.push(`relay.js:${w.n} (block ${w.block.from}-${w.block.to}) can overwrite a slot without ever answering 409`);
+  }
+  assert.deepStrictEqual(offenders, [], `an identity slot that anyone can refill:\n  ${offenders.join('\n  ')}`);
+});
+
+test('the refusal is about the owner, so the owner can still refresh', () => {
+  // A bare presence check turns every honest refresh into a 409. The pubkey
+  // slots refuse on a LIVE entry and let an expired one through; the DID
+  // registry refuses on a DIFFERENT owner and lets the same one re-register.
+  // Both are "not you", spelled for their own lifetime model.
+  const offenders = [];
+  for (const w of writes()) {
+    const b = w.block.text;
+    const ownerAware = /\.key !== ownerKey/.test(b)          // didRegistry
+      || /expires \|\| Date\.now\(\) </.test(b)              // a live-slot check
+      || /ecdh_pub !== d\.ecdh_pub/.test(b);                 // an identical refresh
+    if (!ownerAware) offenders.push(`relay.js:${w.n} refuses on presence alone; an honest refresh gets a 409`);
+  }
+  assert.deepStrictEqual(offenders, [], `a slot nobody can refresh:\n  ${offenders.join('\n  ')}`);
+});
+
+test('an existence test never only feeds a counter', () => {
+  // The exact idiom finding 22b hid behind. `has()` whose result is used for
+  // arithmetic and nothing else looks like a guard and is not one.
+  const offenders = [];
+  LINES.forEach((l, i) => {
+    const m = /const\s+(\w+)\s*=\s*!?\s*(didRegistry|pubkeys|apiKeys)\.has\(/.exec(l);
+    if (!m) return;
+    const name = m[1];
+    const block = blockAround(i).text;
+    const uses = block.split('\n').filter((x) => new RegExp(`\\b${name}\\b`).test(x) && !x.includes(`const ${name}`));
+    const refuses = uses.some((x) => /writeHead\(|return .*(409|403|401|conflict)/i.test(x));
+    const counts = uses.some((x) => /\+ 1|\+\+|set\(.*\+/.test(x));
+    if (counts && !refuses) offenders.push(`relay.js:${i + 1} \`${name}\` decides a counter and nothing else`);
+  });
+  assert.deepStrictEqual(offenders, [], `an existence test that only counts:\n  ${offenders.join('\n  ')}`);
+});
+
+test('the DID pubkey slot is not a shared namespace', () => {
+  // Under DID-auth apiKey is '' and acctOf('') returns '', so the old
+  // `${device_id}:${acctOf(apiKey)}` collapsed to `${device_id}:` for every
+  // DID-authenticated caller at once, readable through GET /v2/pubkey/:device.
+  // The slot expression itself is unchanged; what closed it is that the write
+  // now refuses a live slot holding a different key.
+  const start = SRC.indexOf("if (path === '/v2/did/register'");
+  assert.ok(start > 0, 'the DID register route was not found');
+  const route = SRC.slice(start, SRC.indexOf("\n  // ── GET /v2/did ", start));
+  assert.match(route, /_heldPk && \(!_heldPk\.expires \|\| Date\.now\(\) < _heldPk\.expires\)/, 'the DID route writes a pubkey slot without checking whether it is live');
+  assert.match(route, /writeHead\(409/, 'the DID route cannot refuse anything');
+});
+
+test('self-test: the scanner catches the pre-repair shape and clears the repaired one', () => {
+  const broken = [
+    "  if (path === '/v2/x' && req.method === 'POST') {",
+    '    const isNew = !didRegistry.has(id);',
+    '    didRegistry.set(id, { key: ownerKey });',
+    '    if (isNew && ownerKey) counts.set(ownerKey, (counts.get(ownerKey) || 0) + 1);',
+    '    res.writeHead(200); return res.end();',
+    '  }',
+  ].join('\n');
+  const fixed = [
+    "  if (path === '/v2/x' && req.method === 'POST') {",
+    '    const held = didRegistry.get(id);',
+    "    if (held && held.key !== ownerKey) { res.writeHead(409); return res.end(); }",
+    '    didRegistry.set(id, { key: ownerKey });',
+    '    res.writeHead(200); return res.end();',
+    '  }',
+  ].join('\n');
+
+  const scanFor409 = (src) => src.split('\n').some((l) => REGISTRIES.test(l)) && /writeHead\(409/.test(src);
+  assert.strictEqual(scanFor409(broken), false, 'the gate would pass the pre-repair shape');
+  assert.strictEqual(scanFor409(fixed), true, 'the gate would fail the repaired shape');
+});

--- a/relay/test/grant-expiry-gate.test.js
+++ b/relay/test/grant-expiry-gate.test.js
@@ -1,0 +1,199 @@
+'use strict';
+// THE GRANT EXPIRY GATE. An entitlement that is stored as a flag must never be
+// read without asking whether the period behind it is still running.
+//
+// WHY THIS EXISTS. Finding 11 of the 2026-09-05 hostile review: buy one month
+// of ParaSign Pro, let it lapse, and POST /v2/user/parasign-keys keeps minting
+// keys forever. Reproduced on 2026-09-06 against a booted relay with a term
+// that ended five weeks ago: eight mints, and it survived a restart, because
+// the flag is persisted.
+//
+// The shape is worth more than the case. `rec.parasign` is a CACHE of "the
+// ParaSign tier is above the floor". entitlements.applyProductTier writes it on
+// a purchase and clears it only on an explicit write down to the floor tier.
+// Expiry, by design, is enforced on READ (effectiveProductTier) and never
+// writes back -- which is the right design, and is exactly why a second copy of
+// the same fact, stored as a boolean, goes stale the moment the term ends.
+// The relay knew: the entitlements endpoint reported `free` for this account
+// the whole time. The gate that decides simply did not ask.
+//
+// A cache of an expiring fact, read without the expiry, is the class. There is
+// one such flag today. This gate is here so there is never a second one that
+// nobody notices, and so the first one cannot quietly go back to being read raw.
+//
+// WHAT IT REQUIRES
+//   E1  the two functions that gate on the flag resolve it through
+//       parasignGrantLive, which consults effectiveProductTier.
+//   E2  nowhere else in the relay or the admin server DECIDES a permission on
+//       the raw flag. Reading it to write it (applyProductTier), to report it,
+//       or to copy a record is not this bug and is not flagged. The expected
+//       answer is an empty list and there is no allow list, because an entry
+//       there would be a place where the term does not end.
+//   E3  absence still means unbounded. A grant with no recorded period has no
+//       term to run out, and reading absence as expiry would downgrade every
+//       account from before billing existed.
+//
+// Runs anywhere: no redis, no engine, plain fs plus the pure functions.
+
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const keysTable = require('../lib/keys-table');
+const entitlements = require('../lib/entitlements');
+
+const ROOT = path.join(__dirname, '..', '..');
+const FILES = ['relay/relay.js', 'relay/lib/keys-table.js', 'relay/lib/entitlements.js', 'admin/server.js'];
+
+const PAST = new Date(Date.now() - 40 * 86_400_000).toISOString();
+const FUTURE = new Date(Date.now() + 40 * 86_400_000).toISOString();
+
+// A read of the stored flag on a RECORD. Deliberately narrow:
+//   (?<![)A-Z_])  not `getEntitlements(...).parasign` (that is the answer, not
+//                 the cache) and not `PRODUCT_PAID_UNTIL_FIELD.parasign` (a
+//                 constant map key).
+//   (?![\w.])     not `plan_parasign`, not `ent.parasign.tier`.
+//   (?!\s*=[^=])  not a write. Writing the flag is applyProductTier's job and
+//                 the one thing that is allowed to treat it as state.
+const RAW = /(?<![)A-Z_])\.parasign(?![\w.])(?!\s*=[^=])/;
+
+// A block that DECIDES: it can refuse, or it answers a permission question.
+// A read of the flag to copy it, report it, or derive a tier from it is not this
+// bug and is not flagged. That is what keeps the gate narrow enough that a hit
+// means something.
+const DECIDES = /\b(40[123]|not_entitled|unauthorized|forbidden|allowed|entitled)\b/;
+
+// The resolver is where the raw read belongs, and it is named so the gate does
+// not flag the one function that is supposed to do this.
+const RESOLVER = 'function parasignGrantLive(';
+
+function blockAround(lines, idx) {
+  let depth = 0; let start = idx;
+  for (let i = idx; i >= 0; i--) {
+    const l = lines[i];
+    depth += (l.match(/\}/g) || []).length - (l.match(/\{/g) || []).length;
+    if (depth < 0) { start = i; break; }
+  }
+  let d = 0; let end = lines.length - 1;
+  for (let i = start; i < lines.length; i++) {
+    const l = lines[i];
+    d += (l.match(/\{/g) || []).length - (l.match(/\}/g) || []).length;
+    if (i > start && d <= 0) { end = i; break; }
+  }
+  return lines.slice(start, end + 1).join('\n');
+}
+
+function decidingReads(src) {
+  const lines = src.split('\n');
+  const out = [];
+  lines.forEach((l, i) => {
+    const t = l.trim();
+    if (t.startsWith('//') || t.startsWith('*')) return;
+    if (!RAW.test(l)) return;
+    const block = blockAround(lines, i);
+    if (block.includes(RESOLVER)) return;
+    if (!DECIDES.test(block)) return;
+    out.push({ n: i + 1, text: t });
+  });
+  return out;
+}
+
+test('the two gates resolve the flag through the period, not raw', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'relay/lib/keys-table.js'), 'utf8');
+  const resolver = src.slice(src.indexOf('function parasignGrantLive('), src.indexOf('function hasParaSignScope('));
+  assert.match(resolver, /effectiveProductTier\(rec, 'parasign'/, 'parasignGrantLive does not consult the period');
+  assert.match(resolver, /\.expired/, 'parasignGrantLive reads the tier but not the expiry');
+
+  const scope = src.slice(src.indexOf('function hasParaSignScope('), src.indexOf('// Non-secret, stable key identifier'));
+  assert.match(scope, /parasignGrantLive\(/, 'hasParaSignScope no longer goes through the resolver');
+
+  const mintGate = src.slice(src.indexOf('function accountHasParasignEntitlement('));
+  assert.match(mintGate, /parasignGrantLive\(/, 'the mint gate no longer goes through the resolver');
+  assert.doesNotMatch(mintGate.slice(0, mintGate.indexOf('\n}')), /r\.parasign === true/, 'the mint gate reads the raw flag again');
+});
+
+test('no permission is decided on the raw flag anywhere', () => {
+  const offenders = [];
+  for (const f of FILES) {
+    const src = fs.readFileSync(path.join(ROOT, f), 'utf8');
+    for (const r of decidingReads(src)) offenders.push(`${f}:${r.n} ${r.text.slice(0, 100)}`);
+  }
+  // No ALLOW list, because the answer is genuinely zero and a list of exceptions
+  // here would be a list of places the term does not end.
+  assert.deepStrictEqual(offenders, [], `a permission decided on a cached, expiring flag:\n  ${offenders.join('\n  ')}`);
+});
+
+test('a lapsed grant is refused, a live one is not, an open one is not', () => {
+  const lapsed = { parasign: true, plan_parasign: 'pro', paid_until_parasign: PAST };
+  const live = { parasign: true, plan_parasign: 'pro', paid_until_parasign: FUTURE };
+  const open = { parasign: true };
+  const scoped = { scope: 'parasign' };
+
+  assert.strictEqual(keysTable.hasParaSignScope(lapsed), false, 'a lapsed grant still opens the /v1 API');
+  assert.strictEqual(keysTable.hasParaSignScope(live), true);
+  assert.strictEqual(keysTable.hasParaSignScope(open), true, 'a grant with no term was read as expired');
+  assert.strictEqual(keysTable.hasParaSignScope(scoped), true);
+  assert.strictEqual(keysTable.hasParaSignScope(null), false);
+  assert.strictEqual(keysTable.hasParaSignScope({}), false);
+
+  assert.strictEqual(keysTable.accountHasParasignEntitlement([lapsed], 'community'), false, 'a lapsed account still mints');
+  assert.strictEqual(keysTable.accountHasParasignEntitlement([live], 'community'), true);
+  assert.strictEqual(keysTable.accountHasParasignEntitlement([open], 'community'), true);
+  // The plan itself still carries the entitlement without any flag at all.
+  assert.strictEqual(keysTable.accountHasParasignEntitlement([], 'pro'), true);
+  assert.strictEqual(keysTable.accountHasParasignEntitlement([], 'community'), false);
+});
+
+test('the gate and the entitlements endpoint agree, which is what they did not before', () => {
+  // The whole finding in one assertion: the relay reported `free` while the gate
+  // said yes. Whatever effectiveProductTier calls expired, the gate must refuse,
+  // for a record that carries the flag.
+  const cases = [
+    { parasign: true, plan_parasign: 'pro', paid_until_parasign: PAST },
+    { parasign: true, plan_parasign: 'business', paid_until_parasign: PAST },
+    { parasign: true, plan_parasign: 'pro', paid_until_parasign: FUTURE },
+    { parasign: true, plan_parasign: 'enterprise' },
+    { parasign: true },
+  ];
+  for (const rec of cases) {
+    const eff = entitlements.effectiveProductTier(rec, 'parasign');
+    assert.strictEqual(keysTable.hasParaSignScope(rec), !eff.expired,
+      `gate and entitlements disagree for ${JSON.stringify(rec)}: gate=${keysTable.hasParaSignScope(rec)} expired=${eff.expired}`);
+  }
+});
+
+test('self-test: the scanner can go red, so zero means zero', () => {
+  // The whole risk of a gate whose expected answer is an empty list: if the
+  // scanner breaks, it keeps returning the empty list and reports green over
+  // anything. So it is driven over the shape it is meant to catch.
+  const broken = [
+    'function mayMint(rec) {',
+    '  if (rec.parasign === true) return { allowed: true };',
+    "  res.writeHead(403); return { error: 'not_entitled' };",
+    '}',
+  ].join('\n');
+  assert.strictEqual(decidingReads(broken).length, 1, 'the scanner missed a permission decided on the raw flag');
+
+  const fixed = [
+    'function mayMint(rec) {',
+    '  if (keysTable.parasignGrantLive(rec)) return { allowed: true };',
+    "  res.writeHead(403); return { error: 'not_entitled' };",
+    '}',
+  ].join('\n');
+  assert.strictEqual(decidingReads(fixed).length, 0, 'the scanner flags the repaired shape');
+
+  // And the three forms it must NOT flag, or it would be noise and get muted.
+  const innocent = [
+    'const ent = entitlements.getEntitlements(rec).parasign;',
+    'out.plan_parasign = derivePlanParasign(entry.plan, entry.parasign);',
+    'if (v.parasign) acct.parasign = true;',
+  ].join('\n');
+  assert.strictEqual(decidingReads(`function copy() {\n${innocent}\n}`).length, 0, 'the scanner flags a copy or a derivation');
+
+  // The pattern itself, at the character level.
+  assert.strictEqual(RAW.test('rec.parasign = true'), false, 'the pattern matches an assignment');
+  assert.strictEqual(RAW.test('if (r.parasign === true)'), true, 'the pattern misses a comparison');
+  assert.strictEqual(RAW.test('v.plan_parasign'), false, 'the pattern matches the tier field');
+  assert.strictEqual(RAW.test('ent.parasign.tier'), false, 'the pattern matches the entitlements object');
+});

--- a/relay/test/grant-expiry-gate.test.js
+++ b/relay/test/grant-expiry-gate.test.js
@@ -105,12 +105,16 @@ test('the two gates resolve the flag through the period, not raw', () => {
   assert.match(resolver, /effectiveProductTier\(rec, 'parasign'/, 'parasignGrantLive does not consult the period');
   assert.match(resolver, /\.expired/, 'parasignGrantLive reads the tier but not the expiry');
 
+  const account = src.slice(src.indexOf('function parasignAccountGrantLive('), src.indexOf('// ── Erasure'));
+  assert.match(account, /effectiveProductTier\(rec, 'parasign'/, 'the account grant does not consult the period');
+  assert.doesNotMatch(account.slice(0, account.indexOf('\n}')), /scope === 'parasign'/,
+    'the account grant reads the key capability again, so holding a psk_ key means permission to mint another');
+
   const scope = src.slice(src.indexOf('function hasParaSignScope('), src.indexOf('// Non-secret, stable key identifier'));
   assert.match(scope, /parasignGrantLive\(/, 'hasParaSignScope no longer goes through the resolver');
 
   const mintGate = src.slice(src.indexOf('function accountHasParasignEntitlement('));
-  assert.match(mintGate, /parasignGrantLive\(/, 'the mint gate no longer goes through the resolver');
-  assert.doesNotMatch(mintGate.slice(0, mintGate.indexOf('\n}')), /r\.parasign === true/, 'the mint gate reads the raw flag again');
+  assert.match(mintGate, /parasignAccountGrantLive\(/, 'the mint gate no longer goes through the account resolver');
 });
 
 test('no permission is decided on the raw flag anywhere', () => {
@@ -140,6 +144,15 @@ test('a lapsed grant is refused, a live one is not, an open one is not', () => {
   assert.strictEqual(keysTable.accountHasParasignEntitlement([lapsed], 'community'), false, 'a lapsed account still mints');
   assert.strictEqual(keysTable.accountHasParasignEntitlement([live], 'community'), true);
   assert.strictEqual(keysTable.accountHasParasignEntitlement([open], 'community'), true);
+  // The account grant is NARROWER than the key capability, and has to stay so.
+  // A psk_ key carries scope 'parasign' for life -- that is what the key is --
+  // and revoking an account clears the `parasign` flag on every member but
+  // cannot clear what a key IS. Reading the scope here let an account that had
+  // charged its payment back go on minting, which tests/koper-hele-weg.test.mjs
+  // caught on the first full run.
+  assert.strictEqual(keysTable.hasParaSignScope(scoped), true, 'a psk_ key lost the /v1 door');
+  assert.strictEqual(keysTable.accountHasParasignEntitlement([scoped], 'community'), false,
+    'holding a psk_ key is being read as permission to mint another');
   // The plan itself still carries the entitlement without any flag at all.
   assert.strictEqual(keysTable.accountHasParasignEntitlement([], 'pro'), true);
   assert.strictEqual(keysTable.accountHasParasignEntitlement([], 'community'), false);

--- a/relay/test/key-mint-gate.test.js
+++ b/relay/test/key-mint-gate.test.js
@@ -1,0 +1,182 @@
+'use strict';
+// THE KEY MINT GATE. Every route that hands out an API key must bind it to an
+// account, give it a scope, count it against a cap, and write it down.
+//
+// WHY THIS EXISTS. Findings 9 and 10 of the 2026-09-05 hostile review read as
+// two bugs and are one class. Both are a mint that skipped part of what a mint
+// has to do, and in both cases a correct mint stood twenty lines away:
+//
+//   9   POST /v2/team/add-device minted a pgp_ key with no account_id, no
+//       scope, 16 bytes of entropy, no cap and no line in users.json. The
+//       review read that as "no quota" -- wrong, a backfill above all routing
+//       fills account_id in -- but the damage was worse than a skipped gate:
+//       the device became its OWN account with its OWN fresh monthly bucket.
+//       One paid seat, unlimited plans.
+//   10  POST /v2/user/parasign-keys called mintParasignKey in a loop with no
+//       cap at all. Measured on 2026-09-06 against a booted relay: fourteen
+//       keys in a row on a Pro account, nine on a community account whose cap
+//       is five, users.json from three entries to twenty-five in one loop.
+//
+// And in both cases /v2/admin/keys, the third mint, did it correctly. Repairing
+// two routes and stopping there buys nothing: the fourth mint is one commit
+// away and it will be written by reading one of the other three.
+//
+// So this scans for the SHAPE of a mint rather than for the routes. It is a
+// linter, not a proof, and it is deliberately narrow so a hit means something.
+//
+// WHAT IT REQUIRES
+//   M1  every apiKeys.set() whose value is a fresh record literal names
+//       `account_id` and `scope`. A record without them is a key that answers
+//       to nobody and may do anything: requireScope reads a missing scope as
+//       'full'.
+//   M2  every such site is inside a block that also checks ACCOUNT_KEY_LIMIT
+//       and calls applyKeyLimitEnforcement().
+//   M3  the key material is 32 bytes. 16 was the entropy add-device used.
+//   M4  the mint is written down: _mutateUsersJson in the same block.
+//
+// Loading users.json is not minting and is not flagged: those sites REBUILD
+// records that already exist and already carry their fields, and they are named
+// in LOADERS with a reason.
+//
+// HOW TO ANSWER A RED
+//   Do what /v2/admin/keys does, or call mintParasignKey, which now carries the
+//   cap itself so the two ParaSign doors cannot drift. Adding a line to LOADERS
+//   is for a site that reconstructs existing records, never for a new mint.
+//
+// Runs anywhere: no redis, no engine, plain fs.
+
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(path.join(__dirname, '..', 'relay.js'), 'utf8');
+const LINES = SRC.split('\n');
+
+// Sites that rebuild records read from storage rather than creating new key
+// material. `count` is exact, so a mint that hides itself in a loader turns the
+// gate red.
+const LOADERS = [
+  { line: 'try { const d = JSON.parse(process.env.USERS_JSON)', reason: 'loadUsers, USERS_JSON branch: rehydrates records that already exist, through keysTable.parseAccountFields.' },
+  { line: 'if (k.active) apiKeys.set(k.key, {', reason: 'loadUsers, file branch: same rehydration, same parseAccountFields.' },
+  { line: 'apiKeys.set(k.key, {', reason: 'loadTrialKeys: rehydrates trial records from their own store.' },
+  { line: 'candidate.forEach((v, k) => apiKeys.set(k, v));', reason: '/v2/reload-users atomic swap: moves whole records from a freshly parsed table, creating none.' },
+  { line: 'apiKeys.set(key, record);', reason: 'mintParasignKey itself. It IS the generator, and it carries the cap, the enforcement pass and the users.json write; asserted by name below rather than by proximity.' },
+  { line: "apiKeys.set(k, { plan, label, email, active: true });", reason: 'the /v2/setup wizard mint. It runs only while the key table is empty (_setupModeOn), writes users.json in the same handler, and is the bootstrap that creates the first account there can be a cap against.' },
+];
+
+function siteLines() {
+  const out = [];
+  LINES.forEach((l, i) => { if (l.includes('apiKeys.set(')) out.push({ n: i + 1, text: l.trim() }); });
+  return out;
+}
+
+function isLoader(text) {
+  return LOADERS.some((l) => text.includes(l.line));
+}
+
+// The enclosing block of a line: walk back to the nearest line whose brace depth
+// is one less, walk forward to where that block closes. Crude and good enough,
+// because the shapes being judged are route handlers and short functions.
+function enclosing(lineNo) {
+  let start = lineNo - 1;
+  let depth = 0;
+  for (let i = lineNo - 1; i >= 0; i--) {
+    const l = LINES[i];
+    depth += (l.match(/\}/g) || []).length - (l.match(/\{/g) || []).length;
+    if (depth < 0) { start = i; break; }
+  }
+  let d = 0; let end = LINES.length - 1;
+  for (let i = start; i < LINES.length; i++) {
+    const l = LINES[i];
+    d += (l.match(/\{/g) || []).length - (l.match(/\}/g) || []).length;
+    if (i > start && d <= 0) { end = i; break; }
+  }
+  return LINES.slice(start, end + 1).join('\n');
+}
+
+test('every fresh key record names an account and a scope', () => {
+  const offenders = [];
+  for (const s of siteLines()) {
+    if (isLoader(s.text)) continue;
+    if (!/account_id/.test(s.text)) offenders.push(`relay.js:${s.n} no account_id: ${s.text.slice(0, 90)}`);
+    if (!/scope/.test(s.text)) offenders.push(`relay.js:${s.n} no scope: ${s.text.slice(0, 90)}`);
+  }
+  assert.deepStrictEqual(offenders, [], `a key that answers to nobody:\n  ${offenders.join('\n  ')}`);
+});
+
+test('every mint block checks a cap, records the key, and re-runs the enforcement pass', () => {
+  const offenders = [];
+  for (const s of siteLines()) {
+    if (isLoader(s.text)) continue;
+    const block = enclosing(s.n);
+    if (!/ACCOUNT_KEY_LIMIT/.test(block)) offenders.push(`relay.js:${s.n} no cap check`);
+    if (!/_mutateUsersJson/.test(block)) offenders.push(`relay.js:${s.n} not written to users.json`);
+    if (!/applyKeyLimitEnforcement\(\)/.test(block)) offenders.push(`relay.js:${s.n} no enforcement pass after the mint`);
+  }
+  assert.deepStrictEqual(offenders, [], `an uncapped or unrecorded mint:\n  ${offenders.join('\n  ')}`);
+});
+
+test('key material is 32 bytes everywhere', () => {
+  // add-device used randomBytes(16). Half the entropy of every other key in the
+  // file, for a credential with the same authority.
+  const weak = [];
+  LINES.forEach((l, i) => {
+    if (!/randomBytes\(\s*(\d+)\s*\)/.test(l)) return;
+    if (!/'pgp_'|"pgp_"|psk_|newKey|apiKey/.test(l)) return;
+    const n = parseInt(/randomBytes\(\s*(\d+)\s*\)/.exec(l)[1], 10);
+    if (n < 32) weak.push(`relay.js:${i + 1} randomBytes(${n}): ${l.trim().slice(0, 90)}`);
+  });
+  assert.deepStrictEqual(weak, [], `key material under 32 bytes:\n  ${weak.join('\n  ')}`);
+});
+
+test('mintParasignKey is the single generator and it carries the cap itself', () => {
+  // The cap lives in the generator rather than at the two routes, because that
+  // is the only arrangement in which a third ParaSign door cannot forget it.
+  const start = SRC.indexOf('function mintParasignKey(');
+  assert.ok(start > 0, 'mintParasignKey not found');
+  const body = SRC.slice(start, SRC.indexOf('\nfunction ', start + 10));
+  assert.match(body, /ACCOUNT_KEY_LIMIT/, 'mintParasignKey does not check the per-account cap');
+  assert.match(body, /LICENSE_MAX_KEYS/, 'mintParasignKey does not check the relay-total cap');
+  assert.match(body, /applyKeyLimitEnforcement\(\)/, 'mintParasignKey does not re-run the enforcement pass');
+  assert.match(body, /account_key_limit/, 'mintParasignKey has no typed refusal for the caller to turn into a 402');
+  // And both callers must turn that refusal into a 402, not a 400 or a 500.
+  const callers = SRC.split('\n').map((l, i) => ({ l, i })).filter((x) => /mintParasignKey\(/.test(x.l) && !/function mintParasignKey/.test(x.l));
+  assert.strictEqual(callers.length, 2, `expected exactly 2 callers of mintParasignKey, found ${callers.length}`);
+  for (const c of callers) {
+    const block = enclosing(c.i + 1);
+    assert.match(block, /keyCapReject\(/, `the mint caller at relay.js:${c.i + 1} does not answer a cap refusal with a 402`);
+  }
+});
+
+test('the per-account cap is a number on every plan', () => {
+  // pro and enterprise were Infinity, which is not a ceiling. A self-serve mint
+  // plus Infinity is unbounded growth of users.json by design.
+  const start = SRC.indexOf('const ACCOUNT_KEY_LIMIT = Object.freeze({');
+  assert.ok(start > 0);
+  const block = SRC.slice(start, SRC.indexOf('});', start));
+  assert.doesNotMatch(block, /Infinity/, 'a plan still has an infinite per-account key cap');
+  for (const plan of ['community', 'pro', 'enterprise']) {
+    assert.match(block, new RegExp(`${plan}:`), `ACCOUNT_KEY_LIMIT has no ${plan} row`);
+  }
+});
+
+test('the LOADERS list is exact and every entry carries a reason', () => {
+  const sites = siteLines();
+  assert.ok(sites.length >= 6, `only ${sites.length} apiKeys.set sites; the scanner has drifted`);
+  const matched = LOADERS.filter((l) => sites.some((s) => s.text.includes(l.line)));
+  assert.strictEqual(matched.length, LOADERS.length,
+    `LOADERS names ${LOADERS.length} sites but ${matched.length} are present; remove what is gone`);
+  for (const l of LOADERS) assert.ok(l.reason && l.reason.length > 40, `${l.line} has no usable reason`);
+  const mints = sites.filter((s) => !isLoader(s.text));
+  assert.ok(mints.length >= 2, `only ${mints.length} sites classified as mints; the LOADERS list is swallowing them`);
+});
+
+test('self-test: the block walker really finds an enclosing block', () => {
+  const s = siteLines().find((x) => x.text.includes('apiKeys.set(newKey, { plan, label, email, active: true, account_id'));
+  assert.ok(s, 'the /v2/admin/keys mint was not found; it is the reference shape');
+  const block = enclosing(s.n);
+  assert.ok(block.length > 400, `the reference mint sliced to ${block.length} chars`);
+  assert.match(block, /ACCOUNT_KEY_LIMIT/);
+  assert.match(block, /applyKeyLimitEnforcement\(\)/);
+});

--- a/relay/test/money-back-parity-gate.test.js
+++ b/relay/test/money-back-parity-gate.test.js
@@ -1,0 +1,186 @@
+'use strict';
+// THE MONEY-BACK PARITY GATE. If the document layer says money went back, the
+// entitlement layer may not leave a paid tier standing.
+//
+// WHY THIS EXISTS. The 2026-09-05 hostile review filed "a refund does not take
+// the entitlement back" as a loose end, and read it as a deliberate policy on a
+// fall-through branch. Both halves were wrong in an instructive way, and the
+// instructive part is the class:
+//
+//   relay/lib/credit-note.js decided "is this money back?" by reading BOTH
+//   cumulative counters (amountRefunded, amountChargedBack) as well as the
+//   status string. relay/lib/billing.js decided the same question by matching
+//   the status string against exactly two values. Two lists that must agree,
+//   drifted.
+//
+// The consequence was not the missing branch the review described. Mollie
+// reports a refund on the SAME tr_ id with the status still 'paid' and
+// amountRefunded set (see tests/helpers/fake-mollie.cjs /_ctl/refund), so a
+// refund never reached a fall-through at all: it went down the GRANT branch,
+// and the only thing between a refunded payment and a fresh month granted on it
+// was the idempotency marker.
+//
+// So this gate does not assert "refunded revokes". That catches the case. It
+// drives BOTH layers with the same generated matrix of payment shapes and
+// asserts they never disagree about whether money went back. A new Mollie
+// status, or a fourth counter, is then a red on arrival instead of a finding
+// in the next review.
+//
+// THE PROPERTY
+//   For every payment shape:
+//     creditNote.isReversal(p) === true   =>   processPayment(p) must NOT
+//                                              return 'granted'
+//   and, one step sharper:
+//     the reversal is WHOLE                =>  processPayment(p) must return
+//                                              'revoked' and floor every product
+//                                              in the order.
+//
+// A part-reversal is allowed to be 'ignored': it is not a cancelled sale. What
+// it may never be is 'granted'.
+//
+// Runs anywhere: no redis, no engine, pure function calls.
+
+const { test } = require('node:test');
+const assert = require('assert');
+
+const billing = require('../lib/billing');
+const creditNote = require('../lib/credit-note');
+const catalog = require('../lib/billing-catalog');
+
+// Every status the webhook can see. The first six are Mollie's payment
+// lifecycle, the last three are the money-back shapes. 'authorized' is in here
+// on purpose: it is a real Mollie status that the source comment in billing.js
+// forgot to list, which is the same drift this gate exists to catch.
+const STATUSES = [
+  'open', 'pending', 'authorized', 'paid',
+  'failed', 'expired', 'canceled',
+  'refunded', 'chargeback', 'charged_back',
+];
+
+// absent / part / whole, for each of the two cumulative counters.
+const COUNTERS = [null, '5.00', '59.29'];
+
+// The catalog price for parasign/pro/monthly. Read from the catalog rather than
+// typed, so a price change does not turn this gate into a study of the
+// amount_mismatch branch instead of the money-back branch.
+const PRICE = catalog.resolveOrder({ product: 'parasign', plan: 'pro', interval: 'monthly' }).amount;
+
+function shape(status, refunded, back) {
+  const p = {
+    id: 'tr_gate',
+    status,
+    amount: { currency: 'EUR', value: PRICE },
+    metadata: { accountId: 'acct_demo', product: 'parasign', plan: 'pro', interval: 'monthly' },
+  };
+  if (refunded) p.amountRefunded = { currency: 'EUR', value: refunded };
+  if (back) p.amountChargedBack = { currency: 'EUR', value: back };
+  return p;
+}
+
+function label(p) {
+  const r = p.amountRefunded ? p.amountRefunded.value : '-';
+  const c = p.amountChargedBack ? p.amountChargedBack.value : '-';
+  return `${p.status} refunded=${r} chargedBack=${c}`;
+}
+
+// A deps stub that records what the decision actually did, so the assertion can
+// look at the effect and not only at the returned word.
+function deps() {
+  const calls = [];
+  return {
+    calls,
+    setProductPlan: (accountId, product, tier, until) => {
+      calls.push({ accountId, product, tier, until: until ? until.toISOString() : null });
+      return { ok: true };
+    },
+    // No marker: idempotency must not be what makes this gate pass. That was
+    // the load-bearing accident being fixed.
+  };
+}
+
+const MATRIX = [];
+for (const status of STATUSES) {
+  for (const refunded of COUNTERS) {
+    for (const back of COUNTERS) MATRIX.push(shape(status, refunded, back));
+  }
+}
+
+test('the matrix is the size it claims to be', () => {
+  assert.strictEqual(MATRIX.length, STATUSES.length * COUNTERS.length * COUNTERS.length);
+  assert.strictEqual(MATRIX.length, 90);
+});
+
+test('a payment the document layer credits is never granted an entitlement', async () => {
+  const offenders = [];
+  for (const p of MATRIX) {
+    if (!creditNote.isReversal(p)) continue;
+    const d = deps();
+    const out = await billing.processPayment(p, d);
+    if (out.result === 'granted') offenders.push(`${label(p)} -> granted (${out.reason})`);
+    // The effect, not only the word: nothing may be moved UP while money is out.
+    const raised = d.calls.filter((c) => c.tier !== catalog.floorTier(c.product));
+    if (raised.length) offenders.push(`${label(p)} -> raised ${JSON.stringify(raised)}`);
+  }
+  assert.deepStrictEqual(offenders, [], `credit note issued but entitlement kept or granted:\n${offenders.join('\n')}`);
+});
+
+test('a WHOLE reversal floors every product in the order, with no paid time left', async () => {
+  const offenders = [];
+  for (const p of MATRIX) {
+    const rev = billing.reversalOf(p);
+    if (!rev || !rev.full) continue;
+    const d = deps();
+    const out = await billing.processPayment(p, d);
+    if (out.result !== 'revoked') { offenders.push(`${label(p)} -> ${out.result} (${out.reason})`); continue; }
+    if (!d.calls.length) { offenders.push(`${label(p)} -> revoked but moved nothing`); continue; }
+    for (const c of d.calls) {
+      if (c.tier !== catalog.floorTier(c.product)) offenders.push(`${label(p)} -> ${c.product} left at ${c.tier}`);
+      if (c.until !== null) offenders.push(`${label(p)} -> ${c.product} kept paid time until ${c.until}`);
+    }
+  }
+  assert.deepStrictEqual(offenders, [], `whole reversal did not revoke:\n${offenders.join('\n')}`);
+});
+
+test('a chargeback stays whole whatever the counters say', () => {
+  // The one direction this gate must NOT weaken. Before 2026-09-06 any
+  // 'chargeback' status revoked outright, counters or no counters, and a
+  // settlement that arrives with a partial amountChargedBack must not turn that
+  // into a shrug.
+  for (const back of COUNTERS) {
+    for (const status of ['chargeback', 'charged_back']) {
+      const rev = billing.reversalOf(shape(status, null, back));
+      assert.ok(rev && rev.full, `${status} chargedBack=${back || '-'} read as partial`);
+      assert.strictEqual(rev.kind, 'chargeback');
+    }
+  }
+});
+
+test('a part-refund grants nothing and revokes nothing', async () => {
+  const d = deps();
+  const out = await billing.processPayment(shape('paid', '5.00', null), d);
+  assert.strictEqual(out.result, 'ignored');
+  assert.match(out.reason, /^partial_refund:500_of_\d+$/);
+  assert.deepStrictEqual(d.calls, [], 'a part-refund moved an entitlement');
+});
+
+test('an ordinary paid payment still grants, so the gate has not simply closed the door', async () => {
+  const d = deps();
+  const out = await billing.processPayment(shape('paid', null, null), d);
+  assert.strictEqual(out.result, 'granted');
+  assert.strictEqual(d.calls.length, 1);
+  assert.strictEqual(d.calls[0].tier, 'pro');
+});
+
+// The gate must be able to go red. This proves the matrix actually exercises
+// the branch, rather than passing because nothing in it is a reversal.
+test('self-test: the matrix contains reversals, whole and partial, of both kinds', () => {
+  const rev = MATRIX.map((p) => billing.reversalOf(p)).filter(Boolean);
+  assert.ok(rev.length >= 60, `only ${rev.length} reversal shapes in the matrix`);
+  assert.ok(rev.some((r) => r.full), 'no whole reversal in the matrix');
+  assert.ok(rev.some((r) => !r.full), 'no partial reversal in the matrix');
+  assert.ok(rev.some((r) => r.kind === 'refund'), 'no refund in the matrix');
+  assert.ok(rev.some((r) => r.kind === 'chargeback'), 'no chargeback in the matrix');
+  // And the layers agree on the count, which is the whole point.
+  const byDoc = MATRIX.filter((p) => creditNote.isReversal(p)).length;
+  assert.strictEqual(rev.length, byDoc, 'billing and credit-note disagree about how many shapes are money back');
+});

--- a/relay/test/route-auth-gate.test.js
+++ b/relay/test/route-auth-gate.test.js
@@ -237,8 +237,12 @@ test('the same token is accepted as a Bearer, and that is the only other form', 
 });
 
 test('the double-gated admin routes need X-Internal-Auth on top of the admin token', async () => {
-  // update-plan / set-product-plan / entitlements are reachable only with BOTH
-  // headers (relay.js:5246, 5286, 5307). The admin token alone must not do.
+  // update-plan / set-product-plan / entitlements were the first three. Since
+  // 2026-09-06 the set is everything under /v2/admin that moves an entitlement
+  // or mints a credential: set-parasign, mint-parasign, keys/erase and
+  // keys/primary joined them. Which routes belong is asserted as a class in
+  // admin-gate-parity.test.js; this is the behavioural half, on a booted relay.
+  // The admin token alone must not do.
   const onlyAdmin = await srv.get('/v2/admin/entitlements/acct_live', { headers: { 'X-Admin-Token': ADMIN } });
   assert.strictEqual(onlyAdmin.status, 401);
   assert.deepStrictEqual(onlyAdmin.json, { error: 'unauthorized' });
@@ -255,6 +259,14 @@ test('the double-gated admin routes need X-Internal-Auth on top of the admin tok
     headers: { 'X-Admin-Token': ADMIN, 'X-Internal-Auth': INTERNAL + 'x' },
   });
   assert.strictEqual(wrongInternal.status, 401);
+
+  // The route that MINTS. It used to stand behind the admin token alone, which
+  // made one leaked secret enough to walk out with a working ParaSign key.
+  const mintOne = await srv.post('/v2/admin/keys/mint-parasign', {
+    headers: { 'X-Admin-Token': ADMIN }, body: { account_id: 'acct_live', test: true },
+  });
+  assert.strictEqual(mintOne.status, 401, 'mint-parasign answered on the admin token alone');
+  assert.ok(!/psk_/.test(mintOne.text), 'a refused mint still leaked a key');
   did();
 });
 

--- a/relay/test/route-billing-entitlements.test.js
+++ b/relay/test/route-billing-entitlements.test.js
@@ -211,19 +211,84 @@ test('a key minted while the subscription is LIVE does not outlive it', async ()
   did();
 });
 
-test('a key minted for an ALREADY lapsed account is a plain floor key, with no stale date', async () => {
+test('an ALREADY lapsed account does not mint at all', async () => {
+  // Until 2026-09-06 this asserted a 201 and then checked that the minted key
+  // came out floored. It was half the fix, and it wrote the other half down as
+  // intended behaviour: the mint gate read `parasign: true` raw, so one month
+  // of ParaSign Pro bought an unlimited supply of working /v1 keys forever. The
+  // key is floored, yes, and it is also a credential, a users.json entry, and
+  // -- since a minted key carries parasign:true itself -- a fresh reason for
+  // the gate to say yes on the next call.
   let srv = await withUsers('mint-after-lapse', [{
     key: 'pgp_lapsed_mint', plan: 'community', active: true, parasign: true,
     account_id: 'acct_lapsed_mint', email: 'lapsed-mint@example.test',
     plan_parasign: 'business', paid_until_parasign: PAST,
   }]);
+  const before = srv.readUsersFile().api_keys.length;
   const minted = await srv.post('/v2/user/parasign-keys', { headers: BOTH, body: { user_id: 'acct_lapsed_mint' } });
-  assert.strictEqual(minted.status, 201, minted.text);
+  assert.strictEqual(minted.status, 403, minted.text);
+  assert.strictEqual(minted.json.error, 'parasign_not_entitled');
   await new Promise((r) => setTimeout(r, 300));
-  const onDisk = srv.readUsersFile().api_keys.find((k) => k.key === minted.json.key);
-  assert.strictEqual(onDisk.plan_parasign, 'free', 'a lapsed account mints what it is entitled to now, not what it paid for once');
-  assert.ok(!('paid_until_parasign' in onDisk),
-    'and carries no date, because a floor tier has no period to be bounded by');
+  assert.strictEqual(srv.readUsersFile().api_keys.length, before,
+    'a refused mint still grew users.json');
+  srv.stop();
+  did();
+});
+
+// ── the cap on minting ───────────────────────────────────────────────────────
+// The behavioural half of key-mint-gate.test.js. The static half can only see
+// that ACCOUNT_KEY_LIMIT is mentioned near the mint; it cannot see whether the
+// comparison still bites. Measured before the repair, on 2026-09-06: nine keys
+// on a community account whose cap is five, and fourteen in a row on Pro, where
+// the cap was Infinity. So the property is asserted over HTTP, as a property:
+// keep minting until it says no, and it must say no.
+test('the self-serve mint stops at the per-account cap, and says 402 with the numbers', async () => {
+  // ACCOUNT_KEY_LIMIT_COMMUNITY is turned down to its floor of 3 on purpose.
+  // At the default of 5 this test passed with the cap DELETED, because the
+  // relay-total community limit is also 5 and answered first with a different
+  // message. A gate satisfied by the wrong refusal is the failure this whole
+  // round is about, so the account cap has to be the only thing that can bite,
+  // and the assertion reads the message to prove which one did.
+  const srv = await boot({
+    tag: 'mint-cap', usersFile: true,
+    users: { api_keys: [{
+      key: 'pgp_cap_anchor', plan: 'community', active: true, parasign: true,
+      account_id: 'acct_cap', email: 'cap@example.test', is_primary: true,
+    }] },
+    env: { ...ADMIN_ENV, ACCOUNT_KEY_LIMIT_COMMUNITY: '3' },
+  });
+  const CAP = 3;
+  const codes = [];
+  let refusal = null;
+  for (let i = 0; i < CAP + 3; i++) {
+    const r = await srv.post('/v2/user/parasign-keys', { headers: BOTH, body: { user_id: 'acct_cap', label: `dev-${i}` } });
+    codes.push(r.status);
+    if (r.status === 402) { refusal = r.json; break; }
+  }
+  assert.ok(refusal, `minted ${codes.length} keys without ever being refused: ${codes.join(',')}`);
+  assert.match(refusal.error, /Account key limit reached \(3 keys on the community plan\)/,
+    `refused by the wrong cap: ${refusal.error}`);
+  assert.strictEqual(refusal.max_keys, CAP);
+  assert.strictEqual(refusal.current_keys, CAP);
+  assert.strictEqual(codes.filter((c) => c === 201).length, CAP - 1,
+    `expected ${CAP - 1} mints on top of the anchor key, got ${codes.filter((c) => c === 201).length}`);
+  await new Promise((r) => setTimeout(r, 300));
+  const onDisk = srv.readUsersFile().api_keys.length;
+  assert.strictEqual(onDisk, CAP, `users.json holds ${onDisk} keys, past a cap of ${CAP}`);
+  srv.stop();
+  did();
+});
+
+test('a grant with no recorded period still mints: absent is unbounded, not expired', async () => {
+  // The other direction of the same rule, and the one that would break every
+  // account predating the paid_until field. An admin set-parasign writes the
+  // flag and no date; that grant has no term to run out.
+  let srv = await withUsers('mint-open-grant', [{
+    key: 'pgp_open_grant', plan: 'community', active: true, parasign: true,
+    account_id: 'acct_open_grant', email: 'open-grant@example.test',
+  }]);
+  const minted = await srv.post('/v2/user/parasign-keys', { headers: BOTH, body: { user_id: 'acct_open_grant' } });
+  assert.strictEqual(minted.status, 201, minted.text);
   srv.stop();
   did();
 });

--- a/relay/test/route-omission-gate.test.js
+++ b/relay/test/route-omission-gate.test.js
@@ -53,6 +53,7 @@ const quota = require('../lib/quota');
 const RUN = crypto.randomBytes(6).toString('hex');
 const OWNER = `pgp_owner_key_for_the_omission_gate_${RUN}`;
 const OWNER_ACCT = `acct_omission_${RUN}`;
+const OTHER = `pgp_other_${RUN}`;
 const DEFAULT_REDIS = 'redis://127.0.0.1:6399';
 
 let srv = null;
@@ -80,6 +81,10 @@ before(async () => {
       api_keys: [
         // community: signs_month is 2, which is what makes the cap observable.
         { key: OWNER, plan: 'community', active: true, parasign: true, email: 'owner@example.test', account_id: OWNER_ACCT },
+        // A second, unrelated account. DOOR 4 needs two callers who both hold a
+        // valid key, because the DID rebind was never an unauthenticated hole:
+        // it was one paying customer taking another one's device.
+        { key: OTHER, plan: 'community', active: true, email: 'other@example.test', account_id: `acct_other_${RUN}` },
       ],
     },
     env: { REDIS_URL: process.env.REDIS_URL || DEFAULT_REDIS },
@@ -368,5 +373,53 @@ test('DOOR 3: an invite pubkey slot is first-registration-wins, and a refresh st
   assert.strictEqual((await srv.post('/v2/pubkey', {
     headers: asParty(), body: { ...manifest, ecdh_pub: token('b'), kyber_pub: 'file|2|3600000' },
   })).status, 409, 'the _ready slot is one-shot too, so a manifest cannot be swapped either');
+  did();
+});
+
+// ── DOOR 4: an identity slot addressed by public inputs is not re-fillable ───
+//
+// Finding 22b. A DID is sha3-256(device_id + ecdh_pub) and both halves come
+// straight back out of GET /v2/did/:did, which is a declared public route
+// because a DID is a public identifier by design. The registration did an
+// unconditional set, so anyone holding a valid key of their own could take the
+// address over. The reason it matters is not the address: authByDid resolves
+// the principal through the registry entry's owner key, so the rebind pointed
+// the victim's own DID-authenticated traffic into the attacker's account.
+//
+// Asserted as the same property as DOOR 3, on a different registry: fill it,
+// and a different owner may not refill it. Same-owner re-registration must keep
+// working, because a device refreshes itself.
+test('DOOR 4: a DID belongs to whoever registered it first, and stays there', async () => {
+  if (!ready()) return;
+  const deviceId = `dev-door4-${RUN}`;
+  const ecdh = 'c'.repeat(64);
+  const body = { device_id: deviceId, ecdh_pub: ecdh };
+
+  const first = await srv.post('/v2/did/register', { headers: asParty({ 'X-Api-Key': OWNER }), body });
+  assert.strictEqual(first.status, 200, first.text);
+  const theDid = first.json.did;
+  assert.ok(theDid && theDid.startsWith('did:paramant:'), first.text);
+
+  // Both halves of the preimage are public, from a route with no credential.
+  const pub = await srv.get(`/v2/did/${encodeURIComponent(theDid)}`, { headers: asParty() });
+  assert.strictEqual(pub.status, 200, pub.text);
+  assert.strictEqual(pub.json.service[0].device, deviceId, 'the device id is not public after all');
+  assert.strictEqual(pub.json.verificationMethod[0].publicKeyHex, ecdh, 'the ecdh key is not public after all');
+
+  // So a stranger holding nothing but that document can rebuild the request.
+  const steal = await srv.post('/v2/did/register', { headers: asParty({ 'X-Api-Key': OTHER }), body });
+  assert.strictEqual(steal.status, 409, `a second owner took the DID: ${steal.status} ${steal.text}`);
+
+  // And the first owner still holds it.
+  const mine = await srv.get('/v2/did', { headers: asParty({ 'X-Api-Key': OWNER }) });
+  assert.strictEqual(mine.status, 200, mine.text);
+  assert.ok(mine.json.dids.some((e) => e.did === theDid), 'the honest owner lost the DID from his own list');
+  const theirs = await srv.get('/v2/did', { headers: asParty({ 'X-Api-Key': OTHER }) });
+  assert.ok(!theirs.json.dids.some((e) => e.did === theDid), 'the DID showed up in the attacker list');
+
+  // The owner refreshing his own device is not a takeover.
+  const refresh = await srv.post('/v2/did/register', { headers: asParty({ 'X-Api-Key': OWNER }), body });
+  assert.strictEqual(refresh.status, 200, `the owner could not refresh his own DID: ${refresh.text}`);
+  assert.strictEqual(refresh.json.did, theDid);
   did();
 });

--- a/tests/koper-hele-weg.test.mjs
+++ b/tests/koper-hele-weg.test.mjs
@@ -306,6 +306,23 @@ test('7. geld terug levert een creditnota op die bij de factuur past', async () 
   assert.ok(gecrediteerd.reversed_at, 'de gecrediteerde factuur draagt geen stempel');
   assert.ok(S.resend.mails.some((m) => /CN-\d{4}-0001/.test(String(m.subject))),
     'de creditnota is niet gemaild');
+
+  // En het recht gaat mee terug. Tot 2026-09-06 stond hier alleen de nota: geld
+  // terug, plan behouden. Erger nog, de terugbetaling komt binnen als een
+  // betaling die 'paid' BLIJFT met amountRefunded erbij, dus hij liep door de
+  // toekenningstak en alleen de idempotentiemarkering hield een verse maand
+  // tegen. De vloer per product staat in relay/lib/billing-catalog.js.
+  const vloer = { parasign: 'free', parasend: 'community' };
+  const gekocht = eerste.metadata && eerste.metadata.product;
+  assert.ok(gekocht, 'de betaling draagt geen product in zijn metadata');
+  const producten = gekocht === 'firm' ? ['parasign', 'parasend'] : [gekocht];
+  for (const [naam, port] of [['main', S.relayPort], ['health', S.healthPort]]) {
+    const e = await rechtenOp(port, S.koper.key);
+    for (const prod of producten) {
+      assert.equal(e[prod].tier, vloer[prod],
+        `${naam} geeft na een volledige terugbetaling nog ${prod} op ${e[prod].tier}`);
+    }
+  }
 });
 
 test('8. na een terugboeking is het recht op BEIDE relays weg', async () => {

--- a/tests/public-route-surface.test.mjs
+++ b/tests/public-route-surface.test.mjs
@@ -18,6 +18,25 @@
 //   2. every declared public route is in the docs, marked "n/a"
 //   3. every declared route dispatches ABOVE the API-key gate in relay.js, and
 //      the set of exemptions inside that gate is the declared set
+//   4. THE CONVERSE. Checks 1-3 all walk from the declaration outward: they
+//      prove the six declared routes really are public. None of them walks the
+//      other way, and thirty-odd handlers dispatch above that gate. So the file
+//      promised that "no new keyless route joins it unannounced" while only
+//      checking the announced ones.
+//
+//      Finding 22c of the 2026-09-05 review walked in through that hole:
+//      POST /v2/qes/sign, no credential of any kind, a 32 MB body, and BOTH of
+//      the relay's own policy files disagreeing with the code. keys-table.js
+//      lists it in SIGN_PATHS, the scope class for a sign-capable key; the
+//      scope check runs inside `if (keyData)` and keyData is always null on a
+//      keyless route, so the classification was policy that could never fire.
+//      public-routes.js did not list it at all.
+//
+//      The converse check is narrow on purpose: a route the relay itself
+//      classifies as SIGN, SEND or ADMIN_WRITE may not be reachable by a caller
+//      carrying nothing. It does not try to judge the whole keyless surface,
+//      which is a bigger question than one review round; it holds the relay to
+//      its own written-down classification.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -127,4 +146,96 @@ test('the deprecated anonymous upload still carries its Sunset headers', () => {
   assert.match(handler, /res\.setHeader\('Sunset',/, 'the Sunset header is gone');
   assert.ok(declared.get('POST /v2/anon-inbound')?.deprecated,
     'the declaration no longer marks the anonymous upload deprecated');
+});
+
+// ── 4. the converse direction ────────────────────────────────────────────────
+
+const SCOPE_TABLES = ['SIGN_PATHS', 'SEND_PATHS', 'ADMIN_WRITE_PATHS'];
+
+// Reaching a handler above the key gate proves nothing on its own: several of
+// them authenticate by other means, in-route. These are the names that count as
+// asking the caller for something.
+const IN_ROUTE_CREDENTIAL = /keyData|apiKey|_internalOk\(|ADMIN_TOKEN|safeEqual\(|x-admin-token|getForParty\(|_setupModeOn\(|token|verify/i;
+
+// Routes the relay classifies but deliberately answers to anyone. Exact count:
+// a second one is a decision somebody has to write down here.
+const CLASSIFIED_BUT_PUBLIC = [
+  {
+    path: '/v2/sign-dpa',
+    reason: 'the self-service data-processing agreement. A prospective customer signs '
+          + 'the DPA before they have a key, so it cannot want one. It is in SIGN_PATHS '
+          + 'because the table keys on the path prefix and not on what is being signed, '
+          + 'which means a read-only KEY holder is refused a form an anonymous caller '
+          + 'may submit. That asymmetry is cosmetic today (nothing reads the answer) but '
+          + 'it is the misclassification, and the right repair is to move the route out '
+          + 'of SIGN_PATHS rather than to weaken this check.',
+  },
+];
+
+function scopePaths() {
+  const src = fs.readFileSync(path.join(ROOT, 'relay/lib/keys-table.js'), 'utf8');
+  const out = [];
+  for (const name of SCOPE_TABLES) {
+    const m = new RegExp(`${name}\\s*=\\s*new Set\\(\\[([\\s\\S]*?)\\]\\)`).exec(src);
+    assert.ok(m, `${name} is no longer a `+"`new Set([...])`"+` in keys-table.js`);
+    for (const p of m[1].matchAll(/'([^']+)'/g)) out.push({ table: name, path: p[1] });
+  }
+  assert.ok(out.length >= 8, `only ${out.length} classified paths found; the scanner has drifted`);
+  return out;
+}
+
+function handlerBlock(at) {
+  const lines = relaySrc.split('\n');
+  let i = relaySrc.slice(0, at).split('\n').length - 1;
+  while (i > 0 && !lines[i].includes('if (')) i--;
+  let d = 0;
+  let end = lines.length - 1;
+  for (let j = i; j < lines.length; j++) {
+    d += (lines[j].match(/\{/g) || []).length - (lines[j].match(/\}/g) || []).length;
+    if (j > i && d <= 0) { end = j; break; }
+  }
+  return lines.slice(i, end + 1).join('\n');
+}
+
+test('a route the relay classifies as sign, send or admin-write is never answered to nobody', () => {
+  const gate = keyGateAt();
+  const allowed = new Set(CLASSIFIED_BUT_PUBLIC.map((a) => a.path));
+  const offenders = [];
+  const hit = [];
+  for (const { table, path: p } of scopePaths()) {
+    const at = relaySrc.indexOf(`path === '${p}'`);
+    if (at === -1 || at > gate) continue;      // below the gate, or not a literal dispatch
+    hit.push(p);
+    if (IN_ROUTE_CREDENTIAL.test(handlerBlock(at))) continue;
+    if (allowed.has(p)) continue;
+    offenders.push(`${p} (${table}) dispatches above the API-key gate and asks the caller for nothing`);
+  }
+  assert.ok(hit.length >= 5, `only ${hit.length} classified routes found above the gate; the scanner has drifted`);
+  assert.deepEqual(offenders, [], 'dead policy: the relay classifies these and then answers anyone.\n  ' + offenders.join('\n  '));
+});
+
+test('the classified-but-public list is exact and reasoned', () => {
+  const gate = keyGateAt();
+  const stillPublic = [];
+  for (const { path: p } of scopePaths()) {
+    const at = relaySrc.indexOf(`path === '${p}'`);
+    if (at === -1 || at > gate) continue;
+    if (!IN_ROUTE_CREDENTIAL.test(handlerBlock(at))) stillPublic.push(p);
+  }
+  assert.deepEqual([...new Set(stillPublic)].sort(), CLASSIFIED_BUT_PUBLIC.map((a) => a.path).sort(),
+    'the set of classified-but-anonymous routes has changed. Add the new one with a\n'
+    + 'reason, or give it a credential check; remove one that has been closed.');
+  for (const a of CLASSIFIED_BUT_PUBLIC) assert.ok(a.reason.length > 80, `${a.path} has no usable reason`);
+});
+
+test('the qualified-signature route asks who is calling', () => {
+  // The finding itself, pinned as behaviour of the source rather than as a
+  // member of a list, so moving it between lists cannot make it pass.
+  const at = relaySrc.indexOf("path === '/v2/qes/sign'");
+  assert.notEqual(at, -1, 'the QES route is gone; update keys-table.js and this test');
+  const block = handlerBlock(at);
+  assert.match(block, /getForParty\(/, 'the QES route no longer checks the party invite token');
+  assert.match(block, /keyData\?\.active/, 'the QES route no longer accepts a key-holding caller either');
+  assert.match(block, /qes_capability_required/, 'the QES route has no refusal for a caller with no capability');
+  assert.doesNotMatch(block, /readBody\(req, 32 \* 1024 \* 1024\)/, 'the QES route still reads 32 MB from an unnamed caller');
 });


### PR DESCRIPTION
De tweede ronde van de vijandige review van 5 september: bevindingen 9, 10, 11,
14, 15, 19 en uit 22 de delen b, c, e, f en i. Elke bevinding is eerst zelf
gecontroleerd tegen de code, want van de negentien uit de vorige ronde hielden er
vier geen stand.

## Wat er nog bestond, en wat niet

Tien van de elf bestonden nog. Een niet, en dat is de duurste uitkomst van de
ronde omdat "repareren" daar iets anders had betekend dan wat er nodig was.

**Bevinding 9, teamklant mint sleutels zonder quota. Weerlegd zoals opgeschreven,
op twee punten.** Het mechanisme klopt niet: een aanvulling boven alle routering
zet `keyData.account_id` alsnog, dus geen enkele quotapoort werd overgeslagen. De
schade was dat het apparaat zijn EIGEN account werd, met een eigen verse
maandemmer naast de zetel die betaald was. En het bereik klopt ook niet:
`team_id` bereikt nooit een runtime-record, want `parseAccountFields` levert een
vast veldenstel en laat het vallen, en geen enkele andere `apiKeys.set` schrijft
het. Je hebt een record met `team_id` nodig om er een met `team_id` te minten. De
route antwoordt dus iedereen 403 en heeft dat altijd gedaan, terwijl
`deploy/paramant-admin.py team-create` het wel naar users.json schrijft en de
adminproxy hem doorlaat. De feature werkt van begin tot eind niet.

De route is onbereikbaar gelaten, de mint wel gerepareerd op de plek waar de
schade zat: gebonden aan het ouderaccount, scope overgenomen, geplafonneerd,
weggeschreven, 32 bytes in plaats van 16. De dag dat iemand de loader over
`team_id` vertelt, mag dit niet de vorm zijn die dan landt.

De overige tien staan hieronder, met de reparatie en de poort.

## De reparaties

**10, minten zonder plafond.** Gemeten op een gestarte relay: veertien sleutels
achter elkaar op Pro, negen op een community-account waarvan het plafond vijf is,
users.json van drie naar vijfentwintig regels in een lus. Het plafond zit nu in
`mintParasignKey` zelf, atomair met de insert, zodat een derde deur het niet kan
vergeten. `ACCOUNT_KEY_LIMIT.pro` en `.enterprise` stonden op `Infinity`, wat
geen plafond is maar een afwezigheid; nu een ruim eindig misbruikplafond.

**11, de parasign-vlag vervalt nooit.** Een maand ParaSign Pro kocht de /v1-API
voor altijd: termijn verlopen, het rechtenendpoint meldde `free`, en de poort die
erover besliste vroeg er nooit naar. Overleeft een herstart, want de vlag wordt
gepersisteerd. Beide poorten lopen nu via `effectiveProductTier`. Een grant
zonder termijn blijft geldig, want afwezig betekent onbegrensd.

**14, een volledige redis-scan per accountscherm.** Acht plekken liepen de hele
keyspace af op `paramant:user:session:*` en haalden elke sleutel op om daarna op
`user_id` te filteren, tegen de redis die vijf sectoren en het adminvlak delen.
Het is ook een privacyvorm die niemand koos: om jou je eigen twee sessies te
tonen werd het IP en de user-agent van elke andere klant gelezen. Nu een index
per gebruiker, met een terugvalpad voor bestaande sessies dat zichzelf eenmalig
adopteert.

**15, de setup-link leeft veertien dagen en trekt niets in.** `14 * 86400` stond
met de hand getypt op zeven plekken. Voor een account waarvan de tweede factor
nog niet actief is IS die link het account. Een niet-ingelogde inlogpoging muntte
er elke keer een verse bij zonder de vorige op te ruimen. Vier van de zeven paden
trokken geen sessies in, waaronder de route die de TOTP-staat en de backupcodes
wist. Nu een constante van twee dagen, een mail die zijn tekst uit diezelfde
constante haalt, en een `issueSetupToken` die de vorige link opruimt en de
sessies intrekt.

Half weerlegd: de review zegt dat de route de backupcodes teruggeeft. Beide
relaypaden geven `backup_codes: []`; de codes komen alleen uit `/confirm`, dat
eerst een geldige TOTP-code eist. En de overname werkt alleen op een account
waarvan de tweede factor nog niet actief is, want daarboven staat een 409 die ook
via de idempotente tak niet te omzeilen is.

**19, geen CSRF-bescherming.** SameSite=Lax werkt op het registreerbare domein,
en de vijf sectorhosts zijn same-site met paramant.app. Twaalf muterende routes
hebben geen lichaam nodig. Er staat nu een controle voor de hele /api-router,
niet per route. De volgorde is uitgeschreven: een toegestane Origin wint eerst,
omdat de browserextensies echte bellers zijn die per constructie cross-site
lijken; daarna Sec-Fetch-Site; geen van beide headers is geen browser en gaat
door.

**22b, DID-registratie te overschrijven.** Een DID is
`sha3-256(device_id + ecdh_pub)` en `GET /v2/did/:did` geeft beide helften terug.
De ondertekensleutel zit in de hash en is dus niet te wisselen, maar `authByDid`
leidt de principal af uit de eigenaar in het register: na een overname liep het
DID-verkeer van het slachtoffer in het account van de aanvaller. Nu eerst-wint
met een 409. De aanwezigheidscontrole die er stond voedde een teller en geen
weigering, en dat idioom is nu zelf een poort. Twee dingen die niet in de review
stonden gingen mee: de teller van 500 DIDs was te omzeilen via een herbinding, en
het pubkey-slot van dezelfde route deelde onder DID-auth een namespace met alle
andere DID-bellers.

**22c, `/v2/qes/sign` heeft geen auth.** Alleen een vlagcontrole, en 32 MB van wie
dan ook. Twee eigen beleidsbestanden spraken de code tegen: `keys-table.js` zet
de route in `SIGN_PATHS`, en die controle draait binnen `if (keyData)`, wat op een
sleutelloze route nooit waar is; `public-routes.js` noemde hem niet. De route
neemt nu dezelfde capability als `/sign`, het uitnodigingstoken van de partij,
plus een limiet per adres en 12 MB.

De echte reparatie zit in de poort eronder. `public-route-surface.test.mjs`
beloofde dat geen enkele sleutelloze route er onaangekondigd bij komt en
controleerde alleen de zes aangekondigde, terwijl er zesendertig handlers boven
die poort liggen. De omgekeerde richting staat er nu bij.

**22e, een terugbetaling neemt het recht niet terug.** Scherper dan opgeschreven:
Mollie meldt een terugbetaling op hetzelfde `tr_`-id met status `paid` en
`amountRefunded` erbij, dus hij bereikte de fall-through-tak nooit en liep door de
TOEKENNINGStak. Alleen de idempotentiemarkering hield een verse maand tegen op
een betaling die al terug was. `credit-note.js` las beide cumulatieve tellers,
`billing.js` matchte op de statustekst en alleen op chargeback. Het predicaat
wordt nu geimporteerd in plaats van herschreven en staat boven de betaaltak.

**22f, mint-parasign achter een hek in plaats van twee.** "Geen escalatie" was te
mild: `plan` ging ongevalideerd door naar `buildParasignKeyRecord`, en op een
account zonder productplan op record levert `{"plan":"enterprise"}` een
enterprise-sleutel zonder `paid_until`, wat de rechtenlaag leest als nooit
vervallen. De route liet ook geen auditspoor achter. En de asymmetrie was breder:
`set-parasign`, `keys/erase` en `keys/primary` stonden ook achter een hek.

**22i, de sessie draagt de kale API-sleutel.** Erger dan opgeschreven: `user_id`
IS die sleutel, dus het veld weghalen verandert niets. `ip` en `ua` werden
opgeslagen en alleen op het accountscherm afgedrukt. De sessie is nu gebonden aan
de client die hem opende, op de user-agent en niet op het IP, en de ene route die
een koekje in een sleutel omzet laat een spoor achter. Wat NIET gerepareerd is:
dat de sleutel de identiteit is. Dat raakt vijf muntplekken, `account-keys`, de
parasend-tokenmunt en elke fixture, en is een eigen wijziging.

## De poorten

Elke reparatie heeft er een die de klasse pakt en niet het geval, in de stijl van
`authz-omission-gate.test.js` uit de vorige ronde: een scan met een
uitzonderingenlijst die een exact aantal draagt, plus een zelftest die bewijst dat
de poort rood kan worden.

- `relay/test/key-mint-gate.test.js` (9, 10) telt elke plek die een sleutel maakt
- `relay/test/grant-expiry-gate.test.js` (11) verbiedt een recht op een rauwe vlag
- `relay/test/first-wins-gate.test.js` (22b) herkent het teller-idioom
- `relay/test/money-back-parity-gate.test.js` (22e) draait negentig betalingsvormen
- `relay/test/admin-gate-parity.test.js` (22f) telt elke muterende admin-POST
- `admin/test/keyspace-scan-gate.test.js` (14) volgt een niveau van de aanroepgraaf
- `admin/test/credential-reset-gate.test.js` (15) eist intrekken na afbreken
- `admin/test/csrf-origin-gate.test.js` (19) statisch plus over HTTP
- `admin/test/session-credential-gate.test.js` (22i) statisch plus over HTTP
- `tests/public-route-surface.test.mjs` (22c) kreeg de ontbrekende richting
- `relay/test/route-omission-gate.test.js` kreeg DOOR 4 voor de DID
- `admin/test/user-sessions.test.js` draait de index tegen een echte redis

## Sabotage

Elke reparatie is teruggedraaid en de poort moest rood worden. Alle elf deden dat,
op een na, en die uitkomst staat hieronder omdat hij iets zegt over de grens van
een statische scan.

- 22e, het oude predicaat terug: 3 van de 7 rood
- 22f, `_internalOk` weg bij mint-parasign: 3 van de 5 rood
- 9, de oude add-device-mint terug: rood
- 10, `if (false && _active >= _cap)`: de statische helft bleef groen, de
  gedragshelft werd rood. De scan ziet dat `ACCOUNT_KEY_LIMIT` genoemd wordt, niet
  of de vergelijking nog bijt. Dat is precies waarom er een gedragshelft is
- 11, de periodecontrole weg: rood
- 22b, de eerst-wint-guard weg: statisch rood en DOOR 4 rood
- 22c, de capability-controle weg en 32 MB terug: rood
- 14, het accountscherm scant weer: 3 van de 7 rood
- 15a, veertien dagen terug: rood. 15b, resend-setup trekt niet meer in: 2 rood
- 19, sectorsubdomeinen weer toestaan: 4 van de 12 rood
- 22i, de clientvergelijking uit: 2 rood. Een tweede onthulroute erbij: rood

## Bouwstraat

Letterlijk de commando's uit de workflows, op de boom na rebase op main
(`6e40d60e`), met verse afhankelijkheden. Alles groen: shell-syntax, static
sanity (13 checks), test-declarations (217 suites), eslint, CSP, cache-bust,
deploy-3.1 dry run (478), relay crypto (144), parasign engine (4), integratie
(13), route-suites (202) plus de flaky-watch met 3 herhalingen, relay units
(472), root integratie (298), admin units (169), admin login-timing tegen een
echte relay (4), de hele koperreis (9), de browsersuites (84), sign-full (33),
en `docker build -f relay/Dockerfile` komt schoon door.

Gitleaks over de gewijzigde bestanden: schoon.

## Wat het nalopen van de bellers opleverde

Een reparatie kan ook iets breken dat geen test aanraakt. Het Outlook-taakpaneel
wordt geserveerd vanaf `addin.paramant.app` en doet
`POST paramant.app/api/user/logout` met credentials, zonder lichaam en zonder
Content-Type. Dat is een simple request: geen preflight, dus de browser stuurt
hem, het koekje gaat mee, en alleen het antwoord wordt door CORS verborgen. Die
aanroep werkt vandaag en de add-in negeert de uitkomst, dus de oorsprongscontrole
had hem stil laten mislukken terwijl de add-in succes bleef melden.

Uitloggen is de ene schrijfactie waar weigeren duurder is dan toelaten: het
ergste wat een vreemde pagina ermee bereikt is iemand uitloggen, en de sessie die
sneuvelt is die van het slachtoffer zelf. Een uitzondering dus, op een pad en niet
op een prefix, met de reden erbij en exact geteld. De sabotage die hem oprekt tot
`/user/` zet acht controles op rood.

## Wat de bouwstraat ving en de review niet

Bij de eerste volledige run zakte `tests/koper-hele-weg.test.mjs` op punt 8: na
een terugboeking kon het account nog steeds API-sleutels minten, terwijl beide
relays het recht wel op de vloer hadden gezet. Dat was een regressie uit mijn
eigen reparatie van bevinding 11. Ik liet de muntpoort dezelfde drie vormen lezen
als de /v1-deur, en een daarvan is scope `parasign`. Dat is wat een psk_-sleutel
IS, zijn hele leven lang; intrekken wist de vlag op elke ledensleutel en kan niet
wissen wat een sleutel is. De vlag is de toekenning, de scope is een bevoegdheid
die de toekenning al heeft uitgedeeld, en dat zijn nu twee predicaten. Losse
suites hadden dit niet gevonden.
