### PR TITLE
de stand van Paramant op een pagina die niet groen kan liegen

### DIFF
--- a/admin/ADMIN.md
+++ b/admin/ADMIN.md
@@ -26,6 +26,40 @@ Sessions are stored in Redis under `paramant:admin:session:{sid}` with a 12-hour
 | **Billing** | Active subscriptions and MRR breakdown |
 | **Relay** | Live health + uptime + metrics for all 5 sector relays, auto-refreshes every 10s |
 
+## De standpagina (`/admin/stand`)
+
+Een aparte pagina naast de tabs, in het Nederlands, voor de vraag "hoe staat het
+ervoor" zonder eerst ergens in te loggen op een server. Zelfde inlog als de rest
+van deze adminkant: `X-Session` uit `sessionStorage`, dus er komt geen nieuwe
+openbare route bij. Het bestand `public/stand.html` is een leeg geraamte; alles
+wat erop komt haalt `public/stand.js` op bij `GET /api/admin/stand`, en die zit
+achter `authMiddleware`.
+
+Vier blokken, in deze volgorde: werkt het, wordt het gebruikt, staat er iets
+rood, en wat wacht er op de eigenaar. Gaat een blok goed, dan staat het dicht.
+
+Twee regels worden in `lib/stand.js` afgedwongen en niet alleen beschreven:
+
+- `punt()` zet elk punt zonder `meting` op "niet gemeten". Een getal dat er niet
+  is kan dus niet als groen eindigen.
+- In `RANG` staat "niet gemeten" boven "let op", zodat een weggevallen meting de
+  kop wegtrekt van groen in plaats van mee te liften op wat wel lukte.
+
+De metingen staan in `lib/stand.js`, de buitenwereld in `lib/stand-io.js`.
+GitHub wordt zonder sleutel bevraagd (openbare repo, 60 vragen per uur, vijf
+minuten cache in redis); lukt dat niet, dan staat er "niet gemeten".
+
+De knop "doe de echte proef" stuurt via `POST /api/admin/stand/proef` werkelijk
+een bestand door de relay, haalt het terug, vergelijkt de bytes en controleert
+dat een tweede ophaalpoging 410 geeft. Dat is een echte handeling die in het
+openbare transparantielogboek komt, dus hij draait op verzoek en niet bij elk
+paginabezoek, en hij telt op de pagina zelf als zelftest en nooit als gebruik.
+Eigen rem: een proef per vijf minuten.
+
+Instellingen: `PARAMANT_SITE_URL`, `PARAMANT_REPO`, `STAND_ZELFTEST_ACCOUNTS`
+(zie `deploy/.env.example`). De sabotagetoets is
+`admin/test/stand-gate.test.js`.
+
 ---
 
 ## User action menu

--- a/admin/lib/stand-io.js
+++ b/admin/lib/stand-io.js
@@ -1,0 +1,222 @@
+'use strict';
+// De buitenwereld voor lib/stand.js: relays, de eigen site, redis en de
+// openbare GitHub-API.
+//
+// Twee dingen zijn hier met opzet zo:
+//
+// * GitHub wordt zonder sleutel bevraagd. paramant-relay is een openbare repo,
+//   dus de uitslag van een workflow en de lijst openstaande wijzigingen zijn
+//   openbaar. Geen token betekent geen extra geheim dat gezet, bewaard of
+//   gelekt kan worden, en het betekent dat deze pagina niets nieuws mag dat de
+//   admin nog niet mocht. De prijs is de anonieme limiet van 60 vragen per uur,
+//   en die wordt met een korte cache in redis ruim onder gebleven.
+// * Elke functie hier geeft bij twijfel `null` terug en verzint nooit iets.
+//   lib/stand.js zet een punt zonder meting automatisch op "niet gemeten", dus
+//   een fout hier eindigt zichtbaar op de pagina en niet als groen bolletje.
+
+const crypto = require('crypto');
+
+const GH_API = 'https://api.github.com';
+const GH_CACHE_S = 300;
+const WEB_TIMEOUT_MS = 8000;
+
+function repoNaam() {
+  return process.env.PARAMANT_REPO || 'Apolloccrypt/paramant-relay';
+}
+
+function siteUrl() {
+  return (process.env.PARAMANT_SITE_URL || 'https://paramant.app').replace(/\/$/, '');
+}
+
+// De accounts die als eigen zelftest gelden. Leeg is een geldige stand en de
+// pagina zegt dat er dan alleen op het kanarie-kenmerk gefilterd wordt.
+function zelftestAccounts() {
+  return String(process.env.STAND_ZELFTEST_ACCOUNTS || '')
+    .split(',').map(s => s.trim()).filter(Boolean);
+}
+
+// `binair: true` levert de ruwe bytes. Dat is niet hetzelfde als de tekst door
+// een Buffer halen: een tekstdecodering vervangt alles wat geen geldige UTF-8
+// is door een vervangingsteken, en dan zou de vergelijking "kwamen dezelfde
+// bytes terug" slagen op bytes die onderweg kapot zijn gegaan.
+async function haal(url, opts = {}) {
+  const t0 = Date.now();
+  const r = await fetch(url, {
+    ...opts,
+    signal: AbortSignal.timeout(opts.timeoutMs || WEB_TIMEOUT_MS),
+    headers: { 'User-Agent': 'paramant-stand', ...(opts.headers || {}) },
+  });
+  if (opts.binair) {
+    const bytes = Buffer.from(await r.arrayBuffer());
+    return { status: r.status, bytes, ms: Date.now() - t0 };
+  }
+  const text = await r.text();
+  return { status: r.status, text, ms: Date.now() - t0 };
+}
+
+// Een GitHub-vraag met een korte cache. Een mislukte vraag wordt niet gecachet
+// en niet gladgestreken: hij gooit, en het punt erboven wordt "niet gemeten".
+function maakGh(redis) {
+  return async function gh(pad) {
+    const sleutel = 'paramant:stand:gh:' + crypto.createHash('sha256').update(pad).digest('hex').slice(0, 32);
+    try {
+      const uit = await redis().get(sleutel);
+      if (uit) return JSON.parse(uit);
+    } catch { /* geen cache is geen fout, dan vragen we het opnieuw */ }
+
+    const r = await haal(GH_API + pad, { headers: { Accept: 'application/vnd.github+json' } });
+    if (r.status !== 200) throw new Error(`github ${r.status} op ${pad}`);
+    const body = JSON.parse(r.text);
+    try { await redis().set(sleutel, JSON.stringify(body), { EX: GH_CACHE_S }); } catch { /* cache is optioneel */ }
+    return body;
+  };
+}
+
+// De echte proef: een blok gaat erin, moet er byte voor byte uitkomen, en moet
+// daarna vernietigd zijn. Dezelfde drie stappen als de kanarie in
+// scripts/heartbeat/parasend.mjs, want dat is de belofte van het product.
+//
+// Deze proef schrijft een regel in het openbare transparantielogboek. Daarom
+// draait hij alleen als iemand erom vraagt en niet bij elk bezoek aan de
+// pagina: een statuspagina die zichzelf meetelt is precies hoe 485 handelingen
+// in augustus bijna allemaal de eigen robot bleken te zijn.
+async function doeProef(site) {
+  const id = crypto.randomUUID();
+  const buf = Buffer.from(`stand-proef ${id} ${new Date().toISOString()}`);
+  const hash = crypto.createHash('sha256').update(buf).digest('hex');
+  const ts = Date.now();
+  const stappen = [];
+
+  const mislukt = (reden) => ({ ok: false, ts, reden, id: `stand-${id}`, stappen });
+
+  let op;
+  try {
+    op = await haal(`${site}/v2/anon-inbound`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hash, payload: buf.toString('base64'), ttl_ms: 60000 }),
+    });
+  } catch (e) { return mislukt(`het versturen liep vast (${e.message})`); }
+  stappen.push({ stap: 'versturen', status: op.status, ms: op.ms });
+  if (op.status !== 200) return mislukt(`de relay weigerde het bestand met antwoord ${op.status}`);
+
+  let uit;
+  try { uit = JSON.parse(op.text); } catch { return mislukt('de relay gaf geen leesbaar antwoord op het versturen'); }
+  if (uit.hash !== hash) return mislukt('de relay bewaarde het bestand onder een andere naam dan het meekreeg');
+  const token = uit.download_token;
+  if (!token) return mislukt('er kwam geen ophaallink terug, dus een ontvanger zou er niet bij kunnen');
+
+  let neer;
+  try { neer = await haal(`${site}/v2/dl/${token}/get`, { binair: true }); } catch (e) { return mislukt(`het ophalen liep vast (${e.message})`); }
+  stappen.push({ stap: 'ophalen', status: neer.status, ms: neer.ms });
+  if (neer.status !== 200) return mislukt(`het ophalen mislukte met antwoord ${neer.status}`);
+  const terug = crypto.createHash('sha256').update(neer.bytes).digest('hex');
+  if (terug !== hash) return mislukt('er kwamen andere bytes terug dan er in gingen');
+
+  let weer;
+  try { weer = await haal(`${site}/v2/dl/${token}/get`); } catch (e) { return mislukt(`de vernietigingscontrole liep vast (${e.message})`); }
+  stappen.push({ stap: 'nog een keer ophalen', status: weer.status, ms: weer.ms });
+  if (weer.status !== 410) return mislukt(`het bestand overleefde het lezen: een tweede keer ophalen gaf ${weer.status} in plaats van 410. Wat eenmalig heet, is dat niet`);
+
+  return {
+    ok: true, ts, id: `stand-${id}`, bytes: buf.length, hash_heen: hash, hash_terug: terug,
+    ms: stappen.reduce((n, s) => n + (s.ms || 0), 0), stappen,
+  };
+}
+
+// Bouwt het io-object dat lib/stand.js verwacht.
+//
+// `relayFetch` en `sectors` komen uit server.js, zodat deze module niets weet
+// van de admin-token en er geen tweede plek ontstaat waar dat geheim leeft.
+function maakIo({ redis, relayFetch, sectors, adminToken }) {
+  const site = siteUrl();
+  const gh = maakGh(redis);
+  const repo = repoNaam();
+
+  return {
+    nu: () => Date.now(),
+    site,
+    sectors,
+    zelftestAccounts: zelftestAccounts(),
+
+    relay: (sector, pad, opts = {}) =>
+      relayFetch(sector, pad, 'GET', null, false, adminToken, !!opts.internal),
+
+    web: (url) => haal(url),
+
+    // Alle accounts over alle relays heen, ontdubbeld door de aanroeper.
+    async sleutels() {
+      const uit = [];
+      let gelukt = 0;
+      await Promise.all(sectors.map(async (s) => {
+        try {
+          const r = await relayFetch(s, '/v2/admin/usage', 'GET', null, false, adminToken, true);
+          if (r.status === 200 && r.body && Array.isArray(r.body.accounts)) {
+            gelukt++;
+            uit.push(...r.body.accounts);
+          }
+        } catch { /* een relay die niet antwoordt telt niet mee */ }
+      }));
+      if (gelukt === 0) throw new Error('geen enkele relay gaf een accountlijst');
+      return uit;
+    },
+
+    // De audittrail over een venster. Elke regel is JSON zoals lib/audit.js
+    // hem wegschrijft; een regel die niet te lezen is wordt overgeslagen en
+    // niet geraden.
+    async auditRegels(vanafMs) {
+      const ruw = await redis().zRangeByScore('paramant:audit:global', vanafMs, '+inf');
+      const uit = [];
+      for (const r of ruw) {
+        try { uit.push(JSON.parse(r)); } catch { /* onleesbare regel telt niet mee */ }
+      }
+      return uit;
+    },
+
+    async laatsteProef() {
+      const ruw = await redis().get('paramant:stand:proef');
+      return ruw ? JSON.parse(ruw) : null;
+    },
+
+    async bewaarProef(p) {
+      await redis().set('paramant:stand:proef', JSON.stringify(p));
+    },
+
+    doeProef: () => doeProef(site),
+
+    // De laatste run van een workflow. `tak` mag null zijn voor "welke tak dan
+    // ook", wat nodig is voor de geplande controles: die draaien op main maar
+    // worden door GitHub niet altijd aan een tak gehangen.
+    async laatsteRun(bestand, tak) {
+      const q = new URLSearchParams({ per_page: '1' });
+      if (tak) q.set('branch', tak);
+      const body = await gh(`/repos/${repo}/actions/workflows/${bestand}/runs?${q}`);
+      const run = (body.workflow_runs || [])[0];
+      if (!run) return null;
+      return {
+        status: run.status,
+        conclusion: run.conclusion,
+        ts: Date.parse(run.updated_at || run.created_at) || null,
+        nummer: run.run_number,
+      };
+    },
+
+    async hoofdCommit() {
+      const body = await gh(`/repos/${repo}/commits/main`);
+      return body.sha || null;
+    },
+
+    async openPRs() {
+      const body = await gh(`/repos/${repo}/pulls?state=open&per_page=100`);
+      return body.map(p => ({ nummer: p.number, ts: Date.parse(p.created_at) || null }));
+    },
+
+    async codeManifest() {
+      const r = await haal(`${site}/v1/code-manifest`);
+      if (r.status !== 200) throw new Error(`code-manifest gaf ${r.status}`);
+      return JSON.parse(r.text);
+    },
+  };
+}
+
+module.exports = { maakIo, doeProef, siteUrl, repoNaam, zelftestAccounts };

--- a/admin/lib/stand.js
+++ b/admin/lib/stand.js
@@ -1,0 +1,508 @@
+'use strict';
+// De stand van Paramant, in gewone taal, en nooit meer dan er gemeten is.
+//
+// Dit bestand bestaat om een fout niet te herhalen. In de nacht van 5 op 6
+// september bleek negen keer op rij dat een waarborg er stond en niets deed:
+// een overgeslagen taak faalt niet, een rookproef slaagde juist toen een route
+// helemaal niet antwoordde, en de deploy las de statuscode van de diepe
+// gezondheidscontrole in plaats van de uitslag erin. Alle negen zagen er van
+// een afstand groen uit.
+//
+// Daarom gelden hier twee regels, en ze worden afgedwongen in code en niet in
+// een comment:
+//
+//   1. Geen oordeel zonder meting. `punt()` zet elk punt zonder `meting` op
+//      NIET_GEMETEN, wat de aanroeper ook meegaf. Een waarde die er niet is
+//      kan hier dus niet als groen eindigen.
+//   2. Niet gemeten is niet goed. In `RANG` staat NIET_GEMETEN bóven "let op":
+//      een blok waar de meting wegviel trekt de kop naar beneden in plaats van
+//      stilletjes mee te liften op de punten die wel lukten.
+//
+// Alle buitenwereld komt binnen via `io`, zodat de sabotagetoets een kapotte
+// relay, een stille GitHub en een lege audittrail kan naspelen zonder netwerk.
+
+const GOED = 'goed';
+const LET_OP = 'let op';
+const NIET_GEMETEN = 'niet gemeten';
+const KAPOT = 'kapot';
+
+// Slechter is hoger. NIET_GEMETEN staat expres boven LET_OP: een meting die
+// wegviel is erger dan een meting die iets kleins liet zien, omdat je van de
+// eerste niet weet wat je mist.
+const RANG = { [GOED]: 0, [LET_OP]: 1, [NIET_GEMETEN]: 2, [KAPOT]: 3 };
+
+const WEEK_MS = 7 * 24 * 3600 * 1000;
+const UUR_MS = 3600 * 1000;
+
+// Een dagelijkse controle die langer dan dit stil is, is stil. Twee dagen, niet
+// een week: een alarm dat een halve week mag zwijgen is geen alarm. Dezelfde
+// redenering als HEARTBEAT_ROOD_UREN in scripts/directie/signalen.py.
+const CONTROLE_STIL_UREN = 48;
+// Een tak of PR die langer dan dit buiten main staat is voorraad, geen werk.
+// Gelijk aan LANDEN_TERMIJN_DAGEN in scripts/check-landen.mjs.
+const LANDEN_DAGEN = 7;
+
+function slechtste(standen) {
+  return standen.reduce((m, s) => (RANG[s] > RANG[m] ? s : m), GOED);
+}
+
+// De enige manier waarop een punt ontstaat.
+//
+// `meting` is wat er werkelijk gezien is: een getal, een statuscode, een lijst,
+// een tijdstip. Is dat null of undefined, dan is er niets gemeten en wordt het
+// punt NIET_GEMETEN, ongeacht de meegegeven stand. Dit is de regel waar de hele
+// pagina op rust, dus hij staat hier en nergens anders.
+function punt(naam, stand, zin, meting, bron) {
+  const gemeten = meting !== null && meting !== undefined;
+  return {
+    naam,
+    stand: gemeten ? stand : NIET_GEMETEN,
+    zin: gemeten ? zin : (zin || `Dit kon ik niet meten, dus ik weet het niet.`),
+    meting: gemeten ? meting : null,
+    bron,
+  };
+}
+
+function blok(id, titel, punten) {
+  return { id, titel, stand: slechtste(punten.map(p => p.stand)), punten };
+}
+
+// Een zin die begint met een ingevulde naam begint met een kleine letter. Dat
+// leest als een halve regel, dus hij krijgt hier alsnog zijn hoofdletter.
+function hoofdletter(zin) {
+  return zin.charAt(0).toUpperCase() + zin.slice(1);
+}
+
+function ouderdom(nu, ts) {
+  if (!ts) return null;
+  const ms = nu - ts;
+  const min = Math.round(ms / 60000);
+  if (min < 60) return `${min} minuten`;
+  const uur = Math.round(ms / UUR_MS);
+  if (uur < 48) return `${uur} uur`;
+  return `${Math.round(ms / 86400000)} dagen`;
+}
+
+// ── Blok 1. Werkt het ───────────────────────────────────────────────────────
+//
+// Niet "antwoordt het adres", maar "doet het iets". Vandaar de diepe controle,
+// die op de relay zelf een bestand wegschrijft en redis aanspreekt, en de weg
+// die een klant aflegt.
+
+async function blokWerkt(io) {
+  const punten = [];
+
+  // 1a. Antwoorden de relays, en met welke versie.
+  const levens = await Promise.all(io.sectors.map(async (s) => {
+    try {
+      const r = await io.relay(s, '/health');
+      return { sector: s, status: r.status, versie: r.body && r.body.version };
+    } catch (e) {
+      return { sector: s, status: 0, fout: e.message };
+    }
+  }));
+  const op = levens.filter(l => l.status === 200);
+  const stuk = levens.filter(l => l.status !== 200);
+  punten.push(punt(
+    'De relays',
+    stuk.length === 0 ? GOED : KAPOT,
+    stuk.length === 0
+      ? `Alle ${levens.length} relays draaien, op versie ${[...new Set(op.map(l => l.versie).filter(Boolean))].join(' en ') || 'onbekend'}.`
+      : `${stuk.length} van de ${levens.length} relays antwoordt niet: ${stuk.map(l => l.sector).join(', ')}. Wie daar iets heen stuurt, krijgt niets terug.`,
+    levens.length ? levens : null,
+    'GET /health op elke relay',
+  ));
+
+  // 1b. De diepe controle. Deze schrijft echt een bestand weg en pingt redis.
+  //
+  // We lezen `overall` uit het antwoord en niet de HTTP-status. Die route
+  // antwoordt namelijk altijd 200, ook als de uitslag erin rood is. Dat is
+  // precies de fout die de deploy 34 keer op rij maakte: 34 logboeken lang
+  // "deep overall = red" terwijl de deploy doorliep omdat de statuscode klopte.
+  const diepen = await Promise.all(io.sectors.map(async (s) => {
+    try {
+      const r = await io.relay(s, '/v2/health/deep', { internal: true });
+      if (r.status !== 200 || !r.body || !r.body.overall) return { sector: s, uitslag: null, status: r.status };
+      const slecht = (r.body.checks || []).filter(c => c.status === 'red' || c.status === 'yellow');
+      return { sector: s, uitslag: r.body.overall, slecht };
+    } catch (e) {
+      return { sector: s, uitslag: null, fout: e.message };
+    }
+  }));
+  const gelezen = diepen.filter(d => d.uitslag);
+  const rood = gelezen.filter(d => d.uitslag === 'red');
+  const geel = gelezen.filter(d => d.uitslag === 'yellow');
+  const namen = (d) => (d.slecht || []).map(c => `${c.name} (${c.detail})`).join(', ');
+  punten.push(punt(
+    'De diepe controle',
+    rood.length ? KAPOT : (geel.length ? LET_OP : GOED),
+    gelezen.length === 0
+      ? 'Geen enkele relay gaf een uitslag terug, dus ik weet niet of opslag en geheugen het doen.'
+      : rood.length
+        ? `Op ${rood.map(d => d.sector).join(', ')} is iets stuk: ${namen(rood[0])}.`
+        : geel.length
+          ? `Alles draait, met een waarschuwing op ${geel.map(d => d.sector).join(', ')}: ${namen(geel[0])}.`
+          : `Alle ${gelezen.length} relays kunnen wegschrijven, hun geheugen is in orde en de opslag antwoordt.`,
+    gelezen.length ? diepen : null,
+    'GET /v2/health/deep, de uitslag in het antwoord en niet de statuscode',
+  ));
+
+  // 1c. De weg die een klant aflegt: de voordeur, de inlog, en de tekenpagina
+  //     die niet naar de inlog mag wegspringen.
+  const wegen = [
+    { naam: 'de voorpagina', url: io.site + '/', verwacht: 200 },
+    { naam: 'de inlogpagina', url: io.site + '/auth/login', verwacht: 200 },
+    { naam: 'de tekenpagina', url: io.site + '/sign', verwacht: 200 },
+  ];
+  const gelopen = [];
+  for (const w of wegen) {
+    try {
+      const r = await io.web(w.url);
+      gelopen.push({ ...w, status: r.status, ms: r.ms, leeg: !(r.text && r.text.length > 500) });
+    } catch (e) {
+      gelopen.push({ ...w, status: 0, fout: e.message });
+    }
+  }
+  const mis = gelopen.filter(w => w.status !== w.verwacht || w.leeg);
+  punten.push(punt(
+    'De weg van een klant',
+    mis.length ? KAPOT : GOED,
+    mis.length
+      ? hoofdletter(`${mis.map(w => w.naam).join(' en ')} komt niet goed omhoog (${mis.map(w => w.status === 0 ? 'geen antwoord' : `antwoord ${w.status}`).join(', ')}). Een bezoeker loopt daar vast.`)
+      : `De voorpagina, de inlog en de tekenpagina komen alle drie omhoog, de traagste in ${Math.max(...gelopen.map(w => w.ms || 0))} ms.`,
+    gelopen.some(w => w.status) ? gelopen : null,
+    `GET op ${io.site}, zoals een bezoeker het doet`,
+  ));
+
+  // 1d. De laatste echte proef: een blok dat er werkelijk in ging en er
+  //     byte voor byte weer uit kwam. Die proef schrijft in het openbare
+  //     logboek, dus hij draait niet bij elke keer dat deze pagina opent;
+  //     anders zou deze pagina zelf het gebruikscijfer opblazen. Wat hier
+  //     staat is de laatste die gedaan is, met zijn leeftijd erbij.
+  let proef = null;
+  try { proef = await io.laatsteProef(); } catch { proef = null; }
+  const proefOud = proef && proef.ts ? io.nu() - proef.ts > 24 * UUR_MS : false;
+  punten.push(punt(
+    'De laatste echte proef',
+    proef && proef.ok ? (proefOud ? LET_OP : GOED) : KAPOT,
+    !proef
+      ? 'Er is nog nooit een echte proef gedaan, dus niemand heeft aangetoond dat een bestand er heelhuids doorheen komt. Druk op de knop hieronder om er nu een te doen.'
+      : proef.ok
+        ? `${ouderdom(io.nu(), proef.ts)} geleden ging er een bestand in en kwam byte voor byte hetzelfde weer terug, en het werd daarna vernietigd zoals beloofd.`
+        : `De laatste proef, ${ouderdom(io.nu(), proef.ts)} geleden, is mislukt: ${proef.reden}.`,
+    proef,
+    'POST /v2/anon-inbound, dan de download, dan nog een keer om te zien dat hij weg is',
+  ));
+
+  return blok('werkt', 'Werkt het', punten);
+}
+
+// ── Blok 2. Wordt het gebruikt ──────────────────────────────────────────────
+//
+// Het getal dat hier hoort te staan is het aantal handelingen door mensen. In
+// augustus meldde ik 485 handelingen als gebruik; 855 van de 891 regels in het
+// openbare logboek kwamen van de eigen uurlijkse zelftest en de laatste echte
+// overdracht door een mens was van 18 augustus. Het getal was dus vrijwel
+// helemaal de eigen robot.
+//
+// Daarom staan hier drie getallen naast elkaar en nooit één: mensen, Mick zelf,
+// en de zelftest. De regel waarmee ze uit elkaar gehouden worden staat op de
+// pagina zelf, zodat een cijfer altijd na te rekenen is.
+
+// Een handeling telt als zelftest wanneer hij van een als zelftest aangemerkt
+// account komt, of wanneer er een kanarie-kenmerk in de gegevens zit. De
+// kanarie zet `canary-` voor alles wat hij aanmaakt (scripts/heartbeat/lib.mjs),
+// en de proefknop op deze pagina zet er `stand-` voor.
+function soortVanHandeling(regel, zelftestAccounts) {
+  const type = String(regel.event_type || '');
+  if (type.startsWith('admin_')) return 'mick';
+  const id = String(regel.user_id || '');
+  if (zelftestAccounts.includes(id)) return 'zelftest';
+  const plat = JSON.stringify(regel.metadata || {});
+  if (plat.includes('canary-') || plat.includes('stand-')) return 'zelftest';
+  return 'mens';
+}
+
+async function blokGebruik(io) {
+  const punten = [];
+  const nu = io.nu();
+  const zelftestAccounts = io.zelftestAccounts || [];
+
+  // 2a. Hoeveel accounts zijn er, en hoeveel daarvan staan aan.
+  let sleutels = null;
+  try { sleutels = await io.sleutels(); } catch { sleutels = null; }
+  if (sleutels) {
+    const uniek = new Set(sleutels.map(k => k.account_id || k.api_key_prefix));
+    const actief = sleutels.filter(k => k.active !== false).length;
+    punten.push(punt(
+      'Accounts',
+      GOED,
+      `Er zijn ${uniek.size} accounts, waarvan ${actief} actief. Een account is nog geen gebruiker.`,
+      { accounts: uniek.size, actief },
+      'GET /v2/admin/usage op elke relay',
+    ));
+  } else {
+    punten.push(punt('Accounts', GOED, 'De accountlijst kwam niet terug, dus ik weet niet hoeveel er zijn.', null, 'GET /v2/admin/usage op elke relay'));
+  }
+
+  // 2b. Handelingen in de afgelopen week, uit elkaar gehouden.
+  let regels = null;
+  try { regels = await io.auditRegels(nu - WEEK_MS); } catch { regels = null; }
+  if (regels) {
+    const tel = { mens: 0, mick: 0, zelftest: 0 };
+    let laatsteMens = 0;
+    for (const r of regels) {
+      const soort = soortVanHandeling(r, zelftestAccounts);
+      tel[soort]++;
+      if (soort === 'mens' && r.ts > laatsteMens) laatsteMens = r.ts;
+    }
+    punten.push(punt(
+      'Handelingen door mensen, laatste zeven dagen',
+      tel.mens > 0 ? GOED : LET_OP,
+      tel.mens > 0
+        ? `${tel.mens} handelingen door mensen. Daarnaast ${tel.mick} van jou als beheerder en ${tel.zelftest} van de zelftest; die twee tellen hier niet mee.`
+        : `Nul handelingen door mensen deze week. Wat er wel gebeurde: ${tel.mick} beheerhandelingen van jou en ${tel.zelftest} van de zelftest. Het product draait, maar niemand gebruikt het.`,
+      tel,
+      'paramant:audit:global over zeven dagen, gesplitst',
+    ));
+
+    punten.push(punt(
+      'De laatste handeling door een mens',
+      laatsteMens ? GOED : LET_OP,
+      laatsteMens
+        ? `${ouderdom(nu, laatsteMens)} geleden.`
+        : 'In de hele bewaarde week staat geen enkele handeling van een mens.',
+      // De meting is de hele doorzochte stapel, niet alleen een gevonden
+      // tijdstip. Geen enkele handeling van een mens in 485 doorzochte regels
+      // IS een uitkomst; die als "niet gemeten" wegzetten zou juist het
+      // ongemakkelijke antwoord onzichtbaar maken.
+      { laatste_ts: laatsteMens || 0, regels_bekeken: regels.length },
+      'de nieuwste niet-beheer, niet-zelftest regel in paramant:audit:global',
+    ));
+
+    // 2c. Wat de zelftest zelf deed, apart genoemd. Dit getal staat er zodat
+    //     het nooit meer per ongeluk in het getal hierboven belandt.
+    punten.push(punt(
+      'Wat de zelftest zelf deed',
+      GOED,
+      zelftestAccounts.length === 0
+        ? `${tel.zelftest} handelingen herkend aan een kanarie-kenmerk. Er is nog geen account als zelftest aangemerkt (STAND_ZELFTEST_ACCOUNTS is leeg), dus die herkenning leunt alleen op dat kenmerk.`
+        : `${tel.zelftest} handelingen, van ${zelftestAccounts.length} als zelftest aangemerkte accounts plus alles met een kanarie-kenmerk.`,
+      { zelftest: tel.zelftest, aangemerkte_accounts: zelftestAccounts.length },
+      'dezelfde regels, de kant die eruit gefilterd is',
+    ));
+  } else {
+    punten.push(punt('Handelingen door mensen, laatste zeven dagen', GOED, 'De audittrail kwam niet terug, dus ik kan geen enkel gebruikscijfer geven. Liever geen getal dan een verkeerd getal.', null, 'paramant:audit:global'));
+  }
+
+  return blok('gebruik', 'Wordt het gebruikt', punten);
+}
+
+// ── Blok 3. Staat er iets rood ──────────────────────────────────────────────
+//
+// Vier dingen, in gewone taal. De bouwstraat en de landingspoort staan op
+// GitHub; dat is een openbare repo, dus die vragen kunnen zonder sleutel
+// gesteld worden. Lukt dat niet, dan zegt dit blok dat, en wordt het niet
+// groen omdat er niets binnenkwam.
+
+function runOordeel(run) {
+  if (!run) return null;
+  // Een overgeslagen run is geen geslaagde run. Dat verschil is de hele reden
+  // dat de uurlijkse zelftest negentien keer op rij ongemerkt niets deed: een
+  // overgeslagen taak faalt niet, dus niemand kreeg een alarm.
+  if (run.conclusion === 'skipped') return 'overgeslagen';
+  if (run.status !== 'completed') return 'bezig';
+  return run.conclusion === 'success' ? 'geslaagd' : 'gefaald';
+}
+
+async function blokRood(io) {
+  const punten = [];
+  const nu = io.nu();
+
+  // 3a. De bouwstraat: de negen taken die elke wijziging moeten goedkeuren.
+  let bouw = null;
+  try { bouw = await io.laatsteRun('test.yml', 'main'); } catch { bouw = null; }
+  const bouwOordeel = runOordeel(bouw);
+  punten.push(punt(
+    'De bouwstraat',
+    bouwOordeel === 'geslaagd' ? GOED : (bouwOordeel === 'bezig' ? LET_OP : KAPOT),
+    bouwOordeel === 'geslaagd'
+      ? `De controles op de hoofdtak zijn ${ouderdom(nu, bouw.ts)} geleden allemaal geslaagd.`
+      : bouwOordeel === 'bezig'
+        ? 'De controles op de hoofdtak draaien nu nog.'
+        : bouwOordeel === 'overgeslagen'
+          ? 'De controles op de hoofdtak zijn overgeslagen. Overgeslagen is niet geslaagd: er is niets gecontroleerd.'
+          : `De controles op de hoofdtak zijn gefaald, ${ouderdom(nu, bouw && bouw.ts)} geleden. Wat er nu op main staat is niet goedgekeurd.`,
+    bouw,
+    'de laatste run van test.yml op main, via de openbare GitHub-API',
+  ));
+
+  // 3b. De dagelijkse controles. Hier wordt naar de uitkomst gekeken en niet
+  //     naar de aanwezigheid: een taak die niet draaide is stil, geen succes.
+  const controles = [
+    { bestand: 'heartbeat.yml', naam: 'de uurlijkse zelftest' },
+    { bestand: 'security-posture.yml', naam: 'de dagelijkse veiligheidsscan' },
+    { bestand: 'guards.yml', naam: 'de poort op de poorten' },
+  ];
+  const gezien = [];
+  for (const c of controles) {
+    try {
+      const r = await io.laatsteRun(c.bestand, null);
+      gezien.push({ ...c, oordeel: runOordeel(r), ts: r && r.ts });
+    } catch {
+      gezien.push({ ...c, oordeel: null });
+    }
+  }
+  const gemeten = gezien.filter(c => c.oordeel);
+  const stil = gemeten.filter(c => c.oordeel === 'overgeslagen' || (c.oordeel === 'geslaagd' && c.ts && nu - c.ts > CONTROLE_STIL_UREN * UUR_MS));
+  const gefaald = gemeten.filter(c => c.oordeel === 'gefaald');
+  punten.push(punt(
+    'De dagelijkse controles',
+    gefaald.length ? KAPOT : (stil.length ? KAPOT : GOED),
+    gemeten.length === 0
+      ? 'Ik kon niet bij de uitslagen van de controles.'
+      : stil.length
+        ? hoofdletter(`${stil.map(c => c.naam).join(' en ')} ${stil.length === 1 ? 'draait' : 'draaien'} niet. Er kijkt dus niemand mee of het product in productie nog werkt, en juist die stilte is wat een storing zou verbergen.`)
+        : gefaald.length
+          ? hoofdletter(`${gefaald.map(c => c.naam).join(' en ')} ${gefaald.length === 1 ? 'is' : 'zijn'} gedraaid en gefaald. Er is dus iets gemeten en het klopte niet.`)
+          : `Alle ${gemeten.length} controles hebben recent gedraaid en zijn geslaagd.`,
+    gemeten.length ? gezien : null,
+    'de laatste run per workflow, waarbij overgeslagen als niet-gedraaid telt',
+  ));
+
+  // 3c. Repo en server: draait op de server wat er in de repo staat.
+  let manifest = null;
+  let hoofd = null;
+  try { manifest = await io.codeManifest(); } catch { manifest = null; }
+  try { hoofd = await io.hoofdCommit(); } catch { hoofd = null; }
+  const beide = manifest && manifest.git_commit && hoofd;
+  const gelijk = beide && String(manifest.git_commit).startsWith(String(hoofd).slice(0, 10));
+  punten.push(punt(
+    'Repo en server',
+    gelijk ? GOED : KAPOT,
+    beide
+      ? (gelijk
+        ? `De server draait dezelfde code als de hoofdtak (${String(hoofd).slice(0, 8)}).`
+        : `De server draait ${String(manifest.git_commit).slice(0, 8)} terwijl de hoofdtak op ${String(hoofd).slice(0, 8)} staat. Wat er gerepareerd is, staat dus niet allemaal live.`)
+      : 'Ik kon de code op de server niet naast de repo leggen, dus ik weet niet of ze gelijk zijn.',
+    beide ? { server: manifest.git_commit, repo: hoofd, gepubliceerd: manifest.published || null } : null,
+    'het code-manifest van de server naast de kop van main',
+  ));
+
+  // 3d. De landingspoort: werk telt pas als het op main staat.
+  let prs = null;
+  try { prs = await io.openPRs(); } catch { prs = null; }
+  if (prs) {
+    const grens = nu - LANDEN_DAGEN * 86400000;
+    const oud = prs.filter(p => p.ts && p.ts < grens);
+    punten.push(punt(
+      'De landingspoort',
+      oud.length === 0 ? GOED : LET_OP,
+      oud.length === 0
+        ? `Er staan ${prs.length} wijzigingen open en geen enkele langer dan ${LANDEN_DAGEN} dagen.`
+        : `${oud.length} van de ${prs.length} openstaande wijzigingen staan langer dan ${LANDEN_DAGEN} dagen buiten de hoofdtak. De oudste ${ouderdom(nu, Math.min(...oud.map(p => p.ts)))}. Dat is geen werk meer maar voorraad, en er zat eerder een beveiligingsgat in die stapel.`,
+      { open: prs.length, te_oud: oud.length },
+      `openstaande pull requests ouder dan ${LANDEN_DAGEN} dagen`,
+    ));
+  } else {
+    punten.push(punt('De landingspoort', GOED, 'Ik kon de openstaande wijzigingen niet ophalen.', null, 'openstaande pull requests'));
+  }
+
+  return blok('rood', 'Staat er iets rood', punten);
+}
+
+// ── Blok 4. Wat wacht er op Mick ────────────────────────────────────────────
+//
+// Alleen dingen die niemand anders kan doen, met erbij wat er niet gebeurt
+// zolang ze blijven liggen. Afgeleid uit de metingen hierboven, niet uit een
+// lijstje dat iemand ooit heeft opgeschreven en dat kan verouderen.
+
+async function blokMick(io, roodBlok) {
+  const punten = [];
+  const controles = (roodBlok.punten.find(p => p.naam === 'De dagelijkse controles') || {}).meting;
+
+  const staat = (bestand) => Array.isArray(controles) ? controles.find(c => c.bestand === bestand) : null;
+  const hartslag = staat('heartbeat.yml');
+  const scan = staat('security-posture.yml');
+
+  punten.push(punt(
+    'De twee sleutels van de zelftest',
+    hartslag && hartslag.oordeel !== 'overgeslagen' ? GOED : KAPOT,
+    !hartslag || !hartslag.oordeel
+      ? 'Ik kon niet zien of de zelftest draait.'
+      : hartslag.oordeel === 'overgeslagen'
+        ? 'De uurlijkse zelftest slaat zichzelf over omdat zijn twee sleutels niet bestaan. Zolang dat zo is, is er niets dat aantoont dat versturen en ondertekenen in productie werken, en merkt een klant een storing eerder dan jij. Alleen jij kunt die sleutels zetten; ze staan op jouw machine en nergens anders.'
+        : 'De zelftest draait.',
+    hartslag || null,
+    'de laatste run van heartbeat.yml',
+  ));
+  if (hartslag && hartslag.oordeel === 'overgeslagen') {
+    punten[punten.length - 1].hoe = [
+      'gh secret set PARAMANT_CANARY_KEY',
+      'gh secret set PARASIGN_CANARY_KEY',
+      'gh variable set HEARTBEAT_ENABLED --body true',
+    ];
+  }
+
+  punten.push(punt(
+    'De dagelijkse veiligheidsscan',
+    scan && scan.oordeel !== 'overgeslagen' ? GOED : LET_OP,
+    !scan || !scan.oordeel
+      ? 'Ik kon niet zien of de veiligheidsscan draait.'
+      : scan.oordeel === 'overgeslagen'
+        ? 'De dagelijkse scan van de productieomgeving heeft nog nooit gedraaid, omdat zijn schakelaar niet bestaat. Er kijkt dus niemand dagelijks naar de buitenkant van de servers.'
+        : 'De veiligheidsscan draait.',
+    scan || null,
+    'de laatste run van security-posture.yml',
+  ));
+  if (scan && scan.oordeel === 'overgeslagen') {
+    punten[punten.length - 1].hoe = ['gh variable set SECURITY_POSTURE_ENABLED --body true'];
+  }
+
+  return blok('mick', 'Wat wacht er op jou', punten);
+}
+
+// ── De kop ──────────────────────────────────────────────────────────────────
+
+function kop(blokken) {
+  const stand = slechtste(blokken.map(b => b.stand));
+  const ergste = [];
+  for (const b of blokken) for (const p of b.punten) if (p.stand === stand) ergste.push(p);
+
+  if (stand === GOED) {
+    return { stand, zin: 'Het gaat goed. Alles wat ik kan meten, doet het.' };
+  }
+  if (stand === KAPOT) {
+    return { stand, zin: `Er is iets kapot: ${ergste[0].zin}` };
+  }
+  if (stand === NIET_GEMETEN) {
+    return { stand, zin: `Ik kan niet alles meten, dus ik weet het niet zeker. ${ergste.length} ${ergste.length === 1 ? 'punt kwam' : 'punten kwamen'} niet binnen.` };
+  }
+  return { stand, zin: `Het draait, maar er is iets om naar te kijken: ${ergste[0].zin}` };
+}
+
+// ── Het geheel ──────────────────────────────────────────────────────────────
+
+async function meetDeStand(io) {
+  const werkt = await blokWerkt(io);
+  const gebruik = await blokGebruik(io);
+  const rood = await blokRood(io);
+  const mick = await blokMick(io, rood);
+  const blokken = [werkt, gebruik, rood, mick];
+  return {
+    gemeten_op: new Date(io.nu()).toISOString(),
+    kop: kop(blokken),
+    blokken,
+  };
+}
+
+module.exports = {
+  meetDeStand,
+  punt,
+  blok,
+  slechtste,
+  soortVanHandeling,
+  runOordeel,
+  GOED, LET_OP, NIET_GEMETEN, KAPOT, RANG,
+  LANDEN_DAGEN, CONTROLE_STIL_UREN,
+};

--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -274,6 +274,7 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
     </nav>
     <div class="hdr-meta">
       <span class="lic">v3.0.0 · Licensed</span>
+      <a class="lo-btn" href="/admin/stand">Stand</a>
       <a class="lo-btn" href="/admin/settings.html">Settings</a>
       <a class="lo-btn" href="/admin/cli.html">CLI</a>
       <button class="lo-btn" data-click="doLogout">Sign out</button>

--- a/admin/public/stand.html
+++ b/admin/public/stand.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PARAMANT &middot; Stand</title>
+<style>
+:root{
+  --nacht:#08284A; --nacht-2:#0B3A6A; --nacht-3:#0E4680;
+  --bone:#F8FAFC; --bone-dim:rgba(248,250,252,.68); --bone-hair:rgba(248,250,252,.16);
+  --goed:#B2FF3F; --letop:#FFC24B; --onbekend:#9FB3C8; --kapot:#FF6B6B;
+  --mono:'IBM Plex Mono',ui-monospace,'SF Mono','JetBrains Mono',Menlo,Consolas,monospace;
+  --sans:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;
+}
+*{margin:0;padding:0;box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{background:var(--nacht);color:var(--bone);font-family:var(--sans);font-size:17px;line-height:1.5;-webkit-font-smoothing:antialiased;padding:20px 16px 64px}
+.wrap{max-width:640px;margin:0 auto}
+
+.merk{font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--bone-dim);margin-bottom:24px}
+.merk a{color:var(--bone-dim);text-decoration:none;border-bottom:1px solid var(--bone-hair)}
+
+/* De kop: het enige dat je in tien seconden hoeft te lezen. */
+.kop{border-left:5px solid var(--onbekend);padding:2px 0 2px 16px;margin-bottom:8px}
+.kop-woord{font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--bone-dim);margin-bottom:8px}
+.kop-zin{font-size:23px;line-height:1.32;font-weight:600;letter-spacing:-.015em}
+.kop.s-goed{border-color:var(--goed)} .kop.s-letop{border-color:var(--letop)}
+.kop.s-onbekend{border-color:var(--onbekend)} .kop.s-kapot{border-color:var(--kapot)}
+.kop.s-goed .kop-woord{color:var(--goed)} .kop.s-letop .kop-woord{color:var(--letop)}
+.kop.s-onbekend .kop-woord{color:var(--onbekend)} .kop.s-kapot .kop-woord{color:var(--kapot)}
+
+.gemeten{font-family:var(--mono);font-size:12px;color:var(--bone-dim);margin:14px 0 26px}
+
+/* Blokken. Gaat het goed, dan staan ze dicht. */
+details.blok{border-top:1px solid var(--bone-hair);padding:2px 0}
+details.blok:last-of-type{border-bottom:1px solid var(--bone-hair)}
+summary{list-style:none;cursor:pointer;padding:15px 2px;display:flex;align-items:center;gap:12px;font-weight:600;font-size:17px}
+summary::-webkit-details-marker{display:none}
+.stip{width:11px;height:11px;border-radius:50%;flex:0 0 auto}
+.stip.s-goed{background:var(--goed)} .stip.s-letop{background:var(--letop)}
+.stip.s-kapot{background:var(--kapot)}
+/* Niet gemeten is geen bolletje: een holle ring, zodat hij nooit voor groen
+   kan doorgaan als je snel kijkt. */
+.stip.s-onbekend{background:none;border:2px solid var(--onbekend)}
+.blok-titel{flex:1}
+.blok-tel{font-family:var(--mono);font-size:11px;color:var(--bone-dim);letter-spacing:.06em}
+.pijl{color:var(--bone-dim);font-size:13px;transition:transform .15s}
+details[open] .pijl{transform:rotate(90deg)}
+
+.punt{padding:0 0 20px 23px;margin-left:0}
+.punt-kop{display:flex;align-items:baseline;gap:9px;margin-bottom:5px}
+.punt-naam{font-weight:600;font-size:15px}
+.punt-stand{font-family:var(--mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;padding:2px 7px;border-radius:2px;white-space:nowrap}
+.punt-stand.s-goed{background:rgba(178,255,63,.16);color:var(--goed)}
+.punt-stand.s-letop{background:rgba(255,194,75,.16);color:var(--letop)}
+.punt-stand.s-onbekend{background:rgba(159,179,200,.16);color:var(--onbekend)}
+.punt-stand.s-kapot{background:rgba(255,107,107,.18);color:var(--kapot)}
+.punt-zin{font-size:16px;line-height:1.5;color:var(--bone)}
+.punt-bron{font-family:var(--mono);font-size:11.5px;color:var(--bone-dim);margin-top:7px;line-height:1.45}
+.hoe{margin-top:10px;background:rgba(0,0,0,.22);border-left:3px solid var(--letop);padding:10px 12px}
+.hoe-lbl{font-family:var(--mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--letop);margin-bottom:7px}
+.hoe code{display:block;font-family:var(--mono);font-size:12.5px;color:var(--bone);word-break:break-all;padding:2px 0}
+
+.regel{font-size:13.5px;color:var(--bone-dim);margin-bottom:20px;line-height:1.5}
+.knoppen{display:flex;gap:10px;flex-wrap:wrap;margin:26px 0 10px}
+button{font-family:var(--mono);font-size:12px;letter-spacing:.09em;text-transform:uppercase;font-weight:700;padding:13px 18px;border:1.5px solid var(--bone-hair);background:transparent;color:var(--bone);cursor:pointer;border-radius:2px;min-height:46px}
+button:hover:not(:disabled){border-color:var(--bone)}
+button:disabled{opacity:.45;cursor:default}
+button.hoofd{background:var(--goed);color:var(--nacht);border-color:var(--goed)}
+.melding{font-size:14.5px;line-height:1.5;padding:12px 14px;border-left:3px solid var(--onbekend);background:rgba(0,0,0,.2);margin-top:14px;display:none}
+.laden{font-family:var(--mono);font-size:12px;color:var(--bone-dim);letter-spacing:.06em}
+@media (max-width:420px){ body{font-size:16px} .kop-zin{font-size:20px} }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="merk"><a href="/admin/">&larr; Paramant admin</a> &nbsp;&middot;&nbsp; Stand</div>
+
+  <div id="kop" class="kop s-onbekend">
+    <div class="kop-woord" id="kop-woord">bezig met meten</div>
+    <div class="kop-zin" id="kop-zin">Ik kijk hoe het ervoor staat.</div>
+  </div>
+  <div class="gemeten" id="gemeten"></div>
+
+  <div id="blokken"><div class="laden">meten...</div></div>
+
+  <div class="knoppen">
+    <button id="ververs" type="button">Opnieuw meten</button>
+    <button id="proef" type="button" class="hoofd">Doe de echte proef</button>
+  </div>
+  <div class="melding" id="melding"></div>
+  <p class="regel" style="margin-top:16px">
+    De echte proef stuurt nu een klein bestand door de relay, haalt het terug en
+    controleert of het daarna vernietigd is. Dat is een echte handeling, dus hij
+    komt in het openbare logboek te staan en telt hieronder mee als zelftest,
+    nooit als gebruik.
+  </p>
+</div>
+<script src="/admin/stand.js?v=1"></script>
+</body>
+</html>

--- a/admin/public/stand.js
+++ b/admin/public/stand.js
@@ -1,0 +1,152 @@
+'use strict';
+
+// De standpagina. Hergebruikt de adminsessie uit de SPA (sessionStorage
+// 'adm_session') en stuurt bij afwezigheid of afwijzing terug naar de inlog op
+// /admin/. Zelfde patroon als settings.js, met opzet: er hoort geen tweede
+// manier te bestaan om hier binnen te komen.
+
+var SESSION = sessionStorage.getItem('adm_session') || '';
+if (!SESSION) location.href = '/admin/';
+
+// De vier standen zoals lib/stand.js ze noemt, elk met een eigen klasse. Ze
+// staan hier bij elkaar zodat "niet gemeten" nooit per ongeluk als "goed" kan
+// worden getekend: dat is precies de fout die deze pagina moet uitsluiten.
+var KLASSE = {
+  'goed': 's-goed',
+  'let op': 's-letop',
+  'niet gemeten': 's-onbekend',
+  'kapot': 's-kapot',
+};
+var KOPWOORD = {
+  'goed': 'het gaat goed',
+  'let op': 'let op',
+  'niet gemeten': 'onbekend',
+  'kapot': 'er is iets kapot',
+};
+
+function klasse(stand) { return KLASSE[stand] || 's-onbekend'; }
+
+function esc(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function api(pad, opts) {
+  opts = opts || {};
+  return fetch('/admin/api' + pad, {
+    method: opts.method || 'GET',
+    headers: { 'X-Session': SESSION, 'Content-Type': 'application/json' },
+  }).then(function (r) {
+    if (r.status === 401) { sessionStorage.removeItem('adm_session'); location.href = '/admin/'; throw new Error('unauthorized'); }
+    return r.json().catch(function () { return null; }).then(function (data) {
+      return { ok: r.ok, status: r.status, data: data };
+    });
+  });
+}
+
+function melden(tekst, stand) {
+  var el = document.getElementById('melding');
+  el.textContent = tekst;
+  el.style.display = tekst ? 'block' : 'none';
+  el.style.borderLeftColor = stand === 'kapot' ? 'var(--kapot)' : (stand === 'goed' ? 'var(--goed)' : 'var(--onbekend)');
+}
+
+function tekenPunt(p) {
+  var h = '<div class="punt">';
+  h += '<div class="punt-kop">';
+  h += '<span class="punt-naam">' + esc(p.naam) + '</span>';
+  h += '<span class="punt-stand ' + klasse(p.stand) + '">' + esc(p.stand) + '</span>';
+  h += '</div>';
+  h += '<div class="punt-zin">' + esc(p.zin) + '</div>';
+  h += '<div class="punt-bron">gemeten met: ' + esc(p.bron) + '</div>';
+  if (p.hoe && p.hoe.length) {
+    h += '<div class="hoe"><div class="hoe-lbl">dit kun alleen jij doen</div>';
+    for (var i = 0; i < p.hoe.length; i++) h += '<code>' + esc(p.hoe[i]) + '</code>';
+    h += '</div>';
+  }
+  h += '</div>';
+  return h;
+}
+
+function tekenBlok(b) {
+  // Gaat een blok goed, dan staat het dicht. Is er iets aan de hand, dan staat
+  // het open: dan hoort het gelezen te worden zonder eerst te tikken.
+  var open = b.stand !== 'goed' ? ' open' : '';
+  var mis = b.punten.filter(function (p) { return p.stand !== 'goed'; }).length;
+  var tel = mis ? mis + ' van ' + b.punten.length : b.punten.length + ' in orde';
+
+  var h = '<details class="blok"' + open + '><summary>';
+  h += '<span class="stip ' + klasse(b.stand) + '"></span>';
+  h += '<span class="blok-titel">' + esc(b.titel) + '</span>';
+  h += '<span class="blok-tel">' + esc(tel) + '</span>';
+  h += '<span class="pijl">&#9656;</span>';
+  h += '</summary>';
+  for (var i = 0; i < b.punten.length; i++) h += tekenPunt(b.punten[i]);
+  h += '</details>';
+  return h;
+}
+
+function tekenen(stand) {
+  var kop = document.getElementById('kop');
+  kop.className = 'kop ' + klasse(stand.kop.stand);
+  document.getElementById('kop-woord').textContent = KOPWOORD[stand.kop.stand] || stand.kop.stand;
+  document.getElementById('kop-zin').textContent = stand.kop.zin;
+
+  var d = new Date(stand.gemeten_op);
+  document.getElementById('gemeten').textContent =
+    'gemeten op ' + d.toLocaleString('nl-NL', { dateStyle: 'short', timeStyle: 'short' });
+
+  var uit = '';
+  for (var i = 0; i < stand.blokken.length; i++) uit += tekenBlok(stand.blokken[i]);
+  document.getElementById('blokken').innerHTML = uit;
+}
+
+function meten() {
+  var knop = document.getElementById('ververs');
+  knop.disabled = true;
+  knop.textContent = 'Meten...';
+  return api('/admin/stand').then(function (r) {
+    if (!r.ok || !r.data || !r.data.blokken) {
+      // Ook hier geen groen bij gebrek aan uitslag: de kop zegt dan dat het
+      // meten zelf niet lukte.
+      document.getElementById('kop').className = 'kop s-onbekend';
+      document.getElementById('kop-woord').textContent = 'onbekend';
+      document.getElementById('kop-zin').textContent =
+        'Ik kon de stand niet meten' + (r.data && r.data.message ? ' (' + r.data.message + ')' : '') + '.';
+      document.getElementById('blokken').innerHTML = '';
+      return;
+    }
+    tekenen(r.data);
+  }).catch(function (e) {
+    if (e.message !== 'unauthorized') melden('Het meten liep vast: ' + e.message, 'kapot');
+  }).then(function () {
+    knop.disabled = false;
+    knop.textContent = 'Opnieuw meten';
+  });
+}
+
+document.getElementById('ververs').addEventListener('click', function () { melden(''); meten(); });
+
+document.getElementById('proef').addEventListener('click', function () {
+  var knop = document.getElementById('proef');
+  knop.disabled = true;
+  knop.textContent = 'Bezig...';
+  melden('Er gaat nu een bestand door de relay heen.');
+  api('/admin/stand/proef', { method: 'POST' }).then(function (r) {
+    if (r.status === 429) {
+      melden(r.data && r.data.message ? r.data.message : 'Er is net een proef gedaan.');
+    } else if (r.data && r.data.ok) {
+      melden('Gelukt. Het bestand ging erin, kwam byte voor byte hetzelfde terug en was daarna vernietigd. Dat duurde ' + r.data.ms + ' ms.', 'goed');
+    } else {
+      melden('Mislukt: ' + ((r.data && r.data.reden) || 'onbekende reden') + '.', 'kapot');
+    }
+    return meten();
+  }).catch(function (e) {
+    if (e.message !== 'unauthorized') melden('De proef liep vast: ' + e.message, 'kapot');
+  }).then(function () {
+    knop.disabled = false;
+    knop.textContent = 'Doe de echte proef';
+  });
+});
+
+meten();

--- a/admin/server.js
+++ b/admin/server.js
@@ -16,6 +16,8 @@ const cliRate = require('./lib/cli-ratelimit');
 const configStore = require('./lib/config-store');
 const webauthn = require('./lib/webauthn');
 const { sessionKeyFields, proxyApiKey, revealKey } = require('./lib/account-keys');
+const { meetDeStand } = require('./lib/stand');
+const standIo = require('./lib/stand-io');
 // One user's sessions, without reading everybody else's. See admin/lib/user-sessions.js.
 const userSessions = require('./lib/user-sessions');
 // The scan is now a FALLBACK, handed to user-sessions only for a user who has no
@@ -4037,6 +4039,61 @@ api.get("/admin/relay-detail", authMiddleware, async (req, res) => {
   } catch (err) { console.error("[admin/relay-detail]", err.message); res.status(500).json({ error: "internal" }); }
 });
 
+// ── De standpagina ──────────────────────────────────────────────────────────
+//
+// Eén pagina die de werkelijke stand toont, achter dezelfde inlog als de rest
+// van deze adminkant: token plus TOTP, sessie in redis, X-Session op elke
+// vraag. Er komt dus geen nieuwe openbare route bij, en er staat niets op deze
+// route dat een beheerder hier niet allang mocht zien.
+//
+// De metingen zelf staan in lib/stand.js, met de buitenwereld in lib/stand-io.js.
+
+function bouwStandIo() {
+  return standIo.maakIo({
+    redis,
+    relayFetch,
+    sectors: Object.keys(SECTORS),
+    adminToken: ADMIN_TOKEN,
+  });
+}
+
+api.get('/admin/stand', authMiddleware, async (req, res) => {
+  try {
+    res.json(await meetDeStand(bouwStandIo()));
+  } catch (err) {
+    // Geen halve pagina met een verzonnen kop: als het meten zelf omvalt zegt
+    // de pagina dat, en dat is iets anders dan "alles groen".
+    console.error('[admin/stand]', err.message);
+    res.status(503).json({ error: 'meten_mislukt', message: err.message });
+  }
+});
+
+// De echte proef, alleen op verzoek. Hij stuurt werkelijk een bestand door de
+// relay en laat het weer vernietigen, en dat schrijft een regel in het
+// openbare transparantielogboek. Vandaar de knop en niet elk paginabezoek: een
+// statuspagina die zichzelf meetelt maakt het gebruikscijfer onbruikbaar,
+// precies zoals in augustus gebeurde.
+//
+// De anonieme uploadroute laat tien pogingen per uur per IP toe, dus hier
+// staat een eigen rem van één proef per vijf minuten. Loopt die af, dan is dat
+// een 429 met een reden en niet een stilzwijgend mislukte proef.
+api.post('/admin/stand/proef', authMiddleware, async (req, res) => {
+  const rem = 'paramant:stand:proef:rem';
+  try {
+    const bezet = await redis().set(rem, '1', { NX: true, EX: 300 });
+    if (bezet === null) {
+      return res.status(429).json({ error: 'te_snel', message: 'Er is net een proef gedaan. Over vijf minuten kan er weer een.' });
+    }
+  } catch (err) {
+    if (isRedisOutage(err)) throw err;
+  }
+
+  const io = bouwStandIo();
+  const uitslag = await io.doeProef();
+  try { await io.bewaarProef(uitslag); } catch (err) { console.error('[admin/stand] proef niet bewaard:', err.message); }
+  res.json(uitslag);
+});
+
 
 // ── POST /admin/force-totp ───────────────────────────────────────────────────────
 api.post('/admin/force-totp', authMiddleware, async (req, res) => {
@@ -4630,6 +4687,11 @@ app.use(`${BASE_PATH}/api`, requireSameOrigin);
 app.use(`${BASE_PATH}/api`, api);
 // /cli -- web debug terminal page (served before the SPA wildcard fallback).
 app.get(`${BASE_PATH}/cli`, (req, res) => res.sendFile(path.join(__dirname, 'public', 'cli.html')));
+// /stand -- de standpagina, ook voor de SPA-wildcard langs. De pagina zelf is
+// een leeg geraamte: alles wat er te zien is komt van GET /api/admin/stand, en
+// dat zit achter authMiddleware. Er staat dus geen enkel gegeven in dit
+// bestand dat een buitenstaander niet mag zien.
+app.get(`${BASE_PATH}/stand`, (req, res) => res.sendFile(path.join(__dirname, 'public', 'stand.html')));
 // Express 5: named wildcard required (path-to-regexp v8 — bare /* not allowed)
 app.get(`${BASE_PATH}/*path`, (req, res) => res.sendFile(path.join(__dirname, 'public', 'index.html')));
 

--- a/admin/test/stand-gate.test.js
+++ b/admin/test/stand-gate.test.js
@@ -1,0 +1,323 @@
+'use strict';
+// De sabotagetoets op de standpagina.
+//
+// De pagina is gebouwd omdat negen waarborgen er als een waarborg uitzagen en
+// niets deden. Een statuspagina die daar bij komt is alleen iets waard als
+// aantoonbaar is dat hij een echte storing ook werkelijk toont. Deze toets
+// breekt daarom om de beurt iets kapot en eist dat de pagina dat zegt, en eist
+// vooral het omgekeerde: dat er nergens groen verschijnt waar niets gemeten is.
+//
+//   node --test admin/test/stand-gate.test.js
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { meetDeStand, punt, slechtste, soortVanHandeling, runOordeel,
+        GOED, LET_OP, NIET_GEMETEN, KAPOT } = require('../lib/stand');
+
+const NU = Date.parse('2026-09-06T20:00:00Z');
+const UUR = 3600 * 1000;
+
+function alleP(stand) {
+  const uit = [];
+  for (const b of stand.blokken) for (const p of b.punten) uit.push(p);
+  return uit;
+}
+function zoek(stand, naam) {
+  return alleP(stand).find(p => p.naam === naam);
+}
+
+// Een wereld waarin alles het doet. Elke toets hieronder verandert er precies
+// één ding aan, zodat de uitslag nooit aan iets anders kan liggen.
+function gezondeIo(over = {}) {
+  const io = {
+    nu: () => NU,
+    site: 'https://paramant.app',
+    sectors: ['main', 'health', 'legal', 'finance', 'iot'],
+    zelftestAccounts: ['pgp_kanarie'],
+
+    relay: async (sector, pad) => {
+      if (pad === '/health') return { status: 200, body: { ok: true, version: '3.1.0', sector } };
+      if (pad === '/v2/health/deep') {
+        return { status: 200, body: { overall: 'green', version: '3.1.0', sector, checks: [
+          { name: 'storage', status: 'green', detail: 'data dir writable (/data)' },
+          { name: 'redis', status: 'green', detail: 'reachable' },
+        ] } };
+      }
+      throw new Error('onverwacht pad ' + pad);
+    },
+
+    web: async () => ({ status: 200, text: 'x'.repeat(2000), ms: 120 }),
+
+    sleutels: async () => ([
+      { account_id: 'acct_demo', active: true },
+      { account_id: 'acct_tweede', active: true },
+      { account_id: 'acct_uit', active: false },
+    ]),
+
+    auditRegels: async () => ([
+      { user_id: 'acct_demo', event_type: 'webauthn_login', metadata: {}, ts: NU - 2 * UUR },
+      { user_id: 'acct_demo', event_type: 'parasign_doc_signed', metadata: {}, ts: NU - 3 * UUR },
+      { user_id: 'acct_beheer', event_type: 'admin_user_viewed', metadata: {}, ts: NU - UUR },
+      { user_id: 'pgp_kanarie', event_type: 'webauthn_login', metadata: {}, ts: NU - UUR },
+      { user_id: 'acct_x', event_type: 'parasign_doc_signed', metadata: { original_filename: 'canary-abc.bin' }, ts: NU - UUR },
+    ]),
+
+    laatsteProef: async () => ({ ok: true, ts: NU - 2 * UUR, ms: 340, bytes: 64 }),
+
+    laatsteRun: async (bestand) => {
+      if (bestand === 'test.yml') return { status: 'completed', conclusion: 'success', ts: NU - UUR, nummer: 900 };
+      return { status: 'completed', conclusion: 'success', ts: NU - 6 * UUR, nummer: 12 };
+    },
+
+    hoofdCommit: async () => '6ab3647fabcdef1234567890',
+    codeManifest: async () => ({ git_commit: '6ab3647fabcdef1234567890', published: '2026-09-06T05:40:00Z' }),
+    openPRs: async () => ([{ nummer: 470, ts: NU - 2 * 86400000 }]),
+  };
+  return Object.assign(io, over);
+}
+
+// ── De grondregels ──────────────────────────────────────────────────────────
+
+test('een punt zonder meting kan nooit groen worden, wat de aanroeper ook vraagt', () => {
+  const p = punt('verzonnen', GOED, 'alles prima', null, 'nergens');
+  assert.strictEqual(p.stand, NIET_GEMETEN);
+  assert.strictEqual(p.meting, null);
+  const q = punt('ook verzonnen', GOED, 'alles prima', undefined, 'nergens');
+  assert.strictEqual(q.stand, NIET_GEMETEN);
+});
+
+test('een meting van nul is wel een meting en mag wel groen zijn', () => {
+  // Nul handelingen is een uitkomst, geen gebrek aan uitkomst. Zou 0 hier als
+  // "niet gemeten" gelden, dan werd een eerlijk nul stilgezet.
+  const p = punt('nul', GOED, 'nul gezien', 0, 'de telling');
+  assert.strictEqual(p.stand, GOED);
+});
+
+test('niet gemeten weegt zwaarder dan let op', () => {
+  assert.strictEqual(slechtste([GOED, LET_OP, NIET_GEMETEN]), NIET_GEMETEN);
+  assert.strictEqual(slechtste([GOED, NIET_GEMETEN, KAPOT]), KAPOT);
+  assert.strictEqual(slechtste([GOED, GOED]), GOED);
+});
+
+test('een overgeslagen run geldt niet als geslaagd', () => {
+  assert.strictEqual(runOordeel({ status: 'completed', conclusion: 'skipped' }), 'overgeslagen');
+  assert.strictEqual(runOordeel({ status: 'completed', conclusion: 'success' }), 'geslaagd');
+  assert.strictEqual(runOordeel({ status: 'in_progress', conclusion: null }), 'bezig');
+  assert.strictEqual(runOordeel(null), null);
+});
+
+// ── De gezonde wereld ───────────────────────────────────────────────────────
+
+test('gaat alles goed, dan zegt de pagina dat in een zin en is niets kapot', async () => {
+  const stand = await meetDeStand(gezondeIo());
+  assert.strictEqual(stand.kop.stand, GOED);
+  for (const b of stand.blokken) assert.strictEqual(b.stand, GOED, `blok ${b.id} is ${b.stand}`);
+  assert.ok(stand.kop.zin.length > 10);
+  assert.deepStrictEqual(stand.blokken.map(b => b.id), ['werkt', 'gebruik', 'rood', 'mick']);
+});
+
+// ── Sabotage, een voor een ──────────────────────────────────────────────────
+
+test('sabotage: een relay ligt eruit en de pagina noemt hem bij naam', async () => {
+  const io = gezondeIo();
+  const echt = io.relay;
+  io.relay = async (sector, pad) => {
+    if (sector === 'legal' && pad === '/health') return { status: 502, body: null };
+    return echt(sector, pad);
+  };
+  const stand = await meetDeStand(io);
+  const p = zoek(stand, 'De relays');
+  assert.strictEqual(p.stand, KAPOT);
+  assert.match(p.zin, /legal/);
+  assert.strictEqual(stand.kop.stand, KAPOT);
+});
+
+test('sabotage: de diepe controle zegt rood terwijl de statuscode 200 blijft', async () => {
+  // Dit is de fout van 34 deploys op rij: de statuscode klopte, de uitslag
+  // erin niet, en de deploy las de verkeerde van de twee.
+  const io = gezondeIo();
+  io.relay = async (sector, pad) => {
+    if (pad === '/health') return { status: 200, body: { version: '3.1.0', sector } };
+    return { status: 200, body: { overall: sector === 'health' ? 'red' : 'green', checks: [
+      { name: 'storage', status: sector === 'health' ? 'red' : 'green', detail: 'not writable (/data): EROFS' },
+    ] } };
+  };
+  const stand = await meetDeStand(io);
+  const p = zoek(stand, 'De diepe controle');
+  assert.strictEqual(p.stand, KAPOT, 'een rode uitslag achter een 200 moet kapot zijn');
+  assert.match(p.zin, /storage/);
+  assert.match(p.zin, /health/);
+});
+
+test('sabotage: de weg van een klant loopt vast', async () => {
+  const io = gezondeIo();
+  io.web = async (url) => {
+    if (url.endsWith('/sign')) return { status: 302, text: '', ms: 30 };
+    return { status: 200, text: 'x'.repeat(2000), ms: 100 };
+  };
+  const stand = await meetDeStand(io);
+  const p = zoek(stand, 'De weg van een klant');
+  assert.strictEqual(p.stand, KAPOT);
+  assert.match(p.zin, /tekenpagina/);
+});
+
+test('sabotage: een pagina antwoordt 200 maar is leeg, en dat telt als kapot', async () => {
+  // Een route die 200 zegt en niets levert is precies waar de oude rookproef
+  // op slaagde. Een antwoord is nog geen pagina.
+  const io = gezondeIo();
+  io.web = async () => ({ status: 200, text: '', ms: 10 });
+  const stand = await meetDeStand(io);
+  assert.strictEqual(zoek(stand, 'De weg van een klant').stand, KAPOT);
+});
+
+test('sabotage: de uurlijkse zelftest wordt overgeslagen', async () => {
+  const io = gezondeIo();
+  io.laatsteRun = async (bestand) => {
+    if (bestand === 'heartbeat.yml') return { status: 'completed', conclusion: 'skipped', ts: NU - UUR };
+    if (bestand === 'test.yml') return { status: 'completed', conclusion: 'success', ts: NU - UUR };
+    return { status: 'completed', conclusion: 'success', ts: NU - 6 * UUR };
+  };
+  const stand = await meetDeStand(io);
+
+  const controles = zoek(stand, 'De dagelijkse controles');
+  assert.strictEqual(controles.stand, KAPOT, 'een overgeslagen controle mag nooit groen zijn');
+  assert.match(controles.zin, /zelftest/);
+
+  // En het moet als werk voor Mick op de pagina staan, met de commando's erbij.
+  const sleutels = zoek(stand, 'De twee sleutels van de zelftest');
+  assert.strictEqual(sleutels.stand, KAPOT);
+  assert.ok(Array.isArray(sleutels.hoe), 'er hoort te staan wat hij precies moet doen');
+  assert.ok(sleutels.hoe.some(r => r.includes('PARAMANT_CANARY_KEY')));
+  assert.ok(sleutels.hoe.some(r => r.includes('PARASIGN_CANARY_KEY')));
+  assert.match(sleutels.zin, /klant/, 'er hoort te staan wat er niet gebeurt zolang het blijft liggen');
+});
+
+test('sabotage: een controle die al twee dagen niets van zich liet horen is stil, niet groen', async () => {
+  const io = gezondeIo();
+  io.laatsteRun = async (bestand) => {
+    if (bestand === 'test.yml') return { status: 'completed', conclusion: 'success', ts: NU - UUR };
+    return { status: 'completed', conclusion: 'success', ts: NU - 100 * UUR };
+  };
+  const stand = await meetDeStand(io);
+  assert.strictEqual(zoek(stand, 'De dagelijkse controles').stand, KAPOT);
+});
+
+test('sabotage: de server draait andere code dan de repo', async () => {
+  const io = gezondeIo();
+  io.codeManifest = async () => ({ git_commit: '0fcbb746deadbeef', published: '2026-09-04T02:00:00Z' });
+  const stand = await meetDeStand(io);
+  const p = zoek(stand, 'Repo en server');
+  assert.strictEqual(p.stand, KAPOT);
+  assert.match(p.zin, /0fcbb746/);
+  assert.match(p.zin, /6ab3647f/);
+});
+
+test('sabotage: de laatste echte proef is mislukt', async () => {
+  const io = gezondeIo();
+  io.laatsteProef = async () => ({ ok: false, ts: NU - UUR, reden: 'het bestand overleefde het lezen' });
+  const stand = await meetDeStand(io);
+  const p = zoek(stand, 'De laatste echte proef');
+  assert.strictEqual(p.stand, KAPOT);
+  assert.match(p.zin, /overleefde/);
+});
+
+test('sabotage: er is nog nooit een echte proef gedaan', async () => {
+  const io = gezondeIo();
+  io.laatsteProef = async () => null;
+  const stand = await meetDeStand(io);
+  assert.strictEqual(zoek(stand, 'De laatste echte proef').stand, NIET_GEMETEN);
+});
+
+test('sabotage: wijzigingen blijven te lang buiten de hoofdtak', async () => {
+  const io = gezondeIo();
+  io.openPRs = async () => ([
+    { nummer: 1, ts: NU - 40 * 86400000 },
+    { nummer: 2, ts: NU - 9 * 86400000 },
+    { nummer: 3, ts: NU - 86400000 },
+  ]);
+  const stand = await meetDeStand(io);
+  const p = zoek(stand, 'De landingspoort');
+  assert.strictEqual(p.stand, LET_OP);
+  assert.strictEqual(p.meting.te_oud, 2);
+});
+
+// ── De les van de 485 ───────────────────────────────────────────────────────
+
+test('de zelftest telt niet mee als gebruik, en staat er apart bij', async () => {
+  const stand = await meetDeStand(gezondeIo());
+  const p = zoek(stand, 'Handelingen door mensen, laatste zeven dagen');
+  // Twee mensen, een beheerhandeling, en twee zelftesthandelingen: een van een
+  // aangemerkt account en een aan het kanarie-kenmerk herkend.
+  assert.deepStrictEqual(p.meting, { mens: 2, mick: 1, zelftest: 2 });
+  const z = zoek(stand, 'Wat de zelftest zelf deed');
+  assert.strictEqual(z.meting.zelftest, 2);
+});
+
+test('bestaat het gebruik alleen uit de zelftest, dan is het cijfer nul en zegt de pagina dat', async () => {
+  const io = gezondeIo();
+  io.auditRegels = async () => {
+    const uit = [];
+    for (let i = 0; i < 485; i++) {
+      uit.push({ user_id: 'pgp_kanarie', event_type: 'parasign_doc_signed', metadata: { original_filename: 'canary-x.bin' }, ts: NU - i * 60000 });
+    }
+    return uit;
+  };
+  const stand = await meetDeStand(io);
+  const p = zoek(stand, 'Handelingen door mensen, laatste zeven dagen');
+  assert.strictEqual(p.meting.mens, 0, '485 kanarieregels mogen nooit als gebruik tellen');
+  assert.strictEqual(p.meting.zelftest, 485);
+  assert.strictEqual(p.stand, LET_OP);
+  assert.match(p.zin, /niemand gebruikt het/);
+
+  const laatste = zoek(stand, 'De laatste handeling door een mens');
+  assert.strictEqual(laatste.stand, LET_OP);
+});
+
+test('de indeling van een handeling volgt een regel die na te rekenen is', () => {
+  const z = ['pgp_kanarie'];
+  assert.strictEqual(soortVanHandeling({ user_id: 'a', event_type: 'admin_key_viewed' }, z), 'mick');
+  assert.strictEqual(soortVanHandeling({ user_id: 'pgp_kanarie', event_type: 'webauthn_login' }, z), 'zelftest');
+  assert.strictEqual(soortVanHandeling({ user_id: 'a', event_type: 'x', metadata: { f: 'canary-1' } }, z), 'zelftest');
+  assert.strictEqual(soortVanHandeling({ user_id: 'a', event_type: 'x', metadata: { f: 'stand-1' } }, z), 'zelftest');
+  assert.strictEqual(soortVanHandeling({ user_id: 'a', event_type: 'webauthn_login', metadata: {} }, z), 'mens');
+});
+
+// ── De belangrijkste toets van allemaal ─────────────────────────────────────
+
+test('valt alles weg, dan is niets groen en zegt de kop dat het onbekend is', async () => {
+  // Dit is de hele les van de nacht van 5 op 6 september in een toets. Negen
+  // waarborgen zagen eruit als een waarborg en deden niets, en zolang niemand
+  // keek stond alles op groen. Hier mag dat niet kunnen.
+  const stuk = async () => { throw new Error('niets bereikbaar'); };
+  const io = gezondeIo({
+    relay: stuk, web: stuk, sleutels: stuk, auditRegels: stuk, laatsteProef: stuk,
+    laatsteRun: stuk, hoofdCommit: stuk, codeManifest: stuk, openPRs: stuk,
+  });
+  const stand = await meetDeStand(io);
+
+  const groen = alleP(stand).filter(p => p.stand === GOED);
+  assert.deepStrictEqual(groen.map(p => p.naam), [], 'geen enkel punt mag groen zijn als er niets gemeten is');
+  assert.notStrictEqual(stand.kop.stand, GOED);
+
+  // Elk punt zonder meting moet ook werkelijk null als meting hebben, zodat de
+  // pagina geen getal kan tonen dat nergens vandaan komt.
+  for (const p of alleP(stand)) {
+    if (p.stand === NIET_GEMETEN) assert.strictEqual(p.meting, null, `${p.naam} heeft een meting terwijl hij niet gemeten is`);
+  }
+});
+
+test('een enkel weggevallen blok trekt de kop weg van groen', async () => {
+  const io = gezondeIo({ openPRs: async () => { throw new Error('github stil'); } });
+  const stand = await meetDeStand(io);
+  assert.strictEqual(zoek(stand, 'De landingspoort').stand, NIET_GEMETEN);
+  assert.notStrictEqual(stand.kop.stand, GOED, 'een weggevallen meting mag niet als goed doorgaan');
+  assert.match(stand.kop.zin, /niet alles meten/);
+});
+
+test('elk punt draagt een bron, zodat elk getal te herleiden is', async () => {
+  const stand = await meetDeStand(gezondeIo());
+  for (const p of alleP(stand)) {
+    assert.ok(p.bron && p.bron.length > 4, `${p.naam} heeft geen bron`);
+    assert.ok(p.zin && p.zin.length > 10, `${p.naam} heeft geen leesbare zin`);
+  }
+});

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,6 +1,6 @@
 # PARAMANT: complete environment reference
 #
-# 106 variables. Copy to deploy/.env and fill in what the "required" blocks ask
+# 109 variables. Copy to deploy/.env and fill in what the "required" blocks ask
 # for. .env is NEVER committed to git.
 #
 # This file is the reference: every name the relay or the admin panel reads is
@@ -890,3 +890,31 @@ PARAMANT_TOTP_MASTER_KEY=
 # optional · default: the tag pinned in each installer
 # read in: install.sh, frontend/install.sh, frontend/install-pi.sh
 # PARAMANT_VERSION=v3.0.0
+
+# ==============================================================================
+# ADMIN: de standpagina (/admin/stand)
+# ==============================================================================
+
+# De site die de standpagina bevraagt als "de weg van een klant": de voorpagina,
+# de inlog, de tekenpagina, het code-manifest en de echte proef gaan hierheen.
+# Wijs hem naar de eigen installatie bij zelf hosten.
+# optional · default: https://paramant.app
+# read in: admin/lib/stand-io.js
+# PARAMANT_SITE_URL=https://paramant.app
+
+# De repo waar de standpagina de bouwstraat, de dagelijkse controles en de
+# openstaande wijzigingen aan vraagt. Dit gaat via de openbare GitHub-API zonder
+# sleutel, dus alleen een openbare repo levert hier een uitslag; bij een
+# afgeschermde repo zegt de pagina "niet gemeten" in plaats van groen.
+# optional · default: Apolloccrypt/paramant-relay
+# read in: admin/lib/stand-io.js
+# PARAMANT_REPO=Apolloccrypt/paramant-relay
+
+# Accounts die als eigen zelftest gelden, gescheiden door komma's. Hun
+# handelingen worden op de standpagina apart geteld en tellen nooit mee als
+# gebruik. Leeg is een geldige stand: dan wordt alleen op het kanarie-kenmerk
+# gefilterd en zegt de pagina er zelf bij dat de herkenning daarop leunt. Zet
+# hier het account achter PARAMANT_CANARY_KEY zodra dat bestaat.
+# optional · default: leeg
+# read in: admin/lib/stand-io.js
+# STAND_ZELFTEST_ACCOUNTS=

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -207,6 +207,7 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
     </nav>
     <div class="hdr-meta">
       <span class="lic">v3.0.0 · Licensed</span>
+      <a class="lo-btn" href="/admin/stand">Stand</a>
       <button class="lo-btn" data-click="doLogout">Sign out</button>
     </div>
   </header>


### PR DESCRIPTION
Alles wat er de afgelopen nachten gerepareerd is, speelde zich af op plekken waar de eigenaar nooit komt: de bouwstraat, deploylogboeken, testuitslagen. Deze PR zet de werkelijke stand op een pagina.

## Waar hij staat

`https://paramant.app/admin/stand`, achter de bestaande admininlog (token plus TOTP, sessie in redis, `X-Session` op elke vraag). Geen nieuwe openbare route: `public/stand.html` is een leeg geraamte zonder een enkel gegeven erin, en alles wat erop verschijnt komt van `GET /api/admin/stand` achter `authMiddleware`. Zelfde patroon als `settings.html` en `cli.html`, die er al zo staan. Een lokaal draaiende pagina zou veiliger zijn maar is 's avonds niet vanaf een telefoon te openen, en dat is precies waar deze pagina voor is.

## Wat erop staat

Vier blokken. Gaat een blok goed, dan staat het dicht.

1. **Werkt het.** De relays met hun versie, de diepe controle, de weg van een klant over de voorpagina, de inlog en de tekenpagina, en de laatste echte proef met zijn leeftijd.
2. **Wordt het gebruikt.** Accounts, en de handelingen van de afgelopen zeven dagen gesplitst in mensen, beheer en zelftest.
3. **Staat er iets rood.** De bouwstraat, de dagelijkse controles, de meting tussen repo en server, en de landingspoort. Per stuk in gewone taal wat er mis is.
4. **Wat wacht er op de eigenaar.** Afgeleid uit de metingen hierboven, met de commando's erbij en met wat er niet gebeurt zolang het blijft liggen.

## De twee regels die dit een waarborg maken en geen versiering

Ze staan in `admin/lib/stand.js` en worden afgedwongen in code:

- `punt()` zet elk punt zonder `meting` op "niet gemeten", wat de aanroeper ook meegaf. Een getal dat er niet is kan dus niet als groen eindigen.
- In `RANG` staat "niet gemeten" boven "let op", zodat een weggevallen meting de kop wegtrekt van groen in plaats van mee te liften op de punten die wel lukten.

Verder wordt er gemeten in plaats van aangenomen:

- de diepe controle wordt gelezen op de uitslag in het antwoord en niet op de statuscode, want die route antwoordt altijd 200. Dat is de fout die 34 deploys op rij maakten.
- een pagina die 200 antwoordt en niets levert telt als kapot, want daar slaagde de oude rookproef juist op.
- een overgeslagen workflow-run telt als niet gedraaid en nooit als geslaagd.

## Zelftest tegenover echt gebruik

De handelingen komen uit `paramant:audit:global` en worden in drie gesplitst: `admin_*` is beheer, een account uit `STAND_ZELFTEST_ACCOUNTS` of een regel met een kanarie-kenmerk (`canary-`, of `stand-` voor de proefknop op deze pagina) is zelftest, de rest is een mens. De regel staat op de pagina zelf, zodat elk cijfer na te rekenen is, en de drie getallen staan naast elkaar in plaats van opgeteld. Zo kan wat in augustus 485 handelingen leek maar vrijwel geheel de eigen robot was, niet meer als gebruik langskomen.

De knop "doe de echte proef" stuurt werkelijk een bestand door de relay, haalt het byte voor byte terug en controleert dat een tweede poging 410 geeft. Dat is een echte handeling die in het openbare transparantielogboek komt, dus hij draait op verzoek en niet bij elk paginabezoek: een statuspagina die zichzelf meetelt maakt het gebruikscijfer onbruikbaar. Op de pagina telt hij als zelftest.

## Sabotagetoets

`admin/test/stand-gate.test.js`, eenentwintig gevallen. Ze breken om de beurt iets kapot en eisen dat de pagina het toont: een relay eruit, een rode uitslag achter een 200, een lege pagina met een 200, een overgeslagen zelftest, een controle die twee dagen zweeg, een server op andere code dan de repo, een mislukte proef, en een stapel wijzigingen die niet landde. De zwaarste toets zet de hele buitenwereld uit en eist dat geen enkel punt groen is.

De toets vond ook echt iets: nul handelingen door mensen in 485 doorzochte regels werd eerst als "niet gemeten" weggezet, terwijl dat juist een uitkomst is. Nu staat het er.

## Bewijs

- `admin/test/stand-gate.test.js`: 21 van 21
- `bash tests/static-sanity.sh`: PASS
- `bash scripts/check-csp-inline.sh`, `node scripts/check-guards.mjs`: OK
- `tests/env-documented.test.mjs`, `tests/knoppen-compleet.test.mjs`, `tests/public-route-surface.test.mjs`, `tests/landen-poort.test.mjs`, `tests/site-claims.test.mjs`: groen
- `npx eslint@9` over de nieuwe bestanden: schoon
- de adminsuite houdt hetzelfde aantal falende gevallen als op main (die falen hier op een ontbrekende redis en ontbrekende dependencies) en telt er 21 geslaagde bij
- de pagina is in een echte browser op 390 bij 844 gerenderd, zonder fouten in de console, in twee standen: alles goed levert een kop van een zin met alle vier de blokken dicht, en de wereld van vandaag levert vier blokken open met de overgeslagen zelftest bovenaan
