### PR TITLE
de rookproef vangt elke serverfout

### DIFF
--- a/tests/auth-smoke.sh
+++ b/tests/auth-smoke.sh
@@ -42,6 +42,17 @@ check_not() {
     printf "  FAIL  %s  (no response at all: curl returned '%s')\n" "$name" "$actual"
     FAIL=$((FAIL + 1))
     FAILURES="$FAILURES\n  - $name (no response)"
+  elif [ "$actual" != "$bad" ] && [ "${actual#5}" != "$actual" ]; then
+    # Every caller of this helper sits under a section header that promises
+    # "never 5xx", but the check only ever excluded the ONE code it was handed.
+    # A 503 therefore passed a check named "not 500", which is how the store
+    # outage of 2026-09-06 left nineteen of twenty-one checks green while the
+    # admin could not write to redis at all: only the captcha check, the one
+    # that demands an exact 200, went red. The name stays (it is what the
+    # runbook and the deploy log quote); the verdict now matches the promise.
+    printf "  FAIL  %s  (got '%s'; the endpoint must never answer 5xx)\n" "$name" "$actual"
+    FAIL=$((FAIL + 1))
+    FAILURES="$FAILURES\n  - $name (got $actual)"
   elif [ "$actual" != "$bad" ]; then
     printf "  PASS  %s\n" "$name"
     PASS=$((PASS + 1))
@@ -71,6 +82,18 @@ BODY=$(curl -sS --max-time 8 \
   -d '{"email":"smoke-test@example.com"}')
 HAS_PATH=$(echo "$BODY" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("yes" if "migration_path" in d else "no")' 2>/dev/null || echo 'no')
 check '410 body contains migration_path' "$HAS_PATH" 'yes'
+
+# ── 2a. The admin can still reach its store ──────────────────────────────────
+# admin/server.js already answers this honestly on GET /admin/health ("degraded"
+# when redis cannot be reached) and nothing checked it, so a store fault could
+# only be inferred from whichever route happened to write first. On 2026-09-06
+# that was the captcha challenge, which reported a bare 500 internal_error and
+# named nothing. Checked BEFORE the captcha, so the log reads cause then effect.
+STORE=$(curl -sS --max-time 8 "$BASE/admin/health" 2>/dev/null || echo '{}')
+STORE_OK=$(echo "$STORE" | python3 -c \
+  'import json,sys; d=json.load(sys.stdin); print("yes" if d.get("redis",{}).get("ok") is True else "no")' \
+  2>/dev/null || echo 'no')
+check 'admin can reach its redis store' "$STORE_OK" 'yes'
 
 # ── 2. CAPTCHA challenge returns correct shape ────────────────────────────────
 # Regression: if pow-captcha.js is broken, signup crashes with 500


### PR DESCRIPTION
Op productie kon niemand zich aanmelden. De redis van de adminkant kon lezen maar niet schrijven, dus de captcha gaf een serverfout en het aanmeldscherm brak af. De rookproef die na elke deploy draait meldde ondertussen negentien van de eenentwintig groen.

De oorzaak was de controle zelf: hij faalde alleen op de ene foutcode die erin stond, terwijl de kop erboven belooft dat er nooit een serverfout mag komen. Alles daarbuiten gleed erdoor.

Nu faalt hij op elke serverfout, en er staat een controle voor de captcha die eerst de opslag van de adminkant leest, zodat de uitslag de oorzaak noemt in plaats van het gevolg.