### PR TITLE
de storing die geen storing heette

### DIFF
--- a/admin/lib/redis-deadline.js
+++ b/admin/lib/redis-deadline.js
@@ -77,6 +77,45 @@ const OUTAGE_CODES = new Set([
   'ENOTFOUND', 'ETIMEDOUT', 'EAI_AGAIN',
 ]);
 
+// The store answers, and refuses. Redis replies to a command with an error
+// whose message starts with one of these words; node-redis raises that as a
+// plain Error, so neither the constructor set nor the socket codes above see
+// it. Every one of them means the same thing to a caller as an unreachable
+// store: the request failed for a reason that is not the caller's fault and
+// that a retry may fix. They are NOT command mistakes -- WRONGTYPE, a bad Lua
+// script and a wrong arity stay 500, because those are bugs in this code.
+//
+// Found on 07-09-2026: /api/captcha/challenge answered 500 internal_error in
+// production while signup and password reset were dead. The route's own catch
+// could not have produced that body, and the 503 branch in the error handler
+// did not fire, because the store was not unreachable -- it was refusing
+// writes. A safeguard that exists and cannot fire for the failure that is
+// actually happening.
+const REFUSAL_PREFIXES = [
+  'READONLY',   // write sent to a read-only replica
+  'MISCONF',    // RDB snapshot failing, so writes are refused (usually a full disk)
+  'OOM',        // maxmemory reached
+  'NOPERM',     // the ACL user may read but not write
+  'NOAUTH',     // the connection never authenticated
+  'WRONGPASS',  // it tried and the password is wrong
+  'LOADING',    // still reading the dataset from disk
+  'BUSY',       // a script is blocking the server
+  'CLUSTERDOWN',
+  'TRYAGAIN',
+  'MASTERDOWN',
+];
+
+// The refusal word Redis put at the front of its reply, or null. Kept separate
+// from the boolean so a caller can log WHICH refusal it was; without that the
+// operator sees "redis_unavailable" and still has to guess between a full disk
+// and a wrong ACL.
+function redisRefusal(err) {
+  const msg = err && typeof err.message === 'string' ? err.message : '';
+  if (!msg) return null;
+  const first = msg.split(/[\s:]/, 1)[0].toUpperCase();
+  return REFUSAL_PREFIXES.includes(first) ? first : null;
+}
+
 // One failure type for "the store could not answer", whatever the reason. A
 // route that catches this knows the request failed for a reason that is not the
 // caller's fault, which is exactly the 503 case.
@@ -94,16 +133,18 @@ class RedisUnavailableError extends Error {
   }
 }
 
-// Is this error the store being unreachable, rather than the command being
-// wrong? A WRONGTYPE or a bad Lua script is a 500 and must not be laundered
-// into a 503, so the match is on connection failures only.
+// Is this error the store failing us, rather than the command being wrong? A
+// WRONGTYPE or a bad Lua script is a 500 and must not be laundered into a 503,
+// so the match stays on connection failures plus the refusals above -- never on
+// a command this code got wrong.
 function isRedisOutage(err) {
   if (!err || typeof err !== 'object') return false;
   if (err.isRedisOutage === true) return true;
   if (err.code && OUTAGE_CODES.has(err.code)) return true;
   const ctor = err.constructor && err.constructor.name;
   if (ctor && OUTAGE_CONSTRUCTORS.has(ctor)) return true;
-  return OUTAGE_CONSTRUCTORS.has(err.name);
+  if (OUTAGE_CONSTRUCTORS.has(err.name)) return true;
+  return redisRefusal(err) !== null;
 }
 
 // The configured bound, in milliseconds. One name for the whole estate:
@@ -287,6 +328,8 @@ module.exports = {
   DEFAULT_DEADLINE_MS,
   RESET_AFTER_BREACHES,
   RedisUnavailableError,
+  REFUSAL_PREFIXES,
+  redisRefusal,
   isRedisOutage,
   redisDeadlineMs,
   withRedisDeadline,

--- a/admin/server.js
+++ b/admin/server.js
@@ -6,7 +6,7 @@ const http    = require('http');
 const crypto  = require('crypto');
 const path    = require('path');
 const { initRedis, redis, redisHealthy, scanKeys } = require('./lib/redis');
-const { isRedisOutage } = require('./lib/redis-deadline');
+const { isRedisOutage, redisRefusal } = require('./lib/redis-deadline');
 const { incrInWindow } = require('./lib/redis-counter');
 const { logAuditEvent, getAuditEvents } = require('./lib/audit');
 const { spawn } = require('child_process');
@@ -4706,6 +4706,11 @@ app.get(`${BASE_PATH}/*path`, (req, res) => res.sendFile(path.join(__dirname, 'p
     // bounded (lib/redis-deadline) this one branch turns EVERY redis-backed
     // route in this file into an honest 503 inside the deadline, instead of a
     // request that waits for a store that is never going to answer.
+    // Name the refusal in the log. "redis_unavailable" alone leaves the operator
+    // guessing between a full disk (MISCONF), a hit ceiling (OOM) and a wrong
+    // ACL (NOPERM); the word Redis itself used points straight at the fix.
+    const refusal = redisRefusal(err);
+    if (refusal) console.error('[redis refused]', refusal, err.message);
     if (isRedisOutage(err)) {
       res.setHeader('Retry-After', '5');
       return res.status(503).json({ error: 'redis_unavailable' });

--- a/relay/lib/redis-deadline.js
+++ b/relay/lib/redis-deadline.js
@@ -77,6 +77,45 @@ const OUTAGE_CODES = new Set([
   'ENOTFOUND', 'ETIMEDOUT', 'EAI_AGAIN',
 ]);
 
+// The store answers, and refuses. Redis replies to a command with an error
+// whose message starts with one of these words; node-redis raises that as a
+// plain Error, so neither the constructor set nor the socket codes above see
+// it. Every one of them means the same thing to a caller as an unreachable
+// store: the request failed for a reason that is not the caller's fault and
+// that a retry may fix. They are NOT command mistakes -- WRONGTYPE, a bad Lua
+// script and a wrong arity stay 500, because those are bugs in this code.
+//
+// Found on 07-09-2026: /api/captcha/challenge answered 500 internal_error in
+// production while signup and password reset were dead. The route's own catch
+// could not have produced that body, and the 503 branch in the error handler
+// did not fire, because the store was not unreachable -- it was refusing
+// writes. A safeguard that exists and cannot fire for the failure that is
+// actually happening.
+const REFUSAL_PREFIXES = [
+  'READONLY',   // write sent to a read-only replica
+  'MISCONF',    // RDB snapshot failing, so writes are refused (usually a full disk)
+  'OOM',        // maxmemory reached
+  'NOPERM',     // the ACL user may read but not write
+  'NOAUTH',     // the connection never authenticated
+  'WRONGPASS',  // it tried and the password is wrong
+  'LOADING',    // still reading the dataset from disk
+  'BUSY',       // a script is blocking the server
+  'CLUSTERDOWN',
+  'TRYAGAIN',
+  'MASTERDOWN',
+];
+
+// The refusal word Redis put at the front of its reply, or null. Kept separate
+// from the boolean so a caller can log WHICH refusal it was; without that the
+// operator sees "redis_unavailable" and still has to guess between a full disk
+// and a wrong ACL.
+function redisRefusal(err) {
+  const msg = err && typeof err.message === 'string' ? err.message : '';
+  if (!msg) return null;
+  const first = msg.split(/[\s:]/, 1)[0].toUpperCase();
+  return REFUSAL_PREFIXES.includes(first) ? first : null;
+}
+
 // One failure type for "the store could not answer", whatever the reason. A
 // route that catches this knows the request failed for a reason that is not the
 // caller's fault, which is exactly the 503 case.
@@ -94,16 +133,18 @@ class RedisUnavailableError extends Error {
   }
 }
 
-// Is this error the store being unreachable, rather than the command being
-// wrong? A WRONGTYPE or a bad Lua script is a 500 and must not be laundered
-// into a 503, so the match is on connection failures only.
+// Is this error the store failing us, rather than the command being wrong? A
+// WRONGTYPE or a bad Lua script is a 500 and must not be laundered into a 503,
+// so the match stays on connection failures plus the refusals above -- never on
+// a command this code got wrong.
 function isRedisOutage(err) {
   if (!err || typeof err !== 'object') return false;
   if (err.isRedisOutage === true) return true;
   if (err.code && OUTAGE_CODES.has(err.code)) return true;
   const ctor = err.constructor && err.constructor.name;
   if (ctor && OUTAGE_CONSTRUCTORS.has(ctor)) return true;
-  return OUTAGE_CONSTRUCTORS.has(err.name);
+  if (OUTAGE_CONSTRUCTORS.has(err.name)) return true;
+  return redisRefusal(err) !== null;
 }
 
 // The configured bound, in milliseconds. One name for the whole estate:
@@ -287,6 +328,8 @@ module.exports = {
   DEFAULT_DEADLINE_MS,
   RESET_AFTER_BREACHES,
   RedisUnavailableError,
+  REFUSAL_PREFIXES,
+  redisRefusal,
   isRedisOutage,
   redisDeadlineMs,
   withRedisDeadline,

--- a/tests/redis-refusal.test.mjs
+++ b/tests/redis-refusal.test.mjs
@@ -1,0 +1,85 @@
+// Redis can answer and still refuse. This test is the one that would have
+// caught the outage of 07-09-2026.
+//
+// WHAT HAPPENED. /api/captcha/challenge answered 500 internal_error in
+// production. Signup and password reset were dead, login survived. The route
+// has its own catch that answers 'challenge_failed', and the error handler has
+// a branch that answers 503 'redis_unavailable' when the store is down. Neither
+// fired, because neither describes what was wrong: the store was reachable and
+// answering, and it was refusing the write.
+//
+// isRedisOutage() only knew about connection failures -- closed clients, socket
+// timeouts, ECONNREFUSED. A server-side refusal (MISCONF because the disk is
+// full, OOM at maxmemory, NOPERM from an ACL, READONLY on a replica) arrives as
+// a plain Error with the refusal word at the front of the message, matched
+// nothing, and fell through to a bare 500 that named no cause.
+//
+// The line this test holds: a refusal is the store failing us and answers 503;
+// a command this code got wrong is still a 500, because that is a bug and
+// laundering it into 503 would hide it.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const admin = require('../admin/lib/redis-deadline.js');
+const relay = require('../relay/lib/redis-deadline.js');
+
+const REFUSALS = [
+  'MISCONF Redis is configured to save RDB snapshots, but is currently not able to persist on disk.',
+  'OOM command not allowed when used memory > \'maxmemory\'.',
+  'NOPERM this user has no permissions to run the \'set\' command',
+  'READONLY You can\'t write against a read only replica.',
+  'NOAUTH Authentication required.',
+  'WRONGPASS invalid username-password pair or user is disabled.',
+  'LOADING Redis is loading the dataset in memory',
+  'BUSY Redis is busy running a script.',
+  'CLUSTERDOWN The cluster is down',
+  'TRYAGAIN Multiple keys request during rehashing of slot',
+  'MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to no.',
+];
+
+// Mistakes in our own commands. These must stay 500.
+const OUR_BUGS = [
+  'WRONGTYPE Operation against a key holding the wrong kind of value',
+  'ERR unknown command \'foo\'',
+  'ERR wrong number of arguments for \'set\' command',
+  'ERR value is not an integer or out of range',
+  'NOSCRIPT No matching script.',
+];
+
+for (const [naam, mod] of [['admin', admin], ['relay', relay]]) {
+  test(`${naam}: een weigering van de server is een storing`, () => {
+    for (const msg of REFUSALS) {
+      assert.equal(mod.isRedisOutage(new Error(msg)), true, msg);
+      assert.equal(typeof mod.redisRefusal(new Error(msg)), 'string', msg);
+    }
+  });
+
+  test(`${naam}: een fout commando van ons blijft een fout van ons`, () => {
+    for (const msg of OUR_BUGS) {
+      assert.equal(mod.isRedisOutage(new Error(msg)), false, msg);
+      assert.equal(mod.redisRefusal(new Error(msg)), null, msg);
+    }
+  });
+
+  test(`${naam}: de connectiefouten blijven werken`, () => {
+    const e = new Error('connect ECONNREFUSED 127.0.0.1:6379');
+    e.code = 'ECONNREFUSED';
+    assert.equal(mod.isRedisOutage(e), true);
+    assert.equal(mod.isRedisOutage(new mod.RedisUnavailableError('get', 'deadline')), true);
+  });
+
+  test(`${naam}: rommel binnen geeft geen uitzondering`, () => {
+    for (const x of [null, undefined, 0, '', 'MISCONF', {}, { message: 42 }]) {
+      assert.equal(mod.isRedisOutage(x), false);
+    }
+  });
+}
+
+test('de weigering wordt bij naam genoemd, niet alleen geteld', () => {
+  assert.equal(admin.redisRefusal(new Error('MISCONF Redis is configured...')), 'MISCONF');
+  assert.equal(admin.redisRefusal(new Error('OOM command not allowed')), 'OOM');
+  assert.equal(admin.redisRefusal(new Error('noperm lowercase from a proxy')), 'NOPERM');
+});


### PR DESCRIPTION
## Wat er nu misgaat in productie

`GET /api/captcha/challenge` antwoordt **500 `internal_error`**. Signup en wachtwoordherstel liggen daarmee plat; inloggen werkt.

```
$ curl -s https://paramant.app/api/captcha/challenge
{"error":"internal_error"}
```

Dat lichaam kan niet uit de route zelf komen. Die heeft een eigen catch die `challenge_failed` teruggeeft. En het kan ook niet uit de 503-tak van de foutafhandeling komen, want die geeft `redis_unavailable`.

## Waarom geen van beide waarborgen afging

`isRedisOutage()` kende alleen **verbindings**fouten: `ClientClosedError`, `SocketTimeoutError`, `ECONNREFUSED` en verwanten. De store was echter bereikbaar en antwoordde; hij weigerde de schrijfactie.

Redis beantwoordt zo'n commando met een fout waarvan het bericht begint met het weigeringswoord, en node-redis maakt daar een gewone `Error` van. Die matchte de constructorlijst niet en de socketcodes niet, en viel door naar de kale 500 onderaan, die geen oorzaak noemt.

De rate-limiter staat in elf routes vóór elke `try`, dus dit raakt niet alleen de captcha.

## De wijziging

- Elf weigeringswoorden gelden nu als storing: `READONLY`, `MISCONF`, `OOM`, `NOPERM`, `NOAUTH`, `WRONGPASS`, `LOADING`, `BUSY`, `CLUSTERDOWN`, `TRYAGAIN`, `MASTERDOWN`. Die leveren 503 met `Retry-After`.
- De foutafhandeling logt **welk** woord het was. `redis_unavailable` alleen laat de operator gokken tussen een volle schijf (`MISCONF`), een bereikt plafond (`OOM`) en een verkeerde ACL (`NOPERM`).
- Een commando dat wij fout sturen blijft 500. `WRONGTYPE`, `NOSCRIPT` en een verkeerde arity zijn bugs van ons en worden niet als beschikbaarheidsantwoord weggemoffeld.
- `admin/lib/redis-deadline.js` en `relay/lib/redis-deadline.js` blijven byte-identiek; de pariteitstest bewaakt dat.

## Bewijs

`tests/redis-refusal.test.mjs`, negen tests, per kopie: elf weigeringen worden herkend, vijf eigen commandofouten blijven 500, de bestaande connectiefouten blijven werken, en rommel (`null`, `{}`, `{message: 42}`) gooit niets.

```
tests/redis-refusal.test.mjs         9/9 pass
tests/redis-deadline-parity.test.mjs 6/6 pass
admin/test/redis-outage.test.js      3/3 pass
```

## Wat dit NIET oplost

De onderliggende oorzaak zit op de server: de store weigert schrijfacties. Deze PR maakt zichtbaar welke weigering het is, zodat de volgende stap gericht kan zijn in plaats van een gok. Signup blijft plat tot dat op de server is verholpen.