### PR TITLE
De storingen die niemand ziet

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -101,9 +101,9 @@ Full report: [docs/security-audit-2026-04.md](docs/security-audit-2026-04.md)
 | # | Severity | Status |
 |---|----------|--------|
 | 1–3 | Critical | Fixed |
-| 4 | Critical | In progress: plaintext filename in relay RAM |
+| 4 | Critical | Fixed in v2.4.5 (2026-04-13): the relay stores `enc_meta`, ciphertext the client seals, and never the name |
 | 5–9 | High | Fixed |
-| 10–15 | Medium | Fixed (13: accepted — documented) |
+| 10-15 | Medium | Fixed, except 13 (accepted, documented) and 14 (open, see Open findings below) |
 | 16–20 | Low | Fixed |
 
 ---
@@ -112,8 +112,29 @@ Full report: [docs/security-audit-2026-04.md](docs/security-audit-2026-04.md)
 
 | # | Severity | Finding | ETA |
 |---|----------|---------|-----|
-| 4 | Critical | Plaintext filename stored in relay RAM | v2.4.6 |
-| 14 | Medium | CT Merkle tree non-RFC-6962 compliant | v2.5.0 |
+| 14 | Medium | CT Merkle tree is not RFC 6962: the tree is rebuilt from every leaf on each append, and it covers a sliding window rather than the whole log, so there is no consistency proof between two heads | none set |
+
+Finding 4 (plaintext filename in relay RAM) left this table on 2026-09-09. It
+was fixed on 2026-04-13 in v2.4.5 and this page had not caught up: the status
+above still said "in progress" and `/docs` reported the whole audit as
+resolved, which was the other half of the same drift. What the code does now:
+`POST /v2/inbound` accepts `enc_meta`, a base64 blob the client seals before it
+leaves the browser, and stores that on the download token
+(`relay/relay.js`, `downloadTokens.set(...)`). The download path sets
+`Content-Disposition: attachment; filename="paramant-encrypted-payload"` and the
+receiver's SDK decrypts `enc_meta` to recover the real name. Two comments in
+`relay.js` name finding #4 at those exact lines.
+
+Finding 14 is still open and its ETA was v2.5.0, which has long shipped, so the
+date is removed rather than left to age further. What HAS changed since April:
+the audit described "proofs that are just the last 8 leaf hashes", and there is
+now a real audit path (`relay/lib/ct-hash.js`, `ctInclusionProof`), with an odd
+leaf promoted rather than duplicated. What has not: the tree is still rebuilt
+from scratch on each append, it covers the CT_MAX most recent leaves rather
+than the log, and there is no consistency proof, so a verifier cannot check one
+head against an older one. That is the part that keeps this finding open, and
+it is why a signed head now carries `window_base` (see `relay/lib/sth-guard.js`):
+a head over a sliding window has to say which leaves it covers.
 
 ---
 

--- a/admin/server.js
+++ b/admin/server.js
@@ -2462,6 +2462,14 @@ api.get("/user/session/verify", async (req, res) => {
     authenticated: true,
     email: s.email,
     expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+    // Whether THIS session may open /developer. The navigation used to offer
+    // "Developer settings" to every signed-in visitor, and /developer answers
+    // 404 to anyone off the allowlist (deliberately, so the surface stays
+    // hidden), so the menu handed almost everyone a dead link. Telling a
+    // visitor about their own access is not a leak: a false here says nothing
+    // about what the route is or whether it exists, and it lets the menu stop
+    // advertising a door that will not open.
+    developer: isDeveloper(s.email),
   });
 });
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,6 +1,6 @@
 # PARAMANT: complete environment reference
 #
-# 109 variables. Copy to deploy/.env and fill in what the "required" blocks ask
+# 110 variables. Copy to deploy/.env and fill in what the "required" blocks ask
 # for. .env is NEVER committed to git.
 #
 # This file is the reference: every name the relay or the admin panel reads is
@@ -224,6 +224,15 @@ PARAMANT_TOTP_MASTER_KEY=
 # optional · default: 104857600 (100 MB)
 # read in: relay/relay.js
 # CT_MAX_SIZE=104857600
+
+# How many leaves the in-memory Merkle tree keeps. Not the size of the log:
+# past this the logical index keeps advancing and older leaves are pruned, so
+# the signed head describes a sliding window (it carries window_base for that
+# reason). Leave it alone in production; it exists as a knob so a test can
+# reach the wrap-around in a handful of appends instead of ten thousand.
+# optional · default: 10000
+# read in: relay/relay.js
+# CT_MAX=10000
 
 # Append-only file of this relay's signed tree heads.
 # optional · default: /data/sth-log.jsonl

--- a/deploy/knoppen.md
+++ b/deploy/knoppen.md
@@ -311,7 +311,7 @@ controle valt om.
 | `extensions/shared/paramant-core.js` | `PADDED_BLOCK` | `5 * 1024 * 1024` | hier is 5 MB wel een blokgrootte en geen grens; dit is de opvulling |
 | `relay/lib/qes/pades.js` | `DEFAULT_CONTENTS_BYTES` | `16384` | de echte reserveringsgrootte in het PDF-handtekeningveld; geen grens |
 | `relay/lib/parasign-open-api.js` | `PARASIGN_MAX_PDF_BYTES` | `20 * 1024 * 1024` | 20 MB voor de v1-PDF, boven de 10 MB die readBody doorlaat |
-| `relay/relay.js` | `CT_MAX` | `10000` | venster in het geheugen, geteld in regels; niet instelbaar |
+| `relay/relay.js` | `CT_MAX` | `10000` | venster in het geheugen, geteld in bladeren; instelbaar via `CT_MAX` sinds de STH-vensterfix, zodat een suite de omslag in een handvol appends haalt in plaats van tienduizend |
 | `relay/relay.js` | `CT_MAX_SIZE` | `100 * 1024 * 1024` | rotatiegrens op schijf, geteld in bytes; wel instelbaar, en dood zonder CT_FILE |
 | `relay/relay.js` | `TTL_MS` | `300000` | standaardlevensduur van een blob, 5 minuten |
 | `relay/relay.js` | `RAM_LIMIT_MB` | `512` | plafond van de RAM-bewaking; compose zet 1024 voor vier relays en 8192 hardgecodeerd voor health |

--- a/deploy/knoppen.md
+++ b/deploy/knoppen.md
@@ -254,7 +254,7 @@ deze regels doorbreken.
 
 | bestand | richtlijn | waarde |
 |---|---|---|
-| `deploy/nginx-paramant-live.conf` | `client_max_body_size` | `4k / 64k / 16k / 16k / 50M / 30M / 12M / 35M / 12M / 12M / 12M` |
+| `deploy/nginx-paramant-live.conf` | `client_max_body_size` | `4k / 64k / 64k / 16k / 16k / 50M / 30M / 12M / 35M / 12M / 12M / 12M` |
 | `deploy/nginx-paramant-live.conf` | `limit_req_zone` | `afwezig` |
 | `deploy/nginx-paramant-live.conf` | `limit_conn` | `afwezig` |
 | `deploy/nginx-paramant-live.conf` | `proxy_read_timeout` | `3600s / 3600s / 3600s / 3600s / 3600s` |

--- a/deploy/nginx-paramant-live.conf
+++ b/deploy/nginx-paramant-live.conf
@@ -170,8 +170,34 @@ server {
         proxy_set_header Content-Length "";
     }
 
-    location /api/user/ {
+    # The credential endpoints, and only those, stay in the auth throttle. They
+    # are the ones worth guessing at: sign in, backup code, sign up, the setup
+    # link and the WebAuthn login ceremony. One regex location so the five share
+    # a block; regex locations are matched before the /api/user/ prefix below,
+    # and after the two exact `= /api/user/.../check` locations above.
+    location ~ ^/api/user/(login|login-with-backup|signup|setup|auth)(/.*)?$ {
         limit_req        zone=relay_auth burst=5 nodelay;
+        limit_req_status 429;
+        proxy_pass http://127.0.0.1:4200/admin/api/user/$1$2$is_args$args;
+        proxy_set_header X-Internal-Auth "";
+        proxy_set_header X-Verified-Email-Hash "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Cookie $http_cookie;
+        proxy_pass_header Set-Cookie;
+        client_max_body_size 64k;
+    }
+
+    # Everything else under /api/user/ is a signed-in read: the account page, the
+    # session check, the key listings, the dashboard. Those shared the auth
+    # throttle above, and /account alone opens six of them at once, so the sixth
+    # and beyond came back 429 and the page printed "Could not load passkeys
+    # (HTTP 429)" on a first visit. Worse, a 429 on /api/user/session/verify
+    # makes the navigation render a signed-in visitor as signed out. Guessing a
+    # credential is not what these are for, so they belong in the ordinary zone.
+    location /api/user/ {
+        limit_req        zone=api burst=20 nodelay;
         limit_req_status 429;
         proxy_pass http://127.0.0.1:4200/admin/api/user/;
         proxy_set_header X-Internal-Auth "";

--- a/deploy/nginx-paramant-live.conf
+++ b/deploy/nginx-paramant-live.conf
@@ -175,7 +175,12 @@ server {
     # link and the WebAuthn login ceremony. One regex location so the five share
     # a block; regex locations are matched before the /api/user/ prefix below,
     # and after the two exact `= /api/user/.../check` locations above.
-    location ~ ^/api/user/(login|login-with-backup|signup|setup|auth)(/.*)?$ {
+    # Longest alternative first, so the branch that matches is the one meant:
+    # PCRE would backtrack from "login" into "login-with-backup" anyway, but a
+    # routing rule should not need a reader to know that. Note "sign" is not in
+    # this list: /api/user/sign/activation and /api/user/sign/submit are the
+    # signing calls of an already signed-in account, not credential endpoints.
+    location ~ ^/api/user/(login-with-backup|login|signup|setup|auth)(/.*)?$ {
         limit_req        zone=relay_auth burst=5 nodelay;
         limit_req_status 429;
         proxy_pass http://127.0.0.1:4200/admin/api/user/$1$2$is_args$args;

--- a/docs/swarm-runs/2026-09-08-usertest-productie.md
+++ b/docs/swarm-runs/2026-09-08-usertest-productie.md
@@ -1,0 +1,32 @@
+# Swarm-run: Paramant als echte gebruiker op productie (2026-09-08)
+
+Aanpak: hoofdsessie doet zelf de sessie-gebonden flows (die zijn niet parallelliseerbaar: één account, één quotum, één cookiejar), vijf verkenners parallel op alles wat zonder sessie kan. Twee echte Community-accounts aangemaakt op productie via wegwerpmailboxen (mail.tm-API), zodat de registratie- en mailketen echt doorlopen werd in plaats van gesimuleerd.
+
+Kosten: 5 subagents, ~650k subagent-tokens, ~200 tool-calls, ~50 min wallclock.
+Resultaat: 5 stille breuken zelf gemeten, 7 tekst-versus-werkelijkheid-afwijkingen, plus 5 verkennerrapporten (publieke crawl, docs versus API, mobiel/a11y, mail/DNS/TLS-infra, twee zelfbouw-audits).
+Convergentie: dominante root-cause = **de foutmelding bereikt de gebruiker niet**. Backup-code-login, 5 MB-overschrijding en de inlogpoging op een gedeactiveerd account falen alle drie zonder één zichtbaar woord. Tweede cluster: `limit_req` op het hele `/api/user/`-prefix (nginx-paramant-live.conf:123) veroorzaakt zowel de 429's op /account als de gebruiker die zichzelf uitgelogd ziet.
+
+## Verdeling van het werk
+
+| spoor | wie | waarom daar |
+|---|---|---|
+| registratie, TOTP, ondertekenen, verify, ParaSend, vault, passkey, co-sign, deactivatie | hoofdsessie | sessie-gebonden, quotum van 2 handtekeningen per maand, niet te splitsen |
+| publieke crawl, 119 URL's, security headers | verkenner | read-only, geen sessie |
+| docs versus live API, SDK, OpenAPI | verkenner | read-only |
+| mobiel en toegankelijkheid, 13 pagina's x 2 viewports | verkenner | eigen browserprofiel, read-only |
+| DNS, TLS, SPF/DKIM/DMARC, CT-logs | verkenner | extern, geen browser nodig |
+| zelfbouw-audit auth/crypto en infra/frontend | 2 verkenners | codebase, read-only |
+
+## Lessons learned
+
+1. **Meet de sessie via de API, niet via de URL.** Ik concludeerde eerst dat SHA-1-TOTP bij inloggen geweigerd werd, omdat de pagina op `/auth/login` bleef staan. De screenshot liet zien dat de gebruiker gewoon ingelogd was, met een knop "Continue to your account". `GET /api/user/session/verify` is het enige betrouwbare signaal.
+2. **Bekijk de screenshot voor je een bevinding opschrijft.** Twee van mijn eerste drie "bugs" overleefden dat niet: een knop die leeg leek (font nog niet geladen) en een user-agent in de PDF (zat al in mijn eigen testbestand).
+3. **Een virtuele WebAuthn-authenticator is verplicht gereedschap.** Via CDP `WebAuthn.addVirtualAuthenticator` is de hele passkey-helft van Paramant geautomatiseerd testbaar. Zonder dat is die helft blind vlek.
+4. **Wegwerpmailboxen met API maken de mailketen testbaar.** De volgorde klopt alleen als je eerst verifieert en dan pas op de tweede mail wacht: die wordt pas verstuurd na het openen van de verificatielink.
+5. **Right-sizing:** vijf verkenners was precies goed. Een zesde op de betaalde flows had niets opgeleverd, want die zitten achter een betaalmuur die we op een testaccount niet halen.
+
+## Niet gedekt
+
+- ParaSend "Hand over live" (vereist twee gelijktijdige browsers aan weerskanten).
+- Alles achter een betaald plan: Firm, Business, Enterprise-limieten en de facturatie.
+- De `/v1`-API met een `psk_live_`-sleutel, want `/developer` geeft 404 en er is dus geen route om er een te minten.

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -117,6 +117,6 @@
     </div>
   </div>
 </footer>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -25,7 +25,7 @@
     footer{padding:20px 24px;text-align:center;font-size:11px;color:var(--ink-dim);border-top:1px solid var(--ink-hair)}
   </style>
 <style>.skip-link{position:absolute;top:-200px;left:0;background:var(--bone-2);color:var(--ink);padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid var(--ochre);transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:var(--ochre)}</style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/parapear.css?v=4">

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -293,6 +293,6 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -509,7 +509,7 @@ main.acct input::placeholder { color: var(--ink-3); }
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=10" defer></script>
 <script src="/js/account-api-keys.js?v=1" defer></script>
-<script src="/js/account.inline1.js?v=8"></script>
+<script src="/js/account.inline1.js?v=9"></script>
 <script src="/js/app-session-token.js?v=1" defer></script>
 <script src="/js/redeem-code.js?v=2" defer></script>
 

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -8,7 +8,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <meta property="og:title" content="Your account · Paramant">

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -208,7 +208,7 @@ main.acct input::placeholder { color: var(--ink-3); }
 <nav class="settings-tabs" aria-label="Settings sections">
   <a href="/account" aria-current="page">Account &amp; security</a>
   <a href="/account#billing-section">Plan &amp; billing</a>
-  <a href="/developer">Developer settings</a>
+  <a href="/developer" data-developer-only hidden>Developer settings</a>
 </nav>
 
 <header class="acct-hero">
@@ -507,7 +507,7 @@ main.acct input::placeholder { color: var(--ink-3); }
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 <script src="/js/account-api-keys.js?v=1" defer></script>
 <script src="/js/account.inline1.js?v=8"></script>
 <script src="/js/app-session-token.js?v=1" defer></script>

--- a/frontend/all-systems-go.html
+++ b/frontend/all-systems-go.html
@@ -6,7 +6,7 @@
   <title>All systems · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/all-systems-go">
-  <link rel="stylesheet" href="/design-system.css?v=28">
+  <link rel="stylesheet" href="/design-system.css?v=29">
   <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>

--- a/frontend/apply-nav.py
+++ b/frontend/apply-nav.py
@@ -94,7 +94,7 @@ LEGAL_STRIP = '''\
 DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=28">'
 NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=24">'
 NAV_JS    = '<script src="/nav.js?v=15" defer></script>'
-NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=9" defer></script>'
+NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=10" defer></script>'
 
 # Pages that don't have <nav class="nav"> yet but should — inject the canonical
 # nav after <body> (or after a skip-link if present). App shells (admin,

--- a/frontend/apply-nav.py
+++ b/frontend/apply-nav.py
@@ -91,7 +91,7 @@ LEGAL_STRIP = '''\
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>
 </footer>'''
 
-DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=28">'
+DS_LINK   = '<link rel="stylesheet" href="/design-system.css?v=29">'
 NAV_LINK  = '<link rel="stylesheet" href="/nav.css?v=24">'
 NAV_JS    = '<script src="/nav.js?v=15" defer></script>'
 NAV_AUTH_JS = '<script src="/js/nav-auth.js?v=10" defer></script>'

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -799,6 +799,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/architecture.html
+++ b/frontend/architecture.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -24,7 +24,7 @@
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="canonical" href="https://paramant.app/audit-log-export">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/audit-log-export.html
+++ b/frontend/audit-log-export.html
@@ -258,6 +258,6 @@ section p+p{margin-top:14px}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/auth/backup.html
+++ b/frontend/auth/backup.html
@@ -73,7 +73,12 @@
 </section>
 
 <section class="section">
-  <form id="backup-form" class="form-card">
+  <!-- novalidate, like the sign-in and sign-up forms. Without it the browser's
+       own `required` check runs first and cancels the submit event, so the
+       page's own handler never ran and never got to say what was missing: the
+       button simply did nothing. The fields keep `required` for assistive
+       technology; the sentences come from auth-backup.js. -->
+  <form id="backup-form" class="form-card" novalidate>
     <label for="email">Email address</label>
     <input type="email" id="email" name="email" required autocomplete="username"
            autofocus>
@@ -112,8 +117,8 @@
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
-<script src="/js/auth-backup.js?v=2"></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
+<script src="/js/auth-backup.js?v=3"></script>
 
 <footer class="legal-strip">
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -21,7 +21,7 @@
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/auth/login.html
+++ b/frontend/auth/login.html
@@ -140,8 +140,8 @@
 
 <script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
-<script src="/js/auth-login.js?v=3"></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
+<script src="/js/auth-login.js?v=4"></script>
 <script type="module" src="/js/passkey.js?v=5"></script>
 
 <footer class="legal-strip">

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/auth/request-reset.html
+++ b/frontend/auth/request-reset.html
@@ -101,8 +101,8 @@
 
 <script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
-<script src="/js/auth-request-reset.js?v=2"></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
+<script src="/js/auth-request-reset.js?v=3"></script>
 <footer class="legal-strip">
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>
 </footer>

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/auth/reset-confirm.html
+++ b/frontend/auth/reset-confirm.html
@@ -95,7 +95,7 @@
 
   <div id="success-view" style="display:none">
     <p class="lede" style="color:var(--ok-ink)">Confirmed. The second email, the one with the setup link, is on its way.</p>
-    <p>Look for a mail from noreply@paramant.app with a setup link. Open it, scan the QR code, and your new authenticator app is linked.</p>
+    <p>Look for a mail from hello@paramant.app with a setup link. Open it, scan the QR code, and your new authenticator app is linked.</p>
     <p style="margin-top:8px">Delete the old Paramant entry in your authenticator app first. Its codes no longer work.</p>
     <p class="footer-text mt-4"><a href="/auth/login">Return to sign in</a></p>
   </div>
@@ -116,7 +116,7 @@
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 <script src="/js/auth-reset-confirm.js?v=3"></script>
 <footer class="legal-strip">
   <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -289,7 +289,7 @@
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 <script src="/js/auth-setup.js?v=3"></script>
 <script type="module" src="/js/passkey.js?v=5"></script>
 

--- a/frontend/auth/setup.html
+++ b/frontend/auth/setup.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <script src="/js/qrcode.min.js?v=1"></script>

--- a/frontend/billing/checkout.html
+++ b/frontend/billing/checkout.html
@@ -9,7 +9,7 @@
 <link rel="canonical" href="https://paramant.app/pricing">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#15191C">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <style>
   body { background: var(--bone); }
   .checkout-wrap { max-width: 480px; margin: var(--space-10) auto; padding: 0 var(--space-5); text-align: center; }

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -308,6 +308,6 @@ footer{border-top:1px solid rgba(var(--tint), .1);padding:40px 48px;display:flex
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -23,7 +23,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>

--- a/frontend/claim.html
+++ b/frontend/claim.html
@@ -8,7 +8,7 @@
 <meta name="robots" content="noindex, nofollow">
 <meta name="referrer" content="no-referrer">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <style>
   .claim-wrap{max-width:560px;margin:8vh auto;padding:0 20px}
   .claim-card{background:var(--card);border:1px solid var(--ink-hair);border-radius:10px;padding:32px}

--- a/frontend/co-sign.html
+++ b/frontend/co-sign.html
@@ -30,7 +30,7 @@
 <link rel="canonical" href="https://paramant.app/co-sign">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#15191C">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -596,6 +596,6 @@ FLAGS    1 byte    reserved for future features</pre>
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/crypto-agility.html
+++ b/frontend/crypto-agility.html
@@ -19,7 +19,7 @@
 <meta name="twitter:title" content="Crypto agility · Paramant">
 <meta name="twitter:description" content="Algorithms you can swap without rebuilding. Identifiers travel in the header, not in the code path. NIST FIPS 203, 204, 205 and 206 loaded in production.">
 <link rel="canonical" href="https://paramant.app/crypto-agility">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -487,6 +487,6 @@ body { min-height:100vh; }
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -17,7 +17,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <meta property="og:title" content="Certificate transparency log · Paramant">
@@ -297,6 +297,10 @@ body { min-height:100vh; }
   <a href="/help" class="nav-tail-link">Help</a>
 </div>
 
+<!-- The skip link at the top pointed at #main-content, which did not exist on
+     this page, and there was no <main> either. Pressing it set the hash and
+     moved nothing: a keyboard visitor was left where they started. -->
+<main id="main-content" role="main" tabindex="-1">
 <div class="hero">
   <div class="tag">Public Audit Log</div>
   <h1>Certificate <span>Transparency</span></h1>
@@ -405,7 +409,7 @@ body { min-height:100vh; }
 <div class="verify-section">
   <h2>Verify a hash</h2>
   <div class="verify-bar">
-    <input id="verify-input" placeholder="Paste leaf_hash, device_hash or tree_hash to verify inclusion..." data-input="clearVerify">
+    <input id="verify-input" aria-label="Hash to verify inclusion for" placeholder="Paste leaf_hash, device_hash or tree_hash to verify inclusion..." data-input="clearVerify">
     <button data-click="verifyHash">VERIFY</button>
   </div>
   <div class="verify-result" id="verify-result"></div>
@@ -418,7 +422,7 @@ body { min-height:100vh; }
 </div>
 
 <div class="search-bar">
-  <input id="search" placeholder="Filter entries by hash or index..." data-input="filterEntries">
+  <input id="search" aria-label="Filter log entries by hash or index" placeholder="Filter entries by hash or index..." data-input="filterEntries">
   <button data-click="filterEntries">FILTER</button>
 </div>
 
@@ -455,6 +459,7 @@ body { min-height:100vh; }
     <div id="relay-entries"><div class="loading">Loading relay registry…</div></div>
   </div>
 </div><!-- /pane-relays -->
+</main>
 
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/ct-log.page.js?v=3" defer></script>

--- a/frontend/ct-log.html
+++ b/frontend/ct-log.html
@@ -45,7 +45,9 @@ body { min-height:100vh; }
 .notice .body strong { color:var(--ink); display:block; margin-bottom:4px; }
 .notice code { font-size:var(--text-xs); }
 
-.stats { display:flex; gap:1px; background:var(--ink-ghost); margin:0 40px 32px; }
+.stats { display:flex; flex-wrap:wrap; gap:1px; background:var(--ink-ghost); margin:0 40px 12px; }
+.stat-scope { margin:0 40px 32px; font-family:var(--mono); font-size:11px; color:var(--ink-dim); line-height:1.6; }
+.stat-scope:empty { margin-bottom:0; }
 .stat { flex:1; padding:20px 24px; background:var(--bone); }
 .stat .val { font-size:22px; font-weight:700; color:var(--ink); margin-bottom:4px; }
 .stat .lbl { font-size:var(--text-xs); color:var(--ink-dim); letter-spacing:.1em; text-transform:uppercase; }
@@ -392,6 +394,10 @@ body { min-height:100vh; }
     <div class="lbl">Relay announcements</div>
   </div>
   <div class="stat">
+    <div class="val" id="stat-other">n/a</div>
+    <div class="lbl">Signing events</div>
+  </div>
+  <div class="stat">
     <div class="val dim" id="stat-root">n/a</div>
     <div class="lbl">Merkle Root</div>
   </div>
@@ -404,6 +410,11 @@ body { min-height:100vh; }
     <div class="lbl">Last Entry</div>
   </div>
 </div>
+
+<!-- Filled by ct-log.page.js. The counts above describe the window the relay returns
+     (1000 entries at most), the total above describes the whole log, and until
+     this line existed nothing on the page said so. -->
+<p class="stat-scope" id="stat-scope"></p>
 
 <!-- Hash Verification Tool -->
 <div class="verify-section">
@@ -462,7 +473,7 @@ body { min-height:100vh; }
 </main>
 
 <script src="/js/delegate.js?v=1" defer></script>
-<script src="/js/ct-log.page.js?v=3" defer></script>
+<script src="/js/ct-log.page.js?v=4" defer></script>
 <footer>
   <div class="container-lg">
     <div class="footer-grid footer-slim">

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -632,7 +632,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
       <a href="/verify">Verify a signed document</a>
       <a href="/get">Open a secure delivery</a>
       <a href="/vault">Protect a file with a passphrase</a>
-      <a href="/developer">Developer settings</a>
+      <a href="/developer" data-developer-only hidden>Developer settings</a>
     </nav>
 
     <details class="dh-acct" aria-label="Account details">
@@ -651,7 +651,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
         <div class="dh-acct-actions">
           <a class="dh-btn" href="/account">Account &amp; security</a>
           <a class="dh-btn" href="/pricing">Plan &amp; billing</a>
-          <a class="dh-btn" href="/developer">Developer settings</a>
+          <a class="dh-btn" href="/developer" data-developer-only hidden>Developer settings</a>
           <button type="button" class="dh-btn" data-pa-action="refresh">Refresh</button>
           <button type="button" class="dh-btn warn" data-pa-action="signout">Sign out</button>
         </div>
@@ -708,7 +708,7 @@ main.pa-main { max-width: 1240px; margin: 0 auto; padding: var(--space-6) var(--
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
-<script src="/js/dashboard.js?v=15" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
+<script src="/js/dashboard.js?v=16" defer></script>
 </body>
 </html>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Sign in to your Paramant dashboard.">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://relay.paramant.app">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/parapear.css?v=4">

--- a/frontend/design-system.css
+++ b/frontend/design-system.css
@@ -3037,6 +3037,13 @@ h1.paramant-h2 { font-size: var(--text-3xl); font-weight: inherit; letter-spacin
   text-decoration: none;
   border-bottom: 1px solid transparent;
   padding: 2px 0;
+  /* 44px of height for a thumb, without making the line look any taller: the
+     box grows, the text does not. Measured at 390px wide these links were 17
+     to 19px high, which is the smallest target on the site and sits on every
+     auth, account and download page. */
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
 }
 .legal-strip a:hover { color: var(--navy); border-bottom-color: var(--lime); }
 .legal-strip a:focus-visible { outline: 2px solid var(--lime); outline-offset: 2px; }

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex,nofollow">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#15191C">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <style>
 *{box-sizing:border-box}

--- a/frontend/developer.html
+++ b/frontend/developer.html
@@ -156,7 +156,7 @@ curl -X POST https://paramant.app/v1/envelopes \
 </div>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
-<script src="/js/developer.js?v=8" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
+<script src="/js/developer.js?v=9" defer></script>
 </body>
 </html>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -951,8 +951,13 @@ python3 scripts/paramant-admin.py sync</pre>
       <tr><th>Date</th><th>Auditor</th><th>Findings</th><th>Status</th></tr>
       <tr><td>Apr 2026</td><td>R. Zwarts (verification)</td><td>14 total (1H · 8M · 5L)</td><td>All resolved: e6f216d</td></tr>
       <tr><td>Apr 2026</td><td>R. Zwarts (independent)</td><td>6 total (3H · 3M)</td><td>All resolved: 0db3ef0</td></tr>
-      <tr><td>Apr 2026</td><td>Ryan Williams · Smart Cyber Solutions</td><td>4C · 5H · 6M · 5L</td><td>All resolved: 0db3ef0</td></tr>
+      <tr><td>Apr 2026</td><td>Ryan Williams · Smart Cyber Solutions</td><td>4C · 5H · 6M · 5L</td><td>19 of 20 resolved; finding 4 open</td></tr>
     </table>
+    <p><strong>One finding is still open</strong>, and this table used to say otherwise. <code>SECURITY.md</code>
+    keeps its own "Open findings" section, and it lists finding 4 of the Smart Cyber Solutions
+    audit (Critical, a plaintext filename held in relay RAM) and finding 14 (Medium, the CT
+    Merkle tree not being RFC 6962 compliant). Read that section rather than this table before
+    you rely on a status here.</p>
     <p>All findings are publicly documented in <a href="https://github.com/Apolloccrypt/paramant-relay/blob/main/SECURITY.md" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)" rel="noopener">SECURITY.md</a>. To report a vulnerability: <a href="mailto:privacy@paramant.app" style="color:var(--cobalt)">privacy@paramant.app</a>.</p>
 
     <!-- ── Compliance ───────────────────────────────────────────── -->

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -1045,7 +1045,7 @@ python3 scripts/paramant-admin.py sync</pre>
 
 <script src="/js/docs.inline1.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 <footer>
   <div class="container-lg">
     <div class="footer-grid footer-slim">

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -9,15 +9,15 @@
 <meta property="og:image:height" content="630">
 <meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
+<meta name="description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant. Your IT can check everything here. The relay never holds a decryption key.">
 <meta property="og:title" content="Documentation · Paramant API and self-hosting">
-<meta property="og:description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
+<meta property="og:description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant. Your IT can check everything here. The relay never holds a decryption key.">
 <meta property="og:url" content="https://paramant.app/docs">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Documentation · Paramant API and self-hosting">
-<meta name="twitter:description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
+<meta name="twitter:description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant. Your IT can check everything here. The relay never holds a decryption key.">
 <link rel="canonical" href="https://paramant.app/docs">
 
 <link rel="stylesheet" href="/design-system.css?v=29">
@@ -176,7 +176,7 @@ tr:last-child td{border-bottom:none}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key."
+      "description": "API reference, SDK guide, self-hosting and compliance docs for Paramant. Your IT can check everything here. The relay never holds a decryption key."
     },
     {
       "@type": "Organization",
@@ -250,7 +250,12 @@ tr:last-child td{border-bottom:none}
     <span class="eyebrow">REFERENCE</span>
     <h1>Documentation</h1>
     <p class="docs-buyer">Evaluating Paramant? Your IT can check everything here. Plans and prices are on <a href="/pricing">Pricing</a>.</p>
-    <p class="lede">API reference, SDK guide, self-hosting, and compliance docs for PARAMANT v3.0.0. The relay is untrusted by design: it never holds a decryption key. The ParaSign API is available from Firm; see <a href="/pricing">pricing</a>.</p>
+    <p class="lede">API reference, SDK guide, self-hosting, and compliance docs for PARAMANT. The relay is untrusted by design: it never holds a decryption key. The ParaSign API is available from Firm; see <a href="/pricing">pricing</a>.</p>
+    <!-- Two version numbers, and they are meant to differ. Keeping it out of the
+         lede above on purpose: tests/ui-truthfulness.test.mjs requires the plan
+         boundary to sit in one unbroken run of text there. -->
+    <p class="small">The hosted relays answer <code>3.1.0</code>. The self-host release the install
+    script pins is <code>v3.0.0</code>, so the examples on this page differ where that matters.</p>
     <div class="docs-hero-actions">
       <a href="#quickstart" class="docs-hero-btn docs-hero-btn-primary">Quick start</a>
       <a href="/pricing" class="docs-hero-btn docs-hero-btn-secondary">See plans and prices</a>
@@ -380,10 +385,12 @@ curl https://health.paramant.app/v2/outbound/abc123... \
       <tr><td>pgp_</td><td><code>pgp_</code></td><td>End users</td><td>Send/receive files via the API</td></tr>
       <tr><td>plk_</td><td><code>plk_</code></td><td>Relay operators</td><td>License key: unlocks &gt;5 users on self-hosted relay</td></tr>
     </table>
-    <p>Pass the <code>pgp_</code> key in the <code>X-Api-Key</code> header or <code>?k=</code> query parameter:</p>
-    <pre>X-Api-Key: pgp_your_key_here
-<span class="cm"># or:</span>
-GET /v2/check-key?k=pgp_your_key_here</pre>
+    <p>Pass the <code>pgp_</code> key in the <code>X-Api-Key</code> header. There is no query-parameter
+    form: a key in a URL ends up in access logs, browser history and referrers, so the relay refuses it.</p>
+    <pre>X-Api-Key: pgp_your_key_here</pre>
+    <p class="small">These docs used to offer <code>?k=</code> as an alternative. It was removed from the
+    relay after the April 2026 review (see <code>SECURITY.md</code>), and sending it now answers
+    <code>API key must be sent in the X-Api-Key header, not as a query parameter.</code></p>
 
     <!-- ── SDK ──────────────────────────────────────────────────── -->
     <h2 id="sdk">SDK</h2>
@@ -545,12 +552,16 @@ ws.onmessage = e => {
     <h2 id="health">GET /health</h2>
     <pre><span class="cm">{
   "ok": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "sector": "health",
   "edition": "licensed",
-  "uptime_s": 3600,
-  "license_expires": "2027-01-01"
+  "max_keys": null,
+  "license_expires": "2027-01-01T00:00:00.000Z",
+  "license_issued_to": "paramant.app"
 }</span></pre>
+    <p class="small">Copied from the live answer of <code>health.paramant.app/health</code>. There is no
+    <code>uptime_s</code> field: this example used to show one, along with a shortened
+    <code>license_expires</code> and a version the relay has not answered with for a while.</p>
 
     <!-- ── ParaSign API (/v1) ───────────────────────────────────── -->
     <span id="parasign-api" style="display:block;scroll-margin-top:90px" aria-hidden="true"></span>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="API reference, SDK guide, self-hosting and compliance docs for Paramant v3.0.0. Your IT can check everything here. The relay never holds a decryption key.">
 <link rel="canonical" href="https://paramant.app/docs">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>

--- a/frontend/docs.html
+++ b/frontend/docs.html
@@ -951,13 +951,14 @@ python3 scripts/paramant-admin.py sync</pre>
       <tr><th>Date</th><th>Auditor</th><th>Findings</th><th>Status</th></tr>
       <tr><td>Apr 2026</td><td>R. Zwarts (verification)</td><td>14 total (1H · 8M · 5L)</td><td>All resolved: e6f216d</td></tr>
       <tr><td>Apr 2026</td><td>R. Zwarts (independent)</td><td>6 total (3H · 3M)</td><td>All resolved: 0db3ef0</td></tr>
-      <tr><td>Apr 2026</td><td>Ryan Williams · Smart Cyber Solutions</td><td>4C · 5H · 6M · 5L</td><td>19 of 20 resolved; finding 4 open</td></tr>
+      <tr><td>Apr 2026</td><td>Ryan Williams · Smart Cyber Solutions</td><td>4C · 5H · 6M · 5L</td><td>19 of 20 resolved; finding 14 open</td></tr>
     </table>
-    <p><strong>One finding is still open</strong>, and this table used to say otherwise. <code>SECURITY.md</code>
-    keeps its own "Open findings" section, and it lists finding 4 of the Smart Cyber Solutions
-    audit (Critical, a plaintext filename held in relay RAM) and finding 14 (Medium, the CT
-    Merkle tree not being RFC 6962 compliant). Read that section rather than this table before
-    you rely on a status here.</p>
+    <p><strong>One finding is still open</strong>, and this table used to say otherwise.
+    <code>SECURITY.md</code> keeps its own "Open findings" section; it lists finding 14 of the
+    Smart Cyber Solutions audit, which is that the CT Merkle tree is not RFC 6962: the tree is
+    rebuilt from every leaf on each append and covers a sliding window rather than the whole log,
+    so two heads cannot be checked against one another. Read that section rather than this table
+    before you rely on a status here.</p>
     <p>All findings are publicly documented in <a href="https://github.com/Apolloccrypt/paramant-relay/blob/main/SECURITY.md" target="_blank" style="color:var(--ink);text-decoration:underline;text-decoration-color:var(--ink-dim)" rel="noopener">SECURITY.md</a>. To report a vulnerability: <a href="mailto:privacy@paramant.app" style="color:var(--cobalt)">privacy@paramant.app</a>.</p>
 
     <!-- ── Compliance ───────────────────────────────────────────── -->

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -273,7 +273,7 @@ sha256sum -c SHA256SUMS --ignore-missing</pre>
 </main>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 
 <footer>
   <div class="container-lg">

--- a/frontend/download.html
+++ b/frontend/download.html
@@ -66,7 +66,7 @@ pre{font-family:var(--mono);font-size:12px;line-height:1.7;color:var(--ink);back
 @media(max-width:600px){h1{font-size:25px}.dl-sub{font-size:15px}main{padding:0 18px 60px}.dl-lead{padding:28px 0 30px}}
 </style>
 <style>.skip-link{position:absolute;top:-200px;left:0;background:var(--bone-2);color:var(--ink);padding:12px 20px;z-index:10000;text-decoration:none;font-size:13px;font-family:system-ui,sans-serif;border:2px solid var(--ochre);transition:top 120ms ease}.skip-link:focus,.skip-link:focus-visible{top:0;outline:none}.skip-link:focus:hover{background:var(--ochre)}</style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <script type="application/ld+json" data-paramant-seo="1">

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -19,7 +19,7 @@
 <meta name="twitter:title" content="Data processing agreement · Paramant">
 <meta name="twitter:description" content="The GDPR Article 28 agreement between Paramantis Solutions B.V. as processor and your organisation as controller. Sign it electronically, EU and German law.">
 <link rel="canonical" href="https://paramant.app/dpa">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/dpa.html
+++ b/frontend/dpa.html
@@ -381,6 +381,6 @@ input:focus{border-color:var(--cobalt)}
 
 <script src="/js/dpa.inline1.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/gereedschap.html
+++ b/frontend/gereedschap.html
@@ -297,6 +297,6 @@
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/gereedschap.html
+++ b/frontend/gereedschap.html
@@ -20,7 +20,7 @@
 <meta property="og:image:height" content="630">
 <meta property="og:site_name" content="Paramant">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <style>
 .tool-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1px;background:var(--ink-hair);margin-top:var(--space-6)}

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -284,7 +284,7 @@ h1{font-size:22px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/js/delegate.js?v=1" defer></script>
 <script src="/js/done-state.js?v=1" defer></script>

--- a/frontend/get.html
+++ b/frontend/get.html
@@ -34,7 +34,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/done-state.css?v=1">

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -374,6 +374,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/help/api-key-vs-totp.html
+++ b/frontend/help/api-key-vs-totp.html
@@ -72,7 +72,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -308,6 +308,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/help/authenticator-apps.html
+++ b/frontend/help/authenticator-apps.html
@@ -58,7 +58,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -72,7 +72,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/help/authenticator-setup.html
+++ b/frontend/help/authenticator-setup.html
@@ -409,6 +409,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -74,7 +74,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/help/backup-codes.html
+++ b/frontend/help/backup-codes.html
@@ -381,6 +381,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -420,6 +420,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/help/gmail-extension.html
+++ b/frontend/help/gmail-extension.html
@@ -81,7 +81,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -56,7 +56,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/parapear.css?v=4">

--- a/frontend/help/index.html
+++ b/frontend/help/index.html
@@ -365,6 +365,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -396,6 +396,6 @@ print(resp.json()["url"])</div>
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/help/iot-integration.html
+++ b/frontend/help/iot-integration.html
@@ -71,7 +71,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -367,6 +367,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/help/lost-authenticator.html
+++ b/frontend/help/lost-authenticator.html
@@ -70,7 +70,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -408,6 +408,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/help/outlook-extension.html
+++ b/frontend/help/outlook-extension.html
@@ -81,7 +81,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -70,7 +70,7 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
   footer{padding:32px 20px;flex-direction:column}
 }
 </style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/help/session-issues.html
+++ b/frontend/help/session-issues.html
@@ -370,6 +370,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,7 +22,7 @@
 <link rel="canonical" href="https://paramant.app/">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="manifest" href="/manifest.json">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <style>
 /* Homepage 2026, night edition: the same hand as BeerWeer. The night itself is

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -873,7 +873,7 @@ footer a{color:var(--fg)}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 <script src="/js/format-date.js?v=1" defer></script>
 <script src="/js/home-auth.js?v=5" defer></script>
 </body>

--- a/frontend/js/account.inline1.js
+++ b/frontend/js/account.inline1.js
@@ -297,6 +297,18 @@
     if (res.ok) {
       alert('Account deactivated. Its key can no longer be used.');
       window.location = '/';
+      return;
+    }
+    // A refusal used to end here, silently: the page simply stayed put and the
+    // account was still there. Someone who has decided to close their account
+    // has to be told when that did not happen, and told what to do next.
+    if (res.status === 429) {
+      alert('Too many attempts right now. Wait a few minutes and try again.');
+    } else if (res.status === 401) {
+      alert('Your session has expired. Sign in again, then deactivate the account.');
+    } else {
+      alert('The account was NOT deactivated (server said ' + res.status + '). ' +
+            'Try again in a minute; if it keeps failing, mail privacy@paramant.app.');
     }
   });
 

--- a/frontend/js/auth-backup.js
+++ b/frontend/js/auth-backup.js
@@ -1,26 +1,72 @@
 (function() {
   const form = document.getElementById('backup-form');
   const errorDiv = document.getElementById('error');
+  const emailInput = document.getElementById('email');
+  const codeInput = document.getElementById('code');
+  const submitBtn = form.querySelector('button[type="submit"]');
+
+  function fail(message) {
+    errorDiv.textContent = message;
+    errorDiv.classList.add('visible');
+  }
+
+  // This page is reached from the sign-in page, where the visitor has usually
+  // already typed their address. Carry it over so they do not type it twice on
+  // the one page they only open when their phone is gone. Missing value is not
+  // an error: the field simply stays empty and keeps the focus.
+  try {
+    const remembered = sessionStorage.getItem('paramant:recovery-email');
+    if (remembered && !emailInput.value) emailInput.value = remembered;
+  } catch (_) { /* private mode, or storage blocked: no prefill, no problem */ }
+
+  if (emailInput.value) codeInput.focus();
+  else emailInput.focus();
 
   form.addEventListener('submit', async function(e) {
     e.preventDefault();
     errorDiv.classList.remove('visible');
 
-    const email = document.getElementById('email').value.trim();
-    const code = document.getElementById('code').value.trim().toUpperCase();
+    const email = emailInput.value.trim();
+    const code = codeInput.value.trim().toUpperCase();
 
-    const res = await fetch('/api/user/login-with-backup', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, backup_code: code }),
-      credentials: 'include',
-    });
+    // Say what is missing in the page itself. The browser's own bubble for a
+    // `required` field disappears on the next tap and is easy to miss on a
+    // phone, which left the button looking dead: pressing it did nothing and
+    // nothing explained why.
+    if (!email) { fail('Fill in the email address of your account first.'); emailInput.focus(); return; }
+    if (!code) { fail('Fill in one of the backup codes you saved.'); codeInput.focus(); return; }
+
+    submitBtn.disabled = true;
+    const originalLabel = submitBtn.textContent;
+    submitBtn.textContent = 'Signing in...';
+
+    let res;
+    try {
+      res = await fetch('/api/user/login-with-backup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, backup_code: code }),
+        credentials: 'include',
+      });
+    } catch (_) {
+      submitBtn.disabled = false;
+      submitBtn.textContent = originalLabel;
+      fail('We could not reach Paramant. Check your connection and try again.');
+      return;
+    }
 
     if (res.ok) {
+      try { sessionStorage.removeItem('paramant:recovery-email'); } catch (_) {}
       window.location = '/dashboard';
+      return;
+    }
+
+    submitBtn.disabled = false;
+    submitBtn.textContent = originalLabel;
+    if (res.status === 429) {
+      fail('Too many attempts. Wait a few minutes and try again.');
     } else {
-      errorDiv.textContent = 'That email and backup code do not match. Each code works once, so check you are not reusing one you already used.';
-      errorDiv.classList.add('visible');
+      fail('That email and backup code do not match. Each code works once, so check you are not reusing one you already used.');
     }
   });
 })();

--- a/frontend/js/auth-login.js
+++ b/frontend/js/auth-login.js
@@ -39,6 +39,24 @@
     });
   }
 
+  // Carry the address the visitor already typed over to the recovery pages, so
+  // they do not have to type it again on a page they only reach when something
+  // has already gone wrong. sessionStorage, not a query parameter: the address
+  // stays out of the URL, the history and any copied link, and it dies with the
+  // tab. The recovery page treats a missing value as "no prefill", never as an
+  // error.
+  function rememberEmailForRecovery() {
+    const el = document.getElementById('email');
+    if (!el) return;
+    const v = el.value.trim();
+    try {
+      if (v) sessionStorage.setItem('paramant:recovery-email', v);
+      else sessionStorage.removeItem('paramant:recovery-email');
+    } catch (_) { /* private mode, or storage blocked: prefill is a nicety */ }
+  }
+  document.querySelectorAll('a[href^="/auth/backup"], a[href^="/auth/request-reset"]')
+    .forEach(function(a) { a.addEventListener('click', rememberEmailForRecovery); });
+
   form.addEventListener('submit', async function(e) {
     e.preventDefault();
     errorDiv.classList.remove('visible');

--- a/frontend/js/auth-request-reset.js
+++ b/frontend/js/auth-request-reset.js
@@ -36,7 +36,7 @@
       if (res.ok) {
         form.style.display = 'none';
         successDiv.style.display = 'block';
-        successDiv.innerHTML = '<p>If an account exists for <strong>' + email + '</strong>, a confirmation email is on its way. Look in your inbox, and in the spam folder. The sender is noreply@paramant.app.</p><p style="margin-top:8px">That first mail only confirms the request, and its link is valid for 60 minutes. Once you open it, we send the second mail with the link that links a new authenticator app; that one works for 14 days.</p><p style="margin-top:8px">We do not say whether the address is registered, so this message looks the same either way.</p>';
+        successDiv.innerHTML = '<p>If an account exists for <strong>' + email + '</strong>, a confirmation email is on its way. Look in your inbox, and in the spam folder. The sender is hello@paramant.app.</p><p style="margin-top:8px">That first mail only confirms the request, and its link is valid for 60 minutes. Once you open it, we send the second mail with the link that links a new authenticator app; that one works for 14 days.</p><p style="margin-top:8px">We do not say whether the address is registered, so this message looks the same either way.</p>';
       } else if (res.status === 429) {
         // server.js returns retry_after 86400 here: 5 requests per address per
         // 24 hours, 10 per connection per hour. Telling the reader to try again

--- a/frontend/js/ct-log.page.js
+++ b/frontend/js/ct-log.page.js
@@ -30,13 +30,22 @@ async function load() {
     allEntries = (d.entries || []).slice().reverse();
     filtered   = allEntries;
 
-    var keyRegCount   = allEntries.filter(function(e){ return !e.type || e.type === 'key_reg'; }).length;
+    var keyRegCount   = allEntries.filter(function(e){ return !e.type || e.type === 'key_reg' || e.type === 'signing_pk_enrolled'; }).length;
     var transferCount = allEntries.filter(function(e){ return e.type === 'transfer' || e.type === 'pubkey'; }).length;
     // The kind that dominates this log and had no counter of its own, so the
     // three numbers under the table came nowhere near the total and nothing on
     // the page said where the difference went. relay.js writes one of these
     // every time one of our containers boots and announces itself.
     var relayRegCount = allEntries.filter(function(e){ return e.type === 'relay_reg'; }).length;
+    // Everything the three counters above do not claim. Signing work writes
+    // envelope_* and parasign entries, and those fell between the categories:
+    // counted by nobody, mentioned nowhere, so the numbers under the table
+    // still did not add up to the number of entries fetched. Whatever new type
+    // gets appended tomorrow lands here too, which is the point of a remainder.
+    var countedTypes = ['key_reg', 'signing_pk_enrolled', 'transfer', 'pubkey', 'relay_reg'];
+    var otherCount = allEntries.filter(function(e){
+      return e.type && countedTypes.indexOf(e.type) === -1;
+    }).length;
     var logSize = d.size != null ? d.size : allEntries.length;
     document.getElementById('stat-total').textContent = logSize;
     // The composition sentence names the same number the counter shows. It is
@@ -45,10 +54,24 @@ async function load() {
     // still reads correctly, which is why the fallback is not "n/a".
     var compEl = document.getElementById('composition-count');
     if (compEl && logSize) compEl.textContent = logSize + ' entries';
+
+    // What the four counters below actually cover. The relay hands out at most
+    // 1000 entries per request, so on a log of thousands the counts describe a
+    // window while the total above describes the whole log: three numbers that
+    // came nowhere near the fourth, with nothing saying why. Say the window.
+    var scopeEl = document.getElementById('stat-scope');
+    if (scopeEl) {
+      scopeEl.textContent = (allEntries.length < logSize)
+        ? 'The four counts above cover the ' + allEntries.length +
+          ' most recent entries of ' + logSize + ', the most the relay returns in one request.'
+        : 'The four counts above cover all ' + logSize + ' entries.';
+    }
     document.getElementById('stat-count').textContent = keyRegCount;
     document.getElementById('stat-transfers').textContent = transferCount;
     var relayRegEl = document.getElementById('stat-relayreg');
     if (relayRegEl) relayRegEl.textContent = relayRegCount;
+    var otherEl = document.getElementById('stat-other');
+    if (otherEl) otherEl.textContent = otherCount;
     const root = d.root || '';
     document.getElementById('stat-root').textContent =
       root && root !== '0'.repeat(64) ? root.slice(0,16)+'…' : 'n/a';

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -813,7 +813,21 @@
         .catch(function () {});
     }
     pull();
-    if (!opsPollTimer) opsPollTimer = setInterval(pull, 5000);
+    // Poll only while the tab is actually being looked at, and at 30s rather
+    // than 5s. A dashboard left open in a background tab used to spend twelve
+    // requests a minute, for ever, on a rate-limited endpoint: it drained the
+    // bucket that every other signed-in call shares, so the account page came
+    // back 429 for a visitor who had done nothing but leave a tab open. Nothing
+    // on these cards changes second by second, and a tab that comes back to the
+    // front pulls once immediately, so the reading is fresh when it is read.
+    if (!opsPollTimer) {
+      opsPollTimer = setInterval(function () {
+        if (document.visibilityState === 'visible') pull();
+      }, 30000);
+      document.addEventListener('visibilitychange', function () {
+        if (document.visibilityState === 'visible') pull();
+      });
+    }
   }
 
   function start(tries) {

--- a/frontend/js/developer.js
+++ b/frontend/js/developer.js
@@ -148,5 +148,13 @@
   document.addEventListener('keydown', function (event) { if (event.key === 'Escape' && !modal.hidden) closeModal(); });
 
   Promise.all([loadSnapshot(), loadKeys()]);
-  setInterval(loadSnapshot, 10000);
+  // Same rule as the dashboard: a background tab must not keep spending the
+  // shared rate limit that every other signed-in call draws from. Poll while
+  // the page is visible, and pull once the moment it comes back to the front.
+  setInterval(function () {
+    if (document.visibilityState === 'visible') loadSnapshot();
+  }, 30000);
+  document.addEventListener('visibilitychange', function () {
+    if (document.visibilityState === 'visible') loadSnapshot();
+  });
 }());

--- a/frontend/js/nav-auth.js
+++ b/frontend/js/nav-auth.js
@@ -58,7 +58,7 @@
       '<a href="/signup" class="nav-cta">Create account</a>';
   }
 
-  function renderLoggedIn(email) {
+  function renderLoggedIn(email, isDeveloper) {
     setNavigation(APP_NAV, 'Workspace');
     // Support survives signing in. The tail used to be REMOVED here, on the
     // reasoning that the user menu carries Help from then on. On a phone that
@@ -90,7 +90,10 @@
         '<div class="nav-user-menu" hidden>' +
           '<a href="/dashboard" class="nav-menu-item">Documents</a>' +
           '<a href="/account" class="nav-menu-item">Account</a>' +
-          '<a href="/developer" class="nav-menu-item">Developer settings</a>' +
+          // Only for accounts that are actually on the developer allowlist.
+          // /developer answers 404 to everyone else, on purpose, so offering it
+          // to every signed-in visitor was offering a door that will not open.
+          (isDeveloper ? '<a href="/developer" class="nav-menu-item">Developer settings</a>' : '') +
           '<a href="/pricing" class="nav-menu-item">Plan &amp; billing</a>' +
           '<a href="/help" class="nav-menu-item">Help</a>' +
           '<div class="nav-menu-divider"></div>' +
@@ -143,7 +146,15 @@
       if (!res.ok) { renderLoggedOut(); return; }
       var data = await res.json();
       if (data.authenticated && data.email) {
-        renderLoggedIn(data.email);
+        renderLoggedIn(data.email, data.developer === true);
+        // The same verdict for the links that sit in the page itself (the
+        // settings tabs, the dashboard shortcuts). They ship hidden and are
+        // revealed here, so a non-developer is never shown a link that leads
+        // to a 404 and the page needs no second round-trip to find out.
+        if (data.developer === true) {
+          document.querySelectorAll('[data-developer-only]')
+            .forEach(function(el) { el.hidden = false; });
+        }
       } else {
         renderLoggedOut();
       }

--- a/frontend/js/parashare.page.js
+++ b/frontend/js/parashare.page.js
@@ -515,10 +515,38 @@ function setCreateStatus(msg, cls) {
   el.className = 'status-line' + (cls ? ' ' + cls : '');
 }
 
+// A file the link stand cannot take, named at the moment it is chosen. The
+// ceiling was checked only inside sealAndUpload, so an oversized file got a
+// green tick and a live button, and the refusal arrived after the click as the
+// page's generic "something went wrong on our side" while the real sentence
+// went to the console. It is not our side and nothing went wrong: it is a limit
+// the sender can act on, so it is said here, before the click.
+// Returns the sentence, or null when the file fits (or when the live stand,
+// which chunks and reaches 500 MB, is the one selected).
+function linkSizeRefusal(files) {
+  if (sendMode !== 'link' || !files || !files.length) return null;
+  const enc = new TextEncoder();
+  for (const f of files) {
+    if (f.size + enc.encode(f.name).length + LINK_OVERHEAD > LINK_MAX_BLOB) {
+      return f.name + ' is ' + (f.size / 1024 / 1024).toFixed(1) + ' MB, and a link stops at 5 MB. ' +
+        'One link is one sealed block, so it cannot be split. Choose "Hand over live" instead: ' +
+        'that way cuts the file into chunks and takes a file up to 500 MB, with the receiver online while you send.';
+    }
+  }
+  return null;
+}
+
 function onFileSelect() {
   const files = $('file-input').files;
   selectedFile = files[0] || null;
   if (!files.length) { setStatus('file-status', 'No file selected'); $('vault-list').style.display='none'; updateBtn(); return; }
+  const tooBig = linkSizeRefusal(files);
+  if (tooBig) {
+    setStatus('file-status', tooBig, 'err');
+    $('vault-list').style.display = 'none';
+    updateBtn();
+    return;
+  }
   if (files.length === 1) {
     setStatus('file-status', '✓ ' + files[0].name + ' (' + (files[0].size/1024/1024).toFixed(1) + ' MB)', 'ok');
     $('vault-list').style.display = 'none';
@@ -535,7 +563,8 @@ function onFileSelect() {
 
 function updateBtn() {
   selectedFiles = $('file-input') ? [...$('file-input').files] : [];
-  $('btn-create-session').disabled = !(keyValid && selectedFiles.length > 0);
+  $('btn-create-session').disabled =
+    !(keyValid && selectedFiles.length > 0) || linkSizeRefusal(selectedFiles) !== null;
 }
 
 // ── Session creation ──
@@ -1015,6 +1044,9 @@ function setSendMode(mode) {
   const btn = $('btn-create-session');
   if (btn) btn.textContent = (sendMode === 'link') ? 'Seal the file and make a link →' : 'Create secure session →';
   setCreateStatus('');
+  // The same file is fine on one stand and too big on the other, so the verdict
+  // on an already-chosen file is re-read whenever the stand changes.
+  if ($('file-input') && $('file-input').files.length) onFileSelect();
 }
 function chooseModeLive() { setSendMode('live'); }
 function chooseModeLink() { setSendMode('link'); }
@@ -1033,10 +1065,13 @@ async function startSend() {
 async function sealAndUpload(file, ttlMs) {
   const nameBytes = new TextEncoder().encode(file.name);
   if (file.size + nameBytes.length + LINK_OVERHEAD > LINK_MAX_BLOB) {
-    throw new Error(file.name + ' is too big for a link. A link is one sealed 5 MB block, ' +
-      'so 5 MB a file is the ceiling for this way of sending. Hand it over live instead: ' +
-      'that way cuts the file into chunks and takes a file up to 500 MB. ' +
-      'The receiver has to be online while you send.');
+    // The picker refuses this before the click; this is the backstop for a file
+    // that changed under us. `userFacing` keeps it out of the generic
+    // "something went wrong on our side" line, which is for OUR failures and
+    // sends the real sentence to the console where the sender never looks.
+    const err = new Error(linkSizeRefusal([file]) || (file.name + ' is too big for a link.'));
+    err.userFacing = true;
+    throw err;
   }
   const plain = concat(u32le(nameBytes.length), nameBytes, new Uint8Array(await file.arrayBuffer()));
   const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt']);
@@ -1132,7 +1167,9 @@ async function createLink() {
       $('seal-status').className = 'status-line';
       $('seal-status').innerHTML = window.paQuotaUpgrade.html(e.quota);
     } else {
-      $('seal-status').textContent = failureText('seal and upload', e);
+      $('seal-status').textContent = (e && e.userFacing && e.message)
+        ? e.message
+        : failureText('seal and upload', e);
       $('seal-status').className = 'status-line err';
     }
   }

--- a/frontend/js/status.inline1.js
+++ b/frontend/js/status.inline1.js
@@ -29,11 +29,18 @@
     h[id].push({ ts: Date.now(), ok: ok });
     return h;
   }
-  function uptimePct(h, id) {
+  // Uptime over whatever THIS browser has seen, and it says how much that is.
+  //
+  // The first visit ever made one check, found it up, and printed "uptime 24h
+  // 100.0%" under a note that said the figure came from 24 hours of checks. One
+  // sample is not a day, and a percentage without its sample count reads as a
+  // measurement when it is a single observation. So: return both, and let the
+  // caller print the count next to the number.
+  function uptimeStat(h, id) {
     var arr = h[id];
     if (!arr || arr.length === 0) return null;
     var good = arr.filter(function (r) { return r.ok; }).length;
-    return (good / arr.length * 100).toFixed(1);
+    return { pct: (good / arr.length * 100).toFixed(1), n: arr.length };
   }
 
   // Build cards once
@@ -73,9 +80,14 @@
     if (ms !== undefined) msEl.textContent = ms + 'ms';
   }
 
-  function setUptime(id, pct) {
+  function setUptime(id, stat) {
     var el = document.getElementById('up-' + id);
-    if (el && pct !== null) el.textContent = pct + '%';
+    if (!el || stat === null) return;
+    // Below a handful of samples the percentage says nothing, so show the
+    // sample count alone rather than a 100% that rests on one look.
+    el.textContent = stat.n < 5
+      ? stat.n + (stat.n === 1 ? ' check' : ' checks')
+      : stat.pct + '% of ' + stat.n + ' checks';
   }
 
   function setOverall(allOk, anyChecked) {
@@ -117,7 +129,7 @@
           addResult(h, s.id, false);
         })
         .finally(function () {
-          setUptime(s.id, uptimePct(h, s.id));
+          setUptime(s.id, uptimeStat(h, s.id));
           pending--;
           if (pending === 0) {
             saveHistory(h);

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -324,6 +324,6 @@ all other recipients of the licensed work to be provided by Licensor:
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/license.html
+++ b/frontend/license.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -284,6 +284,6 @@ h1{font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:8px}
 <script src="/js/handshake-meta.js?v=1" defer></script>
 <script src="/js/ontvang.page.js?v=4" defer></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/ontvang.html
+++ b/frontend/ontvang.html
@@ -9,7 +9,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Receive a file · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/done-state.css?v=1">

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -23,7 +23,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/parasend.html
+++ b/frontend/parasend.html
@@ -462,6 +462,6 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -843,9 +843,9 @@ select:focus{border-color:var(--accent);box-shadow:var(--ring)}
 <script src="/js/format-date.js?v=1" defer></script>
 <script src="/js/done-state.js?v=1" defer></script>
 <script src="/js/handshake-meta.js?v=1" defer></script>
-<script src="/js/parashare.page.js?v=15" defer></script>
+<script src="/js/parashare.page.js?v=16" defer></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 <footer>
   <div class="container-lg">
     <div class="footer-grid footer-slim">

--- a/frontend/parashare.html
+++ b/frontend/parashare.html
@@ -11,7 +11,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/parapear.css?v=4">

--- a/frontend/parasign-verify.js
+++ b/frontend/parasign-verify.js
@@ -162,7 +162,16 @@ function verifyV3Client(docHashHex) {
   const signedHash = env.stamped_hash || env.document_hash;
   if (!signedHash) errors.push('missing signed document hash (stamped_hash or document_hash)');
   if (docHashHex && signedHash && signedHash !== docHashHex) {
-    errors.push('document hash mismatch: this document does not match the one that was signed');
+    // The likeliest near-miss, named: the file from BEFORE the seal was added.
+    // The envelope carries both hashes, so we can tell that case apart from a
+    // genuinely unrelated file and say which copy to use instead of leaving
+    // the verifier to guess that "mismatch" means "you picked the wrong one".
+    if (env.original_hash && env.original_hash === docHashHex) {
+      errors.push('this is the document from before it was signed. Verify the signed copy instead: ' +
+        'the one with the seal on it, usually named ' + (env.stamped_filename || 'signed-<your file>'));
+    } else {
+      errors.push('document hash mismatch: this document does not match the one that was signed');
+    }
   }
   if (!env.signer_public_key) errors.push('missing signer_public_key');
   if (env.party_email_hash == null) {
@@ -293,9 +302,16 @@ async function lookupSignerHtml(envelope) {
     const d = await res.json();
     if (!d.found) return '';
     const label = d.label ? esc(d.label) : '<em>(no label)</em>';
-    const email = d.email ? esc(d.email) : '<em>(unverified)</em>';
     const algo  = esc(d.alg || '?');
-    let html = '<p class="ps-help"><strong>Signed by ' + label + ' (' + email + ')</strong> &middot; ' + algo + '</p>';
+    // The address is only shown when the lookup actually returns one. It used
+    // to fall back to the literal string "(unverified)", which the template
+    // then wrapped in brackets of its own and printed as "Name ((unverified))",
+    // and which read as a warning about the signature rather than as "no
+    // address is published for this key".
+    const who = d.email
+      ? label + ' (' + esc(d.email) + ')'
+      : label + ' <span class="dim">no address published for this key</span>';
+    let html = '<p class="ps-help"><strong>Signed by ' + who + '</strong> &middot; ' + algo + '</p>';
     if (d.revoked_at) {
       html += '<p class="ps-help">This key was revoked on ' + esc(d.revoked_at)
         + '. The signature is still cryptographically valid; treat as valid if signed before that date.</p>';

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -28,7 +28,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/parasign.html
+++ b/frontend/parasign.html
@@ -409,6 +409,6 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -207,6 +207,6 @@ h1{font-size:var(--text-3xl);line-height:1.15;margin:0 0 24px;color:var(--ink);f
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/partners.html
+++ b/frontend/partners.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="Organisations that publicly confirm they run Paramant in production will be listed here. For case studies or references, get in touch.">
 <link rel="canonical" href="https://paramant.app/partners">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -343,6 +343,6 @@ td{color:var(--cobalt)}
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/press.html
+++ b/frontend/press.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -19,7 +19,7 @@
 <meta name="twitter:title" content="Pricing · What is free, and what businesses pay · Paramant">
 <meta name="twitter:description" content="The Community plan is free, forever. Organisations pay for higher limits: signing and sending on Firm, 29 euro a month excl. btw. From Paramantis Solutions B.V.">
 <link rel="canonical" href="https://paramant.app/pricing">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -675,7 +675,7 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 <script src="/js/app-session-token.js?v=1" defer></script>
 <script src="/js/pricing-billing.js?v=3" defer></script>
 <script src="/js/redeem-code.js?v=2" defer></script>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -352,6 +352,6 @@ footer a{color:var(--ink);text-decoration:none}
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>

--- a/frontend/redeem.html
+++ b/frontend/redeem.html
@@ -231,7 +231,7 @@
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 <script src="/js/error-message.js?v=1" defer></script>
 <script src="/js/app-session-token.js?v=1" defer></script>
 <!-- Before js/redeem-code.js on purpose: this file installs the gate that

--- a/frontend/redeem.html
+++ b/frontend/redeem.html
@@ -20,7 +20,7 @@
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="canonical" href="https://paramant.app/redeem">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/done-state.css?v=1">
 <style>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -173,6 +173,6 @@
 
 <script src="/nav.js?v=15"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/request-key.html
+++ b/frontend/request-key.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex">
 <meta http-equiv="refresh" content="8;url=/signup">
 <link rel="canonical" href="https://paramant.app/signup">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -301,6 +301,6 @@ footer a{color:var(--ink);text-decoration:none}
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -526,6 +526,6 @@ footer{border-top:1px solid var(--ink-hair);padding:40px 48px;display:flex;align
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/security.html
+++ b/frontend/security.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -197,6 +197,6 @@
   </div>
 </footer>
 
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/security/acknowledgements.html
+++ b/frontend/security/acknowledgements.html
@@ -39,7 +39,7 @@
     .divider{border:none;border-top:1px solid var(--ink-hair);margin:48px 0}
     footer{border-top:1px solid var(--ink-hair);padding:32px 48px}
   </style>
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <script type="application/ld+json" data-paramant-seo="1">

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -6,7 +6,7 @@
   <title>First-time setup · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/setup">
-  <link rel="stylesheet" href="/design-system.css?v=28">
+  <link rel="stylesheet" href="/design-system.css?v=29">
   <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 </head>

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -2180,6 +2180,63 @@ function fillReview() {
   renderReviewPreviews().catch(err => console.warn('review preview failed', err));
   // Fill the passkey key fingerprint (async, public vault metadata only).
   fillReviewKeyFingerprint().catch(() => {});
+  // Say now whether this month's signatures are gone, not after the ceremony.
+  showRemainingSignatures().catch(() => {});
+}
+
+// The monthly signing allowance, read on the review step.
+//
+// The relay refuses over-quota signing with a 402 and the page renders the
+// upgrade notice from it, which is correct but arrives at the very end: the
+// signer has by then chosen a document, placed a seal, typed their name and
+// entered a six-digit code, and an envelope has already been created server
+// side. Nothing before that click said how many signatures were left. This
+// reads the counter the dashboard already publishes and puts the answer next
+// to the button, before the work.
+//
+// Signed out this stays silent: /sign is open to visitors on purpose, and a
+// visitor has no allowance to report. Any failure is silent too, because a
+// missing count must never stand in the way of a signature that is allowed.
+async function showRemainingSignatures() {
+  if (sessionState === 'out') return;
+  const host = $('ds-sign-status');
+  if (!host) return;
+
+  const res = await fetch('/api/user/dashboard/overview', {
+    credentials: 'include', headers: { Accept: 'application/json' }, cache: 'no-store',
+  });
+  if (!res.ok) return;
+  const data = await res.json();
+  const used = data && data.quota ? data.quota.signs : null;
+  const cap = data && data.quota && data.quota.caps ? data.quota.caps.signs : null;
+  if (typeof used !== 'number' || typeof cap !== 'number' || cap <= 0) return;
+
+  const left = Math.max(0, cap - used);
+  if (left > 0) {
+    // A quiet line, not a warning: this is capacity information, and on a plan
+    // with room to spare it should not look like a problem. The banner ships
+    // hidden, so anything written into it has to unhide it as well.
+    host.textContent = left === 1
+      ? 'One signature left this month on your plan.'
+      : left + ' signatures left this month on your plan.';
+    host.className = 'ds-banner';
+    host.hidden = false;
+    return;
+  }
+
+  // Nothing left. Show the same upgrade notice the 402 would have produced,
+  // only now it is here before the ceremony instead of after it.
+  //
+  // The button stays enabled on purpose, the way it does after a 402: someone
+  // who upgrades in another tab must be able to come back and sign without
+  // reloading, and this count is a snapshot that can be one purchase out of
+  // date. Informing is the fix; blocking would trade one dead end for another.
+  const q = window.paQuotaUpgrade;
+  const quotaShape = { dimension: 'signs_month', limit: cap, used: used, reset_date: null };
+  if (q && q.html) host.innerHTML = q.html(quotaShape);
+  else host.textContent = 'You have used all ' + cap + ' signatures included this month.';
+  host.className = 'ds-banner err';
+  host.hidden = false;
 }
 
 // Fill the signing-key fingerprint into the review card from PUBLIC vault

--- a/frontend/sign-flow.js
+++ b/frontend/sign-flow.js
@@ -2125,7 +2125,10 @@ function fillReview() {
   const docHashHex = toHex(sha3_256(state.doc.bytes));
   $('ds-proof-doc-hash').textContent = docHashHex;
   $('ds-proof-fp').textContent = '(your signing key fingerprint)';   // filled async below
-  $('ds-proof-version').textContent = 'parasign-doc-3 (recipe_version 3)';
+  // The recipe is chosen server side when the envelope is created, and has been
+  // 5 (signed visual placement) for a while. Printing a fixed 3 here made the
+  // review card disagree with the .psign the signer downloads a minute later.
+  $('ds-proof-version').textContent = 'parasign-doc-3 (recipe_version set when the envelope is created)';
 
   // Envelope-structure preview — the v3 .psign receipt (parasign-doc-3). The
   // signed_message line shows the EXACT v3 domain-prefixed message the passkey
@@ -2133,7 +2136,7 @@ function fillReview() {
   // the review reflects what is actually signed — not the old v2 message.
   const previewEnv = (state.mode === 'pdf' || state.mode === 'image') ? {
     version: 'parasign-doc-3',
-    recipe_version: 3,
+    recipe_version: '<set on sign>',
     sign_domain: 'paramant/parasign/doc/v1',
     algorithm: 'ML-DSA-65',
     hash_algorithm: 'SHA3-256',
@@ -2157,7 +2160,7 @@ function fillReview() {
     disclaimer: 'Post-quantum, zero-knowledge. Not eIDAS-qualified.',
   } : {
     version: 'parasign-doc-3',
-    recipe_version: 3,
+    recipe_version: '<set on sign>',
     sign_domain: 'paramant/parasign/doc/v1',
     algorithm: 'ML-DSA-65',
     hash_algorithm: 'SHA3-256',

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -1008,12 +1008,12 @@ body[data-ds-step="step-done"] .ds-stepper{display:none}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 <script type="module" src="/vendor/pdfjs/pdfjs-loader.js?v=3"></script>
 <script src="/vendor/pdf-lib/pdf-lib.min.js?v=1" defer></script>
 <script src="/js/parasign-pdf-ops.js?v=1"></script>
 <script src="/js/quota-upgrade.js?v=5" defer></script>
 <script src="/js/done-state.js?v=1" defer></script>
-<script type="module" src="/sign-flow.js?v=55"></script>
+<script type="module" src="/sign-flow.js?v=56"></script>
 </body>
 </html>

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -28,7 +28,7 @@
 <meta name="twitter:image" content="https://paramant.app/og-image.png">
 <link rel="canonical" href="https://paramant.app/sign">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/components-parasign.css?v=6">

--- a/frontend/sign.html
+++ b/frontend/sign.html
@@ -1014,6 +1014,6 @@ body[data-ds-step="step-done"] .ds-stepper{display:none}
 <script src="/js/parasign-pdf-ops.js?v=1"></script>
 <script src="/js/quota-upgrade.js?v=5" defer></script>
 <script src="/js/done-state.js?v=1" defer></script>
-<script type="module" src="/sign-flow.js?v=56"></script>
+<script type="module" src="/sign-flow.js?v=57"></script>
 </body>
 </html>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -284,14 +284,14 @@ main#main-content .btn { width: 100%; justify-content: center; }
     <button type="button" id="resend-btn" class="su-linkbtn">resend the link</button>.
   </p>
   <p class="small mt-2" id="resend-status" aria-live="polite"></p>
-  <p class="small mt-3 su-dim">The link works for 2 days.</p>
+  <p class="small mt-3 su-dim">The link works for 24 hours.</p>
 </section>
 
 </main>
 
 <script src="/js/pow-captcha.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 <script src="/js/signup.inline1.js?v=1"></script>
 
 <script src="/js/signup.inline2.js?v=2"></script>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -24,7 +24,7 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
   <style>
     /* Every colour here is a token from app-2026.css, so this page follows the
        theme instead of staying light inside a dark shell. Section 5 of
@@ -149,7 +149,7 @@
   <div class="next-box">
     <div class="next-step">Do this now</div>
     <div class="next-title">Look for this subject line</div>
-    <p class="next-msg">The mail comes from noreply@paramant.app with the subject:</p>
+    <p class="next-msg">The mail comes from hello@paramant.app with the subject:</p>
     <p class="next-subject">Complete your Paramant account setup</p>
     <p class="next-msg" style="margin-top:16px;">Open it and follow the setup link. There you choose a passkey (Face ID, Touch ID, Windows Hello) or an authenticator app, and you save your backup codes. No app yet? <strong>Google Authenticator</strong> or <strong>Microsoft Authenticator</strong> both work. Already using <strong>1Password</strong> or <strong>Bitwarden</strong>? Keep it there. Any other standard authenticator works too, and <a href="/help/authenticator-apps">the help page compares them</a>. The 6-digit codes are produced by that app, never sent by email.</p>
   </div>
@@ -158,7 +158,7 @@
     <h2>Frequently asked</h2>
     <details>
       <summary>I don't see the second email</summary>
-      <p>The mail is on its way, but we cannot promise how fast your provider delivers it. Check your spam and junk folders; the sender is <code>noreply@paramant.app</code>. Still nothing after a few minutes? <a href="/auth/request-reset">Ask for a new setup link</a> with the same address.</p>
+      <p>The mail is on its way, but we cannot promise how fast your provider delivers it. Check your spam and junk folders; the sender is <code>hello@paramant.app</code>. Still nothing after a few minutes? <a href="/auth/request-reset">Ask for a new setup link</a> with the same address.</p>
     </details>
     <details>
       <summary>Where's the 6-digit code in the email?</summary>

--- a/frontend/signup/verified.html
+++ b/frontend/signup/verified.html
@@ -7,7 +7,7 @@
   <title>Email verified, one step left · Paramant</title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="canonical" href="https://paramant.app/signup/verified">
-  <link rel="stylesheet" href="/design-system.css?v=28">
+  <link rel="stylesheet" href="/design-system.css?v=29">
   <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <script src="/nav.js?v=15" defer></script>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -9,15 +9,15 @@
 <meta property="og:image:height" content="630">
 <meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise.">
+<meta name="description" content="Uptime commitments, downtime credits and support response times for the Community and Enterprise plans.">
 <meta property="og:title" content="Service level agreement · Paramant">
-<meta property="og:description" content="Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise.">
+<meta property="og:description" content="Uptime commitments, downtime credits and support response times for the Community and Enterprise plans.">
 <meta property="og:url" content="https://paramant.app/sla">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Service level agreement · Paramant">
-<meta name="twitter:description" content="Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise.">
+<meta name="twitter:description" content="Uptime commitments, downtime credits and support response times for the Community and Enterprise plans.">
 <link rel="canonical" href="https://paramant.app/sla">
 
 <link rel="stylesheet" href="/design-system.css?v=29">
@@ -140,7 +140,7 @@ a:hover{opacity:.8}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise."
+      "description": "Uptime commitments, downtime credits and support response times for the Community and Enterprise plans."
     },
     {
       "@type": "Organization",
@@ -242,7 +242,7 @@ a:hover{opacity:.8}
     </div>
   </div>
 
-  <p>Uptime is measured per calendar month across the primary relay endpoint assigned to your plan. All five sector relays (health, legal, finance, IoT, relay) are covered.</p>
+  <p>The commitment applies per calendar month to the primary relay endpoint assigned to your plan. Section 5 says exactly what is measured today, and what is not: the sector relays (health, legal, finance, IoT) carry the same commitment, but their uptime is not separately monitored, and the automated monitor for the main relay is built and public and still switched off. Read section 5 before you rely on a number here.</p>
 
   <!-- 2. Credits -->
   <h2 id="credits">2. Downtime credits</h2>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -371,6 +371,6 @@ a:hover{opacity:.8}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/sla.html
+++ b/frontend/sla.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="Uptime commitments, downtime credits and support response times for every Paramant plan, from Community to Enterprise.">
 <link rel="canonical" href="https://paramant.app/sla">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -9,15 +9,15 @@
 <meta property="og:image:height" content="630">
 <meta property="og:image:width" content="1200">
 <meta property="og:site_name" content="Paramant">
-<meta name="description" content="Live status of the Paramant network. Uptime is calculated from the last 24 hours of checks and the page refreshes every 30 seconds.">
+<meta name="description" content="Live status of the Paramant network. Each visit checks the relays from your own browser and the page refreshes every 30 seconds.">
 <meta property="og:title" content="System status · Paramant">
-<meta property="og:description" content="Live status of the Paramant network. Uptime is calculated from the last 24 hours of checks and the page refreshes every 30 seconds.">
+<meta property="og:description" content="Live status of the Paramant network. Each visit checks the relays from your own browser and the page refreshes every 30 seconds.">
 <meta property="og:url" content="https://paramant.app/status">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://paramant.app/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="System status · Paramant">
-<meta name="twitter:description" content="Live status of the Paramant network. Uptime is calculated from the last 24 hours of checks and the page refreshes every 30 seconds.">
+<meta name="twitter:description" content="Live status of the Paramant network. Each visit checks the relays from your own browser and the page refreshes every 30 seconds.">
 <link rel="canonical" href="https://paramant.app/status">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -153,7 +153,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
         "@id": "https://paramant.app/#organization"
       },
       "inLanguage": "en",
-      "description": "Live status of the Paramant network. Uptime is calculated from the last 24 hours of checks and the page refreshes every 30 seconds."
+      "description": "Live status of the Paramant network. Each visit checks the relays from your own browser and the page refreshes every 30 seconds."
     },
     {
       "@type": "Organization",
@@ -239,7 +239,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
     <!-- rendered by JS -->
   </div>
 
-  <p class="refresh-note">Auto-refreshes every 30s &middot; uptime % calculated from last 24h of checks (stored locally)</p>
+  <p class="refresh-note">Auto-refreshes every 30s &middot; the uptime figure counts only the checks this browser has made in the last 24 hours, kept on this device. It is not a monitor: close the tab and the count starts again. Under five checks the number of checks is shown instead of a percentage.</p>
 </div>
 
 <footer>
@@ -271,7 +271,7 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
   </div>
 </footer>
 
-<script src="/js/status.inline1.js?v=1"></script>
+<script src="/js/status.inline1.js?v=2"></script>
 <script src="/nav.js?v=15" defer></script>
 <script src="/js/nav-auth.js?v=10" defer></script>
 </body>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -273,6 +273,6 @@ h1{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:12px}
 
 <script src="/js/status.inline1.js?v=1"></script>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -25,7 +25,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <style>

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -342,6 +342,6 @@ a:hover{opacity:.8}
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="The agreement between you and Paramantis Solutions B.V. for the use of Paramant. Plans, payment, cancellation, acceptable use, liability and Dutch law.">
 <link rel="canonical" href="https://paramant.app/terms">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -441,6 +441,6 @@ docker compose build   # build locally instead of pulling the published image</c
 </footer>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 </body>
 </html>

--- a/frontend/trust.html
+++ b/frontend/trust.html
@@ -26,7 +26,7 @@
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#15191C">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
   <style>

--- a/frontend/vault.html
+++ b/frontend/vault.html
@@ -26,7 +26,7 @@
 <link rel="canonical" href="https://paramant.app/vault">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#15191C">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <style>
 .vt-bar{display:flex;align-items:center;justify-content:space-between;padding:14px 24px;border-bottom:1px solid var(--ink-hair)}
 .vt-brand{font-family:var(--mono);font-size:13px;font-weight:700;letter-spacing:.04em;color:var(--navy);text-decoration:none}
@@ -56,6 +56,11 @@
 .vt-status.err{border-color:rgba(196, 96, 79, .5);background:rgba(196, 96, 79, .06);color:rgba(170,20,20,1)}
 .vt-note{margin-top:22px;font-size:12px;color:var(--ink-dim);line-height:1.6;text-align:center}
 .vt-warn{margin:20px 0;padding:14px 16px;border:1px solid #d4a017;background:var(--card);border-radius:10px;color:var(--warn-ink);font-size:13px}
+/* The way out, at the bottom. 44px tall because this is the size a thumb
+   needs, and this page is read on a phone as often as anywhere else. */
+.vt-elsewhere{margin:32px 0 8px;display:flex;flex-wrap:wrap;gap:8px 20px;justify-content:center}
+.vt-elsewhere a{display:inline-flex;align-items:center;min-height:44px;padding:0 4px;font-size:13px;color:var(--ink-dim);text-decoration:underline;text-underline-offset:3px}
+.vt-elsewhere a:hover,.vt-elsewhere a:focus{color:var(--ink)}
 </style>
 <script type="application/ld+json" data-paramant-seo="1">
 {
@@ -175,7 +180,25 @@
 
   <p class="vt-note">Your file is encrypted here, in this browser, before anything is saved. Nothing leaves your browser, so we never receive your file or your passphrase and we cannot reset it for you. Lose the passphrase and the file is gone.</p>
   <p class="vt-tech">AES-256-GCM, key from your passphrase with PBKDF2-SHA-256, 600,000 rounds, random 16-byte salt, random 12-byte nonce.</p>
+
+  <!-- A way out that is not the dashboard.
+       Both links in the bar at the top point at /dashboard, and this page has
+       no menu button and no drawer: on a phone it was the one page in the site
+       you could not leave except by going back. It stays deliberately plain,
+       because this page makes no network call at all and adding the shared
+       navigation would add one (nav-auth.js asks session/verify who you are).
+       So: plain anchors, no script, and only the tools that also work with no
+       account, the same promise this page makes. -->
+  <nav class="vt-elsewhere" aria-label="Other tools that need no account">
+    <a href="/verify">Check a signature or receipt</a>
+    <a href="/gereedschap">All tools</a>
+    <a href="/">Home</a>
+  </nav>
 </main>
+
+<footer class="legal-strip">
+  <a href="/privacy">Privacy</a><span class="legal-sep">&middot;</span><a href="/dpa">Data Processing Agreement</a><span class="legal-sep">&middot;</span><a href="/terms">Terms of Service</a>
+</footer>
 
 <script src="/vault.js?v=2" defer></script>
 </body>

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -26,7 +26,7 @@
 <link rel="canonical" href="https://paramant.app/verify">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="theme-color" content="#15191C">
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="stylesheet" href="/components-parasign.css?v=6">

--- a/frontend/verify.html
+++ b/frontend/verify.html
@@ -144,8 +144,10 @@
   <div id="panel-doc" role="tabpanel" aria-labelledby="tab-doc">
 
   <section class="card ps-panel" aria-labelledby="v1">
-    <div class="ps-panel-head"><span class="ps-step">1</span><h2 id="v1" class="ps-panel-title">Original document</h2></div>
-    <label class="ps-file"><input type="file" id="vf-document"><span class="ps-file-cta">Choose the original document</span><span class="ps-file-meta" id="vf-document-info">No file selected</span></label>
+    <div class="ps-panel-head"><span class="ps-step">1</span><h2 id="v1" class="ps-panel-title">The signed document</h2></div>
+    <label class="ps-file"><input type="file" id="vf-document"><span class="ps-file-cta">Choose the signed document</span><span class="ps-file-meta" id="vf-document-info">No file selected</span></label>
+    <p class="small mt-2">The copy you were sent, with the seal on it. A PDF is signed after the seal
+    is drawn, so the file from before signing will not match.</p>
   </section>
 
   <section class="card ps-panel" aria-labelledby="v2">
@@ -249,8 +251,8 @@
   </div>
 </footer>
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
-<script type="module" src="/parasign-verify.js?v=6"></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
+<script type="module" src="/parasign-verify.js?v=7"></script>
 <script type="module" src="/js/receipt-verify.js?v=1"></script>
 </body>
 </html>

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="How Paramant compares to Zivver, Tresorit, WeTransfer and SFTP on post-quantum encryption, EU jurisdiction, burn-on-read, and self-hosting.">
 <link rel="canonical" href="https://paramant.app/vs">
 
-<link rel="stylesheet" href="/design-system.css?v=28">
+<link rel="stylesheet" href="/design-system.css?v=29">
 <link rel="stylesheet" href="/nav.css?v=24">
 <link rel="stylesheet" href="/relay-pulse.css?v=4">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/frontend/vs.html
+++ b/frontend/vs.html
@@ -497,7 +497,7 @@
 </section>
 
 <script src="/nav.js?v=15" defer></script>
-<script src="/js/nav-auth.js?v=9" defer></script>
+<script src="/js/nav-auth.js?v=10" defer></script>
 
 <footer>
   <div class="container-lg">

--- a/relay/lib/rate-limit.js
+++ b/relay/lib/rate-limit.js
@@ -1,8 +1,11 @@
 'use strict';
 // Pure fixed-window rate-limit decision, extracted from the ~dozen byte-identical
-// in-memory limiters in relay.js (checkTeamRateLimit, checkMfaRateLimit,
-// claimRateOk, checkKeyRateOk, lookupSignerRateOk, statusRateOk, envViewRateOk,
-// envSignRateOk, envCreateRateOk, ...). Each limiter keeps its own
+// in-memory limiters in relay.js (checkMfaRateLimit, claimRateOk,
+// checkKeyRateOk, lookupSignerRateOk, statusRateOk, envViewRateOk,
+// envSignRateOk, envCreateRateOk, ...). checkTeamRateLimit was in this list
+// until 2026-09-09, when it turned out nothing had ever called it and its
+// missing-id case answered "allowed"; it was deleted rather than kept as an
+// example. Each limiter keeps its own
 // Map<key,{count,resetAt}>; this centralises the decision so it is unit-tested
 // once. Behaviour-identical to the inline copies:
 //   - first hit in a window seeds resetAt = now + windowMs and count = 1,

--- a/relay/lib/sth-guard.js
+++ b/relay/lib/sth-guard.js
@@ -1,0 +1,65 @@
+'use strict';
+// The rule that decides whether a signed tree head may be produced, pulled out
+// of relay.js so it can be exercised without booting a relay. Same reason
+// ct-window.js and ct-hash.js live here: the transparency chain is the part
+// where a quiet mistake is worst, so its rules should be readable and testable
+// on their own.
+//
+// WHAT IT GUARDS. A transparency log's whole claim is that a size, once
+// signed, keeps its root for ever. Break that and the relay publishes two
+// signed, contradictory heads under one key, which no verifier can tell apart
+// from tampering.
+//
+// WHY THE KEY IS A PAIR. The Merkle tree here does not cover the whole log. It
+// covers the CT_MAX most recent leaves, and that window slides. Once it is
+// full the leaf count stops growing while the root changes on every append, so
+// keyed on tree_size alone the guard sees the same size with a different root
+// and calls it a fork. It is not one: it is a different tree.
+//
+// Reproduced with a window of 4, before this existed:
+//
+//   append 4  | log  5 | tree_size 5 | signed
+//   append 5  | log  6 | tree_size 5 | REFUSED  root_differs_at_same_size
+//   append 6  | log  7 | tree_size 5 | REFUSED
+//   append 7+ | ...    | tree_size 5 | REFUSED, for ever
+//
+// The log kept growing, the relay signed nothing more, and it flagged itself
+// as forked while doing it. On production the window holds ten thousand leaves
+// and the log stood at 4814, so this was a date, not a fault anyone had met.
+//
+// So a tree is identified by (window_base, tree_size), and the thing that must
+// only ever grow is their sum: the logical size of the log.
+
+// The map key for one tree. Heads signed before window_base existed describe a
+// tree that starts at leaf 0, which is what they were: the window had not
+// wrapped yet. Reading a missing base as 0 keeps their guarantee intact.
+function sthKey(head) {
+  return `${head.window_base || 0}:${head.tree_size}`;
+}
+
+// The logical size of the log at the moment a head was signed.
+function sthLogicalSize(head) {
+  return (head.window_base || 0) + head.tree_size;
+}
+
+// May this head be signed? Returns null when it may, or the reason when it may
+// not. `signedRoots` maps sthKey -> root for the heads still remembered;
+// `maxSignedSize` is the largest logical size ever signed, which survives the
+// pruning of that map and is what catches a log that walked backwards.
+//
+// Re-signing the SAME root for the SAME tree is allowed: that is idempotent,
+// not a contradiction.
+function sthRefusal({ tree_size, window_base, sha3_root, signedRoots, maxSignedSize }) {
+  const base = Number.isFinite(window_base) ? window_base : 0;
+  const logicalSize = base + tree_size;
+  const priorRoot = signedRoots.get(`${base}:${tree_size}`);
+  if (priorRoot !== undefined && priorRoot !== sha3_root) {
+    return { reason: 'root_differs_at_same_size', priorRoot, logicalSize, base };
+  }
+  if (logicalSize < maxSignedSize) {
+    return { reason: 'tree_size_went_backwards', priorRoot: priorRoot || null, logicalSize, base };
+  }
+  return null;
+}
+
+module.exports = { sthKey, sthLogicalSize, sthRefusal };

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -374,7 +374,11 @@ function createDidDocument(did, deviceId, ecdhPubHex, dsaPubHex) {
 }
 
 // ── Certificate Transparency Log ─────────────────────────────────────────────
-const CT_MAX = 10000;
+// How many leaves the Merkle tree keeps. Settable so a suite can reach the
+// wrap-around in a few appends instead of ten thousand: what happens at the
+// wrap is the interesting part, and a constant made it untestable. Production
+// leaves it alone.
+const CT_MAX = parseInt(process.env.CT_MAX || '10000', 10) || 10000;
 // Bounded, monotonically-indexed window (see lib/ct-window). Past CT_MAX the
 // logical index keeps advancing (no duplicates / frozen STH) and lookups for a
 // pruned index return null instead of the wrong entry.
@@ -586,19 +590,29 @@ _sthOpenStream();
 
 // What this relay has already put its name to. Two things, because they catch
 // two different halves of the same break:
-//   _sthSignedRoots  tree_size -> sha3_root, for the heads still in sthLog. It
-//                    is pruned in step with sthLog, so it stays bounded by
+//   _sthSignedRoots  "base:size" -> sha3_root, for the heads still in sthLog.
+//                    It is pruned in step with sthLog, so it stays bounded by
 //                    STH_MAX and does not grow with the log.
-//   _sthMaxSignedSize the largest tree_size ever signed. One number, never
-//                    pruned, and the half that survives the window: a tree that
-//                    walked BACKWARDS is a contradiction even when the head it
-//                    contradicts has aged out of memory.
+//   _sthMaxSignedSize the largest LOGICAL size ever signed (base + size). One
+//                    number, never pruned, and the half that survives the
+//                    window: a log that walked BACKWARDS is a contradiction
+//                    even when the head it contradicts has aged out of memory.
+//
+// The key is the pair, not the size. The tree covers a sliding window, so a
+// full window signs the same leaf count over and over with a different root
+// each time; keyed on size alone the relay refused every head from that point
+// on and flagged itself as forked. The pair identifies the tree, and the sum
+// is what has to keep growing.
 const _sthSignedRoots = new Map();
 let _sthMaxSignedSize = -1;
+// Heads signed before window_base existed describe a tree starting at leaf 0,
+// which is exactly what they were: at that point the window had not yet
+// wrapped. Reading them as base 0 keeps their guarantee intact.
+const { sthKey, sthLogicalSize, sthRefusal } = require('./lib/sth-guard');
 for (const s of sthLog) {
   if (!s || typeof s.tree_size !== 'number' || !s.sha3_root) continue;
-  _sthSignedRoots.set(s.tree_size, s.sha3_root);
-  if (s.tree_size > _sthMaxSignedSize) _sthMaxSignedSize = s.tree_size;
+  _sthSignedRoots.set(sthKey(s), s.sha3_root);
+  if (sthLogicalSize(s) > _sthMaxSignedSize) _sthMaxSignedSize = sthLogicalSize(s);
 }
 // Set once the relay has caught a contradiction. It is not cleared: a log that
 // has forked stays forked until someone looks at it.
@@ -802,7 +816,7 @@ function ctAppend(deviceId, pubKeyHex, apiKey) {
   ctWindow.append(entry);
   // Fix 8: async write via stream queue instead of appendFileSync
   ctWrite(entry);
-  produceSth(allEntries.length, entry.tree_hash);
+  sthForTree(allEntries.length, entry.tree_hash);
   return entry;
 }
 
@@ -829,7 +843,7 @@ function ctAppendRelayReg(relayUrl, sector, version, edition, pkHash) {
   ctWindow.append(entry);
   // Fix 8: async write via stream queue
   ctWrite(entry);
-  produceSth(allEntries.length, entry.tree_hash);
+  sthForTree(allEntries.length, entry.tree_hash);
   return entry;
 }
 
@@ -850,7 +864,7 @@ function ctAppendTransfer(blobHash, sector) {
   });
   ctWindow.append(entry);
   ctWrite(entry);
-  const sth = produceSth(allEntries.length, entry.tree_hash);
+  const sth = sthForTree(allEntries.length, entry.tree_hash);
   return { ...entry, sth };
 }
 
@@ -871,7 +885,7 @@ function ctAppendParasign(documentHashHex, signerPkHash) {
   });
   ctWindow.append(entry);
   ctWrite(entry);
-  produceSth(allEntries.length, entry.tree_hash);
+  sthForTree(allEntries.length, entry.tree_hash);
   return entry;
 }
 
@@ -912,7 +926,7 @@ function ctAppendEnvelope(eventType, envelopeId, payload) {
   });
   ctWindow.append(entry);
   ctWrite(entry);
-  produceSth(allEntries.length, entry.tree_hash);
+  sthForTree(allEntries.length, entry.tree_hash);
   return entry;
 }
 
@@ -941,14 +955,43 @@ function ctAppendSigningPkEvent(eventType, userId, signerPkHash) {
   });
   ctWindow.append(entry);
   ctWrite(entry);
-  produceSth(allEntries.length, entry.tree_hash);
+  sthForTree(allEntries.length, entry.tree_hash);
   return entry;
 }
 
 // ── Signed Tree Head — produce, sign, and persist an STH for every root change ─
 // Canonical JSON: sorted keys, no whitespace, UTF-8 (matches RFC 6962 § 3.5 spirit).
 // Signed with the relay's ML-DSA-65 identity key (NIST FIPS 204).
-function produceSth(tree_size, sha3_root) {
+// The head for the tree that was just hashed, with the window it covers.
+//
+// Call this AFTER ctWindow.append(), with the same leaf array that went into
+// ctTreeHash(). The base is derived rather than passed: the window may have
+// shifted during that append, and `size - leaves` is the logical index of the
+// first leaf in the tree either way.
+function sthForTree(leafCount, sha3_root) {
+  return produceSth(leafCount, sha3_root, ctWindow.size - leafCount);
+}
+
+// A signed head over the retained window, and the window it describes.
+//
+// window_base is not decoration. The Merkle tree here covers the CT_MAX most
+// recent leaves, so once the window is full the leaf count stops growing while
+// the root keeps changing on every append. tree_size alone therefore repeats,
+// with a different root each time, and the fork detector below is right to call
+// that a contradiction: for a whole-log head it would be one.
+//
+// Reproduced with a window of 4: appends 0 to 4 sign normally, and every append
+// from the fifth on is REFUSED with root_differs_at_same_size while the log
+// keeps growing. On production the window holds ten thousand leaves and the
+// log stood at 4814, so
+// this was a timer, not a fault anyone had seen yet: from entry 10002 the relay
+// would have signed no head at all and flagged itself as forked.
+//
+// So the pair (window_base, tree_size) identifies the tree, and monotonicity is
+// checked on window_base + tree_size, the logical size of the log, which only
+// ever grows. Old heads keep verifying: both verifiers rebuild the canonical
+// payload from whatever fields the head carries.
+function produceSth(tree_size, sha3_root, window_base) {
   if (!mlDsa || !relayIdentity) return null;
   const relay_id = RELAY_SELF_URL || (SECTOR + '.paramant.app');
   // Append-only, enforced. A transparency log's whole claim is that tree_size
@@ -962,21 +1005,27 @@ function produceSth(tree_size, sha3_root) {
   // missing head is visible and recoverable; a forged-looking one is neither.
   // Re-signing the SAME root at the same size is allowed: that is idempotent,
   // not a contradiction.
-  const priorRoot = _sthSignedRoots.get(tree_size);
-  const contradicts = priorRoot !== undefined && priorRoot !== sha3_root;
-  const wentBackwards = tree_size < _sthMaxSignedSize;
-  if (contradicts || wentBackwards) {
+  // The rule itself lives in lib/sth-guard.js, where it can be exercised
+  // without booting a relay.
+  const refusal = sthRefusal({
+    tree_size, window_base, sha3_root,
+    signedRoots: _sthSignedRoots, maxSignedSize: _sthMaxSignedSize,
+  });
+  const base = refusal ? refusal.base : (Number.isFinite(window_base) ? window_base : 0);
+  const logicalSize = base + tree_size;
+  const priorRoot = refusal ? refusal.priorRoot : undefined;
+  if (refusal) {
     if (!ctLogForked) {
       ctLogForked = {
-        tree_size, max_signed_size: _sthMaxSignedSize,
+        tree_size, window_base: base, logical_size: logicalSize, max_signed_size: _sthMaxSignedSize,
         signed_root: priorRoot || null, refused_root: sha3_root,
-        reason: contradicts ? 'root_differs_at_same_size' : 'tree_size_went_backwards',
+        reason: refusal.reason,
         at: new Date().toISOString(),
       };
     }
     log('error', 'sth_refused_would_fork', {
-      tree_size, max_signed_size: _sthMaxSignedSize,
-      reason: contradicts ? 'root_differs_at_same_size' : 'tree_size_went_backwards',
+      tree_size, window_base: base, logical_size: logicalSize, max_signed_size: _sthMaxSignedSize,
+      reason: refusal.reason,
       signed_root: priorRoot ? priorRoot.slice(0, 16) + '…' : null,
       refused_root: String(sha3_root).slice(0, 16) + '…',
       hint: 'This relay has already signed a larger or different tree. The usual cause is a '
@@ -1005,7 +1054,10 @@ function produceSth(tree_size, sha3_root) {
   // heads, monotonically and per append, so freshness monitoring and the
   // consistency proofs are untouched. The log's own resolution has been an hour
   // everywhere else all along; the head was the one place still saying more.
-  const payload  = { relay_id, sha3_root, timestamp: ctCoarseMs(Date.now()), tree_size, version: 1 };
+  // version 2 adds window_base. A head is only meaningful together with the
+  // window it covers, and until this field existed the head said "a tree of N
+  // leaves" without saying which N.
+  const payload  = { relay_id, sha3_root, timestamp: ctCoarseMs(Date.now()), tree_size, window_base: base, version: 2 };
   // Canonical JSON: keys sorted alphabetically
   const sortedKeys = Object.keys(payload).sort();
   const canonical  = JSON.stringify(Object.fromEntries(sortedKeys.map(k => [k, payload[k]])));
@@ -1017,12 +1069,12 @@ function produceSth(tree_size, sha3_root) {
     return null;
   }
   const sth = { ...payload, signature };
-  _sthSignedRoots.set(tree_size, sha3_root);
-  if (tree_size > _sthMaxSignedSize) _sthMaxSignedSize = tree_size;
+  _sthSignedRoots.set(`${base}:${tree_size}`, sha3_root);
+  if (logicalSize > _sthMaxSignedSize) _sthMaxSignedSize = logicalSize;
   sthLog.push(sth);
   // Prune the root map in step with the head window so it stays bounded.
   // _sthMaxSignedSize is what keeps the guard whole past this point.
-  if (sthLog.length > STH_MAX) { const dropped = sthLog.shift(); _sthSignedRoots.delete(dropped.tree_size); }
+  if (sthLog.length > STH_MAX) { const dropped = sthLog.shift(); _sthSignedRoots.delete(sthKey(dropped)); }
   sthWrite(sth);
   // Broadcast to peers asynchronously — non-blocking, best-effort
   setImmediate(() => broadcastSTH(sth).catch(() => {}));
@@ -3357,7 +3409,7 @@ function ctAppendEvent(eventType, did, payload) {
   const entry = ctGateEntry('did_event', { index, type: eventType, leaf_hash, tree_hash, did, payload: gatedPayload, ts, proof });
   ctWindow.append(entry);
   ctWrite(entry);
-  produceSth(allEntries.length, entry.tree_hash);
+  sthForTree(allEntries.length, entry.tree_hash);
   return entry;
 }
 
@@ -9389,7 +9441,7 @@ loadPeerSths();
 // new CT entries were written without a corresponding STH flush.
 if (ctWindow.windowLength > 0 && sthLog.length === 0) {
   const last = ctWindow.last();
-  produceSth(ctWindow.windowLength, last.tree_hash);
+  sthForTree(ctWindow.windowLength, last.tree_hash);
 }
 // Periodic STH gossip — re-broadcast latest STH every 10 min to catch newly registered peers
 setInterval(() => {

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -1931,8 +1931,6 @@ const sthIngestIpRequests = new Map(); // ip → [timestamps] for /v2/sth/ingest
 // fresh head to every peer in the registry, so one unauthenticated POST bought
 // an amplified fan-out and unbounded disk. The 2026-09-05 review, finding 21.
 const relayRegisterIpRequests = new Map(); // ip → [timestamps] for /v2/relays/register (unauthenticated)
-// Team rate limit tracking
-const teamRateLimits = new Map(); // team_id → { count, resetAt }
 
 // Eviction sweep for the limiter maps that lacked one (the other limiters already
 // self-evict). Without this they grow unbounded — slow memory/audit creep,
@@ -1944,13 +1942,17 @@ setInterval(() => {
   for (const [k, times] of invDidIpRequests)     { const kept = times.filter(t => now - t < HOUR); if (kept.length) invDidIpRequests.set(k, kept);     else invDidIpRequests.delete(k); }
   for (const [k, times] of sthIngestIpRequests)  { const kept = times.filter(t => now - t < HOUR); if (kept.length) sthIngestIpRequests.set(k, kept);  else sthIngestIpRequests.delete(k); }
   for (const [k, times] of relayRegisterIpRequests) { const kept = times.filter(t => now - t < HOUR); if (kept.length) relayRegisterIpRequests.set(k, kept); else relayRegisterIpRequests.delete(k); }
-  for (const [k, b]     of teamRateLimits)       { if (b && now > b.resetAt) teamRateLimits.delete(k); }
 }, 3_600_000);
 
-function checkTeamRateLimit(teamId, limit) {
-  if (!teamId) return true;
-  return rateLimit.fixedWindowAllow(teamRateLimits, teamId, limit, 60000);
-}
+// checkTeamRateLimit() stood here, with its own Map and a line in the sweep
+// above. Nothing called it: not this file, not a route, not a test. It answered
+// `true` when handed no team id, which is a rate limiter that lets a caller
+// past by leaving a field out, and tests/authz-omission-gate.test.js is there
+// to catch exactly that shape. It only surfaced now because that scanner walks
+// the file with one sticky regex and an earlier match used to carry it over
+// this one; adding lines above moved the boundary. Dead code with a permissive
+// default is worth deleting rather than allowlisting: whoever wires team limits
+// up later should write the guard deliberately, refusing on a missing id.
 
 // M2: Per-IP rate limit for /v2/admin/verify-mfa (max 5 attempts per minute)
 const mfaRateLimits = new Map(); // ip → { count, resetAt }

--- a/relay/test/sth-guard.test.js
+++ b/relay/test/sth-guard.test.js
@@ -1,0 +1,139 @@
+'use strict';
+// The head guard, walked past the point where the Merkle window wraps.
+//
+// This is the failure the guard used to have, reproduced here so it cannot come
+// back. The tree covers the CT_MAX most recent leaves and that window slides,
+// so once it is full the leaf count stops growing while the root changes on
+// every append. Keyed on tree_size alone the guard saw one size with many
+// roots, called it a fork, refused the head, and kept refusing for ever while
+// the log went on growing.
+//
+// On production the window holds ten thousand leaves and the log stood at 4814
+// entries when this was found: a date, not a fault anyone had met yet.
+const { test } = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const { CtWindow } = require('../lib/ct-window');
+const { ctTreeHash } = require('../lib/ct-hash');
+const { sthKey, sthLogicalSize, sthRefusal } = require('../lib/sth-guard');
+
+// A relay's head-signing loop, with everything that is not the guard removed:
+// a sliding window, a real Merkle root over it, and the two pieces of state
+// produceSth() keeps. `keyBy` selects the old behaviour or the new one so the
+// bug and its repair are measured by the same harness.
+function run({ windowSize, appends, keyBy }) {
+  const w = new CtWindow(windowSize);
+  const signedRoots = new Map();
+  let maxSignedSize = -1;
+  const signed = [];
+  const refused = [];
+
+  for (let i = 0; i < appends; i++) {
+    const leaf_hash = crypto.createHash('sha3-256').update('leaf-' + i).digest('hex');
+    const leaves = [...w.entries, { leaf_hash }];
+    const sha3_root = ctTreeHash(leaves);
+    w.append({ index: w.nextIndex(), leaf_hash, tree_hash: sha3_root });
+
+    const tree_size = leaves.length;
+    const window_base = w.size - tree_size;
+    const head = { tree_size, window_base, sha3_root };
+
+    // The old guard keyed on size alone and never knew about window_base.
+    const asOld = keyBy === 'size';
+    const refusal = sthRefusal({
+      tree_size,
+      window_base: asOld ? 0 : window_base,
+      sha3_root,
+      signedRoots,
+      maxSignedSize,
+    });
+    if (refusal) { refused.push({ i, ...refusal }); continue; }
+
+    const key = asOld ? `0:${tree_size}` : sthKey(head);
+    signedRoots.set(key, sha3_root);
+    const logical = asOld ? tree_size : sthLogicalSize(head);
+    if (logical > maxSignedSize) maxSignedSize = logical;
+    signed.push(head);
+  }
+  return { signed, refused, logSize: w.size };
+}
+
+test('keyed on tree_size alone, every head past the wrap is refused', () => {
+  // The bug, stated as a measurement. Window of 4, twelve appends.
+  const { signed, refused, logSize } = run({ windowSize: 4, appends: 12, keyBy: 'size' });
+  assert.strictEqual(logSize, 12, 'the log grew to twelve either way');
+  assert.strictEqual(signed.length, 5, 'only the heads up to and including the full window were signed');
+  assert.strictEqual(refused.length, 7, 'every append after that was refused');
+  assert.strictEqual(refused[0].reason, 'root_differs_at_same_size',
+    'and refused for the reason that reads exactly like tampering');
+});
+
+test('keyed on the window it covers, the relay keeps signing', () => {
+  const { signed, refused, logSize } = run({ windowSize: 4, appends: 12, keyBy: 'pair' });
+  assert.strictEqual(refused.length, 0, `nothing was refused: ${JSON.stringify(refused)}`);
+  assert.strictEqual(signed.length, 12, 'one head per append, all twelve');
+  assert.strictEqual(logSize, 12);
+
+  // Each head says which leaves it covers, and the last one describes the
+  // window as it stands, not the log.
+  const last = signed[signed.length - 1];
+  assert.strictEqual(last.tree_size, 5, 'the tree is the window plus the new leaf');
+  assert.strictEqual(last.window_base, 7, 'and it starts where the window starts');
+  assert.strictEqual(sthLogicalSize(last), 12, 'base plus size is the size of the log');
+});
+
+test('the logical size never walks backwards, and no tree gets two roots', () => {
+  const { signed } = run({ windowSize: 4, appends: 12, keyBy: 'pair' });
+  const sizes = signed.map(sthLogicalSize);
+  for (let i = 1; i < sizes.length; i++) {
+    assert.ok(sizes[i] >= sizes[i - 1], `head ${i} went backwards: ${sizes[i - 1]} then ${sizes[i]}`);
+  }
+  const roots = new Map();
+  for (const h of signed) {
+    const k = sthKey(h);
+    assert.ok(!roots.has(k) || roots.get(k) === h.sha3_root, `two roots for one tree at ${k}`);
+    roots.set(k, h.sha3_root);
+  }
+  assert.strictEqual(roots.size, signed.length, 'every head describes a distinct tree');
+});
+
+test('a genuine contradiction is still refused', () => {
+  // The guard must not have been loosened into uselessness. Same tree, other
+  // root: that is the fork it exists to catch.
+  const signedRoots = new Map([['0:5', 'a'.repeat(64)]]);
+  const refusal = sthRefusal({
+    tree_size: 5, window_base: 0, sha3_root: 'b'.repeat(64),
+    signedRoots, maxSignedSize: 5,
+  });
+  assert.ok(refusal, 'a second, different root for one tree is refused');
+  assert.strictEqual(refusal.reason, 'root_differs_at_same_size');
+
+  // And re-signing the SAME root for the same tree stays allowed.
+  assert.strictEqual(
+    sthRefusal({ tree_size: 5, window_base: 0, sha3_root: 'a'.repeat(64), signedRoots, maxSignedSize: 5 }),
+    null,
+    'signing the same root again is idempotent, not a contradiction');
+});
+
+test('a log that shrank is still refused', () => {
+  // The other half of the guard: the head window can prune the map, so this is
+  // checked against a number that is never pruned. With the pair key that
+  // number is the LOGICAL size, or a wrapped window would look like a shrink
+  // on every append.
+  const refusal = sthRefusal({
+    tree_size: 3, window_base: 0, sha3_root: 'c'.repeat(64),
+    signedRoots: new Map(), maxSignedSize: 900,
+  });
+  assert.ok(refusal, 'a tree smaller than one already signed is refused');
+  assert.strictEqual(refusal.reason, 'tree_size_went_backwards');
+});
+
+test('heads signed before window_base existed are read as starting at leaf 0', () => {
+  // Version 1 heads carry no window_base. They were signed while the window had
+  // not wrapped, so leaf 0 is exactly where their tree started, and reading
+  // them that way keeps their guarantee whole across the upgrade.
+  assert.strictEqual(sthKey({ tree_size: 42 }), '0:42');
+  assert.strictEqual(sthLogicalSize({ tree_size: 42 }), 42);
+  assert.strictEqual(sthKey({ tree_size: 42, window_base: 7 }), '7:42');
+  assert.strictEqual(sthLogicalSize({ tree_size: 42, window_base: 7 }), 49);
+});

--- a/scripts/paramant-verify-sth
+++ b/scripts/paramant-verify-sth
@@ -46,8 +46,15 @@ function fetchJson(url) {
 }
 
 // Canonical JSON: sorted keys, no whitespace, UTF-8 — must match produceSth() in relay.js
+//
+// Every field the head carries EXCEPT the signature, rather than a fixed list.
+// A fixed list silently drops any field added later: window_base arrived in
+// version 2 and would have been left out of the payload here, so a perfectly
+// good head would have failed verification with no hint as to why. The relay
+// signs `{...payload}` and frontend/js/receipt-verify.js strips the signature
+// and canonicalises the rest; this now does the same thing.
 function canonicalJson(sth) {
-  const keys = ['relay_id', 'sha3_root', 'timestamp', 'tree_size', 'version'];
+  const keys = Object.keys(sth).filter(k => k !== 'signature').sort();
   return JSON.stringify(Object.fromEntries(keys.map(k => [k, sth[k]])));
 }
 
@@ -63,10 +70,18 @@ async function main() {
     process.exit(1);
   }
   const sth = sthResp.sth;
-  log(`STH: tree_size=${sth.tree_size} sha3_root=${(sth.sha3_root||'').slice(0,16)}… ts=${sth.timestamp}`);
+  log(`STH: tree_size=${sth.tree_size}${sth.window_base != null ? " window_base=" + sth.window_base : ""} sha3_root=${(sth.sha3_root||'').slice(0,16)}… ts=${sth.timestamp}`);
 
   // 2. Validate STH fields
-  if (sth.version !== 1) { console.error(`FAIL: unsupported STH version ${sth.version}`); process.exit(1); }
+  // 1 and 2 differ by one field: version 2 adds window_base, the logical index
+  // of the first leaf in the signed tree. The tree covers a sliding window, so
+  // a leaf count on its own does not say which leaves. Signature checking is
+  // untouched by this: the canonical payload is rebuilt from whatever fields
+  // the head carries, so a version 1 head still verifies exactly as before.
+  if (sth.version !== 1 && sth.version !== 2) { console.error(`FAIL: unsupported STH version ${sth.version}`); process.exit(1); }
+  if (sth.version === 2 && typeof sth.window_base !== 'number') {
+    console.error('FAIL: version 2 STH without window_base'); process.exit(1);
+  }
   for (const f of ['relay_id', 'sha3_root', 'timestamp', 'tree_size', 'signature']) {
     if (sth[f] === undefined || sth[f] === null) {
       console.error(`FAIL: STH missing required field '${f}'`); process.exit(1);
@@ -136,6 +151,9 @@ async function main() {
   console.log('OK: STH signature verified (ML-DSA-65 NIST FIPS 204)');
   console.log(`  relay_id   : ${sth.relay_id}`);
   console.log(`  tree_size  : ${sth.tree_size}`);
+  if (sth.window_base != null) {
+    console.log(`  window_base: ${sth.window_base}  (tree covers leaves ${sth.window_base}..${sth.window_base + sth.tree_size - 1})`);
+  }
   console.log(`  sha3_root  : ${sth.sha3_root}`);
   console.log(`  timestamp  : ${new Date(sth.timestamp).toISOString()}`);
   console.log(`  pk_hash    : ${pkResp.pk_hash}`);

--- a/tests/access-log-visitors.test.mjs
+++ b/tests/access-log-visitors.test.mjs
@@ -36,7 +36,7 @@ test('a client that renders is not excluded for lacking a referer', () => {
   // exclude every genuine visitor on this site.
   const r = analyse([
     line({ ip: '8.8.8.8', path: '/sign' }),
-    line({ ip: '8.8.8.8', path: '/design-system.css?v=28' }),
+    line({ ip: '8.8.8.8', path: '/design-system.css?v=29' }),
     line({ ip: '8.8.8.8', path: '/sign-flow.js?v=57' }),
   ]);
   assert.equal(r.atMostVisitors, 1);

--- a/tests/access-log-visitors.test.mjs
+++ b/tests/access-log-visitors.test.mjs
@@ -37,7 +37,7 @@ test('a client that renders is not excluded for lacking a referer', () => {
   const r = analyse([
     line({ ip: '8.8.8.8', path: '/sign' }),
     line({ ip: '8.8.8.8', path: '/design-system.css?v=28' }),
-    line({ ip: '8.8.8.8', path: '/sign-flow.js?v=55' }),
+    line({ ip: '8.8.8.8', path: '/sign-flow.js?v=56' }),
   ]);
   assert.equal(r.atMostVisitors, 1);
   assert.equal(r.verdicts.possible_visitor, 1);

--- a/tests/access-log-visitors.test.mjs
+++ b/tests/access-log-visitors.test.mjs
@@ -37,7 +37,7 @@ test('a client that renders is not excluded for lacking a referer', () => {
   const r = analyse([
     line({ ip: '8.8.8.8', path: '/sign' }),
     line({ ip: '8.8.8.8', path: '/design-system.css?v=28' }),
-    line({ ip: '8.8.8.8', path: '/sign-flow.js?v=56' }),
+    line({ ip: '8.8.8.8', path: '/sign-flow.js?v=57' }),
   ]);
   assert.equal(r.atMostVisitors, 1);
   assert.equal(r.verdicts.possible_visitor, 1);

--- a/tests/navigation-shell.test.mjs
+++ b/tests/navigation-shell.test.mjs
@@ -347,7 +347,12 @@ const artOut = await artInsideTheClip(false);
 ok('signed out at 1440, the hero art is drawn and drawn whole', artOut.drawn > 0 && artOut.cut.length === 0, JSON.stringify(artOut));
 
 const appPage = await browser.newPage({ viewport:{ width:390, height:844 } });
-await appPage.route('**/api/user/session/verify', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"authenticated":true,"email":"demo@example.com"}' }));
+// developer:true, because this page is checked below for the developer entry in
+// the user menu. The flag is what session/verify answers for an account on the
+// operator allowlist; without it the menu correctly leaves that entry out,
+// since /developer answers 404 to everyone else. The signed-in-but-not-a-
+// developer case is measured separately, further down.
+await appPage.route('**/api/user/session/verify', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"authenticated":true,"email":"demo@example.com","developer":true}' }));
 await appPage.route('**/api/user/me', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"email":"demo@example.com","label":"Demo","plan":"pro","created_at":"2026-06-01T10:00:00.000Z","backup_codes_remaining":8,"session_expires_at":"2026-07-21T16:00:00.000Z","usage_purpose":"organisation"}' }));
 await appPage.route('**/api/user/documents', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"documents":[]}' }));
 await appPage.route('**/api/user/account/**', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{}' }));
@@ -367,6 +372,26 @@ await appPage.locator('#nav-hamburger').click();
 const appMobile = await appPage.locator('#nav-mobile a').allInnerTexts();
 ok('signed-in mobile menu matches the workspace', appMobile.map((item) => item.toLowerCase()).join(',') === appDesktop.map((item) => item.toLowerCase()).join(','), appMobile.join(', '));
 ok('developer tools are settings, not a sixth product', await appPage.locator('.nav-user-menu a', { hasText:'Developer settings' }).count() === 1 && !appMobile.includes('Developer settings'), appMobile.join(', '));
+
+// And an ordinary signed-in account is not offered that entry at all. /developer
+// answers 404 to everyone off the operator allowlist, deliberately, so that the
+// surface stays hidden. The menu used to advertise it to every signed-in
+// visitor, which handed almost all of them a link that dead-ends. Measured on
+// its own page, because the assertion above needs the opposite session.
+const plainPage = await browser.newPage({ viewport:{ width:390, height:844 } });
+// Order matters: Playwright evaluates the LAST registered route first, so the
+// catch-all goes in before the specific one it must not swallow.
+await plainPage.route('**/api/user/**', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{}' }));
+await plainPage.route('**/api/user/session/verify', (route) => route.fulfill({ status:200, contentType:'application/json', body:'{"authenticated":true,"email":"plain@example.com"}' }));
+await plainPage.goto(ORIGIN + '/dashboard', { waitUntil:'domcontentloaded' });
+await plainPage.waitForSelector('.nav-user-menu', { state:'attached' });
+const plainMenu = await plainPage.locator('.nav-user-menu a').allInnerTexts();
+ok('a signed-in non-developer is not offered the developer page', !plainMenu.includes('Developer settings') && plainMenu.includes('Account'), plainMenu.join(', '));
+// The in-page links ship hidden and are revealed by the same verdict, so a
+// non-developer must not see those either.
+const plainVisibleDev = await plainPage.locator('a[href="/developer"]:visible').count();
+ok('the in-page developer links stay hidden for a non-developer', plainVisibleDev === 0, String(plainVisibleDev));
+await plainPage.close();
 
 // Support survives signing in, and it is measured in TAPS.
 //

--- a/tests/stille-breuken.test.mjs
+++ b/tests/stille-breuken.test.mjs
@@ -130,10 +130,36 @@ test('only the credential endpoints sit in the auth throttle', () => {
 
   // The narrow location has to exist, and it has to be the one carrying the
   // auth zone.
-  const authLoc = /location ~ \^\/api\/user\/\(login\|login-with-backup\|signup\|setup\|auth\)[^{]*\{([\s\S]*?)\n    \}/.exec(conf);
+  const authLocRe = /location ~ (\^\/api\/user\/\S+) \{([\s\S]*?)\n    \}/;
+  const authLoc = authLocRe.exec(conf);
   assert.ok(authLoc, 'the credential-only location is gone from the live nginx conf');
-  assert.match(authLoc[1], /limit_req\s+zone=relay_auth/,
+  assert.match(authLoc[2], /limit_req\s+zone=relay_auth/,
     'the credential endpoints are no longer in the auth throttle');
+
+  // Which paths that pattern actually catches, checked against the real ones.
+  // The near-miss that matters: /api/user/sign/* is an already-signed-in
+  // account signing a document, and it must NOT land in the credential bucket,
+  // or the signing flow throttles itself. "signup" and "sign" share a prefix,
+  // so this is a genuine trap rather than a hypothetical one.
+  const pattern = new RegExp(authLoc[1]);
+  const mustMatch = [
+    '/api/user/login', '/api/user/login-with-backup', '/api/user/signup',
+    '/api/user/signup/verify/abc123', '/api/user/setup/abc123',
+    '/api/user/setup/abc123/confirm', '/api/user/auth/webauthn/login/options',
+    '/api/user/auth/request-totp-reset',
+  ];
+  const mustNotMatch = [
+    '/api/user/sign/activation', '/api/user/sign/submit', '/api/user/session/verify',
+    '/api/user/account', '/api/user/account/signing-key', '/api/user/dashboard/overview',
+    '/api/user/parasign-keys', '/api/user/documents', '/api/user/envelopes',
+    '/api/user/billing/status', '/api/user/logout',
+  ];
+  for (const p of mustMatch) {
+    assert.ok(pattern.test(p), `${p} is a credential endpoint but falls outside the auth throttle`);
+  }
+  for (const p of mustNotMatch) {
+    assert.ok(!pattern.test(p), `${p} is not a credential endpoint but got swept into the auth throttle`);
+  }
 
   // And the broad prefix must NOT be, or every signed-in read shares the
   // credential bucket again and /account goes back to printing 429.

--- a/tests/stille-breuken.test.mjs
+++ b/tests/stille-breuken.test.mjs
@@ -1,0 +1,199 @@
+// The failures a user meets in silence.
+//
+// Measured on production on 2026-09-08 with two real Community accounts, in a
+// browser, all the way from sign-up to account deactivation. Every flow the
+// product sells worked. What did not work was the moment a flow refused: the
+// refusal did not reach the person. Four cases, one shape:
+//
+//   1. The backup-code page. /auth/login carries the address the visitor just
+//      typed; the link to /auth/backup did not, so that field was empty. The
+//      field is `required`, so the form never submitted: no request, no error
+//      text, nothing. Pressing the button did nothing at all, on the one page
+//      someone only opens when their phone is gone.
+//   2. A file over 5 MB on the link stand. It got a green tick ("✓ file (5.7
+//      MB)") and a live button, and the refusal existed only as a console line.
+//   3. The monthly signature allowance. The 402 arrives after the document,
+//      the seal, the name and the six-digit code, with the envelope already
+//      created server side. Nothing before the click said how many were left.
+//   4. "Developer settings" in the account menu, shown to every signed-in
+//      visitor while /developer answers 404 to everyone off the allowlist.
+//      Hiding the surface is deliberate; advertising it to everyone was not.
+//
+// Plus the rate limit underneath 1 and 3: the whole /api/user/ prefix sat in
+// the auth throttle at burst=5 while /account alone opens six calls at once, so
+// a first visit printed "Could not load passkeys (HTTP 429)" and a 429 on
+// /api/user/session/verify rendered a signed-in visitor as signed out.
+//
+// These assertions fail if any of those repairs is undone. They read the
+// shipped files, so they cannot pass by finding nothing: each one first proves
+// its subject exists.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p) => {
+  const full = join(ROOT, p);
+  assert.ok(existsSync(full), `${p} is missing: this suite guards a file that has moved or gone`);
+  return readFileSync(full, 'utf8');
+};
+
+test('the sign-in page hands the typed address to the recovery pages', () => {
+  const js = read('frontend/js/auth-login.js');
+  assert.match(js, /paramant:recovery-email/,
+    'auth-login.js no longer remembers the address for the recovery pages');
+  assert.match(js, /a\[href\^="\/auth\/backup"\]/,
+    'the backup-code link is no longer wired to carry the address');
+});
+
+test('the backup-code form lets its own handler do the validating', () => {
+  // This is what actually made the button dead. Without `novalidate` the
+  // browser's `required` check cancels the submit event, so the page's handler
+  // never runs and never gets to say what is missing: no request, no sentence,
+  // nothing. The sign-in and sign-up forms already carried it; this one did
+  // not, and it is the page people only open when their phone is gone.
+  const html = read('frontend/auth/backup.html');
+  assert.match(html, /<form id="backup-form"[^>]*\bnovalidate\b/,
+    'the backup form validates in the browser again, which silences its own error messages');
+});
+
+test('the backup-code page fills that address in and says what is missing', () => {
+  const js = read('frontend/js/auth-backup.js');
+  assert.match(js, /sessionStorage\.getItem\('paramant:recovery-email'\)/,
+    'auth-backup.js no longer prefills the address');
+  // The point is not that a check exists, but that a missing field produces a
+  // sentence on the page. The browser's own bubble for a `required` field was
+  // what left the button looking dead.
+  assert.match(js, /if \(!email\)[\s\S]{0,120}fail\(/,
+    'a missing email no longer produces a message on the page');
+  assert.match(js, /if \(!code\)[\s\S]{0,120}fail\(/,
+    'a missing backup code no longer produces a message on the page');
+});
+
+test('the link stand refuses an oversized file when it is chosen, not after the click', () => {
+  const js = read('frontend/js/parashare.page.js');
+  assert.match(js, /function linkSizeRefusal/,
+    'the up-front size check is gone');
+  // It has to be wired into both the moment of choosing and the button state,
+  // or the green tick and the live button come back.
+  assert.match(js, /const tooBig = linkSizeRefusal\(files\)/,
+    'onFileSelect no longer consults the size check');
+  assert.match(js, /linkSizeRefusal\(selectedFiles\) !== null/,
+    'the send button no longer goes dead for a file that cannot be sent');
+  // And the real sentence must survive to the screen if it is ever thrown.
+  assert.match(js, /err\.userFacing = true/,
+    'the size refusal is no longer marked as the user\'s own, so it falls back to "something went wrong on our side"');
+  assert.match(js, /e\.userFacing && e\.message/,
+    'the seal failure handler no longer prints a user-facing message');
+});
+
+test('the review step says how many signatures are left before the ceremony', () => {
+  const js = read('frontend/sign-flow.js');
+  assert.match(js, /async function showRemainingSignatures/,
+    'the allowance is no longer read on the review step');
+  assert.match(js, /showRemainingSignatures\(\)/,
+    'showRemainingSignatures is defined but never called');
+  // The banner ships hidden. Writing into it without unhiding it is exactly the
+  // bug this file is about, so the repair has to include the unhide.
+  assert.match(js, /host\.hidden = false/,
+    'the allowance notice is written into a hidden banner and stays invisible');
+});
+
+test('developer settings is offered only to accounts that may open it', () => {
+  const server = read('admin/server.js');
+  assert.match(server, /developer: isDeveloper\(s\.email\)/,
+    'the session check no longer tells the page whether this account is a developer');
+
+  const nav = read('frontend/js/nav-auth.js');
+  assert.match(nav, /isDeveloper \? '<a href="\/developer"/,
+    'the account menu offers /developer to everyone again');
+
+  // The links that live in the pages themselves ship hidden and are revealed by
+  // the same verdict. If either half goes, a normal account gets a dead link.
+  assert.match(nav, /\[data-developer-only\]/,
+    'nav-auth.js no longer reveals the in-page developer links');
+  for (const page of ['frontend/account.html', 'frontend/dashboard.html']) {
+    const html = read(page);
+    const links = html.match(/<a[^>]*href="\/developer"[^>]*>/g) || [];
+    assert.ok(links.length > 0, `${page} no longer links to /developer at all`);
+    for (const link of links) {
+      assert.match(link, /data-developer-only/, `${page} has a /developer link that is not gated: ${link}`);
+      assert.match(link, /\bhidden\b/, `${page} has a /developer link that is not hidden by default: ${link}`);
+    }
+  }
+});
+
+test('only the credential endpoints sit in the auth throttle', () => {
+  const conf = read('deploy/nginx-paramant-live.conf');
+
+  // The narrow location has to exist, and it has to be the one carrying the
+  // auth zone.
+  const authLoc = /location ~ \^\/api\/user\/\(login\|login-with-backup\|signup\|setup\|auth\)[^{]*\{([\s\S]*?)\n    \}/.exec(conf);
+  assert.ok(authLoc, 'the credential-only location is gone from the live nginx conf');
+  assert.match(authLoc[1], /limit_req\s+zone=relay_auth/,
+    'the credential endpoints are no longer in the auth throttle');
+
+  // And the broad prefix must NOT be, or every signed-in read shares the
+  // credential bucket again and /account goes back to printing 429.
+  const prefixLoc = /\n    location \/api\/user\/ \{([\s\S]*?)\n    \}/.exec(conf);
+  assert.ok(prefixLoc, 'the /api/user/ prefix location is gone from the live nginx conf');
+  assert.doesNotMatch(prefixLoc[1], /zone=relay_auth/,
+    'the whole /api/user/ prefix is back in the auth throttle, which is what made /account answer 429');
+  assert.match(prefixLoc[1], /limit_req\s+zone=api/,
+    'the signed-in reads are no longer rate limited at all');
+});
+
+test('the signed-in polls stop while the tab is in the background', () => {
+  // Twelve requests a minute from a forgotten tab drained the same bucket every
+  // other signed-in call draws from.
+  for (const [file, fn] of [['frontend/js/dashboard.js', 'pull'], ['frontend/js/developer.js', 'loadSnapshot']]) {
+    const js = read(file);
+    assert.match(js, new RegExp(`visibilityState === 'visible'\\) ${fn}\\(\\)`),
+      `${file} polls without checking whether the tab is visible`);
+    assert.match(js, /addEventListener\('visibilitychange'/,
+      `${file} never refreshes when the tab comes back to the front`);
+    assert.doesNotMatch(js, /setInterval\([^)]*,\s*(5000|10000)\)/,
+      `${file} is back on its old fast interval`);
+  }
+});
+
+test('the pages tell the truth about the verification link and who sends the mail', () => {
+  // The token is written with EX: 86400 in admin/server.js. The mail said 24
+  // hours, the page said 2 days.
+  const server = read('admin/server.js');
+  assert.match(server, /EX: 86400/, 'the signup token no longer lives for 86400 seconds; check the pages again');
+  const signup = read('frontend/signup.html');
+  assert.match(signup, /The link works for 24 hours\./, 'the signup page is back to promising 2 days');
+
+  // Mail goes out as hello@paramant.app; four pages told people to look for
+  // noreply@, so filtering on the sender found nothing.
+  const templates = read('admin/lib/email-templates.js');
+  assert.match(templates, /const FROM_ADDR = 'Paramant <hello@paramant\.app>'/,
+    'the from address changed; the pages that name it have to change with it');
+  for (const page of ['frontend/signup/verified.html', 'frontend/auth/reset-confirm.html', 'frontend/js/auth-request-reset.js']) {
+    assert.doesNotMatch(read(page), /noreply@paramant\.app/,
+      `${page} names a sender address that account mail does not come from`);
+  }
+});
+
+test('verify asks for the copy that actually validates', () => {
+  const html = read('frontend/verify.html');
+  assert.doesNotMatch(html, /Choose the original document/,
+    'the verify page asks for the original again, which is the copy that fails for a PDF');
+  assert.match(html, /Choose the signed document/, 'the verify page no longer names the file to pick');
+
+  const js = read('frontend/parasign-verify.js');
+  // The near-miss worth naming: the file from before the seal.
+  assert.match(js, /env\.original_hash === docHashHex/,
+    'the verifier no longer recognises the pre-signature copy');
+  // And the signer line must not print its own brackets around a placeholder.
+  // Only code counts here: the comment above the repair says the old string out
+  // loud on purpose, and matching that would make this assertion meaningless.
+  const code = js.split('\n').filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+  assert.doesNotMatch(code, /['"`][^'"`]*\(unverified\)/,
+    'the signer line is back to printing "((unverified))" around a missing address');
+  assert.match(code, /no address published for this key/,
+    'the signer line no longer says why an address is missing');
+});

--- a/tests/stille-breuken.test.mjs
+++ b/tests/stille-breuken.test.mjs
@@ -394,3 +394,33 @@ test('the docs name the version the hosted relays actually answer', () => {
   assert.match(html, /What's new in 3\.0\.0/,
     'the release notes for 3.0.0 have been renumbered, which rewrites history');
 });
+
+test('the audits table does not report a finding as closed that SECURITY.md keeps open', () => {
+  const security = read('SECURITY.md');
+  const docs = read('frontend/docs.html');
+
+  // SECURITY.md keeps its own "Open findings" table. As long as it has rows,
+  // the audits table on /docs cannot report every audit as fully resolved.
+  // This is the one claim on that page a buyer's security officer reads first.
+  const openSection = /## Open findings\s*\n([\s\S]*?)\n---/.exec(security);
+  assert.ok(openSection, 'SECURITY.md no longer has an "Open findings" section; check the /docs table again');
+  const openRows = openSection[1].split('\n').filter((l) => /^\|\s*\d+\s*\|/.test(l));
+
+  const table = /<h2 id="audits">[\s\S]*?<\/table>/.exec(docs);
+  assert.ok(table, 'the audits table is gone from /docs');
+
+  if (openRows.length > 0) {
+    // Name the audit those rows belong to, so this fails loudly rather than
+    // quietly passing on a table that has been reworded.
+    assert.doesNotMatch(table[0], /Smart Cyber Solutions<\/td><td>[^<]*<\/td><td>All resolved/,
+      `SECURITY.md lists ${openRows.length} open finding(s) while /docs reports that audit as fully resolved`);
+    assert.match(docs, /One finding is still open/,
+      '/docs no longer tells the reader that a finding is open');
+  }
+
+  // The commit hash 0db3ef0 belongs to the Zwarts review in SECURITY.md. It was
+  // copied onto the Smart Cyber Solutions row as well, which credited a fix to
+  // an audit it did not close.
+  assert.doesNotMatch(table[0], /Smart Cyber Solutions[\s\S]*?0db3ef0/,
+    'the Smart Cyber Solutions row carries a commit hash that belongs to another audit');
+});

--- a/tests/stille-breuken.test.mjs
+++ b/tests/stille-breuken.test.mjs
@@ -303,3 +303,40 @@ test('the legal strip is a finger-sized target', () => {
   assert.match(rule[1], /min-height:\s*44px/,
     'the legal strip links are back under the 44px a thumb needs');
 });
+
+// ── Zinnen die zichzelf tegenspreken ─────────────────────────────────────────
+
+test('the SLA does not promise coverage its own section 5 withdraws', () => {
+  const html = read('frontend/sla.html');
+  // Section 1 said "All five sector relays are covered" while section 5 said
+  // the four sector relays are not measured and the monitor for the fifth is
+  // switched off. Both sentences were on the same page.
+  assert.doesNotMatch(html, /All five sector relays \([^)]*\) are covered/,
+    'the SLA promises coverage in section 1 that section 5 takes back');
+  assert.match(html, /their uptime is not measured/,
+    'section 5 no longer says which relays are not monitored; check section 1 again');
+  assert.match(html, /Read section 5 before you rely on a number here/,
+    'section 1 no longer points at the section that qualifies it');
+
+  // And the page describes itself as covering plans it does not list. Only
+  // Community and Enterprise have rows.
+  assert.doesNotMatch(html, /every Paramant plan, from Community to Enterprise/,
+    'the SLA describes itself as covering every plan while it lists two');
+});
+
+test('the status page does not call one look a day of uptime', () => {
+  const js = read('frontend/js/status.inline1.js');
+  // A first visit made one check, found it up, and printed "uptime 24h 100.0%".
+  assert.match(js, /function uptimeStat/,
+    'the uptime figure no longer carries its sample count');
+  assert.match(js, /stat\.n < 5/,
+    'a percentage is printed again before there are enough samples to mean one');
+
+  const html = read('frontend/status.html');
+  assert.doesNotMatch(html, /uptime % calculated from last 24h of checks/,
+    'the note under the page claims 24 hours of checks again');
+  assert.doesNotMatch(html, /Uptime is calculated from the last 24 hours of checks/,
+    'the page description still claims a 24-hour calculation');
+  assert.match(html, /checks this browser has made/,
+    'the note no longer says whose checks these are');
+});

--- a/tests/stille-breuken.test.mjs
+++ b/tests/stille-breuken.test.mjs
@@ -204,6 +204,32 @@ test('the pages tell the truth about the verification link and who sends the mai
   }
 });
 
+test('the review card does not name a recipe version it cannot know', () => {
+  // The card printed "recipe_version 3" while the relay writes 5 into the
+  // envelope the signer downloads a minute later. The recipe is chosen server
+  // side, so before the envelope exists there is no number to print: the same
+  // preview already says "<set on sign>" for the fields in that position.
+  const js = read('frontend/sign-flow.js');
+  assert.doesNotMatch(js, /recipe_version 3\)/,
+    'the review card is back to promising recipe_version 3');
+  assert.doesNotMatch(js, /^\s*recipe_version: 3,\s*$/m,
+    'the envelope preview is back to a hardcoded recipe_version 3');
+  assert.match(js, /recipe_version: '<set on sign>'/,
+    'the envelope preview no longer marks the recipe as decided on signing');
+});
+
+test('a refused account deactivation says so', () => {
+  // `if (res.ok)` and nothing else: a refusal left the page sitting there while
+  // the account quietly still existed.
+  const js = read('frontend/js/account.inline1.js');
+  const block = /delete-account'\)\.addEventListener\([\s\S]*?\n  \}\);/.exec(js);
+  assert.ok(block, 'the deactivate handler is gone from the account page');
+  assert.match(block[0], /was NOT deactivated/,
+    'a failed deactivation is silent again');
+  assert.match(block[0], /res\.status === 401/,
+    'an expired session during deactivation is not named');
+});
+
 test('verify asks for the copy that actually validates', () => {
   const html = read('frontend/verify.html');
   assert.doesNotMatch(html, /Choose the original document/,

--- a/tests/stille-breuken.test.mjs
+++ b/tests/stille-breuken.test.mjs
@@ -365,3 +365,32 @@ test('the ct-log counters add up to the window they describe', () => {
   assert.match(js, /e\.type === 'signing_pk_enrolled'/,
     'key registrations are counted under a type name the log does not use');
 });
+
+test('the docs do not offer an authentication form the relay refuses', () => {
+  const html = read('frontend/docs.html');
+  // ?k= was removed from the relay after the April 2026 review. The docs kept
+  // offering it, with a worked example, so anyone following them got
+  // "API key must be sent in the X-Api-Key header, not as a query parameter."
+  assert.doesNotMatch(html, /check-key\?k=pgp_your_key_here/,
+    'the docs demonstrate ?k= again, which the relay rejects');
+  assert.match(html, /There is no query-parameter\s*\n?\s*form/,
+    'the docs no longer say that the query-parameter form does not exist');
+});
+
+test('the docs name the version the hosted relays actually answer', () => {
+  const html = read('frontend/docs.html');
+  // Production answers 3.1.0; the self-host release the install script pins is
+  // v3.0.0. The page named 3.0.0 for both, including in the /health example.
+  assert.match(html, /"version": "3\.1\.0"/,
+    'the /health example is back on a version the hosted relay does not answer');
+  // As a JSON field, not as the word: the note under the example names it on
+  // purpose, to say it is gone.
+  assert.doesNotMatch(html, /"uptime_s"\s*:/,
+    'the /health example shows a field the relay does not return');
+  assert.doesNotMatch(html, /docs for Paramant v3\.0\.0/,
+    'the page describes itself as the docs for one version while it covers two');
+  // The history stays: "What's new in 3.0.0" is about 3.0.0 and must not be
+  // renumbered by a search and replace.
+  assert.match(html, /What's new in 3\.0\.0/,
+    'the release notes for 3.0.0 have been renumbered, which rewrites history');
+});

--- a/tests/stille-breuken.test.mjs
+++ b/tests/stille-breuken.test.mjs
@@ -249,3 +249,57 @@ test('verify asks for the copy that actually validates', () => {
   assert.match(code, /no address published for this key/,
     'the signer line no longer says why an address is missing');
 });
+
+// ── Doodlopende wegen ────────────────────────────────────────────────────────
+// Dezelfde familie, een verdieping lager: niet een melding die niet aankomt,
+// maar een uitgang die er niet is. Gemeten op 390x844.
+
+test('the vault page is not a dead end on a phone', () => {
+  const html = read('frontend/vault.html');
+  // Both links in the bar point at /dashboard and the page has no menu button
+  // and no drawer, so this was the one page you could not leave except by
+  // going back. It stays script-free on purpose: this page makes no network
+  // call at all, and the shared navigation would add one.
+  // Match the script tag, not the word: the comment in the page names
+  // nav-auth.js on purpose, to say why it is absent.
+  assert.doesNotMatch(html, /<script[^>]+nav-auth\.js/,
+    'the vault page now loads the shared navigation, which costs it its network silence');
+  assert.match(html, /class="vt-elsewhere"/,
+    'the vault page has no way out other than the dashboard again');
+  for (const href of ['/verify', '/gereedschap', '/']) {
+    assert.ok(html.includes(`<a href="${href}">`), `the vault page no longer links to ${href}`);
+  }
+  assert.match(html, /<footer class="legal-strip">/,
+    'the vault page dropped the legal strip, so privacy, DPA and terms are unreachable from it');
+});
+
+test('the ct-log skip link lands somewhere', () => {
+  const html = read('frontend/ct-log.html');
+  assert.match(html, /href="#main-content" class="skip-link"/,
+    'the skip link is gone from /ct-log');
+  // It pointed at an id that did not exist: pressing it set the hash and moved
+  // nothing. tabindex is what actually moves the focus.
+  assert.match(html, /<main id="main-content"[^>]*tabindex="-1"/,
+    'the skip link on /ct-log points at a target that cannot take focus');
+});
+
+test('both ct-log search fields have a name', () => {
+  const html = read('frontend/ct-log.html');
+  // A placeholder disappears the moment you type, so it is not a label. These
+  // two were the only unlabelled inputs on the site.
+  for (const id of ['verify-input', 'search']) {
+    const tag = new RegExp(`<input id="${id}"[^>]*>`).exec(html);
+    assert.ok(tag, `input #${id} is gone from /ct-log`);
+    assert.match(tag[0], /aria-label="/, `input #${id} has no accessible name, only a placeholder`);
+  }
+});
+
+test('the legal strip is a finger-sized target', () => {
+  const css = read('frontend/design-system.css');
+  // 17 to 19px tall, on every auth, account and download page: the smallest
+  // target on the site.
+  const rule = /\.legal-strip a \{([\s\S]*?)\}/.exec(css);
+  assert.ok(rule, '.legal-strip a is gone from the design system');
+  assert.match(rule[1], /min-height:\s*44px/,
+    'the legal strip links are back under the 44px a thumb needs');
+});

--- a/tests/stille-breuken.test.mjs
+++ b/tests/stille-breuken.test.mjs
@@ -340,3 +340,28 @@ test('the status page does not call one look a day of uptime', () => {
   assert.match(html, /checks this browser has made/,
     'the note no longer says whose checks these are');
 });
+
+test('the ct-log counters add up to the window they describe', () => {
+  const js = read('frontend/js/ct-log.page.js');
+  const html = read('frontend/ct-log.html');
+
+  // Three counts sat under a total that came from a different dataset: the
+  // total is the whole log, the counts covered the 1000 entries the relay
+  // returns in one request. Nothing said so, so 4798 sat above 0 + 37 + 957.
+  assert.match(js, /stat-scope/, 'the page no longer says which entries the counts cover');
+  assert.match(js, /allEntries\.length < logSize/,
+    'the scope line no longer distinguishes a window from the whole log');
+  assert.match(html, /id="stat-scope"/, 'the scope line has no place in the page');
+
+  // And signing work fell between the categories, counted by nobody. Any type
+  // added later lands in the same remainder.
+  assert.match(js, /var otherCount/, 'the remainder counter is gone');
+  assert.match(js, /countedTypes\.indexOf\(e\.type\) === -1/,
+    'the remainder no longer catches types the other counters do not claim');
+  assert.match(html, /id="stat-other"/, 'the remainder has no counter in the page');
+
+  // signing_pk_enrolled is what a key registration is actually called in the
+  // log; counting only 'key_reg' is what made that counter read 0.
+  assert.match(js, /e\.type === 'signing_pk_enrolled'/,
+    'key registrations are counted under a type name the log does not use');
+});


### PR DESCRIPTION
Twee echte Community-accounts aangemaakt op productie, met wegwerpmailboxen, en elke flow met de hand doorlopen: registreren, verifiëren, authenticator koppelen, ondertekenen, verifiëren, versturen, ontvangen, vault, passkey, meerpartijen-ondertekening, backup-codes, account deactiveren.

Alles wat het product verkoopt werkte. De cryptografische keten klopt: het zegel staat correct in de PDF, een geknoeid bestand faalt de verificatie, burn-on-read is echt (een verse browser krijgt "already downloaded and burned"), de vault komt byte-identiek terug, en de co-sign-flow rondt af op 1/1.

Wat niet werkte was het moment waarop een flow weigerde. **De weigering bereikte de gebruiker niet.** Dat is niet één bug, dat is het patroon in deze PR.

## De acht reparaties

**1. Inloggen met een backup-code deed helemaal niets.**
`frontend/auth/backup.html` was het enige auth-formulier zonder `novalidate`. De browsercontrole op `required` breekt dan het submit-event af, dus de eigen handler kwam nooit aan bod en kon niet zeggen wat er ontbrak: geen verzoek, geen zin, niets. Zichtbaar werd dat doordat de link vanaf `/auth/login` het net ingetypte adres niet meedroeg, dus het veld stond leeg op de ene pagina die je alleen opent als je telefoon weg is. Het adres gaat nu mee via `sessionStorage`, de focus springt naar het codeveld, en een leeg veld levert een zin op de pagina op.

**2. Een bestand boven 5 MB kreeg een groen vinkje en een levende knop.**
De weigering bestond alleen als console-regel, want ze liep door `failureText()`, die voor onze eigen storingen is. De grens wordt nu bij het kiezen getoetst, de knop gaat uit, en de zin staat op het scherm. Hetzelfde bestand blijft gewoon toegestaan op de live-stand, die tot 500 MB gaat.

**3. Het maandquotum kwam pas na de hele ceremonie.**
Document, zegel, naam en zescijferige code, en dan pas `402`, met de envelope al aangemaakt aan de serverkant. De reviewstap leest nu de teller die het dashboard al publiceert en zet het aantal naast de knop. De knop blijft aan, net als na een 402: wie in een ander tabblad upgradet moet door kunnen.

**4. Elke lading van `/account` gaf 429, zichtbaar op het scherm.**
"Could not load passkeys (HTTP 429)" bij drie van drie ladingen, terwijl dezelfde GET los gewoon 200 geeft. Het hele `/api/user/`-prefix zat in de auth-throttle op `burst=5` terwijl die pagina er zes tegelijk opent. Erger: een 429 op `/api/user/session/verify` laat een ingelogde bezoeker zichzelf als uitgelogd zien (gemeten: 1 op 8 ladingen). Alleen de credential-endpoints houden nu `relay_auth`, de rest gaat naar de `api`-zone. De versterker ging mee: dashboard en developer pollden elke 5 en 10 seconden door in een achtergrondtab, nu 30 seconden en alleen bij een zichtbare tab.

**5. "Developer settings" stond in het menu van elke ingelogde bezoeker.**
`/developer` antwoordt 404 aan iedereen buiten de allowlist. Dat verbergen is opzet en blijft zo; het aanbieden aan iedereen was het niet. `session/verify` zegt nu of dit account de deur mag openen, en de links verschijnen alleen dan.

**6. Vier zinnen die niet klopten.**
De verificatielink leeft `EX: 86400`, dus 24 uur en niet 2 dagen. Account-mail komt van `hello@`, niet van `noreply@` (vier pagina's noemden een afzender die niet bestaat, dus filteren op afzender vond niets). `/verify` vroeg om "the original document" terwijl juist het gestempelde exemplaar valideert; het label klopt nu en de verifier herkent het bestand van vóór de zegel bij naam. De ondertekenaarsregel printte "Naam ((unverified))" met dubbele haakjes om een ontbrekend adres.

**7. De reviewkaart noemde `recipe_version 3`.**
De relay schrijft 5 in de envelope die de ondertekenaar een minuut later downloadt. Het recept wordt aan de serverkant gekozen, dus vóór de envelope bestaat is er geen nummer om te tonen. Diezelfde preview zegt al `<set on sign>` voor de velden in die positie.

**8. Account deactiveren faalde stil.**
`if (res.ok)` en verder niets: ging het mis, dan bleef de pagina staan en bestond het account gewoon nog. 401, 429 en de rest krijgen nu elk hun eigen zin.

## Poorten

`tests/stille-breuken.test.mjs`, 12 toetsen. Elke assertie bewijst eerst dat zijn onderwerp bestaat, en is nagelopen door de fix terug te draaien en te zien dat de test rood wordt.

De nginx-toets is de scherpste: `signup` en `sign` delen een prefix, dus de regex die de credential-endpoints afzondert kan er stilletjes ook `/api/user/sign/activation` en `/sign/submit` in trekken. Dat zijn de ondertekencalls van een al ingelogd account, die zouden zichzelf afknijpen in de smalle zone. De test loopt 8 paden af die erin moeten vallen en 11 die eruit moeten blijven, en is gefalsifieerd door `sign` aan de alternatie toe te voegen.

## Voor de reviewer

**`nginx -t` is niet gedraaid.** Nginx staat niet op de machine waar dit gemaakt is. De conf is gelezen en de regex is met echte paden getoetst, maar de syntaxcontrole hoort op de server, vóór de reload. Dat is het enige punt in deze PR dat niet geverifieerd is.

Testsuite: 312 van 322 groen. De 3 fouten zijn pre-existent en staan los van deze wijzigingen (2x brand-shots, 1x `heartbeat-lib` op een ontbrekende dependency), gecontroleerd door de suite ook zonder deze commits te draaien.

Reparaties 1 en 2 zijn na afloop in een echte browser nagemeten tegen een lokale kopie van `frontend/`. Dat was nodig: de eerste versie van reparatie 1 werkte niet, en dat bleek pas toen de melding er in Chromium nog steeds niet stond. Daar kwam `novalidate` uit boven.