### PR TITLE
een afzender kan nu nagaan of hij dit document al aanbood

### DIFF
--- a/admin/server.js
+++ b/admin/server.js
@@ -2990,6 +2990,26 @@ api.get("/user/documents", authUser, async (req, res) => {
   }
 });
 
+// Heb ik dit document al aangeboden. Alleen over het eigen account, en alleen
+// op een hash die de vrager zelf al kent: de lijst hierboven laat de
+// documenthash bewust weg en dat blijft zo. Bedoeld voor een client die afbrak
+// tussen het aanmaken van de envelope en het opschrijven van het id, en die nu
+// niet kan vaststellen of hij er al een heeft.
+api.get("/user/documents/lookup", authUser, async (req, res) => {
+  const { user_id } = req.userSession;
+  const docHash = String(req.query.doc_hash || "").trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(docHash)) return res.status(400).json({ error: "invalid_doc_hash" });
+  try {
+    const relayRes = await callRelay("/v2/user/envelopes/lookup", { user_id, doc_hash: docHash }, "POST");
+    const body = await relayRes.json().catch(() => ({ error: "bad_relay_response" }));
+    res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, private");
+    return res.status(relayRes.status).json(body);
+  } catch (err) {
+    console.error("[user/documents lookup]", err.message);
+    return res.status(502).json({ error: "relay_unreachable" });
+  }
+});
+
 // Owner actions for the account-scoped document worklist. The browser supplies
 // only an envelope id; the relay receives the session account's own API key and
 // performs the durable account_id ownership check again.

--- a/relay/envelope.js
+++ b/relay/envelope.js
@@ -738,6 +738,31 @@ class EnvelopeStore {
     return rows.filter(Boolean);
   }
 
+  // Welke envelopes van dit account gaan over DIT document.
+  //
+  // Waarom dit er is: een client die afbreekt tussen create() en het opschrijven
+  // van het envelope-id kan nu niet vaststellen of hij al een envelope voor dit
+  // document heeft. De dashboardlijst laat de documenthash bewust weg, en dat
+  // blijft zo; dit is een gerichte vraag waarop je alleen antwoord krijgt als je
+  // de hash al kent, en alleen over je eigen account. Het alternatief in de
+  // praktijk is bestandsnaam plus tijdstip als anker, en dat kan twee verzoeken
+  // voor hetzelfde bestand niet uit elkaar houden: dan is de veilige uitkomst
+  // een dubbele envelope of stilstand.
+  async findAccountEnvelopeIdsByDocHash(accountId, docHash, { limit = 100 } = {}) {
+    if (!this.available()) throw new Error('redis unavailable');
+    const hash = String(docHash || '').trim().toLowerCase();
+    if (!accountId || !/^[0-9a-f]{64}$/.test(hash)) return [];
+    const ids = await this.listAccountEnvelopeIds(accountId, { limit, prune: true });
+    const rijen = await Promise.all(ids.map(async (id) => {
+      const [storedAccount, storedHash] = await this.redis.hmGet(
+        'env:' + id, ['account_id', 'doc_hash']);
+      if (!storedAccount || !safeTextEqual(storedAccount, accountId)) return null;
+      if (!storedHash || !safeHexEqual(storedHash, hash)) return null;
+      return id;
+    }));
+    return rijen.filter(Boolean);
+  }
+
   // One-shot backfill of the per-account envelope index from existing env:* keys.
   // The index is only written at create() time, so envelopes made BEFORE it
   // existed are absent -- this SCANs every envelope hash and (re)builds the index.

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -4418,6 +4418,31 @@ async function handleRelayRequest(req, res) {
     }
   }
 
+  // ── POST /v2/user/envelopes/lookup: heb ik dit document al aangeboden ─────
+  // Voor een client die afbrak tussen het aanmaken van de envelope en het
+  // opschrijven van het id. Je krijgt alleen antwoord over je eigen account en
+  // alleen op een hash die je zelf al kent, dus dit legt niets bloot dat de
+  // vrager niet had. De dashboardlijst blijft de documenthash weglaten.
+  if (req.method === "POST" && path === "/v2/user/envelopes/lookup") {
+    if (!_internalOk()) return _internalReject();
+    try {
+      const input = JSON.parse((await readBody(req, 4096)).toString());
+      const userId = (input.user_id || "").toString();
+      const docHash = (input.doc_hash || "").toString().trim().toLowerCase();
+      if (!userId || userId.length > 200) { res.writeHead(400); return res.end(J({ error: "invalid_user_id" })); }
+      if (!/^[0-9a-f]{64}$/.test(docHash)) { res.writeHead(400); return res.end(J({ error: "invalid_doc_hash" })); }
+      const store = _envStore();
+      if (!store) { res.writeHead(503); return res.end(J({ error: "envelope_store_unavailable" })); }
+      const ids = await store.findAccountEnvelopeIdsByDocHash(userId, docHash);
+      res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+      return res.end(J({ ok: true, envelope_ids: ids, count: ids.length }));
+    } catch (err) {
+      if (redisOutage503(err, res)) return;
+      console.error("[user/envelopes lookup]", err.message);
+      res.writeHead(500); return res.end(J({ error: "internal" }));
+    }
+  }
+
   // ── POST /v2/parasign/inbox/:id/resend: send me that invitation again ──────
   // Internal auth plus an asserted verified email hash, the same pair the
   // recipient-side document and participant-receipt reads take. It is NOT in

--- a/relay/test/parasign-envelope-index.test.js
+++ b/relay/test/parasign-envelope-index.test.js
@@ -85,6 +85,25 @@ async function main() {
     assert.deepStrictEqual(await store.listAccountEnvelopes(OTHER, {}), [], 'stored account mismatch is rejected');
     ok('dashboard summary rejects a cross-account index entry');
 
+      // 1c) hervinden op documenthash --------------------------------------------
+      // Voor een client die afbrak tussen create() en het opschrijven van het id.
+      // De dashboardlijst laat de hash bewust weg (zie hierboven); dit is de
+      // gerichte vraag, alleen over het eigen account en alleen op een hash die
+      // de vrager al kent.
+      assert.deepStrictEqual(await store.findAccountEnvelopeIdsByDocHash(ACCT, docHash), [out.id],
+        'lookup by document hash finds the account own envelope');
+      assert.deepStrictEqual(await store.findAccountEnvelopeIdsByDocHash(ACCT, docHash.toUpperCase()), [out.id],
+        'lookup by document hash is case-insensitive');
+      assert.deepStrictEqual(await store.findAccountEnvelopeIdsByDocHash(OTHER, docHash), [],
+        'lookup by document hash rejects a cross-account index entry');
+      assert.deepStrictEqual(await store.findAccountEnvelopeIdsByDocHash(ACCT, 'f'.repeat(64)), [],
+        'lookup by document hash finds nothing for another document');
+      assert.deepStrictEqual(await store.findAccountEnvelopeIdsByDocHash(ACCT, 'niet-een-hash'), [],
+        'lookup by document hash refuses a malformed hash');
+      assert.deepStrictEqual(await store.findAccountEnvelopeIdsByDocHash('', docHash), [],
+        'lookup by document hash refuses an empty account');
+      ok('lookup by document hash is account-scoped and hash-exact');
+
     // 1b) the requested signing position ---------------------------------------
     // What the invite flow on /sign sends: one seal box, the same for every
     // party, normalized on the way in and durable across a read.


### PR DESCRIPTION
## Wat er stuk was

Een client die afbreekt tussen `create()` en het opschrijven van het envelope-id
kan niet vaststellen of hij al een envelope voor dit document heeft. `GET
/api/user/documents` geeft geen documenthash terug, en er is geen
detail-endpoint voor de eigenaar. Het enige anker is dan bestandsnaam plus
tijdstip, en dat houdt twee verzoeken voor hetzelfde bestand niet uit elkaar.
De veilige uitkomst is een dubbele envelope of stilstand.

Gevonden door een volledige documentroute te lopen met een onderbreking ná de
bijwerking en vóór het vastleggen van succes.

## Wat dit doet

- `findAccountEnvelopeIdsByDocHash` op de envelope-store
- `POST /v2/user/envelopes/lookup` op de relay, interne auth
- `GET /api/user/documents/lookup?doc_hash=` op de admin, sessie-auth

Strikt account-scoped, en je krijgt alleen antwoord op een hash die je zelf al
kent. Er komt dus niets bloot dat de vrager niet had.

## Wat dit expres niet doet

De dashboardlijst blijft de documenthash weglaten. Dat is een bewuste keuze met
een eigen toets (`dashboard summary omits document hash`), en die staat er nog.
Dit is een gerichte vraag in plaats van een bredere projectie.

## Toetsen

Toegevoegd aan `relay/test/parasign-envelope-index.test.js`, tegen een echte
store en een echte redis: eigen account vindt hem, hoofdletters maken niet uit,
een ander account niet, een andere hash niet, een misvormde hash niet, een leeg
account niet.

`bash tests/static-sanity.sh` -> PASS.

Let op: `1b) the requested signing position` in datzelfde bestand faalt in mijn
omgeving ook zonder deze wijziging, op `origin/main`. Niet door deze PR
veroorzaakt en hier niet aangeraakt.